### PR TITLE
[xla:gpu] Add dynamic-slice fusion analysis library

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1312,6 +1312,38 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "dynamic_slice_fusion",
+    srcs = ["dynamic_slice_fusion.cc"],
+    hdrs = ["dynamic_slice_fusion.h"],
+    deps = [
+        "//xla:shape_util",
+        "//xla:util",
+        "//xla/hlo/ir:hlo",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)
+
+xla_cc_test(
+    name = "dynamic_slice_fusion_test",
+    srcs = ["dynamic_slice_fusion_test.cc"],
+    deps = [
+        ":dynamic_slice_fusion",
+        "//xla:shape_util",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service/gpu:backend_configs_cc",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",  # fixdeps: keep
+    ],
+)
+
+cc_library(
     name = "dynamic_slice_fusion_rewriter",
     srcs = ["dynamic_slice_fusion_rewriter.cc"],
     hdrs = ["dynamic_slice_fusion_rewriter.h"],

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion.cc
@@ -1,0 +1,260 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/dynamic_slice_fusion.h"
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/util.h"
+
+namespace xla::gpu {
+
+const HloInstruction* DynamicSliceFusion::FindHero(const HloComputation* body) {
+  for (const HloInstruction* instr : body->instructions()) {
+    switch (instr->opcode()) {
+      case HloOpcode::kParameter:
+      case HloOpcode::kConstant:
+      case HloOpcode::kSlice:
+      case HloOpcode::kDynamicSlice:
+      case HloOpcode::kDynamicUpdateSlice:
+      case HloOpcode::kBitcast:
+      case HloOpcode::kTuple:
+      case HloOpcode::kGetTupleElement:
+        continue;
+      default:
+        return instr;
+    }
+  }
+  return nullptr;
+}
+
+namespace {
+
+const HloInstruction* WalkThroughBitcasts(const HloInstruction* instr) {
+  while (instr->opcode() == HloOpcode::kBitcast) {
+    instr = instr->operand(0);
+  }
+  return instr;
+}
+
+std::optional<DynamicSliceConfig> ExtractDynamicSliceConfig(
+    const HloInstruction* instr) {
+  auto config = instr->backend_config<GpuBackendConfig>();
+  if (!config.ok() || !config->has_dynamic_slice_config()) {
+    return std::nullopt;
+  }
+  return config->dynamic_slice_config();
+}
+
+std::optional<DynamicSliceConfig> ComputeStaticSliceConfig(
+    const HloSliceInstruction* slice) {
+  auto byte_strides = ShapeUtil::ByteStrides(slice->operand(0)->shape());
+  if (!byte_strides.has_value()) {
+    return std::nullopt;
+  }
+  int64_t byte_offset = 0;
+  for (int64_t dim = 0; dim < slice->shape().dimensions_size(); ++dim) {
+    byte_offset += slice->slice_starts(dim) * (*byte_strides)[dim];
+  }
+  DynamicSliceConfig config;
+  config.set_byte_offset(byte_offset);
+  config.set_byte_stride(0);
+  return config;
+}
+
+// Resolves per-dimension offset info for a DS/DUS. Returns one entry per
+// dimension: RuntimeOffset for fusion parameters, ConstantOffset for
+// constants sunk into the fusion body.
+std::vector<DynamicSliceFusion::Offset> ResolveOffsets(
+    const HloInstruction* instr, int32_t first_offset_index) {
+  std::vector<DynamicSliceFusion::Offset> offsets;
+  offsets.reserve(instr->operand_count() - first_offset_index);
+  for (int64_t i = first_offset_index; i < instr->operand_count(); ++i) {
+    int64_t dim = i - first_offset_index;
+    const HloInstruction* idx = WalkThroughBitcasts(instr->operand(i));
+    auto* idx_param = DynCast<HloParameterInstruction>(idx);
+    if (idx_param != nullptr) {
+      offsets.push_back(DynamicSliceFusion::RuntimeOffset{
+          idx_param->parameter_number(), dim});
+    } else {
+      offsets.push_back(DynamicSliceFusion::ConstantOffset{0, dim});
+    }
+  }
+  return offsets;
+}
+
+// Resolves one result chain: walks from a hero output through bitcasts to a
+// DUS, extracts the config, and finds the target parameter.
+static absl::StatusOr<std::optional<DynamicSliceFusion::Result>>
+ResolveOneResultChain(const HloInstruction* start, const Shape& hero_shape,
+                      int64_t result_number) {
+  const HloInstruction* walk = start;
+  while (walk->opcode() == HloOpcode::kBitcast) {
+    if (walk->user_count() != 1) {
+      break;
+    }
+    walk = walk->users().front();
+  }
+
+  auto* dus = DynCast<HloDynamicUpdateSliceInstruction>(walk);
+  if (dus == nullptr) {
+    return std::nullopt;
+  }
+
+  std::optional<DynamicSliceConfig> config = ExtractDynamicSliceConfig(dus);
+
+  const HloInstruction* target = WalkThroughBitcasts(dus->operand(0));
+  auto* target_param = DynCast<HloParameterInstruction>(target);
+  if (target_param == nullptr) {
+    return Internal(
+        "DynamicSliceFusionV2: DUS target must be a fusion parameter, got %s",
+        target->ToString());
+  }
+
+  return DynamicSliceFusion::Result{
+      std::optional<int64_t>(target_param->parameter_number()),
+      result_number,
+      dus->operand(0)->shape(),
+      dus->operand(1)->shape(),
+      config,
+      std::optional(ResolveOffsets(dus, 2)),
+  };
+}
+
+// Walks a GTE chain from `instr` following the given ShapeIndex path. For
+// example, ShapeIndex{0,1} means: find the GTE with index 0 among instr's
+// users, then find the GTE with index 1 among that GTE's users. Returns
+// nullptr if the chain does not exist.
+const HloInstruction* WalkGteChain(const HloInstruction* instr,
+                                   const ShapeIndex& index) {
+  const HloInstruction* current = instr;
+  for (int64_t i = 0; i < index.size(); ++i) {
+    const HloInstruction* found = nullptr;
+    for (const HloInstruction* user : current->users()) {
+      auto* gte = DynCast<HloGetTupleElementInstruction>(user);
+      if (gte != nullptr && gte->tuple_index() == index[i]) {
+        found = gte;
+        break;
+      }
+    }
+    if (found == nullptr) {
+      return nullptr;
+    }
+    current = found;
+  }
+  return current;
+}
+
+}  // namespace
+
+absl::StatusOr<std::vector<DynamicSliceFusion::Parameter>>
+DynamicSliceFusion::ResolveParameters(const HloInstruction* hero) {
+  std::vector<DynamicSliceFusion::Parameter> result;
+  result.reserve(hero->operand_count());
+
+  for (const HloInstruction* operand : hero->operands()) {
+    const HloInstruction* walk = WalkThroughBitcasts(operand);
+
+    std::optional<DynamicSliceConfig> config;
+    std::optional<std::vector<DynamicSliceFusion::Offset>> offsets;
+    const HloInstruction* source = walk;
+    Shape slice_shape = operand->shape();
+
+    if (auto* ds = DynCast<HloDynamicSliceInstruction>(walk)) {
+      config = ExtractDynamicSliceConfig(ds);
+      offsets = ResolveOffsets(ds, 1);
+      slice_shape = ds->shape();
+      source = ds->operand(0);
+    } else if (auto* slice = DynCast<HloSliceInstruction>(walk)) {
+      config = ComputeStaticSliceConfig(slice);
+      slice_shape = slice->shape();
+      source = slice->operand(0);
+    }
+
+    source = WalkThroughBitcasts(source);
+    auto* parameter = DynCast<HloParameterInstruction>(source);
+    if (parameter == nullptr) {
+      return Internal(
+          "DynamicSliceFusionV2: expected fusion parameter backing hero "
+          "operand, got %s",
+          source->ToString());
+    }
+
+    result.push_back(DynamicSliceFusion::Parameter{
+        parameter->parameter_number(),
+        source->shape(),
+        slice_shape,
+        config,
+        std::move(offsets),
+    });
+  }
+
+  return result;
+}
+
+absl::StatusOr<std::vector<DynamicSliceFusion::Result>>
+DynamicSliceFusion::ResolveResults(const HloInstruction* hero) {
+  if (hero->shape().IsTuple()) {
+    auto leaves = ShapeUtil::GetLeafShapes(hero->shape());
+    int64_t n = leaves.size();
+    std::vector<DynamicSliceFusion::Result> results(n);
+
+    for (int64_t i = 0; i < n; ++i) {
+      const Shape& leaf = leaves[i].shape;
+      results[i] = Result{std::nullopt, i, leaf, leaf};
+    }
+
+    for (int64_t i = 0; i < n; ++i) {
+      const ShapeIndex& index = leaves[i].index;
+      const HloInstruction* leaf_gte = WalkGteChain(hero, index);
+      if (leaf_gte == nullptr) {
+        continue;
+      }
+
+      for (const HloInstruction* user : leaf_gte->users()) {
+        TF_ASSIGN_OR_RETURN(auto rs,
+                            ResolveOneResultChain(user, leaves[i].shape, i));
+        if (rs.has_value()) {
+          results[i] = *std::move(rs);
+        }
+      }
+    }
+    return results;
+  }
+
+  // Non-tuple hero: single result.
+  for (const HloInstruction* user : hero->users()) {
+    TF_ASSIGN_OR_RETURN(auto rs, ResolveOneResultChain(user, hero->shape(), 0));
+    if (rs.has_value()) {
+      return std::vector{*std::move(rs)};
+    }
+  }
+
+  return std::vector{Result{std::nullopt, 0, hero->shape(), hero->shape()}};
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion.h
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion.h
@@ -1,0 +1,322 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_FUSION_H_
+#define XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_FUSION_H_
+
+#include <cstdint>
+#include <optional>
+#include <ostream>
+#include <variant>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+
+namespace xla::gpu {
+
+// Utilities for analyzing dynamic-slice fusion instructions. These fusions are
+// created by the dynamic-slice fusion rewriter when it can prove that DS/DUS
+// offsets depend only on the while-loop induction variable or are fully static.
+//
+// A dynamic-slice fusion wraps a hero computation (e.g. a custom call or a
+// kernel fusion) with dynamic-slice (DS) inputs and dynamic-update-slice (DUS)
+// outputs. At run time, the DynamicSliceFusionThunk adjusts buffer offsets
+// per while-loop iteration so the hero operates on a different slice each time.
+//
+// Example HLO (a custom call reading and writing one row per iteration of a
+// 4-iteration while loop). The induction variable `ivar` is passed as a fusion
+// parameter so the runtime can verify the annotated offset.
+//
+//   %dsf_computation {
+//     %p0 = f32[4,8,8] parameter(0)         // input buffer
+//     %p1 = s32[] parameter(1)              // ivar (runtime offset)
+//     %p2 = f32[4,8,8] parameter(2)         // output buffer
+//     %c0 = s32[] constant(0)
+//     %ds = f32[1,8,8] dynamic-slice(%p0, %p1, %c0, %c0),
+//       dynamic_slice_sizes={1,8,8},
+//       backend_config={"dynamic_slice_config":{
+//         "loop_index":0, "byte_offset":0, "byte_stride":256}}
+//     %bc_in = f32[8,8] bitcast(%ds)
+//     %hero = f32[8,8] custom-call(%bc_in),
+//       custom_call_target="fake_target"
+//     %bc_out = f32[1,8,8] bitcast(%hero)
+//     ROOT %dus = f32[4,8,8] dynamic-update-slice(%p2, %bc_out, %p1, %c0, %c0),
+//       backend_config={"dynamic_slice_config":{
+//         "loop_index":0, "byte_offset":0, "byte_stride":256}}
+//   }
+//
+//   body {
+//     %param = (s32[], f32[4,8,8], f32[4,8,8]) parameter(0)
+//     %ivar = s32[] get-tuple-element(%param), index=0
+//     %input = f32[4,8,8] get-tuple-element(%param), index=1
+//     %output = f32[4,8,8] get-tuple-element(%param), index=2
+//     %updated = f32[4,8,8] fusion(%input, %ivar, %output),
+//       kind=kCustom, calls=%dsf_computation,
+//       backend_config={"fusion_backend_config":{
+//         "kind":"__custom_fusion",
+//         "custom_fusion_config":{"name":"dynamic_slice_fusion"}}}
+//     %one = s32[] constant(1)
+//     %next_ivar = s32[] add(%ivar, %one)
+//     ROOT %result = (s32[], f32[4,8,8], f32[4,8,8])
+//       tuple(%next_ivar, %input, %updated)
+//   }
+//
+// This library extracts the hero, resolves parameter/result slices, and returns
+// DynamicSliceConfig protos that the ThunkEmitter converts into runtime thunks.
+
+// Analysis result for a dynamic-slice fusion. Describes how each hero
+// parameter and result maps to fusion parameters and how offsets are computed
+// at runtime.
+struct DynamicSliceFusion {
+  // A DS/DUS offset for one dimension that is a compile-time constant (e.g.
+  // `s32[] constant(0)` inside the fusion body). The actual byte contribution
+  // for this dimension is `offset * byte_stride_for_dimension`.
+  struct ConstantOffset {
+    int64_t offset;            // Constant index value for this dimension.
+    int64_t dimension_number;  // Which dimension of the DS/DUS this applies to.
+  };
+
+  // A DS/DUS offset for one dimension that comes from a fusion parameter
+  // holding a runtime scalar (e.g. the loop induction variable passed as a
+  // fusion operand). At emit time the thunk emitter maps `parameter_number`
+  // to a BufferAllocation::Slice; at runtime the thunk D2H-copies the scalar
+  // to verify that the annotated DynamicSliceConfig offset matches the actual
+  // XLA-computed offset.
+  struct RuntimeOffset {
+    int64_t parameter_number;  // Fusion parameter index of the offset scalar.
+    int64_t dimension_number;  // Which dimension of the DS/DUS this applies to.
+  };
+
+  // Per-dimension offset for a DS or DUS instruction: either a compile-time
+  // constant (literal inside the fusion) or a reference to a runtime scalar
+  // fusion parameter.
+  using Offset = std::variant<ConstantOffset, RuntimeOffset>;
+
+  // Parameter numbers in the structs below correspond to
+  // HloParameterInstruction::parameter_number() inside the fusion body. Note
+  // that a fusion parameter can be a tuple, which at runtime is flattened into
+  // multiple buffers by the buffer assignment. The thunk emitter is responsible
+  // for mapping these HLO-level parameter numbers to buffer slices.
+
+  // A resolved hero operand: describes which fusion parameter backs the hero
+  // input and how the buffer is sliced at runtime.
+  struct Parameter {
+    // Fusion parameter number of the buffer backing this hero operand
+    // (the DS source or direct parameter).
+    int64_t parameter_number;
+
+    // Shape of the fusion parameter (the full, unsliced buffer).
+    Shape parameter_shape;
+
+    // Shape of the slice fed to the hero (DS output shape, or same as
+    // parameter_shape when not sliced).
+    Shape slice_shape;
+
+    // DynamicSliceConfig from the DS backend_config. Encodes the host-side
+    // offset formula: `offset + loop_iteration[loop_index] * stride`.
+    // Absent when the operand is not sliced (direct parameter pass-through).
+    std::optional<DynamicSliceConfig> slice_config;
+
+    // Per-dimension offset info from the DS index operands. Absent when the
+    // operand is not sliced (no DS between the parameter and the hero).
+    std::optional<std::vector<Offset>> slice_offsets;
+  };
+
+  // A resolved hero result: describes which fusion parameter holds the DUS
+  // target buffer and how the result is sliced back at runtime.
+  struct Result {
+    // Fusion parameter number of the DUS target buffer. Absent when the
+    // result does not flow through a DUS.
+    std::optional<int64_t> parameter_number;
+
+    // Flat leaf index (DFS order) within the hero's output shape. 0 for a
+    // single non-tuple result. For nested tuples like ((f32, f32), f32)
+    // the leaves are numbered 0, 1, 2.
+    int64_t result_number = 0;
+
+    // Shape of the DUS target buffer (the full output buffer).
+    Shape result_shape;
+
+    // Shape of the DUS update (the hero output slice inserted into the
+    // result buffer).
+    Shape update_shape;
+
+    // DynamicSliceConfig from the DUS backend_config. Absent when the
+    // result does not flow through a DUS.
+    std::optional<DynamicSliceConfig> update_config;
+
+    // Per-dimension offset info from the DUS index operands. Absent when
+    // the result does not flow through a DUS.
+    std::optional<std::vector<Offset>> update_offsets;
+  };
+
+  // Finds the "hero" instruction inside a dynamic-slice fusion body.
+  static const HloInstruction* FindHero(const HloComputation* body);
+
+  // Resolves parameters for the hero instruction. Returns an entry for each
+  // operand of the hero; the same fusion parameter may appear more than once
+  // if it feeds multiple hero operands.
+  static absl::StatusOr<std::vector<Parameter>> ResolveParameters(
+      const HloInstruction* hero);
+
+  // Resolves results for the hero instruction. Returns an entry for all results
+  // of the dynamic slice fusion (root of the hero, or for each tuple entry).
+  static absl::StatusOr<std::vector<Result>> ResolveResults(
+      const HloInstruction* hero);
+};
+
+//===----------------------------------------------------------------------===//
+// DynamicSliceFusion comparison and stringification
+//===----------------------------------------------------------------------===//
+
+inline bool operator==(const DynamicSliceFusion::ConstantOffset& a,
+                       const DynamicSliceFusion::ConstantOffset& b) {
+  return a.offset == b.offset && a.dimension_number == b.dimension_number;
+}
+
+inline bool operator==(const DynamicSliceFusion::RuntimeOffset& a,
+                       const DynamicSliceFusion::RuntimeOffset& b) {
+  return a.parameter_number == b.parameter_number &&
+         a.dimension_number == b.dimension_number;
+}
+
+inline bool ConfigsEqual(const std::optional<DynamicSliceConfig>& a,
+                         const std::optional<DynamicSliceConfig>& b) {
+  if (a.has_value() != b.has_value()) {
+    return false;
+  }
+  if (!a.has_value()) {
+    return true;
+  }
+  return a->has_loop_index() == b->has_loop_index() &&
+         a->loop_index() == b->loop_index() &&
+         a->byte_offset() == b->byte_offset() &&
+         a->byte_stride() == b->byte_stride();
+}
+
+inline bool operator==(const DynamicSliceFusion::Parameter& a,
+                       const DynamicSliceFusion::Parameter& b) {
+  return a.parameter_number == b.parameter_number &&
+         a.parameter_shape == b.parameter_shape &&
+         a.slice_shape == b.slice_shape &&
+         ConfigsEqual(a.slice_config, b.slice_config) &&
+         a.slice_offsets == b.slice_offsets;
+}
+
+inline bool operator==(const DynamicSliceFusion::Result& a,
+                       const DynamicSliceFusion::Result& b) {
+  return a.parameter_number == b.parameter_number &&
+         a.result_number == b.result_number &&
+         a.result_shape == b.result_shape && a.update_shape == b.update_shape &&
+         ConfigsEqual(a.update_config, b.update_config) &&
+         a.update_offsets == b.update_offsets;
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, const DynamicSliceFusion::ConstantOffset& o) {
+  absl::Format(&sink, "c(d%d,%d)", o.dimension_number, o.offset);
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, const DynamicSliceFusion::RuntimeOffset& o) {
+  absl::Format(&sink, "r(d%d,p%d)", o.dimension_number, o.parameter_number);
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, const DynamicSliceFusion::Offset& o) {
+  std::visit([&sink](const auto& v) { AbslStringify(sink, v); }, o);
+}
+
+template <typename Sink>
+void StringifyConfig(Sink& sink, const std::optional<DynamicSliceConfig>& c) {
+  if (!c.has_value()) {
+    absl::Format(&sink, "config{}");
+    return;
+  }
+  absl::Format(&sink, "config{loop=%d, offset=%d, stride=%d}", c->loop_index(),
+               c->byte_offset(), c->byte_stride());
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, const DynamicSliceFusion::Parameter& p) {
+  absl::Format(&sink, "Parameter{param=%d %s->%s, ", p.parameter_number,
+               ShapeUtil::HumanString(p.parameter_shape),
+               ShapeUtil::HumanString(p.slice_shape));
+  StringifyConfig(sink, p.slice_config);
+  if (p.slice_offsets.has_value()) {
+    absl::Format(&sink, ", offsets=[%s]",
+                 absl::StrJoin(*p.slice_offsets, ", "));
+  } else {
+    absl::Format(&sink, ", offsets=none");
+  }
+  absl::Format(&sink, "}");
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, const DynamicSliceFusion::Result& r) {
+  if (r.parameter_number.has_value()) {
+    absl::Format(&sink, "Result{param=%d", *r.parameter_number);
+  } else {
+    absl::Format(&sink, "Result{param=none");
+  }
+  absl::Format(&sink, ", result=%d %s->%s, ", r.result_number,
+               ShapeUtil::HumanString(r.update_shape),
+               ShapeUtil::HumanString(r.result_shape));
+  StringifyConfig(sink, r.update_config);
+  if (r.update_offsets.has_value()) {
+    absl::Format(&sink, ", offsets=[%s]",
+                 absl::StrJoin(*r.update_offsets, ", "));
+  } else {
+    absl::Format(&sink, ", offsets=none");
+  }
+  absl::Format(&sink, "}");
+}
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const DynamicSliceFusion::ConstantOffset& o) {
+  return os << absl::StrCat(o);
+}
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const DynamicSliceFusion::RuntimeOffset& o) {
+  return os << absl::StrCat(o);
+}
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const DynamicSliceFusion::Offset& o) {
+  return os << absl::StrCat(o);
+}
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const DynamicSliceFusion::Parameter& p) {
+  return os << absl::StrCat(p);
+}
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const DynamicSliceFusion::Result& r) {
+  return os << absl::StrCat(r);
+}
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_FUSION_H_

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_test.cc
@@ -1,0 +1,694 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/dynamic_slice_fusion.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/strings/str_cat.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+namespace {
+
+using Parameter = DynamicSliceFusion::Parameter;
+using Result = DynamicSliceFusion::Result;
+
+using CstOff = DynamicSliceFusion::ConstantOffset;
+using RtOff = DynamicSliceFusion::RuntimeOffset;
+
+using Offsets = std::vector<DynamicSliceFusion::Offset>;
+
+DynamicSliceConfig MakeConfig(int64_t loop_index, int64_t offset,
+                              int64_t stride) {
+  DynamicSliceConfig config;
+  config.set_loop_index(loop_index);
+  config.set_byte_offset(offset);
+  config.set_byte_stride(stride);
+  return config;
+}
+
+DynamicSliceConfig MakeStaticConfig(int64_t offset) {
+  DynamicSliceConfig config;
+  config.set_byte_offset(offset);
+  return config;
+}
+
+class DynamicSliceFusionTest : public HloHardwareIndependentTestBase {};
+
+//===----------------------------------------------------------------------===//
+// DynamicSliceFusion::FindHero tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionTest, FindHeroCustomCall) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %fill = f32[4] custom-call(), custom_call_target="fill"
+      %bitcast = f32[1,4] bitcast(%fill)
+      %zero = s32[] constant(0)
+      ROOT %dus = f32[4,4] dynamic-update-slice(%p0, %bitcast, %zero, %zero)
+    }
+
+    ENTRY main {
+      %input = f32[4,4] parameter(0)
+      ROOT %fusion = f32[4,4] fusion(%input), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  ASSERT_NE(body, nullptr);
+
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+  EXPECT_EQ(hero->opcode(), HloOpcode::kCustomCall);
+  EXPECT_EQ(hero->custom_call_target(), "fill");
+}
+
+TEST_F(DynamicSliceFusionTest, FindHeroSkipsInfrastructure) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[8,8] parameter(0)
+      %p1 = f32[8,8] parameter(1)
+      %slice = f32[4,8] slice(%p0), slice={[0:4], [0:8]}
+      %bitcast = f32[4,8] bitcast(%slice)
+      %dot = f32[4,8] dot(%bitcast, %p1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+      %zero = s32[] constant(0)
+      ROOT %dus = f32[8,8] dynamic-update-slice(%p0, %dot, %zero, %zero)
+    }
+
+    ENTRY main {
+      %a = f32[8,8] parameter(0)
+      %b = f32[8,8] parameter(1)
+      ROOT %fusion = f32[8,8] fusion(%a, %b), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+  EXPECT_EQ(hero->opcode(), HloOpcode::kDot);
+}
+
+TEST_F(DynamicSliceFusionTest, FindHeroReturnsNullWhenNoHero) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[8,4] parameter(0)
+      %slice = f32[4,4] slice(%p0), slice={[0:4], [0:4]}
+      ROOT %bitcast = f32[16] bitcast(%slice)
+    }
+
+    ENTRY main {
+      %a = f32[8,4] parameter(0)
+      ROOT %fusion = f32[16] fusion(%a), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+
+  EXPECT_EQ(DynamicSliceFusion::FindHero(body), nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// DynamicSliceFusion::ResolveParameters tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionTest, ResolveParamWithDynamicSliceConstantOffsets) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %zero = s32[] constant(0)
+      %ds = f32[1,4] dynamic-slice(%p0, %zero, %zero), dynamic_slice_sizes={1,4},
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+      ROOT %custom = f32[1,4] custom-call(%ds), custom_call_target="hero"
+    }
+
+    ENTRY main {
+      %input = f32[4,4] parameter(0)
+      ROOT %fusion = f32[1,4] fusion(%input), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto params,
+                       DynamicSliceFusion::ResolveParameters(hero));
+  ASSERT_EQ(params.size(), 1);
+  EXPECT_EQ(params[0],
+            (Parameter{0, ShapeUtil::MakeShape(F32, {4, 4}),
+                       ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+                       Offsets{CstOff{0, 0}, CstOff{0, 1}}}));
+}
+
+TEST_F(DynamicSliceFusionTest, ResolveParamWithDynamicSliceRuntimeOffsets) {
+  // DS with one runtime offset (ivar from p1) and one constant offset.
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %p1 = s32[] parameter(1)
+      %zero = s32[] constant(0)
+      %ds = f32[1,4] dynamic-slice(%p0, %p1, %zero), dynamic_slice_sizes={1,4},
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+      ROOT %custom = f32[1,4] custom-call(%ds), custom_call_target="hero"
+    }
+
+    ENTRY main {
+      %input = f32[4,4] parameter(0)
+      %ivar = s32[] parameter(1)
+      ROOT %fusion = f32[1,4] fusion(%input, %ivar), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto params,
+                       DynamicSliceFusion::ResolveParameters(hero));
+  ASSERT_EQ(params.size(), 1);
+  EXPECT_EQ(params[0],
+            (Parameter{0, ShapeUtil::MakeShape(F32, {4, 4}),
+                       ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+                       Offsets{RtOff{1, 0}, CstOff{0, 1}}}));
+}
+
+TEST_F(DynamicSliceFusionTest, ResolveParamWithStaticSlice) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[2,8,8]{2,1,0} parameter(0)
+      %slice = f32[1,8,8]{2,1,0} slice(%p0), slice={[1:2], [0:8], [0:8]}
+      %bitcast = f32[8,8]{1,0} bitcast(%slice)
+      ROOT %custom = f32[8,8]{1,0} custom-call(%bitcast), custom_call_target="hero"
+    }
+
+    ENTRY main {
+      %input = f32[2,8,8]{2,1,0} parameter(0)
+      ROOT %fusion = f32[8,8]{1,0} fusion(%input), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto params,
+                       DynamicSliceFusion::ResolveParameters(hero));
+  ASSERT_EQ(params.size(), 1);
+  // f32[2,8,8] has byte strides [256, 32, 4]. Slice starts at [1,0,0].
+  // byte_offset = 1 * 256 = 256. Static slice has no DS offsets.
+  // slice_shape is the static slice output shape (before bitcast to hero).
+  EXPECT_EQ(
+      params[0],
+      (Parameter{0,
+                 ShapeUtil::MakeShapeWithDenseLayout(F32, {2, 8, 8}, {2, 1, 0}),
+                 ShapeUtil::MakeShapeWithDenseLayout(F32, {1, 8, 8}, {2, 1, 0}),
+                 MakeStaticConfig(256)}));
+}
+
+TEST_F(DynamicSliceFusionTest, ResolveParamDirectParameter) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %p1 = f32[4,4] parameter(1)
+      ROOT %add = f32[4,4] add(%p0, %p1)
+    }
+
+    ENTRY main {
+      %a = f32[4,4] parameter(0)
+      %b = f32[4,4] parameter(1)
+      ROOT %fusion = f32[4,4] fusion(%a, %b), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto params,
+                       DynamicSliceFusion::ResolveParameters(hero));
+  ASSERT_EQ(params.size(), 2);
+  Shape f32_4x4 = ShapeUtil::MakeShape(F32, {4, 4});
+  EXPECT_EQ(params[0], (Parameter{0, f32_4x4, f32_4x4}));
+  EXPECT_EQ(params[1], (Parameter{1, f32_4x4, f32_4x4}));
+}
+
+//===----------------------------------------------------------------------===//
+// DynamicSliceFusion::ResolveResults tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionTest, ResolveResultWithDUSConstantOffsets) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %fill = f32[4] custom-call(), custom_call_target="fill"
+      %bitcast = f32[1,4] bitcast(%fill)
+      %zero = s32[] constant(0)
+      ROOT %dus = f32[4,4] dynamic-update-slice(%p0, %bitcast, %zero, %zero),
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+    }
+
+    ENTRY main {
+      %input = f32[4,4] parameter(0)
+      ROOT %fusion = f32[4,4] fusion(%input), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
+  ASSERT_EQ(results.size(), 1);
+  EXPECT_EQ(results[0],
+            (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+                    ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+                    Offsets{CstOff{0, 0}, CstOff{0, 1}}}));
+}
+
+TEST_F(DynamicSliceFusionTest, ResolveResultWithDUSRuntimeOffsets) {
+  // DUS with one runtime offset (ivar from p1) and one constant.
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %p1 = s32[] parameter(1)
+      %fill = f32[4] custom-call(), custom_call_target="fill"
+      %bitcast = f32[1,4] bitcast(%fill)
+      %zero = s32[] constant(0)
+      ROOT %dus = f32[4,4] dynamic-update-slice(%p0, %bitcast, %p1, %zero),
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+    }
+
+    ENTRY main {
+      %input = f32[4,4] parameter(0)
+      %ivar = s32[] parameter(1)
+      ROOT %fusion = f32[4,4] fusion(%input, %ivar), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
+  ASSERT_EQ(results.size(), 1);
+  EXPECT_EQ(results[0],
+            (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+                    ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+                    Offsets{RtOff{1, 0}, CstOff{0, 1}}}));
+}
+
+TEST_F(DynamicSliceFusionTest, ResolveResultWithBitcastThenDUS) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %fill = f32[1,4] custom-call(), custom_call_target="fill"
+      %bitcast = f32[4] bitcast(%fill)
+      %bitcast2 = f32[1,4] bitcast(%bitcast)
+      %zero = s32[] constant(0)
+      ROOT %dus = f32[4,4] dynamic-update-slice(%p0, %bitcast2, %zero, %zero),
+        backend_config={"dynamic_slice_config":{"loop_index":1,"byte_offset":32,"byte_stride":64}}
+    }
+
+    ENTRY main {
+      %input = f32[4,4] parameter(0)
+      ROOT %fusion = f32[4,4] fusion(%input), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
+  ASSERT_EQ(results.size(), 1);
+  EXPECT_EQ(results[0],
+            (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+                    ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(1, 32, 64),
+                    Offsets{CstOff{0, 0}, CstOff{0, 1}}}));
+}
+
+TEST_F(DynamicSliceFusionTest, ResolveResultNoDUS) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %p1 = f32[4,4] parameter(1)
+      ROOT %add = f32[4,4] add(%p0, %p1)
+    }
+
+    ENTRY main {
+      %a = f32[4,4] parameter(0)
+      %b = f32[4,4] parameter(1)
+      ROOT %fusion = f32[4,4] fusion(%a, %b), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
+  ASSERT_EQ(results.size(), 1);
+  Shape f32_4x4 = ShapeUtil::MakeShape(F32, {4, 4});
+  EXPECT_EQ(results[0], (Result{std::nullopt, 0, f32_4x4, f32_4x4}));
+}
+
+TEST_F(DynamicSliceFusionTest, ResolveResultDUSWithoutConfig) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %fill = f32[4] custom-call(), custom_call_target="fill"
+      %bitcast = f32[1,4] bitcast(%fill)
+      %zero = s32[] constant(0)
+      ROOT %dus = f32[4,4] dynamic-update-slice(%p0, %bitcast, %zero, %zero)
+    }
+
+    ENTRY main {
+      %input = f32[4,4] parameter(0)
+      ROOT %fusion = f32[4,4] fusion(%input), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
+  ASSERT_EQ(results.size(), 1);
+  EXPECT_EQ(results[0], (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+                                ShapeUtil::MakeShape(F32, {1, 4}), std::nullopt,
+                                Offsets{CstOff{0, 0}, CstOff{0, 1}}}));
+}
+
+//===----------------------------------------------------------------------===//
+// Combined: both parameters and results with runtime offsets
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionTest, ParamsAndResultsWithRuntimeOffsets) {
+  // DS and DUS share the same runtime offset (ivar from p2).
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %p1 = f32[4,4] parameter(1)
+      %p2 = s32[] parameter(2)
+      %zero = s32[] constant(0)
+      %ds = f32[1,4] dynamic-slice(%p0, %p2, %zero), dynamic_slice_sizes={1,4},
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+      %custom = f32[1,4] custom-call(%ds), custom_call_target="hero"
+      ROOT %dus = f32[4,4] dynamic-update-slice(%p1, %custom, %p2, %zero),
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+    }
+
+    ENTRY main {
+      %a = f32[4,4] parameter(0)
+      %b = f32[4,4] parameter(1)
+      %ivar = s32[] parameter(2)
+      ROOT %fusion = f32[4,4] fusion(%a, %b, %ivar), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+  EXPECT_EQ(hero->opcode(), HloOpcode::kCustomCall);
+
+  ASSERT_OK_AND_ASSIGN(auto params,
+                       DynamicSliceFusion::ResolveParameters(hero));
+  ASSERT_EQ(params.size(), 1);
+  EXPECT_EQ(params[0],
+            (Parameter{0, ShapeUtil::MakeShape(F32, {4, 4}),
+                       ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+                       Offsets{RtOff{2, 0}, CstOff{0, 1}}}));
+
+  ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
+  ASSERT_EQ(results.size(), 1);
+  EXPECT_EQ(results[0],
+            (Result{1, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+                    ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+                    Offsets{RtOff{2, 0}, CstOff{0, 1}}}));
+}
+
+//===----------------------------------------------------------------------===//
+// Nested tuple results
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionTest, ResolveResultsFlatTupleWithDUS) {
+  // Hero returns (f32[1,4], f32[1,8]) — both elements feed into DUS.
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %p1 = f32[4,8] parameter(1)
+      %p2 = s32[] parameter(2)
+      %zero = s32[] constant(0)
+      %custom = (f32[1,4], f32[1,8]) custom-call(), custom_call_target="hero"
+      %gte0 = f32[1,4] get-tuple-element(%custom), index=0
+      %gte1 = f32[1,8] get-tuple-element(%custom), index=1
+      %dus0 = f32[4,4] dynamic-update-slice(%p0, %gte0, %p2, %zero),
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+      %dus1 = f32[4,8] dynamic-update-slice(%p1, %gte1, %zero, %zero),
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":32}}
+      ROOT %tuple = (f32[4,4], f32[4,8]) tuple(%dus0, %dus1)
+    }
+
+    ENTRY main {
+      %a = f32[4,4] parameter(0)
+      %b = f32[4,8] parameter(1)
+      %ivar = s32[] parameter(2)
+      ROOT %fusion = (f32[4,4], f32[4,8]) fusion(%a, %b, %ivar), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
+  ASSERT_EQ(results.size(), 2);
+  EXPECT_EQ(results[0],
+            (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+                    ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+                    Offsets{RtOff{2, 0}, CstOff{0, 1}}}));
+  EXPECT_EQ(results[1],
+            (Result{1, 1, ShapeUtil::MakeShape(F32, {4, 8}),
+                    ShapeUtil::MakeShape(F32, {1, 8}), MakeConfig(0, 0, 32),
+                    Offsets{CstOff{0, 0}, CstOff{0, 1}}}));
+}
+
+TEST_F(DynamicSliceFusionTest, ResolveResultsNestedTupleWithDUS) {
+  // Hero returns ((f32[4], f32[4]), f32[8]) — 3 leaves, all feed into DUS.
+  // Leaf 0 = {0,0}, Leaf 1 = {0,1}, Leaf 2 = {1}.
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %p1 = f32[4,4] parameter(1)
+      %p2 = f32[4,8] parameter(2)
+      %zero = s32[] constant(0)
+      %custom = ((f32[4], f32[4]), f32[8]) custom-call(), custom_call_target="hero"
+      %gte_outer0 = (f32[4], f32[4]) get-tuple-element(%custom), index=0
+      %gte00 = f32[4] get-tuple-element(%gte_outer0), index=0
+      %gte01 = f32[4] get-tuple-element(%gte_outer0), index=1
+      %gte1 = f32[8] get-tuple-element(%custom), index=1
+      %bitcast00 = f32[1,4] bitcast(%gte00)
+      %bitcast01 = f32[1,4] bitcast(%gte01)
+      %bitcast1 = f32[1,8] bitcast(%gte1)
+      %dus0 = f32[4,4] dynamic-update-slice(%p0, %bitcast00, %zero, %zero),
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+      %dus1 = f32[4,4] dynamic-update-slice(%p1, %bitcast01, %zero, %zero),
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+      %dus2 = f32[4,8] dynamic-update-slice(%p2, %bitcast1, %zero, %zero),
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":32}}
+      ROOT %tuple = (f32[4,4], f32[4,4], f32[4,8]) tuple(%dus0, %dus1, %dus2)
+    }
+
+    ENTRY main {
+      %a = f32[4,4] parameter(0)
+      %b = f32[4,4] parameter(1)
+      %c = f32[4,8] parameter(2)
+      ROOT %fusion = (f32[4,4], f32[4,4], f32[4,8]) fusion(%a, %b, %c), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
+  ASSERT_EQ(results.size(), 3);
+  Offsets const_2d{CstOff{0, 0}, CstOff{0, 1}};
+  EXPECT_EQ(results[0], (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+                                ShapeUtil::MakeShape(F32, {1, 4}),
+                                MakeConfig(0, 0, 16), const_2d}));
+  EXPECT_EQ(results[1], (Result{1, 1, ShapeUtil::MakeShape(F32, {4, 4}),
+                                ShapeUtil::MakeShape(F32, {1, 4}),
+                                MakeConfig(0, 0, 16), const_2d}));
+  EXPECT_EQ(results[2], (Result{2, 2, ShapeUtil::MakeShape(F32, {4, 8}),
+                                ShapeUtil::MakeShape(F32, {1, 8}),
+                                MakeConfig(0, 0, 32), const_2d}));
+}
+
+TEST_F(DynamicSliceFusionTest, ResolveResultsNestedTuplePartialDUS) {
+  // Hero returns ((f32[4], f32[4]), f32[8]) — only leaf 0 and 2 have DUS.
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %p1 = f32[4,8] parameter(1)
+      %zero = s32[] constant(0)
+      %custom = ((f32[4], f32[4]), f32[8]) custom-call(), custom_call_target="hero"
+      %gte_outer0 = (f32[4], f32[4]) get-tuple-element(%custom), index=0
+      %gte00 = f32[4] get-tuple-element(%gte_outer0), index=0
+      %gte1 = f32[8] get-tuple-element(%custom), index=1
+      %bitcast00 = f32[1,4] bitcast(%gte00)
+      %bitcast1 = f32[1,8] bitcast(%gte1)
+      %dus0 = f32[4,4] dynamic-update-slice(%p0, %bitcast00, %zero, %zero),
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+      %dus2 = f32[4,8] dynamic-update-slice(%p1, %bitcast1, %zero, %zero),
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":32}}
+      ROOT %tuple = (f32[4,4], f32[4,8]) tuple(%dus0, %dus2)
+    }
+
+    ENTRY main {
+      %a = f32[4,4] parameter(0)
+      %b = f32[4,8] parameter(1)
+      ROOT %fusion = (f32[4,4], f32[4,8]) fusion(%a, %b), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
+  ASSERT_EQ(results.size(), 3);
+  Offsets const_2d{CstOff{0, 0}, CstOff{0, 1}};
+  EXPECT_EQ(results[0], (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+                                ShapeUtil::MakeShape(F32, {1, 4}),
+                                MakeConfig(0, 0, 16), const_2d}));
+  EXPECT_EQ(results[1], (Result{std::nullopt, 1, ShapeUtil::MakeShape(F32, {4}),
+                                ShapeUtil::MakeShape(F32, {4})}));
+  EXPECT_EQ(results[2], (Result{1, 2, ShapeUtil::MakeShape(F32, {4, 8}),
+                                ShapeUtil::MakeShape(F32, {1, 8}),
+                                MakeConfig(0, 0, 32), const_2d}));
+}
+
+//===----------------------------------------------------------------------===//
+// Stringify tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionTest, StringifyParameterWithConfig) {
+  Parameter p{0, ShapeUtil::MakeShape(F32, {4, 4}),
+              ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+              Offsets{RtOff{1, 0}, CstOff{0, 1}}};
+  std::string s = absl::StrCat(p);
+  EXPECT_EQ(s,
+            "Parameter{param=0 f32[4,4]->f32[1,4], "
+            "config{loop=0, offset=0, stride=16}, "
+            "offsets=[r(d0,p1), c(d1,0)]}");
+}
+
+TEST_F(DynamicSliceFusionTest, StringifyParameterWithoutConfig) {
+  Parameter p{1, ShapeUtil::MakeShape(F32, {8, 8}),
+              ShapeUtil::MakeShape(F32, {8, 8})};
+  std::string s = absl::StrCat(p);
+  EXPECT_EQ(s,
+            "Parameter{param=1 f32[8,8]->f32[8,8], "
+            "config{}, offsets=none}");
+}
+
+TEST_F(DynamicSliceFusionTest, StringifyResultWithConfig) {
+  Result r{0,
+           0,
+           ShapeUtil::MakeShape(F32, {4, 4}),
+           ShapeUtil::MakeShape(F32, {1, 4}),
+           MakeConfig(0, 0, 16),
+           Offsets{CstOff{0, 0}, CstOff{0, 1}}};
+  std::string s = absl::StrCat(r);
+  EXPECT_EQ(s,
+            "Result{param=0, result=0 f32[1,4]->f32[4,4], "
+            "config{loop=0, offset=0, stride=16}, "
+            "offsets=[c(d0,0), c(d1,0)]}");
+}
+
+TEST_F(DynamicSliceFusionTest, StringifyResultWithoutConfig) {
+  Result r{std::nullopt, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+           ShapeUtil::MakeShape(F32, {4, 4})};
+  std::string s = absl::StrCat(r);
+  EXPECT_EQ(s,
+            "Result{param=none, result=0 f32[4,4]->f32[4,4], "
+            "config{}, offsets=none}");
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/service/gpu/backend_configs.proto
+++ b/xla/service/gpu/backend_configs.proto
@@ -231,6 +231,31 @@ message BlockLevelFusionConfig {
   int32 waves_per_eu = 8;
 }
 
+// A backend config for dynamic-slice and dynamic-update-slice instructions
+// whose runtime offset is a simple function of the parent loop iteration.
+// Only set on instructions where offset analysis succeeds; absence of this
+// config means the slice is truly data-dependent.
+message DynamicSliceConfig {
+  // Index into the while loop nest. Value `0` means that the dynamic slice
+  // offset depends on the innermost while loop. Value `1` means that it depends
+  // on the parent while loop. See `while_loop.h` in `xla/backends/gpu/runtime`
+  // that documents how while loops work at run time in XLA:GPU.
+  //
+  // Must be set when byte_stride != 0. When byte_stride == 0 the offset is
+  // loop invariant and fully defined by constant offsets.
+  optional int64 loop_index = 1;
+
+  // Initial byte offset into the sliced buffer. Together with a negative
+  // byte_stride it allows traversing buffer slices backwards.
+  int64 byte_offset = 2;
+
+  // Byte stride into the sliced buffer. At run time the buffer offset is
+  // computed as `byte_offset + loop_iteration[loop_index] * byte_stride`.
+  //
+  // When byte_stride is 0 the DS/DUS is loop-invariant (fully static offset).
+  int64 byte_stride = 3;
+}
+
 message DynamicMemcpyConfig {
   // If true, the offsets depend on the innermost while loop's induction
   // variable. `src_offset_bytes` and `dst_offset_bytes` contain one entry
@@ -405,7 +430,7 @@ enum DeviceType {
 }
 
 // Generic backend config for XLA:GPU
-// Next-Id: 18
+// Next-Id: 19
 message GpuBackendConfig {
   // Specifies which operation queue the current instruction will run on.
   // A backend may have multiple operation queues to run instructions
@@ -439,6 +464,8 @@ message GpuBackendConfig {
     CollectiveMetadataBackendConfig collective_metadata_backend_config = 16;
 
     GroupedGemmBackendConfig grouped_gemm_backend_config = 17;
+
+    DynamicSliceConfig dynamic_slice_config = 18;
   }
 
   // This attribute instructs the latency-hiding scheduler to


### PR DESCRIPTION
- Add `DynamicSliceFusion` analysis library  that extracts hero instructions, resolves parameter/result slices, and returns `DynamicSliceConfig` protos from dynamic-slice fusion computations.
- Key APIs: `FindHero()` locates the hero op inside a fusion body, `ResolveParameters()` maps hero operands back to fusion parameters with slice configs and per-dimension offsets, `ResolveResults()` does the same for DUS outputs.
- Offsets are either `ConstantOffset` (literal sunk into the fusion) or `RuntimeOffset` (fusion parameter holding the induction variable), enabling the thunk emitter to verify annotated offsets at runtime.