### PR TITLE
[ROCm] Fix leading comma in AMDGPU feature string

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/amdgpu_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/amdgpu_backend.cc
@@ -717,7 +717,8 @@ std::pair<std::string, std::string> GetFeatureStrFromGCNArchName(
     // The rest of the tokens are the feature/targetid strings
     auto mapped_token = MapGCNArchNameTokenToFeatureStr(tokens[i], gfx);
     if (!mapped_token.empty()) {
-      mapped_tokens += "," + mapped_token;
+      if (!mapped_tokens.empty()) mapped_tokens += ",";
+      mapped_tokens += mapped_token;
     }
   }
   return std::pair{gfx, mapped_tokens};


### PR DESCRIPTION
## Summary

`GetFeatureStrFromGCNArchName` in `amdgpu_backend.cc` returns a
target-feature string with a stray leading comma for any GCN arch that
has feature suffixes (`gfx908`, `gfx90a`, `gfx942`, `gfx950`). This PR
removes the leading comma, restoring the pre-[#38613](https://github.com/openxla/xla/pull/38613)
behavior.

```text
gfx950:sramecc+:xnack-  was ->  ",+sramecc,-xnack"
gfx950:sramecc+:xnack-  now ->  "+sramecc,-xnack"