### PR TITLE
[XLA:GPU][oneAPI] Skip event wait for completed event in SyclEvent::WaitStreamOnEvent

### DIFF
--- a/xla/stream_executor/sycl/sycl_event.cc
+++ b/xla/stream_executor/sycl/sycl_event.cc
@@ -63,6 +63,18 @@ absl::Status SyclEvent::WaitStreamOnEvent(StreamExecutor* executor,
     return absl::InternalError(
         "WaitStreamOnEvent: Stream handle is not initialized.");
   }
+  try {
+    auto event_status =
+        event.get_info<::sycl::info::event::command_execution_status>();
+    if (event_status == ::sycl::info::event_command_status::complete) {
+      VLOG(2) << "Event is already complete; no need to wait.";
+      return absl::OkStatus();
+    }
+  } catch (const ::sycl::exception& e) {
+    return absl::InternalError(
+        "WaitStreamOnEvent: Failed to check event status before waiting: " +
+        std::string(e.what()));
+  }
   std::vector<::sycl::event> event_list{event};
   stream_handle->submit([&](::sycl::handler& cgh) {
     cgh.depends_on(event_list);

--- a/xla/stream_executor/sycl/sycl_event.h
+++ b/xla/stream_executor/sycl/sycl_event.h
@@ -29,7 +29,11 @@ class SyclEvent : public Event {
  public:
   Event::Status PollForStatus() override;
 
-  // Waits for the event to complete on the specified stream.
+  // Submits a dependency on event to stream_handle so subsequent work
+  // on that stream waits for event to complete. If event is already
+  // complete at call time, returns immediately without submitting any work
+  // to stream_handle.
+  // TODO(intel-tf): Remove unused executor parameter.
   static absl::Status WaitStreamOnEvent(StreamExecutor* executor,
                                         ::sycl::queue* stream_handle,
                                         const ::sycl::event& event);


### PR DESCRIPTION
This PR updates `SyclEvent::WaitStreamOnEvent` to skip the `depends_on()` submission if the event is already complete. Calling `depends_on()` on an already completed event triggers a bug in the Level Zero adapter's `urEventWait` which can cause a segmentation fault when running some XLA tests. Skipping the wait is correct since a completed event already satisfies the ordering guarantee.