### PR TITLE
xla/profiler: Support CUPTI 13.2 multi-subscriber tracing

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -731,7 +731,6 @@ cc_library(
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings:string_view",
-        "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:stringpiece",
     ],
     alwayslink = 1,
@@ -811,7 +810,6 @@ xla_cc_test(
         ":cupti_utils",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@tsl//tsl/platform:test",
     ],
 )
 

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -46,6 +46,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cupti_headers",
         "@tsl//tsl/profiler/lib:profiler_factory",
         "@tsl//tsl/profiler/lib:profiler_interface",
         "@tsl//tsl/profiler/protobuf:profiler_options_proto_cc",
@@ -93,6 +94,7 @@ cc_library(
     deps = [
         "//xla/tsl/cuda:cupti",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cupti_headers",
         "@tsl//tsl/platform:macros",
         "@tsl//tsl/platform:types",
     ],
@@ -158,7 +160,9 @@ cc_library(
     deps = [
         ":cupti_interface",
         "//xla/tsl/platform:test",
+        "@com_google_googletest//:gtest_for_library",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cupti_headers",
         "@tsl//tsl/platform:test",
     ],
 )
@@ -178,6 +182,7 @@ cc_library(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/synchronization",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cupti_headers",
         "@tsl//tsl/platform:logging",
         "@tsl//tsl/platform:thread_annotations",
     ],
@@ -202,7 +207,9 @@ xla_test(
         ":cupti_wrapper",
         ":mock_cupti",
         "//xla/tsl/profiler/utils:time_utils",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
+        "@local_config_cuda//cuda:cupti_headers",
     ],
 )
 
@@ -243,6 +250,7 @@ cc_library(
         ":cupti_interface",
         "//xla/tsl/cuda:cupti",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cupti_headers",
     ],
 )
 
@@ -308,6 +316,7 @@ cc_library(
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cupti_headers",
         "@tsl//tsl/platform:env",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:logging",
@@ -333,15 +342,13 @@ cc_library(
     deps = [
         ":cupti_collector",
         ":cupti_interface",
+        ":cupti_pm_sampler_impl",
+        ":cupti_pm_sampler_stub",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/time",
         "@local_config_cuda//cuda:cupti_headers",
-    ] + if_cuda_newer_than(
-        "12_6",
-        [":cupti_pm_sampler_impl"],
-        [":cupti_pm_sampler_stub"],
-    ),
+    ],
 )
 
 cc_library(
@@ -379,17 +386,17 @@ cc_library(
 
 cc_library(
     name = "cupti_pm_sampler_impl",
-    srcs = ["cupti_pm_sampler_impl.cc"],
-    hdrs = [
+    srcs = if_cuda_newer_than("12_6", ["cupti_pm_sampler_impl.cc"]),
+    hdrs = if_cuda_newer_than("12_6", [
         "cupti_pm_sampler.h",
         "cupti_pm_sampler_impl.h",
-    ],
+    ]),
     tags = [
         "cuda-only",
         "gpu",
         "manual",  # This target requires CUDA 12.6+, therefore we only built it if it was requested via a dependency.
     ],
-    deps = [
+    deps = if_cuda_newer_than("12_6", [
         ":cupti_collector",
         ":cupti_interface",
         ":cupti_status",
@@ -408,7 +415,7 @@ cc_library(
         "@com_google_absl//absl/time",
         "@local_config_cuda//cuda:cupti_headers",
         "@tsl//tsl/platform:errors",
-    ],
+    ]),
 )
 
 cc_library(

--- a/xla/backends/profiler/gpu/cupti_buffer_events_test.cc
+++ b/xla/backends/profiler/gpu/cupti_buffer_events_test.cc
@@ -16,7 +16,6 @@ limitations under the License.
 #include "xla/backends/profiler/gpu/cupti_buffer_events.h"
 
 #include <gtest/gtest.h>
-#include "tsl/platform/test.h"
 
 namespace xla {
 namespace profiler {

--- a/xla/backends/profiler/gpu/cupti_error_manager.cc
+++ b/xla/backends/profiler/gpu/cupti_error_manager.cc
@@ -25,9 +25,12 @@ limitations under the License.
 #include "absl/debugging/leak_check.h"
 #include "absl/log/log.h"
 #include "absl/synchronization/mutex.h"
-#include "third_party/gpus/cuda/extras/CUPTI/include/cupti.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_profiler_target.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_target.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/backends/profiler/gpu/cupti_interface.h"
 
 namespace xla {
@@ -137,6 +140,69 @@ CUptiResult CuptiErrorManager::ActivityRegisterCallbacks(
   return error;
 }
 
+CUptiResult CuptiErrorManager::ActivityRegisterCallbacksV2(
+    CUpti_SubscriberHandle subscriber,
+    CuptiBuffersCallbackRequestFuncV2 func_buffer_requested,
+    CuptiBuffersCallbackCompleteFuncV2 func_buffer_completed) {
+  IGNORE_CALL_IF_DISABLED;
+  absl::LeakCheckDisabler disabler;
+  CUptiResult error = interface_->ActivityRegisterCallbacksV2(
+      subscriber, func_buffer_requested, func_buffer_completed);
+  LOG_AND_DISABLE_IF_ERROR(error);
+  return error;
+}
+
+CUptiResult CuptiErrorManager::ActivityEnableV2(
+    CUpti_SubscriberHandle subscriber, CUpti_ActivityKind kind, void* cfg) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult error = interface_->ActivityEnableV2(subscriber, kind, cfg);
+  if (error == CUPTI_SUCCESS) {
+    auto f = std::bind(&CuptiErrorManager::ActivityDisableV2, this, subscriber,
+                       kind, nullptr);
+    RegisterUndoFunction(f);
+  } else {
+    LOG(ERROR) << "ActivityEnableV2() error on activity kind: " << kind;
+  }
+  LOG_AND_DISABLE_IF_ERROR(error);
+  return error;
+}
+
+CUptiResult CuptiErrorManager::ActivityDisableV2(
+    CUpti_SubscriberHandle subscriber, CUpti_ActivityKind kind, void* cfg) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult error = interface_->ActivityDisableV2(subscriber, kind, cfg);
+  if (error != CUPTI_SUCCESS) {
+    LOG(ERROR) << "ActivityDisableV2() error on activity kind: " << kind;
+  }
+  LOG_AND_DISABLE_IF_ERROR(error);
+  return error;
+}
+
+CUptiResult CuptiErrorManager::ActivitySetAttributeV2(
+    CUpti_SubscriberHandle subscriber, CUpti_ActivityAttribute attr,
+    size_t* valueSize, void* value) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult error =
+      interface_->ActivitySetAttributeV2(subscriber, attr, valueSize, value);
+  LOG_AND_DISABLE_IF_ERROR(error);
+  return error;
+}
+
+CUptiResult CuptiErrorManager::ActivityUseSystemThreadIdV2(
+    CUpti_SubscriberHandle subscriber) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult error = interface_->ActivityUseSystemThreadIdV2(subscriber);
+  LOG_AND_DISABLE_IF_ERROR(error);
+  return error;
+}
+
+CUptiResult CuptiErrorManager::ActivityUsePerThreadBufferV2() {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult error = interface_->ActivityUsePerThreadBufferV2();
+  LOG_AND_DISABLE_IF_ERROR(error);
+  return error;
+}
+
 CUptiResult CuptiErrorManager::ActivityUsePerThreadBuffer() {
   IGNORE_CALL_IF_DISABLED;
   CUptiResult error = interface_->ActivityUsePerThreadBuffer();
@@ -224,6 +290,22 @@ CUptiResult CuptiErrorManager::Subscribe(CUpti_SubscriberHandle* subscriber,
     auto f = std::bind(&CuptiErrorManager::Unsubscribe, this, *subscriber);
     RegisterUndoFunction(f);
   }
+  LOG_AND_DISABLE_IF_ERROR(error);
+  return error;
+}
+
+CUptiResult CuptiErrorManager::SubscribeV2(CUpti_SubscriberHandle* subscriber,
+                                           CUpti_CallbackFunc callback,
+                                           void* userdata) {
+  IGNORE_CALL_IF_DISABLED;
+  absl::LeakCheckDisabler disabler;
+  CUptiResult error = interface_->SubscribeV2(subscriber, callback, userdata);
+  if (error == CUPTI_SUCCESS) {
+    auto f = std::bind(&CuptiErrorManager::Unsubscribe, this, *subscriber);
+    RegisterUndoFunction(f);
+  }
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_SUPPORTED);
+  ALLOW_ERROR(error, CUPTI_ERROR_UNKNOWN);
   LOG_AND_DISABLE_IF_ERROR(error);
   return error;
 }
@@ -701,9 +783,9 @@ void CuptiErrorManager::CleanUp() {
   undo_disabled_ = false;
 }
 
-std::string CuptiErrorManager::ResultString(CUptiResult error) const {
+std::string CuptiErrorManager::ResultString(CUptiResult result) const {
   const char* error_message = nullptr;
-  if (interface_->GetResultString(error, &error_message) == CUPTI_SUCCESS &&
+  if (interface_->GetResultString(result, &error_message) == CUPTI_SUCCESS &&
       error_message != nullptr) {
     return error_message;
   }

--- a/xla/backends/profiler/gpu/cupti_error_manager.h
+++ b/xla/backends/profiler/gpu/cupti_error_manager.h
@@ -16,19 +16,21 @@ limitations under the License.
 #ifndef XLA_BACKENDS_PROFILER_GPU_CUPTI_ERROR_MANAGER_H_
 #define XLA_BACKENDS_PROFILER_GPU_CUPTI_ERROR_MANAGER_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
 #include <atomic>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "absl/synchronization/mutex.h"
-#include "third_party/gpus/cuda/extras/CUPTI/include/cupti.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_profiler_target.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_target.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/backends/profiler/gpu/cupti_interface.h"
 #include "tsl/platform/thread_annotations.h"
 
@@ -73,6 +75,27 @@ class CuptiErrorManager : public xla::profiler::CuptiInterface {
       CUpti_BuffersCallbackRequestFunc func_buffer_requested,
       CUpti_BuffersCallbackCompleteFunc func_buffer_completed) override;
 
+  // V2 multi-subscriber variants (CUPTI >= 13.2).
+  CUptiResult ActivityRegisterCallbacksV2(
+      CUpti_SubscriberHandle subscriber,
+      CuptiBuffersCallbackRequestFuncV2 func_buffer_requested,
+      CuptiBuffersCallbackCompleteFuncV2 func_buffer_completed) override;
+
+  CUptiResult ActivityEnableV2(CUpti_SubscriberHandle subscriber,
+                               CUpti_ActivityKind kind, void* cfg) override;
+
+  CUptiResult ActivityDisableV2(CUpti_SubscriberHandle subscriber,
+                                CUpti_ActivityKind kind, void* cfg) override;
+
+  CUptiResult ActivitySetAttributeV2(CUpti_SubscriberHandle subscriber,
+                                     CUpti_ActivityAttribute attr,
+                                     size_t* valueSize, void* value) override;
+
+  CUptiResult ActivityUseSystemThreadIdV2(
+      CUpti_SubscriberHandle subscriber) override;
+
+  CUptiResult ActivityUsePerThreadBufferV2() override;
+
   CUptiResult ActivityUsePerThreadBuffer() override;
 
   CUptiResult SetActivityFlushPeriod(uint32_t period_ms) override;
@@ -103,6 +126,9 @@ class CuptiErrorManager : public xla::profiler::CuptiInterface {
   // Unsubscribe to the undo log.
   CUptiResult Subscribe(CUpti_SubscriberHandle* subscriber,
                         CUpti_CallbackFunc callback, void* userdata) override;
+
+  CUptiResult SubscribeV2(CUpti_SubscriberHandle* subscriber,
+                          CUpti_CallbackFunc callback, void* userdata) override;
 
   // Unsubscribes callbacks.
   CUptiResult Unsubscribe(CUpti_SubscriberHandle subscriber) override;

--- a/xla/backends/profiler/gpu/cupti_error_manager_test.cc
+++ b/xla/backends/profiler/gpu/cupti_error_manager_test.cc
@@ -21,6 +21,10 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_driver_cbid.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
 #include "xla/backends/profiler/gpu/cuda_test.h"
 #include "xla/backends/profiler/gpu/cupti_collector.h"
 #include "xla/backends/profiler/gpu/cupti_interface.h"
@@ -114,27 +118,28 @@ TEST_F(CuptiErrorManagerTest, GpuTraceActivityEnableTest) {
   // Enforces the order of execution below.
   Sequence s1;
   // CuptiBase::EnableProfiling()
-  EXPECT_CALL(*mock_, Subscribe(_, _, _))
+  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::Subscribe));
+      .WillOnce([](CUpti_SubscriberHandle* subscriber,
+                   CUpti_CallbackFunc /*callback*/, void* /*userdata*/) {
+        *subscriber = reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+        return CUPTI_SUCCESS;
+      });
   const int cb_enable_times = IsCudaNewEnoughForGraphTraceTest() ? 6 : 1;
   EXPECT_CALL(*mock_, EnableCallback(1, _, _, _))
       .Times(cb_enable_times)
       .InSequence(s1)
-      .WillRepeatedly(
-          Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableCallback));
-  EXPECT_CALL(*mock_, SetThreadIdType(_))
+      .WillRepeatedly(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(_))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::SetThreadIdType));
-  EXPECT_CALL(*mock_, ActivityUsePerThreadBuffer())
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(),
-                       &CuptiWrapper::ActivityUsePerThreadBuffer));
-  EXPECT_CALL(*mock_, ActivityRegisterCallbacks(_, _))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityRegisterCallbacksV2(_, _, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(),
-                       &CuptiWrapper::ActivityRegisterCallbacks));
-  EXPECT_CALL(*mock_, ActivityEnable(CUPTI_ACTIVITY_KIND_KERNEL))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityEnableV2(_, CUPTI_ACTIVITY_KIND_KERNEL, _))
       .InSequence(s1)
       .WillOnce(Return(CUPTI_ERROR_UNKNOWN));  // injected error
   // CuptiErrorManager::ResultString()
@@ -145,11 +150,10 @@ TEST_F(CuptiErrorManagerTest, GpuTraceActivityEnableTest) {
   EXPECT_CALL(*mock_, EnableCallback(0, _, _, _))
       .Times(cb_enable_times)
       .InSequence(s1)
-      .WillRepeatedly(
-          Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableCallback));
+      .WillRepeatedly(Return(CUPTI_SUCCESS));
   EXPECT_CALL(*mock_, Unsubscribe(_))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::Unsubscribe));
+      .WillOnce(Return(CUPTI_SUCCESS));
 
   EXPECT_FALSE(CuptiDisabled());
   CuptiTracerOptions options;
@@ -170,35 +174,36 @@ TEST_F(CuptiErrorManagerTest, GpuTraceAutoEnableTest) {
   EXPECT_FALSE(CuptiDisabled());
   // Enforces the order of execution below.
   Sequence s1;
-  EXPECT_CALL(*mock_, Subscribe(_, _, _))
+  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::Subscribe));
+      .WillOnce([](CUpti_SubscriberHandle* subscriber,
+                   CUpti_CallbackFunc /*callback*/, void* /*userdata*/) {
+        *subscriber = reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+        return CUPTI_SUCCESS;
+      });
   const int cb_enable_times = IsCudaNewEnoughForGraphTraceTest() ? 5 : 0;
   if (cb_enable_times > 0) {
     EXPECT_CALL(*mock_, EnableCallback(1, _, _, _))
         .Times(cb_enable_times)
         .InSequence(s1)
-        .WillRepeatedly(
-            Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableCallback));
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
   }
   EXPECT_CALL(*mock_, EnableDomain(1, _, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableDomain));
-  EXPECT_CALL(*mock_, SetThreadIdType(_))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(_))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::SetThreadIdType));
-  EXPECT_CALL(*mock_, ActivityUsePerThreadBuffer())
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(),
-                       &CuptiWrapper::ActivityUsePerThreadBuffer));
-  EXPECT_CALL(*mock_, ActivityRegisterCallbacks(_, _))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityRegisterCallbacksV2(_, _, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(),
-                       &CuptiWrapper::ActivityRegisterCallbacks));
-  EXPECT_CALL(*mock_, ActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityEnableV2(_, CUPTI_ACTIVITY_KIND_MEMCPY, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::ActivityEnable));
-  EXPECT_CALL(*mock_, ActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY2))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityEnableV2(_, CUPTI_ACTIVITY_KIND_MEMCPY2, _))
       .InSequence(s1)
       .WillOnce(Return(CUPTI_ERROR_UNKNOWN));  // injected error
   // CuptiErrorManager::ResultString()
@@ -206,22 +211,21 @@ TEST_F(CuptiErrorManagerTest, GpuTraceAutoEnableTest) {
       .InSequence(s1)
       .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::GetResultString));
   // CuptiErrorManager::UndoAndDisable()
-  EXPECT_CALL(*mock_, ActivityDisable(CUPTI_ACTIVITY_KIND_MEMCPY))
+  EXPECT_CALL(*mock_, ActivityDisableV2(_, CUPTI_ACTIVITY_KIND_MEMCPY, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::ActivityDisable));
+      .WillOnce(Return(CUPTI_SUCCESS));
   EXPECT_CALL(*mock_, EnableDomain(0, _, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableDomain));
+      .WillOnce(Return(CUPTI_SUCCESS));
   if (cb_enable_times > 0) {
     EXPECT_CALL(*mock_, EnableCallback(0, _, _, _))
         .Times(cb_enable_times)
         .InSequence(s1)
-        .WillRepeatedly(
-            Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableCallback));
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
   }
   EXPECT_CALL(*mock_, Unsubscribe(_))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::Unsubscribe));
+      .WillOnce(Return(CUPTI_SUCCESS));
 
   EXPECT_FALSE(CuptiDisabled());
   CuptiTracerOptions options;

--- a/xla/backends/profiler/gpu/cupti_interface.h
+++ b/xla/backends/profiler/gpu/cupti_interface.h
@@ -19,8 +19,10 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 
-#include "third_party/gpus/cuda/extras/CUPTI/include/cupti.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_profiler_target.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_target.h"
 #include "third_party/gpus/cuda/include/cuda.h"
 
@@ -58,6 +60,15 @@ struct CUpti_PmSampling_CounterData_GetSampleInfo_Params;
 namespace xla {
 namespace profiler {
 
+// CUPTI 13.2 V2 callback metadata parameters are intentionally erased to void*
+// so this common interface can compile with older CUPTI headers.
+using CuptiBuffersCallbackRequestFuncV2 =
+    void(CUPTIAPI*)(uint8_t** buffer, size_t* size, size_t* max_num_records,
+                    void* buffer_request_info);
+using CuptiBuffersCallbackCompleteFuncV2 =
+    void(CUPTIAPI*)(uint8_t* buffer, size_t size, size_t valid_size,
+                    void* buffer_complete_info);
+
 // Provides a wrapper interface to every single CUPTI API function. This class
 // is needed to create an easy mock object for CUPTI API calls. All member
 // functions are defined in the following order: activity related APIs, callback
@@ -65,9 +76,9 @@ namespace profiler {
 // the order in the original CUPTI documentation.
 class CuptiInterface {
  public:
-  CuptiInterface() {}
+  CuptiInterface() = default;
 
-  virtual ~CuptiInterface() {}
+  virtual ~CuptiInterface() = default;
 
   // CUPTI activity API
   virtual CUptiResult ActivityDisable(CUpti_ActivityKind kind) = 0;
@@ -90,6 +101,30 @@ class CuptiInterface {
   virtual CUptiResult ActivityRegisterCallbacks(
       CUpti_BuffersCallbackRequestFunc func_buffer_requested,
       CUpti_BuffersCallbackCompleteFunc func_buffer_completed) = 0;
+
+  // CUDA 13.2 CUPTI V2 multi-subscriber variants.
+  // These must be used alongside cuptiSubscribe_v2; mixing V1 and V2 activity
+  // APIs is unsupported and causes undefined behavior.
+  virtual CUptiResult ActivityRegisterCallbacksV2(
+      CUpti_SubscriberHandle subscriber,
+      CuptiBuffersCallbackRequestFuncV2 func_buffer_requested,
+      CuptiBuffersCallbackCompleteFuncV2 func_buffer_completed) = 0;
+
+  virtual CUptiResult ActivityEnableV2(CUpti_SubscriberHandle subscriber,
+                                       CUpti_ActivityKind kind, void* cfg) = 0;
+
+  virtual CUptiResult ActivityDisableV2(CUpti_SubscriberHandle subscriber,
+                                        CUpti_ActivityKind kind, void* cfg) = 0;
+
+  virtual CUptiResult ActivitySetAttributeV2(CUpti_SubscriberHandle subscriber,
+                                             CUpti_ActivityAttribute attr,
+                                             size_t* valueSize,
+                                             void* value) = 0;
+
+  virtual CUptiResult ActivityUseSystemThreadIdV2(
+      CUpti_SubscriberHandle subscriber) = 0;
+
+  virtual CUptiResult ActivityUsePerThreadBufferV2() = 0;
 
   virtual CUptiResult ActivityUsePerThreadBuffer() = 0;
 
@@ -114,6 +149,10 @@ class CuptiInterface {
   virtual CUptiResult Subscribe(CUpti_SubscriberHandle* subscriber,
                                 CUpti_CallbackFunc callback,
                                 void* userdata) = 0;
+
+  virtual CUptiResult SubscribeV2(CUpti_SubscriberHandle* subscriber,
+                                  CUpti_CallbackFunc callback,
+                                  void* userdata) = 0;
 
   virtual CUptiResult Unsubscribe(CUpti_SubscriberHandle subscriber) = 0;
 

--- a/xla/backends/profiler/gpu/cupti_tracer.cc
+++ b/xla/backends/profiler/gpu/cupti_tracer.cc
@@ -45,11 +45,8 @@ limitations under the License.
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
-// Note: can not include cupti_driver_cbid.h because it is not once guarded in
-// cuda 11. Remove comment here once cuda 11 is no longer supported.
-// #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_driver_cbid.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_driver_cbid.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
-#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_target.h"
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/backends/profiler/gpu/cuda_version_variants.h"
 #include "xla/backends/profiler/gpu/cupti_buffer_events.h"
@@ -316,6 +313,32 @@ void CUPTIAPI ProcessCuptiActivityBuffer(CUcontext context, uint32_t stream_id,
   absl::Status status =
       CuptiTracer::GetCuptiTracerSingleton()->ProcessActivityBuffer(
           context, stream_id, buffer, valid_size);
+  if (!status.ok()) {
+    LOG(ERROR) << status;
+  }
+}
+
+// V2 activity callbacks for cuptiSubscribe_v2 (allowMultipleSubscribers=1).
+
+void CUPTIAPI RequestCuptiActivityBuffer_v2(uint8_t** buffer, size_t* size,
+                                            size_t* maxNumRecords,
+                                            void* /*info*/) {
+  CuptiTracer::GetCuptiTracerSingleton()->RequestActivityBuffer(buffer, size);
+  VLOG(3) << "Requested CUPTI V2 Buffer, buffer=" << std::hex
+          << reinterpret_cast<uintptr_t>(*buffer) << std::dec
+          << " size=" << *size;
+  *maxNumRecords = 0;
+}
+
+void CUPTIAPI ProcessCuptiActivityBuffer_v2(uint8_t* buffer, size_t size,
+                                            size_t valid_size, void* /*info*/) {
+  VLOG(3) << "Processing CUPTI V2 Buffer, buffer:" << std::hex
+          << reinterpret_cast<uintptr_t>(buffer) << std::dec
+          << " size: " << size << " valid_size: " << valid_size;
+  // V2 mode has no per-subscriber context/stream_id; pass nullptr/0.
+  absl::Status status =
+      CuptiTracer::GetCuptiTracerSingleton()->ProcessActivityBuffer(
+          /*context=*/nullptr, /*stream_id=*/0, buffer, valid_size);
   if (!status.ok()) {
     LOG(ERROR) << status;
   }
@@ -1043,8 +1066,12 @@ class CuptiDriverApiHookWithActivityApi : public CuptiDriverApiHook {
 
  private:
   void TrackContext(CUpti_CallbackId cbid, CUcontext ctx) {
-    if (!option_.sync_devices_before_stop) return;
-    if (ctx == nullptr) return;
+    if (!option_.sync_devices_before_stop) {
+      return;
+    }
+    if (ctx == nullptr) {
+      return;
+    }
     absl::MutexLock lock(mutex_);
     if (cbid == CUPTI_DRIVER_TRACE_CBID_cuCtxDestroy_v2 ||
         cbid == CUPTI_DRIVER_TRACE_CBID_cuCtxDestroy) {
@@ -1200,8 +1227,16 @@ void CuptiTracer::Disable() {
     pm_sampling_enabled_ = false;
   }
 
-  DisableApiTracing().IgnoreError();
-  DisableActivityTracing().IgnoreError();
+  // ActivityDisableV2 needs the subscriber handle still valid; disable
+  // activities before API tracing (which calls Unsubscribe) only in the V2
+  // subscriber path.
+  if (using_v2_subscriber_api_) {
+    DisableActivityTracing().IgnoreError();
+    DisableApiTracing().IgnoreError();
+  } else {
+    DisableApiTracing().IgnoreError();
+    DisableActivityTracing().IgnoreError();
+  }
   cupti_interface_->CleanUp();
   Finalize().IgnoreError();
   cupti_driver_api_hook_->SyncAndFlush().IgnoreError();
@@ -1234,6 +1269,7 @@ void CuptiTracer::Disable() {
   collector_ = nullptr;
   option_.reset();
   cupti_driver_api_hook_.reset();
+  using_v2_subscriber_api_ = false;
   tsl::profiler::AnnotationStack::Enable(false);
 }
 
@@ -1371,16 +1407,41 @@ absl::Status CuptiTracer::FlushActivityBuffers() {
 
 // Need to trace graph ids from creation and instantiation.
 absl::Status CuptiTracer::EnableApiTracing() {
-  if (api_tracing_enabled_) return absl::OkStatus();
+  if (api_tracing_enabled_) {
+    return absl::OkStatus();
+  }
 
   PrepareCallbackStart();
+  using_v2_subscriber_api_ = false;
 
   VLOG(1) << "Enable subscriber";
   // Subscribe can return CUPTI_ERROR_MAX_LIMIT_REACHED.
   // The application which calls CUPTI APIs cannot be used with Nvidia tools
   // like nvprof, Nvidia Visual Profiler, Nsight Compute, Nsight Systems.
-  RETURN_IF_CUPTI_ERROR(
-      Subscribe(&subscriber_, (CUpti_CallbackFunc)ApiCallback, this));
+  CUptiResult subscribe_status = CUPTI_ERROR_NOT_SUPPORTED;
+  if (option_->prefer_cupti_v2) {
+    subscribe_status = cupti_interface_->SubscribeV2(
+        &subscriber_, (CUpti_CallbackFunc)ApiCallback, this);
+    if (subscribe_status == CUPTI_SUCCESS) {
+      using_v2_subscriber_api_ = true;
+    }
+  }
+  if (!using_v2_subscriber_api_) {
+    if (subscribe_status == CUPTI_ERROR_NOT_SUPPORTED ||
+        subscribe_status == CUPTI_ERROR_UNKNOWN) {
+      subscribe_status = cupti_interface_->Subscribe(
+          &subscriber_, (CUpti_CallbackFunc)ApiCallback, this);
+    }
+  }
+  if (ABSL_PREDICT_FALSE(subscribe_status != CUPTI_SUCCESS)) {
+    const char* errstr = "";
+    cupti_interface_->GetResultString(subscribe_status, &errstr);
+    LOG(ERROR) << "function Subscribe failed with error " << errstr;
+    if (subscribe_status == CUPTI_ERROR_INSUFFICIENT_PRIVILEGES) {
+      return absl::PermissionDeniedError("CUPTI needs root access");
+    }
+    return absl::InternalError(absl::StrCat("CUPTI call error: ", errstr));
+  }
   api_tracing_enabled_ = true;
 
   absl::Span<const CUpti_CallbackIdResource> res_cbids =
@@ -1408,7 +1469,9 @@ absl::Status CuptiTracer::EnableApiTracing() {
 }
 
 absl::Status CuptiTracer::DisableApiTracing() {
-  if (!api_tracing_enabled_) return absl::OkStatus();
+  if (!api_tracing_enabled_) {
+    return absl::OkStatus();
+  }
 
   api_tracing_enabled_ = false;
 
@@ -1435,24 +1498,45 @@ absl::Status CuptiTracer::DisableApiTracing() {
 }
 
 absl::Status CuptiTracer::EnableActivityTracing() {
-  if (activity_tracing_enabled_) return absl::OkStatus();
+  if (activity_tracing_enabled_) {
+    return absl::OkStatus();
+  }
   PrepareActivityStart();
   if (!option_->activities_selected.empty()) {
-    if (cupti_interface_->SetThreadIdType(
-            CUPTI_ACTIVITY_THREAD_ID_TYPE_SYSTEM) != CUPTI_SUCCESS) {
-      LOG(WARNING)
-          << "Failed to set CUPTI activity thread id type to "
-             "CUPTI_ACTIVITY_THREAD_ID_TYPE_SYSTEM, CUPTI reported thread id "
-             "may be different from system thread id get with gettid()";
-    };
+    if (using_v2_subscriber_api_) {
+      // V2 mode uses subscriber-scoped activity APIs.
+      if (cupti_interface_->ActivityUseSystemThreadIdV2(subscriber_) !=
+          CUPTI_SUCCESS) {
+        LOG(WARNING)
+            << "Failed to set CUPTI activity thread id type to "
+               "CUPTI_ACTIVITY_THREAD_ID_TYPE_SYSTEM, CUPTI reported thread "
+               "id may be different from system thread id get with gettid()";
+      }
+      // This attribute is global, so pass a null subscriber handle.
+      if (cupti_interface_->ActivityUsePerThreadBufferV2() != CUPTI_SUCCESS) {
+        LOG(WARNING)
+            << "Fail to set global per-thread activity buffer "
+               "attribute (expected and harmless if another subscriber "
+               "already set it or tracing is already active); cupti "
+               "trace overhead may be big.";
+      }
+    } else {
+      if (cupti_interface_->SetThreadIdType(
+              CUPTI_ACTIVITY_THREAD_ID_TYPE_SYSTEM) != CUPTI_SUCCESS) {
+        LOG(WARNING)
+            << "Failed to set CUPTI activity thread id type to "
+               "CUPTI_ACTIVITY_THREAD_ID_TYPE_SYSTEM, CUPTI reported thread id "
+               "may be different from system thread id get with gettid()";
+      };
 
-    // Initialize callback functions for Cupti Activity API.
-    VLOG(1) << "Registering CUPTI activity callbacks";
-    if (auto err = cupti_interface_->ActivityUsePerThreadBuffer();
-        err != CUPTI_SUCCESS) {
-      LOG(WARNING) << "Fail to use per-thread activity buffer, cupti trace "
-                      "overhead may be big. CUPTI ERROR CODE:"
-                   << err;
+      // Initialize callback functions for Cupti Activity API.
+      VLOG(1) << "Registering CUPTI activity callbacks";
+      if (auto err = cupti_interface_->ActivityUsePerThreadBuffer();
+          err != CUPTI_SUCCESS) {
+        LOG(WARNING) << "Fail to use per-thread activity buffer, cupti trace "
+                        "overhead may be big. CUPTI ERROR CODE:"
+                     << err;
+      }
     }
     if (option_->enable_activity_hardware_tracing) {
       if (IsCuptiHardwareEventSystemEnabled()) {
@@ -1480,16 +1564,32 @@ absl::Status CuptiTracer::EnableActivityTracing() {
       }
     }
 
-    RETURN_IF_CUPTI_ERROR(ActivityRegisterCallbacks(
-        RequestCuptiActivityBuffer, ProcessCuptiActivityBuffer));
-    VLOG(1) << "Enabling activity tracing for "
-            << option_->activities_selected.size() << " activities";
-    for (auto activity : option_->activities_selected) {
-      VLOG(1) << "Enabling activity tracing for: " << activity;
-      if (activity == CUPTI_ACTIVITY_KIND_UNIFIED_MEMORY_COUNTER) {
-        ConfigureActivityUnifiedMemoryCounter(true);
+    if (using_v2_subscriber_api_) {
+      RETURN_IF_CUPTI_ERROR(ActivityRegisterCallbacksV2(
+          subscriber_, RequestCuptiActivityBuffer_v2,
+          ProcessCuptiActivityBuffer_v2));
+      VLOG(1) << "Enabling activity tracing (V2) for "
+              << option_->activities_selected.size() << " activities";
+      for (auto activity : option_->activities_selected) {
+        VLOG(1) << "Enabling activity tracing (V2) for: " << activity;
+        if (activity == CUPTI_ACTIVITY_KIND_UNIFIED_MEMORY_COUNTER) {
+          // No V2 equivalent exists for this call.
+          ConfigureActivityUnifiedMemoryCounter(true);
+        }
+        RETURN_IF_CUPTI_ERROR(ActivityEnableV2(subscriber_, activity, nullptr));
       }
-      RETURN_IF_CUPTI_ERROR(ActivityEnable(activity));
+    } else {
+      RETURN_IF_CUPTI_ERROR(ActivityRegisterCallbacks(
+          RequestCuptiActivityBuffer, ProcessCuptiActivityBuffer));
+      VLOG(1) << "Enabling activity tracing for "
+              << option_->activities_selected.size() << " activities";
+      for (auto activity : option_->activities_selected) {
+        VLOG(1) << "Enabling activity tracing for: " << activity;
+        if (activity == CUPTI_ACTIVITY_KIND_UNIFIED_MEMORY_COUNTER) {
+          ConfigureActivityUnifiedMemoryCounter(true);
+        }
+        RETURN_IF_CUPTI_ERROR(ActivityEnable(activity));
+      }
     }
   }
   activity_tracing_enabled_ = true;
@@ -1514,7 +1614,12 @@ absl::Status CuptiTracer::DisableActivityTracing() {
                 << " due to deadlock";
         continue;
       }
-      RETURN_IF_CUPTI_ERROR(ActivityDisable(activity));
+      if (using_v2_subscriber_api_) {
+        RETURN_IF_CUPTI_ERROR(
+            ActivityDisableV2(subscriber_, activity, nullptr));
+      } else {
+        RETURN_IF_CUPTI_ERROR(ActivityDisable(activity));
+      }
     }
     option_->activities_selected.clear();
 
@@ -1527,7 +1632,7 @@ absl::Status CuptiTracer::DisableActivityTracing() {
 }
 
 absl::Status CuptiTracer::Finalize() {
-  if (option_->cupti_finalize) {
+  if (option_->cupti_finalize && !using_v2_subscriber_api_) {
     VLOG(1) << "CuptiFinalize";
     RETURN_IF_CUPTI_ERROR(Finalize());
   }
@@ -1602,7 +1707,9 @@ absl::Status CuptiTracer::HandleResourceCallback(
 absl::Status CuptiTracer::HandleDriverApiCallback(
     CUpti_CallbackId cbid, const CUpti_CallbackData* cbdata) {
   constexpr CUpti_CallbackDomain domain = CUPTI_CB_DOMAIN_DRIVER_API;
-  if (internalCuCall) return absl::OkStatus();
+  if (internalCuCall) {
+    return absl::OkStatus();
+  }
 
   if (cbdata->context == nullptr) {
     // API callback is called before any CUDA context is created.
@@ -1631,13 +1738,18 @@ absl::Status CuptiTracer::HandleDriverApiCallback(
 absl::Status CuptiTracer::HandleCallback(CUpti_CallbackDomain domain,
                                          CUpti_CallbackId cbid,
                                          const CUpti_CallbackData* cbdata) {
-  if (!api_tracing_enabled_) return absl::OkStatus();  // already unsubscribed.
-  if (!cupti_driver_api_hook_)
+  if (!api_tracing_enabled_) {
     return absl::OkStatus();  // already unsubscribed.
-  if (domain == CUPTI_CB_DOMAIN_DRIVER_API)
+  }
+  if (!cupti_driver_api_hook_) {
+    return absl::OkStatus();  // already unsubscribed.
+  }
+  if (domain == CUPTI_CB_DOMAIN_DRIVER_API) {
     return HandleDriverApiCallback(cbid, cbdata);
-  if (domain == CUPTI_CB_DOMAIN_RESOURCE)
+  }
+  if (domain == CUPTI_CB_DOMAIN_RESOURCE) {
     return HandleResourceCallback(cbid, cbdata);
+  }
   return absl::OkStatus();
 }
 
@@ -1696,7 +1808,9 @@ void CuptiTracer::RequestActivityBuffer(uint8_t** buffer, size_t* size) {
 
 static size_t CountCuptiActivityEvent(uint8_t* buffer, size_t size) {
   size_t total_event_count = 0;
-  if (size == 0 || buffer == nullptr) return total_event_count;
+  if (size == 0 || buffer == nullptr) {
+    return total_event_count;
+  }
   CuptiInterface* cupti_interface = GetCuptiInterface();
   CUpti_Activity* record = nullptr;
   while (true) {
@@ -1714,7 +1828,9 @@ absl::Status CuptiTracer::ProcessActivityBuffer(CUcontext context,
                                                 uint32_t stream_id,
                                                 uint8_t* buffer, size_t size) {
   absl::Cleanup buffer_cleanup = [&]() {
-    if (buffer) activity_buffers_->ReclaimBuffer(buffer);
+    if (buffer) {
+      activity_buffers_->ReclaimBuffer(buffer);
+    }
   };
   if (size == 0 || buffer == nullptr) {
     return absl::OkStatus();
@@ -1723,13 +1839,19 @@ absl::Status CuptiTracer::ProcessActivityBuffer(CUcontext context,
     LOG(WARNING) << "CUPTI activity buffer is reclaimed after flush.";
     return absl::OkStatus();
   }
-  if (cupti_interface_->Disabled()) return absl::InternalError("Disabled.");
+  if (cupti_interface_->Disabled()) {
+    return absl::InternalError("Disabled.");
+  }
 
-  // Report dropped records.
-  size_t dropped = 0;
-  if (cupti_interface_->ActivityGetNumDroppedRecords(
-          context, stream_id, &dropped) == CUPTI_SUCCESS) {
-    cupti_dropped_activity_event_count_ += dropped;
+  // Report dropped records. Skipped in V2 mode: the tracer uses the CUPTI V2
+  // subscriber APIs for coexistence, but the legacy dropped-record query is
+  // still global and would misattribute another subscriber's drops to XLA.
+  if (!using_v2_subscriber_api_) {
+    size_t dropped = 0;
+    if (cupti_interface_->ActivityGetNumDroppedRecords(
+            context, stream_id, &dropped) == CUPTI_SUCCESS) {
+      cupti_dropped_activity_event_count_ += dropped;
+    }
   }
 
   size_t event_count_in_buffer = CountCuptiActivityEvent(buffer, size);
@@ -1761,10 +1883,12 @@ absl::Status CuptiTracer::ProcessActivityBuffer(CUcontext context,
 /*static*/ std::string CuptiTracer::ErrorIfAny() {
   if (CuptiTracer::NumGpus() == 0) {
     return ErrorWithHostname("No GPU detected.");
-  } else if (CuptiTracer::GetCuptiTracerSingleton()->NeedRootAccess()) {
+  }
+  if (CuptiTracer::GetCuptiTracerSingleton()->NeedRootAccess()) {
     return ErrorWithHostname(
         "Insufficient privilege to run libcupti (you need root permission).");
-  } else if (CuptiTracer::GetTimestamp() == 0) {
+  }
+  if (CuptiTracer::GetTimestamp() == 0) {
     return ErrorWithHostname(
         "Failed to load libcupti (is it installed and accessible?)");
   }

--- a/xla/backends/profiler/gpu/cupti_tracer.h
+++ b/xla/backends/profiler/gpu/cupti_tracer.h
@@ -25,7 +25,10 @@ limitations under the License.
 #include <vector>
 
 #include "absl/status/status.h"
-#include "third_party/gpus/cuda/extras/CUPTI/include/cupti.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_driver_cbid.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 #include "third_party/gpus/cuda/include/nvtx3/nvToolsExt.h"
 #include "xla/backends/profiler/gpu/cupti_buffer_events.h"
 #include "xla/backends/profiler/gpu/cupti_collector.h"
@@ -49,6 +52,8 @@ struct CuptiTracerOptions {
   std::vector<CUpti_ActivityKind> activities_selected;
   // Whether to call cuptiFinalize.
   bool cupti_finalize = false;
+  // Whether to prefer CUPTI V2 multi-subscriber APIs when available.
+  bool prefer_cupti_v2 = true;
   // Whether to call cuCtxSynchronize for each device before Stop().
   bool sync_devices_before_stop = false;
   // Whether to enable NVTX tracking, we need this for TensorRT tracking.
@@ -68,7 +73,7 @@ class CuptiTracer;
 
 class CuptiDriverApiHook {
  public:
-  virtual ~CuptiDriverApiHook() {}
+  virtual ~CuptiDriverApiHook() = default;
 
   virtual absl::Status OnDriverApiEnter(
       int device_id, CUpti_CallbackDomain domain, CUpti_CallbackId cbid,
@@ -124,7 +129,7 @@ class CuptiTracer {
 
   absl::Status HandleCallback(CUpti_CallbackDomain domain,
                               CUpti_CallbackId cbid,
-                              const CUpti_CallbackData* callback_info);
+                              const CUpti_CallbackData* cbdata);
 
   // Returns a buffer and its size for CUPTI to store activities. This buffer
   // will be reclaimed when CUPTI makes a callback to ProcessActivityBuffer.
@@ -211,6 +216,7 @@ class CuptiTracer {
   // subscriber to be active at any time and can be used to trace Cuda runtime
   // as and driver calls for all contexts and devices.
   CUpti_SubscriberHandle subscriber_;  // valid when api_tracing_enabled_.
+  bool using_v2_subscriber_api_ = false;
 
   bool activity_tracing_enabled_ = false;
 

--- a/xla/backends/profiler/gpu/cupti_utils.cc
+++ b/xla/backends/profiler/gpu/cupti_utils.cc
@@ -21,7 +21,6 @@ limitations under the License.
 #include "xla/backends/profiler/gpu/cupti_interface.h"
 #include "xla/backends/profiler/gpu/cupti_wrapper.h"
 #include "xla/tsl/util/env_var.h"
-#include "tsl/platform/logging.h"
 #include "tsl/platform/stringpiece.h"
 
 namespace xla {

--- a/xla/backends/profiler/gpu/cupti_wrapper.cc
+++ b/xla/backends/profiler/gpu/cupti_wrapper.cc
@@ -15,13 +15,19 @@ limitations under the License.
 
 #include "xla/backends/profiler/gpu/cupti_wrapper.h"
 
+#include <cstddef>
 #include <cstdint>
+#include <type_traits>
+#include <utility>
 
-#include "third_party/gpus/cuda/extras/CUPTI/include/cupti.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_profiler_target.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_target.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_version.h"
 #include "third_party/gpus/cuda/include/cuda.h"
+#include "xla/backends/profiler/gpu/cupti_interface.h"
 
 #if CUPTI_API_VERSION >= 24
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_pmsampling.h"
@@ -30,6 +36,89 @@ limitations under the License.
 
 namespace xla {
 namespace profiler {
+
+// CUPTI V2 symbols are optional across CUDA installations. Weak declarations
+// let the wrapper detect missing symbols at runtime and fall back to V1.
+namespace {
+
+#ifdef CUpti_ActivityConfig_STRUCT_SIZE
+using CuptiActivityConfigAbi = CUpti_ActivityConfig;
+using CuptiBuffersCallbackRequestFuncV2Abi =
+    CUpti_BuffersCallbackRequestFunc_v2;
+using CuptiBuffersCallbackCompleteFuncV2Abi =
+    CUpti_BuffersCallbackCompleteFunc_v2;
+#else
+using CuptiActivityConfigAbi = void;
+using CuptiBuffersCallbackRequestFuncV2Abi = CuptiBuffersCallbackRequestFuncV2;
+using CuptiBuffersCallbackCompleteFuncV2Abi =
+    CuptiBuffersCallbackCompleteFuncV2;
+#endif
+
+#ifdef CUpti_SubscriberParams_STRUCT_SIZE
+using CuptiSubscriberParamsAbi = CUpti_SubscriberParams;
+constexpr size_t kCuptiSubscriberParamsStructSize =
+    CUpti_SubscriberParams_STRUCT_SIZE;
+#else
+struct CuptiSubscriberParamsAbi {
+  size_t structSize;
+  const char* subscriberName;
+  char* oldSubscriberName;
+  size_t oldSubscriberSize;
+  uint8_t allowMultipleSubscribers;
+  uint8_t padding[7];
+};
+constexpr size_t kCuptiSubscriberParamsStructSize =
+    sizeof(CuptiSubscriberParamsAbi);
+#endif
+
+// The multi-subscriber path requires
+// CUpti_SubscriberParams::allowMultipleSubscribers. Detect the field so older
+// CUPTI headers fall back to the V1 path.
+template <typename Params, typename = void>
+struct HasAllowMultipleSubscribers : std::false_type {};
+
+template <typename Params>
+struct HasAllowMultipleSubscribers<
+    Params,
+    std::void_t<decltype(std::declval<Params&>().allowMultipleSubscribers)>>
+    : std::true_type {};
+
+template <typename Params>
+bool SetAllowMultipleSubscribersIfSupported(Params* params) {
+  if constexpr (HasAllowMultipleSubscribers<Params>::value) {
+    params->allowMultipleSubscribers = 1;
+    return true;
+  }
+  return false;
+}
+
+// Older CUPTI headers do not define CUPTI_ACTIVITY_ATTR_THREAD_ID_TYPE. Use the
+// CUDA 13.2 enum value so this file can compile with those headers; weak V2
+// symbol checks still decide runtime availability.
+constexpr auto kCuptiActivityAttrThreadIdType =
+    static_cast<CUpti_ActivityAttribute>(21);
+
+}  // namespace
+
+extern "C" {
+[[gnu::weak]] CUptiResult cuptiActivityRegisterCallbacks_v2(
+    CUpti_SubscriberHandle subscriber,
+    CuptiBuffersCallbackRequestFuncV2Abi func_buffer_requested,
+    CuptiBuffersCallbackCompleteFuncV2Abi func_buffer_completed);
+[[gnu::weak]] CUptiResult cuptiActivityEnable_v2(
+    CUpti_SubscriberHandle subscriber, CUpti_ActivityKind kind,
+    CuptiActivityConfigAbi* cfg);
+[[gnu::weak]] CUptiResult cuptiActivityDisable_v2(
+    CUpti_SubscriberHandle subscriber, CUpti_ActivityKind kind,
+    CuptiActivityConfigAbi* cfg);
+[[gnu::weak]] CUptiResult cuptiActivitySetAttribute_v2(
+    CUpti_SubscriberHandle subscriber, CUpti_ActivityAttribute attr,
+    size_t* valueSize, void* value);
+[[gnu::weak]] CUptiResult cuptiSubscribe_v2(CUpti_SubscriberHandle* subscriber,
+                                            CUpti_CallbackFunc callback,
+                                            void* userdata,
+                                            CuptiSubscriberParamsAbi* params);
+}  // extern "C"
 
 CUptiResult CuptiWrapper::ActivityDisable(CUpti_ActivityKind kind) {
   return cuptiActivityDisable(kind);
@@ -65,6 +154,66 @@ CUptiResult CuptiWrapper::ActivityRegisterCallbacks(
     CUpti_BuffersCallbackCompleteFunc func_buffer_completed) {
   return cuptiActivityRegisterCallbacks(func_buffer_requested,
                                         func_buffer_completed);
+}
+
+CUptiResult CuptiWrapper::ActivityRegisterCallbacksV2(
+    CUpti_SubscriberHandle subscriber,
+    CuptiBuffersCallbackRequestFuncV2 func_buffer_requested,
+    CuptiBuffersCallbackCompleteFuncV2 func_buffer_completed) {
+  if (cuptiActivityRegisterCallbacks_v2 == nullptr) {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+  return cuptiActivityRegisterCallbacks_v2(
+      subscriber,
+      reinterpret_cast<CuptiBuffersCallbackRequestFuncV2Abi>(
+          func_buffer_requested),
+      reinterpret_cast<CuptiBuffersCallbackCompleteFuncV2Abi>(
+          func_buffer_completed));
+}
+
+CUptiResult CuptiWrapper::ActivityEnableV2(CUpti_SubscriberHandle subscriber,
+                                           CUpti_ActivityKind kind, void* cfg) {
+  if (cuptiActivityEnable_v2 == nullptr) {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+  return cuptiActivityEnable_v2(subscriber, kind,
+                                reinterpret_cast<CuptiActivityConfigAbi*>(cfg));
+}
+
+CUptiResult CuptiWrapper::ActivityDisableV2(CUpti_SubscriberHandle subscriber,
+                                            CUpti_ActivityKind kind,
+                                            void* cfg) {
+  if (cuptiActivityDisable_v2 == nullptr) {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+  return cuptiActivityDisable_v2(
+      subscriber, kind, reinterpret_cast<CuptiActivityConfigAbi*>(cfg));
+}
+
+CUptiResult CuptiWrapper::ActivitySetAttributeV2(
+    CUpti_SubscriberHandle subscriber, CUpti_ActivityAttribute attr,
+    size_t* valueSize, void* value) {
+  if (cuptiActivitySetAttribute_v2 == nullptr) {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+  return cuptiActivitySetAttribute_v2(subscriber, attr, valueSize, value);
+}
+
+CUptiResult CuptiWrapper::ActivityUseSystemThreadIdV2(
+    CUpti_SubscriberHandle subscriber) {
+  CUpti_ActivityThreadIdType thread_id_type =
+      CUPTI_ACTIVITY_THREAD_ID_TYPE_SYSTEM;
+  size_t size = sizeof(thread_id_type);
+  return ActivitySetAttributeV2(subscriber, kCuptiActivityAttrThreadIdType,
+                                &size, &thread_id_type);
+}
+
+CUptiResult CuptiWrapper::ActivityUsePerThreadBufferV2() {
+  uint8_t use_per_thread = 1;
+  size_t size = sizeof(use_per_thread);
+  return ActivitySetAttributeV2(
+      /*subscriber=*/nullptr, CUPTI_ACTIVITY_ATTR_PER_THREAD_ACTIVITY_BUFFER,
+      &size, &use_per_thread);
 }
 
 CUptiResult CuptiWrapper::ActivityUsePerThreadBuffer() {
@@ -116,6 +265,26 @@ CUptiResult CuptiWrapper::Subscribe(CUpti_SubscriberHandle* subscriber,
                                     CUpti_CallbackFunc callback,
                                     void* userdata) {
   return cuptiSubscribe(subscriber, callback, userdata);
+}
+
+CUptiResult CuptiWrapper::SubscribeV2(CUpti_SubscriberHandle* subscriber,
+                                      CUpti_CallbackFunc callback,
+                                      void* userdata) {
+  if (cuptiSubscribe_v2 == nullptr) {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+  CuptiSubscriberParamsAbi params = {};
+  params.structSize = kCuptiSubscriberParamsStructSize;
+  params.subscriberName = "XlaGpuTracer";
+  if (!SetAllowMultipleSubscribersIfSupported(&params)) {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+  CUptiResult result =
+      cuptiSubscribe_v2(subscriber, callback, userdata, &params);
+  if (result == CUPTI_ERROR_MULTIPLE_SUBSCRIBERS_NOT_SUPPORTED) {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+  return result;
 }
 
 CUptiResult CuptiWrapper::Unsubscribe(CUpti_SubscriberHandle subscriber) {
@@ -277,117 +446,104 @@ CUptiResult CuptiWrapper::ProfilerHostInitialize(
     CUpti_Profiler_Host_Initialize_Params* params) {
   if (cuptiProfilerHostInitialize != nullptr) {
     return cuptiProfilerHostInitialize(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerHostDeinitialize(
     CUpti_Profiler_Host_Deinitialize_Params* params) {
   if (cuptiProfilerHostDeinitialize != nullptr) {
     return cuptiProfilerHostDeinitialize(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerHostGetSupportedChips(
     CUpti_Profiler_Host_GetSupportedChips_Params* params) {
   if (cuptiProfilerHostGetSupportedChips != nullptr) {
     return cuptiProfilerHostGetSupportedChips(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerHostGetBaseMetrics(
     CUpti_Profiler_Host_GetBaseMetrics_Params* params) {
   if (cuptiProfilerHostGetBaseMetrics != nullptr) {
     return cuptiProfilerHostGetBaseMetrics(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerHostGetSubMetrics(
     CUpti_Profiler_Host_GetSubMetrics_Params* params) {
   if (cuptiProfilerHostGetSubMetrics != nullptr) {
     return cuptiProfilerHostGetSubMetrics(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerHostGetMetricProperties(
     CUpti_Profiler_Host_GetMetricProperties_Params* params) {
   if (cuptiProfilerHostGetMetricProperties != nullptr) {
     return cuptiProfilerHostGetMetricProperties(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerHostGetRangeName(
     CUpti_Profiler_Host_GetRangeName_Params* params) {
   if (cuptiProfilerHostGetRangeName != nullptr) {
     return cuptiProfilerHostGetRangeName(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerHostEvaluateToGpuValues(
     CUpti_Profiler_Host_EvaluateToGpuValues_Params* params) {
   if (cuptiProfilerHostEvaluateToGpuValues != nullptr) {
     return cuptiProfilerHostEvaluateToGpuValues(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerHostConfigAddMetrics(
     CUpti_Profiler_Host_ConfigAddMetrics_Params* params) {
   if (cuptiProfilerHostConfigAddMetrics != nullptr) {
     return cuptiProfilerHostConfigAddMetrics(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerHostGetConfigImageSize(
     CUpti_Profiler_Host_GetConfigImageSize_Params* params) {
   if (cuptiProfilerHostGetConfigImageSize != nullptr) {
     return cuptiProfilerHostGetConfigImageSize(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerHostGetConfigImage(
     CUpti_Profiler_Host_GetConfigImage_Params* params) {
   if (cuptiProfilerHostGetConfigImage != nullptr) {
     return cuptiProfilerHostGetConfigImage(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerHostGetNumOfPasses(
     CUpti_Profiler_Host_GetNumOfPasses_Params* params) {
   if (cuptiProfilerHostGetNumOfPasses != nullptr) {
     return cuptiProfilerHostGetNumOfPasses(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerHostGetMaxNumHardwareMetricsPerPass(
     CUpti_Profiler_Host_GetMaxNumHardwareMetricsPerPass_Params* params) {
   if (cuptiProfilerHostGetMaxNumHardwareMetricsPerPass != nullptr) {
     return cuptiProfilerHostGetMaxNumHardwareMetricsPerPass(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 // Profiler Target APIs
@@ -395,278 +551,247 @@ CUptiResult CuptiWrapper::ProfilerInitialize(
     CUpti_Profiler_Initialize_Params* params) {
   if (cuptiProfilerInitialize != nullptr) {
     return cuptiProfilerInitialize(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerDeInitialize(
     CUpti_Profiler_DeInitialize_Params* params) {
   if (cuptiProfilerDeInitialize != nullptr) {
     return cuptiProfilerDeInitialize(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerCounterDataImageCalculateSize(
     CUpti_Profiler_CounterDataImage_CalculateSize_Params* params) {
   if (cuptiProfilerCounterDataImageCalculateSize != nullptr) {
     return cuptiProfilerCounterDataImageCalculateSize(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerCounterDataImageInitialize(
     CUpti_Profiler_CounterDataImage_Initialize_Params* params) {
   if (cuptiProfilerCounterDataImageInitialize != nullptr) {
     return cuptiProfilerCounterDataImageInitialize(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerCounterDataImageCalculateScratchBufferSize(
     CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params* params) {
   if (cuptiProfilerCounterDataImageCalculateScratchBufferSize != nullptr) {
     return cuptiProfilerCounterDataImageCalculateScratchBufferSize(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerCounterDataImageInitializeScratchBuffer(
     CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params* params) {
   if (cuptiProfilerCounterDataImageInitializeScratchBuffer != nullptr) {
     return cuptiProfilerCounterDataImageInitializeScratchBuffer(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerBeginSession(
     CUpti_Profiler_BeginSession_Params* params) {
   if (cuptiProfilerBeginSession != nullptr) {
     return cuptiProfilerBeginSession(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerEndSession(
     CUpti_Profiler_EndSession_Params* params) {
   if (cuptiProfilerEndSession != nullptr) {
     return cuptiProfilerEndSession(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerSetConfig(
     CUpti_Profiler_SetConfig_Params* params) {
   if (cuptiProfilerSetConfig != nullptr) {
     return cuptiProfilerSetConfig(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerUnsetConfig(
     CUpti_Profiler_UnsetConfig_Params* params) {
   if (cuptiProfilerUnsetConfig != nullptr) {
     return cuptiProfilerUnsetConfig(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerBeginPass(
     CUpti_Profiler_BeginPass_Params* params) {
   if (cuptiProfilerBeginPass != nullptr) {
     return cuptiProfilerBeginPass(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerEndPass(
     CUpti_Profiler_EndPass_Params* params) {
   if (cuptiProfilerEndPass != nullptr) {
     return cuptiProfilerEndPass(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerEnableProfiling(
     CUpti_Profiler_EnableProfiling_Params* params) {
   if (cuptiProfilerEnableProfiling != nullptr) {
     return cuptiProfilerEnableProfiling(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerDisableProfiling(
     CUpti_Profiler_DisableProfiling_Params* params) {
   if (cuptiProfilerDisableProfiling != nullptr) {
     return cuptiProfilerDisableProfiling(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerIsPassCollected(
     CUpti_Profiler_IsPassCollected_Params* params) {
   if (cuptiProfilerIsPassCollected != nullptr) {
     return cuptiProfilerIsPassCollected(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerFlushCounterData(
     CUpti_Profiler_FlushCounterData_Params* params) {
   if (cuptiProfilerFlushCounterData != nullptr) {
     return cuptiProfilerFlushCounterData(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerPushRange(
     CUpti_Profiler_PushRange_Params* params) {
   if (cuptiProfilerPushRange != nullptr) {
     return cuptiProfilerPushRange(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerPopRange(
     CUpti_Profiler_PopRange_Params* params) {
   if (cuptiProfilerPopRange != nullptr) {
     return cuptiProfilerPopRange(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerGetCounterAvailability(
     CUpti_Profiler_GetCounterAvailability_Params* params) {
   if (cuptiProfilerGetCounterAvailability != nullptr) {
     return cuptiProfilerGetCounterAvailability(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::ProfilerDeviceSupported(
     CUpti_Profiler_DeviceSupported_Params* params) {
   if (cuptiProfilerDeviceSupported != nullptr) {
     return cuptiProfilerDeviceSupported(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::PmSamplingSetConfig(
     CUpti_PmSampling_SetConfig_Params* params) {
   if (cuptiPmSamplingSetConfig != nullptr) {
     return cuptiPmSamplingSetConfig(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::PmSamplingEnable(
     CUpti_PmSampling_Enable_Params* params) {
   if (cuptiPmSamplingEnable != nullptr) {
     return cuptiPmSamplingEnable(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::PmSamplingDisable(
     CUpti_PmSampling_Disable_Params* params) {
   if (cuptiPmSamplingDisable != nullptr) {
     return cuptiPmSamplingDisable(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::PmSamplingStart(
     CUpti_PmSampling_Start_Params* params) {
   if (cuptiPmSamplingStart != nullptr) {
     return cuptiPmSamplingStart(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::PmSamplingStop(CUpti_PmSampling_Stop_Params* params) {
   if (cuptiPmSamplingStop != nullptr) {
     return cuptiPmSamplingStop(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::PmSamplingDecodeData(
     CUpti_PmSampling_DecodeData_Params* params) {
   if (cuptiPmSamplingDecodeData != nullptr) {
     return cuptiPmSamplingDecodeData(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::PmSamplingGetCounterAvailability(
     CUpti_PmSampling_GetCounterAvailability_Params* params) {
   if (cuptiPmSamplingGetCounterAvailability != nullptr) {
     return cuptiPmSamplingGetCounterAvailability(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::PmSamplingGetCounterDataSize(
     CUpti_PmSampling_GetCounterDataSize_Params* params) {
   if (cuptiPmSamplingGetCounterDataSize != nullptr) {
     return cuptiPmSamplingGetCounterDataSize(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::PmSamplingCounterDataImageInitialize(
     CUpti_PmSampling_CounterDataImage_Initialize_Params* params) {
   if (cuptiPmSamplingCounterDataImageInitialize != nullptr) {
     return cuptiPmSamplingCounterDataImageInitialize(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::PmSamplingGetCounterDataInfo(
     CUpti_PmSampling_GetCounterDataInfo_Params* params) {
   if (cuptiPmSamplingGetCounterDataInfo != nullptr) {
     return cuptiPmSamplingGetCounterDataInfo(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 CUptiResult CuptiWrapper::PmSamplingCounterDataGetSampleInfo(
     CUpti_PmSampling_CounterData_GetSampleInfo_Params* params) {
   if (cuptiPmSamplingCounterDataGetSampleInfo != nullptr) {
     return cuptiPmSamplingCounterDataGetSampleInfo(params);
-  } else {
-    return CUPTI_ERROR_NOT_SUPPORTED;
   }
+  return CUPTI_ERROR_NOT_SUPPORTED;
 }
 
 // Restore disabled warnings (required because CUPTI declares non-weak functions

--- a/xla/backends/profiler/gpu/cupti_wrapper.h
+++ b/xla/backends/profiler/gpu/cupti_wrapper.h
@@ -16,12 +16,14 @@ limitations under the License.
 #ifndef XLA_BACKENDS_PROFILER_GPU_CUPTI_WRAPPER_H_
 #define XLA_BACKENDS_PROFILER_GPU_CUPTI_WRAPPER_H_
 
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_profiler_target.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_target.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 #include <stddef.h>
 #include <stdint.h>
-
-#include "third_party/gpus/cuda/extras/CUPTI/include/cupti.h"
-#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_profiler_target.h"
-#include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/backends/profiler/gpu/cupti_interface.h"
 
 namespace xla {
@@ -29,9 +31,9 @@ namespace profiler {
 
 class CuptiWrapper : public xla::profiler::CuptiInterface {
  public:
-  CuptiWrapper() {}
+  CuptiWrapper() = default;
 
-  ~CuptiWrapper() override {}
+  ~CuptiWrapper() override = default;
 
   // CUPTI activity API
   CUptiResult ActivityDisable(CUpti_ActivityKind kind) override;
@@ -56,6 +58,26 @@ class CuptiWrapper : public xla::profiler::CuptiInterface {
       CUpti_BuffersCallbackRequestFunc func_buffer_requested,
       CUpti_BuffersCallbackCompleteFunc func_buffer_completed) override;
 
+  CUptiResult ActivityRegisterCallbacksV2(
+      CUpti_SubscriberHandle subscriber,
+      CuptiBuffersCallbackRequestFuncV2 func_buffer_requested,
+      CuptiBuffersCallbackCompleteFuncV2 func_buffer_completed) override;
+
+  CUptiResult ActivityEnableV2(CUpti_SubscriberHandle subscriber,
+                               CUpti_ActivityKind kind, void* cfg) override;
+
+  CUptiResult ActivityDisableV2(CUpti_SubscriberHandle subscriber,
+                                CUpti_ActivityKind kind, void* cfg) override;
+
+  CUptiResult ActivitySetAttributeV2(CUpti_SubscriberHandle subscriber,
+                                     CUpti_ActivityAttribute attr,
+                                     size_t* valueSize, void* value) override;
+
+  CUptiResult ActivityUseSystemThreadIdV2(
+      CUpti_SubscriberHandle subscriber) override;
+
+  CUptiResult ActivityUsePerThreadBufferV2() override;
+
   CUptiResult ActivityUsePerThreadBuffer() override;
 
   CUptiResult SetActivityFlushPeriod(uint32_t period_ms) override;
@@ -79,6 +101,9 @@ class CuptiWrapper : public xla::profiler::CuptiInterface {
 
   CUptiResult Subscribe(CUpti_SubscriberHandle* subscriber,
                         CUpti_CallbackFunc callback, void* userdata) override;
+
+  CUptiResult SubscribeV2(CUpti_SubscriberHandle* subscriber,
+                          CUpti_CallbackFunc callback, void* userdata) override;
 
   CUptiResult Unsubscribe(CUpti_SubscriberHandle subscriber) override;
 
@@ -209,9 +234,9 @@ class CuptiWrapper : public xla::profiler::CuptiInterface {
 // collected profiles will be empty.
 class CuptiWrapperStub : public xla::profiler::CuptiInterface {
  public:
-  CuptiWrapperStub() {}
+  CuptiWrapperStub() = default;
 
-  ~CuptiWrapperStub() override {}
+  ~CuptiWrapperStub() override = default;
 
   // CUPTI activity API
   CUptiResult ActivityDisable(CUpti_ActivityKind kind) override;
@@ -236,6 +261,26 @@ class CuptiWrapperStub : public xla::profiler::CuptiInterface {
       CUpti_BuffersCallbackRequestFunc func_buffer_requested,
       CUpti_BuffersCallbackCompleteFunc func_buffer_completed) override;
 
+  CUptiResult ActivityRegisterCallbacksV2(
+      CUpti_SubscriberHandle subscriber,
+      CuptiBuffersCallbackRequestFuncV2 func_buffer_requested,
+      CuptiBuffersCallbackCompleteFuncV2 func_buffer_completed) override;
+
+  CUptiResult ActivityEnableV2(CUpti_SubscriberHandle subscriber,
+                               CUpti_ActivityKind kind, void* cfg) override;
+
+  CUptiResult ActivityDisableV2(CUpti_SubscriberHandle subscriber,
+                                CUpti_ActivityKind kind, void* cfg) override;
+
+  CUptiResult ActivitySetAttributeV2(CUpti_SubscriberHandle subscriber,
+                                     CUpti_ActivityAttribute attr,
+                                     size_t* valueSize, void* value) override;
+
+  CUptiResult ActivityUseSystemThreadIdV2(
+      CUpti_SubscriberHandle subscriber) override;
+
+  CUptiResult ActivityUsePerThreadBufferV2() override;
+
   CUptiResult ActivityUsePerThreadBuffer() override;
 
   CUptiResult SetActivityFlushPeriod(uint32_t period_ms) override;
@@ -259,6 +304,9 @@ class CuptiWrapperStub : public xla::profiler::CuptiInterface {
 
   CUptiResult Subscribe(CUpti_SubscriberHandle* subscriber,
                         CUpti_CallbackFunc callback, void* userdata) override;
+
+  CUptiResult SubscribeV2(CUpti_SubscriberHandle* subscriber,
+                          CUpti_CallbackFunc callback, void* userdata) override;
 
   CUptiResult Unsubscribe(CUpti_SubscriberHandle subscriber) override;
 

--- a/xla/backends/profiler/gpu/cupti_wrapper_stub.cc
+++ b/xla/backends/profiler/gpu/cupti_wrapper_stub.cc
@@ -16,9 +16,12 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 
-#include "third_party/gpus/cuda/extras/CUPTI/include/cupti.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_profiler_target.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_target.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/backends/profiler/gpu/cupti_interface.h"
 #include "xla/backends/profiler/gpu/cupti_wrapper.h"
 
@@ -60,6 +63,40 @@ CUptiResult CuptiWrapperStub::ActivityRegisterCallbacks(
   return CUPTI_SUCCESS;
 }
 
+CUptiResult CuptiWrapperStub::ActivityRegisterCallbacksV2(
+    CUpti_SubscriberHandle /*subscriber*/,
+    CuptiBuffersCallbackRequestFuncV2 /*func_buffer_requested*/,
+    CuptiBuffersCallbackCompleteFuncV2 /*func_buffer_completed*/) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::ActivityEnableV2(
+    CUpti_SubscriberHandle /*subscriber*/, CUpti_ActivityKind /*kind*/,
+    void* /*cfg*/) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::ActivityDisableV2(
+    CUpti_SubscriberHandle /*subscriber*/, CUpti_ActivityKind /*kind*/,
+    void* /*cfg*/) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::ActivitySetAttributeV2(
+    CUpti_SubscriberHandle /*subscriber*/, CUpti_ActivityAttribute /*attr*/,
+    size_t* /*valueSize*/, void* /*value*/) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::ActivityUseSystemThreadIdV2(
+    CUpti_SubscriberHandle /*subscriber*/) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::ActivityUsePerThreadBufferV2() {
+  return CUPTI_SUCCESS;
+}
+
 CUptiResult CuptiWrapperStub::ActivityUsePerThreadBuffer() {
   return CUPTI_SUCCESS;
 }
@@ -95,6 +132,12 @@ CUptiResult CuptiWrapperStub::EnableDomain(uint32_t enable,
 CUptiResult CuptiWrapperStub::Subscribe(CUpti_SubscriberHandle* subscriber,
                                         CUpti_CallbackFunc callback,
                                         void* userdata) {
+  return CUPTI_SUCCESS;
+}
+
+CUptiResult CuptiWrapperStub::SubscribeV2(CUpti_SubscriberHandle* subscriber,
+                                          CUpti_CallbackFunc callback,
+                                          void* userdata) {
   return CUPTI_SUCCESS;
 }
 

--- a/xla/backends/profiler/gpu/device_tracer_cuda.cc
+++ b/xla/backends/profiler/gpu/device_tracer_cuda.cc
@@ -13,8 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include <stdlib.h>
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -24,7 +22,9 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
 #include "third_party/gpus/cuda/include/cuda.h"
+#include <stdlib.h>
 #include "xla/backends/profiler/gpu/cupti_collector.h"
 #include "xla/backends/profiler/gpu/cupti_tracer.h"
 #include "xla/backends/profiler/gpu/cupti_tracer_options_utils.h"
@@ -51,7 +51,7 @@ class GpuTracer : public tsl::profiler::ProfilerInterface {
       : cupti_tracer_(cupti_tracer), profile_options_(profile_options) {
     VLOG(1) << "GpuTracer created.";
   }
-  ~GpuTracer() override {}
+  ~GpuTracer() override = default;
 
   // GpuTracer interface:
   absl::Status Start() override;
@@ -102,7 +102,7 @@ absl::Status GpuTracer::DoStart() {
                      &options_.enable_activity_hardware_tracing)
       .IgnoreError();
 
-// CUDA/CUPTI 10 have issues (leaks and crashes) with CuptiFinalize.
+// CUDA/CUPTI 10 have issues (leaks and crashes) with cuptiFinalize.
 #if CUDA_VERSION >= 11000
   options_.cupti_finalize = true;
 #endif

--- a/xla/backends/profiler/gpu/mock_cupti.h
+++ b/xla/backends/profiler/gpu/mock_cupti.h
@@ -16,16 +16,17 @@ limitations under the License.
 #ifndef XLA_BACKENDS_PROFILER_GPU_MOCK_CUPTI_H_
 #define XLA_BACKENDS_PROFILER_GPU_MOCK_CUPTI_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
+#include <cstddef>
 #include <cstdint>
 
-#include "third_party/gpus/cuda/extras/CUPTI/include/cupti.h"
+#include <gmock/gmock.h>
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_profiler_target.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_target.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/backends/profiler/gpu/cupti_interface.h"
-#include "tsl/platform/test.h"
 
 #if CUPTI_PM_SAMPLING_SUPPORTED  // Defined in cupti_interface.h
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_pmsampling.h"
@@ -58,6 +59,26 @@ class MockCupti : public xla::profiler::CuptiInterface {
               (CUpti_BuffersCallbackRequestFunc func_buffer_requested,
                CUpti_BuffersCallbackCompleteFunc func_buffer_completed),
               (override));
+  MOCK_METHOD(CUptiResult, ActivityRegisterCallbacksV2,
+              (CUpti_SubscriberHandle subscriber,
+               CuptiBuffersCallbackRequestFuncV2 func_buffer_requested,
+               CuptiBuffersCallbackCompleteFuncV2 func_buffer_completed),
+              (override));
+  MOCK_METHOD(CUptiResult, ActivityEnableV2,
+              (CUpti_SubscriberHandle subscriber, CUpti_ActivityKind kind,
+               void* cfg),
+              (override));
+  MOCK_METHOD(CUptiResult, ActivityDisableV2,
+              (CUpti_SubscriberHandle subscriber, CUpti_ActivityKind kind,
+               void* cfg),
+              (override));
+  MOCK_METHOD(CUptiResult, ActivitySetAttributeV2,
+              (CUpti_SubscriberHandle subscriber, CUpti_ActivityAttribute attr,
+               size_t* valueSize, void* value),
+              (override));
+  MOCK_METHOD(CUptiResult, ActivityUseSystemThreadIdV2,
+              (CUpti_SubscriberHandle subscriber), (override));
+  MOCK_METHOD(CUptiResult, ActivityUsePerThreadBufferV2, (), (override));
   MOCK_METHOD(CUptiResult, ActivityUsePerThreadBuffer, (), (override));
   MOCK_METHOD(CUptiResult, SetActivityFlushPeriod, (uint32_t period_ms),
               (override));
@@ -74,6 +95,10 @@ class MockCupti : public xla::profiler::CuptiInterface {
                CUpti_CallbackDomain domain),
               (override));
   MOCK_METHOD(CUptiResult, Subscribe,
+              (CUpti_SubscriberHandle * subscriber, CUpti_CallbackFunc callback,
+               void* userdata),
+              (override));
+  MOCK_METHOD(CUptiResult, SubscribeV2,
               (CUpti_SubscriberHandle * subscriber, CUpti_CallbackFunc callback,
                void* userdata),
               (override));

--- a/xla/backends/profiler/gpu/profile_with_cuda_kernels_test.cc
+++ b/xla/backends/profiler/gpu/profile_with_cuda_kernels_test.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_version.h"
 #include "xla/backends/profiler/gpu/cupti_collector.h"
 #include "xla/backends/profiler/gpu/cupti_error_manager.h"
 #include "xla/backends/profiler/gpu/cupti_pm_sampler.h"

--- a/xla/tsl/cuda/cupti.symbols
+++ b/xla/tsl/cuda/cupti.symbols
@@ -4,6 +4,7 @@ cuptiActivityConfigurePCSampling
 cuptiActivityConfigureUnifiedMemoryCounter
 cuptiActivityDisable
 cuptiActivityDisableContext
+cuptiActivityDisable_v2
 cuptiActivityEnable
 cuptiActivityEnableAndDump
 cuptiActivityEnableBufferSummary
@@ -11,6 +12,7 @@ cuptiActivityEnableContext
 cuptiActivityEnableLatencyTimestamps
 cuptiActivityEnableLaunchAttributes
 cuptiActivityEnableRawTimestamps
+cuptiActivityEnable_v2
 cuptiActivityFlush
 cuptiActivityFlushAll
 cuptiActivityFlushPeriod
@@ -22,8 +24,10 @@ cuptiActivityGetNvtxExtPayloadEntryTypeInfo
 cuptiActivityPopExternalCorrelationId
 cuptiActivityPushExternalCorrelationId
 cuptiActivityRegisterCallbacks
+cuptiActivityRegisterCallbacks_v2
 cuptiActivityRegisterTimestampCallback
 cuptiActivitySetAttribute
+cuptiActivitySetAttribute_v2
 cuptiComputeCapabilitySupported
 cuptiDeviceEnumEventDomains
 cuptiDeviceEnumMetrics
@@ -171,5 +175,6 @@ cuptiSetEventCollectionMode
 cuptiSetThreadIdType
 cuptiStateQuery
 cuptiSubscribe
+cuptiSubscribe_v2
 cuptiSupportedDomains
 cuptiUnsubscribe


### PR DESCRIPTION
📝 Summary of Changes
Add XLA support for CUPTI 13.2 multi-subscriber tracing. The change uses CUPTI V2 subscribe/activity APIs when available, falls back to the existing CUPTI V1 path when needed, and tracks the runtime subscription mode so activity handling and teardown stay consistent.

🎯 Justification
This allows XLA profiling to coexist with other CUPTI subscribers in the same process on CUDA/CUPTI 13.2. It benefits workloads that run XLA profiling alongside another CUPTI-based tool.

🚀 Kind of Contribution
Please remove what does not apply: ✨ New Feature, 🧪 Tests

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
Extended xla/backends/profiler/gpu/cupti_error_manager_test.cc to cover runtime V1/V2 subscription selection and the matching activity setup/error-handling paths.

🧪 Execution Tests:
N/A
