### PR TITLE
[xla:gpu] Resolve multimem from SymmetricMemory

### DIFF
--- a/xla/backends/gpu/collectives/nccl_symmetric_memory.cc
+++ b/xla/backends/gpu/collectives/nccl_symmetric_memory.cc
@@ -22,9 +22,15 @@ limitations under the License.
 #include "absl/memory/memory.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
-#include "third_party/nccl/nccl.h"
 #include "xla/backends/gpu/collectives/nccl_errors.h"
 #include "xla/stream_executor/device_address.h"
+
+// Include NCCL after XLA headers.
+#include "third_party/nccl/nccl.h"
+
+#if NCCL_VERSION_CODE >= 22800
+#include "third_party/nccl/nccl_device.h"
+#endif  // NCCL_VERSION_CODE >= 22800
 
 namespace xla::gpu {
 
@@ -49,6 +55,22 @@ NcclSymmetricMemory::Create(ncclComm_t comm,
 NcclSymmetricMemory::~NcclSymmetricMemory() {
   VLOG(3) << absl::StrFormat("Destroy %v", *this);
   XLA_NCCL_LOG_IF_ERROR(ncclCommWindowDeregister(comm_, win_));
+}
+
+stream_executor::DeviceAddressBase NcclSymmetricMemory::addr() const {
+  return addr_;
+}
+
+absl::StatusOr<stream_executor::DeviceAddressBase>
+NcclSymmetricMemory::multimem_addr() const {
+#if (NCCL_VERSION_CODE >= 22900)
+  void* multimem = nullptr;
+  XLA_NCCL_RETURN_IF_ERROR(ncclGetLsaMultimemDevicePointer(win_, 0, &multimem));
+  if (multimem) {
+    return stream_executor::DeviceAddressBase(multimem, addr_.size());
+  }
+#endif
+  return stream_executor::DeviceAddressBase();
 }
 
 std::string NcclSymmetricMemory::ToString() const {

--- a/xla/backends/gpu/collectives/nccl_symmetric_memory.h
+++ b/xla/backends/gpu/collectives/nccl_symmetric_memory.h
@@ -35,7 +35,10 @@ class NcclSymmetricMemory final : public SymmetricMemory {
   static absl::StatusOr<std::unique_ptr<NcclSymmetricMemory>> Create(
       ncclComm_t comm, stream_executor::DeviceAddressBase addr);
 
-  stream_executor::DeviceAddressBase addr() const override { return addr_; }
+  stream_executor::DeviceAddressBase addr() const final;
+  absl::StatusOr<stream_executor::DeviceAddressBase> multimem_addr()
+      const final;
+
   ncclWindow_t win() const { return win_; }
 
   std::string ToString() const final;

--- a/xla/backends/gpu/tests/collective_ops_ffi_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_ffi_test.cc
@@ -150,8 +150,7 @@ static absl::Status PrepareDeviceAllReduce(
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(
           *collective_params, {AllDevices()},
-          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID,
-          AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE));
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID));
 
   // Ask for a device communicator with 8 lsa barriers.
   CollectiveCliqueRequests::CliqueRequirements requirements;
@@ -188,8 +187,7 @@ static absl::Status PrepareMulticastAllReduce(
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(
           *collective_params, {AllDevices()},
-          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID,
-          AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE));
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID));
 
   std::vector<GlobalDeviceId> all_device_groups;
   for (int i = 0; i < kNumReplicas; ++i) {
@@ -210,6 +208,36 @@ static absl::Status PrepareMulticastAllReduce(
 }
 
 // This is a prepare handler for device-initiated collective operation which
+// uses collective multimem to access peer devices, but does it via symmetric
+// memory handle.
+static absl::Status PrepareSymMulticastAllReduce(
+    ffi::BufferR0<U32> src, ffi::Result<ffi::BufferR0<U32>> dst,
+    const CollectiveParams* collective_params,
+    CollectiveCliqueRequests* clique_requests,
+    CollectiveMemoryRequests* memory_requests) {
+  TF_RET_CHECK(collective_params && memory_requests);
+
+  // Request a clique that covers all devices (this test runs on 2 gpus).
+  TF_ASSIGN_OR_RETURN(
+      GpuCliqueKey clique_key,
+      GetGpuCliqueKey(
+          *collective_params, {AllDevices()},
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID));
+
+  std::vector<GlobalDeviceId> all_device_groups;
+  for (int i = 0; i < kNumReplicas; ++i) {
+    all_device_groups.push_back(GlobalDeviceId(i));
+  }
+  TF_RETURN_IF_ERROR(clique_requests->RequestClique(
+      clique_key, /*device_groups=*/{all_device_groups}));
+
+  // Request src buffer to be symmetric on the given clique.
+  TF_RETURN_IF_ERROR(memory_requests->RequestSymmetricAddress(
+      clique_key, src.device_memory()));
+
+  return absl::OkStatus();
+}
+// This is a prepare handler for device-initiated collective operation which
 // uses collective peer memory to access peer devices.
 static absl::Status PreparePeerAllReduce(
     ffi::BufferR0<U32> src, ffi::Result<ffi::BufferR0<U32>> dst,
@@ -222,8 +250,7 @@ static absl::Status PreparePeerAllReduce(
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(
           *collective_params, {AllDevices()},
-          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID,
-          AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE));
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID));
 
   // Request src buffer from all peers in the given clique.
   TF_RETURN_IF_ERROR(
@@ -248,7 +275,7 @@ static absl::Status AllReduce(se::Stream* stream, se::Stream* comm_stream,
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(
           *collective_params, {AllDevices()},
-          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID, false));
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID));
 
   // Get the communicator for the requested clique.
   TF_ASSIGN_OR_RETURN(Communicator * comm,
@@ -286,7 +313,7 @@ static absl::Status DeviceAllReduce(se::Stream* stream, ffi::BufferR0<U32> src,
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(
           *collective_params, {AllDevices()},
-          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID, false));
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID));
 
   // Find collective memory for src and dst buffers.
   auto [sym_src, src_offset] =
@@ -357,8 +384,7 @@ static absl::Status MulticastAllReduce(
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(
           *collective_params, {AllDevices()},
-          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID,
-          AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE));
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID));
 
   auto [src_mmem, src_offset] =
       collective_memory->FindMultimemAddress(clique_key, src.device_memory());
@@ -421,6 +447,82 @@ static absl::Status BlockedMulticastAllReduce(
   return stream->BlockHostUntilDone();
 }
 
+static absl::Status SymMulticastAllReduce(
+    se::Stream* stream, ffi::BufferR0<U32> src,
+    ffi::Result<ffi::BufferR0<U32>> dst,
+    const CollectiveParams* collective_params,
+    const CollectiveMemory* collective_memory) {
+  TF_RET_CHECK(collective_params && collective_memory);
+
+  TF_ASSIGN_OR_RETURN(
+      GpuCliqueKey clique_key,
+      GetGpuCliqueKey(
+          *collective_params, {AllDevices()},
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID));
+
+  // Find collective memory for src buffer.
+  auto [sym_src, src_offset] =
+      collective_memory->FindSymmetricMemory(clique_key, src.device_memory());
+
+  // Load custom kernel that does device-initiated collectives.
+  TF_ASSIGN_OR_RETURN(
+      auto kernel,
+      se::gpu::GpuKernelRegistry::GetGlobalRegistry()
+          .LoadKernel<MultimemAllReduce>(collective_params->executor));
+
+  // Get multimem address for the src buffer.
+  TF_ASSIGN_OR_RETURN(auto src_multimem, sym_src->multimem_addr());
+  if (!src_multimem) {
+    return absl::InternalError("Multimem address can't be resolved");
+  }
+
+  // Because we launch a trivial kernel we use a device-side rendezvous to make
+  // sure that both devices will execute the kernel together after inputs become
+  // ready on both devices. Any real kernel must use device-side barriers.
+  static constexpr int32_t kKey = 0;
+  const int32_t* key = &kKey;
+  TF_RETURN_IF_ERROR(Rendezvous<const int32_t*>(
+      "MulticastAllReduce", key, 2, absl::Seconds(1), absl::Seconds(5)));
+
+  se::BlockDim block_dims(1);
+  se::ThreadDim thread_dims(8);
+
+  TF_RETURN_IF_ERROR(kernel.Launch(thread_dims, block_dims, stream,
+                                   se::DeviceAddress<uint32_t>(src_multimem),
+                                   dst->device_memory(), src_offset,
+                                   src.element_count()));
+  TF_RETURN_IF_ERROR(stream->BlockHostUntilDone());
+  SynchronizationSignals* signals = global_signals->get();
+  signals->IncrementFinishedKernels();
+  return absl::OkStatus();
+}
+
+// FFI handler that launches device kernel that does all-reduce using multicast
+// memory access through the symmetric memory handle.
+static absl::Status DelayedSymMulticastAllReduce(
+    se::Stream* stream, ffi::BufferR0<U32> src,
+    ffi::Result<ffi::BufferR0<U32>> dst,
+    const CollectiveParams* collective_params,
+    const CollectiveMemory* collective_memory) {
+  TF_RETURN_IF_ERROR(
+      stream->DoHostCallback([]() { absl::SleepFor(absl::Seconds(1)); }));
+  TF_RETURN_IF_ERROR(SymMulticastAllReduce(stream, src, dst, collective_params,
+                                           collective_memory));
+  return absl::OkStatus();
+}
+
+// FFI handler that launches device kernel that does all-reduce using multicast
+// memory access through the symmetric memory handle.
+static absl::Status BlockedSymMulticastAllReduce(
+    se::Stream* stream, ffi::BufferR0<U32> src,
+    ffi::Result<ffi::BufferR0<U32>> dst,
+    const CollectiveParams* collective_params,
+    const CollectiveMemory* collective_memory) {
+  TF_RETURN_IF_ERROR(SymMulticastAllReduce(stream, src, dst, collective_params,
+                                           collective_memory));
+  return stream->BlockHostUntilDone();
+}
+
 // FFI handler that launches device kernel that does all-reduce using peer
 // memory access.
 static absl::Status PeerAllReduce(se::Stream* stream, ffi::BufferR0<U32> src,
@@ -433,8 +535,7 @@ static absl::Status PeerAllReduce(se::Stream* stream, ffi::BufferR0<U32> src,
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(
           *collective_params, {AllDevices()},
-          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID,
-          AsyncStreamKind::ASYNC_STREAM_KIND_COLLECTIVE));
+          CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID));
 
   auto src0 = collective_memory->FindPeerAddress(clique_key, RankId(0),
                                                  src.device_memory());
@@ -555,6 +656,32 @@ XLA_FFI_DEFINE_HANDLER(kDelayedMulticastAllReduce, DelayedMulticastAllReduce,
                            .Ctx<ffi::CollectiveParams>()
                            .Ctx<ffi::CollectiveMemory>());
 
+XLA_FFI_DEFINE_HANDLER(kPrepareSymMulticastAllReduce,
+                       PrepareSymMulticastAllReduce,
+                       ffi::Ffi::BindPrepare()
+                           .Arg<ffi::BufferR0<U32>>()  // src
+                           .Ret<ffi::BufferR0<U32>>()  // dst
+                           .Ctx<ffi::CollectiveParams>()
+                           .Ctx<ffi::CollectiveCliqueRequests>()
+                           .Ctx<ffi::CollectiveMemoryRequests>());
+
+XLA_FFI_DEFINE_HANDLER(kSymMulticastAllReduce, BlockedSymMulticastAllReduce,
+                       ffi::Ffi::Bind()
+                           .Ctx<ffi::Stream>()
+                           .Arg<ffi::BufferR0<U32>>()  // src
+                           .Ret<ffi::BufferR0<U32>>()  // dst
+                           .Ctx<ffi::CollectiveParams>()
+                           .Ctx<ffi::CollectiveMemory>());
+
+XLA_FFI_DEFINE_HANDLER(kDelayedSymMulticastAllReduce,
+                       DelayedSymMulticastAllReduce,
+                       ffi::Ffi::Bind()
+                           .Ctx<ffi::Stream>()
+                           .Arg<ffi::BufferR0<U32>>()  // src
+                           .Ret<ffi::BufferR0<U32>>()  // dst
+                           .Ctx<ffi::CollectiveParams>()
+                           .Ctx<ffi::CollectiveMemory>());
+
 XLA_FFI_DEFINE_HANDLER(kPreparePeerAllReduce, PreparePeerAllReduce,
                        ffi::Ffi::BindPrepare()
                            .Arg<ffi::BufferR0<U32>>()  // src
@@ -607,6 +734,28 @@ XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(),
                              /*prepare=*/kPrepareMulticastAllReduce,
                              /*initialize=*/nullptr,
                              /*execute=*/kDelayedMulticastAllReduce,
+                         });
+
+// Register handler bundle for the custom all-reduce operation with
+// device-initiated collective kernels that use multimem addresses.
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(),
+                         "__xla_test_blocked_sym_multimem_all_reduce", "gpu",
+                         XLA_FFI_Handler_Bundle{
+                             /*instantiate=*/nullptr,
+                             /*prepare=*/kPrepareSymMulticastAllReduce,
+                             /*initialize=*/nullptr,
+                             /*execute=*/kSymMulticastAllReduce,
+                         });
+
+// Register handler bundle for the custom all-reduce operation with
+// device-initiated collective kernels that use multimem addresses.
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(),
+                         "__xla_test_delayed_sym_multimem_all_reduce", "gpu",
+                         XLA_FFI_Handler_Bundle{
+                             /*instantiate=*/nullptr,
+                             /*prepare=*/kPrepareSymMulticastAllReduce,
+                             /*initialize=*/nullptr,
+                             /*execute=*/kDelayedSymMulticastAllReduce,
                          });
 
 // Register handler bundle for the custom all-reduce operation with
@@ -755,7 +904,7 @@ TEST_P(AllReduceTest, PeerAllReduce) {
 
   if (!IsHopperAndHigher()) {
     GTEST_SKIP() << "Test requires Hopper+ since on a previous platforms there "
-                    "are no guarantess that GPUs have direct peer access";
+                    "are no guarantees that GPUs have direct peer access";
   }
 
   std::string hlo_string = absl::Substitute(R"(
@@ -809,6 +958,54 @@ TEST_P(AllReduceTest, MulticastAllReduce) {
         in = u32[]{:S(1)} copy(c0)
         ROOT all-reduce = u32[] custom-call(in),
           custom_call_target="__xla_test_$0_multimem_all_reduce",
+          api_version=API_VERSION_TYPED_FFI
+      }
+    )",
+                                            GetParam());
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(hlo_string, kNumReplicas));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/std::vector<Literal*>(),
+                        /*run_hlo_passes=*/false));
+  SynchronizationSignals* signals = global_signals->get();
+  signals->finished_kernels_counter.Wait();
+
+  absl::Span<const Literal> results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+
+  const uint32_t expected = 2;
+  for (int i = 0; i < kNumReplicas; ++i) {
+    LiteralTestUtil::ExpectR0Equal<uint32_t>(expected, results[i]);
+  }
+}
+
+TEST_P(AllReduceTest, SymMulticastAllReduce) {
+  if (device_count() < kNumReplicas) {
+    GTEST_SKIP() << "Test requires at least " << kNumReplicas << " devices ("
+                 << device_count() << " available)";
+  }
+
+  if (!IsHopperAndHigher()) {
+    GTEST_SKIP() << "Test requires Hopper+";
+  }
+
+  GpuCollectives* collectives = GpuCollectives::Default("CUDA");
+  if (!collectives || !collectives->SupportsOneSidedComm()) {
+    GTEST_SKIP() << "GPU collectives do not support one sided comm";
+  }
+
+  std::string hlo_string = absl::Substitute(R"(
+      HloModule m, replica_count=2
+
+      ENTRY test_computation {
+        c0 = u32[] constant(1)
+        in = u32[]{:S(1)} copy(c0)
+        ROOT all-reduce = u32[] custom-call(in),
+          custom_call_target="__xla_test_$0_sym_multimem_all_reduce",
           api_version=API_VERSION_TYPED_FFI
       }
     )",

--- a/xla/core/collectives/symmetric_memory.h
+++ b/xla/core/collectives/symmetric_memory.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <string>
 
+#include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/kernel_args.h"
@@ -30,7 +31,20 @@ namespace xla {
 class SymmetricMemory {
  public:
   virtual ~SymmetricMemory() = default;
+
+  // Device address on the local device backing the symmetric memory.
   virtual stream_executor::DeviceAddressBase addr() const = 0;
+
+  // For platforms that support multimem (i.e. CUDA) returns a multimem address
+  // for the LSA (load/store accessible) team associated with the given
+  // symmetric memory. Return default-constructed (nullptr) address if multimem
+  // is not supported. Returns an error only if resolving multimem address
+  // ended up in an error.
+  virtual absl::StatusOr<stream_executor::DeviceAddressBase> multimem_addr()
+      const {
+    return stream_executor::DeviceAddressBase();
+  }
+
   virtual std::string ToString() const = 0;
 
   // A packed kernel argument type for passing symmetric memory to device


### PR DESCRIPTION
Use symmetric memory to create multimem instead of using low level APIs directly.