### PR TITLE
[XLA:GPU][oneAPI][BugFix] Fix oneAPI presubmit build

### DIFF
--- a/xla/service/gpu/intel_gpu_compiler.cc
+++ b/xla/service/gpu/intel_gpu_compiler.cc
@@ -36,6 +36,12 @@ absl::Status IntelGpuCompiler::OptimizeHloConvolutionCanonicalization(
   return absl::OkStatus();
 }
 
+void IntelGpuCompiler::AddPaddingForGpublasGemms(
+    HloPassPipeline& pipeline, const DebugOptions& debug_options,
+    const se::GpuComputeCapability& gpu_version) {
+  // Stub for Intel GPUs
+}
+
 absl::Status IntelGpuCompiler::AddConvAndGemmAutotuningPass(
     HloPassPipeline* pipeline, HloModule* hlo_module,
     const se::GpuComputeCapability& gpu_version, const CompileOptions& options,

--- a/xla/service/gpu/intel_gpu_compiler.h
+++ b/xla/service/gpu/intel_gpu_compiler.h
@@ -59,6 +59,10 @@ class IntelGpuCompiler : public GpuCompiler {
   std::vector<std::string> GetLLVMCommandLineOptions(
       const DebugOptions& debug_options) const override;
 
+  void AddPaddingForGpublasGemms(
+      HloPassPipeline& pipeline, const DebugOptions& debug_options,
+      const se::GpuComputeCapability& gpu_version) override;
+
  private:
   IntelGpuCompiler(const IntelGpuCompiler&) = delete;
   IntelGpuCompiler& operator=(const IntelGpuCompiler&) = delete;


### PR DESCRIPTION
A recent upstream commit (5d73295ca8965c735339ef318d038b33e7a289b1) introduced a new virtual method in the compiler base class. This broke the oneAPI GPU compiler build, as no override was provided for the new method. This PR adds the necessary stub implementation to fix the failing check.