### PR TITLE
[tsl:concurrency] Add automatic Future::Map flattening

### DIFF
--- a/xla/tsl/concurrency/future.h
+++ b/xla/tsl/concurrency/future.h
@@ -553,10 +553,21 @@ template <>
 struct IsMappable<void, absl::Status> : public std::true_type {};
 template <typename R, typename U>
 struct IsMappable<R, absl::StatusOr<U>> : public std::is_constructible<R, U> {};
+template <typename R>
+struct IsMappable<R, Future<>> : public IsMappable<R, absl::Status> {};
+template <typename R, typename U>
+struct IsMappable<R, Future<U>> : public IsMappable<R, absl::StatusOr<U>> {};
 
 // A pre C++20 "concept" that checks if `R` and `U` are mappable types.
 template <typename R, typename U>
 using Mappable = std::enable_if_t<IsMappable<R, U>::value>;
+
+// True when the functor returns a Future (U is a Future type) but the Map
+// result type R is the unwrapped inner type (not a Future). In this case
+// SetPromise subscribes to the inner future and forwards its result.
+template <typename R, typename U>
+struct IsFlattened
+    : std::bool_constant<IsFuture<U>::value && !IsFuture<R>::value> {};
 
 // Automatic type inference for the result type of `Future<T>::Map(...)` is
 // based on the result type of `f` functor:
@@ -564,6 +575,7 @@ using Mappable = std::enable_if_t<IsMappable<R, U>::value>;
 // - `void`              to `Future<>`
 // - `absl::Status`      to `Future<>`
 // - `absl::StatusOr<T>` to `Future<T>`
+// - `Future<T>`         to `Future<T>` (flattened)
 // - `R`                 to `Future<R>` (default)
 //
 // clang-format off
@@ -571,6 +583,8 @@ template <typename R> struct MapResult                    { using T = R; };
 template <>           struct MapResult<void>              { using T = void; };
 template <>           struct MapResult<absl::Status>      { using T = void; };
 template <typename R> struct MapResult<absl::StatusOr<R>> { using T = R; };
+template <>           struct MapResult<Future<>>          { using T = void; };
+template <typename R> struct MapResult<Future<R>>         { using T = R; };
 // clang-format on
 
 template <typename R>
@@ -649,6 +663,7 @@ class Future : public internal::FutureBase<absl::StatusOr<T>> {
   // - `Future<>`  from `(const T&) -> void`
   // - `Future<>`  from `(const T&) -> absl::Status`
   // - `Future<R>` from `(const T&) -> absl::StatusOr<U>`
+  // - `Future<R>` from `(const T&) -> Future<R>` (flattened)
   // - `Future<R>` from `(const T&) -> U`
   //
   // See `Map` functor type inference defined below for more details.
@@ -682,6 +697,7 @@ class Future : public internal::FutureBase<absl::StatusOr<T>> {
   // - `Future<>`  from `(T) -> void`
   // - `Future<>`  from `(T) -> absl::Status`
   // - `Future<R>` from `(T) -> absl::StatusOr<U>`
+  // - `Future<R>` from `(T) -> Future<R>` (flattened)
   // - `Future<R>` from `(T) -> U`
   //
   // See `Map` functor type inference defined below for more details.
@@ -704,6 +720,7 @@ class Future : public internal::FutureBase<absl::StatusOr<T>> {
   //
   // - `R` is `absl::Status`      -> Future<>
   // - `R` is `absl::StatusOr<T>` -> Future<T>
+  // - `R` is `Future<T>`         -> Future<T> (flattened)
   // - `R` is any other type      -> Future<R>
   //
   template <int&... ExplicitParameterBarrier, typename F,
@@ -723,6 +740,7 @@ class Future : public internal::FutureBase<absl::StatusOr<T>> {
   //
   // - `R` is `absl::Status`      -> Future<>
   // - `R` is `absl::StatusOr<T>` -> Future<T>
+  // - `R` is `Future<T>`         -> Future<T> (flattened)
   // - `R` is any other type      -> Future<R>
   //
   template <int&... ExplicitParameterBarrier, typename F,
@@ -871,6 +889,7 @@ class Future<void> : public internal::FutureBase<absl::Status> {
   // - `Future<>`  from `() -> void`
   // - `Future<>`  from `() -> absl::Status`
   // - `Future<R>` from `() -> absl::StatusOr<U>`
+  // - `Future<R>` from `() -> Future<R>` (flattened)
   // - `Future<R>` from `() -> U`
   //
   // See `Map` functor type inference defined below for more details.
@@ -889,6 +908,7 @@ class Future<void> : public internal::FutureBase<absl::Status> {
   //
   // - `R` is `absl::Status`      -> Future<>
   // - `R` is `absl::StatusOr<T>` -> Future<T>
+  // - `R` is `Future<T>`         -> Future<T> (flattened)
   // - `R` is any other type      -> Future<R>
   //
   // Functor `f` will be invoked on a thread that sets the promise value,
@@ -1167,8 +1187,8 @@ template <typename R, int&... ExplicitParameterBarrier, typename F, typename U,
     }
   }
 
-  // If `*this` is not ready yet, we need to create a new promise and fulfill
-  // it with a result of `f` when `*this` becomes ready.
+  // If `*this` is not ready yet, create a new promise and fulfill it with a
+  // result of `f` when `*this` becomes ready.
   auto [promise, future] = ::tsl::MakePromise<R>();
   OnReady(SetPromise<R, U>(std::move(promise), std::forward<F>(f)));
   return std::move(future);
@@ -1224,8 +1244,8 @@ template <typename R, int&... ExplicitParameterBarrier, typename F, typename U,
     }
   }
 
-  // If `*this` is not ready yet, we need to create a new promise and fulfill
-  // it with a result of `f` when `*this` becomes ready.
+  // If `*this` is not ready yet, create a new promise and fulfill it with a
+  // result of `f` when `*this` becomes ready.
   auto [promise, future] = ::tsl::MakePromise<R>();
   std::move(*this).OnReady(SetPromise<R, U, /*rvalue=*/true>(
       std::move(promise), std::forward<F>(f)));
@@ -1282,7 +1302,7 @@ Future<internal::future_type_t<typename U::value_type>> Future<T>::Flatten()
 
   // For const& API call we always get nested futures and values by reference.
   using NestedFuture = const absl::StatusOr<Future<R>>&;
-  using Value = const absl::StatusOr<R>&;
+  using Value = const typename Future<R>::value_type&;
 
   OnReady([promise = std::move(promise)](NestedFuture nested_future) mutable {
     // Immediately forward error to flatten future.
@@ -1313,8 +1333,8 @@ Future<T>::Flatten() && {
   using NestedFuture =
       std::conditional_t<is_move_only, absl::StatusOr<Future<R>>,
                          const absl::StatusOr<Future<R>>&>;
-  using Value = std::conditional_t<is_move_only, absl::StatusOr<R>,
-                                   const absl::StatusOr<R>&>;
+  using Value = std::conditional_t<is_move_only, typename Future<R>::value_type,
+                                   const typename Future<R>::value_type&>;
 
   std::move(*this).OnReady(
       [promise = std::move(promise)](NestedFuture nested_future) mutable {
@@ -1359,6 +1379,14 @@ auto Future<T>::SetPromise(Promise<R> promise, F&& f) {
     // Set the result future available with a result of invoking `f`.
     if constexpr (std::is_void_v<U>) {
       promise.Set((f(std::move(*value)), absl::OkStatus()));
+    } else if constexpr (internal::IsFlattened<R, U>::value) {
+      // If the functor returns a Future, subscribe to it and forward the
+      // result to the promise when it becomes ready.
+      f(std::move(*value))
+          .OnReady([promise = std::move(promise)](
+                       typename U::value_type result) mutable {
+            promise.Set(std::move(result));
+          });
     } else {
       promise.Set(f(std::move(*value)));
     }
@@ -1388,8 +1416,8 @@ template <typename R, int&... ExplicitParameterBarrier, typename F, typename U,
     }
   }
 
-  // If `*this` is not ready yet, we need to create a new promise and fulfill
-  // it with a result of `f` when `*this` becomes ready.
+  // If `*this` is not ready yet, create a new promise and fulfill it with a
+  // result of `f` when `*this` becomes ready.
   auto [promise, future] = ::tsl::MakePromise<R>();
   OnReady(SetPromise<R, U>(std::move(promise), std::forward<F>(f)));
   return std::move(future);
@@ -1436,6 +1464,13 @@ auto Future<void>::SetPromise(Promise<R> promise, F&& f) {
     // Set the result future available with a result of invoking `f`.
     if constexpr (std::is_void_v<U>) {
       promise.Set((f(), absl::OkStatus()));
+    } else if constexpr (internal::IsFlattened<R, U>::value) {
+      // If the functor returns a Future, subscribe to it and forward the
+      // result to the promise when it becomes ready.
+      f().OnReady([promise = std::move(promise)](
+                      typename U::value_type result) mutable {
+        promise.Set(std::move(result));
+      });
     } else {
       promise.Set(f());
     }

--- a/xla/tsl/concurrency/future_test.cc
+++ b/xla/tsl/concurrency/future_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -45,6 +46,12 @@ using ::testing::Not;
 static_assert(internal::IsMoveOnly<std::unique_ptr<int32_t>>::value);
 static_assert(
     internal::IsMoveOnly<std::vector<std::unique_ptr<int32_t>>>::value);
+
+// IsMappable for Future types: only void can be produced from Future<void>.
+static_assert(internal::IsMappable<void, Future<>>::value);
+static_assert(!internal::IsMappable<int32_t, Future<>>::value);
+static_assert(internal::IsMappable<int32_t, Future<int32_t>>::value);
+static_assert(!internal::IsMappable<int32_t, Future<std::string>>::value);
 
 // Inline executor that counts the number of tasks executed.
 struct CountingExecutor : public Executor {
@@ -1181,10 +1188,11 @@ TEST(FutureTest, FlattenCopyable) {
 
   auto [promise, future] = MakePromise<int32_t>();
 
-  Future<Future<int32_t>> mapped = future.Map([&](int32_t value) {
-    return MakeFutureOn(*thread_pool.AsExecutor(),
-                        [value] { return value + 1; });
-  });
+  Future<Future<int32_t>> mapped =
+      future.Map<Future<int32_t>>([&](int32_t value) {
+        return MakeFutureOn(*thread_pool.AsExecutor(),
+                            [value] { return value + 1; });
+      });
 
   Future<int32_t> flatten = mapped.Flatten();
   EXPECT_FALSE(mapped.IsReady());
@@ -1202,10 +1210,11 @@ TEST(FutureTest, FlattenCopyableRvalue) {
 
   auto [promise, future] = MakePromise<int32_t>();
 
-  Future<Future<int32_t>> mapped = future.Map([&](int32_t value) {
-    return MakeFutureOn(*thread_pool.AsExecutor(),
-                        [value] { return value + 1; });
-  });
+  Future<Future<int32_t>> mapped =
+      future.Map<Future<int32_t>>([&](int32_t value) {
+        return MakeFutureOn(*thread_pool.AsExecutor(),
+                            [value] { return value + 1; });
+      });
 
   Future<int32_t> flatten = std::move(mapped).Flatten();
   EXPECT_FALSE(flatten.IsReady());
@@ -1222,7 +1231,7 @@ TEST(FutureTest, FlattenMoveOnly) {
   auto [promise, future] = MakePromise<int32_t>();
 
   Future<Future<std::unique_ptr<int32_t>>> mapped =
-      future.Map([&](int32_t value) {
+      future.Map<Future<std::unique_ptr<int32_t>>>([&](int32_t value) {
         return MakeFutureOn(*thread_pool.AsExecutor(), [value] {
           return std::make_unique<int32_t>(value + 1);
         });
@@ -1236,6 +1245,210 @@ TEST(FutureTest, FlattenMoveOnly) {
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<int32_t> result,
                        std::move(flatten).Await());
   EXPECT_EQ(*result, 43);
+}
+
+TEST(FutureTest, MapAutoFlattenCopyable) {
+  thread::ThreadPool thread_pool(Env::Default(), "test", 4);
+
+  auto [promise, future] = MakePromise<int32_t>();
+
+  Future<int32_t> mapped = future.Map([&](int32_t value) {
+    return MakeFutureOn(*thread_pool.AsExecutor(),
+                        [value] { return value + 1; });
+  });
+
+  EXPECT_FALSE(mapped.IsReady());
+
+  promise.Set(42);
+
+  ASSERT_OK_AND_ASSIGN(int32_t result, mapped.Await());
+  EXPECT_EQ(result, 43);
+}
+
+TEST(FutureTest, MapAutoFlattenCopyableRvalue) {
+  thread::ThreadPool thread_pool(Env::Default(), "test", 4);
+
+  auto [promise, future] = MakePromise<int32_t>();
+
+  Future<int32_t> mapped = std::move(future).Map([&](int32_t value) {
+    return MakeFutureOn(*thread_pool.AsExecutor(),
+                        [value] { return value + 1; });
+  });
+
+  EXPECT_FALSE(mapped.IsReady());
+
+  promise.Set(42);
+
+  ASSERT_OK_AND_ASSIGN(int32_t result, mapped.Await());
+  EXPECT_EQ(result, 43);
+}
+
+TEST(FutureTest, MapAutoFlattenMoveOnly) {
+  thread::ThreadPool thread_pool(Env::Default(), "test", 4);
+
+  auto [promise, future] = MakePromise<int32_t>();
+
+  Future<std::unique_ptr<int32_t>> mapped =
+      std::move(future).Map([&](int32_t value) {
+        return MakeFutureOn(*thread_pool.AsExecutor(), [value] {
+          return std::make_unique<int32_t>(value + 1);
+        });
+      });
+
+  EXPECT_FALSE(mapped.IsReady());
+
+  promise.Set(42);
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<int32_t> result,
+                       std::move(mapped).Await());
+  EXPECT_EQ(*result, 43);
+}
+
+TEST(FutureTest, MapAutoFlattenStateless) {
+  thread::ThreadPool thread_pool(Env::Default(), "test", 4);
+
+  auto [promise, future] = MakePromise<>();
+
+  Future<int32_t> mapped = future.Map([&]() {
+    return MakeFutureOn(*thread_pool.AsExecutor(), [] { return 42; });
+  });
+
+  EXPECT_FALSE(mapped.IsReady());
+
+  promise.Set();
+
+  ASSERT_OK_AND_ASSIGN(int32_t result, mapped.Await());
+  EXPECT_EQ(result, 42);
+}
+
+TEST(FutureTest, MapAutoFlattenStatelessToStateless) {
+  thread::ThreadPool thread_pool(Env::Default(), "test", 4);
+
+  auto [promise, future] = MakePromise<>();
+
+  Future<> mapped = future.Map([&]() -> Future<> {
+    return MakeFutureOn<void>(*thread_pool.AsExecutor(),
+                              [] { return absl::OkStatus(); });
+  });
+
+  EXPECT_FALSE(mapped.IsReady());
+
+  promise.Set();
+
+  EXPECT_THAT(mapped.Await(), IsOk());
+}
+
+TEST(FutureTest, MapAutoFlattenToStateless) {
+  thread::ThreadPool thread_pool(Env::Default(), "test", 4);
+
+  auto [promise, future] = MakePromise<int32_t>();
+
+  Future<> mapped = future.Map([&](int32_t value) -> Future<> {
+    return MakeFutureOn<void>(*thread_pool.AsExecutor(),
+                              [] { return absl::OkStatus(); });
+  });
+
+  EXPECT_FALSE(mapped.IsReady());
+
+  promise.Set(42);
+
+  EXPECT_THAT(mapped.Await(), IsOk());
+}
+
+TEST(FutureTest, MapAutoFlattenToStatelessError) {
+  auto [promise, future] = MakePromise<int32_t>();
+
+  Future<> mapped = future.Map([&](int32_t value) -> Future<> {
+    return Future<>(absl::InternalError("inner"));
+  });
+
+  promise.Set(42);
+
+  EXPECT_TRUE(mapped.IsReady());
+  EXPECT_THAT(mapped.Await(), StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST(FutureTest, MapAutoFlattenAlreadyReady) {
+  Future<int32_t> future(42);
+
+  Future<int32_t> mapped =
+      future.Map([](int32_t value) { return Future<int32_t>(value + 1); });
+
+  EXPECT_TRUE(mapped.IsReady());
+  ASSERT_OK_AND_ASSIGN(int32_t result, mapped.Await());
+  EXPECT_EQ(result, 43);
+}
+
+TEST(FutureTest, MapAutoFlattenError) {
+  auto [promise, future] = MakePromise<int32_t>();
+
+  bool called = false;
+  Future<int32_t> mapped = future.Map([&](int32_t value) {
+    called = true;
+    return Future<int32_t>(value + 1);
+  });
+
+  promise.Set(absl::InternalError("test"));
+
+  EXPECT_TRUE(mapped.IsReady());
+  EXPECT_FALSE(called);
+  EXPECT_EQ(mapped.Await().status().code(), absl::StatusCode::kInternal);
+}
+
+TEST(FutureTest, MapExplicitFlattenCopyable) {
+  thread::ThreadPool thread_pool(Env::Default(), "test", 4);
+
+  auto [promise, future] = MakePromise<int32_t>();
+
+  Future<int32_t> mapped = future.Map<int32_t>([&](int32_t value) {
+    return MakeFutureOn(*thread_pool.AsExecutor(),
+                        [value] { return value + 1; });
+  });
+
+  EXPECT_FALSE(mapped.IsReady());
+
+  promise.Set(42);
+
+  ASSERT_OK_AND_ASSIGN(int32_t result, mapped.Await());
+  EXPECT_EQ(result, 43);
+}
+
+TEST(FutureTest, MapExplicitFlattenMoveOnly) {
+  thread::ThreadPool thread_pool(Env::Default(), "test", 4);
+
+  auto [promise, future] = MakePromise<int32_t>();
+
+  Future<std::unique_ptr<int32_t>> mapped =
+      std::move(future).Map<std::unique_ptr<int32_t>>([&](int32_t value) {
+        return MakeFutureOn(*thread_pool.AsExecutor(), [value] {
+          return std::make_unique<int32_t>(value + 1);
+        });
+      });
+
+  EXPECT_FALSE(mapped.IsReady());
+
+  promise.Set(42);
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<int32_t> result,
+                       std::move(mapped).Await());
+  EXPECT_EQ(*result, 43);
+}
+
+TEST(FutureTest, MapExplicitFlattenStateless) {
+  thread::ThreadPool thread_pool(Env::Default(), "test", 4);
+
+  auto [promise, future] = MakePromise<>();
+
+  Future<int32_t> mapped = future.Map<int32_t>([&]() {
+    return MakeFutureOn(*thread_pool.AsExecutor(), [] { return 42; });
+  });
+
+  EXPECT_FALSE(mapped.IsReady());
+
+  promise.Set();
+
+  ASSERT_OK_AND_ASSIGN(int32_t result, mapped.Await());
+  EXPECT_EQ(result, 42);
 }
 
 TEST(FutureTest, WithProfiling) {


### PR DESCRIPTION
Add support for automatic mapping of Future<Future<T>> to Future<T>