### PR TITLE
[XLA:GPU] Add ncclGetLsaMultimemDevicePointer to nccl.symbols

### DIFF
--- a/xla/tsl/cuda/nccl.symbols
+++ b/xla/tsl/cuda/nccl.symbols
@@ -25,6 +25,7 @@ ncclDevCommCreate
 ncclDevCommDestroy
 ncclGetErrorString
 ncclGetLastError
+ncclGetLsaMultimemDevicePointer
 ncclGetUniqueId
 ncclGetVersion
 ncclGroupEnd


### PR DESCRIPTION
📝 Summary of Changes
Adds ncclGetLsaMultimemDevicePointer to the NCCL stub symbol list.

🎯 Justification
NcclSymmetricMemory::multimem_addr() calls ncclGetLsaMultimemDevicePointer under NCCL_VERSION_CODE >= 22900 (introduced in PR #41515), but the symbol was never added to nccl.symbols. This is breaking builds on NCCL ≥ 2.29. 

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
N/A

🧪 Execution Tests:
N/A
