### PR TITLE
[ROCm] Add PCIe and interconnect bandwidth information to device description

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -282,6 +282,7 @@ rocm_lib_import(
     interface_library = "%{rocm_root}/lib/librccl.so",
     deps = [
         ":hip_runtime_libs",
+        ":amdsmi_libs",
         ":rocm_smi_libs",
         ":rocprofiler_register_libs",
         ":roctx_libs",
@@ -289,11 +290,14 @@ rocm_lib_import(
 )
 
 cc_library(
-    name = "rocm_smi_libs",
-    data = glob([
-        "%{rocm_root}/lib/librocm_smi64.so*",
-        "%{rocm_root}/lib/libamd_smi.so*",
-    ]),
+    name = "amdsmi_libs",
+    data = glob(["%{rocm_root}/lib/libamd_smi.so*"]),
+)
+
+rocm_lib_import(
+    name = "rocm_smi",
+    data = glob(["%{rocm_root}/lib/librocm_smi64.so*"]),
+    interface_library = "%{rocm_root}/lib/librocm_smi64.so",
 )
 
 bzl_library(

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -126,7 +126,9 @@ cc_library(
         ":rocm_context",
         ":rocm_event",
         ":rocm_kernel",
+        ":rocm_pcie_bandwidth",
         ":rocm_platform_id",
+        ":rocm_xgmi_topology",
         ":rocm_status",
         ":rocm_stream",
         ":rocm_timer",
@@ -307,6 +309,70 @@ cc_library(
     srcs = ["rocm_platform_id.cc"],
     hdrs = ["rocm_platform_id.h"],
     deps = ["//xla/stream_executor:platform_id"],
+)
+
+cc_library(
+    name = "rocm_smi_util",
+    srcs = ["rocm_smi_util.cc"],
+    hdrs = ["rocm_smi_util.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "//xla/tsl/platform:logging",
+        "@com_google_absl//absl/strings",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:rocm_smi",
+    ],
+)
+
+cc_library(
+    name = "rocm_pcie_bandwidth",
+    srcs = ["rocm_pcie_bandwidth.cc"],
+    hdrs = ["rocm_pcie_bandwidth.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_smi_util",
+        "//xla/tsl/platform:logging",
+        "@com_google_absl//absl/strings",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:rocm_smi",
+    ],
+)
+
+cc_library(
+    name = "rocm_xgmi_topology",
+    srcs = ["rocm_xgmi_topology.cc"],
+    hdrs = ["rocm_xgmi_topology.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_smi_util",
+        "//xla/tsl/platform:logging",
+        "@com_google_absl//absl/strings",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:rocm_smi",
+    ],
+)
+
+
+xla_cc_test(
+    name = "rocm_xgmi_topology_test",
+    srcs = ["rocm_xgmi_topology_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_xgmi_topology",
+        "@com_google_googletest//:gtest_main",
+    ],
 )
 
 cc_library(

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -78,11 +78,13 @@ limitations under the License.
 #include "xla/stream_executor/rocm/rocm_context.h"
 #include "xla/stream_executor/rocm/rocm_event.h"
 #include "xla/stream_executor/rocm/rocm_kernel.h"
+#include "xla/stream_executor/rocm/rocm_pcie_bandwidth.h"
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/stream_executor/rocm/rocm_status.h"
 #include "xla/stream_executor/rocm/rocm_stream.h"
 #include "xla/stream_executor/rocm/rocm_timer.h"
 #include "xla/stream_executor/rocm/rocm_version_parser.h"
+#include "xla/stream_executor/rocm/rocm_xgmi_topology.h"
 #include "xla/stream_executor/semantic_version.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
@@ -1101,13 +1103,10 @@ RocmExecutor::CreateDeviceDescription(int device_ordinal) {
 
   DeviceDescription desc;
 
+  std::string pci_bus_id = GetPCIBusID(device);
+  pci_bus_id = absl::AsciiStrToLower(pci_bus_id);
+  desc.set_pci_bus_id(pci_bus_id);
   {
-    std::string pci_bus_id = GetPCIBusID(device);
-
-    // Lower the hex characters to match sysfs.
-    pci_bus_id = absl::AsciiStrToLower(pci_bus_id);
-    desc.set_pci_bus_id(pci_bus_id);
-
     // Read the NUMA node corresponding to the PCI bus ID out of sysfs.
     std::optional<int> numa_node = ReadNumaNode(pci_bus_id, device_ordinal);
     // If the kernel reports -1, adjust to 0; leave as -1 if no value could be
@@ -1138,8 +1137,29 @@ RocmExecutor::CreateDeviceDescription(int device_ordinal) {
     desc.set_l2_cache_size(prop.l2CacheSize);
   }
 
-  // PCIe bandwidth for PCI Gen4 x16 (approximate)
-  desc.set_pcie_bandwidth(32LL * 1024 * 1024 * 1024);
+  {
+    std::optional<int64_t> pcie_bw = gpu::GetRocmPcieBandwidth(pci_bus_id);
+    if (pcie_bw.has_value()) {
+      desc.set_pcie_bandwidth(*pcie_bw);
+    } else {
+      LOG(WARNING) << "Could not determine PCIe bandwidth for device "
+                   << device_ordinal
+                   << " via rocm_smi. Assuming PCIe Gen4 x16.";
+      desc.set_pcie_bandwidth(32LL * 1024 * 1024 * 1024);
+    }
+  }
+
+  {
+    gpu::XgmiTopologyInfo xgmi = gpu::GetRocmXgmiTopology(pci_bus_id);
+    if (xgmi.active_links > 0) {
+      DeviceInterconnectInfo info;
+      info.active_links = xgmi.active_links;
+      desc.set_device_interconnect_info(info);
+      VLOG(1) << "Device " << device_ordinal << ": detected "
+              << xgmi.active_links << " active xGMI links"
+              << " (hive_id=" << xgmi.hive_id << ")";
+    }
+  }
 
   {
     auto ecc_enabled_or = IsEccEnabled(device);

--- a/xla/stream_executor/rocm/rocm_executor_test.cc
+++ b/xla/stream_executor/rocm/rocm_executor_test.cc
@@ -57,6 +57,8 @@ TEST(RocmExecutorTest, CreateDeviceDescription) {
                   .rocm_compute_capability()
                   ->gcn_arch_name(),
               Not(IsEmpty()));
+
+  EXPECT_GT(result->pcie_bandwidth(), 1024 * 1024);
 }
 
 TEST(RocmExecutorTest, GetRocmKernel) {

--- a/xla/stream_executor/rocm/rocm_pcie_bandwidth.cc
+++ b/xla/stream_executor/rocm/rocm_pcie_bandwidth.cc
@@ -1,0 +1,98 @@
+/* Copyright 2026 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_pcie_bandwidth.h"
+
+#include <cstdint>
+#include <optional>
+
+#include "absl/strings/string_view.h"
+#include "rocm/include/rocm_smi/rocm_smi.h"
+#include "xla/stream_executor/rocm/rocm_smi_util.h"
+#include "xla/tsl/platform/logging.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+// PCIe encoding efficiencies by generation
+constexpr double kPcieGen1Gen2Efficiency = 0.8;
+constexpr double kPcieGen3To5Efficiency = 128.0 / 130.0;
+constexpr double kPcieGen6Efficiency = 242.0 / 256.0;
+
+// PCIe transfer rate thresholds in MT/s
+constexpr uint32_t kPcieGen2MaxSpeedMTps = 5000;
+constexpr uint32_t kPcieGen5MaxSpeedMTps = 32000;
+
+constexpr double PcieEncodingEfficiency(uint32_t speed_mt_per_sec) {
+  if (speed_mt_per_sec <= kPcieGen2MaxSpeedMTps) return kPcieGen1Gen2Efficiency;
+  if (speed_mt_per_sec <= kPcieGen5MaxSpeedMTps) return kPcieGen3To5Efficiency;
+  return kPcieGen6Efficiency;
+}
+
+constexpr int64_t ComputePcieBandwidthFromSpeedAndWidth(
+    uint32_t speed_mt_per_sec, uint16_t width) {
+  if (width == 0 || speed_mt_per_sec == 0) return 0;
+  double efficiency = PcieEncodingEfficiency(speed_mt_per_sec);
+  return static_cast<int64_t>(static_cast<double>(speed_mt_per_sec) * 1e6 *
+                              width / 8.0 * efficiency);
+}
+
+}  // namespace
+
+std::optional<int64_t> GetRocmPcieBandwidth(absl::string_view pci_bus_id) {
+  if (!InitRocmSmi()) return std::nullopt;
+
+  std::optional<BdfComponents> bdf = ParseBdf(pci_bus_id);
+  if (!bdf.has_value()) {
+    LOG(WARNING) << "Failed to parse PCI bus ID: " << pci_bus_id;
+    return std::nullopt;
+  }
+
+  std::optional<uint32_t> dev_idx = FindDeviceIndex(*bdf);
+  if (!dev_idx.has_value()) {
+    LOG(WARNING) << "rocm_smi: could not find device for PCI bus ID "
+                 << pci_bus_id;
+    return std::nullopt;
+  }
+
+  rsmi_gpu_metrics_t gpu_metrics = {};
+  rsmi_status_t status = rsmi_dev_gpu_metrics_info_get(*dev_idx, &gpu_metrics);
+  if (status != RSMI_STATUS_SUCCESS) {
+    const char* err_str = nullptr;
+    rsmi_status_string(status, &err_str);
+    LOG(WARNING) << "rsmi_dev_gpu_metrics_info_get failed for " << pci_bus_id
+                 << ": " << (err_str ? err_str : "unknown error");
+    return std::nullopt;
+  }
+
+  uint32_t speed_mt_per_sec =
+      static_cast<uint32_t>(gpu_metrics.pcie_link_speed) * 100;
+  uint16_t width = gpu_metrics.pcie_link_width;
+
+  if (speed_mt_per_sec == 0 || width == 0) {
+    LOG(WARNING) << "rocm_smi gpu_metrics reported zero PCIe speed ("
+                 << speed_mt_per_sec << " MT/s) or width (" << width
+                 << " lanes) for " << pci_bus_id;
+    return std::nullopt;
+  }
+
+  int64_t bandwidth =
+      ComputePcieBandwidthFromSpeedAndWidth(speed_mt_per_sec, width);
+
+  VLOG(1) << "PCIe bandwidth for " << pci_bus_id << ": " << speed_mt_per_sec
+          << " MT/s x" << width << " = " << bandwidth / (1024 * 1024 * 1024)
+          << " GB/s (" << bandwidth << " bytes/s)";
+
+  return bandwidth;
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_pcie_bandwidth.h
+++ b/xla/stream_executor/rocm/rocm_pcie_bandwidth.h
@@ -1,0 +1,29 @@
+/* Copyright 2026 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_PCIE_BANDWIDTH_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_PCIE_BANDWIDTH_H_
+
+#include <cstdint>
+#include <optional>
+
+#include "absl/strings/string_view.h"
+
+namespace stream_executor::gpu {
+
+// pci_bus_id is the PCI bus ID string from HIP (e.g. "0000:41:00.0").
+// Returns bandwidth in bytes/second, or std::nullopt if the query fails.
+std::optional<int64_t> GetRocmPcieBandwidth(absl::string_view pci_bus_id);
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_PCIE_BANDWIDTH_H_

--- a/xla/stream_executor/rocm/rocm_smi_util.cc
+++ b/xla/stream_executor/rocm/rocm_smi_util.cc
@@ -1,0 +1,122 @@
+/* Copyright 2026 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_smi_util.h"
+
+#include <cstdint>
+#include <optional>
+
+#include "absl/strings/numbers.h"
+#include "absl/strings/string_view.h"
+#include "rocm/include/rocm_smi/rocm_smi.h"
+#include "xla/tsl/platform/logging.h"
+
+namespace stream_executor::gpu {
+
+bool InitRocmSmi() {
+  static bool initialized = []() {
+    rsmi_status_t status = rsmi_init(0);
+    if (status != RSMI_STATUS_SUCCESS) {
+      const char* err_str = nullptr;
+      rsmi_status_string(status, &err_str);
+      LOG(WARNING) << "rsmi_init failed: "
+                   << (err_str ? err_str : "unknown error");
+      return false;
+    }
+    return true;
+  }();
+  return initialized;
+}
+
+// Parses a PCI bus/device/function ID string into its numeric components.
+// Accepts two formats:
+//   DDDD:BB:DD.F - domain:bus:device.function (e.g. "0000:41:00.0")
+//   BB:DD.F      - bus:device.function, domain defaults to 0
+// All fields are hex
+std::optional<BdfComponents> ParseBdf(absl::string_view pci_bus_id) {
+  BdfComponents bdf = {};
+
+  // Determine which format we have by counting colons.
+  // Two colons -> DDDD:BB:DD.F, one colon -> BB:DD.F.
+  size_t first_colon = pci_bus_id.find(':');
+  if (first_colon == absl::string_view::npos) return std::nullopt;
+
+  size_t second_colon = pci_bus_id.find(':', first_colon + 1);
+  size_t dot;
+
+  if (second_colon != absl::string_view::npos) {
+    // DDDD:BB:DD.F format
+    dot = pci_bus_id.find('.', second_colon + 1);
+    if (dot == absl::string_view::npos) return std::nullopt;
+
+    if (!absl::SimpleHexAtoi(pci_bus_id.substr(0, first_colon), &bdf.domain))
+      return std::nullopt;
+    if (!absl::SimpleHexAtoi(
+            pci_bus_id.substr(first_colon + 1, second_colon - first_colon - 1),
+            &bdf.bus))
+      return std::nullopt;
+    if (!absl::SimpleHexAtoi(
+            pci_bus_id.substr(second_colon + 1, dot - second_colon - 1),
+            &bdf.device))
+      return std::nullopt;
+    if (!absl::SimpleHexAtoi(pci_bus_id.substr(dot + 1), &bdf.function))
+      return std::nullopt;
+  } else {
+    // BB:DD.F format (domain = 0)
+    dot = pci_bus_id.find('.', first_colon + 1);
+    if (dot == absl::string_view::npos) return std::nullopt;
+
+    bdf.domain = 0;
+    if (!absl::SimpleHexAtoi(pci_bus_id.substr(0, first_colon), &bdf.bus))
+      return std::nullopt;
+    if (!absl::SimpleHexAtoi(
+            pci_bus_id.substr(first_colon + 1, dot - first_colon - 1),
+            &bdf.device))
+      return std::nullopt;
+    if (!absl::SimpleHexAtoi(pci_bus_id.substr(dot + 1), &bdf.function))
+      return std::nullopt;
+  }
+
+  return bdf;
+}
+
+std::optional<uint32_t> FindDeviceIndex(const BdfComponents& target_bdf) {
+  uint32_t num_devices = 0;
+  rsmi_status_t status = rsmi_num_monitor_devices(&num_devices);
+  if (status != RSMI_STATUS_SUCCESS || num_devices == 0) {
+    return std::nullopt;
+  }
+
+  for (uint32_t i = 0; i < num_devices; ++i) {
+    uint64_t bdfid = 0;
+    status = rsmi_dev_pci_id_get(i, &bdfid);
+    if (status != RSMI_STATUS_SUCCESS) continue;
+
+    // Unpack rocm_smi's 64-bit BDF format into individual fields.
+    // See
+    // rocm-systems/projects/rocm-smi-lib/src/rocm_smi.cc:rsmi_dev_pci_id_get
+    // for details on the packing.
+    uint32_t domain = (bdfid >> 32) & 0xFFFFFFFF;
+    uint8_t bus = (bdfid >> 8) & 0xFF;
+    uint8_t device = (bdfid >> 3) & 0x1F;
+    uint8_t function = bdfid & 0x7;
+
+    if (domain == target_bdf.domain && bus == target_bdf.bus &&
+        device == target_bdf.device && function == target_bdf.function) {
+      return i;
+    }
+  }
+
+  return std::nullopt;
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_smi_util.h
+++ b/xla/stream_executor/rocm/rocm_smi_util.h
@@ -1,0 +1,43 @@
+/* Copyright 2026 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_SMI_UTIL_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_SMI_UTIL_H_
+
+#include <cstdint>
+#include <optional>
+
+#include "absl/strings/string_view.h"
+
+namespace stream_executor::gpu {
+
+struct BdfComponents {
+  uint64_t domain;
+  uint64_t bus;
+  uint64_t device;
+  uint64_t function;
+};
+
+// Returns true if rocm_smi was successfully initialized.
+bool InitRocmSmi();
+
+// Parses a PCI bus ID string (e.g., "0000:41:00.0") into its BDF components.
+// Returns std::nullopt on parse failure.
+std::optional<BdfComponents> ParseBdf(absl::string_view pci_bus_id);
+
+// Finds the rocm_smi device index that matches the given PCI bus ID.
+// Returns std::nullopt if not found.
+std::optional<uint32_t> FindDeviceIndex(const BdfComponents& target_bdf);
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_SMI_UTIL_H_

--- a/xla/stream_executor/rocm/rocm_xgmi_topology.cc
+++ b/xla/stream_executor/rocm/rocm_xgmi_topology.cc
@@ -1,0 +1,83 @@
+/* Copyright 2026 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_xgmi_topology.h"
+
+#include <cstdint>
+#include <optional>
+
+#include "absl/strings/string_view.h"
+#include "rocm/include/rocm_smi/rocm_smi.h"
+#include "xla/stream_executor/rocm/rocm_smi_util.h"
+#include "xla/tsl/platform/logging.h"
+
+namespace stream_executor::gpu {
+
+XgmiTopologyInfo GetRocmXgmiTopology(absl::string_view pci_bus_id) {
+  XgmiTopologyInfo info;
+
+  if (!InitRocmSmi()) return info;
+
+  std::optional<BdfComponents> bdf = ParseBdf(pci_bus_id);
+  if (!bdf.has_value()) {
+    LOG(WARNING) << "Failed to parse PCI bus ID for xGMI query: " << pci_bus_id;
+    return info;
+  }
+
+  std::optional<uint32_t> dev_idx = FindDeviceIndex(*bdf);
+  if (!dev_idx.has_value()) {
+    LOG(WARNING) << "rocm_smi: could not find device for PCI bus ID "
+                 << pci_bus_id << " (xGMI query)";
+    return info;
+  }
+
+  // Query xGMI hive ID.
+  uint64_t hive_id = 0;
+  rsmi_status_t status = rsmi_dev_xgmi_hive_id_get(*dev_idx, &hive_id);
+  if (status == RSMI_STATUS_SUCCESS) {
+    info.hive_id = hive_id;
+  } else {
+    VLOG(1) << "rsmi_dev_xgmi_hive_id_get failed for " << pci_bus_id
+            << "; device may not be in an xGMI hive.";
+  }
+
+  // Count xGMI links by querying link type to every other device.
+  uint32_t num_devices = 0;
+  status = rsmi_num_monitor_devices(&num_devices);
+  if (status != RSMI_STATUS_SUCCESS || num_devices <= 1) {
+    return info;
+  }
+
+  int xgmi_links = 0;
+  for (uint32_t i = 0; i < num_devices; ++i) {
+    if (i == *dev_idx) continue;
+
+    uint64_t hops = 0;
+    RSMI_IO_LINK_TYPE link_type = RSMI_IOLINK_TYPE_UNDEFINED;
+    status = rsmi_topo_get_link_type(*dev_idx, i, &hops, &link_type);
+    if (status != RSMI_STATUS_SUCCESS) continue;
+
+    if (link_type == RSMI_IOLINK_TYPE_XGMI) {
+      ++xgmi_links;
+    }
+  }
+
+  info.active_links = xgmi_links;
+
+  VLOG(1) << "xGMI topology for " << pci_bus_id << ": " << xgmi_links
+          << " active xGMI links"
+          << " (hive_id=" << hive_id << ", num_devices=" << num_devices << ")";
+
+  return info;
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_xgmi_topology.h
+++ b/xla/stream_executor/rocm/rocm_xgmi_topology.h
@@ -1,0 +1,34 @@
+/* Copyright 2026 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_XGMI_TOPOLOGY_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_XGMI_TOPOLOGY_H_
+
+#include <cstdint>
+
+#include "absl/strings/string_view.h"
+
+namespace stream_executor::gpu {
+
+struct XgmiTopologyInfo {
+  int active_links = 0;  // Number of active xGMI P2P links to other GPUs
+  uint64_t hive_id = 0;  // xGMI hive ID
+};
+
+// Queries xGMI topology information for a ROCm device.
+// pci_bus_id is the PCI bus ID string from HIP (e.g. "0000:41:00.0").
+// Returns topology info. On failure, returns default (0 links, no hive).
+XgmiTopologyInfo GetRocmXgmiTopology(absl::string_view pci_bus_id);
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_XGMI_TOPOLOGY_H_

--- a/xla/stream_executor/rocm/rocm_xgmi_topology_test.cc
+++ b/xla/stream_executor/rocm/rocm_xgmi_topology_test.cc
@@ -1,0 +1,40 @@
+/* Copyright 2025 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_xgmi_topology.h"
+
+#include "gtest/gtest.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+TEST(XgmiTopologyInfoTest, DefaultValues) {
+  XgmiTopologyInfo info;
+  EXPECT_EQ(info.active_links, 0);
+  EXPECT_EQ(info.hive_id, 0);
+}
+
+TEST(GetRocmXgmiTopologyTest, InvalidBdfReturnsDefault) {
+  // An invalid PCI bus ID should return default topology (0 links).
+  XgmiTopologyInfo info = GetRocmXgmiTopology("invalid");
+  EXPECT_EQ(info.active_links, 0);
+  EXPECT_EQ(info.hive_id, 0);
+}
+
+TEST(GetRocmXgmiTopologyTest, EmptyBdfReturnsDefault) {
+  XgmiTopologyInfo info = GetRocmXgmiTopology("");
+  EXPECT_EQ(info.active_links, 0);
+  EXPECT_EQ(info.hive_id, 0);
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu


### PR DESCRIPTION
📝 Summary of Changes
Queries PCIe/device interconnect information into device description using rocm-smi
 
🎯 Justification
Improves accuracy e.g. latency estimations on ROCm where this information is used.

🚀 Kind of Contribution
✨ New Feature