### PR TITLE
[XLA:GPU] Deterministic autotuner selection without a trusted backend

### DIFF
--- a/xla/backends/autotuner/autotuner.cc
+++ b/xla/backends/autotuner/autotuner.cc
@@ -825,7 +825,9 @@ int Autotuner::AssignToOutputCluster(std::vector<OutputCluster>& clusters,
       return c;
     }
   }
-  if (!allow_new_cluster) return -1;
+  if (!allow_new_cluster) {
+    return -1;
+  }
   int new_idx = clusters.size();
   clusters.push_back(OutputCluster{std::move(output), /*count=*/1,
                                    /*has_trusted_member=*/is_trusted_config});
@@ -835,15 +837,21 @@ int Autotuner::AssignToOutputCluster(std::vector<OutputCluster>& clusters,
 void Autotuner::DemoteNonWinningClusterConfigs(
     std::vector<ConfigResult>& results,
     const std::vector<OutputCluster>& clusters) {
-  if (clusters.empty()) return;
+  if (clusters.empty()) {
+    return;
+  }
   // Prefer clusters with a trusted member; among the preferred set, pick the
   // largest count (earliest insertion wins on tie).
   const bool any_trusted = absl::c_any_of(
       clusters, [](const OutputCluster& c) { return c.has_trusted_member; });
   int winner = -1;
   for (int c = 0; c < clusters.size(); ++c) {
-    if (any_trusted && !clusters[c].has_trusted_member) continue;
-    if (winner < 0 || clusters[c].count > clusters[winner].count) winner = c;
+    if (any_trusted && !clusters[c].has_trusted_member) {
+      continue;
+    }
+    if (winner < 0 || clusters[c].count > clusters[winner].count) {
+      winner = c;
+    }
   }
   VLOG(2) << "Output clustering formed " << clusters.size()
           << " cluster(s); selected cluster " << winner << " with "

--- a/xla/backends/autotuner/autotuner.cc
+++ b/xla/backends/autotuner/autotuner.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <string>
 #include <utility>
@@ -636,8 +637,7 @@ Autotuner::CompileAll(const HloInstruction* instr,
 
 absl::StatusOr<std::vector<Autotuner::ConfigResult>> Autotuner::ProfileAll(
     std::vector<ExecutableCandidate> candidates, const HloInstruction* instr) {
-  std::vector<ConfigResult> config_results;
-  config_results.reserve(candidates.size());
+  std::vector<ConfigResult> config_results(candidates.size());
 
   absl::MutexLock lock(profiler_m_);
 
@@ -645,46 +645,40 @@ absl::StatusOr<std::vector<Autotuner::ConfigResult>> Autotuner::ProfileAll(
       std::unique_ptr<InputBuffers> input_buffers,
       profiler_->CreateInputBuffers(candidates[0].executable.get(), instr));
 
+  const auto is_trusted = [](const ExecutableCandidate& candidate) {
+    return !candidate.config.codegen_backend->CanProduceWrongResults();
+  };
+
+  std::vector<OutputCluster> clusters;
+  std::vector<int> profile_order(candidates.size());
+  std::iota(profile_order.begin(), profile_order.end(), 0);
+
+  auto first_untrusted = profile_order.begin();
   if (autotune_config_.check_buffers) {
+    first_untrusted =
+        std::stable_partition(profile_order.begin(), profile_order.end(),
+                              [&](int i) { return is_trusted(candidates[i]); });
+
     VLOG(2) << "Validating outputs via clustering across " << candidates.size()
             << " config(s).";
   }
 
-  std::vector<OutputCluster> clusters;
+  for (auto it = profile_order.begin(); it != first_untrusted; ++it) {
+    const int i = *it;
+    config_results[i] =
+        ProfileCandidate(candidates[i], *input_buffers, clusters,
+                         /*is_trusted_config=*/true,
+                         /*allow_new_cluster=*/true);
+  }
 
-  for (int i = 0; i < candidates.size(); ++i) {
-    absl::StatusOr<ProfileResult> profile_result =
-        profiler_->Profile(candidates[i].executable.get(), *input_buffers);
-
-    std::optional<Failure> failure = std::nullopt;
-    absl::Duration duration = absl::ZeroDuration();
-    int scratch_bytes = 0;
-    int assigned_cluster = -1;
-    if (!profile_result.ok()) {
-      failure = Failure{FailureKind::kExecutionFailed,
-                        profile_result.status().ToString()};
-    } else {
-      duration = profile_result->duration;
-      scratch_bytes = profile_result->scratch_bytes;
-      if (autotune_config_.check_buffers) {
-        // Input buffers are shared across candidates; CheckInputBuffers both
-        // verifies redzone canaries and refreshes the buffers so the next
-        // candidate starts from a clean state.
-        absl::Status redzone = profiler_->CheckInputBuffers(*input_buffers);
-        if (!redzone.ok()) {
-          failure =
-              Failure{FailureKind::kRedzoneCheckFailed, redzone.ToString()};
-        } else {
-          CHECK(profile_result->output_buffer.has_value());
-          const bool is_trusted =
-              !candidates[i].config.codegen_backend->CanProduceWrongResults();
-          assigned_cluster = AssignToOutputCluster(
-              clusters, profile_result->output_buffer.value(), is_trusted);
-        }
-      }
-    }
-    config_results.push_back({std::move(candidates[i].config), failure,
-                              duration, scratch_bytes, assigned_cluster});
+  // Untrusted configs create consensus clusters only if the trusted phase
+  // found no usable reference.
+  const bool has_trusted_reference = !clusters.empty();
+  for (auto it = first_untrusted; it != profile_order.end(); ++it) {
+    const int i = *it;
+    config_results[i] = ProfileCandidate(
+        candidates[i], *input_buffers, clusters, /*is_trusted_config=*/false,
+        /*allow_new_cluster=*/!has_trusted_reference);
   }
 
   if (autotune_config_.check_buffers) {
@@ -707,6 +701,42 @@ absl::StatusOr<std::vector<Autotuner::ConfigResult>> Autotuner::ProfileAll(
   // precise CUDA event-based timing.
   candidates.clear();
   return config_results;
+}
+
+Autotuner::ConfigResult Autotuner::ProfileCandidate(
+    ExecutableCandidate& candidate, InputBuffers& input_buffers,
+    std::vector<OutputCluster>& clusters, bool is_trusted_config,
+    bool allow_new_cluster) {
+  absl::StatusOr<ProfileResult> profile_result =
+      profiler_->Profile(candidate.executable.get(), input_buffers);
+
+  std::optional<Failure> failure = std::nullopt;
+  absl::Duration duration = absl::ZeroDuration();
+  int scratch_bytes = 0;
+  int assigned_cluster = -1;
+  if (!profile_result.ok()) {
+    failure = Failure{FailureKind::kExecutionFailed,
+                      profile_result.status().ToString()};
+  } else {
+    duration = profile_result->duration;
+    scratch_bytes = profile_result->scratch_bytes;
+    if (autotune_config_.check_buffers) {
+      // Input buffers are shared across candidates; CheckInputBuffers both
+      // verifies redzone canaries and refreshes the buffers so the next
+      // candidate starts from a clean state.
+      absl::Status redzone = profiler_->CheckInputBuffers(input_buffers);
+      if (!redzone.ok()) {
+        failure = Failure{FailureKind::kRedzoneCheckFailed, redzone.ToString()};
+      } else {
+        CHECK(profile_result->output_buffer.has_value());
+        assigned_cluster = AssignToOutputCluster(
+            clusters, profile_result->output_buffer.value(), is_trusted_config,
+            allow_new_cluster);
+      }
+    }
+  }
+  return ConfigResult{std::move(candidate.config), failure, duration,
+                      scratch_bytes, assigned_cluster};
 }
 
 absl::StatusOr<Autotuner::ConfigResult> Autotuner::PickBestConfig(
@@ -783,7 +813,8 @@ absl::Status Autotuner::DumpHlo(HloInstruction* instr, const Config& config) {
 
 int Autotuner::AssignToOutputCluster(std::vector<OutputCluster>& clusters,
                                      ScopedShapedBuffer& output,
-                                     bool is_trusted_config) {
+                                     bool is_trusted_config,
+                                     bool allow_new_cluster) {
   for (int c = 0; c < clusters.size(); ++c) {
     if (profiler_
             ->CheckOutputBuffer(output, clusters[c].representative,
@@ -794,6 +825,7 @@ int Autotuner::AssignToOutputCluster(std::vector<OutputCluster>& clusters,
       return c;
     }
   }
+  if (!allow_new_cluster) return -1;
   int new_idx = clusters.size();
   clusters.push_back(OutputCluster{std::move(output), /*count=*/1,
                                    /*has_trusted_member=*/is_trusted_config});

--- a/xla/backends/autotuner/autotuner.cc
+++ b/xla/backends/autotuner/autotuner.cc
@@ -651,10 +651,6 @@ absl::StatusOr<std::vector<Autotuner::ConfigResult>> Autotuner::ProfileAll(
   }
 
   std::vector<OutputCluster> clusters;
-  std::vector<int> cluster_of_result;
-  if (autotune_config_.check_buffers) {
-    cluster_of_result.reserve(candidates.size());
-  }
 
   for (int i = 0; i < candidates.size(); ++i) {
     absl::StatusOr<ProfileResult> profile_result =
@@ -687,15 +683,12 @@ absl::StatusOr<std::vector<Autotuner::ConfigResult>> Autotuner::ProfileAll(
         }
       }
     }
-    config_results.push_back(
-        {std::move(candidates[i].config), failure, duration, scratch_bytes});
-    if (autotune_config_.check_buffers) {
-      cluster_of_result.push_back(assigned_cluster);
-    }
+    config_results.push_back({std::move(candidates[i].config), failure,
+                              duration, scratch_bytes, assigned_cluster});
   }
 
   if (autotune_config_.check_buffers) {
-    DemoteNonWinningClusterConfigs(config_results, clusters, cluster_of_result);
+    DemoteNonWinningClusterConfigs(config_results, clusters);
     if (autotune_config_.crash_on_check_failure) {
       // Only correctness-check failures are fatal here. kCompilationFailed and
       // kExecutionFailed are expected outcomes during autotuning and silently
@@ -809,8 +802,7 @@ int Autotuner::AssignToOutputCluster(std::vector<OutputCluster>& clusters,
 
 void Autotuner::DemoteNonWinningClusterConfigs(
     std::vector<ConfigResult>& results,
-    const std::vector<OutputCluster>& clusters,
-    const std::vector<int>& cluster_of_result) {
+    const std::vector<OutputCluster>& clusters) {
   if (clusters.empty()) return;
   // Prefer clusters with a trusted member; among the preferred set, pick the
   // largest count (earliest insertion wins on tie).
@@ -825,18 +817,18 @@ void Autotuner::DemoteNonWinningClusterConfigs(
           << " cluster(s); selected cluster " << winner << " with "
           << clusters[winner].count << " member(s), trusted="
           << clusters[winner].has_trusted_member;
-  for (int i = 0; i < results.size(); ++i) {
-    if (!results[i].failure.has_value() && cluster_of_result[i] != winner) {
-      results[i].failure = Failure{
+  for (ConfigResult& result : results) {
+    if (!result.failure.has_value() && result.cluster_index != winner) {
+      result.failure = Failure{
           FailureKind::kWrongResults,
           absl::StrCat("Output disagrees with winning cluster (member of "
                        "cluster ",
-                       cluster_of_result[i], " of ", clusters.size(),
+                       result.cluster_index, " of ", clusters.size(),
                        "; winning cluster has ", clusters[winner].count,
                        " member(s), trusted=",
                        clusters[winner].has_trusted_member, ").")};
-      VLOG(3) << "Demoted config " << results[i].config.ToString()
-              << " (cluster " << cluster_of_result[i] << ").";
+      VLOG(3) << "Demoted config " << result.config.ToString() << " (cluster "
+              << result.cluster_index << ").";
     }
   }
 }

--- a/xla/backends/autotuner/autotuner.cc
+++ b/xla/backends/autotuner/autotuner.cc
@@ -645,13 +645,15 @@ absl::StatusOr<std::vector<Autotuner::ConfigResult>> Autotuner::ProfileAll(
       std::unique_ptr<InputBuffers> input_buffers,
       profiler_->CreateInputBuffers(candidates[0].executable.get(), instr));
 
-  std::optional<ScopedShapedBuffer> reference_output;
   if (autotune_config_.check_buffers) {
-    VLOG(2) << "Checking buffers";
-    reference_output = GetReferenceOutput(candidates, *input_buffers);
-    if (!reference_output.has_value()) {
-      LOG(WARNING) << "No reference output found even though buffer checking ";
-    }
+    VLOG(2) << "Validating outputs via clustering across " << candidates.size()
+            << " config(s).";
+  }
+
+  std::vector<OutputCluster> clusters;
+  std::vector<int> cluster_of_result;
+  if (autotune_config_.check_buffers) {
+    cluster_of_result.reserve(candidates.size());
   }
 
   for (int i = 0; i < candidates.size(); ++i) {
@@ -661,24 +663,50 @@ absl::StatusOr<std::vector<Autotuner::ConfigResult>> Autotuner::ProfileAll(
     std::optional<Failure> failure = std::nullopt;
     absl::Duration duration = absl::ZeroDuration();
     int scratch_bytes = 0;
+    int assigned_cluster = -1;
     if (!profile_result.ok()) {
       failure = Failure{FailureKind::kExecutionFailed,
                         profile_result.status().ToString()};
     } else {
       duration = profile_result->duration;
       scratch_bytes = profile_result->scratch_bytes;
-      if (autotune_config_.check_buffers && reference_output.has_value()) {
-        CHECK(profile_result->output_buffer.has_value());
-        failure =
-            CheckBuffers(*input_buffers, profile_result->output_buffer.value(),
-                         reference_output.value());
-        if (failure.has_value()) {
-          CHECK(!autotune_config_.crash_on_check_failure);
+      if (autotune_config_.check_buffers) {
+        // Input buffers are shared across candidates; CheckInputBuffers both
+        // verifies redzone canaries and refreshes the buffers so the next
+        // candidate starts from a clean state.
+        absl::Status redzone = profiler_->CheckInputBuffers(*input_buffers);
+        if (!redzone.ok()) {
+          failure =
+              Failure{FailureKind::kRedzoneCheckFailed, redzone.ToString()};
+        } else {
+          CHECK(profile_result->output_buffer.has_value());
+          const bool is_trusted =
+              !candidates[i].config.codegen_backend->CanProduceWrongResults();
+          assigned_cluster = AssignToOutputCluster(
+              clusters, profile_result->output_buffer.value(), is_trusted);
         }
       }
     }
     config_results.push_back(
         {std::move(candidates[i].config), failure, duration, scratch_bytes});
+    if (autotune_config_.check_buffers) {
+      cluster_of_result.push_back(assigned_cluster);
+    }
+  }
+
+  if (autotune_config_.check_buffers) {
+    DemoteNonWinningClusterConfigs(config_results, clusters, cluster_of_result);
+    if (autotune_config_.crash_on_check_failure) {
+      // Only correctness-check failures are fatal here. kCompilationFailed and
+      // kExecutionFailed are expected outcomes during autotuning and silently
+      // discarding them is the intended behavior.
+      for (const ConfigResult& r : config_results) {
+        CHECK(!r.failure.has_value() ||
+              (r.failure->kind != FailureKind::kRedzoneCheckFailed &&
+               r.failure->kind != FailureKind::kWrongResults))
+            << "crash_on_check_failure: " << r.failure->ToString();
+      }
+    }
   }
   // Clear the candidates while holding the profiler lock
   // to unload their CUDA modules before any other thread starts profiling;
@@ -760,40 +788,57 @@ absl::Status Autotuner::DumpHlo(HloInstruction* instr, const Config& config) {
   return absl::OkStatus();
 }
 
-std::optional<ScopedShapedBuffer> Autotuner::GetReferenceOutput(
-    std::vector<ExecutableCandidate>& candidates, InputBuffers& input_buffers) {
-  for (auto& candidate : candidates) {
-    if (candidate.config.codegen_backend->CanProduceWrongResults()) {
-      continue;
-    }
-    absl::StatusOr<ProfileResult> profile_result =
-        profiler_->Profile(candidate.executable.get(), input_buffers);
-    if (!profile_result.ok()) {
-      VLOG(2) << "Failed to profile executable: " << profile_result.status();
-      continue;
-    }
-    if (profile_result->output_buffer.has_value()) {
-      VLOG(2) << "Found reference output for config: "
-              << candidate.config.ToString();
-      return std::move(profile_result->output_buffer.value());
+int Autotuner::AssignToOutputCluster(std::vector<OutputCluster>& clusters,
+                                     ScopedShapedBuffer& output,
+                                     bool is_trusted_config) {
+  for (int c = 0; c < clusters.size(); ++c) {
+    if (profiler_
+            ->CheckOutputBuffer(output, clusters[c].representative,
+                                autotune_config_.relative_tolerance)
+            .ok()) {
+      clusters[c].count++;
+      clusters[c].has_trusted_member |= is_trusted_config;
+      return c;
     }
   }
-  return std::nullopt;
+  int new_idx = clusters.size();
+  clusters.push_back(OutputCluster{std::move(output), /*count=*/1,
+                                   /*has_trusted_member=*/is_trusted_config});
+  return new_idx;
 }
 
-std::optional<Autotuner::Failure> Autotuner::CheckBuffers(
-    InputBuffers& input_buffers, ScopedShapedBuffer& output_buffer,
-    ScopedShapedBuffer& reference_output) {
-  absl::Status status = profiler_->CheckInputBuffers(input_buffers);
-  if (!status.ok()) {
-    return Failure{FailureKind::kRedzoneCheckFailed, status.ToString()};
+void Autotuner::DemoteNonWinningClusterConfigs(
+    std::vector<ConfigResult>& results,
+    const std::vector<OutputCluster>& clusters,
+    const std::vector<int>& cluster_of_result) {
+  if (clusters.empty()) return;
+  // Prefer clusters with a trusted member; among the preferred set, pick the
+  // largest count (earliest insertion wins on tie).
+  const bool any_trusted = absl::c_any_of(
+      clusters, [](const OutputCluster& c) { return c.has_trusted_member; });
+  int winner = -1;
+  for (int c = 0; c < clusters.size(); ++c) {
+    if (any_trusted && !clusters[c].has_trusted_member) continue;
+    if (winner < 0 || clusters[c].count > clusters[winner].count) winner = c;
   }
-  status = profiler_->CheckOutputBuffer(output_buffer, reference_output,
-                                        autotune_config_.relative_tolerance);
-  if (!status.ok()) {
-    return Failure{FailureKind::kWrongResults, status.ToString()};
+  VLOG(2) << "Output clustering formed " << clusters.size()
+          << " cluster(s); selected cluster " << winner << " with "
+          << clusters[winner].count << " member(s), trusted="
+          << clusters[winner].has_trusted_member;
+  for (int i = 0; i < results.size(); ++i) {
+    if (!results[i].failure.has_value() && cluster_of_result[i] != winner) {
+      results[i].failure = Failure{
+          FailureKind::kWrongResults,
+          absl::StrCat("Output disagrees with winning cluster (member of "
+                       "cluster ",
+                       cluster_of_result[i], " of ", clusters.size(),
+                       "; winning cluster has ", clusters[winner].count,
+                       " member(s), trusted=",
+                       clusters[winner].has_trusted_member, ").")};
+      VLOG(3) << "Demoted config " << results[i].config.ToString()
+              << " (cluster " << cluster_of_result[i] << ").";
+    }
   }
-  return std::nullopt;
 }
 
 void Autotuner::LogConfigResults(const HloInstruction& instr,

--- a/xla/backends/autotuner/autotuner.h
+++ b/xla/backends/autotuner/autotuner.h
@@ -159,6 +159,10 @@ class Autotuner {
     std::optional<Failure> failure;
     absl::Duration duration = absl::ZeroDuration();
     int scratch_bytes = 0;
+    // Index into the OutputCluster vector built by ProfileAll, or -1 if the
+    // config was not clustered (output check disabled, or profiling failed
+    // before reaching the cluster assignment step).
+    int cluster_index = -1;
 
     std::string ToString(bool verbose = false) const;
     AutotuneResult ToProto() const;
@@ -246,12 +250,11 @@ class Autotuner {
   // Stamps kWrongResults on every successful result that is not in the
   // winning cluster. Winner: if any cluster has a trustworthy member, the
   // largest among those; otherwise the largest overall. Earliest insertion
-  // wins on tie. `cluster_of_result[i]` is the cluster index of `results[i]`,
-  // or -1 if the config was not clustered (failed or check_buffers off).
+  // wins on tie. Reads `ConfigResult::cluster_index` to find each result's
+  // cluster.
   void DemoteNonWinningClusterConfigs(
       std::vector<ConfigResult>& results,
-      const std::vector<OutputCluster>& clusters,
-      const std::vector<int>& cluster_of_result);
+      const std::vector<OutputCluster>& clusters);
   absl::Status IsValidExecutable(
       const absl::StatusOr<std::unique_ptr<Executable>>& executable) const;
 

--- a/xla/backends/autotuner/autotuner.h
+++ b/xla/backends/autotuner/autotuner.h
@@ -233,18 +233,27 @@ class Autotuner {
   absl::StatusOr<std::vector<ConfigResult>> ProfileAll(
       std::vector<ExecutableCandidate> candidates,
       const HloInstruction* instr = nullptr);
+
+  ConfigResult ProfileCandidate(ExecutableCandidate& candidate,
+                                InputBuffers& input_buffers,
+                                std::vector<OutputCluster>& clusters,
+                                bool is_trusted_config, bool allow_new_cluster)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(profiler_m_);
+
   // Picks the best config from the given results.
   // Result is moved from the input vector.
   absl::StatusOr<ConfigResult> PickBestConfig(
       std::vector<ConfigResult>& results);
 
   // Assigns `output` to the first cluster whose representative matches within
-  // autotune_config_.relative_tolerance; creates a new cluster if no match.
+  // autotune_config_.relative_tolerance. If `allow_new_cluster` is true,
+  // creates a new cluster if no match is found; otherwise returns -1.
   // `is_trusted_config` marks the cluster as having a trustworthy-backend
   // member (propagates through the OR of member trust flags). Returns the
   // assigned cluster index.
   int AssignToOutputCluster(std::vector<OutputCluster>& clusters,
-                            ScopedShapedBuffer& output, bool is_trusted_config)
+                            ScopedShapedBuffer& output, bool is_trusted_config,
+                            bool allow_new_cluster)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(profiler_m_);
 
   // Stamps kWrongResults on every successful result that is not in the

--- a/xla/backends/autotuner/autotuner.h
+++ b/xla/backends/autotuner/autotuner.h
@@ -163,6 +163,15 @@ class Autotuner {
     std::string ToString(bool verbose = false) const;
     AutotuneResult ToProto() const;
   };
+  // A group of configs whose profiled outputs agree within
+  // autotune_config_.relative_tolerance.
+  struct OutputCluster {
+    ScopedShapedBuffer representative;
+    int count = 0;
+    // True iff at least one member comes from a backend that declares
+    // CanProduceWrongResults()==false.
+    bool has_trusted_member = false;
+  };
 
   Autotuner(std::vector<std::unique_ptr<CodegenBackend>> codegen_backends,
             std::unique_ptr<Profiler> profiler, AutotuneConfig autotune_config,
@@ -225,14 +234,24 @@ class Autotuner {
   absl::StatusOr<ConfigResult> PickBestConfig(
       std::vector<ConfigResult>& results);
 
-  std::optional<ScopedShapedBuffer> GetReferenceOutput(
-      std::vector<ExecutableCandidate>& candidates, InputBuffers& input_buffers)
+  // Assigns `output` to the first cluster whose representative matches within
+  // autotune_config_.relative_tolerance; creates a new cluster if no match.
+  // `is_trusted_config` marks the cluster as having a trustworthy-backend
+  // member (propagates through the OR of member trust flags). Returns the
+  // assigned cluster index.
+  int AssignToOutputCluster(std::vector<OutputCluster>& clusters,
+                            ScopedShapedBuffer& output, bool is_trusted_config)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(profiler_m_);
 
-  std::optional<Failure> CheckBuffers(InputBuffers& input_buffers,
-                                      ScopedShapedBuffer& output,
-                                      ScopedShapedBuffer& reference)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(profiler_m_);
+  // Stamps kWrongResults on every successful result that is not in the
+  // winning cluster. Winner: if any cluster has a trustworthy member, the
+  // largest among those; otherwise the largest overall. Earliest insertion
+  // wins on tie. `cluster_of_result[i]` is the cluster index of `results[i]`,
+  // or -1 if the config was not clustered (failed or check_buffers off).
+  void DemoteNonWinningClusterConfigs(
+      std::vector<ConfigResult>& results,
+      const std::vector<OutputCluster>& clusters,
+      const std::vector<int>& cluster_of_result);
   absl::Status IsValidExecutable(
       const absl::StatusOr<std::unique_ptr<Executable>>& executable) const;
 

--- a/xla/backends/autotuner/autotuner_test.cc
+++ b/xla/backends/autotuner/autotuner_test.cc
@@ -516,21 +516,24 @@ TEST_F(AutotunerTest, AutotuneWithBufferCheckFiltersWrongResults) {
   EXPECT_CALL(*backend_2, Compile(_, _))
       .WillOnce(Return(std::unique_ptr<Executable>()));
 
+  // Trusted config wins: its cluster is the only trusted one, so it wins
+  // regardless of the untrusted config's runtime.
   EXPECT_CALL(*backend_1, ApplyConfig(_, ConfigMatcher("test_config_1")))
-      .Times(1)
-      .WillRepeatedly(Return(absl::OkStatus()));
+      .WillOnce(Return(absl::OkStatus()));
 
   auto profiler = std::make_unique<MockProfiler>();
   ScopedShapedBuffer output_1(Shape(), nullptr, 0),
-      output_2(Shape(), nullptr, 0), output_3(Shape(), nullptr, 0);
+      output_2(Shape(), nullptr, 0);
   EXPECT_CALL(*profiler, CreateInputBuffers(_, _))
       .WillOnce(Return(std::make_unique<InputBuffers>()));
+  // Unified clustering path: one Profile per candidate (no pre-loop
+  // GetReferenceOutput). Trusted backend profiled first, untrusted second.
   EXPECT_CALL(*profiler, Profile(_, _))
       .WillOnce(Return(ProfileResult({absl::Seconds(2), std::move(output_1)})))
-      .WillOnce(Return(ProfileResult({absl::Seconds(2), std::move(output_2)})))
-      .WillOnce(Return(ProfileResult({absl::Seconds(1), std::move(output_3)})));
+      .WillOnce(Return(ProfileResult({absl::Seconds(1), std::move(output_2)})));
+  // One CheckOutputBuffer call: untrusted's output vs the trusted cluster's
+  // representative. Mismatch -> own (untrusted) cluster -> demoted.
   EXPECT_CALL(*profiler, CheckOutputBuffer(_, _, _))
-      .WillOnce(Return(absl::OkStatus()))
       .WillOnce(Return(absl::InternalError("Don't match")));
 
   std::vector<std::unique_ptr<CodegenBackend>> backends;
@@ -544,35 +547,109 @@ TEST_F(AutotunerTest, AutotuneWithBufferCheckFiltersWrongResults) {
   EXPECT_THAT(autotuner->Autotune(dummy_instr.get()), IsOk());
 }
 
-TEST_F(AutotunerTest, AutotuneSkipsBufferCheckWhenNoReferenceOutput) {
+TEST_F(AutotunerTest, AutotuneClustersOutputsWhenAllBackendsUntrusted) {
   config_.check_buffers = true;
 
+  // Three untrustworthy configs. Outputs split into a 2-member majority
+  // cluster and a 1-member minority cluster. The minority member is the
+  // globally fastest, but the majority cluster's fastest should be picked —
+  // proving that cluster size beats raw runtime when no backend is trusted.
   std::vector<std::unique_ptr<BackendConfig>> configs;
-  configs.push_back(GetTestConfig("test_config_1"));
-  configs.push_back(GetTestConfig("test_config_2"));
+  configs.push_back(GetTestConfig("majority_slow"));
+  configs.push_back(GetTestConfig("majority_fast"));
+  configs.push_back(GetTestConfig("minority_fastest"));
   auto backend = std::make_unique<MockCodegenBackendWithWrongResults>();
   EXPECT_CALL(*backend, GetSupportedConfigs)
       .WillOnce(Return(std::move(configs)));
   EXPECT_CALL(*backend, Compile(_, _))
-      .WillOnce(Return(std::unique_ptr<Executable>()))
-      .WillOnce(Return(std::unique_ptr<Executable>()));
+      .Times(3)
+      .WillRepeatedly([] { return std::unique_ptr<Executable>(); });
 
-  EXPECT_CALL(*backend, ApplyConfig(_, ConfigMatcher("test_config_1")))
-      .Times(1)
-      .WillRepeatedly(Return(absl::OkStatus()));
+  EXPECT_CALL(*backend, ApplyConfig(_, ConfigMatcher("majority_fast")))
+      .WillOnce(Return(absl::OkStatus()));
 
   auto profiler = std::make_unique<MockProfiler>();
-  ScopedShapedBuffer output_1(Shape(), nullptr, 0),
-      output_2(Shape(), nullptr, 0), output_3(Shape(), nullptr, 0);
+  ScopedShapedBuffer out_a1(Shape(), nullptr, 0), out_a2(Shape(), nullptr, 0),
+      out_b(Shape(), nullptr, 0);
   EXPECT_CALL(*profiler, CreateInputBuffers(_, _))
       .WillOnce(Return(std::make_unique<InputBuffers>()));
   EXPECT_CALL(*profiler, Profile(_, _))
-      .WillOnce(Return(ProfileResult({absl::Seconds(1), std::move(output_1)})))
-      .WillOnce(Return(ProfileResult({absl::Seconds(2), std::nullopt})));
-  EXPECT_CALL(*profiler, CheckOutputBuffer(_, _, _)).Times(0);
+      .WillOnce(Return(ProfileResult({absl::Seconds(3), std::move(out_a1)})))
+      .WillOnce(Return(ProfileResult({absl::Seconds(2), std::move(out_a2)})))
+      .WillOnce(Return(ProfileResult({absl::Seconds(1), std::move(out_b)})));
+  // Cluster assignment compares:
+  //   config 0 -> no clusters yet, creates cluster A (no call).
+  //   config 1 -> vs cluster A -> match, joins A.
+  //   config 2 -> vs cluster A -> mismatch, creates cluster B.
+  EXPECT_CALL(*profiler, CheckOutputBuffer(_, _, _))
+      .WillOnce(Return(absl::OkStatus()))
+      .WillOnce(Return(absl::InternalError("minority")));
 
   std::vector<std::unique_ptr<CodegenBackend>> backends;
   backends.push_back(std::move(backend));
+  ASSERT_OK_AND_ASSIGN(
+      auto autotuner,
+      Autotuner::Create(std::move(backends), std::move(profiler), config_,
+                        std::make_unique<MockAutotunerCache>()));
+  auto dummy_instr = HloInstruction::CreateConstant(LiteralUtil::CreateR0(1));
+  EXPECT_THAT(autotuner->Autotune(dummy_instr.get()), IsOk());
+}
+
+TEST_F(AutotunerTest, AutotuneTrustedClusterWinsOverLargerUntrustedCluster) {
+  config_.check_buffers = true;
+
+  // One trusted config vs three untrusted configs whose outputs agree with
+  // each other (but not with trusted). The untrusted cluster is 3x larger
+  // and globally fastest, but the trusted cluster still wins.
+  std::vector<std::unique_ptr<BackendConfig>> configs_1;
+  configs_1.push_back(GetTestConfig("trusted_config"));
+  auto backend_1 = std::make_unique<MockCodegenBackend>();
+  EXPECT_CALL(*backend_1, GetSupportedConfigs)
+      .WillOnce(Return(std::move(configs_1)));
+  EXPECT_CALL(*backend_1, Compile(_, _))
+      .WillOnce(Return(std::unique_ptr<Executable>()));
+
+  std::vector<std::unique_ptr<BackendConfig>> configs_2;
+  configs_2.push_back(GetTestConfig("untrusted_1"));
+  configs_2.push_back(GetTestConfig("untrusted_2"));
+  configs_2.push_back(GetTestConfig("untrusted_3"));
+  auto backend_2 = std::make_unique<MockCodegenBackendWithWrongResults>();
+  EXPECT_CALL(*backend_2, GetSupportedConfigs)
+      .WillOnce(Return(std::move(configs_2)));
+  EXPECT_CALL(*backend_2, Compile(_, _))
+      .Times(3)
+      .WillRepeatedly([] { return std::unique_ptr<Executable>(); });
+
+  EXPECT_CALL(*backend_1, ApplyConfig(_, ConfigMatcher("trusted_config")))
+      .WillOnce(Return(absl::OkStatus()));
+
+  auto profiler = std::make_unique<MockProfiler>();
+  ScopedShapedBuffer out_trusted(Shape(), nullptr, 0),
+      out_u1(Shape(), nullptr, 0), out_u2(Shape(), nullptr, 0),
+      out_u3(Shape(), nullptr, 0);
+  EXPECT_CALL(*profiler, CreateInputBuffers(_, _))
+      .WillOnce(Return(std::make_unique<InputBuffers>()));
+  EXPECT_CALL(*profiler, Profile(_, _))
+      .WillOnce(
+          Return(ProfileResult({absl::Seconds(10), std::move(out_trusted)})))
+      .WillOnce(Return(ProfileResult({absl::Seconds(1), std::move(out_u1)})))
+      .WillOnce(Return(ProfileResult({absl::Seconds(1), std::move(out_u2)})))
+      .WillOnce(Return(ProfileResult({absl::Seconds(1), std::move(out_u3)})));
+  // Cluster assignment compares (in order):
+  //   trusted -> creates cluster 0 (no call).
+  //   u1 vs cluster 0 -> mismatch -> creates cluster 1.           [call 1]
+  //   u2 vs cluster 0 -> mismatch; vs cluster 1 -> match.         [calls 2,3]
+  //   u3 vs cluster 0 -> mismatch; vs cluster 1 -> match.         [calls 4,5]
+  EXPECT_CALL(*profiler, CheckOutputBuffer(_, _, _))
+      .WillOnce(Return(absl::InternalError("u1 vs c0")))
+      .WillOnce(Return(absl::InternalError("u2 vs c0")))
+      .WillOnce(Return(absl::OkStatus()))
+      .WillOnce(Return(absl::InternalError("u3 vs c0")))
+      .WillOnce(Return(absl::OkStatus()));
+
+  std::vector<std::unique_ptr<CodegenBackend>> backends;
+  backends.push_back(std::move(backend_1));
+  backends.push_back(std::move(backend_2));
   ASSERT_OK_AND_ASSIGN(
       auto autotuner,
       Autotuner::Create(std::move(backends), std::move(profiler), config_,

--- a/xla/backends/autotuner/autotuner_test.cc
+++ b/xla/backends/autotuner/autotuner_test.cc
@@ -532,7 +532,7 @@ TEST_F(AutotunerTest, AutotuneWithBufferCheckFiltersWrongResults) {
       .WillOnce(Return(ProfileResult({absl::Seconds(2), std::move(output_1)})))
       .WillOnce(Return(ProfileResult({absl::Seconds(1), std::move(output_2)})));
   // One CheckOutputBuffer call: untrusted's output vs the trusted cluster's
-  // representative. Mismatch -> own (untrusted) cluster -> demoted.
+  // representative. Mismatch -> no cluster -> demoted.
   EXPECT_CALL(*profiler, CheckOutputBuffer(_, _, _))
       .WillOnce(Return(absl::InternalError("Don't match")));
 
@@ -635,21 +635,196 @@ TEST_F(AutotunerTest, AutotuneTrustedClusterWinsOverLargerUntrustedCluster) {
       .WillOnce(Return(ProfileResult({absl::Seconds(1), std::move(out_u1)})))
       .WillOnce(Return(ProfileResult({absl::Seconds(1), std::move(out_u2)})))
       .WillOnce(Return(ProfileResult({absl::Seconds(1), std::move(out_u3)})));
-  // Cluster assignment compares (in order):
-  //   trusted -> creates cluster 0 (no call).
-  //   u1 vs cluster 0 -> mismatch -> creates cluster 1.           [call 1]
-  //   u2 vs cluster 0 -> mismatch; vs cluster 1 -> match.         [calls 2,3]
-  //   u3 vs cluster 0 -> mismatch; vs cluster 1 -> match.         [calls 4,5]
+  // Once a trusted cluster exists, untrusted outputs only compare against
+  // trusted-backed clusters and cannot create loser clusters.
   EXPECT_CALL(*profiler, CheckOutputBuffer(_, _, _))
       .WillOnce(Return(absl::InternalError("u1 vs c0")))
       .WillOnce(Return(absl::InternalError("u2 vs c0")))
-      .WillOnce(Return(absl::OkStatus()))
-      .WillOnce(Return(absl::InternalError("u3 vs c0")))
-      .WillOnce(Return(absl::OkStatus()));
+      .WillOnce(Return(absl::InternalError("u3 vs c0")));
 
   std::vector<std::unique_ptr<CodegenBackend>> backends;
   backends.push_back(std::move(backend_1));
   backends.push_back(std::move(backend_2));
+  ASSERT_OK_AND_ASSIGN(
+      auto autotuner,
+      Autotuner::Create(std::move(backends), std::move(profiler), config_,
+                        std::make_unique<MockAutotunerCache>()));
+  auto dummy_instr = HloInstruction::CreateConstant(LiteralUtil::CreateR0(1));
+  EXPECT_THAT(autotuner->Autotune(dummy_instr.get()), IsOk());
+}
+
+TEST_F(AutotunerTest, AutotuneProfilesTrustedFirstPreservesCandidateOrder) {
+  config_.check_buffers = true;
+
+  std::vector<std::unique_ptr<BackendConfig>> untrusted_configs;
+  untrusted_configs.push_back(GetTestConfig("untrusted_first"));
+  auto untrusted_backend =
+      std::make_unique<MockCodegenBackendWithWrongResults>();
+  EXPECT_CALL(*untrusted_backend, GetSupportedConfigs)
+      .WillOnce(Return(std::move(untrusted_configs)));
+  std::unique_ptr<Executable> untrusted_executable =
+      RegisterSpillingExecutable(0);
+  Executable* untrusted_exec = untrusted_executable.get();
+  EXPECT_CALL(*untrusted_backend, Compile(_, _))
+      .WillOnce(Return(std::move(untrusted_executable)));
+
+  std::vector<std::unique_ptr<BackendConfig>> trusted_configs;
+  trusted_configs.push_back(GetTestConfig("trusted_second"));
+  auto trusted_backend = std::make_unique<MockCodegenBackend>();
+  EXPECT_CALL(*trusted_backend, GetSupportedConfigs)
+      .WillOnce(Return(std::move(trusted_configs)));
+  EXPECT_CALL(*trusted_backend, CanProduceWrongResults())
+      .WillRepeatedly(Return(false));
+  std::unique_ptr<Executable> trusted_executable =
+      RegisterSpillingExecutable(0);
+  Executable* trusted_exec = trusted_executable.get();
+  EXPECT_CALL(*trusted_backend, Compile(_, _))
+      .WillOnce(Return(std::move(trusted_executable)));
+
+  // The untrusted config is first in candidate order. It still wins the tie
+  // after both outputs join the trusted cluster, proving that profiling order
+  // does not leak into PickBestConfig tie-breaking.
+  EXPECT_CALL(*untrusted_backend,
+              ApplyConfig(_, ConfigMatcher("untrusted_first")))
+      .WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(*trusted_backend, ApplyConfig(_, _)).Times(0);
+
+  auto profiler = std::make_unique<MockProfiler>();
+  ScopedShapedBuffer out_trusted(Shape(), nullptr, 0),
+      out_untrusted(Shape(), nullptr, 0);
+  EXPECT_CALL(*profiler, CreateInputBuffers(_, _))
+      .WillOnce(Return(std::make_unique<InputBuffers>()));
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(*profiler, Profile(testing::Pointer(trusted_exec), _))
+        .WillOnce(
+            Return(ProfileResult({absl::Seconds(1), std::move(out_trusted)})));
+    EXPECT_CALL(*profiler, Profile(testing::Pointer(untrusted_exec), _))
+        .WillOnce(Return(
+            ProfileResult({absl::Seconds(1), std::move(out_untrusted)})));
+  }
+  EXPECT_CALL(*profiler, CheckOutputBuffer(_, _, _))
+      .WillOnce(Return(absl::OkStatus()));
+
+  std::vector<std::unique_ptr<CodegenBackend>> backends;
+  backends.push_back(std::move(untrusted_backend));
+  backends.push_back(std::move(trusted_backend));
+  ASSERT_OK_AND_ASSIGN(
+      auto autotuner,
+      Autotuner::Create(std::move(backends), std::move(profiler), config_,
+                        std::make_unique<MockAutotunerCache>()));
+  auto dummy_instr = HloInstruction::CreateConstant(LiteralUtil::CreateR0(1));
+  EXPECT_THAT(autotuner->Autotune(dummy_instr.get()), IsOk());
+}
+
+TEST_F(AutotunerTest, AutotuneUntrustedVotesForTrustedCluster) {
+  config_.check_buffers = true;
+
+  std::vector<std::unique_ptr<BackendConfig>> trusted_configs;
+  trusted_configs.push_back(GetTestConfig("trusted_a"));
+  trusted_configs.push_back(GetTestConfig("trusted_b"));
+  auto trusted_backend = std::make_unique<MockCodegenBackend>();
+  EXPECT_CALL(*trusted_backend, GetSupportedConfigs)
+      .WillOnce(Return(std::move(trusted_configs)));
+  EXPECT_CALL(*trusted_backend, Compile(_, _)).Times(2).WillRepeatedly([] {
+    return std::unique_ptr<Executable>();
+  });
+
+  std::vector<std::unique_ptr<BackendConfig>> untrusted_configs;
+  untrusted_configs.push_back(GetTestConfig("untrusted_matches_b"));
+  untrusted_configs.push_back(GetTestConfig("untrusted_matches_none"));
+  auto untrusted_backend =
+      std::make_unique<MockCodegenBackendWithWrongResults>();
+  EXPECT_CALL(*untrusted_backend, GetSupportedConfigs)
+      .WillOnce(Return(std::move(untrusted_configs)));
+  EXPECT_CALL(*untrusted_backend, Compile(_, _)).Times(2).WillRepeatedly([] {
+    return std::unique_ptr<Executable>();
+  });
+
+  EXPECT_CALL(*untrusted_backend,
+              ApplyConfig(_, ConfigMatcher("untrusted_matches_b")))
+      .WillOnce(Return(absl::OkStatus()));
+
+  auto profiler = std::make_unique<MockProfiler>();
+  ScopedShapedBuffer out_trusted_a(Shape(), nullptr, 0),
+      out_trusted_b(Shape(), nullptr, 0), out_untrusted_b(Shape(), nullptr, 0),
+      out_untrusted_none(Shape(), nullptr, 0);
+  EXPECT_CALL(*profiler, CreateInputBuffers(_, _))
+      .WillOnce(Return(std::make_unique<InputBuffers>()));
+  EXPECT_CALL(*profiler, Profile(_, _))
+      .WillOnce(
+          Return(ProfileResult({absl::Seconds(10), std::move(out_trusted_a)})))
+      .WillOnce(
+          Return(ProfileResult({absl::Seconds(9), std::move(out_trusted_b)})))
+      .WillOnce(
+          Return(ProfileResult({absl::Seconds(1), std::move(out_untrusted_b)})))
+      .WillOnce(Return(
+          ProfileResult({absl::Seconds(1), std::move(out_untrusted_none)})));
+  // trusted_b creates the second trusted cluster. The first untrusted config
+  // votes for it, making it the largest trusted-backed cluster. The second
+  // untrusted config matches no trusted cluster and is demoted.
+  EXPECT_CALL(*profiler, CheckOutputBuffer(_, _, _))
+      .WillOnce(Return(absl::InternalError("trusted_b vs trusted_a")))
+      .WillOnce(Return(absl::InternalError("untrusted_b vs trusted_a")))
+      .WillOnce(Return(absl::OkStatus()))
+      .WillOnce(Return(absl::InternalError("untrusted_none vs trusted_a")))
+      .WillOnce(Return(absl::InternalError("untrusted_none vs trusted_b")));
+
+  std::vector<std::unique_ptr<CodegenBackend>> backends;
+  backends.push_back(std::move(trusted_backend));
+  backends.push_back(std::move(untrusted_backend));
+  ASSERT_OK_AND_ASSIGN(
+      auto autotuner,
+      Autotuner::Create(std::move(backends), std::move(profiler), config_,
+                        std::make_unique<MockAutotunerCache>()));
+  auto dummy_instr = HloInstruction::CreateConstant(LiteralUtil::CreateR0(1));
+  EXPECT_THAT(autotuner->Autotune(dummy_instr.get()), IsOk());
+}
+
+TEST_F(AutotunerTest, AutotuneClustersUntrustedWhenTrustedReferenceFails) {
+  config_.check_buffers = true;
+
+  std::vector<std::unique_ptr<BackendConfig>> trusted_configs;
+  trusted_configs.push_back(GetTestConfig("trusted_fails"));
+  auto trusted_backend = std::make_unique<MockCodegenBackend>();
+  EXPECT_CALL(*trusted_backend, GetSupportedConfigs)
+      .WillOnce(Return(std::move(trusted_configs)));
+  EXPECT_CALL(*trusted_backend, Compile(_, _))
+      .WillOnce(Return(std::unique_ptr<Executable>()));
+
+  std::vector<std::unique_ptr<BackendConfig>> untrusted_configs;
+  untrusted_configs.push_back(GetTestConfig("majority_slow"));
+  untrusted_configs.push_back(GetTestConfig("majority_fast"));
+  untrusted_configs.push_back(GetTestConfig("minority_fastest"));
+  auto untrusted_backend =
+      std::make_unique<MockCodegenBackendWithWrongResults>();
+  EXPECT_CALL(*untrusted_backend, GetSupportedConfigs)
+      .WillOnce(Return(std::move(untrusted_configs)));
+  EXPECT_CALL(*untrusted_backend, Compile(_, _)).Times(3).WillRepeatedly([] {
+    return std::unique_ptr<Executable>();
+  });
+
+  EXPECT_CALL(*untrusted_backend,
+              ApplyConfig(_, ConfigMatcher("majority_fast")))
+      .WillOnce(Return(absl::OkStatus()));
+
+  auto profiler = std::make_unique<MockProfiler>();
+  ScopedShapedBuffer out_a1(Shape(), nullptr, 0), out_a2(Shape(), nullptr, 0),
+      out_b(Shape(), nullptr, 0);
+  EXPECT_CALL(*profiler, CreateInputBuffers(_, _))
+      .WillOnce(Return(std::make_unique<InputBuffers>()));
+  EXPECT_CALL(*profiler, Profile(_, _))
+      .WillOnce(Return(absl::InternalError("trusted failed")))
+      .WillOnce(Return(ProfileResult({absl::Seconds(3), std::move(out_a1)})))
+      .WillOnce(Return(ProfileResult({absl::Seconds(2), std::move(out_a2)})))
+      .WillOnce(Return(ProfileResult({absl::Seconds(1), std::move(out_b)})));
+  EXPECT_CALL(*profiler, CheckOutputBuffer(_, _, _))
+      .WillOnce(Return(absl::OkStatus()))
+      .WillOnce(Return(absl::InternalError("minority")));
+
+  std::vector<std::unique_ptr<CodegenBackend>> backends;
+  backends.push_back(std::move(trusted_backend));
+  backends.push_back(std::move(untrusted_backend));
   ASSERT_OK_AND_ASSIGN(
       auto autotuner,
       Autotuner::Create(std::move(backends), std::move(profiler), config_,


### PR DESCRIPTION
📝 Summary of Changes
Make the autotuner's pass/fail outcome deterministic when no codegen backend provides a trusted reference output.
Every successful profile's output is assigned to a cluster: either an existing one whose representative matches (under relative_tolerance) or a new one. Each cluster tracks has_trusted_member: set iff at least one member comes from a backend with CanProduceWrongResults() = false. After the profile loop, the winning cluster is picked: among clusters containing a trusted member, the largest one wins. If no cluster has a trusted member, the largest overall wins (earliest insertion breaks ties). Non-winning cluster members are demoted with kWrongResults. The existing PickBestConfig then selects the fastest survivor, i.e. the fastest member of the winning cluster.

**Assumption:** most configs implement the same algorithm and most of them produce correct output. The "majority" cluster is therefore correct. The additional memory/compute cost is low: number of cluster is small.

🎯 Justification
  The flake we observed: `TritonTest.FuseChannelDequantization` drives an int4 GEMM fusion through `AutotunerPass`. For that fusion only the Triton backend emits any configs (CUDNN / cuBLAS / cuBLAS-LT produce zero candidates, and
  CUBLASLT_FISSION is disabled in the test). Every Triton config has `CanProduceWrongResults() == true`, so post-profile the autotuner has no trustworthy reference to compare against. The selection rule reduces to "pick the fastest config", and when two configs with differing outputs have near-equal timings (the repro had configs at ~12 µs where one produced correct output and one produced wrong output) measurement noise decides which one wins.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N/A — correctness/determinism fix. With `check_buffers = true`, per-iteration work goes from one buffer comparison to between 1 and C output comparisons (C = number of clusters seen so far, expected to be small with stated assumptions).
memory overhead is C-1 extra output buffers held for the pass duration. The `check_buffers = false` path is unchanged.
**Possible extension:** We can add parameter to cap C. This will still guarantee determinism but not majority selection. With max_C=1 it resolves to the "first config is a reference" strategy, removing overhead but sacrificing correctness under the assumption of correct majority.

🧪 Unit Tests:
  `xla/backends/autotuner/autotuner_test.cc`:
  - `AutotuneClustersOutputsWhenAllBackendsUntrusted`: three untrusted configs split into a 2-member majority cluster and a 1-member minority cluster whose member is the globally fastest. Verifies the majority cluster's fastest member is picked, not the global fastest.
  - `AutotuneTrustedClusterWinsOverLargerUntrustedCluster`: one trusted config vs three agreeing-but-untrusted configs (3× larger cluster and faster). Verifies the trusted cluster wins.
  - Existing `AutotuneWithBufferCheckFiltersWrongResults` updated to the unified clustering path.
