### PR TITLE
[XLA:GPU] Fix SolLatencyEstimator cost for nested Triton GEMM fusions

### DIFF
--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -858,5 +858,18 @@ bool IsTritonFusedComputation(const HloComputation& computation) {
                  .kind() == kTritonGemmFusionKind;
 }
 
+bool IsTritonGemm(const HloInstruction& instr) {
+  if (instr.opcode() != HloOpcode::kFusion ||
+      instr.called_computations().size() != 1) {
+    return false;
+  }
+  if (!IsGpuFusionKind(instr, kTritonGemmFusionKind) &&
+      !IsGpuFusionKind(instr, kTritonNestedGemmFusionKind)) {
+    return false;
+  }
+  return absl::c_count_if(instr.fused_instructions(),
+                          HloPredicateIsOp<HloOpcode::kDot>) == 1;
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/xla/backends/gpu/codegen/triton/support.h
+++ b/xla/backends/gpu/codegen/triton/support.h
@@ -66,6 +66,11 @@ CodegenDecision IsTritonSupportedComputation(
 // `kTritonGemmFusionKind`.
 bool IsTritonFusedComputation(const HloComputation& computation);
 
+// Returns `true` if `instr` is a kFusion containing exactly one kDot and
+// whose backend config kind is one of the Triton GEMM fusion kinds
+// (`kTritonGemmFusionKind` or `kTritonNestedGemmFusionKind`).
+bool IsTritonGemm(const HloInstruction& instr);
+
 namespace internal {
 // TODO(b/363981282): Remove the function below once all ops are tested via
 // HLOs. This is exposed for testing purposes only and will be removed in the

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -481,9 +481,38 @@ std::unique_ptr<LatencyEstimator> GetLatencyEstimator(
       ReadPGLEProfile(module.config(), fingerprint);
 
   if (profile.has_value()) {
+    std::unique_ptr<LatencyEstimator> base_estimator;
+    if (SolLatencyEstimator::IsSupportedForModule(module, gpu_device_info)) {
+      auto cost_analysis =
+          std::make_unique<GpuHloCostAnalysis>(GpuHloCostAnalysis::Options{
+              ShapeSizeBytesFunction(pointer_size),
+              /*per_second_rates=*/{},
+              /*min_latencies_seconds=*/{},
+              /*count_multiple_input_accesses=*/true,
+          });
+      if (absl::Status status =
+              module.entry_computation()->Accept(cost_analysis.get());
+          status.ok()) {
+        auto sol = SolLatencyEstimator::Create(
+            config, std::move(gpu_latency_estimator), gpu_device_info,
+            ShapeSizeBytesFunction(pointer_size), module.entry_computation(),
+            mlir_context, std::move(cost_analysis));
+        if (sol.ok()) {
+          base_estimator = std::move(*sol);
+          VLOG(1) << "PGLE fallback: using SolLatencyEstimator";
+        }
+      }
+    }
+    if (base_estimator == nullptr) {
+      base_estimator =
+          gpu_latency_estimator
+              ? std::move(gpu_latency_estimator)
+              : std::make_unique<GpuLatencyEstimator>(pointer_size);
+      VLOG(1) << "PGLE fallback: using GpuLatencyEstimator (T-shirt sizes)";
+    }
     auto aggregator = std::make_unique<GPUProfileStatisticsAggregator>();
     auto pg_latency_estimator = std::make_unique<ProfileGuidedLatencyEstimator>(
-        config, std::move(gpu_latency_estimator), profile.value(),
+        config, std::move(base_estimator), profile.value(),
         std::move(aggregator));
     LOG(INFO) << "Found profile for module " << module.name()
               << ", using profile guided latency estimator";

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -500,14 +500,15 @@ std::unique_ptr<LatencyEstimator> GetLatencyEstimator(
         if (sol.ok()) {
           base_estimator = std::move(*sol);
           VLOG(1) << "PGLE fallback: using SolLatencyEstimator";
+        } else {
+          base_estimator = std::make_unique<GpuLatencyEstimator>(pointer_size);
+          VLOG(1) << "PGLE fallback: using GpuLatencyEstimator (T-shirt sizes),"
+                  << " SolLatencyEstimator creation failed: " << sol.status();
         }
       }
     }
     if (base_estimator == nullptr) {
-      base_estimator =
-          gpu_latency_estimator
-              ? std::move(gpu_latency_estimator)
-              : std::make_unique<GpuLatencyEstimator>(pointer_size);
+      base_estimator = std::move(gpu_latency_estimator);
       VLOG(1) << "PGLE fallback: using GpuLatencyEstimator (T-shirt sizes)";
     }
     auto aggregator = std::make_unique<GPUProfileStatisticsAggregator>();

--- a/xla/service/gpu/model/BUILD
+++ b/xla/service/gpu/model/BUILD
@@ -1109,7 +1109,6 @@ cc_library(
         "//xla/service/gpu:gpu_latency_hiding_scheduler",
         "//xla/stream_executor:device_description",
         "//xla/tsl/platform:statusor",
-        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",

--- a/xla/service/gpu/model/matmul_interpolator.cc
+++ b/xla/service/gpu/model/matmul_interpolator.cc
@@ -83,17 +83,6 @@ struct InterpolationSpecificationFlops {
   int64_t flops;
 };
 
-bool IsTritonGemm(const HloInstruction& instr) {
-  if (instr.called_computations().size() != 1) {
-    return false;
-  }
-  if (!IsTritonFusedComputation(*instr.called_computations()[0])) {
-    return false;
-  }
-  auto fused_range = instr.fused_instructions();
-  return absl::c_count_if(fused_range, HloPredicateIsOp<HloOpcode::kDot>) == 1;
-}
-
 InterpolationSpecification ExtractDotSpec(const DotDimensionNumbers& dot_dims,
                                           const Shape& lhs, const Shape& rhs,
                                           const Shape& out) {

--- a/xla/service/gpu/model/matmul_interpolator_test.cc
+++ b/xla/service/gpu/model/matmul_interpolator_test.cc
@@ -15,8 +15,6 @@ limitations under the License.
 
 #include "xla/service/gpu/model/matmul_interpolator.h"
 
-#include <time.h>
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -31,6 +29,7 @@ limitations under the License.
 #include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "google/protobuf/text_format.h"
+#include <time.h>
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/parser/hlo_parser.h"
@@ -759,6 +758,41 @@ TEST_F(MatmulInterpolatorTest, SupportsDotTritonFusion) {
               "num_ctas":"1"
             }
           },
+        }
+    }
+)";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnUnverifiedModule(hlo));
+  const HloInstruction& custom_call =
+      *module->entry_computation()->root_instruction();
+  EXPECT_EQ(*interpolator().EstimatedRuntime(custom_call), absl::Seconds(1));
+}
+
+TEST_F(MatmulInterpolatorTest, SupportsDotTritonNestedGemmFusion) {
+  absl::string_view hlo = R"(
+    HloModule m
+
+    comp {
+      p0 = bf16[1024,1024] parameter(0)
+      p1 = bf16[1024,1024] parameter(1)
+      ROOT dot = bf16[1024,1024] dot(p0,p1), lhs_contracting_dims={0}, rhs_contracting_dims={1}
+    }
+
+    ENTRY e {
+      p0 = bf16[1024,1024] parameter(0)
+      p1 = bf16[1024,1024] parameter(1)
+      ROOT _ =  bf16[1024,1024] fusion(p0,p1),
+        kind=kCustom,
+        calls=comp,
+        backend_config={
+          "fusion_backend_config": {
+            "kind":"__triton_nested_gemm_fusion",
+            "block_level_fusion_config":{
+              "output_tiles":[{"sizes":["64","32"]}],
+              "num_stages":"2",
+              "num_warps":"8",
+              "num_ctas":"1"
+            }
+          }
         }
     }
 )";

--- a/xla/service/gpu/model/sol_gpu_cost_model_stats_collection.cc
+++ b/xla/service/gpu/model/sol_gpu_cost_model_stats_collection.cc
@@ -19,7 +19,6 @@ limitations under the License.
 #include <memory>
 #include <utility>
 
-#include "absl/algorithm/container.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -33,6 +32,7 @@ limitations under the License.
 #include "xla/service/gpu/cublas_cudnn.h"
 #include "xla/service/gpu/gpu_hlo_schedule.h"
 #include "xla/service/gpu/gpu_latency_hiding_scheduler.h"
+#include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/model/gpu_hlo_cost_analysis.h"
 #include "xla/service/gpu/model/sol_latency_estimator.h"
 #include "xla/service/latency_hiding_scheduler.h"
@@ -41,17 +41,6 @@ limitations under the License.
 namespace xla::gpu {
 
 namespace {
-
-bool IsTritonGemm(const HloInstruction& instr) {
-  if (instr.called_computations().size() != 1) {
-    return false;
-  }
-  if (!IsTritonFusedComputation(*instr.called_computations()[0])) {
-    return false;
-  }
-  auto fused_range = instr.fused_instructions();
-  return absl::c_count_if(fused_range, HloPredicateIsOp<HloOpcode::kDot>) == 1;
-}
 
 // Returns true if successfully set the reification cost.
 bool SetReificationCost(HloInstruction* instr, double cost_us) {

--- a/xla/service/gpu/model/sol_gpu_cost_model_stats_collection.cc
+++ b/xla/service/gpu/model/sol_gpu_cost_model_stats_collection.cc
@@ -32,7 +32,6 @@ limitations under the License.
 #include "xla/service/gpu/cublas_cudnn.h"
 #include "xla/service/gpu/gpu_hlo_schedule.h"
 #include "xla/service/gpu/gpu_latency_hiding_scheduler.h"
-#include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/model/gpu_hlo_cost_analysis.h"
 #include "xla/service/gpu/model/sol_latency_estimator.h"
 #include "xla/service/latency_hiding_scheduler.h"


### PR DESCRIPTION
📝 Summary of Changes
- Hoist IsTritonGemm into xla/backends/gpu/codegen/triton/support.{cc,h}, which matches both kTritonGemmFusionKind and kTritonNestedGemmFusionKind with a single kDot. 
- In gpu_hlo_schedule.cc::GetLatencyEstimator, wrap ProfileGuidedLatencyEstimator with SolLatencyEstimator (when supported) instead of GpuLatencyEstimator's T-shirt sizes; fall back to GpuLatencyEstimator if SOL can't be built.
- Add MatmulInterpolatorTest.SupportsDotTritonNestedGemmFusion.

🎯 Justification
- IsTritonGemm predicates missed __triton_nested_gemm_fusion, so the SOL cost model assigned no reification cost to nested Triton GEMMs and produced inaccurate latency estimates.
- When PGLE coverage is partial, the wrapped fallback drives un-profiled ops; using SOL there is much more precise than coarse T-shirt sizing.

🚀 Kind of Contribution
🐛 Bug Fix, 🧪 Tests

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
MatmulInterpolatorTest.SupportsDotTritonNestedGemmFusion.

🧪 Execution Tests:
Tested with Llama3.1-405b on B200 (2 x 8)
