### PR TITLE
add `ClearMemoryStats` to pjrt_c_api

### DIFF
--- a/xla/pjrt/c_api_client/pjrt_c_api_client.cc
+++ b/xla/pjrt/c_api_client/pjrt_c_api_client.cc
@@ -2020,6 +2020,24 @@ absl::StatusOr<std::intptr_t> PjRtCApiDevice::GetStreamForExternalReadyEvents()
   return args.stream;
 }
 
+absl::Status PjRtCApiDevice::ClearMemoryStats() {
+  const PJRT_Api* c_api = client_->pjrt_c_api();
+  if (c_api->PJRT_Device_ClearMemoryStats == nullptr) {
+    return absl::UnimplementedError(
+        "ClearMemoryStats is not supported by the loaded PJRT plugin.");
+  }
+
+  PJRT_Device_ClearMemoryStats_Args args;
+  args.struct_size = PJRT_Device_ClearMemoryStats_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.device = device_;
+
+  RETURN_STATUS_IF_PJRT_ERROR(c_api->PJRT_Device_ClearMemoryStats(&args),
+                              c_api);
+
+  return absl::OkStatus();
+}
+
 void PjRtCApiDevice::InitAttributes() {
   PJRT_Device_GetAttributes_Args args;
   args.struct_size = PJRT_Device_GetAttributes_Args_STRUCT_SIZE;

--- a/xla/pjrt/c_api_client/pjrt_c_api_client.h
+++ b/xla/pjrt/c_api_client/pjrt_c_api_client.h
@@ -209,6 +209,8 @@ class PjRtCApiDevice : public PjRtDevice {
   absl::StatusOr<std::intptr_t> GetStreamForExternalReadyEvents()
       const override;
 
+  absl::Status ClearMemoryStats() override;
+
  private:
   // Initializes device specific attributes.
   void InitAttributes();

--- a/xla/pjrt/c_api_client/pjrt_c_api_client_test.cc
+++ b/xla/pjrt/c_api_client/pjrt_c_api_client_test.cc
@@ -1039,5 +1039,19 @@ TEST(PjRtCApiClientTest, Bitcast) {
   EXPECT_EQ(shared_literal->data<int32_t>(), expected);
 }
 
+TEST(PjRtCApiClientTest, ClearMemoryStats) {
+  SetUpCpuPjRtApi();
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<PjRtClient> client,
+                          GetCApiClient("cpu"));
+  ASSERT_GT(client->addressable_devices().size(), 0);
+  PjRtDevice* device = client->addressable_devices()[0];
+
+  absl::Status clear_status = device->ClearMemoryStats();
+
+  if (!clear_status.ok()) {
+    EXPECT_TRUE(absl::IsUnimplemented(clear_status));
+  }
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/python/ifrt/client_impl_test_lib.cc
+++ b/xla/python/ifrt/client_impl_test_lib.cc
@@ -107,6 +107,18 @@ TEST(ClientImplTest, DefaultDeviceAssignment) {
   }
 }
 
+TEST(ClientImplTest, ClearMemoryStats) {
+  TF_ASSERT_OK_AND_ASSIGN(auto client, test_util::GetClient());
+  ASSERT_GT(client->devices().size(), 0);
+  Device* device = client->devices()[0];
+
+  absl::Status clear_status = device->ClearMemoryStats();
+
+  if (!clear_status.ok()) {
+    EXPECT_TRUE(absl::IsUnimplemented(clear_status));
+  }
+}
+
 }  // namespace
 }  // namespace ifrt
 }  // namespace xla

--- a/xla/python/ifrt/client_impl_test_lib.cc
+++ b/xla/python/ifrt/client_impl_test_lib.cc
@@ -109,13 +109,25 @@ TEST(ClientImplTest, DefaultDeviceAssignment) {
 
 TEST(ClientImplTest, ClearMemoryStats) {
   TF_ASSERT_OK_AND_ASSIGN(auto client, test_util::GetClient());
-  ASSERT_GT(client->devices().size(), 0);
-  Device* device = client->devices()[0];
+  ASSERT_GT(client->addressable_devices().size(), 0);
+  Device* device = client->addressable_devices()[0];
 
   absl::Status clear_status = device->ClearMemoryStats();
 
   if (!clear_status.ok()) {
     EXPECT_TRUE(absl::IsUnimplemented(clear_status));
+  }
+}
+
+TEST(ClientImplTest, ClearMemoryStatsOnNonAddressableDeviceFails) {
+  TF_ASSERT_OK_AND_ASSIGN(auto client, test_util::GetClient());
+  for (Device* device : client->devices()) {
+    if (device->IsAddressable()) continue;
+    absl::Status clear_status = device->ClearMemoryStats();
+    EXPECT_FALSE(clear_status.ok());
+    EXPECT_TRUE(absl::IsFailedPrecondition(clear_status) ||
+                absl::IsUnimplemented(clear_status))
+        << clear_status;
   }
 }
 

--- a/xla/python/ifrt/device.h
+++ b/xla/python/ifrt/device.h
@@ -108,6 +108,10 @@ class Device : public llvm::RTTIExtends<Device, llvm::RTTIRoot> {
   }
 
   static char ID;  // NOLINT
+
+  virtual absl::Status ClearMemoryStats() const {
+    return absl::UnimplementedError("ClearMemoryStats is not supported");
+  }
 };
 
 typedef absl::AnyInvocable<absl::Status(

--- a/xla/python/pjrt_ifrt/pjrt_device.cc
+++ b/xla/python/pjrt_ifrt/pjrt_device.cc
@@ -76,5 +76,9 @@ absl::Span<Memory* const> PjRtDevice::Memories() const { return memories_; }
 
 int PjRtDevice::ProcessIndex() const { return process_index_; }
 
+absl::Status PjRtDevice::ClearMemoryStats() const {
+  return pjrt_device_->ClearMemoryStats();
+}
+
 }  // namespace ifrt
 }  // namespace xla

--- a/xla/python/pjrt_ifrt/pjrt_device.cc
+++ b/xla/python/pjrt_ifrt/pjrt_device.cc
@@ -77,6 +77,10 @@ absl::Span<Memory* const> PjRtDevice::Memories() const { return memories_; }
 int PjRtDevice::ProcessIndex() const { return process_index_; }
 
 absl::Status PjRtDevice::ClearMemoryStats() const {
+  if (!IsAddressable()) {
+    return absl::FailedPreconditionError(
+        "ClearMemoryStats is only supported on addressable devices.");
+  }
   return pjrt_device_->ClearMemoryStats();
 }
 

--- a/xla/python/pjrt_ifrt/pjrt_device.h
+++ b/xla/python/pjrt_ifrt/pjrt_device.h
@@ -69,6 +69,8 @@ class PjRtDevice final
 
   static char ID;  // NOLINT
 
+  absl::Status ClearMemoryStats() const override;
+
  private:
   friend class PjRtClient;
 


### PR DESCRIPTION
Plumbing to expose `PJRT_Device_ClearMemoryStats` (implemented in #41175) through the `PjRtCApiDevice` and IFRT Device interfaces. This is the necessary C API/IFRT follow-up to support resetting peak memory tracking downstream.