### PR TITLE
[ROCm] Skip F64 dot operation paths in Triton backend for ROCm

### DIFF
--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -392,7 +392,6 @@ CodegenDecision IsSupportedDotAlgorithm(
     case PrecisionConfig::ALG_UNSET:
     case PrecisionConfig::ALG_DOT_F16_F16_F16:
     case PrecisionConfig::ALG_DOT_F32_F32_F32:
-    case PrecisionConfig::ALG_DOT_F64_F64_F64:
     case PrecisionConfig::ALG_DOT_F16_F16_F32:
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32:
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32_X3:
@@ -400,6 +399,11 @@ CodegenDecision IsSupportedDotAlgorithm(
     case PrecisionConfig::ALG_DOT_TF32_TF32_F32:
     case PrecisionConfig::ALG_DOT_TF32_TF32_F32_X3:
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32_X9:
+      return CodegenDecision::Allow();
+    case PrecisionConfig::ALG_DOT_F64_F64_F64:
+      if (gpu_version.IsRocm()) {
+        break;
+      }
       return CodegenDecision::Allow();
     case PrecisionConfig::ALG_DOT_BF16_BF16_BF16:
       if (gpu_version.IsRocm()) {
@@ -433,12 +437,17 @@ CodegenDecision AreTypesSupportedByAlgUnsetDot(
     }
   }
 
-  std::vector<PrimitiveType> supported_float_types = {BF16, F16,      F32,
-                                                      F64,  F8E4M3FN, F8E5M2};
+  std::vector<PrimitiveType> supported_float_types = {BF16, F16, F32, F8E4M3FN,
+                                                      F8E5M2};
   if (gpu_version.IsRocm()) {
+    // The F64 type for dot operations in Triton is not currently supported
+    // on ROCm so it is excluded.
     supported_float_types.insert(supported_float_types.end(),
                                  {F8E4M3FNUZ, F8E5M2FNUZ});
+  } else {
+    supported_float_types.push_back(F64);
   }
+
   if (absl::c_linear_search(supported_float_types, input_type)) {
     return CodegenDecision::Allow();
   }


### PR DESCRIPTION
📝 Summary of Changes
A recent commit in XLA (https://github.com/openxla/xla/commit/e742f5b857) moved invocations of `legacy_triton::IsTritonSupportedInstruction` to `IsTritonSupportedInstruction`. Previously, this call had implicitly skipped F64 dot operations in the Triton backend on ROCm because they are not fully supported yet. This allowed for hipBLAS to take over. With the new call, the Triton backend is invoked causing autotuner errors. This PR forbids invocation of the Triton backend on ROCm for F64 dot operations allowing hipBLAS to take over and resume prior behavior.

Changes are contained to `xla/backends/gpu/codegen/triton/support.cc`.
- `IsSupportedDotAlgorithm` now breaks and returns `CodegenDecision::Forbid` if F64 is used on ROCm
- `AreTypesSupportedByAlgUnsetDot` only marks the F64 type as supported if not on ROCm.


🎯 Justification
Several unit tests were failing in JAX in 64-bit mode on ROCm. These were appearing as autotuner errors in XLA. The failing JAX unit tests are as follows:
- `sparse_bcoo_bcsr_test.py::BCOOTest::test_bcoo_rdot_general1`
- `sparse_bcoo_bcsr_test.py::BCOOTest::test_bcoo_dot_general1`

With this patch, they are now passing.

🚀 Kind of Contribution
🐛 Bug Fix
