### PR TITLE
Avoid nonnegative inference for signed integer squares

### DIFF
--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -535,7 +535,8 @@ bool AlgebraicSimplifierVisitor::IsNonNegative(
   }
   switch (hlo->opcode()) {
     case HloOpcode::kMultiply: {
-      return hlo->operand(0) == hlo->operand(1);
+      return hlo->operand(0) == hlo->operand(1) &&
+             !primitive_util::IsSignedIntegralType(hlo->shape().element_type());
     }
     case HloOpcode::kAbs:
     case HloOpcode::kExp:

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -10810,6 +10810,39 @@ TEST_F(AlgebraicSimplifierTest, AbsEliminationMultiply) {
               GmockMatch(m::Multiply(m::Parameter(0), m::Parameter(0))));
 }
 
+TEST_F(AlgebraicSimplifierTest, NoAbsEliminationSignedIntegerMultiply) {
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule m
+    test {
+      p = s8[32]{0} parameter(0)
+      m = s8[32]{0} multiply(p, p)
+      ROOT a = s8[32]{0} abs(m)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  EXPECT_FALSE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Abs(m::Multiply(m::Parameter(0), m::Parameter(0)))));
+}
+
+TEST_F(AlgebraicSimplifierTest, NoCompareLtZeroFoldSignedIntegerMultiply) {
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule m
+    test {
+      p = s8[32]{0} parameter(0)
+      m = s8[32]{0} multiply(p, p)
+      z = s8[] constant(0)
+      b = s8[32]{0} broadcast(z), dimensions={}
+      ROOT r = pred[32]{0} compare(m, b), direction=LT
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  EXPECT_FALSE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Compare(m::Multiply(m::Parameter(0), m::Parameter(0)),
+                                    m::Broadcast(m::ConstantScalar(0)))));
+}
+
 TEST_F(AlgebraicSimplifierTest, AbsEliminationPower2) {
   constexpr absl::string_view kModuleStr = R"(
     HloModule m


### PR DESCRIPTION
Signed integer multiplication can overflow and wrap to a negative value, so treating `multiply(x, x)` as always non-negative is not sound for signed integral element types.

This can let algebraic simplification fold comparisons such as `(x * x) < 0` or remove `abs(x * x)`, changing observable behavior for overflow-sensitive programs.

This change keeps the existing inference for floating-point and unsigned types, but avoids it for signed integral types unless a stronger no-overflow proof is added later.

Regression coverage added for `s8`:

- preserving `abs(multiply(p, p))`
- preserving `compare(multiply(p, p), 0), direction=LT`

Related TensorFlow issue: tensorflow/tensorflow#117142

Local validation:

- `git diff --check`
- Reproduced tensorflow/tensorflow#117142 with TensorFlow 2.21.0 on macOS arm64 CPU

Not run locally:

- Bazel C++ tests; bazel/bazelisk is not installed in this environment.
