### PR TITLE
[xla:gpu] Use strongly typed RankId for peer_addr()

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -524,6 +524,7 @@ cc_library(
     visibility = ["//xla/stream_executor/cuda:__subpackages__"],
     deps = [
         ":nccl_errors",
+        "//xla/core/collectives:rank_id",
         "//xla/core/collectives:symmetric_memory",
         "//xla/stream_executor:device_address",
         "//xla/tsl/cuda:nccl",

--- a/xla/backends/gpu/collectives/nccl_symmetric_memory.cc
+++ b/xla/backends/gpu/collectives/nccl_symmetric_memory.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 #include "xla/backends/gpu/collectives/nccl_errors.h"
+#include "xla/core/collectives/rank_id.h"
 #include "xla/stream_executor/device_address.h"
 
 // Include NCCL after XLA headers.
@@ -76,11 +77,11 @@ NcclSymmetricMemory::multimem_addr() const {
 }
 
 absl::StatusOr<stream_executor::DeviceAddressBase>
-NcclSymmetricMemory::peer_addr(int peer_rank) const {
+NcclSymmetricMemory::peer_addr(RankId peer) const {
 #if (NCCL_VERSION_CODE >= 22900)
   void* peer_addr = nullptr;
   XLA_NCCL_RETURN_IF_ERROR(
-      ncclGetLsaDevicePointer(win_, 0, peer_rank, &peer_addr));
+      ncclGetLsaDevicePointer(win_, 0, peer.value(), &peer_addr));
   if (peer_addr) {
     return stream_executor::DeviceAddressBase(peer_addr, addr_.size());
   }

--- a/xla/backends/gpu/collectives/nccl_symmetric_memory.h
+++ b/xla/backends/gpu/collectives/nccl_symmetric_memory.h
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include "absl/status/statusor.h"
 #include "third_party/nccl/nccl.h"
+#include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/symmetric_memory.h"
 #include "xla/stream_executor/device_address.h"
 
@@ -40,7 +41,7 @@ class NcclSymmetricMemory final : public SymmetricMemory {
       const final;
 
   absl::StatusOr<stream_executor::DeviceAddressBase> peer_addr(
-      int peer_rank) const final;
+      RankId peer) const final;
 
   ncclWindow_t win() const { return win_; }
 

--- a/xla/backends/gpu/tests/collective_ops_ffi_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_ffi_test.cc
@@ -579,8 +579,8 @@ static absl::Status SymPeerAllReduce(
           .LoadKernel<Peer2AllReduce>(collective_params->executor));
 
   // Get peer addresses for src buffer.
-  TF_ASSIGN_OR_RETURN(auto src0, sym_src->peer_addr(0));
-  TF_ASSIGN_OR_RETURN(auto src1, sym_src->peer_addr(1));
+  TF_ASSIGN_OR_RETURN(auto src0, sym_src->peer_addr(RankId(0)));
+  TF_ASSIGN_OR_RETURN(auto src1, sym_src->peer_addr(RankId(1)));
 
   if (!src0 || !src1) {
     return absl::InternalError("Peer address can't be resolved");

--- a/xla/core/collectives/BUILD
+++ b/xla/core/collectives/BUILD
@@ -139,6 +139,7 @@ cc_library(
     name = "symmetric_memory",
     hdrs = ["symmetric_memory.h"],
     deps = [
+        ":rank_id",
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:kernel_args",
         "@com_google_absl//absl/status",

--- a/xla/core/collectives/symmetric_memory.h
+++ b/xla/core/collectives/symmetric_memory.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
+#include "xla/core/collectives/rank_id.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/kernel_args.h"
 
@@ -49,7 +50,7 @@ class SymmetricMemory {
   // Useful for clients who need to pass peer addresses directly as a kernel
   // arguments instead of calculating a peer address from the kernel itself.
   virtual absl::StatusOr<stream_executor::DeviceAddressBase> peer_addr(
-      int peer_rank) const {
+      RankId rank) const {
     return absl::UnimplementedError("Peer address not supported");
   }
 


### PR DESCRIPTION
Prefer strong types for passing communicator ranks