### PR TITLE
[NVIDIA GPU] Add a knob for scheduling collectives as early as possible

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -459,6 +459,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_dot_merger_threshold_mb(64);
   opts.set_xla_enable_fast_math(false);
   opts.set_xla_gpu_experimental_parallel_collective_overlap_limit(1);
+  opts.set_xla_gpu_experimental_collective_start_as_early_as_possible(false);
   opts.set_xla_gpu_experimental_parallel_async_compute_limit(2);
   opts.set_xla_pjrt_allow_auto_layout_in_hlo(false);
   opts.set_xla_gpu_enable_scatter_determinism_expander(false);
@@ -2763,6 +2764,14 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "This controls how many in-flight collectives "
       "latency hiding scheduler can schedule."));
   flag_list->push_back(tsl::Flag(
+      "xla_gpu_experimental_collective_start_as_early_as_possible",
+      bool_setter_for(
+          &DebugOptions::
+              set_xla_gpu_experimental_collective_start_as_early_as_possible),
+      debug_options
+          ->xla_gpu_experimental_collective_start_as_early_as_possible(),
+      "This controls whether collectives should start as early as possible."));
+  flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_parallel_async_compute_limit",
       int32_setter_for(
           &DebugOptions::set_xla_gpu_experimental_parallel_async_compute_limit),
@@ -3327,8 +3336,7 @@ FlagStatus GetFlagStatus(absl::string_view flag_name) {
           "xla_gpu_all_reduce_combine_threshold_bytes",
           "xla_gpu_autotune_level",
           "xla_gpu_collective_permute_decomposer_threshold",
-          "xla_gpu_cublas_fallback",
-          "xla_gpu_dot_merger_threshold_mb",
+          "xla_gpu_cublas_fallback", "xla_gpu_dot_merger_threshold_mb",
           "xla_gpu_enable_dynamic_slice_fusion",
           "xla_gpu_enable_latency_hiding_scheduler",
           "xla_gpu_enable_pipelined_all_gather",

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -676,13 +676,11 @@ absl::Status RunLatencyHidingSchedulerPasses(
     pipeline.AddPass<PGLEAccuracyChecker>(
         dynamic_cast<ProfileGuidedLatencyEstimator&>(*estimator));
   }
-  // If overlap limit is set to be greater than 1 and the default t-short size
-  // estimator is used we will tell LHS to extend async-done intervals as much
-  // as possible to start collectives as early as possible.
-  bool prioritize_compute_over_async_start = false;
-  if (config.parallel_collective_overlap_limit > 1) {
-    prioritize_compute_over_async_start = true;
-  }
+  // It's more beneficial to prioritize compute over async start when we have
+  // more async ops in parallel.
+  bool prioritize_compute_over_async_start =
+      config.parallel_collective_overlap_limit > 1 &&
+      options.xla_gpu_experimental_collective_start_as_early_as_possible();
   auto async_tracker = std::make_unique<GpuAsyncTracker>(config);
 
   std::shared_ptr<const SchedulingContext> scheduling_context =

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -72,13 +72,16 @@ class GpuLatencyHidingSchedulerBaseTest
   absl::StatusOr<HloModule*> ScheduleModule(
       HloModule* module, int64_t num_parallel_resources = 1,
       DebugOptions::PGLEStrictnessLevel strictness =
-          DebugOptions::PGLE_STRICTNESS_LEVEL_ERROR) {
+          DebugOptions::PGLE_STRICTNESS_LEVEL_ERROR,
+      bool enable_early_collective_start = false) {
     stream_executor::DeviceDescription gpu_device_info =
         TestGpuDeviceInfo::CudaOrRocmDeviceInfo();
     GpuAliasInfo alias_info(gpu_device_info);
     DebugOptions& options = module->mutable_config().mutable_debug_options();
     options.set_xla_gpu_experimental_parallel_collective_overlap_limit(
         num_parallel_resources);
+    options.set_xla_gpu_experimental_collective_start_as_early_as_possible(
+        enable_early_collective_start);
     options.set_xla_gpu_pgle_accuracy_checker(strictness);
 
     RETURN_IF_ERROR(ScheduleGpuModule(module, /*pointer_size=*/8,
@@ -1129,7 +1132,8 @@ ENTRY main {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(kHloModule, config));
 
-  TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/16));
+  TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/16,
+                              DebugOptions::PGLE_STRICTNESS_LEVEL_ERROR, true));
   const HloSchedule& schedule = module->schedule();
   std::vector<HloInstruction*> instruction_sequence =
       schedule.sequence(module->entry_computation()).instructions();

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -921,6 +921,16 @@ message DebugOptions {
   //   coll.2-done = collective(coll.2-start)
   optional int32 xla_gpu_experimental_parallel_collective_overlap_limit = 336;
 
+  // Enabling this with larger overlap limit for compute bound graphs is beneficial,
+  // as it maximizes the async-start and done interval.
+  // However, in some extreme communication bound scenarios, even though the scheduling
+  // looks good, some compute kernel launches are pushed back during runtime
+  // since the collectives are bundled too closely which consume a lot of the
+  // resources on GPU. The resource utilization is being addressed in comms library
+  // so for now we will need a flag to toggle this scheduling behavior for different
+  // scenarios.
+  optional bool xla_gpu_experimental_collective_start_as_early_as_possible = 489;
+
   optional PipelineParallelismOptLevel
       xla_gpu_experimental_pipeline_parallelism_opt_level = 351;
 
@@ -1579,7 +1589,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 489
+  // Next id: 490
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
Add a control knob to tell LHS to always schedule collectives before compute instead of relying on overlap limit flag.