### PR TITLE
[XLA:GPU] Set collective command buffers to highest priority

### DIFF
--- a/xla/backends/gpu/runtime/collective_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_thunk.cc
@@ -420,9 +420,7 @@ absl::StatusOr<const se::CommandBuffer::Command*> CollectiveThunk::Record(
         return absl::OkStatus();
       }));
 
-  if (priority() != se::StreamPriority::Default) {
-    RETURN_IF_ERROR(nested_cmd->SetPriority(priority()));
-  }
+  RETURN_IF_ERROR(nested_cmd->SetPriority(se::StreamPriority::Highest));
 
   if (auto* create = std::get_if<RecordCreate>(&record_action)) {
     return command_buffer->CreateChildCommand(*nested_cmd,


### PR DESCRIPTION
  📝 Summary of Changes
  Updates CollectiveThunk::Record to explicitly set the nested traced command buffer priority to se::StreamPriority::Highest before attaching it as a child command.

  🎯 Justification
  CollectiveThunk::Record captures RunCollective into a nested command buffer, then inserts that capture into the enclosing command buffer as a child command. The priority needs to be applied directly to the nested command buffer because the captured graph does not reliably inherit the intended scheduling priority from the outer command buffer path.

  Without this explicit SetPriority(Highest), collective work recorded through command buffers can remain at default priority. That weakens scheduling behavior for NCCL collectives and other GPU collective workloads where high-priority collective progress is important relative to surrounding compute.

  🚀 Kind of Contribution
  🐛 Bug Fix

  📊 Benchmark (for Performance Improvements)
  N/A. This is a priority propagation fix, not a benchmarked performance change.

  🧪 Unit Tests:
  No new unit tests added.

  🧪 Execution Tests:
  No new execution tests added.
