### PR TITLE
add_conv_window_restore_and_amax_support

### DIFF
--- a/xla/backends/gpu/transforms/conv_kind_assignment.cc
+++ b/xla/backends/gpu/transforms/conv_kind_assignment.cc
@@ -541,7 +541,11 @@ absl::StatusOr<bool> RunOnComputation(HloComputation* computation,
   std::vector<HloInstruction*> convs;
   for (auto* hlo : computation->instructions()) {
     if (HloPredicateIsOp<HloOpcode::kConvolution>(hlo)) {
-      convs.push_back(hlo);
+      ConvolutionKind convolution_kind =
+        DynCast<HloConvolutionInstruction>(hlo)->convolution_kind();
+      if (convolution_kind == CONVOLUTION_KIND_UNSET) {
+        convs.push_back(hlo);
+      }
     }
   }
 

--- a/xla/backends/gpu/transforms/cudnn_fusion_compiler.cc
+++ b/xla/backends/gpu/transforms/cudnn_fusion_compiler.cc
@@ -178,7 +178,9 @@ inline std::optional<fe::DataType_t> ToCudnnDataType(const PrimitiveType type) {
 inline std::optional<fe::DataType_t> GetComputeDataType(
     const PrimitiveType type) {
   fe::DataType_t compute_dtype = fe::DataType_t::FLOAT;
-  if (primitive_util::IsIntegralType(type)) {
+  if (type == F64) {
+    compute_dtype = fe::DataType_t::DOUBLE;
+  } else if (primitive_util::IsIntegralType(type)) {
 #if CUDNN_VERSION >= 90100
     compute_dtype = fe::DataType_t::INT32;
 #else
@@ -552,6 +554,8 @@ HandleConstantHloToCudnnGraph(const HloInstruction& hlo, graph::Graph& graph) {
   }
   PrimitiveType constant_type = hlo.shape().element_type();
   switch (constant_type) {
+    case F16:
+      return LiteralToCudnnTensor<F16, __half>(hlo, graph);
     case BF16:
       return LiteralToCudnnTensor<BF16, __nv_bfloat16>(hlo, graph);
     case F32:
@@ -594,6 +598,37 @@ HandleClampToCudnnGraph(
                              .set_mode(fe::PointwiseMode_t::MAX)
                              .set_compute_data_type(compute_dtype);
   return graph.pointwise(min_tensor, hlo_to_cudnn[hlo.operand(0)], max_attrs);
+}
+
+std::optional<std::shared_ptr<graph::Tensor_attributes>>
+HandleExpMinusOneToCudnnGraph(
+    const HloInstruction& hlo, graph::Graph& graph,
+    absl::flat_hash_map<const HloInstruction*,
+                        std::shared_ptr<graph::Tensor_attributes>>
+        hlo_to_cudnn,
+    fe::DataType_t compute_dtype) {
+  CHECK(hlo.opcode() == HloOpcode::kExpm1)
+      << "HLO is not a Exp-minus-one: " << hlo.ToShortString();
+  CHECK(hlo.operands().size() == 1)
+      << "Exp-minus-one requires to have 1 operand: " << hlo.ToShortString();
+  // exp-minus-one = exp(value) - 1;
+  const auto exp_attrs = graph::Pointwise_attributes()
+                             .set_mode(fe::PointwiseMode_t::EXP)
+                             .set_compute_data_type(compute_dtype);
+  std::shared_ptr<graph::Tensor_attributes> exp_tensor =
+      graph.pointwise(hlo_to_cudnn[hlo.operand(0)], exp_attrs);
+  const std::optional<fe::DataType_t> data_type =
+      ToCudnnDataType(hlo.shape().element_type());
+  if (!data_type.has_value()) {
+    VLOG(3) << "Unimplemented data type: "
+            << PrimitiveType_Name(hlo.shape().element_type());
+    return std::nullopt;
+  }
+  exp_tensor->set_data_type(*data_type).set_name(std::string(hlo.name()));
+  const auto minus_attrs = graph::Pointwise_attributes()
+                               .set_mode(fe::PointwiseMode_t::SUB)
+                               .set_compute_data_type(compute_dtype);
+  return graph.pointwise(exp_tensor, graph.tensor(1), minus_attrs);
 }
 
 // Traverses fusion computations and creates cuDNN graphs out of them.
@@ -648,12 +683,6 @@ absl::StatusOr<std::optional<se::gpu::CudnnGraph>> HloFusionToCuDnnGraph(
   };
 
   if (conv_adapter.has_value()) {
-    for (const HloInstruction* operand : conv_adapter->conv_.operands()) {
-      if (!HloPredicateIsOp<HloOpcode::kParameter>(operand)) {
-        VLOG(3) << "Conv operands are expected to be parameters.";
-        return std::nullopt;
-      }
-    }
     for (const HloInstruction* parameter :
          computation.parameter_instructions()) {
       // for now, we assume all parameters have same layout even if they are not
@@ -717,11 +746,17 @@ absl::StatusOr<std::optional<se::gpu::CudnnGraph>> HloFusionToCuDnnGraph(
     auto operand = [&hlo_to_cudnn, &hlo](int i) {
       return hlo_to_cudnn[hlo->operand(i)];
     };
-    if (HloPredicateIsOp<HloOpcode::kParameter>(hlo)) {
+
+    if (HloPredicateIsOp<HloOpcode::kConvert>(hlo) && hlo->user_count() == 1 &&
+        HloPredicateIsOp<HloOpcode::kConvolution>(hlo->users()[0])) {
+      // consume converts of inputs to conv, conv can do fp32 = conv(fp8, fp8)
+      // and int32 = conv(int8, int8)
+      hlo_to_cudnn[hlo] = operand(0);
+      continue;
+    } else if (HloPredicateIsOp<HloOpcode::kParameter>(hlo)) {
       CHECK(hlo_to_cudnn.contains(hlo));
       continue;
-    }
-    if (HloPredicateIsOp<HloOpcode::kCustomCall>(hlo)) {
+    } else if (HloPredicateIsOp<HloOpcode::kCustomCall>(hlo)) {
       if (hlo->user_count() != 1 ||
           !IsWorkspaceAllocationRoot(*hlo->users()[0])) {
         VLOG(3) << "Custom calls are only expected to be used for workspace "
@@ -729,16 +764,14 @@ absl::StatusOr<std::optional<se::gpu::CudnnGraph>> HloFusionToCuDnnGraph(
         return std::nullopt;
       }
       continue;
-    }
-    if (HloPredicateIsOp<HloOpcode::kTuple>(hlo)) {
-      if (!IsWorkspaceAllocationRoot(*hlo)) {
+    } else if (HloPredicateIsOp<HloOpcode::kTuple>(hlo)) {
+      if (!IsWorkspaceAllocationRoot(*hlo) && !IsAmaxRoot(*hlo)) {
         VLOG(3) << "Tuples are only expected at outputs for workspace "
                    "allocation.";
         return std::nullopt;
       }
       continue;
-    }
-    if (HloPredicateIsOp<HloOpcode::kConstant>(hlo)) {
+    } else if (HloPredicateIsOp<HloOpcode::kConstant>(hlo)) {
       if (const auto const_tensor = HandleConstantHloToCudnnGraph(*hlo, graph);
           const_tensor.has_value()) {
         hlo_to_cudnn[hlo] = const_tensor.value();
@@ -764,6 +797,13 @@ absl::StatusOr<std::optional<se::gpu::CudnnGraph>> HloFusionToCuDnnGraph(
           return std::nullopt;
         }
         hlo_to_cudnn[hlo] = clamp.value();
+      } else if (HloPredicateIsOp<HloOpcode::kExpm1>(hlo)) {
+        const auto expm1 = HandleExpMinusOneToCudnnGraph(
+            *hlo, graph, hlo_to_cudnn, compute_dtype.value());
+        if (!expm1.has_value()) {
+          return std::nullopt;
+        }
+        hlo_to_cudnn[hlo] = expm1.value();
       } else {
         const auto mode = GetElementwiseMode(*hlo);
         if (!mode.has_value()) {
@@ -848,7 +888,10 @@ absl::StatusOr<std::optional<se::gpu::CudnnGraph>> HloFusionToCuDnnGraph(
           graph::Matmul_attributes().set_compute_data_type(*compute_dtype));
     } else if (HloPredicateIsOp<HloOpcode::kConvolution>(hlo)) {
       // translate conv windows to cudnn conv attr
-      const Window& window = DynCast<HloConvolutionInstruction>(hlo)->window();
+      std::optional<Window> window_opt =
+          RestoreWindow(DynCast<HloConvolutionInstruction>(hlo));
+      CHECK(window_opt.has_value());
+      Window window = window_opt.value();
       std::vector<int64_t> pre_padding, post_padding, stride, dilation;
       for (int64_t i = 0; i < window.dimensions_size(); ++i) {
         const auto& dim = window.dimensions(i);
@@ -910,6 +953,11 @@ absl::StatusOr<std::optional<se::gpu::CudnnGraph>> HloFusionToCuDnnGraph(
       hlo_to_cudnn[hlo] =
           graph.moe_grouped_matmul(operand(0), operand(1), operand(2), nullptr,
                                    nullptr, moe_grouped_matmul_attr);
+    } else if (HloPredicateIsOp<HloOpcode::kReduce>(hlo)) {
+      hlo_to_cudnn[hlo] = graph.reduction(
+          operand(0), graph::Reduction_attributes()
+                          .set_mode(fe::ReductionMode_t::AMAX)
+                          .set_compute_data_type(fe::DataType_t::FLOAT));
     } else {
       VLOG(3) << "Unimplemented operation.";
       return std::nullopt;
@@ -929,30 +977,40 @@ absl::StatusOr<std::optional<se::gpu::CudnnGraph>> HloFusionToCuDnnGraph(
         ->set_data_type(data_type.value())
         .set_name(std::string(hlo->name()));
   }
-  const HloInstruction* output = instructions.back();
+
+  std::vector<HloInstruction*> outputs;
   if (instructions.back()->shape().IsTuple()) {
-    output = instructions.back()->operand(0);
-  }
-
-  std::optional<Result> dims = std::nullopt;
-  if (conv_adapter.has_value()) {
-    dims = conv_adapter->DimensionsAndStrides(*output);
-  } else if (ragged_dot_adapter.has_value()) {
-    dims = ragged_dot_adapter->DimensionsAndStrides(*output);
+    for (auto operand : instructions.back()->operands()) {
+      if (!operand->IsCustomCall(kWorkspaceAllocationCustomCallTarget)) {
+        outputs.push_back(operand);
+      }
+    }
   } else {
-    dims = gemm_adapter->DimensionsAndStrides(
-        *output, TritonFusionAnalysis::Scope::OUTPUT);
+    outputs.push_back(instructions.back());
   }
 
-  if (!dims.has_value()) {
-    VLOG(3) << "Unsupported dimensions.";
-    return std::nullopt;
+  for (int i = 0; i < outputs.size(); ++i) {
+    HloInstruction* output = outputs[i];
+    std::optional<Result> dims = std::nullopt;
+    if (conv_adapter.has_value()) {
+      dims = conv_adapter->DimensionsAndStrides(*output);
+    } else if (ragged_dot_adapter.has_value()) {
+      dims = ragged_dot_adapter->DimensionsAndStrides(*output);
+    } else {
+      dims = gemm_adapter->DimensionsAndStrides(
+          *output, TritonFusionAnalysis::Scope::OUTPUT);
+    }
+    if (!dims.has_value()) {
+      VLOG(3) << "Unsupported dimensions.";
+      return std::nullopt;
+    }
+    hlo_to_cudnn[output]
+        ->set_output(true)
+        .set_dim(dims->sizes)
+        .set_stride(dims->strides)
+        .set_uid(se::gpu::CuDnnTensorUID(fusion.operand_count() + i));
   }
-  hlo_to_cudnn[output]
-      ->set_output(true)
-      .set_dim(dims->sizes)
-      .set_stride(dims->strides)
-      .set_uid(se::gpu::CuDnnTensorUID(fusion.operand_count()));
+
   if (!fusion.GetModule()->config().debug_options().xla_dump_to().empty()) {
     json dump;
     graph.serialize(dump);
@@ -989,17 +1047,37 @@ absl::StatusOr<HloInstruction*> AddWorkspace(HloInstruction& fusion,
       computation->AddInstruction(HloInstruction::CreateCustomCall(
           ShapeUtil::MakeShape(S8, {workspace_size}), {},
           kWorkspaceAllocationCustomCallTarget));
-  HloInstruction* output_tuple =
-      computation->AddInstruction(HloInstruction::CreateTuple(
-          {computation->root_instruction(), custom_call}));
+  HloInstruction* output_tuple;
+  bool is_tuple_output =
+      computation->root_instruction()->opcode() == HloOpcode::kTuple;
+  if (is_tuple_output) {
+    std::vector<HloInstruction*> operands;
+    operands.insert(operands.begin(),
+                    computation->root_instruction()->operands().begin(),
+                    computation->root_instruction()->operands().end());
+    operands.push_back(custom_call);
+    output_tuple =
+        computation->AddInstruction(HloInstruction::CreateTuple(operands));
+    TF_RETURN_IF_ERROR(computation->ReplaceInstructionWithDifferentShape(
+        computation->root_instruction(), output_tuple));
+  } else {
+    output_tuple = computation->AddInstruction(HloInstruction::CreateTuple(
+        {computation->root_instruction(), custom_call}));
+  }
   computation->set_root_instruction(output_tuple, true);
   HloInstruction* new_fusion = fusion.parent()->AddInstruction(
       fusion.CloneWithNewShape(output_tuple->shape()));
   TF_RETURN_IF_ERROR(new_fusion->CopyAllControlDepsFrom(&fusion));
   TF_RETURN_IF_ERROR(fusion.DropAllControlDeps());
-  TF_RETURN_IF_ERROR(fusion.ReplaceAllUsesWith(fusion.parent()->AddInstruction(
-      HloInstruction::CreateGetTupleElement(new_fusion, 0))));
-  TF_RETURN_IF_ERROR(fusion.parent()->RemoveInstruction(&fusion));
+  if (is_tuple_output) {
+    TF_RETURN_IF_ERROR(fusion.parent()->ReplaceInstructionWithDifferentShape(
+        &fusion, new_fusion));
+  } else {
+    TF_RETURN_IF_ERROR(
+        fusion.ReplaceAllUsesWith(fusion.parent()->AddInstruction(
+            HloInstruction::CreateGetTupleElement(new_fusion, 0))));
+    TF_RETURN_IF_ERROR(fusion.parent()->RemoveInstruction(&fusion));
+  }
   return new_fusion;
 }
 

--- a/xla/service/gpu/cudnn_support_utils.cc
+++ b/xla/service/gpu/cudnn_support_utils.cc
@@ -218,10 +218,14 @@ CudnnInferTransposeForBiasReordering(const Shape& shape) {
 
 bool IsWorkspaceAllocationRoot(const HloInstruction& root) {
   return root.IsRoot() && root.opcode() == HloOpcode::kTuple &&
-         root.operand_count() == 2 &&
-         root.operand(1)->IsCustomCall(kWorkspaceAllocationCustomCallTarget) &&
-         root.operand(1)->operand_count() == 0;
+         root.operand(root.operand_count() - 1)
+             ->IsCustomCall(kWorkspaceAllocationCustomCallTarget) &&
+         root.operand(root.operand_count() - 1)->operand_count() == 0;
 }
 
+bool IsAmaxRoot(const HloInstruction& root) {
+  return root.IsRoot() && root.opcode() == HloOpcode::kTuple &&
+         root.operand(1)->opcode() == HloOpcode::kReduce;
+}
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/cudnn_support_utils.h
+++ b/xla/service/gpu/cudnn_support_utils.h
@@ -75,7 +75,7 @@ inline constexpr absl::string_view kWorkspaceAllocationCustomCallTarget =
 
 // Detects `ROOT tuple(..., custom-call())` used to allocate workspace buffers.
 bool IsWorkspaceAllocationRoot(const HloInstruction& root);
-
+bool IsAmaxRoot(const HloInstruction& root);
 }  // namespace gpu
 }  // namespace xla
 


### PR DESCRIPTION
📝 Summary of Changes
1. the window of dgrad needs to be restored to what fprop is so cudnn can understand it
2. conv assignment should skip any conv that is already assigned with a kind
3. support conv fusion with additional reduce
4. some activation support like Elu

