### PR TITLE
[xla] Add benchmarks + perf optimizations for BFC allocator

### DIFF
--- a/xla/tsl/framework/BUILD
+++ b/xla/tsl/framework/BUILD
@@ -190,11 +190,11 @@ cc_library(
         "//xla/tsl/lib/core:bits",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:logging",
-        "//xla/tsl/platform:types",
         "//xla/tsl/profiler/utils:trace_filter_utils",
         "//xla/tsl/protobuf:bfc_memory_map_proto_cc",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/numeric:bits",
         "@com_google_absl//absl/strings",
@@ -214,10 +214,13 @@ tsl_cc_test(
     deps = [
         ":allocator",
         ":bfc_allocator",
+        "//xla/tsl/platform:env",
         "//xla/tsl/platform:env_impl",  # buildcleaner: keep
         "//xla/tsl/platform:test",
+        "//xla/tsl/platform:test_benchmark",
+        "//xla/tsl/platform:test_main",
         "@com_google_absl//absl/base",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_absl//absl/synchronization",
         "@tsl//tsl/platform:platform_port",
     ],
 )

--- a/xla/tsl/framework/allocator_retry.cc
+++ b/xla/tsl/framework/allocator_retry.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "xla/tsl/framework/allocator_retry.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <optional>
 
@@ -23,7 +24,6 @@ limitations under the License.
 #include "absl/time/time.h"
 #include "xla/tsl/framework/metrics.h"
 #include "xla/tsl/platform/env.h"
-#include "xla/tsl/platform/types.h"
 
 namespace tsl {
 

--- a/xla/tsl/framework/bfc_allocator.cc
+++ b/xla/tsl/framework/bfc_allocator.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/base/casts.h"
+#include "absl/base/optimization.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/numeric/bits.h"
@@ -239,11 +240,10 @@ BFCAllocator::ChunkHandle BFCAllocator::AllocateChunk() {
     Chunk* c = ChunkFromHandle(h);
     free_chunks_list_ = c->next;
     return h;
-  } else {
-    ChunkHandle h = chunks_.size();
-    chunks_.resize(h + 1);
-    return h;
   }
+  ChunkHandle h = chunks_.size();
+  chunks_.resize(h + 1);
+  return h;
 }
 
 void BFCAllocator::DeallocateChunk(ChunkHandle h) {
@@ -262,22 +262,23 @@ void* BFCAllocator::AllocateRawInternalWithRetry(
   if (allocation_attr.freed_by_func != nullptr) {
     freed_by_count = (*allocation_attr.freed_by_func)();
   }
+
   void* r = AllocateRawInternal(alignment, num_bytes, false, freed_by_count);
-  if (r != nullptr) {
-    return r;
-  } else {
-    static const int64_t kMaxMillisToWait = 10000;  // 10 seconds
-    r = retry_helper_.AllocateRaw(
-        [this, &allocation_attr](size_t a, size_t nb, bool v) {
-          uint64_t freed_by_count = 0;
-          if (allocation_attr.freed_by_func != nullptr) {
-            freed_by_count = (*allocation_attr.freed_by_func)();
-          }
-          return AllocateRawInternal(a, nb, v, freed_by_count);
-        },
-        kMaxMillisToWait, alignment, num_bytes);
+  if (ABSL_PREDICT_TRUE(r != nullptr)) {
     return r;
   }
+
+  static const int64_t kMaxMillisToWait = 10000;  // 10 seconds
+  r = retry_helper_.AllocateRaw(
+      [this, &allocation_attr](size_t a, size_t nb, bool v) {
+        uint64_t freed_by_count = 0;
+        if (allocation_attr.freed_by_func != nullptr) {
+          freed_by_count = (*allocation_attr.freed_by_func)();
+        }
+        return AllocateRawInternal(a, nb, v, freed_by_count);
+      },
+      kMaxMillisToWait, alignment, num_bytes);
+  return r;
 }
 
 void* BFCAllocator::AllocateRaw(size_t alignment, size_t num_bytes,
@@ -325,10 +326,8 @@ void* BFCAllocator::AllocateRaw(size_t alignment, size_t num_bytes,
         }
       }
       return res;
-    } else {
-      return AllocateRawInternalWithRetry(alignment, num_bytes,
-                                          allocation_attr);
     }
+    return AllocateRawInternalWithRetry(alignment, num_bytes, allocation_attr);
   }();
   VLOG(3) << "AllocateRaw " << Name() << "  " << num_bytes << " " << result;
   VLOG(4) << "[mem-debug] AllocateRaw," << Name() << "," << num_bytes << ","
@@ -439,7 +438,7 @@ void BFCAllocator::DeallocateRegions(
 void* BFCAllocator::AllocateRawInternal(size_t alignment, size_t num_bytes,
                                         bool dump_log_on_failure,
                                         uint64_t freed_before) {
-  if (num_bytes == 0) {
+  if (ABSL_PREDICT_FALSE(num_bytes == 0)) {
     VLOG(2) << "tried to allocate 0 bytes";
     return nullptr;
   }
@@ -457,13 +456,13 @@ void* BFCAllocator::AllocateRawInternal(size_t alignment, size_t num_bytes,
   BinNum bin_num = BinNumForSize(rounded_bytes);
 
   absl::MutexLock l(mutex_);
-  if (!timestamped_chunks_.empty()) {
+  if (ABSL_PREDICT_FALSE(!timestamped_chunks_.empty())) {
     // Merge timestamped chunks whose counts have become safe for general use.
     MergeTimestampedChunks(0);
   }
   void* ptr =
       FindChunkPtr(bin_num, rounded_bytes, num_bytes, alignment, freed_before);
-  if (ptr != nullptr) {
+  if (ABSL_PREDICT_TRUE(ptr != nullptr)) {
     AddTraceMe("MemoryAllocation", ptr);
     return ptr;
   }
@@ -592,7 +591,8 @@ void* BFCAllocator::FindChunkPtr(BinNum bin_num, size_t rounded_bytes,
       BFCAllocator::ChunkHandle h = (*citer);
       BFCAllocator::Chunk* chunk = ChunkFromHandle(h);
       DCHECK(!chunk->in_use());
-      if (freed_before > 0 && freed_before < chunk->freed_at_count) {
+      if (ABSL_PREDICT_FALSE(freed_before > 0) &&
+          freed_before < chunk->freed_at_count) {
         continue;
       }
 
@@ -758,7 +758,7 @@ void BFCAllocator::DeallocateRawInternal(void* ptr) {
   MarkFree(h);
 
   // Consider coalescing it.
-  if (timing_counter_) {
+  if (ABSL_PREDICT_FALSE(timing_counter_ != nullptr)) {
     InsertFreeChunkIntoBin(h);
     timestamped_chunks_.push_back(h);
   } else {
@@ -851,7 +851,7 @@ void BFCAllocator::MarkFree(BFCAllocator::ChunkHandle h) {
   c->allocation_id = -1;
 
   // Optionally record the free time.
-  if (timing_counter_) {
+  if (ABSL_PREDICT_FALSE(timing_counter_ != nullptr)) {
     c->freed_at_count = timing_counter_->next();
   }
 
@@ -870,7 +870,9 @@ void BFCAllocator::MarkFree(BFCAllocator::ChunkHandle h) {
 BFCAllocator::ChunkHandle BFCAllocator::TryToCoalesce(ChunkHandle h,
                                                       bool ignore_freed_at) {
   Chunk* c = ChunkFromHandle(h);
-  if ((!ignore_freed_at) && c->freed_at_count > 0) return h;
+  if ((!ignore_freed_at) && c->freed_at_count > 0) {
+    return h;
+  }
   ChunkHandle coalesced_chunk = h;
 
   // If the next chunk is free, merge it into c and delete it.
@@ -903,9 +905,8 @@ void BFCAllocator::SetSafeFrontier(uint64_t count) {
     if (safe_frontier_.compare_exchange_strong(current, count)) {
       retry_helper_.NotifyDealloc();
       return;
-    } else {
-      current = safe_frontier_.load(std::memory_order_relaxed);
     }
+    current = safe_frontier_.load(std::memory_order_relaxed);
   }
 }
 
@@ -958,7 +959,9 @@ bool BFCAllocator::MergeTimestampedChunks(size_t required_bytes) {
     // merged and deallocated in a prior iteration so refetch the handle and
     // retest.
     ChunkHandle h = region_manager_.get_handle(ptr);
-    if (h == kInvalidChunkHandle) continue;
+    if (h == kInvalidChunkHandle) {
+      continue;
+    }
     if (required_bytes == 0 || !satisfied) {
       Chunk* c = ChunkFromHandle(h);
       DCHECK_NE(c->bin_num, kInvalidBinNum);

--- a/xla/tsl/framework/bfc_allocator.h
+++ b/xla/tsl/framework/bfc_allocator.h
@@ -24,12 +24,12 @@ limitations under the License.
 #include <deque>
 #include <memory>
 #include <optional>
-#include <set>
 #include <string>
 #include <vector>
 
 #include "absl/base/casts.h"
 #include "absl/base/thread_annotations.h"
+#include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -164,10 +164,10 @@ class BFCAllocator : public Allocator {
 
   // A ChunkHandle is an index into the chunks_ vector in BFCAllocator
   // kInvalidChunkHandle means an invalid chunk
-  typedef size_t ChunkHandle;
+  using ChunkHandle = size_t;
   static constexpr ChunkHandle kInvalidChunkHandle = SIZE_MAX;
 
-  typedef int BinNum;
+  using BinNum = int;
   static constexpr int kInvalidBinNum = -1;
   // The following means that the largest bin'd chunk size is 256 << 21 = 512MB.
   static constexpr int kNumBins = 21;
@@ -275,7 +275,7 @@ class BFCAllocator : public Allocator {
       BFCAllocator* allocator_;  // The parent allocator
     };
 
-    typedef std::set<ChunkHandle, ChunkComparator> FreeChunkSet;
+    using FreeChunkSet = absl::btree_set<ChunkHandle, ChunkComparator>;
     // List of free chunks within the bin, sorted by chunk size.
     // Chunk * not owned.
     FreeChunkSet free_chunks;
@@ -370,7 +370,7 @@ class BFCAllocator : public Allocator {
   class RegionManager {
    public:
     RegionManager() = default;
-    ~RegionManager() {}
+    ~RegionManager() = default;
 
     void AddAllocationRegion(void* ptr, size_t memory_size) {
       // Insert sorted by end_ptr.

--- a/xla/tsl/framework/bfc_allocator_test.cc
+++ b/xla/tsl/framework/bfc_allocator_test.cc
@@ -25,8 +25,12 @@ limitations under the License.
 #include <vector>
 
 #include "absl/base/casts.h"
+#include "absl/synchronization/blocking_counter.h"
 #include "xla/tsl/framework/allocator.h"
+#include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/test.h"
+#include "xla/tsl/platform/test_benchmark.h"
+#include "xla/tsl/platform/threadpool.h"
 #include "tsl/platform/mem.h"
 
 namespace tsl {
@@ -220,6 +224,79 @@ TEST(BFCAllocatorTest, AlignmentWithGpuLikeSubAllocator) {
 
   alloc.DeallocateRaw(filler);
 }
+
+//===----------------------------------------------------------------------===//
+// Performance benchmarks.
+//===----------------------------------------------------------------------===//
+
+static constexpr size_t kBenchAllocSize = 1024;
+static constexpr size_t kBenchAlignment = Allocator::kAllocatorAlignment;
+
+static void BM_AllocAndFree(benchmark::State& state) {
+  BFCAllocator alloc(std::make_unique<MallocSubAllocator>(),
+                     /*total_memory=*/256 << 20, /*name=*/"bench",
+                     BFCAllocator::Options{});
+
+  for (auto _ : state) {
+    void* ptr = alloc.AllocateRaw(kBenchAlignment, kBenchAllocSize);
+    alloc.DeallocateRaw(ptr);
+  }
+  state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK(BM_AllocAndFree);
+
+static void BM_AllocBatchThenFree(benchmark::State& state) {
+  int batch = state.range(0);
+  BFCAllocator alloc(std::make_unique<MallocSubAllocator>(),
+                     /*total_memory=*/256 << 20, /*name=*/"bench",
+                     BFCAllocator::Options{});
+
+  std::vector<void*> ptrs(batch);
+  for (auto _ : state) {
+    for (int i = 0; i < batch; ++i) {
+      ptrs[i] = alloc.AllocateRaw(kBenchAlignment, kBenchAllocSize);
+    }
+    for (int i = 0; i < batch; ++i) {
+      alloc.DeallocateRaw(ptrs[i]);
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * batch);
+}
+
+BENCHMARK(BM_AllocBatchThenFree)->Arg(100)->Arg(1000);
+
+static void BM_AllocAndFreeUnderContention(benchmark::State& state) {
+  size_t num_threads = state.range(0);
+  static constexpr int kItersPerThread = 10000;
+
+  BFCAllocator alloc(std::make_unique<MallocSubAllocator>(),
+                     /*total_memory=*/256 << 20, /*name=*/"bench",
+                     BFCAllocator::Options{});
+  tsl::thread::ThreadPool threads(tsl::Env::Default(), "bench", num_threads);
+
+  for (auto _ : state) {
+    absl::BlockingCounter counter(num_threads);
+    for (int t = 0; t < num_threads; ++t) {
+      threads.Schedule([&] {
+        for (int i = 0; i < kItersPerThread; ++i) {
+          void* ptr = alloc.AllocateRaw(kBenchAlignment, kBenchAllocSize);
+          alloc.DeallocateRaw(ptr);
+        }
+        counter.DecrementCount();
+      });
+    }
+    counter.Wait();
+  }
+  state.SetItemsProcessed(state.iterations() * num_threads * kItersPerThread);
+}
+
+BENCHMARK(BM_AllocAndFreeUnderContention)
+    ->MeasureProcessCPUTime()
+    ->Arg(2)
+    ->Arg(4)
+    ->Arg(8)
+    ->Arg(16);
 
 }  // namespace
 }  // namespace tsl


### PR DESCRIPTION
A couple of benchmarks to know where are the overheads

```
---------------------------------------------------------------------------------------------------------
Benchmark                                               Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------------
BM_AllocAndFree                                       130 ns          130 ns      5351964 items_per_second=7.67336M/s
BM_AllocBatchThenFree/100                           12678 ns        12677 ns        55242 items_per_second=7.88801M/s
BM_AllocBatchThenFree/1000                         126722 ns       126718 ns         5520 items_per_second=7.89153M/s
BM_AllocAndFreeUnderContention/2/process_time     4320984 ns      6018694 ns          134 items_per_second=3.32298M/s
BM_AllocAndFreeUnderContention/4/process_time    10261379 ns     16065238 ns           44 items_per_second=2.48985M/s
BM_AllocAndFreeUnderContention/8/process_time    18720973 ns     35748363 ns           20 items_per_second=2.23786M/s
BM_AllocAndFreeUnderContention/16/process_time   34709519 ns     69248988 ns           11 items_per_second=2.3105M/s
```

Also migrated to `btree_set` + sprinkled likely/unlikely branch annotations