### PR TITLE
[XLA:GPU][codegen] Forward device info to emitters_opt pass pipelines

### DIFF
--- a/xla/backends/gpu/codegen/emitters/transforms/tests/lower_math_oneapi.mlir
+++ b/xla/backends/gpu/codegen/emitters/transforms/tests/lower_math_oneapi.mlir
@@ -1,5 +1,5 @@
 // RUN: emitters_opt %s --split-input-file \
-// RUN:   --xla-lower-to-llvm-gpu="gpu_device_info='oneapi_compute_capability { architecture: \"bmg\"}'" \
+// RUN:   --xla-gpu-test-to-llvm="gpu_device_info='oneapi_compute_capability { architecture: \"bmg\"}'" \
 // RUN: | FileCheck %s
 
 module {
@@ -13,3 +13,25 @@ module {
     return %0 : f32
   }
 }
+
+// -----
+
+module {
+  func.func @test_tan(%arg0: complex<f32>) -> complex<f32> {
+    %0 = complex.tan %arg0 : complex<f32>
+    func.return %0 : complex<f32>
+  }
+}
+
+// CHECK-LABEL: @test_tan
+// CHECK-SAME: %[[ARG0:.*]]: !llvm.struct<(f32, f32)>
+// CHECK: %[[V0:.*]] = llvm.extractvalue %[[ARG0]][0]
+// CHECK: %[[V1:.*]] = llvm.extractvalue %[[ARG0]][1]
+// CHECK: %[[E0:.*]] = llvm.intr.exp
+// CHECK: %[[EM0:.*]] = llvm.fsub %[[E0]], %{{.*}}
+// CHECK: %[[E1:.*]] = llvm.intr.exp
+// CHECK: %[[EM1:.*]] = llvm.fsub %[[E1]], %{{.*}}
+// CHECK: llvm.fsub %[[EM0]], %[[EM1]] : f32
+// CHECK-DAG: llvm.intr.cos(%[[V0]])
+// CHECK-DAG: llvm.intr.sin(%[[V0]])
+// CHECK: llvm.return %{{.*}} : !llvm.struct<(f32, f32)>

--- a/xla/codegen/tools/emitters_opt.cc
+++ b/xla/codegen/tools/emitters_opt.cc
@@ -58,6 +58,29 @@ limitations under the License.
 #include "xla/mlir_hlo/mhlo/IR/hlo_ops.h"
 #include "xla/service/gpu/gpu_device_info_for_tests.h"
 
+struct EmittersOptOptions
+    : public mlir::PassPipelineOptions<EmittersOptOptions> {
+  Option<std::string> gpu_device_info{
+      *this, "gpu_device_info",
+      llvm::cl::desc("Serialized GpuDeviceInfoProto text proto."),
+      llvm::cl::init("")};
+
+  // Parses the gpu_device_info flag and returns a DeviceDescription object. If
+  // the flag is not set, returns the default DeviceDescription for RTXA6000.
+  const stream_executor::DeviceDescription parseDeviceInfo() const {
+    if (gpu_device_info.empty()) {
+      return xla::gpu::TestGpuDeviceInfo::RTXA6000DeviceInfo();
+    }
+    stream_executor::GpuDeviceInfoProto device_info;
+    CHECK(google::protobuf::TextFormat::ParseFromString(gpu_device_info,
+                                                        &device_info));
+    auto device_description =
+        stream_executor::DeviceDescription::FromProto(device_info);
+    CHECK_OK(device_description.status());
+    return *std::move(device_description);
+  }
+};
+
 int main(int argc, char** argv) {
   mlir::DialectRegistry registry;
   registry.insert<
@@ -93,10 +116,10 @@ int main(int argc, char** argv) {
       "xla-test-optimize",
       "Test pipeline of passes up to inlining. No vectorization, also does not "
       "lower xla_gpu. Intended to simplify IR in tests.",
-      [=](mlir::OpPassManager& pm, llvm::StringRef options,
+      [=](mlir::OpPassManager& pm, llvm::StringRef options_str,
           llvm::function_ref<mlir::LogicalResult(const llvm::Twine&)>
               errorHandler) {
-        if (!options.empty()) {
+        if (!options_str.empty()) {
           return mlir::failure();
         }
         xla::emitters::RegisterOptimizationPasses(pm);
@@ -107,14 +130,14 @@ int main(int argc, char** argv) {
       "xla-gpu-test-transform-loops",
       "Test pipeline for vectorization. Should run after "
       "xla-gpu-test-to-inline.",
-      [=](mlir::OpPassManager& pm, llvm::StringRef options,
+      [=](mlir::OpPassManager& pm, llvm::StringRef options_str,
           llvm::function_ref<mlir::LogicalResult(const llvm::Twine&)>
               errorHandler) {
-        if (!options.empty()) {
+        EmittersOptOptions options;
+        if (mlir::failed(options.parseFromString(options_str))) {
           return mlir::failure();
         }
-        xla::gpu::AddLoopTransformationPasses(
-            pm, xla::gpu::TestGpuDeviceInfo::RTXA6000DeviceInfo());
+        xla::gpu::AddLoopTransformationPasses(pm, options.parseDeviceInfo());
         return mlir::success();
       },
       [](llvm::function_ref<void(const mlir::detail::PassOptions&)>) {});
@@ -122,14 +145,14 @@ int main(int argc, char** argv) {
       "xla-gpu-test-to-llvm",
       "Test pipeline for the lowering to LLVM. Should run after "
       "xla-gpu-test-to-transform-loops.",
-      [=](mlir::OpPassManager& pm, llvm::StringRef options,
+      [=](mlir::OpPassManager& pm, llvm::StringRef options_str,
           llvm::function_ref<mlir::LogicalResult(const llvm::Twine&)>
               errorHandler) {
-        if (!options.empty()) {
+        EmittersOptOptions options;
+        if (mlir::failed(options.parseFromString(options_str))) {
           return mlir::failure();
         }
-        xla::gpu::AddLoweringPasses(
-            pm, xla::gpu::TestGpuDeviceInfo::RTXA6000DeviceInfo());
+        xla::gpu::AddLoweringPasses(pm, options.parseDeviceInfo());
         return mlir::success();
       },
       [](llvm::function_ref<void(const mlir::detail::PassOptions&)>) {});


### PR DESCRIPTION
By default `emitters_opt` would use RTX A6000 config for pass pipelines. This PR adds support to use custom device info and default to RTX A6000 config if none specified.
