### PR TITLE
Fix IFRT topology reporting device 0's device_kind for all devices

### DIFF
--- a/xla/python/pjrt_ifrt/pjrt_client.cc
+++ b/xla/python/pjrt_ifrt/pjrt_client.cc
@@ -363,7 +363,10 @@ absl::StatusOr<GlobalTopology> MakeGlobalTopologyFromPjRtClient(
       device.set_device_kind(
           // OSS requires explicit string conversion
           // NOLINTNEXTLINE(*-redundant-string-conversions)
-          std::string(pjrt_client->addressable_devices()[0]->device_kind()));
+          std::string(pjrt_device != nullptr
+                          ? pjrt_device->device_kind()
+                          : pjrt_client->addressable_devices()[0]
+                                ->device_kind()));
 
       // TODO(hyeontaek): Take optional device->partition_index mapping in
       // GlobalDeviceMapping and generate the `partition_index` attribute for


### PR DESCRIPTION
## Summary

- `MakeGlobalTopologyFromPjRtClient` hardcodes `addressable_devices()[0]->device_kind()` for every device in the topology, causing all devices to report device 0's marketing name in mixed-GPU systems
- Use `pjrt_device->device_kind()` for addressable devices, falling back to `addressable_devices()[0]` only for non-addressable devices

## Background

In multi-GPU systems with different architectures (e.g., gfx906 + gfx1101, or Radeon VII + Radeon PRO W7700), `jax.devices()` reports device 0's name for all devices:

```python
>>> [d.device_kind for d in jax.devices()]
['AMD Radeon VII', 'AMD Radeon VII']  # device 1 is actually Radeon PRO W7700
```

While `compute_capability` and `core_count` are correctly per-device, `device_kind` is not — because the IFRT topology builder at `xla/python/pjrt_ifrt/pjrt_client.cc:366` always reads from `addressable_devices()[0]`.

Traced and reproduced on a physical gfx906 + gfx1101 mixed-GPU system. The underlying PJRT layer (`PJRT_DeviceDescription_Kind`) returns correct per-device names — the bug is solely in the IFRT topology construction.

Fixes https://github.com/ROCm/rocm-jax/issues/390 (cosmetic portion)

## Test plan

- [x] Verify `device_kind` reports correct per-device names in mixed-GPU systems
- [x] Verify homogeneous multi-GPU systems are unaffected
- [x] Verify single-GPU systems are unaffected
- [x] Verify non-addressable device fallback still works