### PR TITLE
[ROCm] Use hermetic rpath for xla tests under rocm

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -293,7 +293,9 @@ common:rocm_clang_official --linkopt="-fuse-ld=lld"
 common:rocm_clang_official --host_linkopt="-fuse-ld=lld"
 
 common:rocm --config=rocm_clang_official
+
 common:rocm_ci --config=rocm
+common:rocm_ci --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 common:rocm_ci_hermetic --dynamic_mode=off
 common:rocm_ci_hermetic --config=rocm_clang_official


### PR DESCRIPTION
📝 Summary of Changes
Switch to hermetic rocm rpath when running xla tests under rocm

🎯 Justification
This change ensures /opt/rocm does not influence the test execution
so all the target dependencies inside the rocm repo are set correctly

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
