### PR TITLE
[XLA:GPU] Insert ReshapeDecomposer before LayoutNormalization in AutotunerAndPostCleanup

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1607,6 +1607,7 @@ absl::Status GpuCompiler::AutotunerAndPostCleanup(
       target_config, key_value_store, toolkit_version, alias_info,
       debug_options, mlir_context, shape_size_fn));
   pipeline.AddPass<ConvertTritonGemmConfig>(device_description, mlir_context);
+  pipeline.AddPass<ReshapeDecomposer>();
   pipeline.AddPass<LayoutNormalization>(&NormalizeLayoutForGpuCustomCalls);
   auto simplifier_options = GetAlgebraicSimplifierOptions(
       AlgebraicSimplifierMode::kLayoutNormalization, debug_options,


### PR DESCRIPTION
📝 Summary of Changes
Add the missing pipeline.AddPass<ReshapeDecomposer>() before LayoutNormalization in GpuCompiler::AutotunerAndPostCleanup — the third call site introduced by xla 6874dd2 without ReshapeDecomposer, mirroring the inline pattern at the three pre-existing sites. One-line change.

🎯 Justification
#41481 added ReshapeDecomposer ahead of two LayoutNormalization sites to prevent a RET_CHECK when GemmRewriter pins a __cublas$lt$matmul output and a downstream reshape becomes non-bitcast. xla 6874dd23a1 added a third LayoutNormalization site without the precondition and reopened the bug, most visibly on ROCm under multi-process pytest (tests/nn_test.py::testDotProductAttention*, tests/pallas/gpu_paged_attention_test.py).

AutotunerAndPostCleanup is the autotuner's boundary in the main pipeline: FissionBackend::ApplyConfig + InlineFissionedComputation can re-introduce a non-bitcast reshape there when the hipBLASLt candidate wins. Only that LayoutNormalization invocation is downstream of the layout shift, so the cleanup belongs at exactly that one site.

The fix preserves --xla_disable_hlo_passes=reshape-decomposer (no encapsulation) and stays in a single named pipeline (no HLO-dump pollution).

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Execution Test
xla/tools/run_hlo_module on the jit_dot_general HLO from jax.nn.dot_product_attention(impl='xla'), using the cuBLAS-LT-first hack from #817 + XLA_FLAGS=--xla_gpu_autotune_level=0 to deterministically force the failing path on a single MI355X gfx950.