### PR TITLE
[XLA:CPU][oneDNN] Upgrade async version of oneDNN to v3.11.3

### DIFF
--- a/third_party/mkl_dnn/mkldnn_v1_async.BUILD
+++ b/third_party/mkl_dnn/mkldnn_v1_async.BUILD
@@ -1,0 +1,226 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@xla//xla/tsl:tsl.bzl", "tf_openmp_copts")
+load("@xla//xla/tsl/mkl:build_defs.bzl", "if_mkl", "if_mkl_ml", "if_mkldnn_openmp")
+
+exports_files(["LICENSE"])
+
+_CMAKE_COMMON_LIST = {
+    "#cmakedefine DNNL_DISABLE_GPU_REF_KERNELS": "#define DNNL_DISABLE_GPU_REF_KERNELS 0",
+    "#cmakedefine DNNL_GPU_RUNTIME DNNL_RUNTIME_${DNNL_GPU_RUNTIME}": "#define DNNL_GPU_RUNTIME DNNL_RUNTIME_NONE",
+    "#cmakedefine DNNL_GPU_VENDOR DNNL_VENDOR_${DNNL_GPU_VENDOR}": "#define DNNL_VENDOR_NONE",
+    "#cmakedefine DNNL_USE_RT_OBJECTS_IN_PRIMITIVE_CACHE": "#undef DNNL_USE_RT_OBJECTS_IN_PRIMITIVE_CACHE",
+    "#cmakedefine DNNL_WITH_SYCL": "#undef DNNL_WITH_SYCL",
+    "#cmakedefine DNNL_WITH_LEVEL_ZERO": "#undef DNNL_WITH_LEVEL_ZERO",
+    "#cmakedefine DNNL_SYCL_CUDA": "#undef DNNL_SYCL_CUDA",
+    "#cmakedefine DNNL_SYCL_HIP": "#undef DNNL_SYCL_HIP",
+    "#cmakedefine DNNL_SYCL_GENERIC": "#define DNNL_SYCL_GENERIC 1",
+    "#cmakedefine DNNL_ENABLE_STACK_CHECKER": "#undef DNNL_ENABLE_STACK_CHECKER",
+    "#cmakedefine ONEDNN_BUILD_GRAPH": "#define ONEDNN_BUILD_GRAPH",
+    "#cmakedefine DNNL_EXPERIMENTAL_SPARSE": "#define DNNL_EXPERIMENTAL_SPARSE",
+    "#cmakedefine DNNL_EXPERIMENTAL": "#undef DNNL_EXPERIMENTAL",
+    "#cmakedefine DNNL_SAFE_RBP": "#undef DNNL_SAFE_RBP",
+    "#cmakedefine01 BUILD_TRAINING": "#define BUILD_TRAINING 1",
+    "#cmakedefine01 BUILD_INFERENCE": "#define BUILD_INFERENCE 0",
+    "#cmakedefine01 BUILD_PRIMITIVE_ALL": "#define BUILD_PRIMITIVE_ALL 1",
+    "#cmakedefine01 BUILD_BATCH_NORMALIZATION": "#define BUILD_BATCH_NORMALIZATION 0",
+    "#cmakedefine01 BUILD_BINARY": "#define BUILD_BINARY 0",
+    "#cmakedefine01 BUILD_CONCAT": "#define BUILD_CONCAT 0",
+    "#cmakedefine01 BUILD_CONVOLUTION": "#define BUILD_CONVOLUTION 0",
+    "#cmakedefine01 BUILD_DECONVOLUTION": "#define BUILD_DECONVOLUTION 0",
+    "#cmakedefine01 BUILD_ELTWISE": "#define BUILD_ELTWISE 0",
+    "#cmakedefine01 BUILD_GEMM_KERNELS_ALL": "#define BUILD_GEMM_KERNELS_ALL 1",
+    "#cmakedefine01 BUILD_GEMM_KERNELS_NONE": "#define BUILD_GEMM_KERNELS_NONE 0",
+    "#cmakedefine01 BUILD_GEMM_SSE41": "#define BUILD_GEMM_SSE41 1",
+    "#cmakedefine01 BUILD_GEMM_AVX2": "#define BUILD_GEMM_AVX2 1",
+    "#cmakedefine01 BUILD_GEMM_AVX512": "#define BUILD_GEMM_AVX512 1",
+    "#cmakedefine01 BUILD_GROUP_NORMALIZATION": "#define BUILD_GROUP_NORMALIZATION 1",
+    "#cmakedefine01 BUILD_INNER_PRODUCT": "#define BUILD_INNER_PRODUCT 0",
+    "#cmakedefine01 BUILD_LAYER_NORMALIZATION": "#define BUILD_LAYER_NORMALIZATION 0",
+    "#cmakedefine01 BUILD_LRN": "#define BUILD_LRN 0",
+    "#cmakedefine01 BUILD_MATMUL": "#define BUILD_MATMUL 0",
+    "#cmakedefine01 BUILD_POOLING": "#define BUILD_POOLING 0",
+    "#cmakedefine01 BUILD_PRELU": "#define BUILD_PRELU 0",
+    "#cmakedefine01 BUILD_REDUCTION": "#define BUILD_REDUCTION 0",
+    "#cmakedefine01 BUILD_REORDER": "#define BUILD_REORDER 0",
+    "#cmakedefine01 BUILD_RESAMPLING": "#define BUILD_RESAMPLING 0",
+    "#cmakedefine01 BUILD_RNN": "#define BUILD_RNN 0",
+    "#cmakedefine01 BUILD_SHUFFLE": "#define BUILD_SHUFFLE 0",
+    "#cmakedefine01 BUILD_SOFTMAX": "#define BUILD_SOFTMAX 0",
+    "#cmakedefine01 BUILD_SUM": "#define BUILD_SUM 0",
+    "#cmakedefine01 BUILD_PRIMITIVE_CPU_ISA_ALL": "#define BUILD_PRIMITIVE_CPU_ISA_ALL 1",
+    "#cmakedefine01 BUILD_SSE41": "#define BUILD_SSE41 0",
+    "#cmakedefine01 BUILD_AVX2": "#define BUILD_AVX2 0",
+    "#cmakedefine01 BUILD_AVX512": "#define BUILD_AVX512 0",
+    "#cmakedefine01 BUILD_AMX": "#define BUILD_AMX 0",
+    "#cmakedefine01 BUILD_PRIMITIVE_GPU_ISA_ALL": "#define BUILD_PRIMITIVE_GPU_ISA_ALL 0",
+    "#cmakedefine01 BUILD_GEN9": "#define BUILD_GEN9 0",
+    "#cmakedefine01 BUILD_GEN11": "#define BUILD_GEN11 0",
+    "#cmakedefine01 BUILD_SDPA": "#define BUILD_SDPA 1",
+    "#cmakedefine01 BUILD_XE2": "#define BUILD_XE2 0",
+    "#cmakedefine01 BUILD_XE3": "#define BUILD_XE3 0",
+    "#cmakedefine01 BUILD_XELP": "#define BUILD_XELP 0",
+    "#cmakedefine01 BUILD_XEHPG": "#define BUILD_XEHPG 0",
+    "#cmakedefine01 BUILD_XEHPC": "#define BUILD_XEHPC 0",
+    "#cmakedefine01 BUILD_XEHP": "#define BUILD_XEHP 0",
+}
+
+_DNNL_RUNTIME_OMP = {
+    "#cmakedefine DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_${DNNL_CPU_THREADING_RUNTIME}": "#define DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_OMP",
+    "#cmakedefine DNNL_CPU_RUNTIME DNNL_RUNTIME_${DNNL_CPU_RUNTIME}": "#define DNNL_CPU_RUNTIME DNNL_RUNTIME_OMP",
+}
+
+_DNNL_RUNTIME_OMP.update(_CMAKE_COMMON_LIST)
+
+_DNNL_RUNTIME_THREADPOOL = {
+    "#cmakedefine DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_${DNNL_CPU_THREADING_RUNTIME}": "#define DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_THREADPOOL",
+    "#cmakedefine DNNL_CPU_RUNTIME DNNL_RUNTIME_${DNNL_CPU_RUNTIME}": "#define DNNL_CPU_RUNTIME DNNL_RUNTIME_THREADPOOL",
+}
+
+_DNNL_RUNTIME_THREADPOOL.update(_CMAKE_COMMON_LIST)
+
+expand_template(
+    name = "dnnl_config_h",
+    out = "include/oneapi/dnnl/dnnl_config.h",
+    substitutions = select({
+        "@xla//xla/tsl/mkl:build_with_mkldnn_openmp": _DNNL_RUNTIME_OMP,
+        "//conditions:default": _DNNL_RUNTIME_THREADPOOL,
+    }),
+    template = "include/oneapi/dnnl/dnnl_config.h.in",
+)
+
+# Create the file dnnl_version.h with DNNL version numbers.
+# Currently, the version numbers are hard coded here. If DNNL is upgraded then
+# the version numbers have to be updated manually. The version numbers can be
+# obtained from the PROJECT_VERSION settings in CMakeLists.txt. The variable is
+# set to "version_major.version_minor.version_patch". The git hash version can
+# be set to NA.
+# TODO(agramesh1): Automatically get the version numbers from CMakeLists.txt.
+expand_template(
+    name = "dnnl_version_h",
+    out = "include/oneapi/dnnl/dnnl_version.h",
+    substitutions = {
+        "@DNNL_VERSION_MAJOR@": "3",
+        "@DNNL_VERSION_MINOR@": "11",
+        "@DNNL_VERSION_PATCH@": "3",
+        "@DNNL_VERSION_HASH@": "N/A",
+    },
+    template = "include/oneapi/dnnl/dnnl_version.h.in",
+)
+
+expand_template(
+    name = "dnnl_version_hash_h",
+    out = "include/oneapi/dnnl/dnnl_version_hash.h",
+    substitutions = {
+        "@DNNL_VERSION_HASH@": "74d04752d9eaefff6a9ff62466c4d20b155e5bca",
+    },
+    template = "include/oneapi/dnnl/dnnl_version_hash.h.in",
+)
+
+_COPTS_LIST = select({
+    "@xla//xla/tsl:windows": [],
+    "//conditions:default": ["-fexceptions"],
+}) + [
+    "-UUSE_MKL",
+    "-UUSE_CBLAS",
+    "-DDNNL_ENABLE_MAX_CPU_ISA",
+    "-DDNNL_ENABLE_ITT_TASKS",
+    "-DDNNL_ENABLE_GRAPH_DUMP",
+] + tf_openmp_copts()
+
+_INCLUDES_LIST = [
+    "include",
+    "src",
+    "src/common",
+    "src/cpu",
+    "src/cpu/gemm",
+    "src/graph",
+    "third_party",
+]
+
+_TEXTUAL_HDRS_LIST = glob([
+    "include/**/*",
+    "src/common/*.hpp",
+    "src/cpu/*.hpp",
+    "src/cpu/**/*.hpp",
+    "src/cpu/jit_utils/**/*.hpp",
+    "src/graph/interface/*.hpp",
+    "src/graph/backend/*.hpp",
+    "src/graph/backend/dnnl/*.hpp",
+    "src/graph/backend/fake/*.hpp",
+    "src/graph/backend/dnnl/executables/*.hpp",
+    "src/graph/backend/dnnl/passes/*.hpp",
+    "src/graph/backend/dnnl/patterns/*.hpp",
+    "src/graph/backend/dnnl/kernels/*.hpp",
+    "src/graph/utils/*.hpp",
+    "src/graph/utils/pm/*.hpp",
+    "third_party/**/*.h",
+    "third_party/ittnotify/**/*.h"
+]) + [
+    ":dnnl_config_h",
+    ":dnnl_version_h",
+    ":dnnl_version_hash_h",
+]
+
+# Large autogen files take too long time to compile with usual optimization
+# flags. These files just generate binary kernels and are not the hot spots,
+# so we factor them out to lower compiler optimizations in ":dnnl_autogen".
+# Using -O1 to enable optimizations to reduce stack consumption. (With -O0,
+# compiler doesn't clean up stack from temporary objects.)
+cc_library(
+    name = "onednn_autogen",
+    srcs = glob(["src/cpu/x64/gemm/**/*_kern_autogen*.cpp"]),
+    copts = [
+        "-O1",
+        "-U_FORTIFY_SOURCE",
+    ] + _COPTS_LIST,
+    includes = _INCLUDES_LIST,
+    textual_hdrs = _TEXTUAL_HDRS_LIST,
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "mkl_dnn",
+    srcs = glob(
+        [
+            "src/common/*.cpp",
+            "src/cpu/*.cpp",
+            "src/cpu/**/*.cpp",
+            "src/cpu/jit_utils/**/*.cpp",
+            "src/cpu/x64/**/*.cpp",
+            "src/graph/interface/*.cpp",
+            "src/graph/backend/*.cpp",
+            "src/graph/backend/dnnl/*.cpp",
+            "src/graph/backend/fake/*.cpp",
+            "src/graph/backend/dnnl/executables/*.cpp",
+            "src/graph/backend/dnnl/passes/*.cpp",
+            "src/graph/backend/dnnl/patterns/*.cpp",
+            "src/graph/backend/dnnl/kernels/*.cpp",
+            "src/graph/utils/*.cpp",
+            "src/graph/utils/pm/*.cpp",
+            "third_party/ittnotify/*.c",
+        ],
+        exclude = [
+            "src/cpu/aarch64/**",
+            "src/cpu/ppc64/**",
+            "src/cpu/rv64/**",
+            "src/cpu/x64/gemm/**/*_kern_autogen.cpp",
+            "src/cpu/sycl/**",
+        ],
+    ),
+    copts = _COPTS_LIST,
+    includes = _INCLUDES_LIST,
+    # TODO(penpornk): Use lrt_if_needed from tensorflow.bzl instead.
+    linkopts = select({
+        "@xla//xla/tsl:linux_aarch64": ["-lrt"],
+        "@xla//xla/tsl:linux_x86_64": ["-lrt"],
+        "@xla//xla/tsl:linux_ppc64le": ["-lrt"],
+        "@xla//xla/tsl:linux_riscv64": ["-lrt"],
+        "//conditions:default": [],
+    }),
+    textual_hdrs = _TEXTUAL_HDRS_LIST,
+    visibility = ["//visibility:public"],
+    deps = [":onednn_autogen"] + if_mkl_ml(
+        ["@xla//xla/tsl/mkl:intel_binary_blob"],
+        [],
+    ),
+)

--- a/third_party/mkl_dnn/rename_gtest.patch
+++ b/third_party/mkl_dnn/rename_gtest.patch
@@ -1,0 +1,144 @@
+diff --git a/third_party/gtest/CMakeLists.txt b/third_party/gtest_unused/CMakeLists.txt
+similarity index 100%
+rename from third_party/gtest/CMakeLists.txt
+rename to third_party/gtest_unused/CMakeLists.txt
+diff --git a/third_party/gtest/LICENSE b/third_party/gtest_unused/LICENSE
+similarity index 100%
+rename from third_party/gtest/LICENSE
+rename to third_party/gtest_unused/LICENSE
+diff --git a/third_party/gtest/gtest-death-test.h b/third_party/gtest_unused/gtest-death-test.h
+similarity index 100%
+rename from third_party/gtest/gtest-death-test.h
+rename to third_party/gtest_unused/gtest-death-test.h
+diff --git a/third_party/gtest/gtest-matchers.h b/third_party/gtest_unused/gtest-matchers.h
+similarity index 100%
+rename from third_party/gtest/gtest-matchers.h
+rename to third_party/gtest_unused/gtest-matchers.h
+diff --git a/third_party/gtest/gtest-message.h b/third_party/gtest_unused/gtest-message.h
+similarity index 100%
+rename from third_party/gtest/gtest-message.h
+rename to third_party/gtest_unused/gtest-message.h
+diff --git a/third_party/gtest/gtest-param-test.h b/third_party/gtest_unused/gtest-param-test.h
+similarity index 100%
+rename from third_party/gtest/gtest-param-test.h
+rename to third_party/gtest_unused/gtest-param-test.h
+diff --git a/third_party/gtest/gtest-printers.h b/third_party/gtest_unused/gtest-printers.h
+similarity index 100%
+rename from third_party/gtest/gtest-printers.h
+rename to third_party/gtest_unused/gtest-printers.h
+diff --git a/third_party/gtest/gtest-spi.h b/third_party/gtest_unused/gtest-spi.h
+similarity index 100%
+rename from third_party/gtest/gtest-spi.h
+rename to third_party/gtest_unused/gtest-spi.h
+diff --git a/third_party/gtest/gtest-test-part.h b/third_party/gtest_unused/gtest-test-part.h
+similarity index 100%
+rename from third_party/gtest/gtest-test-part.h
+rename to third_party/gtest_unused/gtest-test-part.h
+diff --git a/third_party/gtest/gtest-typed-test.h b/third_party/gtest_unused/gtest-typed-test.h
+similarity index 100%
+rename from third_party/gtest/gtest-typed-test.h
+rename to third_party/gtest_unused/gtest-typed-test.h
+diff --git a/third_party/gtest/gtest.h b/third_party/gtest_unused/gtest.h
+similarity index 100%
+rename from third_party/gtest/gtest.h
+rename to third_party/gtest_unused/gtest.h
+diff --git a/third_party/gtest/gtest_pred_impl.h b/third_party/gtest_unused/gtest_pred_impl.h
+similarity index 100%
+rename from third_party/gtest/gtest_pred_impl.h
+rename to third_party/gtest_unused/gtest_pred_impl.h
+diff --git a/third_party/gtest/gtest_prod.h b/third_party/gtest_unused/gtest_prod.h
+similarity index 100%
+rename from third_party/gtest/gtest_prod.h
+rename to third_party/gtest_unused/gtest_prod.h
+diff --git a/third_party/gtest/internal/custom/README.md b/third_party/gtest_unused/internal/custom/README.md
+similarity index 100%
+rename from third_party/gtest/internal/custom/README.md
+rename to third_party/gtest_unused/internal/custom/README.md
+diff --git a/third_party/gtest/internal/custom/gtest-port.h b/third_party/gtest_unused/internal/custom/gtest-port.h
+similarity index 100%
+rename from third_party/gtest/internal/custom/gtest-port.h
+rename to third_party/gtest_unused/internal/custom/gtest-port.h
+diff --git a/third_party/gtest/internal/custom/gtest-printers.h b/third_party/gtest_unused/internal/custom/gtest-printers.h
+similarity index 100%
+rename from third_party/gtest/internal/custom/gtest-printers.h
+rename to third_party/gtest_unused/internal/custom/gtest-printers.h
+diff --git a/third_party/gtest/internal/custom/gtest.h b/third_party/gtest_unused/internal/custom/gtest.h
+similarity index 100%
+rename from third_party/gtest/internal/custom/gtest.h
+rename to third_party/gtest_unused/internal/custom/gtest.h
+diff --git a/third_party/gtest/internal/gtest-death-test-internal.h b/third_party/gtest_unused/internal/gtest-death-test-internal.h
+similarity index 100%
+rename from third_party/gtest/internal/gtest-death-test-internal.h
+rename to third_party/gtest_unused/internal/gtest-death-test-internal.h
+diff --git a/third_party/gtest/internal/gtest-filepath.h b/third_party/gtest_unused/internal/gtest-filepath.h
+similarity index 100%
+rename from third_party/gtest/internal/gtest-filepath.h
+rename to third_party/gtest_unused/internal/gtest-filepath.h
+diff --git a/third_party/gtest/internal/gtest-internal.h b/third_party/gtest_unused/internal/gtest-internal.h
+similarity index 100%
+rename from third_party/gtest/internal/gtest-internal.h
+rename to third_party/gtest_unused/internal/gtest-internal.h
+diff --git a/third_party/gtest/internal/gtest-param-util.h b/third_party/gtest_unused/internal/gtest-param-util.h
+similarity index 100%
+rename from third_party/gtest/internal/gtest-param-util.h
+rename to third_party/gtest_unused/internal/gtest-param-util.h
+diff --git a/third_party/gtest/internal/gtest-port-arch.h b/third_party/gtest_unused/internal/gtest-port-arch.h
+similarity index 100%
+rename from third_party/gtest/internal/gtest-port-arch.h
+rename to third_party/gtest_unused/internal/gtest-port-arch.h
+diff --git a/third_party/gtest/internal/gtest-port.h b/third_party/gtest_unused/internal/gtest-port.h
+similarity index 100%
+rename from third_party/gtest/internal/gtest-port.h
+rename to third_party/gtest_unused/internal/gtest-port.h
+diff --git a/third_party/gtest/internal/gtest-string.h b/third_party/gtest_unused/internal/gtest-string.h
+similarity index 100%
+rename from third_party/gtest/internal/gtest-string.h
+rename to third_party/gtest_unused/internal/gtest-string.h
+diff --git a/third_party/gtest/internal/gtest-type-util.h b/third_party/gtest_unused/internal/gtest-type-util.h
+similarity index 100%
+rename from third_party/gtest/internal/gtest-type-util.h
+rename to third_party/gtest_unused/internal/gtest-type-util.h
+diff --git a/third_party/gtest/src/gtest-all.cc b/third_party/gtest_unused/src/gtest-all.cc
+similarity index 100%
+rename from third_party/gtest/src/gtest-all.cc
+rename to third_party/gtest_unused/src/gtest-all.cc
+diff --git a/third_party/gtest/src/gtest-death-test.cc b/third_party/gtest_unused/src/gtest-death-test.cc
+similarity index 100%
+rename from third_party/gtest/src/gtest-death-test.cc
+rename to third_party/gtest_unused/src/gtest-death-test.cc
+diff --git a/third_party/gtest/src/gtest-filepath.cc b/third_party/gtest_unused/src/gtest-filepath.cc
+similarity index 100%
+rename from third_party/gtest/src/gtest-filepath.cc
+rename to third_party/gtest_unused/src/gtest-filepath.cc
+diff --git a/third_party/gtest/src/gtest-internal-inl.h b/third_party/gtest_unused/src/gtest-internal-inl.h
+similarity index 100%
+rename from third_party/gtest/src/gtest-internal-inl.h
+rename to third_party/gtest_unused/src/gtest-internal-inl.h
+diff --git a/third_party/gtest/src/gtest-matchers.cc b/third_party/gtest_unused/src/gtest-matchers.cc
+similarity index 100%
+rename from third_party/gtest/src/gtest-matchers.cc
+rename to third_party/gtest_unused/src/gtest-matchers.cc
+diff --git a/third_party/gtest/src/gtest-port.cc b/third_party/gtest_unused/src/gtest-port.cc
+similarity index 100%
+rename from third_party/gtest/src/gtest-port.cc
+rename to third_party/gtest_unused/src/gtest-port.cc
+diff --git a/third_party/gtest/src/gtest-printers.cc b/third_party/gtest_unused/src/gtest-printers.cc
+similarity index 100%
+rename from third_party/gtest/src/gtest-printers.cc
+rename to third_party/gtest_unused/src/gtest-printers.cc
+diff --git a/third_party/gtest/src/gtest-test-part.cc b/third_party/gtest_unused/src/gtest-test-part.cc
+similarity index 100%
+rename from third_party/gtest/src/gtest-test-part.cc
+rename to third_party/gtest_unused/src/gtest-test-part.cc
+diff --git a/third_party/gtest/src/gtest-typed-test.cc b/third_party/gtest_unused/src/gtest-typed-test.cc
+similarity index 100%
+rename from third_party/gtest/src/gtest-typed-test.cc
+rename to third_party/gtest_unused/src/gtest-typed-test.cc
+diff --git a/third_party/gtest/src/gtest.cc b/third_party/gtest_unused/src/gtest.cc
+similarity index 100%
+rename from third_party/gtest/src/gtest.cc
+rename to third_party/gtest_unused/src/gtest.cc
+diff --git a/third_party/gtest/src/gtest_main.cc b/third_party/gtest_unused/src/gtest_main.cc
+similarity index 100%
+rename from third_party/gtest/src/gtest_main.cc
+rename to third_party/gtest_unused/src/gtest_main.cc

--- a/third_party/mkl_dnn/workspace.bzl
+++ b/third_party/mkl_dnn/workspace.bzl
@@ -14,11 +14,14 @@ def repo():
 
     tf_http_archive(
         name = "onednn_async",
-        build_file = "//third_party/mkl_dnn:mkldnn_v1.BUILD",
-        patch_file = ["//third_party/mkl_dnn:setting_init.patch"],
-        sha256 = "1cfa18fad65b4c3b46ef701a83c64b87411d63e79c8549cdb37f8c1fc10e2398",
-        strip_prefix = "oneDNN-dev-v3.7-thunk-preview",
-        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/refs/heads/dev-v3.7-thunk-preview.tar.gz"),
+        build_file = "//third_party/mkl_dnn:mkldnn_v1_async.BUILD",
+        # Rename the gtest module in oneDNN's third_party to avoid
+        # conflict with Google's gtest module
+        patch_file = ["//third_party/mkl_dnn:setting_init.patch",
+                      "//third_party/mkl_dnn:rename_gtest.patch"],
+        sha256 = "7293a85e146c2710dcf4f7257fdebb91020004cf1627c8de684b814c2498c81a",
+        strip_prefix = "oneDNN-3.11.3",
+        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/refs/tags/v3.11.3.tar.gz"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
Part 2 of 3 to replace #38198.

This PR upgrades only the `onednn_async` version to v3.11.3. The new version unifies support for both synchronous and asynchronous execution.