### PR TITLE
[XLA:CPU][oneDNN] Default to oneDNN async execution for x86_64 Linux builds

### DIFF
--- a/xla/tsl/mkl/build_defs.bzl
+++ b/xla/tsl/mkl/build_defs.bzl
@@ -110,8 +110,8 @@ def mkl_deps():
     return select({
         Label("//xla/tsl/mkl:build_with_mkl_aarch64"): ["@mkl_dnn_acl_compatible//:mkl_dnn_acl"],
         Label("//xla/tsl:linux_x86_64_with_onednn_async"): ["@onednn_async//:mkl_dnn"],
-        Label("//xla/tsl:linux_x86_64"): ["@onednn//:mkl_dnn"],
-        Label("//xla/tsl:windows"): ["@onednn//:mkl_dnn"],
+        Label("//xla/tsl:linux_x86_64"): ["@onednn_async//:mkl_dnn"],
+        Label("//xla/tsl:windows"): ["@onednn_async//:mkl_dnn"],
         "//conditions:default": [],
     })
 

--- a/xla/tsl/mkl/build_defs.bzl
+++ b/xla/tsl/mkl/build_defs.bzl
@@ -128,9 +128,8 @@ def mkl_dep():
     """
     return select({
         Label("//xla/tsl/mkl:build_with_mkl_aarch64"): "@mkl_dnn_acl_compatible//:mkl_dnn_acl",
-        Label("//xla/tsl:linux_x86_64_with_onednn_async"): "@onednn_async//:mkl_dnn",
-        Label("//xla/tsl:linux_x86_64"): "@onednn//:mkl_dnn",
-        Label("//xla/tsl:windows"): "@onednn//:mkl_dnn",
+        Label("//xla/tsl:linux_x86_64"): "@onednn_async//:mkl_dnn",
+        Label("//xla/tsl:windows"): "@onednn_async//:mkl_dnn",
         "//conditions:default": "//xla/tsl/mkl:dummy_mkl_dnn",
     })
 
@@ -143,7 +142,8 @@ def if_onednn_async(if_true, if_false = []):
       Otherwise, the select statement evaluates to if_false.
     """
     return select({
-        Label("//xla/tsl:linux_x86_64_with_onednn_async"): if_true,
+        Label("//xla/tsl:linux_x86_64"): if_true,
+        Label("//xla/tsl:windows"): if_true,
         "//conditions:default": if_false,
     })
 


### PR DESCRIPTION
Depends on https://github.com/openxla/xla/pull/41989 and https://github.com/openxla/xla/pull/41990, thus marking the PR as draft for now.

Part 3 of 3 to replace #38198.

This PR makes the oneDNN asynchronous execution engine the default for x86_64 Linux and Windows builds by updating the Bazel build definitions in `xla/tsl/mkl/build_defs.bzl`.