### PR TITLE
Re-land [PR #36441] Support all-reduce hoisting with scalar multiplication pattern

### DIFF
--- a/xla/service/while_loop_all_reduce_code_motion.cc
+++ b/xla/service/while_loop_all_reduce_code_motion.cc
@@ -779,6 +779,9 @@ MovableAllReduceContext IsAllReduceMovable(
           break;
         }
         case HloOpcode::kMultiply: {
+          // Hoisting reduce-scatter through a multiply is unsupported: it
+          // would require rewriting the other operand to the post-scatter
+          // shape, which this pass does not do.
           if (is_reduce_scatter) {
             is_all_reduce_movable = false;
             break;
@@ -796,11 +799,22 @@ MovableAllReduceContext IsAllReduceMovable(
           }
           const bool current_is_scalar =
               ShapeUtil::IsScalar(all_reduce->shape());
-          const bool other_is_all_reduce =
-              unwrapped_other->opcode() == HloOpcode::kAllReduce ||
-              unwrapped_other->opcode() == HloOpcode::kReduceScatter;
+          const bool unwrapped_other_is_all_reduce =
+              unwrapped_other->opcode() == HloOpcode::kAllReduce;
 
-          if (current_is_scalar && other_is_all_reduce) {
+          if (current_is_scalar && unwrapped_other_is_all_reduce) {
+            // Scalar side of the ZeRO-1 weight-normalization pattern
+            //   grads_accum = tree_map(
+            //       lambda g, b: AR(g) * AR(total_weights) + b,
+            //       grads, grads_accum)
+            // expressed in HLO as
+            //   multiply(all-reduce(g),
+            //            broadcast(convert(all-reduce(total_weights)))).
+            // Hoisting all-reduce(total_weights) would replace it inside
+            // the body with its local pre-all-reduce value, scaling the
+            // gradient by an unreduced scalar and producing an
+            // accumulation off by a factor of num_replicas. Keep it in
+            // the body.
             VLOG(4) << "Scalar all-reduce " << all_reduce->name()
                     << " is used as a factor of a multiply with another "
                        "all-reduce ("
@@ -808,7 +822,12 @@ MovableAllReduceContext IsAllReduceMovable(
                     << "); marking it unmovable so it stays in the loop body "
                        "and preserves the math of the hoisted all-reduce.";
             is_all_reduce_movable = false;
-          } else if (other_is_all_reduce && other_is_broadcast) {
+          } else if (unwrapped_other_is_all_reduce && other_is_broadcast) {
+            // Gradient (non-scalar) side of the same pattern. The other
+            // operand is a broadcasted scalar all-reduce acting as a
+            // per-iteration scaling factor; it is pinned in the body by
+            // the branch above when it is itself analyzed, so hoisting
+            // the current all-reduce is safe.
             to_visit.push(user);
           } else {
             is_all_reduce_movable = false;

--- a/xla/service/while_loop_all_reduce_code_motion.cc
+++ b/xla/service/while_loop_all_reduce_code_motion.cc
@@ -801,6 +801,8 @@ MovableAllReduceContext IsAllReduceMovable(
               ShapeUtil::IsScalar(all_reduce->shape());
           const bool unwrapped_other_is_all_reduce =
               unwrapped_other->opcode() == HloOpcode::kAllReduce;
+          const bool unwrapped_other_is_scalar =
+              ShapeUtil::IsScalar(unwrapped_other->shape());
 
           if (current_is_scalar && unwrapped_other_is_all_reduce) {
             // Scalar side of the ZeRO-1 weight-normalization pattern
@@ -822,12 +824,19 @@ MovableAllReduceContext IsAllReduceMovable(
                     << "); marking it unmovable so it stays in the loop body "
                        "and preserves the math of the hoisted all-reduce.";
             is_all_reduce_movable = false;
-          } else if (unwrapped_other_is_all_reduce && other_is_broadcast) {
+          } else if (unwrapped_other_is_all_reduce && other_is_broadcast &&
+                     unwrapped_other_is_scalar) {
             // Gradient (non-scalar) side of the same pattern. The other
             // operand is a broadcasted scalar all-reduce acting as a
             // per-iteration scaling factor; it is pinned in the body by
             // the branch above when it is itself analyzed, so hoisting
-            // the current all-reduce is safe.
+            // the current all-reduce is safe. Requiring the unwrapped
+            // other operand to be scalar excludes non-scaling shapes such
+            // as multiply(broadcast(all-reduce(a)), broadcast(all-reduce(b)))
+            // where both all-reduces are non-scalar; hoisting either
+            // all-reduce in that pattern would scale the other side by a
+            // pre-all-reduce local value, producing an accumulation off
+            // by a factor of num_replicas.
             to_visit.push(user);
           } else {
             is_all_reduce_movable = false;

--- a/xla/service/while_loop_all_reduce_code_motion.cc
+++ b/xla/service/while_loop_all_reduce_code_motion.cc
@@ -778,6 +778,47 @@ MovableAllReduceContext IsAllReduceMovable(
           }
           break;
         }
+        case HloOpcode::kMultiply: {
+          if (is_reduce_scatter) {
+            is_all_reduce_movable = false;
+            break;
+          }
+          HloInstruction* other_operand =
+              user->mutable_operand(1 - user->operand_index(instruction));
+          HloInstruction* unwrapped_other = other_operand;
+          bool other_is_broadcast = false;
+          while (unwrapped_other->opcode() == HloOpcode::kBroadcast ||
+                 unwrapped_other->opcode() == HloOpcode::kConvert) {
+            if (unwrapped_other->opcode() == HloOpcode::kBroadcast) {
+              other_is_broadcast = true;
+            }
+            unwrapped_other = unwrapped_other->mutable_operand(0);
+          }
+          const bool current_is_scalar =
+              ShapeUtil::IsScalar(all_reduce->shape());
+          const bool other_is_all_reduce =
+              unwrapped_other->opcode() == HloOpcode::kAllReduce ||
+              unwrapped_other->opcode() == HloOpcode::kReduceScatter;
+
+          if (current_is_scalar && other_is_all_reduce) {
+            VLOG(4) << "Scalar all-reduce " << all_reduce->name()
+                    << " is used as a factor of a multiply with another "
+                       "all-reduce ("
+                    << unwrapped_other->name()
+                    << "); marking it unmovable so it stays in the loop body "
+                       "and preserves the math of the hoisted all-reduce.";
+            is_all_reduce_movable = false;
+          } else if (other_is_all_reduce && other_is_broadcast) {
+            to_visit.push(user);
+          } else {
+            is_all_reduce_movable = false;
+          }
+          break;
+        }
+        case HloOpcode::kBroadcast: {
+          to_visit.push(user);
+          break;
+        }
         case HloOpcode::kAdd: {
           int64_t buffer_index = 1 - user->operand_index(instruction);
           HloInstruction* accumulation_buffer =

--- a/xla/service/while_loop_all_reduce_code_motion_test.cc
+++ b/xla/service/while_loop_all_reduce_code_motion_test.cc
@@ -2450,6 +2450,80 @@ TEST_F(WhileLoopAllReduceCodeMotionTest,
 }
 
 TEST_F(WhileLoopAllReduceCodeMotionTest,
+       NonScalarAllReducesMultipliedTogetherStayInBody) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule non_scalar_ar_multiply_correctness
+
+    %reduction {
+      %x = f32[] parameter(0)
+      %y = f32[] parameter(1)
+      ROOT %add = f32[] add(f32[] %x, f32[] %y)
+    }
+
+    %while_condition {
+      %param = (s32[], s32[], f32[128], f32[128], f32[128,128]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = s32[] get-tuple-element(%param), index=1
+      ROOT result = pred[] compare(%gte.0, %gte.1), direction=LT
+    }
+
+    %while_body {
+      %param = (s32[], s32[], f32[128], f32[128], f32[128,128]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = s32[] get-tuple-element(%param), index=1
+      %gte.2 = f32[128] get-tuple-element(%param), index=2
+      %gte.3 = f32[128] get-tuple-element(%param), index=3
+      %gte.4 = f32[128,128] get-tuple-element(%param), index=4
+      %row = f32[128] add(f32[128] %gte.2, f32[128] %gte.2)
+      %col = f32[128] add(f32[128] %gte.3, f32[128] %gte.3)
+      %all-reduce.row = f32[128] all-reduce(f32[128] %row), channel_id=1, replica_groups={{0,1,2,3}}, use_global_device_ids=true, to_apply=%reduction
+      %all-reduce.col = f32[128] all-reduce(f32[128] %col), channel_id=2, replica_groups={{0,1,2,3}}, use_global_device_ids=true, to_apply=%reduction
+      %row.bcast = f32[128,128] broadcast(f32[128] %all-reduce.row), dimensions={0}
+      %col.bcast = f32[128,128] broadcast(f32[128] %all-reduce.col), dimensions={1}
+      %product = f32[128,128] multiply(f32[128,128] %row.bcast, f32[128,128] %col.bcast)
+      %accumulation = f32[128,128] add(f32[128,128] %product, f32[128,128] %gte.4)
+      %constant.1 = s32[] constant(1)
+      %increment_iteration = s32[] add(s32[] %gte.0, s32[] %constant.1)
+      ROOT %loop_result = (s32[], s32[], f32[128], f32[128], f32[128,128]) tuple(%increment_iteration, %gte.1, %gte.2, %gte.3, %accumulation)
+    }
+
+    ENTRY non_scalar_ar_multiply_correctness {
+      %param.0 = s32[] parameter(0)
+      %param.1 = f32[128] parameter(1)
+      %param.2 = f32[128] parameter(2)
+      %constant.0 = s32[] constant(1)
+      %zero = f32[] constant(0)
+      %accumulation_buffer = f32[128,128] broadcast(f32[] %zero), dimensions={}
+      %while_init = (s32[], s32[], f32[128], f32[128], f32[128,128]) tuple(%constant.0, %param.0, %param.1, %param.2, %accumulation_buffer)
+      ROOT %while = (s32[], s32[], f32[128], f32[128], f32[128,128]) while(%while_init), condition=%while_condition, body=%while_body
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool simplified_loop,
+                          WhileLoopAllReduceCodeMotion{}.Run(module.get()));
+  EXPECT_FALSE(simplified_loop);
+  TF_ASSERT_OK(
+      HloVerifier(/*layout_sensitive=*/false, /*allow_mixed_precision=*/true)
+          .Run(module.get())
+          .status());
+  HloComputation* entry = module->entry_computation();
+  HloInstruction* transformed_while = find_op<HloOpcode::kWhile>(entry);
+  ASSERT_THAT(transformed_while, NotNull());
+  HloComputation* body = transformed_while->while_body();
+  std::vector<HloInstruction*> body_all_reduces;
+  absl::c_copy_if(body->instructions(), std::back_inserter(body_all_reduces),
+                  HloPredicateIsOp<HloOpcode::kAllReduce>);
+  ASSERT_THAT(body_all_reduces, SizeIs(2));
+  EXPECT_THAT(body_all_reduces[0], op::Shape("f32[128]"));
+  EXPECT_THAT(body_all_reduces[1], op::Shape("f32[128]"));
+  std::vector<HloInstruction*> entry_all_reduces;
+  absl::c_copy_if(entry->instructions(), std::back_inserter(entry_all_reduces),
+                  HloPredicateIsOp<HloOpcode::kAllReduce>);
+  EXPECT_THAT(entry_all_reduces, SizeIs(0));
+}
+
+TEST_F(WhileLoopAllReduceCodeMotionTest,
        ScalarAllReduceWithOnlyMultiplyUseIsNotDeleted) {
   constexpr absl::string_view kHloModule = R"(
     HloModule scalar_ar_only_multiply_use

--- a/xla/service/while_loop_all_reduce_code_motion_test.cc
+++ b/xla/service/while_loop_all_reduce_code_motion_test.cc
@@ -50,6 +50,7 @@ namespace xla {
 namespace {
 
 namespace op = ::xla::testing::opcode_matchers;
+using ::testing::_;
 using ::testing::Ne;
 using ::testing::NotNull;
 using ::testing::Property;
@@ -2268,6 +2269,257 @@ TEST_F(WhileLoopAllReduceCodeMotionTest, ComputationWithDUSAndAccumulation) {
     CHECK: tuple({{.+}}, {{.+}}, %[[ar2]], {{.+}})
   )"),
               absl_testing::IsOkAndHolds(true));
+}
+
+TEST_F(WhileLoopAllReduceCodeMotionTest,
+       ScalarAllReduceStaysInBodyWhenUsedAsScalingFactor) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule ar_with_scalar_multiply_correctness
+
+    %reduction {
+      %x = f32[] parameter(0)
+      %y = f32[] parameter(1)
+      ROOT %add = f32[] add(f32[] %x, f32[] %y)
+    }
+
+    %scalar_reduction {
+      %x = s32[] parameter(0)
+      %y = s32[] parameter(1)
+      ROOT %add = s32[] add(s32[] %x, s32[] %y)
+    }
+
+    %while_condition {
+      %param = (s32[], s32[], f32[128,128], f32[128,128], s32[]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = s32[] get-tuple-element(%param), index=1
+      ROOT result = pred[] compare(%gte.0, %gte.1), direction=LT
+    }
+
+    %while_body {
+      %param = (s32[], s32[], f32[128,128], f32[128,128], s32[]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = s32[] get-tuple-element(%param), index=1
+      %gte.2 = f32[128,128] get-tuple-element(%param), index=2
+      %gte.3 = f32[128,128] get-tuple-element(%param), index=3
+      %gte.4 = s32[] get-tuple-element(%param), index=4
+      %grad1 = f32[128,128] multiply(f32[128,128] %gte.2, f32[128,128] %gte.2)
+      %all-reduce.1 = f32[128,128] all-reduce(f32[128,128] %grad1), channel_id=1, replica_groups={{0,1,2,3}}, use_global_device_ids=true, to_apply=%reduction
+      %count = s32[] constant(1)
+      %all-reduce.scalar = s32[] all-reduce(s32[] %count), channel_id=2, replica_groups={{0,1,2,3}}, use_global_device_ids=true, to_apply=%scalar_reduction
+      %scalar.f32 = f32[] convert(s32[] %all-reduce.scalar)
+      %scalar.bcast = f32[128,128] broadcast(f32[] %scalar.f32), dimensions={}
+      %scaled.grad1 = f32[128,128] multiply(f32[128,128] %all-reduce.1, f32[128,128] %scalar.bcast)
+      %accumulation.1 = f32[128,128] add(f32[128,128] %scaled.grad1, f32[128,128] %gte.3)
+      %accumulation.scalar = s32[] add(s32[] %all-reduce.scalar, s32[] %gte.4)
+      %constant.1 = s32[] constant(1)
+      %increment_iteration = s32[] add(s32[] %gte.0, s32[] %constant.1)
+      ROOT %loop_result = (s32[], s32[], f32[128,128], f32[128,128], s32[]) tuple(%increment_iteration, %gte.1, %gte.2, %accumulation.1, %accumulation.scalar)
+    }
+
+    ENTRY ar_with_scalar_multiply_correctness {
+      %param.0 = s32[] parameter(0)
+      %param.1 = f32[128,128] parameter(1)
+      %constant.0 = s32[] constant(1)
+      %accumulation_buffer_init = f32[] constant(0)
+      %accumulation_buffer = f32[128,128] broadcast(f32[] %accumulation_buffer_init), dimensions={}
+      %scalar_buffer_init = s32[] constant(0)
+      %while_init = (s32[], s32[], f32[128,128], f32[128,128], s32[]) tuple(%constant.0, %param.0, %param.1, %accumulation_buffer, %scalar_buffer_init)
+      ROOT %while = (s32[], s32[], f32[128,128], f32[128,128], s32[]) while(%while_init), condition=%while_condition, body=%while_body
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool simplified_loop,
+                          WhileLoopAllReduceCodeMotion{}.Run(module.get()));
+  ASSERT_TRUE(simplified_loop);
+  TF_ASSERT_OK(
+      HloVerifier(/*layout_sensitive=*/false, /*allow_mixed_precision=*/true)
+          .Run(module.get())
+          .status());
+  HloComputation* entry = module->entry_computation();
+  HloInstruction* transformed_while = find_op<HloOpcode::kWhile>(entry);
+  ASSERT_THAT(transformed_while, NotNull());
+  HloComputation* body = transformed_while->while_body();
+  std::vector<HloInstruction*> body_all_reduces;
+  absl::c_copy_if(body->instructions(), std::back_inserter(body_all_reduces),
+                  HloPredicateIsOp<HloOpcode::kAllReduce>);
+  ASSERT_THAT(body_all_reduces, SizeIs(1));
+  EXPECT_THAT(body_all_reduces[0], op::Shape("s32[]"));
+  std::vector<HloInstruction*> entry_all_reduces;
+  absl::c_copy_if(entry->instructions(), std::back_inserter(entry_all_reduces),
+                  HloPredicateIsOp<HloOpcode::kAllReduce>);
+  ASSERT_THAT(entry_all_reduces, SizeIs(1));
+  EXPECT_THAT(entry_all_reduces[0], op::Shape("f32[128,128]"));
+  EXPECT_THAT(
+      body->instructions(),
+      Contains(op::Multiply(_, op::Broadcast(op::Convert(op::AllReduce())))));
+}
+
+TEST_F(WhileLoopAllReduceCodeMotionTest,
+       MultipleGradientsScaledByScalarAllReduceStaysInBody) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule multi_grad_scalar_correctness
+
+    %reduction {
+      %x = f32[] parameter(0)
+      %y = f32[] parameter(1)
+      ROOT %add = f32[] add(f32[] %x, f32[] %y)
+    }
+
+    %scalar_reduction {
+      %x = s32[] parameter(0)
+      %y = s32[] parameter(1)
+      ROOT %add = s32[] add(s32[] %x, s32[] %y)
+    }
+
+    %while_condition {
+      %param = (s32[], s32[], f32[64,64], f32[64,64], f32[64,64], f32[64,64], s32[]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = s32[] get-tuple-element(%param), index=1
+      ROOT result = pred[] compare(%gte.0, %gte.1), direction=LT
+    }
+
+    %while_body {
+      %param = (s32[], s32[], f32[64,64], f32[64,64], f32[64,64], f32[64,64], s32[]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = s32[] get-tuple-element(%param), index=1
+      %gte.2 = f32[64,64] get-tuple-element(%param), index=2
+      %gte.3 = f32[64,64] get-tuple-element(%param), index=3
+      %gte.4 = f32[64,64] get-tuple-element(%param), index=4
+      %gte.5 = f32[64,64] get-tuple-element(%param), index=5
+      %gte.6 = s32[] get-tuple-element(%param), index=6
+      %grad1 = f32[64,64] multiply(f32[64,64] %gte.2, f32[64,64] %gte.2)
+      %all-reduce.grad1 = f32[64,64] all-reduce(f32[64,64] %grad1), channel_id=1, replica_groups={{0,1,2,3}}, use_global_device_ids=true, to_apply=%reduction
+      %grad2 = f32[64,64] add(f32[64,64] %gte.3, f32[64,64] %gte.3)
+      %all-reduce.grad2 = f32[64,64] all-reduce(f32[64,64] %grad2), channel_id=2, replica_groups={{0,1,2,3}}, use_global_device_ids=true, to_apply=%reduction
+      %count = s32[] constant(4)
+      %all-reduce.scalar = s32[] all-reduce(s32[] %count), channel_id=3, replica_groups={{0,1,2,3}}, use_global_device_ids=true, to_apply=%scalar_reduction
+      %scalar.f32 = f32[] convert(s32[] %all-reduce.scalar)
+      %scalar.bcast = f32[64,64] broadcast(f32[] %scalar.f32), dimensions={}
+      %scaled.grad1 = f32[64,64] multiply(f32[64,64] %all-reduce.grad1, f32[64,64] %scalar.bcast)
+      %accumulation.1 = f32[64,64] add(f32[64,64] %scaled.grad1, f32[64,64] %gte.4)
+      %scaled.grad2 = f32[64,64] multiply(f32[64,64] %all-reduce.grad2, f32[64,64] %scalar.bcast)
+      %accumulation.2 = f32[64,64] add(f32[64,64] %scaled.grad2, f32[64,64] %gte.5)
+      %accumulation.scalar = s32[] add(s32[] %all-reduce.scalar, s32[] %gte.6)
+      %constant.1 = s32[] constant(1)
+      %increment_iteration = s32[] add(s32[] %gte.0, s32[] %constant.1)
+      ROOT %loop_result = (s32[], s32[], f32[64,64], f32[64,64], f32[64,64], f32[64,64], s32[]) tuple(%increment_iteration, %gte.1, %gte.2, %gte.3, %accumulation.1, %accumulation.2, %accumulation.scalar)
+    }
+
+    ENTRY multi_grad_scalar_correctness {
+      %param.0 = s32[] parameter(0)
+      %param.1 = f32[64,64] parameter(1)
+      %param.2 = f32[64,64] parameter(2)
+      %constant.0 = s32[] constant(1)
+      %zero.init = f32[] constant(0)
+      %zero.buffer = f32[64,64] broadcast(f32[] %zero.init), dimensions={}
+      %scalar_buffer_init = s32[] constant(0)
+      %while_init = (s32[], s32[], f32[64,64], f32[64,64], f32[64,64], f32[64,64], s32[]) tuple(%constant.0, %param.0, %param.1, %param.2, %zero.buffer, %zero.buffer, %scalar_buffer_init)
+      ROOT %while = (s32[], s32[], f32[64,64], f32[64,64], f32[64,64], f32[64,64], s32[]) while(%while_init), condition=%while_condition, body=%while_body
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool simplified_loop,
+                          WhileLoopAllReduceCodeMotion{}.Run(module.get()));
+  ASSERT_TRUE(simplified_loop);
+  TF_ASSERT_OK(
+      HloVerifier(/*layout_sensitive=*/false, /*allow_mixed_precision=*/true)
+          .Run(module.get())
+          .status());
+  HloComputation* entry = module->entry_computation();
+  HloInstruction* transformed_while = find_op<HloOpcode::kWhile>(entry);
+  ASSERT_THAT(transformed_while, NotNull());
+  HloComputation* body = transformed_while->while_body();
+  std::vector<HloInstruction*> body_all_reduces;
+  absl::c_copy_if(body->instructions(), std::back_inserter(body_all_reduces),
+                  HloPredicateIsOp<HloOpcode::kAllReduce>);
+  ASSERT_THAT(body_all_reduces, SizeIs(1));
+  EXPECT_THAT(body_all_reduces[0], op::Shape("s32[]"));
+  EXPECT_EQ(
+      absl::c_count_if(body->instructions(),
+                       Matches(op::Multiply(
+                           _, op::Broadcast(op::Convert(op::AllReduce()))))),
+      2);
+  std::vector<HloInstruction*> entry_all_reduces;
+  absl::c_copy_if(entry->instructions(), std::back_inserter(entry_all_reduces),
+                  HloPredicateIsOp<HloOpcode::kAllReduce>);
+  ASSERT_THAT(entry_all_reduces, SizeIs(2));
+  EXPECT_THAT(entry_all_reduces[0], op::Shape("f32[64,64]"));
+  EXPECT_THAT(entry_all_reduces[1], op::Shape("f32[64,64]"));
+}
+
+TEST_F(WhileLoopAllReduceCodeMotionTest,
+       ScalarAllReduceWithOnlyMultiplyUseIsNotDeleted) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule scalar_ar_only_multiply_use
+
+    %reduction {
+      %x = f32[] parameter(0)
+      %y = f32[] parameter(1)
+      ROOT %add = f32[] add(f32[] %x, f32[] %y)
+    }
+
+    %scalar_reduction {
+      %x = s32[] parameter(0)
+      %y = s32[] parameter(1)
+      ROOT %add = s32[] add(s32[] %x, s32[] %y)
+    }
+
+    %while_condition {
+      %param = (s32[], s32[], f32[128,128], f32[128,128]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = s32[] get-tuple-element(%param), index=1
+      ROOT result = pred[] compare(%gte.0, %gte.1), direction=LT
+    }
+
+    %while_body {
+      %param = (s32[], s32[], f32[128,128], f32[128,128]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = s32[] get-tuple-element(%param), index=1
+      %gte.2 = f32[128,128] get-tuple-element(%param), index=2
+      %gte.3 = f32[128,128] get-tuple-element(%param), index=3
+      %grad1 = f32[128,128] multiply(f32[128,128] %gte.2, f32[128,128] %gte.2)
+      %all-reduce.1 = f32[128,128] all-reduce(f32[128,128] %grad1), channel_id=1, replica_groups={{0,1,2,3}}, use_global_device_ids=true, to_apply=%reduction
+      %count = s32[] constant(1)
+      %all-reduce.scalar = s32[] all-reduce(s32[] %count), channel_id=2, replica_groups={{0,1,2,3}}, use_global_device_ids=true, to_apply=%scalar_reduction
+      %scalar.f32 = f32[] convert(s32[] %all-reduce.scalar)
+      %scalar.bcast = f32[128,128] broadcast(f32[] %scalar.f32), dimensions={}
+      %scaled.grad1 = f32[128,128] multiply(f32[128,128] %all-reduce.1, f32[128,128] %scalar.bcast)
+      %accumulation.1 = f32[128,128] add(f32[128,128] %scaled.grad1, f32[128,128] %gte.3)
+      %constant.1 = s32[] constant(1)
+      %increment_iteration = s32[] add(s32[] %gte.0, s32[] %constant.1)
+      ROOT %loop_result = (s32[], s32[], f32[128,128], f32[128,128]) tuple(%increment_iteration, %gte.1, %gte.2, %accumulation.1)
+    }
+
+    ENTRY scalar_ar_only_multiply_use {
+      %param.0 = s32[] parameter(0)
+      %param.1 = f32[128,128] parameter(1)
+      %constant.0 = s32[] constant(1)
+      %accumulation_buffer_init = f32[] constant(0)
+      %accumulation_buffer = f32[128,128] broadcast(f32[] %accumulation_buffer_init), dimensions={}
+      %while_init = (s32[], s32[], f32[128,128], f32[128,128]) tuple(%constant.0, %param.0, %param.1, %accumulation_buffer)
+      ROOT %while = (s32[], s32[], f32[128,128], f32[128,128]) while(%while_init), condition=%while_condition, body=%while_body
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool simplified_loop,
+                          WhileLoopAllReduceCodeMotion{}.Run(module.get()));
+  ASSERT_TRUE(simplified_loop);
+  TF_ASSERT_OK(
+      HloVerifier(/*layout_sensitive=*/false, /*allow_mixed_precision=*/true)
+          .Run(module.get())
+          .status());
+  HloComputation* entry = module->entry_computation();
+  HloInstruction* transformed_while = find_op<HloOpcode::kWhile>(entry);
+  ASSERT_THAT(transformed_while, NotNull());
+  HloComputation* body = transformed_while->while_body();
+  std::vector<HloInstruction*> body_all_reduces;
+  absl::c_copy_if(body->instructions(), std::back_inserter(body_all_reduces),
+                  HloPredicateIsOp<HloOpcode::kAllReduce>);
+  ASSERT_THAT(body_all_reduces, SizeIs(1));
+  EXPECT_THAT(body_all_reduces[0], op::Shape("s32[]"));
 }
 
 }  // namespace


### PR DESCRIPTION
📝 Summary of Changes
Re-lands the reverted [PR #36441](https://github.com/openxla/xla/pull/36441) with a fix and unit tests.

🎯 Justification
For the ZeRO-1 gradient-accumulation pattern `AR(g) * AR(s) + b` inside a while body, the gradient `AR(g)` is hoisted out of the loop, while the scalar `AR(s)` is now kept inside the loop body so the per-iteration scaling factor remains the all-reduced value.

🚀 Kind of Contribution
Please remove what does not apply: ✨ New Feature, 🧪 Tests

📊 Benchmark (for Performance Improvements)
The HLOs in compiler/xla/tools/benchmarks/hlo/ do not have this pattern.

🧪 Unit Tests:
Added to xla/service/while_loop_all_reduce_code_motion_test.cc

🧪 Execution Tests:
N/A
