### PR TITLE
[xla:se] Make CudaVmmAllocator compatible with NCCL

### DIFF
--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -1319,9 +1319,7 @@ cc_library(
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/base",
-        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/cleanup",
-        "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
@@ -1631,6 +1629,7 @@ cc_library(
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
+        "@local_config_cuda//cuda:cuda_headers",
     ],
 )
 

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -1318,11 +1318,14 @@ cc_library(
         "//xla/stream_executor:memory_allocator",
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/cleanup",
+        "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
         "@local_config_cuda//cuda:cuda_headers",
-        "@tsl//tsl/platform:numbers",
     ],
 )
 

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -62,6 +62,7 @@ limitations under the License.
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/cuda/cuda_context.h"
 #include "xla/stream_executor/cuda/cuda_core_info_table.h"
+#include "xla/stream_executor/cuda/cuda_device_allocator.h"
 #include "xla/stream_executor/cuda/cuda_event.h"
 #include "xla/stream_executor/cuda/cuda_host_allocator.h"
 #include "xla/stream_executor/cuda/cuda_kernel.h"
@@ -111,10 +112,8 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/platform/threadpool.h"
 #include "xla/util.h"
-#include "tsl/platform/casts.h"
 #include "tsl/platform/fingerprint.h"
 #include "tsl/platform/numa.h"
-#include "tsl/platform/numbers.h"
 
 namespace stream_executor {
 namespace gpu {
@@ -517,6 +516,33 @@ absl::StatusOr<bool> IsVmmSupported(CUdevice device) {
   return deviceSupportsVmm;
 }
 
+CUmemAllocationProp GetVmmAllocationProp(
+    CUdevice device, const CudaVmmAllocator::Options& options) {
+  CUmemAllocationProp properties = {};
+  properties.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  properties.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  properties.location.id = device;
+  int handle_types = CU_MEM_HANDLE_TYPE_NONE;
+  if (options.enable_posix_fd_handle) {
+    handle_types |= CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  }
+  if (options.enable_fabric_handle) {
+    handle_types |= CU_MEM_HANDLE_TYPE_FABRIC;
+  }
+  properties.requestedHandleTypes =
+      static_cast<CUmemAllocationHandleType>(handle_types);
+  properties.allocFlags.gpuDirectRDMACapable = options.enable_rdma ? 1 : 0;
+  return properties;
+}
+
+CUmemAccessDesc GetVmmAccessDesc(int device) {
+  CUmemAccessDesc descriptor = {};
+  descriptor.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  descriptor.location.id = device;
+  descriptor.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  return descriptor;
+}
+
 absl::StatusOr<bool> IsRdmaSupported(CUdevice device) {
   int rdma_supported = 0;
   TF_RETURN_IF_ERROR(cuda::ToStatus(cuDeviceGetAttribute(
@@ -541,29 +567,58 @@ absl::StatusOr<bool> IsFabricSupported(CUdevice device) {
   return fabric_supported;
 }
 
-CUmemAllocationProp GetVmmAllocationProperties(CUdevice device,
-                                               bool is_rdma_supported,
-                                               bool is_fabric_supported) {
-  CUmemAllocationProp properties = {};
-  properties.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-  properties.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  int handle_types = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
-  if (is_fabric_supported) {
-    handle_types |= CU_MEM_HANDLE_TYPE_FABRIC;
-  }
-  properties.requestedHandleTypes =
-      static_cast<CUmemAllocationHandleType>(handle_types);
-  properties.location.id = device;
-  properties.allocFlags.gpuDirectRDMACapable = is_rdma_supported ? 1 : 0;
-  return properties;
-}
+// Queries device VMM capabilities and allocation granularity, falling back to
+// simpler handle types if the environment doesn't support POSIX_FD or FABRIC
+// (e.g. MIG partitions, containers, or older drivers). Returns VMM allocator
+// options with alignment set to the queried granularity.
+absl::StatusOr<CudaVmmAllocator::Options> QueryVmmOptions(CUdevice device) {
+  TF_ASSIGN_OR_RETURN(bool rdma, IsRdmaSupported(device));
+  TF_ASSIGN_OR_RETURN(bool fabric, IsFabricSupported(device));
 
-CUmemAccessDesc GetVmmAccessDescriptor(int device) {
-  CUmemAccessDesc descriptor = {};
-  descriptor.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  descriptor.location.id = device;
-  descriptor.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-  return descriptor;
+  bool posix_fd = true;
+  size_t granularity = 0;
+
+  // Query allocation granularity
+  auto try_query = [&]() -> absl::Status {
+    CudaVmmAllocator::Options opts;
+    opts.enable_rdma = rdma;
+    opts.enable_posix_fd_handle = posix_fd;
+    opts.enable_fabric_handle = fabric;
+    CUmemAllocationProp props = GetVmmAllocationProp(device, opts);
+    return cuda::ToStatus(cuMemGetAllocationGranularity(
+        &granularity, &props, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED));
+  };
+
+  absl::Status status = try_query();
+  if (!status.ok() && fabric && posix_fd) {
+    XLA_LOG_DEVICE(WARNING, device)
+        << "VMM granularity query with FABRIC+POSIX_FD handle types failed: "
+        << status << "; retrying without FABRIC.";
+    fabric = false;
+    status = try_query();
+  }
+
+  if (!status.ok() && posix_fd) {
+    XLA_LOG_DEVICE(WARNING, device)
+        << "VMM granularity query with POSIX_FD handle type failed: " << status
+        << "; retrying with HANDLE_TYPE_NONE.";
+    posix_fd = false;
+    status = try_query();
+  }
+
+  if (!status.ok()) {
+    XLA_LOG_DEVICE(WARNING, device)
+        << "VMM granularity query with HANDLE_TYPE_NONE failed: " << status
+        << "; VMM is not supported for this device.";
+    return status;
+  }
+
+  CudaVmmAllocator::Options options;
+  options.alignment = granularity;
+  options.enable_rdma = rdma;
+  options.enable_posix_fd_handle = posix_fd;
+  options.enable_fabric_handle = fabric;
+  return options;
 }
 
 absl::StatusOr<CUmulticastObjectProp> CreateMulticastObjectProperties(
@@ -784,7 +839,7 @@ CudaExecutor::VmmMemoryHandle& CudaExecutor::VmmMemoryHandle::operator=(
 
 absl::StatusOr<CudaExecutor::VmmMemoryHandle>
 CudaExecutor::RetainVmmMemoryHandle(void* ptr) const {
-  if (vmm_granularity_ == 0) {
+  if (vmm_options_.alignment == 0) {
     return absl::InternalError("VMM is not supported on this device.");
   }
 
@@ -795,8 +850,7 @@ CudaExecutor::RetainVmmMemoryHandle(void* ptr) const {
 }
 
 absl::StatusOr<size_t> CudaExecutor::GetVmmGranularity() const {
-  CUmemAllocationProp properties = GetVmmAllocationProperties(
-      device_, is_rdma_supported_, is_fabric_supported_);
+  CUmemAllocationProp properties = GetVmmAllocationProp(device_, vmm_options_);
   size_t granularity = 0;
   TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
       &granularity, &properties, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED)));
@@ -873,9 +927,7 @@ absl::Status CudaExecutor::Init() {
         device_ordinal()));
   }
 
-  TF_ASSIGN_OR_RETURN(is_rdma_supported_, IsRdmaSupported(device_));
   TF_ASSIGN_OR_RETURN(is_multicast_supported_, IsMulticastSupported(device_));
-  TF_ASSIGN_OR_RETURN(is_fabric_supported_, IsFabricSupported(device_));
   TF_ASSIGN_OR_RETURN(CudaContext * context,
                       CudaContext::Create(device_ordinal(), device_));
   cuda_context_ = context;
@@ -896,21 +948,13 @@ absl::Status CudaExecutor::Init() {
     peer_access_cache_[i] = CanEnablePeerAccess(device_, i);
   }
 
-  CUmemAllocationProp properties = GetVmmAllocationProperties(
-      device_, is_rdma_supported_, is_fabric_supported_);
-  TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
-      &vmm_granularity_, &properties, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED)));
-
-  CudaVmmAllocator::Options vmm_options;
-  vmm_options.alignment = vmm_granularity_;
-  vmm_options.enable_peer_access = absl::c_any_of(
+  TF_ASSIGN_OR_RETURN(vmm_options_, QueryVmmOptions(device_));
+  vmm_options_.enable_peer_access = absl::c_any_of(
       peer_access_cache_, [](const auto& p) { return p.second; });
-  vmm_options.enable_fabric_handle = is_fabric_supported_;
-  vmm_options.is_rdma_supported = is_rdma_supported_;
 
   device_allocator_ = std::make_unique<CudaDeviceAllocator>(this);
   host_allocator_ = std::make_unique<CudaHostAllocator>(this, numa_node_);
-  vmm_allocator_ = std::make_unique<CudaVmmAllocator>(this, vmm_options);
+  vmm_allocator_ = std::make_unique<CudaVmmAllocator>(this, vmm_options_);
 
   return absl::OkStatus();
 }
@@ -1246,7 +1290,7 @@ DeviceAddressBase CudaExecutor::Allocate(uint64_t size, int64_t memory_space) {
   }
 
   if (memory_space == static_cast<int64_t>(MemorySpace::kP2P) &&
-      vmm_granularity_ > 0) {
+      vmm_options_.alignment > 0) {
     return AllocateAndTrack(*vmm_allocator_, size, "vmm");
   }
 
@@ -1657,7 +1701,7 @@ CudaExecutor::CreateDeviceDescription(int device_ordinal) {
       LOG(ERROR) << p2p_link_count;
     }
     // nvmlDeviceGetGpuFabricInfoV is only available in driver r545+
-    if (desc.kernel_mode_driver_version().major() >= 545) {
+    if (desc.kernel_mode_driver_version().major() >= 545) {  // NOLINT
       absl::StatusOr<FabricInfo> fabric_info = GetDeviceFabricInfo(*device);
       if (fabric_info.ok()) {
         info.cluster_uuid = fabric_info->cluster_uuid;
@@ -1887,9 +1931,8 @@ absl::Status CudaExecutor::CudaMulticastMemory::Initialize(
                      num_devices, "."));
   }
 
-  CUmemAllocationProp properties = GetVmmAllocationProperties(
-      cuda_executor->device_, cuda_executor->is_rdma_supported_,
-      cuda_executor->is_fabric_supported_);
+  CUmemAllocationProp properties =
+      GetVmmAllocationProp(cuda_executor->device_, cuda_executor->vmm_options_);
   TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
       &granularity_, &properties, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED)));
 
@@ -1977,7 +2020,7 @@ absl::StatusOr<void*> CudaExecutor::CudaMulticastMemory::MapMemory(
   TF_RETURN_IF_ERROR(cuda::ToStatus(
       cuMemMap(multicast_device_ptr, padded_size_, 0, handle_, 0)));
 
-  CUmemAccessDesc accessDesc = GetVmmAccessDescriptor(cuda_executor->device_);
+  CUmemAccessDesc accessDesc = GetVmmAccessDesc(cuda_executor->device_);
   TF_RETURN_IF_ERROR(cuda::ToStatus(
       cuMemSetAccess(multicast_device_ptr, padded_size_, &accessDesc, 1)));
 

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -849,10 +849,6 @@ CudaExecutor::VmmMemoryHandle& CudaExecutor::VmmMemoryHandle::operator=(
 
 absl::StatusOr<CudaExecutor::VmmMemoryHandle>
 CudaExecutor::RetainVmmMemoryHandle(void* ptr) const {
-  if (vmm_options_.alignment == 0) {
-    return absl::InternalError("VMM is not supported on this device.");
-  }
-
   CUmemGenericAllocationHandle handle;
   TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemRetainAllocationHandle(&handle, ptr)));
 
@@ -1299,8 +1295,7 @@ DeviceAddressBase CudaExecutor::Allocate(uint64_t size, int64_t memory_space) {
     return AllocateAndTrack(*host_allocator_, size, "host");
   }
 
-  if (memory_space == static_cast<int64_t>(MemorySpace::kP2P) &&
-      vmm_options_.alignment > 0) {
+  if (memory_space == static_cast<int64_t>(MemorySpace::kP2P)) {
     return AllocateAndTrack(*vmm_allocator_, size, "vmm");
   }
 

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -561,10 +561,20 @@ absl::StatusOr<bool> IsMulticastSupported(CUdevice device) {
 
 absl::StatusOr<bool> IsFabricSupported(CUdevice device) {
   int fabric_supported = 0;
-  TF_RETURN_IF_ERROR(cuda::ToStatus(cuDeviceGetAttribute(
+  CUresult result = cuDeviceGetAttribute(
       &fabric_supported, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
-      device)));
-  return fabric_supported;
+      device);
+
+  // Older drivers return INVALID_VALUE when they don't recognize the attribute.
+  if (result == CUDA_ERROR_INVALID_VALUE) {
+    XLA_VLOG_DEVICE(1, device)
+        << "CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED not supported "
+           "by driver.";
+    return false;
+  }
+
+  TF_RETURN_IF_ERROR(cuda::ToStatus(result));
+  return fabric_supported > 0;
 }
 
 // Queries device VMM capabilities and allocation granularity, falling back to

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -29,7 +29,6 @@ limitations under the License.
 #include <utility>
 #include <variant>
 
-#include "cub/version.cuh"
 #include "absl/algorithm/container.h"
 #include "absl/base/call_once.h"
 #include "absl/base/casts.h"
@@ -52,6 +51,7 @@ limitations under the License.
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/gpus/cuda/include/driver_types.h"
 #include "third_party/gpus/cuda/nvml/include/nvml.h"
+#include "cub/version.cuh"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/core/collectives/collectives.h"
 #include "xla/core/collectives/collectives_registry.h"
@@ -71,6 +71,7 @@ limitations under the License.
 #include "xla/stream_executor/cuda/cuda_timer.h"
 #include "xla/stream_executor/cuda/cuda_unified_allocator.h"
 #include "xla/stream_executor/cuda/cuda_version_parser.h"
+#include "xla/stream_executor/cuda/cuda_vmm_allocator.h"
 #include "xla/stream_executor/cuda/cudnn_api_wrappers.h"
 #include "xla/stream_executor/cuda/tma_util.h"
 #include "xla/stream_executor/device_address.h"
@@ -532,13 +533,26 @@ absl::StatusOr<bool> IsMulticastSupported(CUdevice device) {
   return is_multicast_supported;
 }
 
+absl::StatusOr<bool> IsFabricSupported(CUdevice device) {
+  int fabric_supported = 0;
+  TF_RETURN_IF_ERROR(cuda::ToStatus(cuDeviceGetAttribute(
+      &fabric_supported, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
+      device)));
+  return fabric_supported;
+}
+
 CUmemAllocationProp GetVmmAllocationProperties(CUdevice device,
-                                               bool is_rdma_supported) {
+                                               bool is_rdma_supported,
+                                               bool is_fabric_supported) {
   CUmemAllocationProp properties = {};
   properties.type = CU_MEM_ALLOCATION_TYPE_PINNED;
   properties.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  int handle_types = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  if (is_fabric_supported) {
+    handle_types |= CU_MEM_HANDLE_TYPE_FABRIC;
+  }
   properties.requestedHandleTypes =
-      static_cast<CUmemAllocationHandleType>(CU_MEM_HANDLE_TYPE_NONE);
+      static_cast<CUmemAllocationHandleType>(handle_types);
   properties.location.id = device;
   properties.allocFlags.gpuDirectRDMACapable = is_rdma_supported ? 1 : 0;
   return properties;
@@ -770,7 +784,7 @@ CudaExecutor::VmmMemoryHandle& CudaExecutor::VmmMemoryHandle::operator=(
 
 absl::StatusOr<CudaExecutor::VmmMemoryHandle>
 CudaExecutor::RetainVmmMemoryHandle(void* ptr) const {
-  if (!is_vmm_supported_) {
+  if (vmm_granularity_ == 0) {
     return absl::InternalError("VMM is not supported on this device.");
   }
 
@@ -781,8 +795,8 @@ CudaExecutor::RetainVmmMemoryHandle(void* ptr) const {
 }
 
 absl::StatusOr<size_t> CudaExecutor::GetVmmGranularity() const {
-  CUmemAllocationProp properties =
-      GetVmmAllocationProperties(device_, is_rdma_supported_);
+  CUmemAllocationProp properties = GetVmmAllocationProperties(
+      device_, is_rdma_supported_, is_fabric_supported_);
   size_t granularity = 0;
   TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
       &granularity, &properties, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED)));
@@ -850,9 +864,18 @@ CudaExecutor::CreateMemoryAllocator(MemorySpace type) {
 
 absl::Status CudaExecutor::Init() {
   TF_ASSIGN_OR_RETURN(device_, GetDevice(device_ordinal()));
-  TF_ASSIGN_OR_RETURN(is_vmm_supported_, IsVmmSupported(device_));
+
+  TF_ASSIGN_OR_RETURN(bool is_vmm_supported, IsVmmSupported(device_));
+  if (!is_vmm_supported) {
+    return absl::InternalError(absl::StrFormat(
+        "Device %d does not support CUDA Virtual Memory Management (VMM). "
+        "VMM is required for device memory allocation in XLA.",
+        device_ordinal()));
+  }
+
   TF_ASSIGN_OR_RETURN(is_rdma_supported_, IsRdmaSupported(device_));
   TF_ASSIGN_OR_RETURN(is_multicast_supported_, IsMulticastSupported(device_));
+  TF_ASSIGN_OR_RETURN(is_fabric_supported_, IsFabricSupported(device_));
   TF_ASSIGN_OR_RETURN(CudaContext * context,
                       CudaContext::Create(device_ordinal(), device_));
   cuda_context_ = context;
@@ -863,13 +886,6 @@ absl::Status CudaExecutor::Init() {
     XLA_VLOG_DEVICE(2, device_ordinal()) << "Could not determine NUMA node";
   }
 
-  device_allocator_ = std::make_unique<CudaDeviceAllocator>(this);
-  host_allocator_ = std::make_unique<CudaHostAllocator>(this, numa_node_);
-  if (is_vmm_supported_) {
-    vmm_allocator_ =
-        std::make_unique<CudaVmmAllocator>(this, is_rdma_supported_);
-  }
-
   int cuda_device_count = 0;
   TF_RETURN_IF_ERROR(cuda::ToStatus(cudaGetDeviceCount(&cuda_device_count)));
   for (int i = 0; i < cuda_device_count; ++i) {
@@ -877,9 +893,25 @@ absl::Status CudaExecutor::Init() {
       peer_access_cache_[i] = true;
       continue;
     }
-
     peer_access_cache_[i] = CanEnablePeerAccess(device_, i);
   }
+
+  CUmemAllocationProp properties = GetVmmAllocationProperties(
+      device_, is_rdma_supported_, is_fabric_supported_);
+  TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
+      &vmm_granularity_, &properties, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED)));
+
+  CudaVmmAllocator::Options vmm_options;
+  vmm_options.alignment = vmm_granularity_;
+  vmm_options.enable_peer_access = absl::c_any_of(
+      peer_access_cache_, [](const auto& p) { return p.second; });
+  vmm_options.enable_fabric_handle = is_fabric_supported_;
+  vmm_options.is_rdma_supported = is_rdma_supported_;
+
+  device_allocator_ = std::make_unique<CudaDeviceAllocator>(this);
+  host_allocator_ = std::make_unique<CudaHostAllocator>(this, numa_node_);
+  vmm_allocator_ = std::make_unique<CudaVmmAllocator>(this, vmm_options);
+
   return absl::OkStatus();
 }
 
@@ -1214,7 +1246,7 @@ DeviceAddressBase CudaExecutor::Allocate(uint64_t size, int64_t memory_space) {
   }
 
   if (memory_space == static_cast<int64_t>(MemorySpace::kP2P) &&
-      is_vmm_supported_) {
+      vmm_granularity_ > 0) {
     return AllocateAndTrack(*vmm_allocator_, size, "vmm");
   }
 
@@ -1856,7 +1888,8 @@ absl::Status CudaExecutor::CudaMulticastMemory::Initialize(
   }
 
   CUmemAllocationProp properties = GetVmmAllocationProperties(
-      cuda_executor->device_, cuda_executor->is_rdma_supported_);
+      cuda_executor->device_, cuda_executor->is_rdma_supported_,
+      cuda_executor->is_fabric_supported_);
   TF_RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
       &granularity_, &properties, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED)));
 

--- a/xla/stream_executor/cuda/cuda_executor.h
+++ b/xla/stream_executor/cuda/cuda_executor.h
@@ -220,6 +220,8 @@ class CudaExecutor : public GpuExecutor {
     return is_multicast_supported_;
   }
 
+  bool is_fabric_supported() const { return is_fabric_supported_; }
+
  private:
   // Allocates memory using the given allocator and tracks the resulting
   // allocation. Returns an empty DeviceAddressBase on failure.
@@ -240,11 +242,19 @@ class CudaExecutor : public GpuExecutor {
   // Returns true if a delay kernel is supported.
   absl::StatusOr<bool> DelayKernelIsSupported();
 
-  bool is_vmm_supported_ = false;
+  // Device-reported VMM recommended allocation granularity, cached at Init()
+  // time. Also used as the alignment for symmetric/collective memory buffers
+  // (NCCL NVLS UB requires virtual address alignment to this granularity).
+  size_t vmm_granularity_ = 0;
 
+  // Whether GPUDirect RDMA over VMM is supported by this device.
   bool is_rdma_supported_ = false;
 
+  // Whether multicast objects are supported by this device.
   bool is_multicast_supported_ = false;
+
+  // Whether fabric handle type is supported by this device.
+  bool is_fabric_supported_ = false;
 
   // Guards the in-memory-module mapping.
   absl::Mutex in_memory_modules_mu_;

--- a/xla/stream_executor/cuda/cuda_executor.h
+++ b/xla/stream_executor/cuda/cuda_executor.h
@@ -37,6 +37,7 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/command_buffer.h"
@@ -220,7 +221,7 @@ class CudaExecutor : public GpuExecutor {
     return is_multicast_supported_;
   }
 
-  bool is_fabric_supported() const { return is_fabric_supported_; }
+  bool is_fabric_supported() const { return vmm_options_.enable_fabric_handle; }
 
  private:
   // Allocates memory using the given allocator and tracks the resulting
@@ -242,19 +243,12 @@ class CudaExecutor : public GpuExecutor {
   // Returns true if a delay kernel is supported.
   absl::StatusOr<bool> DelayKernelIsSupported();
 
-  // Device-reported VMM recommended allocation granularity, cached at Init()
-  // time. Also used as the alignment for symmetric/collective memory buffers
-  // (NCCL NVLS UB requires virtual address alignment to this granularity).
-  size_t vmm_granularity_ = 0;
-
-  // Whether GPUDirect RDMA over VMM is supported by this device.
-  bool is_rdma_supported_ = false;
-
   // Whether multicast objects are supported by this device.
   bool is_multicast_supported_ = false;
 
-  // Whether fabric handle type is supported by this device.
-  bool is_fabric_supported_ = false;
+  // VMM allocator options, probed during Init() with fallback. The handle-type
+  // flags may differ from device-reported caps (e.g. in MIG or containers).
+  CudaVmmAllocator::Options vmm_options_;
 
   // Guards the in-memory-module mapping.
   absl::Mutex in_memory_modules_mu_;

--- a/xla/stream_executor/cuda/cuda_executor_test.cc
+++ b/xla/stream_executor/cuda/cuda_executor_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "xla/stream_executor/cuda/cuda_executor.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 
@@ -237,7 +238,9 @@ TEST(CudaExecutorTest, AllocateMemoryWithVmmApi) {
       cuda_executor->Allocate(1024, static_cast<int>(MemorySpace::kP2P));
 
   EXPECT_NE(ptr.opaque(), nullptr);
-  EXPECT_EQ(ptr.size(), 1024);
+  TF_ASSERT_OK_AND_ASSIGN(size_t granularity,
+                          cuda_executor->GetVmmGranularity());
+  EXPECT_EQ(ptr.size(), granularity);
   EXPECT_THAT(executor->GetPointerMemorySpace(ptr.opaque()),
               absl_testing::IsOkAndHolds(MemorySpace::kDevice));
 

--- a/xla/stream_executor/cuda/cuda_executor_test.cc
+++ b/xla/stream_executor/cuda/cuda_executor_test.cc
@@ -18,6 +18,8 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -62,7 +64,7 @@ TEST(CudaExecutorTest, CreateDeviceDescription) {
   EXPECT_TRUE(result->compile_time_toolkit_version().IsValid());
   EXPECT_TRUE(result->cub_version().IsValid());
 
-  EXPECT_GT(result->kernel_mode_driver_version().major(), 300);
+  EXPECT_GT(result->kernel_mode_driver_version().major(), 300);  // NOLINT
 
   EXPECT_GT(result->pcie_bandwidth(), 1024 * 1024);
   EXPECT_THAT(result->platform_version(), Not(IsEmpty()));
@@ -247,6 +249,42 @@ TEST(CudaExecutorTest, AllocateMemoryWithVmmApi) {
   TF_ASSERT_OK_AND_ASSIGN(CudaExecutor::VmmMemoryHandle handle,
                           cuda_executor->RetainVmmMemoryHandle(ptr.opaque()));
   EXPECT_NE(handle.handle(), 0);
+}
+
+TEST(CudaExecutorTest, MultipleExecutorsForSameDevice) {
+  TF_ASSERT_OK_AND_ASSIGN(Platform * platform,
+                          PlatformManager::PlatformWithName("CUDA"));
+  ASSERT_GT(platform->VisibleDeviceCount(), 0);
+
+  // Create multiple executors for device 0, bypassing the platform cache.
+  // This simulates the scenario where multiple PjRt clients are created
+  // without preallocation for the same physical GPU.
+  constexpr int kNumExecutors = 3;
+  std::vector<std::unique_ptr<CudaExecutor>> executors;
+  for (int i = 0; i < kNumExecutors; ++i) {
+    auto executor =
+        std::make_unique<CudaExecutor>(platform, /*device_ordinal=*/0);
+    ASSERT_THAT(executor->Init(), absl_testing::IsOk());
+    executors.push_back(std::move(executor));
+  }
+
+  // Verify all executors can create device descriptions and allocate memory.
+  for (int i = 0; i < kNumExecutors; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(auto desc, executors[i]->CreateDeviceDescription());
+    EXPECT_THAT(desc->name(), Not(IsEmpty()));
+
+    DeviceAddressBase ptr = executors[i]->Allocate(1024, /*memory_space=*/0);
+    EXPECT_NE(ptr.opaque(), nullptr);
+    executors[i]->Deallocate(&ptr);
+
+    // Allocate VMM memory (collective memory space uses the VMM allocator).
+    TF_ASSERT_OK_AND_ASSIGN(
+        std::unique_ptr<MemoryAllocator> vmm_allocator,
+        executors[i]->CreateMemoryAllocator(MemorySpace::kCollective));
+    TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> vmm_allocation,
+                            vmm_allocator->Allocate(4096));
+    EXPECT_NE(vmm_allocation->address().opaque(), nullptr);
+  }
 }
 
 TEST(CudaExecutorTest,

--- a/xla/stream_executor/cuda/cuda_vmm_allocator.cc
+++ b/xla/stream_executor/cuda/cuda_vmm_allocator.cc
@@ -15,12 +15,17 @@ limitations under the License.
 
 #include "xla/stream_executor/cuda/cuda_vmm_allocator.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <tuple>
+#include <utility>
 
+#include "absl/base/casts.h"
+#include "absl/cleanup/cleanup.h"
+#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
@@ -33,23 +38,56 @@ limitations under the License.
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/util.h"
-#include "tsl/platform/numbers.h"
 
 namespace stream_executor::gpu {
 
-static CUmemAllocationProp GetVmmAllocationProperties(CUdevice device,
-                                                      bool is_rdma_supported) {
+// Builds CUmemAllocationProp matching NCCL's ncclMemAlloc: always
+// POSIX_FILE_DESCRIPTOR baseline, plus FABRIC if the device supports it.
+static CUmemAllocationProp GetAllocationProperties(
+    CUdevice device, const CudaVmmAllocator::Options& options) {
   CUmemAllocationProp properties = {};
   properties.type = CU_MEM_ALLOCATION_TYPE_PINNED;
   properties.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  properties.requestedHandleTypes =
-      static_cast<CUmemAllocationHandleType>(CU_MEM_HANDLE_TYPE_NONE);
   properties.location.id = device;
-  properties.allocFlags.gpuDirectRDMACapable = is_rdma_supported ? 1 : 0;
+  properties.allocFlags.gpuDirectRDMACapable =
+      options.is_rdma_supported ? 1 : 0;
+
+  int handle_types = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  if (options.enable_fabric_handle) {
+    handle_types |= CU_MEM_HANDLE_TYPE_FABRIC;
+  }
+  properties.requestedHandleTypes =
+      static_cast<CUmemAllocationHandleType>(handle_types);
   return properties;
 }
 
-static CUmemAccessDesc GetVmmAccessDescriptor(int device) {
+// Creates a physical VMM allocation (matching NCCL's ncclMemAlloc). Tries
+// cuMemCreate with the given properties; if FABRIC handle is included and
+// fails with NOT_PERMITTED/NOT_SUPPORTED, falls back to POSIX_FD alone.
+static absl::StatusOr<CUmemGenericAllocationHandle> CreatePhysicalAllocation(
+    CUmemAllocationProp properties, uint64_t padded_size) {
+  CUmemGenericAllocationHandle handle;
+
+  bool has_fabric = properties.requestedHandleTypes & CU_MEM_HANDLE_TYPE_FABRIC;
+  if (has_fabric) {
+    CUresult result = cuMemCreate(&handle, padded_size, &properties, 0);
+    if (result != CUDA_ERROR_NOT_PERMITTED &&
+        result != CUDA_ERROR_NOT_SUPPORTED) {
+      RETURN_IF_ERROR(cuda::ToStatus(result));
+      return handle;
+    }
+    VLOG(3) << "Fabric memory handle requested but not supported or "
+               "permitted, falling back to non-fabric allocation.";
+    properties.requestedHandleTypes = static_cast<CUmemAllocationHandleType>(
+        properties.requestedHandleTypes & ~CU_MEM_HANDLE_TYPE_FABRIC);
+  }
+
+  RETURN_IF_ERROR(
+      cuda::ToStatus(cuMemCreate(&handle, padded_size, &properties, 0)));
+  return handle;
+}
+
+static CUmemAccessDesc GetAccessDescriptor(int device) {
   CUmemAccessDesc descriptor = {};
   descriptor.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
   descriptor.location.id = device;
@@ -57,86 +95,122 @@ static CUmemAccessDesc GetVmmAccessDescriptor(int device) {
   return descriptor;
 }
 
-// Allocates device memory using CUDA VMM APIs. Returns the mapped pointer,
-// the padded size, and the allocation handle.
+// Allocates device memory using CUDA Virtual Memory Management (VMM) API.
+// Returns (virtual_address, padded_size, allocation_handle).
 static absl::StatusOr<std::tuple<void*, uint64_t, CUmemGenericAllocationHandle>>
-VmmAllocate(StreamExecutor* executor, bool is_rdma_supported, uint64_t size) {
+VmmAllocate(StreamExecutor* executor, const CudaVmmAllocator::Options& options,
+            uint64_t size) {
   std::unique_ptr<ActivateContext> activation = executor->Activate();
 
   CUdevice device;
   RETURN_IF_ERROR(
       cuda::ToStatus(cuDeviceGet(&device, executor->device_ordinal())));
 
-  CUmemAllocationProp properties =
-      GetVmmAllocationProperties(device, is_rdma_supported);
+  // Query VMM allocation granularity and pad size to alignment boundary.
+  CUmemAllocationProp properties = GetAllocationProperties(device, options);
   size_t granularity = 0;
   RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
       &granularity, &properties, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED)));
 
-  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
-  CUmemGenericAllocationHandle handle;
+  size_t effective_alignment = std::max(options.alignment, granularity);
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, effective_alignment);
 
-  // Create physical memory allocation.
-  RETURN_IF_ERROR(
-      cuda::ToStatus(cuMemCreate(&handle, padded_size, &properties, 0)));
+  ASSIGN_OR_RETURN(CUmemGenericAllocationHandle handle,
+                   CreatePhysicalAllocation(properties, padded_size));
 
-  // Reserve and map virtual address space.
+  absl::Cleanup release_handle = [&] {
+    absl::Status status = cuda::ToStatus(cuMemRelease(handle));
+    if (!status.ok()) {
+      XLA_LOG_DEVICE(ERROR, executor->device_ordinal())
+          << "Failed to release VMM handle during cleanup: " << status;
+    }
+  };
+
+  // Reserve virtual address range and map the physical allocation into it.
   CUdeviceptr ptr;
-  absl::Status status =
-      cuda::ToStatus(cuMemAddressReserve(&ptr, padded_size, granularity, 0, 0));
-  if (!status.ok()) {
-    // Clean up the physical allocation on failure.
-    cuda::ToStatus(cuMemRelease(handle)).IgnoreError();
-    return status;
-  }
+  RETURN_IF_ERROR(cuda::ToStatus(
+      cuMemAddressReserve(&ptr, padded_size, effective_alignment, 0, 0)));
+  absl::Cleanup free_address = [&] {
+    absl::Status status = cuda::ToStatus(cuMemUnmap(ptr, padded_size));
+    if (!status.ok()) {
+      XLA_LOG_DEVICE(ERROR, executor->device_ordinal())
+          << "Failed to unmap VMM memory during cleanup: " << status;
+    }
+    status = cuda::ToStatus(cuMemAddressFree(ptr, padded_size));
+    if (!status.ok()) {
+      XLA_LOG_DEVICE(ERROR, executor->device_ordinal())
+          << "Failed to free VMM address during cleanup: " << status;
+    }
+  };
+  RETURN_IF_ERROR(cuda::ToStatus(cuMemMap(ptr, padded_size, 0, handle, 0)));
 
-  status = cuda::ToStatus(cuMemMap(ptr, padded_size, 0, handle, 0));
-  if (!status.ok()) {
-    cuda::ToStatus(cuMemAddressFree(ptr, padded_size)).IgnoreError();
-    cuda::ToStatus(cuMemRelease(handle)).IgnoreError();
-    return status;
+  // Grant read/write access — to all peers if peer access is enabled,
+  // otherwise only to the owning device.
+  if (options.enable_peer_access) {
+    int device_count = 0;
+    RETURN_IF_ERROR(cuda::ToStatus(cudaGetDeviceCount(&device_count)));
+    for (int peer = 0; peer < device_count; peer++) {
+      if (peer == executor->device_ordinal() ||
+          executor->CanEnablePeerAccessTo(peer)) {
+        XLA_VLOG_DEVICE(5, executor->device_ordinal())
+            << "Setting VMM access for peer device " << peer;
+        CUmemAccessDesc access_desc = GetAccessDescriptor(peer);
+        RETURN_IF_ERROR(
+            cuda::ToStatus(cuMemSetAccess(ptr, padded_size, &access_desc, 1)));
+      }
+    }
+  } else {
+    CUmemAccessDesc access_desc =
+        GetAccessDescriptor(executor->device_ordinal());
+    RETURN_IF_ERROR(
+        cuda::ToStatus(cuMemSetAccess(ptr, padded_size, &access_desc, 1)));
   }
 
   XLA_VLOG_DEVICE(3, executor->device_ordinal())
-      << "VMM allocated " << ptr << " requested size: " << size
-      << " padded size: " << padded_size << " granularity: " << granularity;
+      << "Allocated ptr=" << absl::bit_cast<void*>(ptr)
+      << " requested size: " << size << " padded size: " << padded_size
+      << " granularity: " << granularity
+      << " effective alignment: " << effective_alignment;
 
-  // Set access for this device and all peers.
-  int device_count = 0;
-  RETURN_IF_ERROR(cuda::ToStatus(cudaGetDeviceCount(&device_count)));
-  for (int peer = 0; peer < device_count; peer++) {
-    if (peer == executor->device_ordinal() ||
-        executor->CanEnablePeerAccessTo(peer)) {
-      CUmemAccessDesc access_desc = GetVmmAccessDescriptor(peer);
-      RETURN_IF_ERROR(
-          cuda::ToStatus(cuMemSetAccess(ptr, padded_size, &access_desc, 1)));
-    }
-  }
-
-  return std::make_tuple(reinterpret_cast<void*>(ptr), padded_size, handle);
+  // Success — cancel cleanups and return ownership to caller.
+  std::move(release_handle).Cancel();
+  std::move(free_address).Cancel();
+  return std::make_tuple(absl::bit_cast<void*>(ptr), padded_size, handle);
 }
 
-// Frees VMM memory previously allocated by VmmAllocate.
 static void VmmDeallocate(StreamExecutor* executor, void* ptr,
                           uint64_t padded_size,
                           CUmemGenericAllocationHandle handle) {
   std::unique_ptr<ActivateContext> activation = executor->Activate();
 
-  CUdeviceptr device_ptr = reinterpret_cast<CUdeviceptr>(ptr);
-
   XLA_VLOG_DEVICE(3, executor->device_ordinal())
-      << "VMM deallocating " << ptr << " padded size: " << padded_size;
+      << "Deallocating " << ptr << " padded size: " << padded_size;
 
-  absl::Status status = cuda::ToStatus(cuMemUnmap(device_ptr, padded_size));
+  // Unlike cuMemFree which defers until in-flight kernels complete, cuMemUnmap
+  // immediately invalidates the virtual address mapping. Synchronize to ensure
+  // no kernels are still accessing this memory. This is fine, because we never
+  // use this allocator on a hot path and always wrap it into BFCAllocator that
+  // does arena-based allocation.
+  absl::Status status = cuda::ToStatus(cuCtxSynchronize());
+  if (!status.ok()) {
+    XLA_LOG_DEVICE(ERROR, executor->device_ordinal())
+        << "Failed to synchronize before VMM deallocation at " << ptr << ": "
+        << status;
+  }
+
+  CUdeviceptr device_ptr = absl::bit_cast<CUdeviceptr>(ptr);
+  status = cuda::ToStatus(cuMemUnmap(device_ptr, padded_size));
   if (!status.ok()) {
     XLA_LOG_DEVICE(ERROR, executor->device_ordinal())
         << "Failed to unmap VMM memory at " << ptr << ": " << status;
   }
+
   status = cuda::ToStatus(cuMemRelease(handle));
   if (!status.ok()) {
     XLA_LOG_DEVICE(ERROR, executor->device_ordinal())
         << "Failed to release VMM handle for " << ptr << ": " << status;
   }
+
   status = cuda::ToStatus(cuMemAddressFree(device_ptr, padded_size));
   if (!status.ok()) {
     XLA_LOG_DEVICE(ERROR, executor->device_ordinal())
@@ -146,7 +220,6 @@ static void VmmDeallocate(StreamExecutor* executor, void* ptr,
 
 namespace {
 
-// A VMM memory allocation backed by CUDA VMM APIs.
 class CudaVmmMemoryAllocation : public MemoryAllocation {
  public:
   CudaVmmMemoryAllocation(StreamExecutor* executor, void* ptr,
@@ -165,13 +238,15 @@ class CudaVmmMemoryAllocation : public MemoryAllocation {
   }
 
   DeviceAddressBase address() const final {
-    return DeviceAddressBase(ptr_, requested_size_);
+    return DeviceAddressBase(ptr_, padded_size_);
   }
 
   std::string ToString() const final {
     return absl::StrFormat(
-        "CudaVmmMemoryAllocation[device=%d, ptr=%p, size=%d, padded_size=%d]",
-        executor_->device_ordinal(), ptr_, requested_size_, padded_size_);
+        "CudaVmmMemoryAllocation[device=%d, ptr=%p, size=%d, "
+        "padded_size=%d, handle=%llu]",
+        executor_->device_ordinal(), ptr_, requested_size_, padded_size_,
+        handle_);
   }
 
  private:
@@ -184,9 +259,8 @@ class CudaVmmMemoryAllocation : public MemoryAllocation {
 
 }  // namespace
 
-CudaVmmAllocator::CudaVmmAllocator(StreamExecutor* executor,
-                                   bool is_rdma_supported)
-    : executor_(executor), is_rdma_supported_(is_rdma_supported) {}
+CudaVmmAllocator::CudaVmmAllocator(StreamExecutor* executor, Options options)
+    : executor_(executor), options_(options) {}
 
 absl::StatusOr<std::unique_ptr<MemoryAllocation>> CudaVmmAllocator::Allocate(
     uint64_t size) {
@@ -195,8 +269,7 @@ absl::StatusOr<std::unique_ptr<MemoryAllocation>> CudaVmmAllocator::Allocate(
                                                      0);
   }
 
-  ASSIGN_OR_RETURN(auto result,
-                   VmmAllocate(executor_, is_rdma_supported_, size));
+  ASSIGN_OR_RETURN(auto result, VmmAllocate(executor_, options_, size));
   auto [ptr, padded_size, handle] = result;
 
   return std::make_unique<CudaVmmMemoryAllocation>(executor_, ptr, size,

--- a/xla/stream_executor/cuda/cuda_vmm_allocator.cc
+++ b/xla/stream_executor/cuda/cuda_vmm_allocator.cc
@@ -19,13 +19,13 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
 
 #include "absl/base/casts.h"
 #include "absl/cleanup/cleanup.h"
-#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
@@ -41,18 +41,18 @@ limitations under the License.
 
 namespace stream_executor::gpu {
 
-// Builds CUmemAllocationProp matching NCCL's ncclMemAlloc: always
-// POSIX_FILE_DESCRIPTOR baseline, plus FABRIC if the device supports it.
 static CUmemAllocationProp GetAllocationProperties(
     CUdevice device, const CudaVmmAllocator::Options& options) {
   CUmemAllocationProp properties = {};
   properties.type = CU_MEM_ALLOCATION_TYPE_PINNED;
   properties.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
   properties.location.id = device;
-  properties.allocFlags.gpuDirectRDMACapable =
-      options.is_rdma_supported ? 1 : 0;
+  properties.allocFlags.gpuDirectRDMACapable = options.enable_rdma ? 1 : 0;
 
-  int handle_types = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  int handle_types = CU_MEM_HANDLE_TYPE_NONE;
+  if (options.enable_posix_fd_handle) {
+    handle_types |= CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  }
   if (options.enable_fabric_handle) {
     handle_types |= CU_MEM_HANDLE_TYPE_FABRIC;
   }
@@ -61,25 +61,49 @@ static CUmemAllocationProp GetAllocationProperties(
   return properties;
 }
 
-// Creates a physical VMM allocation (matching NCCL's ncclMemAlloc). Tries
-// cuMemCreate with the given properties; if FABRIC handle is included and
-// fails with NOT_PERMITTED/NOT_SUPPORTED, falls back to POSIX_FD alone.
+// Creates a physical VMM allocation. Tries cuMemCreate with the given
+// properties and falls back through progressively simpler handle types:
+//   FABRIC+POSIX_FD -> POSIX_FD -> NONE
 static absl::StatusOr<CUmemGenericAllocationHandle> CreatePhysicalAllocation(
     CUmemAllocationProp properties, uint64_t padded_size) {
   CUmemGenericAllocationHandle handle;
 
-  bool has_fabric = properties.requestedHandleTypes & CU_MEM_HANDLE_TYPE_FABRIC;
-  if (has_fabric) {
+  auto try_create = [&](const char* description)
+      -> std::optional<absl::StatusOr<CUmemGenericAllocationHandle>> {
     CUresult result = cuMemCreate(&handle, padded_size, &properties, 0);
-    if (result != CUDA_ERROR_NOT_PERMITTED &&
-        result != CUDA_ERROR_NOT_SUPPORTED) {
-      RETURN_IF_ERROR(cuda::ToStatus(result));
+    if (result == CUDA_SUCCESS) {
       return handle;
     }
-    VLOG(3) << "Fabric memory handle requested but not supported or "
-               "permitted, falling back to non-fabric allocation.";
+    if (result == CUDA_ERROR_NOT_PERMITTED ||
+        result == CUDA_ERROR_NOT_SUPPORTED ||
+        result == CUDA_ERROR_INVALID_VALUE) {
+      XLA_LOG_DEVICE(WARNING, properties.location.id)
+          << "VMM cuMemCreate with " << description
+          << " handle types failed: " << cuda::ToStatus(result)
+          << "; will retry with simpler handle types.";
+      return std::nullopt;
+    }
+    return cuda::ToStatus(result);
+  };
+
+  bool has_fabric = properties.requestedHandleTypes & CU_MEM_HANDLE_TYPE_FABRIC;
+  bool has_posix_fd = properties.requestedHandleTypes &
+                      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+
+  if (has_fabric) {
+    if (auto r = try_create("FABRIC+POSIX_FD")) {
+      return *r;
+    }
     properties.requestedHandleTypes = static_cast<CUmemAllocationHandleType>(
         properties.requestedHandleTypes & ~CU_MEM_HANDLE_TYPE_FABRIC);
+  }
+
+  if (has_posix_fd) {
+    if (auto r = try_create("POSIX_FD")) {
+      return *r;
+    }
+    properties.requestedHandleTypes =
+        static_cast<CUmemAllocationHandleType>(CU_MEM_HANDLE_TYPE_NONE);
   }
 
   RETURN_IF_ERROR(

--- a/xla/stream_executor/cuda/cuda_vmm_allocator.cc
+++ b/xla/stream_executor/cuda/cuda_vmm_allocator.cc
@@ -41,7 +41,7 @@ limitations under the License.
 
 namespace stream_executor::gpu {
 
-static CUmemAllocationProp GetAllocationProperties(
+static CUmemAllocationProp GetAllocationProp(
     CUdevice device, const CudaVmmAllocator::Options& options) {
   CUmemAllocationProp properties = {};
   properties.type = CU_MEM_ALLOCATION_TYPE_PINNED;
@@ -111,7 +111,7 @@ static absl::StatusOr<CUmemGenericAllocationHandle> CreatePhysicalAllocation(
   return handle;
 }
 
-static CUmemAccessDesc GetAccessDescriptor(int device) {
+static CUmemAccessDesc GetAccessDesc(int device) {
   CUmemAccessDesc descriptor = {};
   descriptor.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
   descriptor.location.id = device;
@@ -131,7 +131,7 @@ VmmAllocate(StreamExecutor* executor, const CudaVmmAllocator::Options& options,
       cuda::ToStatus(cuDeviceGet(&device, executor->device_ordinal())));
 
   // Query VMM allocation granularity and pad size to alignment boundary.
-  CUmemAllocationProp properties = GetAllocationProperties(device, options);
+  CUmemAllocationProp properties = GetAllocationProp(device, options);
   size_t granularity = 0;
   RETURN_IF_ERROR(cuda::ToStatus(cuMemGetAllocationGranularity(
       &granularity, &properties, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED)));
@@ -178,14 +178,13 @@ VmmAllocate(StreamExecutor* executor, const CudaVmmAllocator::Options& options,
           executor->CanEnablePeerAccessTo(peer)) {
         XLA_VLOG_DEVICE(5, executor->device_ordinal())
             << "Setting VMM access for peer device " << peer;
-        CUmemAccessDesc access_desc = GetAccessDescriptor(peer);
+        CUmemAccessDesc access_desc = GetAccessDesc(peer);
         RETURN_IF_ERROR(
             cuda::ToStatus(cuMemSetAccess(ptr, padded_size, &access_desc, 1)));
       }
     }
   } else {
-    CUmemAccessDesc access_desc =
-        GetAccessDescriptor(executor->device_ordinal());
+    CUmemAccessDesc access_desc = GetAccessDesc(executor->device_ordinal());
     RETURN_IF_ERROR(
         cuda::ToStatus(cuMemSetAccess(ptr, padded_size, &access_desc, 1)));
   }

--- a/xla/stream_executor/cuda/cuda_vmm_allocator.h
+++ b/xla/stream_executor/cuda/cuda_vmm_allocator.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_CUDA_CUDA_VMM_ALLOCATOR_H_
 #define XLA_STREAM_EXECUTOR_CUDA_CUDA_VMM_ALLOCATOR_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 
@@ -26,19 +27,40 @@ limitations under the License.
 
 namespace stream_executor::gpu {
 
-// Device memory allocator using CUDA Virtual Memory Management (VMM) APIs.
-// Returned memory allocations are always mapped to a valid device address range
-// and accessible from the device and its peers.
+// Device memory allocator using CUDA Virtual Memory Management (VMM) APIs
+// (cuMemCreate/cuMemAddressReserve/cuMemMap). All allocations use
+// POSIX_FILE_DESCRIPTOR handle type as baseline (matching NCCL's ncclMemAlloc).
+// FABRIC handle support can be optionally requested for NVSwitch-based
+// topologies.
 class CudaVmmAllocator : public MemoryAllocator {
  public:
-  CudaVmmAllocator(StreamExecutor* executor, bool is_rdma_supported);
+  struct Options {
+    // Minimum alignment for allocations. The actual alignment is the maximum
+    // of this value and the device-reported VMM granularity.
+    size_t alignment = 4096;
+
+    // Whether to enable peer access from all accessible devices.
+    bool enable_peer_access = false;
+
+    // Whether to additionally request FABRIC handle type on top of the
+    // POSIX_FILE_DESCRIPTOR baseline. Falls back to POSIX_FD if FABRIC
+    // is not supported or permitted.
+    bool enable_fabric_handle = false;
+
+    // Whether to mark allocations as GPUDirect RDMA capable.
+    bool is_rdma_supported = false;
+  };
+
+  CudaVmmAllocator(StreamExecutor* executor, Options options);
 
   absl::StatusOr<std::unique_ptr<MemoryAllocation>> Allocate(
       uint64_t size) final;
 
+  const Options& options() const { return options_; }
+
  private:
   StreamExecutor* executor_;
-  bool is_rdma_supported_;
+  Options options_;
 };
 
 }  // namespace stream_executor::gpu

--- a/xla/stream_executor/cuda/cuda_vmm_allocator.h
+++ b/xla/stream_executor/cuda/cuda_vmm_allocator.h
@@ -28,10 +28,7 @@ limitations under the License.
 namespace stream_executor::gpu {
 
 // Device memory allocator using CUDA Virtual Memory Management (VMM) APIs
-// (cuMemCreate/cuMemAddressReserve/cuMemMap). All allocations use
-// POSIX_FILE_DESCRIPTOR handle type as baseline (matching NCCL's ncclMemAlloc).
-// FABRIC handle support can be optionally requested for NVSwitch-based
-// topologies.
+// (cuMemCreate/cuMemAddressReserve/cuMemMap).
 class CudaVmmAllocator : public MemoryAllocator {
  public:
   struct Options {
@@ -42,13 +39,14 @@ class CudaVmmAllocator : public MemoryAllocator {
     // Whether to enable peer access from all accessible devices.
     bool enable_peer_access = false;
 
-    // Whether to additionally request FABRIC handle type on top of the
-    // POSIX_FILE_DESCRIPTOR baseline. Falls back to POSIX_FD if FABRIC
-    // is not supported or permitted.
+    // Whether to request POSIX_FILE_DESCRIPTOR handle type.
+    bool enable_posix_fd_handle = true;
+
+    // Whether to request FABRIC handle type.
     bool enable_fabric_handle = false;
 
     // Whether to mark allocations as GPUDirect RDMA capable.
-    bool is_rdma_supported = false;
+    bool enable_rdma = false;
   };
 
   CudaVmmAllocator(StreamExecutor* executor, Options options);

--- a/xla/stream_executor/cuda/cuda_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_vmm_allocator_test.cc
@@ -32,6 +32,12 @@ limitations under the License.
 namespace stream_executor::gpu {
 namespace {
 
+CudaVmmAllocator::Options MakeTestOptions(bool is_rdma_supported) {
+  CudaVmmAllocator::Options options;
+  options.is_rdma_supported = is_rdma_supported;
+  return options;
+}
+
 class CudaVmmAllocatorTest : public ::testing::TestWithParam<bool> {};
 
 TEST_P(CudaVmmAllocatorTest, AllocateAndFree) {
@@ -40,13 +46,13 @@ TEST_P(CudaVmmAllocatorTest, AllocateAndFree) {
   ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
                        platform->ExecutorForDevice(0));
 
-  CudaVmmAllocator allocator(executor, /*is_rdma_supported=*/GetParam());
+  CudaVmmAllocator allocator(executor, MakeTestOptions(GetParam()));
 
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
                        allocator.Allocate(1024));
   ASSERT_NE(allocation, nullptr);
   EXPECT_NE(allocation->address().opaque(), nullptr);
-  EXPECT_EQ(allocation->address().size(), 1024);
+  EXPECT_GE(allocation->address().size(), 1024);
 }
 
 TEST_P(CudaVmmAllocatorTest, AllocateZeroBytes) {
@@ -55,7 +61,7 @@ TEST_P(CudaVmmAllocatorTest, AllocateZeroBytes) {
   ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
                        platform->ExecutorForDevice(0));
 
-  CudaVmmAllocator allocator(executor, /*is_rdma_supported=*/GetParam());
+  CudaVmmAllocator allocator(executor, MakeTestOptions(GetParam()));
 
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
                        allocator.Allocate(0));
@@ -71,7 +77,7 @@ TEST_P(CudaVmmAllocatorTest, MemcpyRoundTrip) {
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<Stream> stream,
                        executor->CreateStream());
 
-  CudaVmmAllocator allocator(executor, /*is_rdma_supported=*/GetParam());
+  CudaVmmAllocator allocator(executor, MakeTestOptions(GetParam()));
 
   constexpr int kSize = 1024;
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
@@ -83,7 +89,10 @@ TEST_P(CudaVmmAllocatorTest, MemcpyRoundTrip) {
     host_src[i] = static_cast<uint8_t>(i);
   }
 
-  DeviceAddress<uint8_t> addr(allocation->address());
+  // Use a DeviceAddress sized to kSize (not the padded allocation size) so
+  // the memcpy transfers exactly the bytes we care about.
+  DeviceAddress<uint8_t> addr(
+      DeviceAddressBase(allocation->address().opaque(), kSize));
   ASSERT_OK(stream->MemcpyH2D(absl::MakeConstSpan(host_src), &addr));
 
   // Copy back from device to host.
@@ -92,6 +101,23 @@ TEST_P(CudaVmmAllocatorTest, MemcpyRoundTrip) {
   ASSERT_OK(stream->BlockHostUntilDone());
 
   EXPECT_EQ(host_src, host_dst);
+}
+
+TEST_P(CudaVmmAllocatorTest, PeerAccessEnabled) {
+  ASSERT_OK_AND_ASSIGN(Platform * platform,
+                       PlatformManager::PlatformWithName("CUDA"));
+  ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
+                       platform->ExecutorForDevice(0));
+
+  CudaVmmAllocator::Options options = MakeTestOptions(GetParam());
+  options.enable_peer_access = true;
+  CudaVmmAllocator allocator(executor, options);
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
+                       allocator.Allocate(4096));
+  ASSERT_NE(allocation, nullptr);
+  EXPECT_NE(allocation->address().opaque(), nullptr);
+  EXPECT_GE(allocation->address().size(), 4096);
 }
 
 INSTANTIATE_TEST_SUITE_P(RdmaSupport, CudaVmmAllocatorTest, ::testing::Bool(),

--- a/xla/stream_executor/cuda/cuda_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_vmm_allocator_test.cc
@@ -32,9 +32,9 @@ limitations under the License.
 namespace stream_executor::gpu {
 namespace {
 
-CudaVmmAllocator::Options MakeTestOptions(bool is_rdma_supported) {
+CudaVmmAllocator::Options MakeTestOptions(bool enable_rdma) {
   CudaVmmAllocator::Options options;
-  options.is_rdma_supported = is_rdma_supported;
+  options.enable_rdma = enable_rdma;
   return options;
 }
 


### PR DESCRIPTION
Second attempt to land: https://github.com/openxla/xla/pull/41652. In addition to previous version add fallbacks + `LOG(WARNING)` when some of the VMM capabilities are not accessible (i.e. fabric handles, POSIX FD handle, etc.).

#### Original PR:

Instead of always linking NCCL make our own NCCL-compatible allocator:

Rewrite `CudaVmmAllocator` for NCCL-compatible VMM allocation. Replace the simple bool-based constructor with an `Options` struct controlling alignment, peer access, FABRIC handle support, and RDMA
  capability. Allocation now uses `POSIX_FILE_DESCRIPTOR` handle type as baseline (matching NCCL's `ncclMemAlloc`), with optional `FABRIC` handle that gracefully falls back if not supported. Deallocation now synchronizes via `cuCtxSynchronize()` before unmapping since `cuMemUnmap` immediately invalidates
  virtual address mappings unlike `cuMemFree`.

Add `is_fabric_supported` and `vmm_granularity_` to `CudaExecutor`. Replace `is_vmm_supported_` bool with cached `vmm_granularity_` (zero means unsupported). VMM support is now mandatory — `Init()` returns an error if the device doesn't support it. Query fabric handle support at init time via `CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED`. Detect peer access across all devices and pass it to VMM allocator options.