### PR TITLE
[ROCm] Enable packed FP16/BF16 atomics support for gfx12XX

### DIFF
--- a/xla/stream_executor/rocm/rocm_compute_capability.h
+++ b/xla/stream_executor/rocm/rocm_compute_capability.h
@@ -172,9 +172,13 @@ class RocmComputeCapability {
     return gfx9_mi100_or_later() || gfx12() || gfx11();
   }
 
-  bool has_packed_fp16_atomics_support() const { return gfx9_mi100_or_later(); }
+  bool has_packed_fp16_atomics_support() const {
+    return gfx9_mi100_or_later() || gfx12();
+  }
 
-  bool has_packed_bf16_atomics_support() const { return gfx9_mi300_series(); }
+  bool has_packed_bf16_atomics_support() const {
+    return gfx9_mi300_series() || gfx12();
+  }
 
   bool fence_before_barrier() const {
     static constexpr absl::string_view kList[] = {"gfx900", "gfx906"};


### PR DESCRIPTION
gfx12XX supports packed FP16 and BF16 atomic operations, so include it in `has_packed_fp16_atomics_support()` and `has_packed_bf16_atomics_support()`.