### PR TITLE
Add OSS-Fuzz harnesses for HLO parser and proto deserialization

### DIFF
--- a/xla/fuzz/BUILD
+++ b/xla/fuzz/BUILD
@@ -1,0 +1,42 @@
+# Description:
+#   libFuzzer harnesses for openxla/xla parser and proto-deserialization
+#   surfaces. Built by the OSS-Fuzz integration under projects/xla/ in
+#   google/oss-fuzz, and runnable locally with -fsanitize=fuzzer flags
+#   passed via --copt and --linkopt.
+
+load("//xla/tsl/platform:rules_cc.bzl", "cc_binary")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+cc_binary(
+    name = "hlo_parser_fuzz",
+    srcs = ["hlo_parser_fuzz.cc"],
+    tags = [
+        "fuzz_target",
+        "nobuilder",
+        "no_oss",
+    ],
+    deps = [
+        "//xla/hlo/parser:hlo_parser",
+        "//xla/service:hlo_module_config",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
+cc_binary(
+    name = "hlo_proto_fuzz",
+    srcs = ["hlo_proto_fuzz.cc"],
+    tags = [
+        "fuzz_target",
+        "nobuilder",
+        "no_oss",
+    ],
+    deps = [
+        "//xla/hlo/ir:hlo",
+        "//xla/service:hlo_module_config",
+        "//xla/service:hlo_proto_cc",
+    ],
+)

--- a/xla/fuzz/hlo_parser_fuzz.cc
+++ b/xla/fuzz/hlo_parser_fuzz.cc
@@ -1,0 +1,32 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// libFuzzer harness for the HLO text-format parser.
+// Exercises xla::ParseAndReturnUnverifiedModule against arbitrary input bytes.
+
+#include <cstddef>
+#include <cstdint>
+
+#include "absl/strings/string_view.h"
+#include "xla/hlo/parser/hlo_parser.h"
+#include "xla/service/hlo_module_config.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  absl::string_view input(reinterpret_cast<const char*>(data), size);
+  xla::HloModuleConfig config;
+  auto result = xla::ParseAndReturnUnverifiedModule(input, config);
+  (void)result;
+  return 0;
+}

--- a/xla/fuzz/hlo_proto_fuzz.cc
+++ b/xla/fuzz/hlo_proto_fuzz.cc
@@ -1,0 +1,38 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// libFuzzer harness for the HLO proto deserialization path.
+// Stage 1: deserialize raw bytes into HloModuleProto.
+// Stage 2: convert HloModuleProto into an HloModule via CreateFromProto.
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/service/hlo.pb.h"
+#include "xla/service/hlo_module_config.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  xla::HloModuleProto proto;
+  if (size > static_cast<size_t>(std::numeric_limits<int>::max())) return 0;
+  if (!proto.ParseFromArray(data, static_cast<int>(size))) {
+    return 0;
+  }
+  xla::HloModuleConfig config;
+  auto result = xla::HloModule::CreateFromProto(proto, config);
+  (void)result;
+  return 0;
+}


### PR DESCRIPTION
Add OSS-Fuzz harnesses for HLO parser and proto deserialization

This PR adds two libFuzzer harnesses to xla/fuzz/ as part of an
OSS-Fuzz integration for openxla/xla. A companion PR in google/oss-fuzz
will be opened concurrently to wire the build and register the project.

The HLO text-format parser and proto deserialization path were selected
as the primary fuzzing surfaces because they accept arbitrary external
input, have significant parsing complexity, and currently have no
OSS-Fuzz coverage.

## Harnesses

**hlo_parser_fuzz** — exercises `xla::ParseAndReturnUnverifiedModule`
against arbitrary text input bytes via `absl::string_view`. Targets
the HLO text-format parser surface.

**hlo_proto_fuzz** — exercises `xla::HloModule::CreateFromProto`
against arbitrary byte sequences. Stage 1 deserializes raw bytes into
`HloModuleProto` via `ParseFromArray`; stage 2 converts the proto into
an `HloModule`. Includes an explicit size guard against integer overflow
on the `ParseFromArray` size argument (guards `size > INT_MAX` before
the cast to `int`, implemented via `std::numeric_limits<int>::max()`
from `<limits>`).

## Build

Both harnesses build via Bazel under `//xla/fuzz/`. The BUILD file uses
`cc_binary` with `fuzz_target` and `nobuilder` tags following standard
OSS-Fuzz practice. Dependencies are minimal and correctly scoped per
target.

The OSS-Fuzz build uses XLA's hermetic LLVM18 toolchain which
dynamic-links libc++. The companion oss-fuzz PR resolves packaging by
embedding `--linkopt=-Wl,-rpath,$ORIGIN` and copying the required
libc++ shared objects into `$OUT/` at build time.

## Testing

Both binaries were smoke-tested inside the OSS-Fuzz Docker base image:
- `hlo_parser_fuzz`: 100 runs, zero crashes, 2,371 coverage PCs with
  growth into `xla::HloLexer` and related parser code paths
- `hlo_proto_fuzz`: 100 runs, zero crashes, 819 coverage PCs with
  growth into `xla::HloModuleConfig` and protobuf `TcParser` family
