### PR TITLE
[ROCm] Add gfx1250 as supported arch to ROCm compute capabilities

### DIFF
--- a/xla/stream_executor/device_description_test.cc
+++ b/xla/stream_executor/device_description_test.cc
@@ -71,6 +71,7 @@ TEST(RocmComputeCapability, IsSupportedGfxVersion) {
   ASSERT_TRUE(RocmComputeCapability{"gfx900"}.is_supported_gfx_version());
   ASSERT_TRUE(RocmComputeCapability{"gfx1201"}.is_supported_gfx_version());
   ASSERT_TRUE(RocmComputeCapability{"gfx942"}.is_supported_gfx_version());
+  ASSERT_TRUE(RocmComputeCapability{"gfx1250"}.is_supported_gfx_version());
   ASSERT_FALSE(RocmComputeCapability{"some_string"}.is_supported_gfx_version());
 }
 
@@ -125,6 +126,21 @@ TEST(RocmComputeCapability, Accessors) {
   EXPECT_TRUE(RocmComputeCapability{"gfx1200"}.has_hipblaslt());
   EXPECT_TRUE(RocmComputeCapability{"gfx1100"}.has_hipblaslt());
   EXPECT_TRUE(RocmComputeCapability{"gfx1103"}.has_hipblaslt());
+  EXPECT_TRUE(RocmComputeCapability{"gfx1250"}.has_hipblaslt());
+
+  EXPECT_FALSE(RocmComputeCapability{"gfx1250"}.has_nhwc_layout_support());
+  EXPECT_TRUE(RocmComputeCapability{"gfx1250"}.has_fast_fp16_support());
+  EXPECT_FALSE(RocmComputeCapability{"gfx1250"}.has_mfma_instr_support());
+  EXPECT_TRUE(
+      RocmComputeCapability{"gfx1250"}.has_packed_fp16_atomics_support());
+  EXPECT_TRUE(
+      RocmComputeCapability{"gfx1250"}.has_packed_bf16_atomics_support());
+  EXPECT_TRUE(RocmComputeCapability{"gfx1250"}.has_ocp_fp8_support());
+  EXPECT_TRUE(RocmComputeCapability{"gfx1250"}.has_mx_type_support());
+
+  EXPECT_TRUE(RocmComputeCapability{"gfx1250"}.has_tdm_support());
+  EXPECT_FALSE(RocmComputeCapability{"gfx942"}.has_tdm_support());
+  EXPECT_FALSE(RocmComputeCapability{"gfx1201"}.has_tdm_support());
 }
 
 TEST(GpuComputeCapability, ProtoConversion) {

--- a/xla/stream_executor/rocm/rocm_compute_capability.h
+++ b/xla/stream_executor/rocm/rocm_compute_capability.h
@@ -96,7 +96,7 @@ class RocmComputeCapability {
       "gfx1030",  // RX68xx / RX69xx
       "gfx1100",  // RX7900
       "gfx1101",  // RX7700 / RX7800
-      "gfx1103", "gfx1150", "gfx1151", "gfx1200", "gfx1201"};
+      "gfx1103", "gfx1150", "gfx1151", "gfx1200", "gfx1201", "gfx1250"};
 
   bool is_supported_gfx_version() const {
     return IsThisGfxInAnyList(kSupportedGfxVersions);
@@ -156,6 +156,8 @@ class RocmComputeCapability {
 
   bool gfx12_rx8900() const { return gfx12_discrete(); }
 
+  bool gfx1250() const { return gfx_version() == "gfx1250"; }
+
   bool has_nhwc_layout_support() const { return gfx9_mi100_or_later(); }
 
   bool has_bf16_dtype_support() const {
@@ -163,7 +165,8 @@ class RocmComputeCapability {
   }
 
   bool has_fast_fp16_support() const {
-    return gfx9_mi100_or_later() || gfx11() || gfx10_rx68xx() || gfx10_rx69xx();
+    return gfx9_mi100_or_later() || gfx11() || gfx10_rx68xx() ||
+           gfx10_rx69xx() || gfx1250();
   }
 
   bool has_mfma_instr_support() const { return gfx9_mi100_or_later(); }
@@ -187,18 +190,23 @@ class RocmComputeCapability {
 
   bool has_hipblaslt() const {
     return IsThisGfxInAnyList(kMI300Series, kMI200Series, kGfx12Discrete,
-                              kGfx11Discrete, kGfx11Apu);
+                              kGfx11Discrete, kGfx11Apu) ||
+           gfx1250();
   }
 
   bool has_fp8_support() const {
     return has_ocp_fp8_support() || has_nanoo_fp8_support();
   }
 
-  bool has_ocp_fp8_support() const { return gfx9_mi350() || gfx12_discrete(); }
+  bool has_ocp_fp8_support() const {
+    return gfx9_mi350() || gfx12_discrete() || gfx1250();
+  }
 
   bool has_nanoo_fp8_support() const { return gfx9_mi300(); }
 
-  bool has_mx_type_support() const { return gfx9_mi350(); }
+  bool has_mx_type_support() const { return gfx9_mi350() || gfx1250(); }
+
+  bool has_tdm_support() const { return gfx1250(); }
 
   int threads_per_warp() const { return gfx9_mi100_or_later() ? 64 : 32; }
 


### PR DESCRIPTION
📝 Summary of Changes
Add gfx1250 as supported arch to ROCm

🚀 Kind of Contribution
✨ New Feature
