### PR TITLE
[GPU] Fix cuBLAS FP8 GEMM dimension handling.

### DIFF
--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -1334,10 +1334,12 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       }
     }
 
+    const DotDimensionNumbers& dot_dimension_numbers =
+        gemm_backend_config.dot_dimension_numbers();
     absl::Span<const int64_t> a_batch_dims =
-        gemm_backend_config.dot_dimension_numbers().lhs_batch_dimensions();
+        dot_dimension_numbers.lhs_batch_dimensions();
     absl::Span<const int64_t> b_batch_dims =
-        gemm_backend_config.dot_dimension_numbers().rhs_batch_dimensions();
+        dot_dimension_numbers.rhs_batch_dimensions();
     const size_t num_batch_dims = a_batch_dims.size();
 
     // cuBLASLt FP8 GEMM kernels require the scaling factors to be in F32
@@ -1432,11 +1434,9 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     // Each operand must have exactly one contracting and one non-contracting
     // dimension.
     absl::Span<const int64_t> a_contracting_dims =
-        gemm_backend_config.dot_dimension_numbers()
-            .lhs_contracting_dimensions();
+        dot_dimension_numbers.lhs_contracting_dimensions();
     absl::Span<const int64_t> b_contracting_dims =
-        gemm_backend_config.dot_dimension_numbers()
-            .rhs_contracting_dimensions();
+        dot_dimension_numbers.rhs_contracting_dimensions();
     if (a_contracting_dims.size() != 1 || b_contracting_dims.size() != 1) {
       VLOG(1) << "Failed to rewrite " << instr->ToShortString()
               << " into FP8 Custom Call. A and B must have one contracting "
@@ -1501,6 +1501,22 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     shift_ops(b.fp8_input, b.commutative_ops);
 
     TF_ASSIGN_OR_RETURN(
+        std::vector<int64_t> a_non_contracting_dims,
+        GetNonContractingDims(a.fp8_input->shape(), a_batch_dims,
+                              a_contracting_dims));
+    TF_ASSIGN_OR_RETURN(
+        std::vector<int64_t> b_non_contracting_dims,
+        GetNonContractingDims(b.fp8_input->shape(), b_batch_dims,
+                              b_contracting_dims));
+    if (a_non_contracting_dims.size() != 1 ||
+        b_non_contracting_dims.size() != 1) {
+      VLOG(1) << "Failed to rewrite " << instr->ToShortString()
+              << " into FP8 Custom Call. A and B must have one "
+                 "non-contracting dimension.";
+      return false;
+    }
+
+    TF_ASSIGN_OR_RETURN(
         GemmConfig gemm_config,
         GemmConfig::For(instr, gemm_backend_config, gpu_version_));
 
@@ -1513,13 +1529,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     // effectively make it column-major.
     if (!cuda_compute_capability.IsBlackwell()) {
       if (gemm_config.lhs_layout.order == MatrixLayout::Order::kColumnMajor) {
-        CHECK(a_contracting_dims[0] == num_batch_dims ||
-              a_contracting_dims[0] == num_batch_dims + 1);
-        if (a_contracting_dims[0] == num_batch_dims) {
-          dim_nums->set_lhs_contracting_dimensions(0, num_batch_dims + 1);
-        } else {
-          dim_nums->set_lhs_contracting_dimensions(0, num_batch_dims);
-        }
+        dim_nums->set_lhs_contracting_dimensions(0, a_non_contracting_dims[0]);
         a.fp8_input =
             TransposeMatrix(a.fp8_input, a_contracting_dims[0], a_batch_dims);
       }
@@ -1528,13 +1538,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       // non-Blackwell systems, so make it column-major if it is currently
       // row-major.
       if (gemm_config.rhs_layout.order == MatrixLayout::Order::kRowMajor) {
-        CHECK(b_contracting_dims[0] == num_batch_dims ||
-              b_contracting_dims[0] == num_batch_dims + 1);
-        if (b_contracting_dims[0] == num_batch_dims) {
-          dim_nums->set_rhs_contracting_dimensions(0, num_batch_dims + 1);
-        } else {
-          dim_nums->set_rhs_contracting_dimensions(0, num_batch_dims);
-        }
+        dim_nums->set_rhs_contracting_dimensions(0, b_non_contracting_dims[0]);
         b.fp8_input =
             TransposeMatrix(b.fp8_input, b_contracting_dims[0], b_batch_dims);
       }

--- a/xla/backends/gpu/transforms/gemm_rewriter_fp8_test.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter_fp8_test.cc
@@ -200,6 +200,34 @@ ENTRY main {
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-2, 1e-2}));
 }
 
+TEST_F(ParameterizedFp8GemmRewriteTest, F8TransposeWithNonMajorBatchDim) {
+  RunAndFilecheckHloRewrite(
+      R"(
+e {
+  lhs = <<F8E5M2>>[2,2,16]{2,1,0} parameter(0)
+  rhs = <<F8E4M3>>[8,2,16]{0,2,1} parameter(1)
+  out = f32[2,2,8]{2,1,0} dot(lhs, rhs),
+      lhs_batch_dims={1}, lhs_contracting_dims={2},
+      rhs_batch_dims={1}, rhs_contracting_dims={2}
+})",
+      GemmRewriter(CudaHopperOrRocmCapability(), GetToolkitVersion(),
+                   GemmRewriterOptions{GemmRewriterOptions::DType::kFp8Only}),
+      R"(
+; CHECK:         [[LHS_PAD:%[^ ]+]] = <<F8E5M2>>[16,2,16]{{.*}} pad
+; CHECK:         [[RHS_TRANSPOSE:%[^ ]+]] = <<F8E4M3>>[2,8,16]{{.*}} transpose
+; CHECK:         [[RHS_BITCAST:%[^ ]+]] = <<F8E4M3>>[16,2,8]{{.*}} bitcast([[RHS_TRANSPOSE]])
+; CHECK:         [[RHS_PAD:%[^ ]+]] = <<F8E4M3>>[16,2,16]{{.*}} pad([[RHS_BITCAST]]
+; CHECK:         {{.*}} custom-call([[LHS_PAD]], [[RHS_PAD]]
+; CHECK:           custom_call_target="__cublas$lt$matmul$f8"
+; CHECK:           backend_config={
+; CHECK-DAG:         "lhs_contracting_dimensions":["2"]
+; CHECK-DAG:         "rhs_contracting_dimensions":["0"]
+; CHECK-DAG:         "lhs_batch_dimensions":["1"]
+; CHECK-DAG:         "rhs_batch_dimensions":["1"]
+; CHECK:           }
+      )");
+}
+
 TEST_F(ParameterizedFp8GemmRewriteTest, DoNotRewriteToF8OnPreAda) {
   if (!IsCuda()) {
     GTEST_SKIP() << "FP8 Rewrite pattern is different on ROCM-6.2 ";


### PR DESCRIPTION
📝 Summary of Changes
The rewrite transposes FP8 operands to satisfy cuBLASLt layout
requirements, but used to update the post-transpose contracting dim
using num_batch_dims. This is not correct with non-leading batch dims.

🎯 Justification
🐛 Bug Fix

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
no

🧪 Unit Tests:
yes

🧪 Execution Tests:
no