### PR TITLE
[ROCM][NFC] Refactor gpuBlasLt and matmul thunk interfaces to reduce duplication and simplify scale handling

### DIFF
--- a/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -68,13 +68,11 @@ def is_rocm_configured():
     """
     return %{rocm_is_configured}
 
-def rocm_hipblaslt():
-    return %{rocm_is_configured} and %{rocm_hipblaslt}
-
 def if_rocm_hipblaslt(x):
-    if %{rocm_is_configured} and (%{rocm_hipblaslt} == "True"):
-        return select({"//conditions:default": x})
-    return select({"//conditions:default": []})
+    """ 
+    hipBlasLt is always available: kept for compatibility with Tensorflow.
+    """
+    return select({"//conditions:default": x})
 
 def rocm_library(copts = [], deps = [], **kwargs):
     """Wrapper over cc_library which adds default ROCm options."""

--- a/third_party/gpus/rocm/rocm_config.h.tpl
+++ b/third_party/gpus/rocm/rocm_config.h.tpl
@@ -21,6 +21,7 @@ limitations under the License.
 #define TF_ROCM_VERSION %{rocm_version_number}
 #define TF_MIOPEN_VERSION %{miopen_version_number}
 #define TF_HIPRUNTIME_VERSION %{hipruntime_version_number}
-#define TF_HIPBLASLT %{hipblaslt_flag}
+// NOTE: HipBlasLt is now always available, this flag is deprecated !
+#define TF_HIPBLASLT 1
 
 #endif  // ROCM_ROCM_CONFIG_H_

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -417,7 +417,6 @@ def _create_dummy_repository(repository_ctx):
             "%{rocm_extra_copts}": "[]",
             "%{rocm_gpu_architectures}": "[]",
             "%{rocm_version_number}": "0",
-            "%{rocm_hipblaslt}": "False",
             "%{single_gpu_rbe_pool}": repository_ctx.os.environ.get(_TF_ROCM_RBE_SINGLE_GPU_POOL, _DEFAULT_TF_ROCM_RBE_SINGLE_GPU_POOL),
             "%{multi_gpu_rbe_pool}": repository_ctx.os.environ.get(_TF_ROCM_RBE_MULTI_GPU_POOL, _DEFAULT_TF_ROCM_RBE_MULTI_GPU_POOL),
         },
@@ -452,7 +451,6 @@ def _create_dummy_repository(repository_ctx):
         "rocm:rocm_config.h",
         {
             "%{rocm_toolkit_path}": _DEFAULT_ROCM_TOOLKIT_PATH,
-            "%{hipblaslt_flag}": "0",
         },
         "rocm/rocm_config/rocm_config.h",
     )
@@ -622,7 +620,6 @@ def _create_local_rocm_repository(repository_ctx):
             "%{multi_gpu_rbe_pool}": repository_ctx.os.environ.get(_TF_ROCM_RBE_MULTI_GPU_POOL, _DEFAULT_TF_ROCM_RBE_MULTI_GPU_POOL),
             "%{rocm_gpu_architectures}": str(rocm_config.amdgpu_targets),
             "%{rocm_version_number}": str(rocm_version_number),
-            "%{rocm_hipblaslt}": "True",
         },
     )
 
@@ -741,7 +738,6 @@ def _create_local_rocm_repository(repository_ctx):
             "%{rocm_version_number}": rocm_config.rocm_version_number,
             "%{miopen_version_number}": rocm_config.miopen_version_number,
             "%{hipruntime_version_number}": rocm_config.hipruntime_version_number,
-            "%{hipblaslt_flag}": "1",
         },
     )
 
@@ -758,7 +754,6 @@ def _create_local_rocm_repository(repository_ctx):
             "%{rocm_version_number}": rocm_config.rocm_version_number,
             "%{miopen_version_number}": rocm_config.miopen_version_number,
             "%{hipruntime_version_number}": rocm_config.hipruntime_version_number,
-            "%{hipblaslt_flag}": "1",
         },
     )
 

--- a/xla/backends/gpu/autotuner/cublaslt.cc
+++ b/xla/backends/gpu/autotuner/cublaslt.cc
@@ -101,12 +101,11 @@ CublasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
   TF_ASSIGN_OR_RETURN(BlasLt::Epilogue epilogue,
                       AsBlasLtEpilogue(backend_config.epilogue()));
 
-  TF_ASSIGN_OR_RETURN(std::unique_ptr<se::Stream> stream,
-                      stream_executor()->CreateStream());
+  TF_ASSIGN_OR_RETURN(BlasLt* blas_lt, se::gpu::BlasLt::Get(stream_executor()));
 
   TF_ASSIGN_OR_RETURN(
       std::unique_ptr<BlasLt::MatmulPlan> plan,
-      se::gpu::BlasLt::GetMatmulPlan(stream.get(), gemm_config, epilogue));
+      blas_lt->GetMatmulPlan(gemm_config, epilogue));
 
   const Shape& output_shape = instr.shape();
   if (!output_shape.IsTuple() || output_shape.tuple_shapes().empty()) {
@@ -119,7 +118,7 @@ CublasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
 
   TF_ASSIGN_OR_RETURN(
       std::vector<BlasLt::MatmulAlgorithm> algorithms,
-      plan->GetAlgorithms(stream.get(), GemmConfig::kNumAlgorithms,
+      plan->GetAlgorithms(GemmConfig::kNumAlgorithms,
                           workspace_size));
   int num_algorithms = algorithms.size();
   std::vector<std::unique_ptr<BackendConfig>> configs;

--- a/xla/backends/gpu/autotuner/hipblaslt.cc
+++ b/xla/backends/gpu/autotuner/hipblaslt.cc
@@ -216,12 +216,11 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
     TF_ASSIGN_OR_RETURN(BlasLt::Epilogue epilogue,
                         AsBlasLtEpilogue(backend_config.epilogue()));
 
-    TF_ASSIGN_OR_RETURN(std::unique_ptr<se::Stream> stream,
-                        stream_executor()->CreateStream());
+    TF_ASSIGN_OR_RETURN(BlasLt* blas_lt, se::gpu::BlasLt::Get(stream_executor()));
 
     TF_ASSIGN_OR_RETURN(
         std::unique_ptr<BlasLt::MatmulPlan> plan,
-        se::gpu::BlasLt::GetMatmulPlan(stream.get(), gemm_config, epilogue));
+        blas_lt->GetMatmulPlan(gemm_config, epilogue));
 
     const Shape& output_shape = instr.shape();
     if (!output_shape.IsTuple() || output_shape.tuple_shapes().empty()) {
@@ -234,7 +233,7 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
 
     TF_ASSIGN_OR_RETURN(
         std::vector<BlasLt::MatmulAlgorithm> algorithms,
-        plan->GetAlgorithms(stream.get(), GemmConfig::kNumAlgorithms,
+        plan->GetAlgorithms(GemmConfig::kNumAlgorithms,
                             workspace_size));
     int num_algorithms = algorithms.size();
     std::vector<std::unique_ptr<BackendConfig>> configs;
@@ -278,9 +277,8 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
       return std::vector<std::unique_ptr<BackendConfig>>();
     }
 
-    TF_ASSIGN_OR_RETURN(std::unique_ptr<se::Stream> stream,
-                        stream_executor()->CreateStream());
-    auto plan_or = se::gpu::BlasLt::GetMatmulPlan(stream.get(), *gemm_config_or,
+    TF_ASSIGN_OR_RETURN(BlasLt* blas_lt, se::gpu::BlasLt::Get(stream_executor()));
+    auto plan_or = blas_lt->GetMatmulPlan(*gemm_config_or,
                                                   BlasLt::Epilogue::kDefault);
     if (!plan_or.ok()) {
       VLOG(2) << "hipBLASLt MX: GetMatmulPlan failed: " << plan_or.status();
@@ -290,7 +288,7 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
     int64_t workspace_size = GemmConfig::kGFX950Workspace;
     TF_ASSIGN_OR_RETURN(
         std::vector<BlasLt::MatmulAlgorithm> algorithms,
-        (*plan_or)->GetAlgorithms(stream.get(), GemmConfig::kNumAlgorithms,
+        (*plan_or)->GetAlgorithms(GemmConfig::kNumAlgorithms,
                                   workspace_size));
     if (algorithms.empty()) {
       VLOG(2) << "hipBLASLt MX: no algorithms found for scaled dot.";
@@ -312,8 +310,7 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
     TF_ASSIGN_OR_RETURN(GpuBackendConfig gpu_config,
                         instr.backend_config<GpuBackendConfig>());
 
-    TF_ASSIGN_OR_RETURN(std::unique_ptr<se::Stream> stream,
-                        stream_executor()->CreateStream());
+    TF_ASSIGN_OR_RETURN(BlasLt* blas_lt, se::gpu::BlasLt::Get(stream_executor()));
 
     std::unique_ptr<BlasLt::MatmulPlan> plan;
     int64_t workspace_size;
@@ -333,8 +330,8 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
 
     std::vector<BlasLt::Epilogue> epilogues = {epilogue};
     TF_ASSIGN_OR_RETURN(plan,
-                        se::gpu::BlasLt::GetGroupedMatmulPlan(
-                            stream.get(), grouped_gemm_config, epilogues));
+                        blas_lt->GetGroupedMatmulPlan(
+                            grouped_gemm_config, epilogues));
 
     const Shape& output_shape = instr.shape();
     if (!output_shape.IsTuple() || output_shape.tuple_shapes().empty()) {
@@ -346,7 +343,7 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
 
     TF_ASSIGN_OR_RETURN(
         std::vector<BlasLt::MatmulAlgorithm> algorithms,
-        plan->GetAlgorithms(stream.get(), GemmConfig::kNumAlgorithms,
+        plan->GetAlgorithms(GemmConfig::kNumAlgorithms,
                             workspace_size));
     int num_algorithms = algorithms.size();
     std::vector<std::unique_ptr<BackendConfig>> configs;

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
@@ -43,27 +43,6 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
-CublasLtMatmulThunk::CublasLtMatmulThunk(const CublasLtMatmulThunk& rhs)
-    : TracedCommand(CommandType::kCublasLtCmd, Kind::kCublasLtMatmul, {}),
-      gemm_config_(rhs.gemm_config_),
-      epilogue_(rhs.epilogue_),
-      algorithm_idx_(rhs.algorithm_idx_),
-      autotune_workspace_size_(rhs.autotune_workspace_size_),
-      canonical_hlo_(rhs.canonical_hlo_),
-      a_(rhs.a_),
-      b_(rhs.b_),
-      c_(rhs.c_),
-      d_(rhs.d_),
-      group_sizes_(rhs.group_sizes_),
-      bias_(rhs.bias_),
-      aux_(rhs.aux_),
-      a_scale_(rhs.a_scale_),
-      b_scale_(rhs.b_scale_),
-      c_scale_(rhs.c_scale_),
-      d_scale_(rhs.d_scale_),
-      d_amax_(rhs.d_amax_),
-      workspace_(rhs.workspace_) {}
-
 CublasLtMatmulThunk::CublasLtMatmulThunk(
     Thunk::ThunkInfo thunk_info, std::string canonical_hlo,
     GemmConfig gemm_config, se::gpu::BlasLt::Epilogue epilogue,
@@ -127,8 +106,7 @@ CublasLtMatmulThunk::CublasLtMatmulThunk(
       d_amax_(d_amax),
       workspace_(workspace) {}
 
-absl::Status CublasLtMatmulThunk::ExecuteOnStreamInternal(
-    se::Stream* stream, const ExecuteParams& params) {
+absl::Status CublasLtMatmulThunk::ExecuteOnStream(const ExecuteParams& params) {
   VLOG(3) << "Running cublas_lt matmul thunk";
   const BufferAllocations& allocs = *params.buffer_allocations;
 
@@ -159,44 +137,51 @@ absl::Status CublasLtMatmulThunk::ExecuteOnStreamInternal(
     workspace = allocs.GetDeviceAddress(workspace_->slice);
   }
 
+  TF_ASSIGN_OR_RETURN(auto* plan, GetCachedMatmulPlan(params));
+  se::gpu::BlasLt::MemoryArgs args{allocs.GetDeviceAddress(a_.slice),
+                                   allocs.GetDeviceAddress(b_.slice),
+                                   allocs.GetDeviceAddress(c_.slice),
+                                   allocs.GetDeviceAddress(d_.slice),
+                                   bias,
+                                   aux,
+                                   a_scale,
+                                   b_scale,
+                                   c_scale,
+                                   d_scale,
+                                   {d_amax},
+                                   workspace,
+                                   nullptr};
+
   if (is_grouped()) {
     if (!group_sizes_.has_value()) {
       return absl::InternalError(
           "GroupedMatmul must have a non-empty group_sizes_");
     }
-    // Grouped matmul execution
-    TF_ASSIGN_OR_RETURN(auto* plan, GetCachedGroupedMatmulPlan(params));
-    return plan->ExecuteOnStream(
-        stream, allocs.GetDeviceAddress(a_.slice),
-        allocs.GetDeviceAddress(b_.slice), allocs.GetDeviceAddress(c_.slice),
-        allocs.GetDeviceAddress(d_.slice),
-        allocs.GetDeviceAddress(group_sizes_->slice), bias, aux, a_scale,
-        b_scale, c_scale, d_scale, d_amax, workspace);
-  } else {
-    // Regular matmul execution
-    TF_ASSIGN_OR_RETURN(auto* plan, GetCachedMatmulPlan(params));
-    return plan->ExecuteOnStream(
-        stream, allocs.GetDeviceAddress(a_.slice),
-        allocs.GetDeviceAddress(b_.slice), allocs.GetDeviceAddress(c_.slice),
-        allocs.GetDeviceAddress(d_.slice), bias, aux, a_scale, b_scale, c_scale,
-        d_scale, d_amax, workspace);
+    args.group_sizes = allocs.GetDeviceAddress(group_sizes_->slice);
   }
+  return plan->ExecuteOnStream(params.stream, args);
 }
 
 absl::StatusOr<se::gpu::BlasLt::MatmulPlan*>
 CublasLtMatmulThunk::GetCachedMatmulPlan(const ExecuteParams& params) {
-  auto* blas_lt = se::gpu::BlasLt::Get(params.stream);
+  TF_ASSIGN_OR_RETURN(auto* blas_lt,
+                      se::gpu::BlasLt::Get(params.stream->parent()));
   auto create = [&]() -> absl::StatusOr<se::gpu::BlasLt::MatmulPlanPtr> {
-    VLOG(2) << this << ": Adding new MatmulPlan for stream: " << params.stream
+    VLOG(2) << this << ": Adding new " << (is_grouped() ? "grouped" : "regular")
+            << " MatmulPlan for stream: " << params.stream
             << " instr: " << canonical_hlo_;
 
-    auto* gemm_config = std::get_if<GemmConfig>(&gemm_config_);
-    if (gemm_config == nullptr) {
-      return absl::InternalError(
-          "Expected GemmConfig but gemm_config_ holds a different type");
-    }
-    TF_ASSIGN_OR_RETURN(auto plan,
-                        blas_lt->GetMatmulPlan(*gemm_config, epilogue_));
+    auto get_plan = [&](const auto& gemm_config)
+        -> absl::StatusOr<se::gpu::BlasLt::MatmulPlanPtr> {
+      using T = std::decay_t<decltype(gemm_config)>;
+      if constexpr (std::is_same_v<T, GemmConfig>) {
+        return blas_lt->GetMatmulPlan(gemm_config, epilogue_);
+      } else {
+        std::vector<se::gpu::BlasLt::Epilogue> epilogues(1, epilogue_);
+        return blas_lt->GetGroupedMatmulPlan(gemm_config, epilogues);
+      }
+    };
+    TF_ASSIGN_OR_RETURN(auto plan, std::visit(get_plan, gemm_config_));
 
     // Set the workspace size to the size that was used for autotuning, so
     // algorithm index will be the same as returned by GetAlgorithms called
@@ -207,9 +192,8 @@ CublasLtMatmulThunk::GetCachedMatmulPlan(const ExecuteParams& params) {
     // algorithms, it's enough to get the default one only.
     int64_t num_algorithms =
         algorithm_idx_ == 0 ? 1 : GemmConfig::kNumAlgorithms;
-    TF_ASSIGN_OR_RETURN(
-        auto algorithms,
-        plan->GetAlgorithms(params.stream, num_algorithms, max_workspace));
+    TF_ASSIGN_OR_RETURN(auto algorithms,
+                        plan->GetAlgorithms(num_algorithms, max_workspace));
 
     if (algorithms.empty()) {
       return absl::InternalError(
@@ -219,46 +203,6 @@ CublasLtMatmulThunk::GetCachedMatmulPlan(const ExecuteParams& params) {
     return std::move(plan);
   };
   return blas_lt->GetOrCreateMatmulPlan(canonical_hlo_, create);
-}
-
-absl::StatusOr<se::gpu::BlasLt::MatmulPlan*>
-CublasLtMatmulThunk::GetCachedGroupedMatmulPlan(const ExecuteParams& params) {
-  auto* blas_lt = se::gpu::BlasLt::Get(params.stream);
-  auto create = [&]() -> absl::StatusOr<se::gpu::BlasLt::MatmulPlanPtr> {
-    VLOG(2) << this
-            << ": Adding new Grouped MatmulPlan for stream: " << params.stream
-            << " instr: " << canonical_hlo_;
-
-    auto* gemm_config = std::get_if<se::gpu::GroupedGemmConfig>(&gemm_config_);
-    if (gemm_config == nullptr) {
-      return absl::InternalError(
-          "Expected GroupedGemmConfig but gemm_config_ holds a different type");
-    }
-    std::vector<se::gpu::BlasLt::Epilogue> epilogues(1, epilogue_);
-    TF_ASSIGN_OR_RETURN(auto plan,
-                        blas_lt->GetGroupedMatmulPlan(*gemm_config, epilogues));
-
-    // Set the workspace size to the size that was used for autotuning, so
-    // algorithm index will be the same as returned by GetAlgorithms called
-    // during autotuning.
-    int64_t max_workspace = autotune_workspace_size_;
-
-    // If autotuning is disabled, there is no point on retrieving all
-    // algorithms, it's enough to get the default one only.
-    int64_t num_algorithms =
-        algorithm_idx_ == 0 ? 1 : GemmConfig::kNumAlgorithms;
-    TF_ASSIGN_OR_RETURN(
-        auto algorithms,
-        plan->GetAlgorithms(params.stream, num_algorithms, max_workspace));
-
-    if (algorithms.empty()) {
-      return absl::InternalError(
-          "Failed to get a GroupedMatmulPlan: no valid algorithm found.");
-    }
-    TF_RETURN_IF_ERROR(plan->SetAlgorithm(algorithms[algorithm_idx_]));
-    return std::move(plan);
-  };
-  return blas_lt->GetOrCreateGroupedMatmulPlan(canonical_hlo_, create);
 }
 
 absl::Status CublasLtMatmulThunk::Initialize(const InitializeParams& params) {

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.h
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.h
@@ -70,9 +70,8 @@ class CublasLtMatmulThunk : public TracedCommand {
                       std::optional<ShapedSlice> d_amax,
                       std::optional<const ShapedSlice> workspace);
 
-  absl::Status ExecuteOnStream(const ExecuteParams& params) override {
-    return ExecuteOnStreamInternal(params.stream, params);
-  }
+  absl::Status ExecuteOnStream(const ExecuteParams& params) override;
+
   absl::Status Initialize(const InitializeParams& params) override;
   std::optional<const ShapedSlice> workspace() const { return workspace_; }
 
@@ -88,13 +87,7 @@ class CublasLtMatmulThunk : public TracedCommand {
       absl::Span<const BufferAllocation> allocations);
 
  protected:
-  CublasLtMatmulThunk(const CublasLtMatmulThunk& rhs);
-
-  absl::Status ExecuteOnStreamInternal(se::Stream* stream,
-                                       const ExecuteParams& params);
   absl::StatusOr<se::gpu::BlasLt::MatmulPlan*> GetCachedMatmulPlan(
-      const ExecuteParams& params);
-  absl::StatusOr<se::gpu::BlasLt::MatmulPlan*> GetCachedGroupedMatmulPlan(
       const ExecuteParams& params);
 
   std::variant<GemmConfig, se::gpu::GroupedGemmConfig> gemm_config_;

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk_test.cc
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk_test.cc
@@ -340,7 +340,7 @@ struct MockBlasLt : public se::gpu::BlasLt {
   }
 
   absl::StatusOr<MatmulPlanPtr> GetGroupedMatmulPlan(
-      se::gpu::GroupedGemmConfig&,
+      const se::gpu::GroupedGemmConfig&,
       const std::vector<Epilogue>&) const override {
     return MatmulPlanPtr{};
   }

--- a/xla/stream_executor/cuda/cuda_blas_lt.cc
+++ b/xla/stream_executor/cuda/cuda_blas_lt.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "xla/stream_executor/cuda/cuda_blas_lt.h"
 
-#include <Eigen/Core>
 #include <algorithm>
 #include <any>
 #include <climits>
@@ -37,6 +36,7 @@ limitations under the License.
 #include "third_party/gpus/cuda/include/cublas_v2.h"
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "third_party/gpus/cuda/include/library_types.h"
+#include <Eigen/Core>
 #include "xla/primitive_util.h"
 #include "xla/status_macros.h"
 #include "xla/stream_executor/activate_context.h"
@@ -150,10 +150,10 @@ absl::StatusOr<cublasLtEpilogue_t> AsCublasLtEpilogue(
 }  // namespace
 
 absl::Status BlasLt::Init() {
-  cublasLtHandle_t blas_lt;
-  SE_CUBLAS_RETURN_IF_ERROR(cublasLtCreate(&blas_lt));
+  cublasLtHandle_t handle;
+  SE_CUBLAS_RETURN_IF_ERROR(cublasLtCreate(&handle));
   absl::MutexLock lock(mu_);
-  blas_lt_.reset(blas_lt);
+  handle_.reset(handle);
   return absl::OkStatus();
 }
 
@@ -177,7 +177,8 @@ absl::Status BlasLt::Init() {
 
   VLOG(2) << "MatrixLayout::Create: num_rows: " << m.num_rows
           << " num_cols:" << (int)m.num_cols << ", order: " << (int)m.order
-          << "," << " batchsz " << m.batch_size
+          << ","
+          << " batchsz " << m.batch_size
           << " leaddimstride: " << m.leading_dim_stride
           << " batch_stride: " << m.batch_stride;
 
@@ -239,16 +240,14 @@ cublasLtPointerMode_t BlasLt::MatmulDesc::pointer_mode() const {
           .value());
 }
 
-auto BlasLt::MatmulPlan::GetAlgorithms(const Stream* stream,
-                                       size_t max_algorithm_count,
+auto BlasLt::MatmulPlan::GetAlgorithms(size_t max_algorithm_count,
                                        size_t max_workspace_size) const
     -> absl::StatusOr<std::vector<MatmulAlgorithm>> {
   max_algorithm_count = std::min(max_algorithm_count, size_t{INT_MAX});
   std::vector<cublasLtMatmulHeuristicResult_t> results(max_algorithm_count);
   {
-    auto blas_lt = static_cast<BlasLt*>(gpu::BlasLt::Get(stream));
-    absl::MutexLock lock(blas_lt->mu_);
-    TF_RET_CHECK(blas_lt->blas_lt_ != nullptr);
+    absl::MutexLock lock(blas_lt_.mu_);
+    TF_RET_CHECK(blas_lt_.handle_.get() != nullptr);
 
     cublasLtMatmulPreference_t cu_preference;
     SE_CUBLAS_RETURN_IF_ERROR(cublasLtMatmulPreferenceCreate(&cu_preference));
@@ -285,11 +284,12 @@ auto BlasLt::MatmulPlan::GetAlgorithms(const Stream* stream,
       }
     }
 #endif
-    std::unique_ptr<ActivateContext> activation = blas_lt->parent_->Activate();
+    std::unique_ptr<ActivateContext> activation =
+        blas_lt_.executor_->Activate();
 
     int found_algorithm_count = 0;
     SE_CUBLAS_RETURN_IF_ERROR(cublasLtMatmulAlgoGetHeuristic(
-        blas_lt->blas_lt_.get(), op_desc_.get(), a_desc_.get(), b_desc_.get(),
+        blas_lt_.handle_.get(), op_desc_.get(), a_desc_.get(), b_desc_.get(),
         c_desc_.get(), d_desc_.get(), preference.get(), max_algorithm_count,
         results.data(), &found_algorithm_count));
     results.resize(found_algorithm_count);
@@ -346,7 +346,7 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
         gpu::GetBlasComputationType(
             cfg.precision_algorithm, lhs_layout.dtype, output_layout.dtype,
             cfg.compute_precision,
-            parent_->GetDeviceDescription().gpu_compute_capability()));
+            executor_->GetDeviceDescription().gpu_compute_capability()));
   }
 
   // FP8 matmuls have a fast accumulation mode that is less precise than the
@@ -367,19 +367,95 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
   TF_ASSIGN_OR_RETURN(auto c_desc, MatrixLayout::Create(c_layout));
   TF_ASSIGN_OR_RETURN(auto d_desc, MatrixLayout::Create(output_layout));
 
-  return std::make_unique<MatmulPlan>(std::move(op_desc), std::move(a_desc),
-                                      std::move(b_desc), std::move(c_desc),
-                                      std::move(d_desc), cfg.alpha, cfg.beta,
-                                      must_swap_operands);
+  std::tuple operand_types{a_desc.type(), b_desc.type(), c_desc.type(),
+                           d_desc.type()};
+
+  auto plan = std::make_unique<MatmulPlan>(*this, std::move(op_desc),
+                                           std::move(a_desc), std::move(b_desc),
+                                           std::move(c_desc), std::move(d_desc),
+                                           cfg.beta == 0.0, must_swap_operands);
+
+  auto assign_alpha_beta = [&](auto scale) {
+    using Scale = decltype(scale);
+    static_assert(sizeof(Scale) <= BlasLt::MatmulPlan::kMaxScaleBytes,
+                  "Scale type must fit in kMaxScaleBytes");
+    auto* palpha = reinterpret_cast<Scale*>(&plan->alpha_[0]);
+    if constexpr (std::is_same_v<Scale, xla::complex64> ||
+                  std::is_same_v<Scale, xla::complex128>) {
+      *palpha = static_cast<Scale>(cfg.alpha);
+    } else {
+      *palpha = static_cast<Scale>(cfg.alpha.real());
+    }
+    auto* pbeta = reinterpret_cast<Scale*>(&plan->beta_[0]);
+    *pbeta = static_cast<Scale>(cfg.beta);
+  };
+
+#define TYPED_MATMUL(Scale, ATYPE, BTYPE, CTYPE, DTYPE)               \
+  else if (operand_types == std::tuple{ATYPE, BTYPE, CTYPE, DTYPE}) { \
+    assign_alpha_beta(Scale{});                                       \
+  }
+
+  if (false) {
+  }  // This is needed to avoid compiler error for the else clause.
+#if CUDA_VERSION >= 11080
+  // FP8 compatible type combinations (see cuBLASLt documentation):
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_16BF)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16BF,
+               CUDA_R_8F_E4M3)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16F,
+               CUDA_R_8F_E4M3)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_16F)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_32F, CUDA_R_32F)
+
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF, CUDA_R_16BF)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF,
+               CUDA_R_8F_E4M3)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF,
+               CUDA_R_8F_E5M2)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F,
+               CUDA_R_8F_E4M3)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F,
+               CUDA_R_8F_E5M2)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F, CUDA_R_16F)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_32F, CUDA_R_32F)
+
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_16BF)
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF,
+               CUDA_R_8F_E4M3)
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF,
+               CUDA_R_8F_E5M2)
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F,
+               CUDA_R_8F_E4M3)
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F,
+               CUDA_R_8F_E5M2)
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_16F)
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_32F, CUDA_R_32F)
+#endif
+
+  // Other data types:
+  TYPED_MATMUL(float, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_16BF)
+  TYPED_MATMUL(float, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
+  TYPED_MATMUL(float, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_32F, CUDA_R_32F)
+  TYPED_MATMUL(float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F, CUDA_R_32F)
+  TYPED_MATMUL(float, CUDA_R_32F, CUDA_R_32F, CUDA_R_32F, CUDA_R_32F)
+  TYPED_MATMUL(double, CUDA_R_64F, CUDA_R_64F, CUDA_R_64F, CUDA_R_64F)
+  TYPED_MATMUL(int32_t, CUDA_R_8I, CUDA_R_8I, CUDA_R_32I, CUDA_R_32I)
+  TYPED_MATMUL(float, CUDA_R_8I, CUDA_R_8I, CUDA_R_32F, CUDA_R_32F)
+  TYPED_MATMUL(xla::complex64, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F)
+  TYPED_MATMUL(xla::complex128, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F)
+  else {
+    return xla::Internal("Unexpected dtype");
+  }
+#undef TYPED_MATMUL
+  return plan;
 }
 
-absl::Status BlasLt::MatmulPlan::DoMatmul(
-    Stream* stream, const void* alpha, const void* beta,
-    const gpu::BlasLt::MemoryArgs& args,
+absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
+    Stream* stream, const gpu::BlasLt::MemoryArgs& args,
     blas::ProfileResult* profile_result) const {
   if (!algorithm_.has_value()) {
     return absl::InternalError(
-        "Algorithm must be set before calling DoMatMul!");
+        "Algorithm must be set before calling ExecuteOnStream!");
   }
   DeviceAddressBase a = args.a, b = args.b;
   DeviceAddressBase a_scale = args.a_scale, b_scale = args.b_scale;
@@ -387,9 +463,6 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     std::swap(a, b);
     std::swap(a_scale, b_scale);
   }
-
-  auto blas_lt = static_cast<BlasLt*>(gpu::BlasLt::Get(stream));
-  TF_RET_CHECK(blas_lt != nullptr);
 
   std::unique_ptr<EventBasedTimer> timer;
   if (profile_result != nullptr) {
@@ -415,8 +488,8 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
 
   auto palgo = std::any_cast<cublasLtMatmulAlgo_t>(&algorithm_->opaque_algo);
   {
-    absl::MutexLock lock(blas_lt->mu_);
-    TF_RET_CHECK(blas_lt->blas_lt_ != nullptr);
+    absl::MutexLock lock(blas_lt_.mu_);
+    TF_RET_CHECK(blas_lt_.handle_.get() != nullptr);
     // We must set the bias and aux pointers while holding the mutex, to avoid a
     // potential race condition from multiple threads sharing the same plan.
     if (args.bias != nullptr) {
@@ -480,18 +553,16 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
 #endif
     }
 
-    std::unique_ptr<ActivateContext> activation = blas_lt->parent_->Activate();
+    std::unique_ptr<ActivateContext> activation =
+        blas_lt_.executor_->Activate();
 
-    void* c_ptr = args.c.opaque();
-    if (beta_ == 0.0) {
-      c_ptr = nullptr;
-    }
-
+    void* c_ptr = zero_beta_ ? nullptr : args.c.opaque();
     if (palgo != nullptr) {
       SE_CUBLAS_RETURN_IF_ERROR(cublasLtMatmul(
-          blas_lt->blas_lt_.get(), op_desc_.get(), alpha, a.opaque(),
-          a_desc_.get(), b.opaque(), b_desc_.get(), beta, c_ptr, c_desc_.get(),
-          args.d.opaque(), d_desc_.get(), palgo, workspace_addr, workspace_size,
+          blas_lt_.handle_.get(), op_desc_.get(), &alpha_[0], a.opaque(),
+          a_desc_.get(), b.opaque(), b_desc_.get(), &beta_[0], c_ptr,
+          c_desc_.get(), args.d.opaque(), d_desc_.get(), palgo, workspace_addr,
+          workspace_size,
           absl::bit_cast<CUstream>(stream->platform_specific_handle().stream)));
     } else {
       return absl::InternalError("cublaslt: Invalid algorithm type");
@@ -506,89 +577,6 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     profile_result->set_elapsed_time_in_ms(absl::ToDoubleMilliseconds(elapsed));
   }
   return absl::OkStatus();
-}
-
-absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
-    Stream* stream, const gpu::BlasLt::MemoryArgs& args,
-    blas::ProfileResult* profile_result) const {
-  auto wrapped_matmul = [&](auto scale) {
-    using Scale = decltype(scale);
-    Scale salpha;
-    if constexpr (std::is_same_v<Scale, xla::complex64> ||
-                  std::is_same_v<Scale, xla::complex128>) {
-      salpha = static_cast<Scale>(alpha_);
-    } else {
-      salpha = static_cast<Scale>(alpha_.real());
-    }
-    Scale sbeta = static_cast<Scale>(beta_);
-    return DoMatmul(stream, &salpha, &sbeta, args, profile_result);
-  };
-
-  std::tuple operand_types{a_desc_.type(), b_desc_.type(), c_desc_.type(),
-                           d_desc_.type()};
-
-#define TYPED_MATMUL(Scale, ATYPE, BTYPE, CTYPE, DTYPE)          \
-  if (operand_types == std::tuple{ATYPE, BTYPE, CTYPE, DTYPE}) { \
-    return wrapped_matmul(Scale{});                              \
-  }
-
-#if CUDA_VERSION >= 11080
-  // FP8 compatible type combinations (see cuBLASLt documentation):
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_16BF)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16BF,
-               CUDA_R_8F_E4M3)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16F,
-               CUDA_R_8F_E4M3)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_16F)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_32F, CUDA_R_32F)
-
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF, CUDA_R_16BF)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF,
-               CUDA_R_8F_E4M3)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF,
-               CUDA_R_8F_E5M2)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F,
-               CUDA_R_8F_E4M3)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F,
-               CUDA_R_8F_E5M2)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F, CUDA_R_16F)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_32F, CUDA_R_32F)
-
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_16BF)
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF,
-               CUDA_R_8F_E4M3)
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF,
-               CUDA_R_8F_E5M2)
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F,
-               CUDA_R_8F_E4M3)
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F,
-               CUDA_R_8F_E5M2)
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_16F)
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_32F, CUDA_R_32F)
-#endif
-
-  // Other data types:
-  TYPED_MATMUL(float, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_16BF)
-  TYPED_MATMUL(float, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
-  TYPED_MATMUL(float, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_32F, CUDA_R_32F)
-  TYPED_MATMUL(float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F, CUDA_R_32F)
-  TYPED_MATMUL(float, CUDA_R_32F, CUDA_R_32F, CUDA_R_32F, CUDA_R_32F)
-  TYPED_MATMUL(double, CUDA_R_64F, CUDA_R_64F, CUDA_R_64F, CUDA_R_64F)
-  TYPED_MATMUL(int32_t, CUDA_R_8I, CUDA_R_8I, CUDA_R_32I, CUDA_R_32I)
-  TYPED_MATMUL(float, CUDA_R_8I, CUDA_R_8I, CUDA_R_32F, CUDA_R_32F)
-  TYPED_MATMUL(xla::complex64, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F)
-  TYPED_MATMUL(xla::complex128, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F)
-
-#undef TYPED_MATMUL
-
-  return xla::Internal("Unexpected dtype");
-}
-
-absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetGroupedMatmulPlan(
-    gpu::GroupedGemmConfig& config,
-    const std::vector<gpu::BlasLt::Epilogue>& epilogues) const {
-  return absl::UnimplementedError(
-      "Grouped GEMM is not supported for CUDA BlasLt");
 }
 
 }  // namespace cuda

--- a/xla/stream_executor/cuda/cuda_blas_lt.h
+++ b/xla/stream_executor/cuda/cuda_blas_lt.h
@@ -84,18 +84,23 @@ class BlasLt : public gpu::BlasLt {
   };
 
   class MatmulPlan : public gpu::BlasLt::MatmulPlan {
+    friend class BlasLt;
+    // We use a fixed-size array to store the alpha and beta values which can
+    // fit all supported scale types.
+    constexpr static size_t kMaxScaleBytes = 16;
+
    public:
-    MatmulPlan(MatmulDesc&& op_desc, MatrixLayout&& a_desc,
-               MatrixLayout&& b_desc, MatrixLayout&& c_desc,
-               MatrixLayout&& d_desc, xla::complex128 alpha, double beta,
+    MatmulPlan(const BlasLt& blas_lt, MatmulDesc&& op_desc,
+               MatrixLayout&& a_desc, MatrixLayout&& b_desc,
+               MatrixLayout&& c_desc, MatrixLayout&& d_desc, bool zero_beta,
                bool must_swap_operands)
-        : op_desc_(std::move(op_desc)),
+        : blas_lt_(blas_lt),
+          op_desc_(std::move(op_desc)),
           a_desc_(std::move(a_desc)),
           b_desc_(std::move(b_desc)),
           c_desc_(std::move(c_desc)),
           d_desc_(std::move(d_desc)),
-          alpha_(alpha),
-          beta_(beta),
+          zero_beta_(zero_beta),
           must_swap_operands_(must_swap_operands) {}
 
     ~MatmulPlan() override = default;
@@ -105,8 +110,7 @@ class BlasLt : public gpu::BlasLt {
         blas::ProfileResult* profile_result) const override;
 
     absl::StatusOr<std::vector<MatmulAlgorithm>> GetAlgorithms(
-        const Stream* stream, size_t max_algorithm_count,
-        size_t max_workspace_size) const override;
+        size_t max_algorithm_count, size_t max_workspace_size) const override;
 
     absl::Status SetAlgorithm(const MatmulAlgorithm& algorithm) override {
       algorithm_ = algorithm;
@@ -114,24 +118,20 @@ class BlasLt : public gpu::BlasLt {
     }
 
    private:
-    absl::Status DoMatmul(Stream* stream, const void* alpha, const void* beta,
-                          const gpu::BlasLt::MemoryArgs& args,
-                          blas::ProfileResult* profile_result) const;
-
-    // TODO(cjfj): Add consistency checks for types, shapes, etc.?
+    const BlasLt& blas_lt_;
     MatmulDesc op_desc_;
     MatrixLayout a_desc_;
     MatrixLayout b_desc_;
     MatrixLayout c_desc_;
     MatrixLayout d_desc_;
-    xla::complex128 alpha_;
-    double beta_;
+    std::array<uint8_t, kMaxScaleBytes> alpha_, beta_;
+    bool zero_beta_;
     bool must_swap_operands_;
     std::optional<MatmulAlgorithm> algorithm_;  // selected algorithm
-  };  // class MatmulPlan
+  };                                            // class MatmulPlan
 
-  explicit BlasLt(StreamExecutor* parent)
-      : parent_(parent), blas_lt_(nullptr, cublasLtDestroy) {}
+  explicit BlasLt(StreamExecutor* executor)
+      : executor_(executor), handle_(nullptr, cublasLtDestroy) {}
 
   absl::Status Init() override;
 
@@ -139,15 +139,18 @@ class BlasLt : public gpu::BlasLt {
                                               Epilogue epilogue) const override;
 
   absl::StatusOr<MatmulPlanPtr> GetGroupedMatmulPlan(
-      gpu::GroupedGemmConfig& config,
-      const std::vector<Epilogue>& epilogues) const override;
+      const gpu::GroupedGemmConfig& config,
+      const std::vector<Epilogue>& epilogues) const override {
+    return absl::UnimplementedError(
+        "Grouped GEMM is not supported for CUDA BlasLt");
+  };
 
   ~BlasLt() override = default;
 
  private:
-  StreamExecutor* parent_;
+  StreamExecutor* executor_;
   mutable absl::Mutex mu_;
-  Owned<cublasLtHandle_t> blas_lt_ ABSL_GUARDED_BY(mu_);
+  Owned<cublasLtHandle_t> handle_ ABSL_GUARDED_BY(mu_);
 };
 
 }  // namespace cuda

--- a/xla/stream_executor/gpu/gpu_blas_lt.cc
+++ b/xla/stream_executor/gpu/gpu_blas_lt.cc
@@ -286,18 +286,13 @@ bool MakeOutputColumnMajor(MatrixLayout& lhs, MatrixLayout& rhs,
   return swap_operands;
 }
 
-/*static*/ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
-    const Stream* stream, const GemmConfig& cfg, Epilogue epilogue) {
-  auto blas = Get(stream);
-  if (blas == nullptr) {
-    return xla::Internal("BlasLt is unavailable");
+/*static*/ absl::StatusOr<BlasLt*> BlasLt::Get(StreamExecutor* executor) {
+  auto blas = executor->AsBlas();
+  auto blas_lt = blas != nullptr ? blas->GetBlasLt() : nullptr;
+  if (blas_lt == nullptr) {
+    return absl::InternalError("BlasLt is unavailable");
   }
-  return blas->GetMatmulPlan(cfg, epilogue);
-}
-
-/*static*/ BlasLt* BlasLt::Get(const Stream* stream) {
-  auto blas = stream->parent()->AsBlas();
-  return (blas != nullptr ? blas->GetBlasLt() : nullptr);
+  return blas_lt;
 }
 
 DataType GetScaleType(DataType c_type, ComputationType computation_type) {
@@ -309,7 +304,7 @@ DataType GetScaleType(DataType c_type, ComputationType computation_type) {
 
 absl::StatusOr<BlasLt::MatmulPlan*> BlasLt::GetOrCreateMatmulPlan(
     const std::string& key, PlanCreateFunc create) {
-  absl::MutexLock lock(plan_cache_mu_);  // double mutex ???
+  absl::MutexLock lock(plan_cache_mu_);
   auto res = plan_cache_.emplace(key, MatmulPlanPtr{});
   // New entry inserted: always create a new matmul plan if key is empty,
   // this is used by command_buffer_thunk test.
@@ -329,41 +324,6 @@ void BlasLt::ClearMatmulPlanCache() {
 size_t BlasLt::GetMatmulPlanCacheSize() const {
   absl::MutexLock lock(plan_cache_mu_);
   return plan_cache_.size();
-}
-
-/*static*/ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetGroupedMatmulPlan(
-    const Stream* stream, GroupedGemmConfig& cfg,
-    const std::vector<Epilogue>& epilogues) {
-  auto blas = Get(stream);
-  if (blas == nullptr) {
-    return xla::Internal("BlasLt is unavailable");
-  }
-  return blas->GetGroupedMatmulPlan(cfg, epilogues);
-}
-
-absl::StatusOr<BlasLt::MatmulPlan*> BlasLt::GetOrCreateGroupedMatmulPlan(
-    const std::string& key, PlanCreateFunc create) {
-  absl::MutexLock lock(plan_cache_mu_);
-  auto res = grouped_plan_cache_.emplace(key, MatmulPlanPtr{});
-  // New entry inserted: always create a new matmul plan if key is empty,
-  // this is used by command_buffer_thunk test.
-  if (res.second || key.empty()) {
-    VLOG(2) << "Creating a grouped plan for: " << key;
-    TF_ASSIGN_OR_RETURN(res.first->second, create());
-    VLOG(2) << "Grouped Plan created: cache size: "
-            << grouped_plan_cache_.size();
-  }
-  return res.first->second.get();
-}
-
-void BlasLt::ClearGroupedMatmulPlanCache() {
-  absl::MutexLock lock(plan_cache_mu_);
-  grouped_plan_cache_.clear();
-}
-
-size_t BlasLt::GetGroupedMatmulPlanCacheSize() const {
-  absl::MutexLock lock(plan_cache_mu_);
-  return grouped_plan_cache_.size();
 }
 
 absl::StatusOr<GemmConfig> GemmConfig::FromProto(

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -228,38 +228,6 @@ struct BlasLt {
   };
 
   struct MatmulPlan {
-    // This function is to be removed once TF interface is fixed,
-    // see tensorflow/core/kernels/matmul_util.cc
-    absl::Status ExecuteOnStream(
-        Stream* stream, DeviceAddressBase a, DeviceAddressBase b,
-        DeviceAddressBase c, DeviceAddressBase d,
-        DeviceAddressBase bias,  // may be null
-        DeviceAddressBase aux,   // may be null
-        DeviceAddressBase a_scale, DeviceAddressBase b_scale,
-        DeviceAddressBase c_scale, DeviceAddressBase d_scale,
-        DeviceAddressBase d_amax, const MatmulAlgorithm& algorithm,
-        ScratchAllocator& scratch_allocator,
-        blas::ProfileResult* profile_result = nullptr) const {
-      // Temporary hack until Tensorflow side is fixed
-      TF_RETURN_IF_ERROR(
-          const_cast<MatmulPlan*>(this)->SetAlgorithm(algorithm));
-      return ExecuteOnStream(stream,
-                             MemoryArgs{a,
-                                        b,
-                                        c,
-                                        d,
-                                        bias,
-                                        aux,
-                                        a_scale,
-                                        b_scale,
-                                        c_scale,
-                                        d_scale,
-                                        {d_amax},
-                                        DeviceAddressBase{},
-                                        &scratch_allocator},
-                             profile_result);
-    }
-
     // API that uses scratch_allocator to allocate workspace.
     // This version is used by TF: see tensorflow/core/kernels/matmul_util.cc
     absl::Status ExecuteOnStream(
@@ -288,70 +256,16 @@ struct BlasLt {
                              profile_result);
     }
 
-    // API that uses pre-allocated buffer as workspace (regular matmul).
-    absl::Status ExecuteOnStream(
-        Stream* stream, DeviceAddressBase a, DeviceAddressBase b,
-        DeviceAddressBase c, DeviceAddressBase d,
-        DeviceAddressBase bias,  // may be null
-        DeviceAddressBase aux,   // may be null
-        DeviceAddressBase a_scale, DeviceAddressBase b_scale,
-        DeviceAddressBase c_scale, DeviceAddressBase d_scale,
-        DeviceAddressBase d_amax, DeviceAddressBase workspace,
-        blas::ProfileResult* profile_result = nullptr) const {
-      return ExecuteOnStream(stream,
-                             MemoryArgs{a,
-                                        b,
-                                        c,
-                                        d,
-                                        bias,
-                                        aux,
-                                        a_scale,
-                                        b_scale,
-                                        c_scale,
-                                        d_scale,
-                                        {d_amax},
-                                        workspace,
-                                        nullptr},
-                             profile_result);
-    }
-
-    // API that uses pre-allocated buffer as workspace (grouped matmul).
-    absl::Status ExecuteOnStream(
-        Stream* stream, DeviceAddressBase a, DeviceAddressBase b,
-        DeviceAddressBase c, DeviceAddressBase d, DeviceAddressBase group_sizes,
-        DeviceAddressBase bias,  // may be null
-        DeviceAddressBase aux,   // may be null
-        DeviceAddressBase a_scale, DeviceAddressBase b_scale,
-        DeviceAddressBase c_scale, DeviceAddressBase d_scale,
-        DeviceAddressBase d_amax, DeviceAddressBase workspace,
-        blas::ProfileResult* profile_result = nullptr) const {
-      return ExecuteOnStream(stream,
-                             MemoryArgs{a,
-                                        b,
-                                        c,
-                                        d,
-                                        bias,
-                                        aux,
-                                        a_scale,
-                                        b_scale,
-                                        c_scale,
-                                        d_scale,
-                                        {group_sizes},
-                                        workspace,
-                                        nullptr},
-                             profile_result);
-    }
-
     // The most general form: to be implemented by derived clases.
     virtual absl::Status ExecuteOnStream(
         Stream* stream, const MemoryArgs& args,
-        blas::ProfileResult* profile_result) const = 0;
+        blas::ProfileResult* profile_result = nullptr) const = 0;
 
     // Returns a list of supported algorithms for DoMatmul. The algorithms are
     // returned in the order of increasing estimated compute time according to
     // an internal heuristic.
     virtual absl::StatusOr<std::vector<MatmulAlgorithm>> GetAlgorithms(
-        const Stream* stream, size_t max_algorithm_count = 128,
+        size_t max_algorithm_count,
         size_t max_workspace_size = 1ll << 32) const = 0;
 
     // Algorithm must to be set before calling ExecuteOnStream function(s).
@@ -372,39 +286,22 @@ struct BlasLt {
       const GemmConfig& cfg, Epilogue epilogue) const = 0;
 
   virtual absl::StatusOr<MatmulPlanPtr> GetGroupedMatmulPlan(
-      gpu::GroupedGemmConfig& config,
+      const gpu::GroupedGemmConfig& config,
       const std::vector<Epilogue>& epilogues) const = 0;
 
-  static BlasLt* Get(const Stream* stream);
-
-  // convenience function to create MatmulPlan directly using stream
-  static absl::StatusOr<MatmulPlanPtr> GetMatmulPlan(const Stream* stream,
-                                                     const GemmConfig& cfg,
-                                                     Epilogue epilogue);
-
-  static absl::StatusOr<MatmulPlanPtr> GetGroupedMatmulPlan(
-      const Stream* stream, gpu::GroupedGemmConfig& config,
-      const std::vector<Epilogue>& epilogues);
+  static absl::StatusOr<BlasLt*> Get(StreamExecutor* executor);
 
   absl::StatusOr<MatmulPlan*> GetOrCreateMatmulPlan(const std::string& key,
                                                     PlanCreateFunc create);
 
-  absl::StatusOr<MatmulPlan*> GetOrCreateGroupedMatmulPlan(
-      const std::string& key, PlanCreateFunc create);
-
   void ClearMatmulPlanCache();
   size_t GetMatmulPlanCacheSize() const;
-
-  void ClearGroupedMatmulPlanCache();
-  size_t GetGroupedMatmulPlanCacheSize() const;
 
   virtual ~BlasLt() = default;
 
  protected:
   mutable absl::Mutex plan_cache_mu_;
   absl::flat_hash_map<std::string, MatmulPlanPtr> plan_cache_
-      ABSL_GUARDED_BY(plan_cache_mu_);
-  absl::flat_hash_map<std::string, MatmulPlanPtr> grouped_plan_cache_
       ABSL_GUARDED_BY(plan_cache_mu_);
 };  // class BlasLt
 

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -24,9 +24,6 @@ limitations under the License.
 #include <vector>
 
 #include "absl/base/casts.h"
-#include "rocm/rocm_config.h"
-#if TF_HIPBLASLT
-
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -36,6 +33,7 @@ limitations under the License.
 #include "rocm/include/hipblas/hipblas.h"
 #include "rocm/include/hipblaslt/hipblaslt.h"
 #include "rocm/include/rocblas/internal/rocblas-types.h"
+#include "rocm/rocm_config.h"
 #include "xla/primitive_util.h"
 #include "xla/status_macros.h"
 #include "xla/stream_executor/activate_context.h"
@@ -153,10 +151,10 @@ static absl::StatusOr<hipblasLtEpilogue_t> AsHipblasLtEpilogue(
 }  // namespace
 
 absl::Status BlasLt::Init() {
-  hipblasLtHandle_t blas_lt;
-  SE_HIPBLAS_RETURN_IF_ERROR(hipblasLtCreate(&blas_lt));
+  hipblasLtHandle_t handle;
+  SE_HIPBLAS_RETURN_IF_ERROR(hipblasLtCreate(&handle));
   absl::MutexLock lock(mu_);
-  blas_lt_.reset(blas_lt);
+  handle_.reset(handle);
   return absl::OkStatus();
 }
 
@@ -222,51 +220,14 @@ absl::Status BlasLt::Init() {
   return std::move(desc);
 }
 
-auto BlasLt::MatmulPlan::GetAlgorithmsForGroupedMatmul(
-    const Stream* stream, size_t max_algorithm_count,
-    size_t max_workspace_size) const
-    -> absl::StatusOr<std::vector<MatmulAlgorithm>> {
-  std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResult;
-
-  auto blas_lt = static_cast<BlasLt*>(gpu::BlasLt::Get(stream));
-  absl::MutexLock lock(&blas_lt->mu_);
-
-  std::unique_ptr<ActivateContext> activation = blas_lt->parent_->Activate();
-
-  auto problem = grouped_gemm_->getProblemTypes()[0];
-
-  grouped_gemm_->setMaxWorkspaceBytes(max_workspace_size);
-
-  SE_HIPBLAS_RETURN_IF_ERROR(hipblaslt_ext::getAllAlgos(
-      blas_lt->blas_lt_.get(), hipblaslt_ext::GemmType::HIPBLASLT_GROUPED_GEMM,
-      problem.getOpA(), problem.getOpB(), problem.getTypeA(),
-      problem.getTypeB(), problem.getTypeC(), problem.getTypeD(),
-      problem.getTypeCompute(), heuristicResult));
-  VLOG(2) << "Total heuristics found: " << heuristicResult.size();
-  std::vector<MatmulAlgorithm> algorithms;
-  algorithms.reserve(max_algorithm_count);
-  for (hipblasLtMatmulHeuristicResult_t& result : heuristicResult) {
-    if (algorithms.size() >= max_algorithm_count) break;
-    size_t workspace_size = 0;
-    if ((result.state == HIPBLAS_STATUS_SUCCESS) &&
-        (grouped_gemm_->isAlgoSupported(result.algo, workspace_size) ==
-         HIPBLAS_STATUS_SUCCESS)) {
-      algorithms.push_back({result.algo, result.workspaceSize});
-    }
-  }
-  return std::move(algorithms);
-}
-
-auto BlasLt::MatmulPlan::GetAlgorithmsForMatmul(const Stream* stream,
-                                                size_t max_algorithm_count,
-                                                size_t max_workspace_size) const
+auto BlasLt::RegularMatmulPlan::GetAlgorithms(size_t max_algorithm_count,
+                                              size_t max_workspace_size) const
     -> absl::StatusOr<std::vector<MatmulAlgorithm>> {
   max_algorithm_count = std::min(max_algorithm_count, size_t{INT_MAX});
   std::vector<hipblasLtMatmulHeuristicResult_t> results(max_algorithm_count);
   {
-    auto blas_lt = static_cast<BlasLt*>(gpu::BlasLt::Get(stream));
-    absl::MutexLock lock(blas_lt->mu_);
-    TF_RET_CHECK(blas_lt->blas_lt_ != nullptr);
+    absl::MutexLock lock(blas_lt_.mu_);
+    TF_RET_CHECK(blas_lt_.handle_ != nullptr);
 
     hipblasLtMatmulPreference_t hip_preference;
     SE_HIPBLAS_RETURN_IF_ERROR(
@@ -280,29 +241,30 @@ auto BlasLt::MatmulPlan::GetAlgorithmsForMatmul(const Stream* stream,
         hip_preference, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
         max_workspace_size));
 
-    std::unique_ptr<ActivateContext> activation = blas_lt->parent_->Activate();
+    std::unique_ptr<ActivateContext> activation =
+        blas_lt_.executor_->Activate();
 
     // hipBlasLt requires setting the bias pointer (even a dummy one), otherwise
     // no algorithms can be found for "bias epilogues". This is to be removed
     // later when this limitation is gone.
-    if (op_desc_->has_bias_epilogue()) {
+    if (op_desc_.has_bias_epilogue()) {
       static int64_t dummy_pointer = 0xACEBALL;
       TF_RETURN_IF_ERROR(SetAttr(
-          op_desc_->get(), HIPBLASLT_MATMUL_DESC_BIAS_POINTER, &dummy_pointer));
+          op_desc_.get(), HIPBLASLT_MATMUL_DESC_BIAS_POINTER, &dummy_pointer));
     }
 
     // hipBlasLt requires setting the a/b scale pointer (even a dummy one),
     // otherwise no algorithms can be found for "a/b scaling". This is to be
     // removed later when this limitation is gone.
-    switch (op_desc_->scale_mode()) {
+    switch (op_desc_.scale_mode()) {
       case gpu::ScaleMode::kNone:
         break;
       case gpu::ScaleMode::kTensorScaling: {
         static int64_t dummy_pointer = 0xACEBALL;
-        TF_RETURN_IF_ERROR(SetAttr(op_desc_->get(),
+        TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                    HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
                                    &dummy_pointer));
-        TF_RETURN_IF_ERROR(SetAttr(op_desc_->get(),
+        TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                    HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER,
                                    &dummy_pointer));
         break;
@@ -310,18 +272,18 @@ auto BlasLt::MatmulPlan::GetAlgorithmsForMatmul(const Stream* stream,
       case gpu::ScaleMode::kBlockScaling: {
 #if TF_ROCM_VERSION >= 70000
         static int64_t dummy_pointer = 0xACEBALL;
-        TF_RETURN_IF_ERROR(SetAttr(op_desc_->get(),
+        TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                    HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
                                    &dummy_pointer));
-        TF_RETURN_IF_ERROR(SetAttr(op_desc_->get(),
+        TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                    HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER,
                                    &dummy_pointer));
         hipblasLtMatmulMatrixScale_t mx_scale =
             HIPBLASLT_MATMUL_MATRIX_SCALE_VEC32_UE8M0;
         TF_RETURN_IF_ERROR(SetAttr(
-            op_desc_->get(), HIPBLASLT_MATMUL_DESC_A_SCALE_MODE, mx_scale));
+            op_desc_.get(), HIPBLASLT_MATMUL_DESC_A_SCALE_MODE, mx_scale));
         TF_RETURN_IF_ERROR(SetAttr(
-            op_desc_->get(), HIPBLASLT_MATMUL_DESC_B_SCALE_MODE, mx_scale));
+            op_desc_.get(), HIPBLASLT_MATMUL_DESC_B_SCALE_MODE, mx_scale));
 #else
         return absl::InternalError("Block scaling requires ROCm >= 7.0");
 #endif
@@ -331,9 +293,9 @@ auto BlasLt::MatmulPlan::GetAlgorithmsForMatmul(const Stream* stream,
 
     int found_algorithm_count = 0;
     auto error = hipblasLtMatmulAlgoGetHeuristic(
-        blas_lt->blas_lt_.get(), op_desc_->get(), a_desc_->get(),
-        b_desc_->get(), c_desc_->get(), d_desc_->get(), preference.get(),
-        max_algorithm_count, results.data(), &found_algorithm_count);
+        blas_lt_.handle_.get(), op_desc_.get(), a_desc_.get(), b_desc_.get(),
+        c_desc_.get(), d_desc_.get(), preference.get(), max_algorithm_count,
+        results.data(), &found_algorithm_count);
     if (error != 0) {
       VLOG(0) << "hipblasLtMatmulAlgoGetHeuristic returned " << (int)error;
       SE_HIPBLAS_RETURN_IF_ERROR(error);
@@ -348,20 +310,7 @@ auto BlasLt::MatmulPlan::GetAlgorithmsForMatmul(const Stream* stream,
       algorithms.push_back({result.algo, result.workspaceSize});
     }
   }
-  return std::move(algorithms);
-}
-
-auto BlasLt::MatmulPlan::GetAlgorithms(const Stream* stream,
-                                       size_t max_algorithm_count,
-                                       size_t max_workspace_size) const
-    -> absl::StatusOr<std::vector<MatmulAlgorithm>> {
-  if (is_grouped()) {
-    return GetAlgorithmsForGroupedMatmul(stream, max_algorithm_count,
-                                         max_workspace_size);
-  } else {
-    return GetAlgorithmsForMatmul(stream, max_algorithm_count,
-                                  max_workspace_size);
-  }
+  return algorithms;
 }
 
 absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
@@ -409,7 +358,7 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
         gpu::GetBlasComputationType(
             cfg.precision_algorithm, lhs_layout.dtype, output_layout.dtype,
             cfg.compute_precision,
-            parent_->GetDeviceDescription().gpu_compute_capability()));
+            executor_->GetDeviceDescription().gpu_compute_capability()));
   }
 
   if (lhs_layout.order == gpu::MatrixLayout::Order::kRowMajor) {
@@ -437,183 +386,47 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
   // data type for fp8 matmul, which is different from cublasLt. This is a
   // workaround to match cublasLt behavior.
   if (epilogue == gpu::BlasLt::Epilogue::kBias) {
-    auto a_dtype = a_desc.type();
-    auto b_dtype = b_desc.type();
-
-    auto bias_dtype = d_desc.type();
+    auto a_dtype = a_desc.type(), b_dtype = b_desc.type();
     if ((a_dtype == HIP_R_8F_E4M3_FNUZ || a_dtype == HIP_R_8F_E5M2_FNUZ) &&
         (b_dtype == HIP_R_8F_E4M3_FNUZ || b_dtype == HIP_R_8F_E5M2_FNUZ)) {
-      auto d_dtype = d_desc.type();
-      if (d_dtype == HIP_R_32F) {
-        bias_dtype = HIP_R_16BF;
-      }
-
-      if (bias_dtype != d_dtype) {
+      auto bias_dtype = d_desc.type();
+      if (bias_dtype == HIP_R_32F) {
         TF_RETURN_IF_ERROR(SetAttr(
-            op_desc.get(), HIPBLASLT_MATMUL_DESC_BIAS_DATA_TYPE, bias_dtype));
+            op_desc.get(), HIPBLASLT_MATMUL_DESC_BIAS_DATA_TYPE, HIP_R_16BF));
       }
     }
   }
 #endif  // TF_ROCM_VERSION >= 60000
 
-  return std::make_unique<MatmulPlan>(std::move(op_desc), std::move(a_desc),
-                                      std::move(b_desc), std::move(c_desc),
-                                      std::move(d_desc), cfg.alpha, cfg.beta,
-                                      must_swap_operands);
-}
+  std::tuple operand_types{a_desc.type(), b_desc.type(), c_desc.type(),
+                           d_desc.type()};
 
-absl::Status BlasLt::MatmulPlan::DoMatmul(
-    Stream* stream, const void* alpha, const void* beta,
-    const gpu::BlasLt::MemoryArgs& args,
-    blas::ProfileResult* profile_result) const {
-  if (!algorithm_.has_value()) {
-    return absl::InternalError(
-        "Algorithm must be set before calling DoMatMul!");
-  }
-  DeviceAddressBase a = args.a, b = args.b;
-  DeviceAddressBase a_scale = args.a_scale, b_scale = args.b_scale;
-  if (must_swap_operands_) {
-    std::swap(a, b);
-    if (a_scale != nullptr && b_scale != nullptr) {
-      std::swap(a_scale, b_scale);
-    }
-  }
+  auto plan = std::make_unique<RegularMatmulPlan>(
+      *this, std::move(op_desc), std::move(a_desc), std::move(b_desc),
+      std::move(c_desc), std::move(d_desc), must_swap_operands);
 
-  auto blas_lt = static_cast<BlasLt*>(gpu::BlasLt::Get(stream));
-  TF_RET_CHECK(blas_lt != nullptr);
-  absl::Status status =
-      blas_lt->parent_->RecordApiTrace(StreamExecutor::GemmCallTrace{
-          StreamExecutor::GemmCallTrace::GemmType::kBlasLt, 0, a.size(),
-          b.size()});
-  std::unique_ptr<EventBasedTimer> timer;
-
-  if (profile_result != nullptr) {
-    TF_ASSIGN_OR_RETURN(timer, stream->CreateEventBasedTimer(
-                                   profile_result->warmup_run_executed()));
-  }
-
-  void* workspace_addr = nullptr;
-  uint64_t workspace_size = algorithm_->workspace_size;
-  if (workspace_size > 0) {
-    if (args.scratch_allocator != nullptr) {
-      TF_ASSIGN_OR_RETURN(
-          DeviceAddress<uint8_t> alloc,
-          args.scratch_allocator->AllocateBytes(workspace_size));
-      workspace_addr = gpu::GpuMemoryMutable(&alloc);
-    } else {
-      workspace_addr = args.workspace.opaque();
-      size_t new_size = args.workspace.size();
-      TF_RET_CHECK(workspace_addr != nullptr && new_size >= workspace_size);
-      workspace_size = new_size;
-    }
-  }
-
-  auto palgo = std::any_cast<hipblasLtMatmulAlgo_t>(&algorithm_->opaque_algo);
-  {
-    absl::MutexLock lock(blas_lt->mu_);
-    TF_RET_CHECK(blas_lt->blas_lt_ != nullptr);
-    // We must set the bias and aux pointers while holding the mutex, to avoid a
-    // potential race condition from multiple threads sharing the same plan.
-    if (op_desc_->has_bias_epilogue() && args.bias != nullptr) {
-      TF_RETURN_IF_ERROR(SetAttr(op_desc_->get(),
-                                 HIPBLASLT_MATMUL_DESC_BIAS_POINTER,
-                                 args.bias.opaque()));
-    }
-
-#if TF_ROCM_VERSION >= 60000
-    if (a_scale != nullptr) {
-      TF_RETURN_IF_ERROR(SetAttr(op_desc_->get(),
-                                 HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
-                                 a_scale.opaque()));
-    }
-    if (b_scale != nullptr) {
-      TF_RETURN_IF_ERROR(SetAttr(op_desc_->get(),
-                                 HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER,
-                                 b_scale.opaque()));
-    }
-    if (args.c_scale != nullptr) {
-      TF_RETURN_IF_ERROR(SetAttr(op_desc_->get(),
-                                 HIPBLASLT_MATMUL_DESC_C_SCALE_POINTER,
-                                 args.c_scale.opaque()));
-    }
-    if (args.d_scale != nullptr) {
-      TF_RETURN_IF_ERROR(SetAttr(op_desc_->get(),
-                                 HIPBLASLT_MATMUL_DESC_D_SCALE_POINTER,
-                                 args.d_scale.opaque()));
-    }
-#else
-    if (!(args.a_scale == nullptr && args.b_scale == nullptr &&
-          args.c_scale == nullptr && args.d_scale == nullptr)) {
-      return absl::InternalError("hipblaslt does not support scale");
-    }
-#endif
-
-    if (args.d_amax != nullptr) {
-      return absl::InternalError("hipblaslt does not support amax");
-    }
-
-    if (args.aux != nullptr) {
-      return absl::InternalError(
-          "hipblaslt does not support auxiliary inputs / outputs");
-    }
-
-    std::unique_ptr<ActivateContext> activation = blas_lt->parent_->Activate();
-
-    if (palgo != nullptr) {
-      SE_HIPBLAS_RETURN_IF_ERROR(hipblasLtMatmul(
-          blas_lt->blas_lt_.get(), op_desc_->get(), alpha, a.opaque(),
-          a_desc_->get(), b.opaque(), b_desc_->get(), beta, args.c.opaque(),
-          c_desc_->get(), args.d.opaque(), d_desc_->get(), palgo,
-          workspace_addr, workspace_size,
-          absl::bit_cast<hipStream_t>(
-              stream->platform_specific_handle().stream)));
-    } else {
-      return absl::InternalError("hipblaslt: Invalid algorithm type");
-    }
-  }
-
-  typedef struct __attribute__((packed, aligned(8))) _rocblaslt_matmul_algo {
-    uint8_t data[8] = {0};
-    bool fallback = false;
-    size_t max_workspace_bytes = 0;
-  } rocblaslt_matmul_algo;
-
-  if (profile_result != nullptr) {
-    TF_ASSIGN_OR_RETURN(absl::Duration elapsed, timer->GetElapsedDuration());
-    // set algorithm ID to be unique (otherwise it gets kDefaultAlgorithm ID)
-    auto roc_algo = (const rocblaslt_matmul_algo*)palgo;
-    auto pindex = (int*)roc_algo->data;
-    profile_result->set_algorithm(static_cast<blas::AlgorithmType>(*pindex));
-    profile_result->set_is_valid(true);
-    profile_result->set_elapsed_time_in_ms(absl::ToDoubleMilliseconds(elapsed));
-  }
-  return absl::OkStatus();
-}
-
-absl::Status BlasLt::MatmulPlan::ExecuteRegularMatmul(
-    Stream* stream, const gpu::BlasLt::MemoryArgs& args,
-    blas::ProfileResult* profile_result) const {
-  auto wrapped_matmul = [&](auto scale) {
+  auto assign_alpha_beta = [&](auto scale) {
     using Scale = decltype(scale);
-    Scale salpha;
+    static_assert(sizeof(Scale) <= RegularMatmulPlan::kMaxScaleBytes,
+                  "Scale type must fit in kMaxScaleBytes");
+    auto* palpha = reinterpret_cast<Scale*>(&plan->alpha_[0]);
     if constexpr (std::is_same_v<Scale, xla::complex64> ||
                   std::is_same_v<Scale, xla::complex128>) {
-      salpha = static_cast<Scale>(*alpha_);
+      *palpha = static_cast<Scale>(cfg.alpha);
     } else {
-      salpha = static_cast<Scale>(alpha_->real());
+      *palpha = static_cast<Scale>(cfg.alpha.real());
     }
-    Scale sbeta = static_cast<Scale>(*beta_);
-    return DoMatmul(stream, &salpha, &sbeta, args, profile_result);
+    auto* pbeta = reinterpret_cast<Scale*>(&plan->beta_[0]);
+    *pbeta = static_cast<Scale>(cfg.beta);
   };
 
-  std::tuple operand_types{a_desc_->type(), b_desc_->type(), c_desc_->type(),
-                           d_desc_->type()};
-
-#define TYPED_MATMUL(Scale, ATYPE, BTYPE, CTYPE, DTYPE)          \
-  if (operand_types == std::tuple{ATYPE, BTYPE, CTYPE, DTYPE}) { \
-    return wrapped_matmul(Scale{});                              \
+#define TYPED_MATMUL(Scale, ATYPE, BTYPE, CTYPE, DTYPE)               \
+  else if (operand_types == std::tuple{ATYPE, BTYPE, CTYPE, DTYPE}) { \
+    assign_alpha_beta(Scale{});                                       \
   }
 
+  if (false) {
+  }  // This is needed to avoid compiler error for the else clause.
 // FP8 compatible types combinations (Full table in
 // https://github.com/ROCm/hipBLASLt/blob/develop/docs/api-reference.rst?plain=1)
 #if TF_ROCM_VERSION >= 60000
@@ -738,45 +551,207 @@ absl::Status BlasLt::MatmulPlan::ExecuteRegularMatmul(
   TYPED_MATMUL(float, HIP_R_8I, HIP_R_8I, HIP_R_32F, HIP_R_32F)
   TYPED_MATMUL(complex64, HIP_C_32F, HIP_C_32F, HIP_C_32F, HIP_C_32F)
   TYPED_MATMUL(complex128, HIP_C_64F, HIP_C_64F, HIP_C_64F, HIP_C_64F)
-
+  else {
+    return xla::Internal("Unexpected dtype");
+  }
 #undef TYPED_MATMUL
-
-  return xla::Internal("Unexpected dtype");
+  return plan;
 }
 
-void BlasLt::MatmulPlan::InitializeGroupedGemm(
-    hipblasLtHandle_t blas_lt_handle, blas::ComputationType compute_type) {
-  auto batch_stride_a = (cfg_->m * cfg_->k);
-  auto batch_stride_b = (cfg_->n * cfg_->k);
-  if (cfg_->ragged_mode == gpu::RaggedDotMode::kRaggedNonContracting) {
-    if (cfg_->must_swap_operands) {
-      batch_stride_a *= cfg_->group_count;
-    } else {
-      batch_stride_b *= cfg_->group_count;
+absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
+    Stream* stream, const gpu::BlasLt::MemoryArgs& args,
+    blas::ProfileResult* profile_result) const {
+  if (!algorithm_.has_value()) {
+    return absl::InternalError(
+        "Algorithm must be set before calling ExecuteOnStream!");
+  }
+  DeviceAddressBase a = args.a, b = args.b;
+  DeviceAddressBase a_scale = args.a_scale, b_scale = args.b_scale;
+  if (must_swap_operands_) {
+    std::swap(a, b);
+    if (a_scale != nullptr && b_scale != nullptr) {
+      std::swap(a_scale, b_scale);
     }
   }
 
-  grouped_gemm_ = std::make_unique<hipblaslt_ext::GroupedGemm>(
-      blas_lt_handle, AsHipblasOperation(cfg_->trans_a),
-      AsHipblasOperation(cfg_->trans_b), AsHipblasDataType(cfg_->type_a),
-      AsHipblasDataType(cfg_->type_b), AsHipblasDataType(cfg_->type_c),
-      AsHipblasDataType(cfg_->type_d), AsHipblasComputeType(compute_type));
+  absl::Status status =
+      blas_lt_.executor_->RecordApiTrace(StreamExecutor::GemmCallTrace{
+          StreamExecutor::GemmCallTrace::GemmType::kBlasLt, 0, a.size(),
+          b.size()});
+  std::unique_ptr<EventBasedTimer> timer;
 
-  std::vector<int64_t> v_m(cfg_->group_count, cfg_->m),
-      v_n(cfg_->group_count, cfg_->n), v_k(cfg_->group_count, cfg_->k),
-      v_batch_count(cfg_->group_count, cfg_->batch_count),
-      v_lda(cfg_->group_count, cfg_->lhs_leading_dim_stride),
-      v_ldb(cfg_->group_count, cfg_->rhs_leading_dim_stride),
-      v_ldc(cfg_->group_count, cfg_->output_leading_dim_stride),
-      v_ldd(cfg_->group_count, cfg_->output_leading_dim_stride),
-      v_strideA(cfg_->group_count, batch_stride_a),
-      v_strideB(cfg_->group_count, batch_stride_b),
-      v_strideC(cfg_->group_count, (cfg_->m * cfg_->n)),
-      v_strideD(cfg_->group_count, (cfg_->m * cfg_->n));
+  if (profile_result != nullptr) {
+    TF_ASSIGN_OR_RETURN(timer, stream->CreateEventBasedTimer(
+                                   profile_result->warmup_run_executed()));
+  }
 
-  switch (cfg_->ragged_mode) {
+  void* workspace_addr = nullptr;
+  uint64_t workspace_size = algorithm_->workspace_size;
+  if (workspace_size > 0) {
+    if (args.scratch_allocator != nullptr) {
+      TF_ASSIGN_OR_RETURN(
+          DeviceAddress<uint8_t> alloc,
+          args.scratch_allocator->AllocateBytes(workspace_size));
+      workspace_addr = gpu::GpuMemoryMutable(&alloc);
+    } else {
+      workspace_addr = args.workspace.opaque();
+      size_t new_size = args.workspace.size();
+      TF_RET_CHECK(workspace_addr != nullptr && new_size >= workspace_size);
+      workspace_size = new_size;
+    }
+  }
+
+  auto palgo = std::any_cast<hipblasLtMatmulAlgo_t>(&algorithm_->opaque_algo);
+  {
+    absl::MutexLock lock(blas_lt_.mu_);
+    TF_RET_CHECK(blas_lt_.handle_ != nullptr);
+    // We must set the bias and aux pointers while holding the mutex, to avoid a
+    // potential race condition from multiple threads sharing the same plan.
+    if (op_desc_.has_bias_epilogue() && args.bias != nullptr) {
+      TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
+                                 HIPBLASLT_MATMUL_DESC_BIAS_POINTER,
+                                 args.bias.opaque()));
+    }
+
+#if TF_ROCM_VERSION >= 60000
+    if (a_scale != nullptr) {
+      TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
+                                 HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
+                                 a_scale.opaque()));
+    }
+    if (b_scale != nullptr) {
+      TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
+                                 HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER,
+                                 b_scale.opaque()));
+    }
+    if (args.c_scale != nullptr) {
+      TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
+                                 HIPBLASLT_MATMUL_DESC_C_SCALE_POINTER,
+                                 args.c_scale.opaque()));
+    }
+    if (args.d_scale != nullptr) {
+      TF_RETURN_IF_ERROR(SetAttr(op_desc_.get(),
+                                 HIPBLASLT_MATMUL_DESC_D_SCALE_POINTER,
+                                 args.d_scale.opaque()));
+    }
+#else
+    if (!(args.a_scale == nullptr && args.b_scale == nullptr &&
+          args.c_scale == nullptr && args.d_scale == nullptr)) {
+      return absl::InternalError("hipblaslt does not support scale");
+    }
+#endif
+
+    if (args.d_amax != nullptr) {
+      return absl::InternalError("hipblaslt does not support amax");
+    }
+
+    if (args.aux != nullptr) {
+      return absl::InternalError(
+          "hipblaslt does not support auxiliary inputs / outputs");
+    }
+
+    std::unique_ptr<ActivateContext> activation =
+        blas_lt_.executor_->Activate();
+
+    if (palgo != nullptr) {
+      SE_HIPBLAS_RETURN_IF_ERROR(hipblasLtMatmul(
+          blas_lt_.handle_.get(), op_desc_.get(), &alpha_, a.opaque(),
+          a_desc_.get(), b.opaque(), b_desc_.get(), &beta_, args.c.opaque(),
+          c_desc_.get(), args.d.opaque(), d_desc_.get(), palgo, workspace_addr,
+          workspace_size,
+          absl::bit_cast<hipStream_t>(
+              stream->platform_specific_handle().stream)));
+    } else {
+      return absl::InternalError("hipblaslt: Invalid algorithm type");
+    }
+  }
+
+  if (profile_result != nullptr) {
+    TF_ASSIGN_OR_RETURN(absl::Duration elapsed, timer->GetElapsedDuration());
+    // set algorithm ID to be unique (otherwise it gets kDefaultAlgorithm ID)
+    profile_result->set_algorithm(hipblaslt_ext::getIndexFromAlgo(*palgo));
+    profile_result->set_is_valid(true);
+    profile_result->set_elapsed_time_in_ms(absl::ToDoubleMilliseconds(elapsed));
+  }
+  return absl::OkStatus();
+}
+
+auto BlasLt::GroupedMatmulPlan::GetAlgorithms(size_t max_algorithm_count,
+                                              size_t max_workspace_size) const
+    -> absl::StatusOr<std::vector<MatmulAlgorithm>> {
+  std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResult;
+
+  absl::MutexLock lock(&blas_lt_.mu_);
+  std::unique_ptr<ActivateContext> activation = blas_lt_.executor_->Activate();
+  auto problem = grouped_gemm_->getProblemTypes()[0];
+  grouped_gemm_->setMaxWorkspaceBytes(max_workspace_size);
+
+  SE_HIPBLAS_RETURN_IF_ERROR(hipblaslt_ext::getAllAlgos(
+      blas_lt_.handle_.get(), hipblaslt_ext::GemmType::HIPBLASLT_GROUPED_GEMM,
+      problem.getOpA(), problem.getOpB(), problem.getTypeA(),
+      problem.getTypeB(), problem.getTypeC(), problem.getTypeD(),
+      problem.getTypeCompute(), heuristicResult));
+  VLOG(2) << "Total heuristics found: " << heuristicResult.size();
+  std::vector<MatmulAlgorithm> algorithms;
+  algorithms.reserve(max_algorithm_count);
+  for (hipblasLtMatmulHeuristicResult_t& result : heuristicResult) {
+    if (algorithms.size() >= max_algorithm_count) break;
+    size_t workspace_size = 0;
+    if ((result.state == HIPBLAS_STATUS_SUCCESS) &&
+        (grouped_gemm_->isAlgoSupported(result.algo, workspace_size) ==
+         HIPBLAS_STATUS_SUCCESS)) {
+      algorithms.push_back({result.algo, result.workspaceSize});
+    }
+  }
+  return algorithms;
+}
+
+absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetGroupedMatmulPlan(
+    const gpu::GroupedGemmConfig& cfg,
+    const std::vector<gpu::BlasLt::Epilogue>& epilogues) const {
+  auto compute_type = cfg.compute_type;
+  if (!compute_type) {  // obtain compute_type unless provided by the user
+    TF_ASSIGN_OR_RETURN(xla::PrimitiveType primitive_type_a,
+                        gpu::AsXlaPrimitiveType(cfg.type_a));
+    TF_ASSIGN_OR_RETURN(xla::PrimitiveType primitive_type_d,
+                        gpu::AsXlaPrimitiveType(cfg.type_d));
+    TF_ASSIGN_OR_RETURN(
+        compute_type,
+        gpu::GetBlasComputationType(
+            cfg.precision_algorithm, primitive_type_a, primitive_type_d,
+            cfg.compute_precision,
+            executor_->GetDeviceDescription().gpu_compute_capability()));
+  }
+  if (!compute_type) {
+    return absl::InternalError(
+        "This algorithm requires a non-zero compute_type!");
+  }
+
+  auto batch_stride_a = (cfg.m * cfg.k);
+  auto batch_stride_b = (cfg.n * cfg.k);
+  if (cfg.ragged_mode == gpu::RaggedDotMode::kRaggedNonContracting) {
+    if (cfg.must_swap_operands) {
+      batch_stride_a *= cfg.group_count;
+    } else {
+      batch_stride_b *= cfg.group_count;
+    }
+  }
+
+  std::vector<int64_t> v_m(cfg.group_count, cfg.m),
+      v_n(cfg.group_count, cfg.n), v_k(cfg.group_count, cfg.k),
+      v_batch_count(cfg.group_count, cfg.batch_count),
+      v_lda(cfg.group_count, cfg.lhs_leading_dim_stride),
+      v_ldb(cfg.group_count, cfg.rhs_leading_dim_stride),
+      v_ldc(cfg.group_count, cfg.output_leading_dim_stride),
+      v_ldd(cfg.group_count, cfg.output_leading_dim_stride),
+      v_strideA(cfg.group_count, batch_stride_a),
+      v_strideB(cfg.group_count, batch_stride_b),
+      v_strideC(cfg.group_count, (cfg.m * cfg.n)),
+      v_strideD(cfg.group_count, (cfg.m * cfg.n));
+
+  switch (cfg.ragged_mode) {
     case gpu::RaggedDotMode::kRaggedNonContracting: {
-      if (cfg_->must_swap_operands) {
+      if (cfg.must_swap_operands) {
         // ragged dimension in the n dimension
         std::fill(v_n.begin() + 1, v_n.end(), 1);
       } else {
@@ -795,12 +770,12 @@ void BlasLt::MatmulPlan::InitializeGroupedGemm(
   }
 
   // TODO: recover GemmEpilogues from args
-  std::vector<hipblaslt_ext::GemmEpilogue> epilogue(cfg_->group_count);
-  std::vector<hipblaslt_ext::GemmInputs> inputs(cfg_->group_count);
+  std::vector<hipblaslt_ext::GemmEpilogue> epilogue(cfg.group_count);
+  std::vector<hipblaslt_ext::GemmInputs> inputs(cfg.group_count);
 
-  float salpha = cfg_->alpha.real();
-  float sbeta = cfg_->beta;
-  for (int64_t i = 0; i < cfg_->group_count; i++) {
+  float salpha = cfg.alpha.real();
+  float sbeta = cfg.beta;
+  for (int64_t i = 0; i < cfg.group_count; i++) {
     epilogue[i].setMode(HIPBLASLT_EPILOGUE_DEFAULT);
     inputs[i].setA(reinterpret_cast<void*>(~0ULL));
     inputs[i].setB(reinterpret_cast<void*>(~0ULL));
@@ -811,57 +786,32 @@ void BlasLt::MatmulPlan::InitializeGroupedGemm(
   }
 
   hipblaslt_ext::GemmProblemType problem(
-      AsHipblasOperation(cfg_->trans_a), AsHipblasOperation(cfg_->trans_b),
-      AsHipblasDataType(cfg_->type_a), AsHipblasDataType(cfg_->type_b),
-      AsHipblasDataType(cfg_->type_c), AsHipblasDataType(cfg_->type_d),
-      AsHipblasComputeType(compute_type));
+      AsHipblasOperation(cfg.trans_a), AsHipblasOperation(cfg.trans_b),
+      AsHipblasDataType(cfg.type_a), AsHipblasDataType(cfg.type_b),
+      AsHipblasDataType(cfg.type_c), AsHipblasDataType(cfg.type_d),
+      AsHipblasComputeType(*compute_type));
+
+  absl::MutexLock lock(&mu_);
+  auto grouped_gemm = std::make_unique<hipblaslt_ext::GroupedGemm>(
+      handle_.get(), problem.getOpA(), problem.getOpB(), 
+      problem.getTypeA(), problem.getTypeB(), problem.getTypeC(), problem.getTypeD(), problem.getTypeCompute());
 
   // Note that Matrices given to HipBlasLt Group-Gemm
   // are expected to be in COLUMN-MAJOR order.
-
-  auto status = grouped_gemm_->setProblem(
+  auto status = grouped_gemm->setProblem(
       v_m, v_n, v_k, v_batch_count, v_lda, v_ldb, v_ldc, v_ldd, v_strideA,
       v_strideB, v_strideC, v_strideD, epilogue, inputs, problem);
 
   if (status != HIPBLAS_STATUS_SUCCESS) {
-    LOG(FATAL) << "Failed to set problem for grouped GEMM: " << status;
-  }
-}
-
-absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetGroupedMatmulPlan(
-    gpu::GroupedGemmConfig& cfg,
-    const std::vector<gpu::BlasLt::Epilogue>& epilogues) const {
-  auto compute_type = cfg.compute_type;
-  if (!compute_type) {  // obtain compute_type unless provided by the user
-    TF_ASSIGN_OR_RETURN(xla::PrimitiveType primitive_type_a,
-                        gpu::AsXlaPrimitiveType(cfg.type_a));
-    TF_ASSIGN_OR_RETURN(xla::PrimitiveType primitive_type_d,
-                        gpu::AsXlaPrimitiveType(cfg.type_d));
-    TF_ASSIGN_OR_RETURN(
-        compute_type,
-        gpu::GetBlasComputationType(
-            cfg.precision_algorithm, primitive_type_a, primitive_type_d,
-            cfg.compute_precision,
-            parent_->GetDeviceDescription().gpu_compute_capability()));
-  }
-  if (!compute_type) {
     return absl::InternalError(
-        "This algorithm requires a non-zero compute_type!");
+        absl::StrFormat("Failed to set problem for grouped GEMM: %d", status));
   }
 
-  hipblasLtHandle_t blas_lt_handle;
-  {
-    absl::MutexLock lock(&mu_);
-    blas_lt_handle = blas_lt_.get();
-  }
-
-  auto plan = std::make_unique<MatmulPlan>(
-      std::move(cfg), cfg.must_swap_operands, blas_lt_handle, *compute_type);
-
-  return absl::StatusOr<MatmulPlanPtr>(std::move(plan));
+  return
+      std::make_unique<GroupedMatmulPlan>(*this, std::move(cfg), std::move(grouped_gemm));
 }
 
-absl::Status BlasLt::MatmulPlan::ExecuteGroupedMatmul(
+absl::Status BlasLt::GroupedMatmulPlan::ExecuteOnStream(
     Stream* stream, const MemoryArgs& args,
     blas::ProfileResult* profile_result) const {
   if (!algorithm_.has_value()) {
@@ -870,18 +820,19 @@ absl::Status BlasLt::MatmulPlan::ExecuteGroupedMatmul(
   }
 
   auto palgo = std::any_cast<hipblasLtMatmulAlgo_t>(&algorithm_->opaque_algo);
-  auto blas_lt = static_cast<BlasLt*>(gpu::BlasLt::Get(stream));
-  absl::MutexLock lock(&blas_lt->mu_);
+  if (palgo == nullptr) {
+    return absl::InternalError("Invalid algorithm type!");
+  }
+  absl::MutexLock lock(&blas_lt_.mu_);
 
   // The first chunk of the workspace is reserved for userargs.
-  if (algorithm_must_be_initialized_ ||
-      !args.workspace.IsSameAs(saved_address_workspace_)) {
+  if (algorithm_dirty_ || !args.workspace.IsSameAs(saved_address_workspace_)) {
     void* addr_workspace = static_cast<void*>(
         static_cast<uint8_t*>(args.workspace.opaque()) +
-        sizeof(hipblaslt_ext::UserArguments) * cfg_->group_count);
+        sizeof(hipblaslt_ext::UserArguments) * cfg_.group_count);
     SE_HIPBLAS_RETURN_IF_ERROR(
         grouped_gemm_->initialize(*palgo, addr_workspace));
-    algorithm_must_be_initialized_ = false;
+    algorithm_dirty_ = false;
     saved_address_workspace_ = args.workspace;
   }
 
@@ -913,26 +864,25 @@ absl::Status BlasLt::MatmulPlan::ExecuteGroupedMatmul(
     }
   };
 
-  DeviceAddressBase a = cfg_->must_swap_operands ? args.b : args.a;
-  DeviceAddressBase b = cfg_->must_swap_operands ? args.a : args.b;
+  DeviceAddressBase a = args.a, b = args.b;
+  if (cfg_.must_swap_operands) std::swap(a, b);
   const DeviceAddressBase& d_userArgs = args.workspace;
 
-  uint8_t log2_byte_width_elem_a = Log2ByteWidth(cfg_->type_a);
-  uint8_t log2_byte_width_elem_b = Log2ByteWidth(cfg_->type_b);
-  uint8_t log2_byte_width_elem_d = Log2ByteWidth(cfg_->type_d);
+  uint8_t log2_byte_width_elem_a = Log2ByteWidth(cfg_.type_a);
+  uint8_t log2_byte_width_elem_b = Log2ByteWidth(cfg_.type_b);
+  uint8_t log2_byte_width_elem_d = Log2ByteWidth(cfg_.type_d);
 
   auto group_size_bytewidth =
-      (cfg_->ragged_mode != gpu::RaggedDotMode::kRaggedBatch)
+      (cfg_.ragged_mode != gpu::RaggedDotMode::kRaggedBatch)
           ? static_cast<size_t>(args.group_sizes.size() /
-                                (cfg_->group_count * cfg_->batch_count))
-          : static_cast<size_t>(args.group_sizes.size() / cfg_->group_count);
+                                (cfg_.group_count * cfg_.batch_count))
+          : static_cast<size_t>(args.group_sizes.size() / cfg_.group_count);
 
-  TF_RET_CHECK(blas_lt != nullptr);
   absl::Status status =
-      blas_lt->parent_->RecordApiTrace(StreamExecutor::GemmCallTrace{
+      blas_lt_.executor_->RecordApiTrace(StreamExecutor::GemmCallTrace{
           StreamExecutor::GemmCallTrace::GemmType::kBlasLt, 0,
-          cfg_->m * cfg_->k * cfg_->batch_count,
-          cfg_->k * cfg_->n * cfg_->batch_count * cfg_->group_count});
+          cfg_.m * cfg_.k * cfg_.batch_count,
+          cfg_.k * cfg_.n * cfg_.batch_count * cfg_.group_count});
   std::unique_ptr<EventBasedTimer> timer;
 
   if (profile_result != nullptr) {
@@ -940,19 +890,19 @@ absl::Status BlasLt::MatmulPlan::ExecuteGroupedMatmul(
                                    profile_result->warmup_run_executed()));
   }
 
-  uint32_t strideA1 = cfg_->lhs_leading_dim_stride;
-  uint32_t strideA2 = cfg_->m * cfg_->k;
-  uint32_t strideB1 = cfg_->rhs_leading_dim_stride;
-  uint32_t strideB2 = cfg_->n * cfg_->k;
-  if (cfg_->ragged_mode == gpu::RaggedDotMode::kRaggedNonContracting) {
-    if (cfg_->must_swap_operands) {
-      strideA2 *= cfg_->group_count;
+  uint32_t strideA1 = cfg_.lhs_leading_dim_stride;
+  uint32_t strideA2 = cfg_.m * cfg_.k;
+  uint32_t strideB1 = cfg_.rhs_leading_dim_stride;
+  uint32_t strideB2 = cfg_.n * cfg_.k;
+  if (cfg_.ragged_mode == gpu::RaggedDotMode::kRaggedNonContracting) {
+    if (cfg_.must_swap_operands) {
+      strideA2 *= cfg_.group_count;
     } else {
-      strideB2 *= cfg_->group_count;
+      strideB2 *= cfg_.group_count;
     }
   }
-  uint32_t strideD1 = cfg_->output_leading_dim_stride;
-  uint32_t strideD2 = cfg_->m * cfg_->n;
+  uint32_t strideD1 = cfg_.output_leading_dim_stride;
+  uint32_t strideD2 = cfg_.m * cfg_.n;
 
   auto hip_stream =
       absl::bit_cast<hipStream_t>(stream->platform_specific_handle().stream);
@@ -960,10 +910,10 @@ absl::Status BlasLt::MatmulPlan::ExecuteGroupedMatmul(
   GroupGemmUpdateArgs(
       hip_stream, d_userArgs, a, b, args.d, args.group_sizes,
       group_size_bytewidth, log2_byte_width_elem_a, log2_byte_width_elem_b,
-      log2_byte_width_elem_d, cfg_->stride_ragged_dim, cfg_->stride_group_dim,
-      cfg_->output_stride_ragged_dim, cfg_->must_swap_operands, cfg_->m,
-      cfg_->n, cfg_->k, cfg_->batch_count, strideA1, strideA2, strideB1,
-      strideB2, strideD1, strideD2, cfg_->ragged_mode, cfg_->group_count);
+      log2_byte_width_elem_d, cfg_.stride_ragged_dim, cfg_.stride_group_dim,
+      cfg_.output_stride_ragged_dim, cfg_.must_swap_operands, cfg_.m, cfg_.n,
+      cfg_.k, cfg_.batch_count, strideA1, strideA2, strideB1, strideB2,
+      strideD1, strideD2, cfg_.ragged_mode, cfg_.group_count);
 
   SE_HIPBLAS_RETURN_IF_ERROR(
       grouped_gemm_->run(d_userArgs.opaque(), hip_stream));
@@ -972,27 +922,13 @@ absl::Status BlasLt::MatmulPlan::ExecuteGroupedMatmul(
   if (profile_result != nullptr) {
     TF_ASSIGN_OR_RETURN(absl::Duration elapsed, timer->GetElapsedDuration());
     // set algorithm ID to be unique (otherwise it gets kDefaultAlgorithm ID)
-    hipblasLtMatmulAlgo_t algo =
-        std::any_cast<hipblasLtMatmulAlgo_t>(algorithm_->opaque_algo);
-    profile_result->set_algorithm(hipblaslt_ext::getIndexFromAlgo(algo));
+    profile_result->set_algorithm(hipblaslt_ext::getIndexFromAlgo(*palgo));
     profile_result->set_is_valid(true);
     profile_result->set_elapsed_time_in_ms(absl::ToDoubleMilliseconds(elapsed));
   }
   return absl::OkStatus();
 }
 
-absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
-    Stream* stream, const gpu::BlasLt::MemoryArgs& args,
-    blas::ProfileResult* profile_result) const {
-  if (is_grouped()) {
-    return ExecuteGroupedMatmul(stream, args, profile_result);
-  } else {
-    return ExecuteRegularMatmul(stream, args, profile_result);
-  }
-}
-
 }  // namespace rocm
 
 }  // namespace stream_executor
-
-#endif  // TF_HIPBLASLT

--- a/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/xla/stream_executor/rocm/hip_blas_lt.h
@@ -20,17 +20,14 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/synchronization/mutex.h"
+#include "rocm/include/hipblaslt/hipblaslt-ext.hpp"
 #include "rocm/rocm_config.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/gpu/gpu_blas_lt.h"
+#include "xla/stream_executor/rocm/hip_blas_utils.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/types.h"
-
-#if TF_HIPBLASLT
-
-#include "rocm/include/hipblaslt/hipblaslt-ext.hpp"
-#include "xla/stream_executor/rocm/hip_blas_utils.h"
 
 namespace hipblaslt_ext {
 class GroupedGemm;
@@ -97,92 +94,81 @@ class BlasLt : public gpu::BlasLt {
     gpu::ScaleMode scale_mode_;
   };
 
-  struct MatmulPlan : public gpu::BlasLt::MatmulPlan {
-    // Constructor for regular matmul
-    MatmulPlan(MatmulDesc&& op_desc, MatrixLayout&& a_desc,
-               MatrixLayout&& b_desc, MatrixLayout&& c_desc,
-               MatrixLayout&& d_desc, xla::complex128 alpha, double beta,
-               bool must_swap_operands)
-        : op_desc_(std::move(op_desc)),
+  struct RegularMatmulPlan : public gpu::BlasLt::MatmulPlan {
+    friend class BlasLt;
+    // We use a fixed-size array to store the alpha and beta values which can
+    // fit all supported scale types.
+    constexpr static size_t kMaxScaleBytes = 16;
+
+    RegularMatmulPlan(const BlasLt& blas_lt, MatmulDesc&& op_desc,
+                      MatrixLayout&& a_desc, MatrixLayout&& b_desc,
+                      MatrixLayout&& c_desc, MatrixLayout&& d_desc,
+                      bool must_swap_operands)
+        : blas_lt_(blas_lt),
+          op_desc_(std::move(op_desc)),
           a_desc_(std::move(a_desc)),
           b_desc_(std::move(b_desc)),
           c_desc_(std::move(c_desc)),
           d_desc_(std::move(d_desc)),
-          alpha_(alpha),
-          beta_(beta),
-          must_swap_operands_(must_swap_operands),
-          grouped_gemm_(nullptr) {}
+          must_swap_operands_(must_swap_operands) {}
 
-    // Constructor for grouped matmul
-    MatmulPlan(gpu::GroupedGemmConfig&& cfg, bool must_swap_operands,
-               hipblasLtHandle_t blas_lt_handle,
-               blas::ComputationType compute_type)
-        : must_swap_operands_(must_swap_operands),
-          cfg_(std::move(cfg)),
-          grouped_gemm_(nullptr) {
-      InitializeGroupedGemm(blas_lt_handle, compute_type);
-    }
-
-    ~MatmulPlan() override = default;
+    ~RegularMatmulPlan() override = default;
 
     absl::Status ExecuteOnStream(
         Stream* stream, const gpu::BlasLt::MemoryArgs& args,
         blas::ProfileResult* profile_result) const override;
 
     absl::StatusOr<std::vector<MatmulAlgorithm>> GetAlgorithms(
-        const Stream* stream, size_t max_algorithm_count,
-        size_t max_workspace_size) const override;
+        size_t max_algorithm_count, size_t max_workspace_size) const override;
 
     absl::Status SetAlgorithm(const MatmulAlgorithm& algorithm) override {
       algorithm_ = algorithm;
-      algorithm_must_be_initialized_ = true;
       return absl::OkStatus();
     }
 
-    bool is_grouped() const { return grouped_gemm_ != nullptr; }
+   private:
+    const BlasLt& blas_lt_;
+    MatmulDesc op_desc_;
+    MatrixLayout a_desc_;
+    MatrixLayout b_desc_;
+    MatrixLayout c_desc_;
+    MatrixLayout d_desc_;
+    std::array<uint8_t, kMaxScaleBytes> alpha_, beta_;
+    bool must_swap_operands_;
+    mutable std::optional<MatmulAlgorithm> algorithm_;  // selected algorithm
+  };  // class RegularMatmulPlan
 
-   protected:
-    absl::Status DoMatmul(Stream* stream, const void* alpha, const void* beta,
-                          const gpu::BlasLt::MemoryArgs& args,
-                          blas::ProfileResult* profile_result) const;
+  struct GroupedMatmulPlan : public gpu::BlasLt::MatmulPlan {
+    GroupedMatmulPlan(const BlasLt& blas_lt, gpu::GroupedGemmConfig cfg,
+      std::unique_ptr<hipblaslt_ext::GroupedGemm> grouped_gemm)
+        : blas_lt_(blas_lt), cfg_(std::move(cfg)), grouped_gemm_(std::move(grouped_gemm)) {}
+
+    ~GroupedMatmulPlan() override = default;
+
+    absl::Status ExecuteOnStream(
+        Stream* stream, const gpu::BlasLt::MemoryArgs& args,
+        blas::ProfileResult* profile_result) const override;
+
+    absl::StatusOr<std::vector<MatmulAlgorithm>> GetAlgorithms(
+        size_t max_algorithm_count, size_t max_workspace_size) const override;
+
+    absl::Status SetAlgorithm(const MatmulAlgorithm& algorithm) override {
+      algorithm_ = algorithm;
+      algorithm_dirty_ = true;
+      return absl::OkStatus();
+    }
 
    private:
-    absl::StatusOr<std::vector<MatmulAlgorithm>> GetAlgorithmsForGroupedMatmul(
-        const Stream* stream, size_t max_algorithm_count,
-        size_t max_workspace_size) const;
-    absl::StatusOr<std::vector<MatmulAlgorithm>> GetAlgorithmsForMatmul(
-        const Stream* stream, size_t max_algorithm_count,
-        size_t max_workspace_size) const;
-    absl::Status ExecuteRegularMatmul(
-        Stream* stream, const gpu::BlasLt::MemoryArgs& args,
-        blas::ProfileResult* profile_result) const;
-    absl::Status ExecuteGroupedMatmul(
-        Stream* stream, const gpu::BlasLt::MemoryArgs& args,
-        blas::ProfileResult* profile_result) const;
-
-    void InitializeGroupedGemm(hipblasLtHandle_t blas_lt_handle,
-                               blas::ComputationType compute_type);
-
-    // TODO(cjfj): Add consistency checks for types, shapes, etc.?
-    // Regular matmul members (optional for grouped matmul)
-    std::optional<MatmulDesc> op_desc_;
-    std::optional<MatrixLayout> a_desc_;
-    std::optional<MatrixLayout> b_desc_;
-    std::optional<MatrixLayout> c_desc_;
-    std::optional<MatrixLayout> d_desc_;
-    std::optional<xla::complex128> alpha_;
-    std::optional<double> beta_;
-    bool must_swap_operands_;
-    std::optional<MatmulAlgorithm> algorithm_;  // selected algorithm
-    // Grouped matmul members
-    std::optional<gpu::GroupedGemmConfig> cfg_;
+    const BlasLt& blas_lt_;
+    gpu::GroupedGemmConfig cfg_;
     std::unique_ptr<hipblaslt_ext::GroupedGemm> grouped_gemm_;
-    mutable bool algorithm_must_be_initialized_ = false;
+    mutable std::optional<MatmulAlgorithm> algorithm_;  // selected algorithm
+    mutable bool algorithm_dirty_ = false;
     mutable DeviceAddressBase saved_address_workspace_{};
-  };  // class MatmulPlan
+  };  // class GroupedMatmulPlan
 
-  explicit BlasLt(StreamExecutor* parent)
-      : parent_(parent), blas_lt_(nullptr, hipblasLtDestroy) {}
+  explicit BlasLt(StreamExecutor* executor)
+      : executor_(executor), handle_(nullptr, hipblasLtDestroy) {}
 
   absl::Status Init() override;
 
@@ -190,19 +176,18 @@ class BlasLt : public gpu::BlasLt {
                                               Epilogue epilogue) const override;
 
   absl::StatusOr<MatmulPlanPtr> GetGroupedMatmulPlan(
-      gpu::GroupedGemmConfig& config,
+      const gpu::GroupedGemmConfig& config,
       const std::vector<Epilogue>& epilogues) const override;
 
   ~BlasLt() override = default;
 
  private:
-  StreamExecutor* parent_;
+  StreamExecutor* executor_;
   mutable absl::Mutex mu_;
-  Owned<hipblasLtHandle_t> blas_lt_ ABSL_GUARDED_BY(mu_);
+  Owned<hipblasLtHandle_t> handle_ ABSL_GUARDED_BY(mu_);
 };
 
 }  // namespace rocm
 }  // namespace stream_executor
 
-#endif  // TF_HIPBLASLT
 #endif  // XLA_STREAM_EXECUTOR_ROCM_HIP_BLAS_LT_H_

--- a/xla/stream_executor/rocm/hip_blas_utils.cc
+++ b/xla/stream_executor/rocm/hip_blas_utils.cc
@@ -20,8 +20,6 @@ limitations under the License.
 #include "rocm/rocm_config.h"
 #include "xla/stream_executor/blas.h"
 
-#if TF_HIPBLASLT
-
 namespace stream_executor {
 namespace rocm {
 
@@ -118,5 +116,3 @@ hipblasOperation_t AsHipblasOperation(blas::Transpose trans) {
 
 }  // namespace rocm
 }  // namespace stream_executor
-
-#endif  // #TF_HIPBLASLT

--- a/xla/stream_executor/rocm/hip_blas_utils.h
+++ b/xla/stream_executor/rocm/hip_blas_utils.h
@@ -23,8 +23,8 @@ limitations under the License.
 #include "rocm/include/hipblaslt/hipblaslt.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/tsl/platform/errors.h"
+#include "rocm/rocm_config.h"
 
-#if TF_HIPBLASLT
 
 #if TF_ROCM_VERSION < 60000
 #define hipDataType hipblasDatatype_t
@@ -56,7 +56,5 @@ hipblasOperation_t AsHipblasOperation(blas::Transpose trans);
 
 }  // namespace rocm
 }  // namespace stream_executor
-
-#endif  // TF_HIPBLASLT
 
 #endif  // XLA_STREAM_EXECUTOR_ROCM_HIP_BLAS_UTILS_H_

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -183,12 +183,10 @@ bool ROCMBlas::Init() {
     return false;
   }
 
-#if TF_HIPBLASLT
   if (!blas_lt_.Init().ok()) {
     LOG(ERROR) << "Failed to initialize hipblasLt";
     return false;
   }
-#endif
 
   int dev = 0;
   hipError_t result = hipGetDevice(&dev);
@@ -205,13 +203,8 @@ bool ROCMBlas::Init() {
 
 ROCMBlas::ROCMBlas(StreamExecutor *parent)
     : parent_(CHECK_NOTNULL(parent)),
-      blas_(nullptr)
-#if TF_HIPBLASLT
-      ,
-      blas_lt_(parent)
-#endif
-{
-}
+      blas_(nullptr), blas_lt_(parent)
+{}
 
 ROCMBlas::~ROCMBlas() {
   if (blas_ != nullptr) {

--- a/xla/stream_executor/rocm/rocm_blas.h
+++ b/xla/stream_executor/rocm/rocm_blas.h
@@ -30,9 +30,7 @@ limitations under the License.
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/gpu/gpu_blas_lt.h"
 #include "xla/stream_executor/plugin_registry.h"
-#if TF_HIPBLASLT
 #include "xla/stream_executor/rocm/hip_blas_lt.h"
-#endif
 #include "xla/stream_executor/stream_executor.h"
 
 namespace stream_executor {
@@ -93,11 +91,7 @@ class ROCMBlas : public blas::BlasSupport {
   TENSORFLOW_STREAM_EXECUTOR_GPU_BLAS_SUPPORT_OVERRIDES
 
   gpu::BlasLt *GetBlasLt() override {
-#if TF_HIPBLASLT
     return &blas_lt_;
-#else
-    return nullptr;
-#endif
   }
 
  private:
@@ -194,9 +188,7 @@ class ROCMBlas : public blas::BlasSupport {
                       blas::CallContext context, uint64_t size1,
                       uint64_t size2);
 
-#if TF_HIPBLASLT
   rocm::BlasLt blas_lt_;
-#endif
 
   ROCMBlas(const ROCMBlas &) = delete;
   void operator=(const ROCMBlas &) = delete;

--- a/xla/stream_executor/sycl/sycl_blas_lt.cc
+++ b/xla/stream_executor/sycl/sycl_blas_lt.cc
@@ -32,7 +32,7 @@ auto BlasLt::GetMatmulPlan(const gpu::GemmConfig& config,
 }
 
 absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetGroupedMatmulPlan(
-    gpu::GroupedGemmConfig& config,
+    const gpu::GroupedGemmConfig& config,
     const std::vector<gpu::BlasLt::Epilogue>& epilogues) const {
   return absl::UnimplementedError(
       "Grouped GEMM is not supported for Sycl BlasLt");

--- a/xla/stream_executor/sycl/sycl_blas_lt.h
+++ b/xla/stream_executor/sycl/sycl_blas_lt.h
@@ -36,7 +36,7 @@ class BlasLt : public gpu::BlasLt {
       const gpu::GemmConfig& config, Epilogue epilogue) const override;
 
   absl::StatusOr<MatmulPlanPtr> GetGroupedMatmulPlan(
-      gpu::GroupedGemmConfig& config,
+      const gpu::GroupedGemmConfig& config,
       const std::vector<Epilogue>& epilogues) const override;
 
   ~BlasLt() override = default;
@@ -52,7 +52,7 @@ class BlasLt : public gpu::BlasLt {
         blas::ProfileResult* profile_result) const override;
 
     absl::StatusOr<std::vector<MatmulAlgorithm>> GetAlgorithms(
-        const Stream* stream, size_t max_algorithm_count,
+        size_t max_algorithm_count,
         size_t max_workspace_size) const override;
 
     absl::Status SetAlgorithm(const MatmulAlgorithm& algorithm) override {


### PR DESCRIPTION
## Summary

- **Simplified `BlasLt::MatmulPlan` interface** by removing multiple overloaded `ExecuteOnStream` convenience wrappers that manually unpacked arguments into `MemoryArgs`. All callers now use the `MemoryArgs`-based API directly, eliminating ~100 lines of boilerplate forwarding code in `gpu_blas_lt.h`. Note that, one forwarding function is kept for compatibility with **Tensorflow**.

- **Unified regular and grouped matmul plan caching** in `CublasLtMatmulThunk`. Removed the separate `GetCachedGroupedMatmulPlan` method and merged it into `GetCachedMatmulPlan` using `std::visit` over the `GemmConfig`/`GroupedGemmConfig` variant. Also removed the separate `grouped_plan_cache_` and `GetOrCreateGroupedMatmulPlan`; both plan types now share a single plan cache.

- **Moved alpha/beta scale computation from `ExecuteOnStream` into plan creation** for both CUDA and ROCm backends. The `MatmulPlan` now stores pre-computed alpha/beta as fixed-size byte arrays (`kMaxScaleBytes`), determined at plan creation time based on operand types. Indeed, this is enough to run a long chain of **TYPED_MATMUL** macros only once during initialization. This also removes the `DoMatmul` indirection and eliminates the need to look up the `BlasLt` instance from the stream at execution time (plans now hold a `const BlasLt&` reference).

- **Split ROCm's monolithic `MatmulPlan` into `RegularMatmulPlan` and `GroupedMatmulPlan`**. The old single class used `std::optional` fields to represent both plan types, making the code harder to follow. The split gives each plan type its own clean set of members and `ExecuteOnStream`/`GetAlgorithms` implementations.

- **Changed `BlasLt::Get()` to take `StreamExecutor*` instead of `const Stream*`** and made it return `absl::StatusOr<BlasLt*>` for proper error propagation. Updated all callers (autotuners, matmul thunk) accordingly -- this also removes unnecessary stream creation in the autotuner paths that only needed the BlasLt handle.

- **Removed `GetAlgorithms`' dependency on `Stream*`**. The stream parameter was unnecessary for algorithm enumeration; plans now use their stored `BlasLt` reference to access the handle directly.

- **Made `TF_HIPBLASLT` always enabled** by hardcoding the flag to `1` and removing the configure-time `rocm_hipblaslt` toggle from `build_defs.bzl.tpl`, `rocm_configure.bzl`, and `rocm_config.h.tpl`. The `#if TF_HIPBLASLT` guard around `hip_blas_lt.h` is also removed since hipBlasLt is now always available.

- **Minor cleanups**: removed the `CublasLtMatmulThunk` copy constructor, inlined `ExecuteOnStreamInternal` into `ExecuteOnStream`, renamed `parent_` to `executor_` and `blas_lt_` to `handle_` for clarity, and accepted `GroupedGemmConfig` by const-ref.

- **GroupedMatmul**: replaced LOG(FATAL) during matmul object creation with a proper error forwarding with `StatusOr<>` 