### PR TITLE
[XLA:GPU][codegen] Use driver intrinsics for natural log/exp and (A)Trig(H) math lowerings in SPIRV backend

### DIFF
--- a/xla/backends/gpu/codegen/emitters/transforms/tests/lower_math_oneapi.mlir
+++ b/xla/backends/gpu/codegen/emitters/transforms/tests/lower_math_oneapi.mlir
@@ -5,10 +5,11 @@
 module {
   // CHECK-LABEL: func @test_log1p
   func.func @test_log1p(%arg0: f32) -> f32 {
-    // CHECK: %[[ONE:.*]] = llvm.mlir.constant(1.000000e+00 : f32) : f32
-    // CHECK: %[[ADD:.*]] = llvm.fadd %[[ONE]], %arg0 : f32
-    // CHECK: %[[LOG:.*]] = llvm.intr.log(%[[ADD]]) : (f32) -> f32
-    // CHECK: return %[[LOG]] : f32
+    // CHECK-NOT: llvm.mlir.constant(1.000000e+00 : f32) : f32
+    // CHECK-NOT: llvm.fadd %{{.*}}, %arg0 : f32
+    // CHECK-NOT: llvm.intr.log
+    // CHECK: llvm.call @_Z{{.*}}__spirv_ocl_log1pf(%arg0)
+    // CHECK: return %{{.*}} : f32
     %0 = math.log1p %arg0 : f32
     return %0 : f32
   }
@@ -23,15 +24,19 @@ module {
   }
 }
 
+// CHECK-DAG: @_Z{{.*}}__spirv_ocl_expm1f
+// CHECK-DAG: @_Z{{.*}}__spirv_ocl_sinf
+// CHECK-DAG: @_Z{{.*}}__spirv_ocl_cosf
 // CHECK-LABEL: @test_tan
 // CHECK-SAME: %[[ARG0:.*]]: !llvm.struct<(f32, f32)>
 // CHECK: %[[V0:.*]] = llvm.extractvalue %[[ARG0]][0]
 // CHECK: %[[V1:.*]] = llvm.extractvalue %[[ARG0]][1]
-// CHECK: %[[E0:.*]] = llvm.intr.exp
-// CHECK: %[[EM0:.*]] = llvm.fsub %[[E0]], %{{.*}}
-// CHECK: %[[E1:.*]] = llvm.intr.exp
-// CHECK: %[[EM1:.*]] = llvm.fsub %[[E1]], %{{.*}}
-// CHECK: llvm.fsub %[[EM0]], %[[EM1]] : f32
-// CHECK-DAG: llvm.intr.cos(%[[V0]])
-// CHECK-DAG: llvm.intr.sin(%[[V0]])
+// CHECK-NOT: llvm.intr.exp
+// CHECK-NOT: llvm.intr.cos
+// CHECK-NOT: llvm.intr.sin
+// CHECK: %[[E0:.*]] = llvm.call @_Z{{.*}}__spirv_ocl_expm1f
+// CHECK: %[[E1:.*]] = llvm.call @_Z{{.*}}__spirv_ocl_expm1f
+// CHECK: llvm.fsub %[[E0]], %[[E1]] : f32
+// CHECK-DAG: llvm.call @_Z{{.*}}__spirv_ocl_cosf(%[[V0]])
+// CHECK-DAG: llvm.call @_Z{{.*}}__spirv_ocl_sinf(%[[V0]])
 // CHECK: llvm.return %{{.*}} : !llvm.struct<(f32, f32)>

--- a/xla/backends/gpu/codegen/emitters/transforms/tests/lower_math_oneapi.mlir
+++ b/xla/backends/gpu/codegen/emitters/transforms/tests/lower_math_oneapi.mlir
@@ -8,7 +8,7 @@ module {
     // CHECK-NOT: llvm.mlir.constant(1.000000e+00 : f32) : f32
     // CHECK-NOT: llvm.fadd %{{.*}}, %arg0 : f32
     // CHECK-NOT: llvm.intr.log
-    // CHECK: llvm.call @_Z{{.*}}__spirv_ocl_log1pf(%arg0)
+    // CHECK: llvm.call spir_funccc @_Z{{.*}}__spirv_ocl_log1pf(%arg0)
     // CHECK: return %{{.*}} : f32
     %0 = math.log1p %arg0 : f32
     return %0 : f32
@@ -24,9 +24,9 @@ module {
   }
 }
 
-// CHECK-DAG: @_Z{{.*}}__spirv_ocl_expm1f
-// CHECK-DAG: @_Z{{.*}}__spirv_ocl_sinf
-// CHECK-DAG: @_Z{{.*}}__spirv_ocl_cosf
+// CHECK-DAG: spir_funccc @_Z{{.*}}__spirv_ocl_expm1f
+// CHECK-DAG: spir_funccc @_Z{{.*}}__spirv_ocl_sinf
+// CHECK-DAG: spir_funccc @_Z{{.*}}__spirv_ocl_cosf
 // CHECK-LABEL: @test_tan
 // CHECK-SAME: %[[ARG0:.*]]: !llvm.struct<(f32, f32)>
 // CHECK: %[[V0:.*]] = llvm.extractvalue %[[ARG0]][0]
@@ -34,9 +34,9 @@ module {
 // CHECK-NOT: llvm.intr.exp
 // CHECK-NOT: llvm.intr.cos
 // CHECK-NOT: llvm.intr.sin
-// CHECK: %[[E0:.*]] = llvm.call @_Z{{.*}}__spirv_ocl_expm1f
-// CHECK: %[[E1:.*]] = llvm.call @_Z{{.*}}__spirv_ocl_expm1f
+// CHECK: %[[E0:.*]] = llvm.call spir_funccc @_Z{{.*}}__spirv_ocl_expm1f
+// CHECK: %[[E1:.*]] = llvm.call spir_funccc @_Z{{.*}}__spirv_ocl_expm1f
 // CHECK: llvm.fsub %[[E0]], %[[E1]] : f32
-// CHECK-DAG: llvm.call @_Z{{.*}}__spirv_ocl_cosf(%[[V0]])
-// CHECK-DAG: llvm.call @_Z{{.*}}__spirv_ocl_sinf(%[[V0]])
+// CHECK-DAG: llvm.call spir_funccc @_Z{{.*}}__spirv_ocl_cosf(%[[V0]])
+// CHECK-DAG: llvm.call spir_funccc @_Z{{.*}}__spirv_ocl_sinf(%[[V0]])
 // CHECK: llvm.return %{{.*}} : !llvm.struct<(f32, f32)>

--- a/xla/codegen/emitters/transforms/BUILD
+++ b/xla/codegen/emitters/transforms/BUILD
@@ -35,8 +35,12 @@ cc_library(
     hdrs = ["lowering_utils.h"],
     deps = [
         "//xla/tsl/platform:logging",
+        "@com_google_absl//absl/strings:str_format",
+        "@llvm-project//mlir:GPUCommonTransforms",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LLVMCommonConversion",
         "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:MathDialect",
     ],
 )
 

--- a/xla/codegen/emitters/transforms/BUILD
+++ b/xla/codegen/emitters/transforms/BUILD
@@ -36,7 +36,6 @@ cc_library(
     deps = [
         "//xla/tsl/platform:logging",
         "@com_google_absl//absl/strings:str_format",
-        "@llvm-project//mlir:GPUCommonTransforms",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LLVMCommonConversion",
         "@llvm-project//mlir:LLVMDialect",

--- a/xla/codegen/emitters/transforms/lower_to_llvm_common.cc
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_common.cc
@@ -47,8 +47,7 @@ mlir::LogicalResult LowerToLLVM(
     absl::FunctionRef<mlir::LogicalResult(mlir::LLVMTypeConverter&,
                                           mlir::RewritePatternSet&,
                                           mlir::ConversionTarget&)>
-        populate_platform_patterns,
-    bool lower_math_log1p) {
+        populate_platform_patterns) {
   // Populate type conversions.
   mlir::LowerToLLVMOptions llvm_opts(op.getContext(), mlir::DataLayout(op));
   mlir::LLVMTypeConverter type_converter(op.getContext(), llvm_opts);
@@ -83,7 +82,7 @@ mlir::LogicalResult LowerToLLVM(
   // Clean up any leftover math ops.
   mlir::RewritePatternSet mathPatterns(op.getContext());
   mlir::populateMathToLLVMConversionPatterns(type_converter, mathPatterns,
-                                             lower_math_log1p);
+                                             /*approximateLog1p=*/false);
   target.addIllegalDialect<mlir::math::MathDialect>();
 
   if (mlir::failed(applyFullConversion(op, target, std::move(mathPatterns)))) {

--- a/xla/codegen/emitters/transforms/lower_to_llvm_common.h
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_common.h
@@ -32,8 +32,7 @@ mlir::LogicalResult LowerToLLVM(
                                           mlir::ConversionTarget&)>
         populate_platform_patterns =
             [](mlir::LLVMTypeConverter&, mlir::RewritePatternSet&,
-               mlir::ConversionTarget&) { return mlir::success(); },
-    bool lower_math_log1p = false);
+               mlir::ConversionTarget&) { return mlir::success(); });
 
 }  // namespace emitters
 }  // namespace xla

--- a/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
@@ -38,8 +38,8 @@ limitations under the License.
 #include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"  // IWYU pragma: keep
-#include "mlir/Dialect/LLVMIR/NVVMDialect.h"  // IWYU pragma: keep
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"   // IWYU pragma: keep
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"   // IWYU pragma: keep
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"  // IWYU pragma: keep
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Diagnostics.h"
@@ -117,6 +117,8 @@ class LowerToLLVMGPUPass
           });
         }
         populateGpuToLLVMSPVConversionPatterns(converter, patterns);
+        spirv::populateMathToLLVMSPVConversionPatterns(spirv::getSPIRVMathOps(),
+                                                       converter, patterns);
         populateGpuMemorySpaceAttributeConversions(converter);
       } else {
         mlir::populateGpuToNVVMConversionPatterns(converter, patterns);
@@ -125,12 +127,7 @@ class LowerToLLVMGPUPass
       return mlir::success();
     };
 
-    // NVVM and ROCDL lower math.log1p directly via their GPU pattern sets, but
-    // the SPIR-V pipeline does not. For Intel GPUs we therefore fall back to
-    // the generic MathToLLVM conversion, hence enabling approximate log1p.
-    bool lower_math_log1p = device_spec_.IsIntelGpu();
-    if (mlir::failed(
-            LowerToLLVM(getOperation(), populate_patterns, lower_math_log1p))) {
+    if (mlir::failed(LowerToLLVM(getOperation(), populate_patterns))) {
       signalPassFailure();
       return;
     }

--- a/xla/codegen/emitters/transforms/lowering_utils.h
+++ b/xla/codegen/emitters/transforms/lowering_utils.h
@@ -16,7 +16,12 @@ limitations under the License.
 #ifndef XLA_CODEGEN_EMITTERS_TRANSFORMS_LOWERING_UTILS_H_
 #define XLA_CODEGEN_EMITTERS_TRANSFORMS_LOWERING_UTILS_H_
 
+#include "absl/strings/str_format.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/lib/Conversion/GPUCommon/GPUOpsLowering.h"
+#include "mlir/lib/Conversion/GPUCommon/OpToFuncCallLowering.h"
 
 namespace xla {
 namespace emitters {
@@ -25,6 +30,43 @@ namespace emitters {
 // AMDGPU requires allocas in AS5, but MLIR lowering creates them in AS0.
 void EnsureAMDGPUAllocasUseAS5(mlir::Operation* operation);
 
+namespace spirv {
+namespace mm = ::mlir::math;
+template <typename... Ops>
+struct SPIRVMathOps {};
+
+inline auto getSPIRVMathOps() {
+  return SPIRVMathOps<
+      mm::AcosOp, mm::AcoshOp, mm::AsinOp, mm::AsinhOp, mm::Atan2Op, mm::AtanOp,
+      mm::AtanhOp, mm::CosOp, mm::CoshOp, mm::ExpM1Op, mm::ExpOp, mm::Log1pOp,
+      mm::LogOp, mm::SinOp, mm::SinhOp, mm::TanOp, mm::TanhOp>{};
+}
+
+// Lowers math ops to SPIR-V OCL driver intrinsics to preserve accuracy,
+// particularly for small-magnitude inputs where generic MLIR lowering may
+// lose precision.
+template <typename Op>
+inline void populateLLVMSPVMathOpPatterns(mlir::LLVMTypeConverter& converter,
+                                          mlir::RewritePatternSet& patterns) {
+  auto op_name =
+      mlir::OperationName(Op::getOperationName(), &converter.getContext())
+          .stripDialect();
+  auto base =
+      absl::StrFormat("_Z%u__spirv_ocl_%s", op_name.size() + 12, op_name.str());
+
+  patterns.add<mlir::ScalarizeVectorOpLowering<Op>>(converter, 1);
+  patterns.add<mlir::OpToFuncCallLowering<Op>>(converter, base + "f",
+                                               base + "d", "", "", "", 1);
+}
+
+template <typename... Ops>
+void populateMathToLLVMSPVConversionPatterns(
+    spirv::SPIRVMathOps<Ops...>, mlir::LLVMTypeConverter& converter,
+    mlir::RewritePatternSet& patterns) {
+  (spirv::populateLLVMSPVMathOpPatterns<Ops>(converter, patterns), ...);
+}
+
+}  // namespace spirv
 }  // namespace emitters
 }  // namespace xla
 

--- a/xla/codegen/emitters/transforms/lowering_utils.h
+++ b/xla/codegen/emitters/transforms/lowering_utils.h
@@ -17,11 +17,11 @@ limitations under the License.
 #define XLA_CODEGEN_EMITTERS_TRANSFORMS_LOWERING_UTILS_H_
 
 #include "absl/strings/str_format.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/IR/Operation.h"
-#include "mlir/lib/Conversion/GPUCommon/GPUOpsLowering.h"
-#include "mlir/lib/Conversion/GPUCommon/OpToFuncCallLowering.h"
 
 namespace xla {
 namespace emitters {
@@ -32,6 +32,7 @@ void EnsureAMDGPUAllocasUseAS5(mlir::Operation* operation);
 
 namespace spirv {
 namespace mm = ::mlir::math;
+namespace ml = ::mlir::LLVM;
 template <typename... Ops>
 struct SPIRVMathOps {};
 
@@ -42,9 +43,58 @@ inline auto getSPIRVMathOps() {
       mm::LogOp, mm::SinOp, mm::SinhOp, mm::TanOp, mm::TanhOp>{};
 }
 
-// Lowers math ops to SPIR-V OCL driver intrinsics to preserve accuracy,
-// particularly for small-magnitude inputs where generic MLIR lowering may
-// lose precision.
+template <typename Op>
+struct OpToSPVFuncCallLowering : public mlir::ConvertOpToLLVMPattern<Op> {
+ public:
+  explicit OpToSPVFuncCallLowering(const mlir::LLVMTypeConverter& converter,
+                                   mlir::StringRef base)
+      : mlir::ConvertOpToLLVMPattern<Op>(converter, 1), base(base) {}
+
+  mlir::LogicalResult matchAndRewrite(
+      Op op, typename Op::Adaptor adaptor,
+      mlir::ConversionPatternRewriter& rewriter) const override {
+    mlir::Type result_type = op->getResultTypes().front();
+    mlir::SmallVector<mlir::Type> arg_types(adaptor.getOperands().getTypes());
+
+    bool can_lower =
+        mlir::isa<mlir::Float32Type, mlir::Float64Type>(result_type);
+    for (mlir::Type type : arg_types) {
+      can_lower = can_lower && (type == result_type);
+    }
+
+    if (!can_lower) {
+      return rewriter.notifyMatchFailure(
+          op, " expected F32 or F64 result and operand types");
+    }
+
+    std::string name =
+        base + (mlir::isa<mlir::Float32Type>(result_type) ? "f" : "d");
+
+    auto symbol_table =
+        op->template getParentWithTrait<mlir::OpTrait::SymbolTable>();
+    auto func = mlir::dyn_cast_or_null<ml::LLVMFuncOp>(
+        mlir::SymbolTable::lookupSymbolIn(symbol_table, name));
+    if (!func) {
+      mlir::OpBuilder b(symbol_table->getRegion(0));
+      func = ml::LLVMFuncOp::create(
+          b, symbol_table->getLoc(), name,
+          ml::LLVMFunctionType::get(result_type, arg_types));
+      func.setCConv(ml::cconv::CConv::SPIR_FUNC);
+    }
+    auto call =
+        ml::CallOp::create(rewriter, op->getLoc(), func, adaptor.getOperands());
+    call.setCConv(func.getCConv());
+
+    rewriter.replaceOp(op, {call.getResult()});
+    return mlir::success();
+  }
+
+  const std::string base;
+};
+
+// Lowers single/double precision math ops to SPIR-V OCL driver intrinsics to
+// preserve accuracy, particularly for small-magnitude inputs where generic MLIR
+// lowering may lose precision.
 template <typename Op>
 inline void populateLLVMSPVMathOpPatterns(mlir::LLVMTypeConverter& converter,
                                           mlir::RewritePatternSet& patterns) {
@@ -53,10 +103,7 @@ inline void populateLLVMSPVMathOpPatterns(mlir::LLVMTypeConverter& converter,
           .stripDialect();
   auto base =
       absl::StrFormat("_Z%u__spirv_ocl_%s", op_name.size() + 12, op_name.str());
-
-  patterns.add<mlir::ScalarizeVectorOpLowering<Op>>(converter, 1);
-  patterns.add<mlir::OpToFuncCallLowering<Op>>(converter, base + "f",
-                                               base + "d", "", "", "", 1);
+  patterns.add<OpToSPVFuncCallLowering<Op>>(converter, base);
 }
 
 template <typename... Ops>


### PR DESCRIPTION
This PR uses driver intrinsics to lower natural log/exp, regular, hyperbolic and inverse trigonometric functions for single and double precision types in SPIR-V backend.
