### PR TITLE
[ROCM][NFC] cleanup: pass amdgpu targets directly to crosstool, remove hipblaslt macros

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -23,6 +23,7 @@ import sys
 import shlex
 
 # Template values set by rocm_configure.bzl or environment
+AMDGPU_TARGETS = ('%{rocm_amdgpu_targets}')
 CPU_COMPILER = os.environ.get('HOST_COMPILER', '/usr/bin/clang')
 
 HIPCC_PATH = '%{rocm_root}/bin/hipcc'
@@ -106,15 +107,14 @@ def GetHipccOptions(argv):
   """
 
   parser = ArgumentParser()
-  parser.add_argument('--offload-arch', nargs='*', action='append')
   # TODO find a better place for this
   parser.add_argument('-gline-tables-only', action='store_true')
 
   args, _ = parser.parse_known_args(argv)
 
   hipcc_opts = ' -gline-tables-only ' if args.gline_tables_only else ''
-  if args.offload_arch:
-    hipcc_opts = hipcc_opts + ' '.join(['--offload-arch=' + a for a in sum(args.offload_arch, [])])
+  for target in AMDGPU_TARGETS.split(','):
+    hipcc_opts += ' --offload-arch=' + target.strip()
 
   return hipcc_opts
 

--- a/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -16,7 +16,7 @@ def if_rocm(if_true, if_false = []):
 
 def rocm_default_copts():
     """Default options for all ROCm compilations."""
-    return if_rocm(["-x", "rocm"] + %{rocm_extra_copts})
+    return if_rocm(["-x", "rocm"])
 
 def rocm_copts(opts = []):
     """Gets the appropriate set of copts for (maybe) ROCm compilation.
@@ -68,13 +68,11 @@ def is_rocm_configured():
     """
     return %{rocm_is_configured}
 
-def rocm_hipblaslt():
-    return %{rocm_is_configured} and %{rocm_hipblaslt}
-
 def if_rocm_hipblaslt(x):
-    if %{rocm_is_configured} and (%{rocm_hipblaslt} == "True"):
-        return select({"//conditions:default": x})
-    return select({"//conditions:default": []})
+    """ 
+    hipBlasLt is always available: kept for compatibility with Tensorflow.
+    """
+    return select({"//conditions:default": x})
 
 def rocm_library(copts = [], deps = [], **kwargs):
     """Wrapper over cc_library which adds default ROCm options."""

--- a/third_party/gpus/rocm/rocm_config.h.tpl
+++ b/third_party/gpus/rocm/rocm_config.h.tpl
@@ -21,6 +21,7 @@ limitations under the License.
 #define TF_ROCM_VERSION %{rocm_version_number}
 #define TF_MIOPEN_VERSION %{miopen_version_number}
 #define TF_HIPRUNTIME_VERSION %{hipruntime_version_number}
-#define TF_HIPBLASLT %{hipblaslt_flag}
+// NOTE: HipBlasLt is now always available, this flag is deprecated !
+#define TF_HIPBLASLT 1
 
 #endif  // ROCM_ROCM_CONFIG_H_

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -392,11 +392,6 @@ def _create_dummy_repository(repository_ctx):
     )
     repository_ctx.file("crosstool/BUILD", _DUMMY_CROSSTOOL_BUILD_FILE)
 
-def _compute_rocm_extra_copts(amdgpu_targets):
-    amdgpu_target_flags = ["--offload-arch=" +
-                           amdgpu_target for amdgpu_target in amdgpu_targets]
-    return str(amdgpu_target_flags)
-
 def _remove_root_dir(path, root_dir):
     if path.startswith(root_dir + "/"):
         return path[len(root_dir) + 1:]
@@ -564,9 +559,6 @@ def _create_remote_rocm_repository(repository_ctx, remote_config_repo):
             "%{rocm_is_configured}": "True",
             "%{gpu_is_configured}": "if_true",
             "%{cuda_or_rocm}": "if_true",
-            "%{rocm_extra_copts}": _compute_rocm_extra_copts(
-                [],
-            ),
         },
     )
     repository_ctx.template(

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -343,10 +343,8 @@ def _create_dummy_repository(repository_ctx):
             "%{rocm_is_configured}": "False",
             "%{gpu_is_configured}": "if_true" if enable_cuda(repository_ctx) or enable_sycl(repository_ctx) else "if_false",
             "%{cuda_or_rocm}": "if_true" if enable_cuda(repository_ctx) else "if_false",
-            "%{rocm_extra_copts}": "[]",
             "%{rocm_gpu_architectures}": "[]",
             "%{rocm_version_number}": "0",
-            "%{rocm_hipblaslt}": "False",
             "%{single_gpu_rbe_pool}": repository_ctx.os.environ.get(_TF_ROCM_RBE_SINGLE_GPU_POOL, _DEFAULT_TF_ROCM_RBE_SINGLE_GPU_POOL),
             "%{multi_gpu_rbe_pool}": repository_ctx.os.environ.get(_TF_ROCM_RBE_MULTI_GPU_POOL, _DEFAULT_TF_ROCM_RBE_MULTI_GPU_POOL),
         },
@@ -381,7 +379,6 @@ def _create_dummy_repository(repository_ctx):
         "rocm:rocm_config.h",
         {
             "%{rocm_toolkit_path}": "/opt/rocm",
-            "%{hipblaslt_flag}": "0",
         },
         "rocm/rocm_config/rocm_config.h",
     )
@@ -457,14 +454,10 @@ def _create_local_rocm_repository(repository_ctx):
             "%{rocm_is_configured}": "True",
             "%{gpu_is_configured}": "if_true",
             "%{cuda_or_rocm}": "if_true",
-            "%{rocm_extra_copts}": _compute_rocm_extra_copts(
-                rocm_config.amdgpu_targets,
-            ),
             "%{single_gpu_rbe_pool}": repository_ctx.os.environ.get(_TF_ROCM_RBE_SINGLE_GPU_POOL, _DEFAULT_TF_ROCM_RBE_SINGLE_GPU_POOL),
             "%{multi_gpu_rbe_pool}": repository_ctx.os.environ.get(_TF_ROCM_RBE_MULTI_GPU_POOL, _DEFAULT_TF_ROCM_RBE_MULTI_GPU_POOL),
             "%{rocm_gpu_architectures}": str(rocm_config.amdgpu_targets),
             "%{rocm_version_number}": str(rocm_version_number),
-            "%{rocm_hipblaslt}": "True",
         },
     )
 
@@ -525,6 +518,9 @@ def _create_local_rocm_repository(repository_ctx):
             "%{hipcc_env}": _hipcc_env(repository_ctx),
             "%{rocr_runtime_library}": "hsa-runtime64",
             "%{crosstool_verbose}": "0",
+            "%{rocm_amdgpu_targets}": ",".join(
+                ["%s" % c for c in rocm_config.amdgpu_targets],
+            ),
             "%{tmpdir}": get_host_environ(
                 repository_ctx,
                 _TMPDIR,
@@ -539,14 +535,10 @@ def _create_local_rocm_repository(repository_ctx):
         "rocm/rocm_config/rocm_config.h",
         tpl_paths["rocm:rocm_config.h"],
         {
-            "%{rocm_amdgpu_targets}": ",".join(
-                ["\"%s\"" % c for c in rocm_config.amdgpu_targets],
-            ),
             "%{rocm_toolkit_path}": rocm_config.install_path,
             "%{rocm_version_number}": rocm_config.rocm_version_number,
             "%{miopen_version_number}": rocm_config.miopen_version_number,
             "%{hipruntime_version_number}": rocm_config.hipruntime_version_number,
-            "%{hipblaslt_flag}": "1",
         },
     )
 
@@ -556,14 +548,10 @@ def _create_local_rocm_repository(repository_ctx):
         "rocm/rocm_config_hermetic/rocm_config.h",
         tpl_paths["rocm:rocm_config.h"],
         {
-            "%{rocm_amdgpu_targets}": ",".join(
-                ["\"%s\"" % c for c in rocm_config.amdgpu_targets],
-            ),
             "%{rocm_toolkit_path}": str(repository_ctx.path(rocm_config.rocm_toolkit_path)),
             "%{rocm_version_number}": rocm_config.rocm_version_number,
             "%{miopen_version_number}": rocm_config.miopen_version_number,
             "%{hipruntime_version_number}": rocm_config.hipruntime_version_number,
-            "%{hipblaslt_flag}": "1",
         },
     )
 

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -24,9 +24,6 @@ limitations under the License.
 #include <vector>
 
 #include "absl/base/casts.h"
-#include "rocm/rocm_config.h"
-#if TF_HIPBLASLT
-
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -36,6 +33,7 @@ limitations under the License.
 #include "rocm/include/hipblas/hipblas.h"
 #include "rocm/include/hipblaslt/hipblaslt.h"
 #include "rocm/include/rocblas/internal/rocblas-types.h"
+#include "rocm/rocm_config.h"
 #include "xla/primitive_util.h"
 #include "xla/status_macros.h"
 #include "xla/stream_executor/activate_context.h"
@@ -1067,5 +1065,3 @@ absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
 }  // namespace rocm
 
 }  // namespace stream_executor
-
-#endif  // TF_HIPBLASLT

--- a/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/xla/stream_executor/rocm/hip_blas_lt.h
@@ -20,17 +20,14 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/synchronization/mutex.h"
+#include "rocm/include/hipblaslt/hipblaslt-ext.hpp"
 #include "rocm/rocm_config.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/gpu/gpu_blas_lt.h"
+#include "xla/stream_executor/rocm/hip_blas_utils.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/types.h"
-
-#if TF_HIPBLASLT
-
-#include "rocm/include/hipblaslt/hipblaslt-ext.hpp"
-#include "xla/stream_executor/rocm/hip_blas_utils.h"
 
 namespace hipblaslt_ext {
 class GroupedGemm;
@@ -215,5 +212,4 @@ class BlasLt : public gpu::BlasLt {
 }  // namespace rocm
 }  // namespace stream_executor
 
-#endif  // TF_HIPBLASLT
 #endif  // XLA_STREAM_EXECUTOR_ROCM_HIP_BLAS_LT_H_

--- a/xla/stream_executor/rocm/hip_blas_utils.cc
+++ b/xla/stream_executor/rocm/hip_blas_utils.cc
@@ -20,8 +20,6 @@ limitations under the License.
 #include "rocm/rocm_config.h"
 #include "xla/stream_executor/blas.h"
 
-#if TF_HIPBLASLT
-
 namespace stream_executor {
 namespace rocm {
 
@@ -118,5 +116,3 @@ hipblasOperation_t AsHipblasOperation(blas::Transpose trans) {
 
 }  // namespace rocm
 }  // namespace stream_executor
-
-#endif  // #TF_HIPBLASLT

--- a/xla/stream_executor/rocm/hip_blas_utils.h
+++ b/xla/stream_executor/rocm/hip_blas_utils.h
@@ -21,10 +21,9 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "rocm/include/hipblas/hipblas.h"
 #include "rocm/include/hipblaslt/hipblaslt.h"
+#include "rocm/rocm_config.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/tsl/platform/errors.h"
-
-#if TF_HIPBLASLT
 
 #if TF_ROCM_VERSION < 60000
 #define hipDataType hipblasDatatype_t
@@ -56,7 +55,5 @@ hipblasOperation_t AsHipblasOperation(blas::Transpose trans);
 
 }  // namespace rocm
 }  // namespace stream_executor
-
-#endif  // TF_HIPBLASLT
 
 #endif  // XLA_STREAM_EXECUTOR_ROCM_HIP_BLAS_UTILS_H_

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -34,10 +34,10 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
 #include "Eigen/Core"
-#include "unsupported/Eigen/CXX11/Tensor"
 #include "rocm/include/hip/amd_detail/hip_fp16_gcc.h"
 #include "rocm/include/hipblas/hipblas.h"
 #include "rocm/rocm_config.h"
+#include "unsupported/Eigen/CXX11/Tensor"
 #include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/device_address.h"
@@ -68,7 +68,7 @@ namespace {
 
 #define ROCBLAS_API_WRAPPER(__name)               \
   struct WrapperShim__##__name {                  \
-    constexpr static const char* kName = #__name; \
+    constexpr static const char *kName = #__name; \
     template <typename... Args>                   \
     rocblas_status operator()(Args... args) {     \
       return (::__name)(args...);                 \
@@ -123,17 +123,17 @@ extern void rocm_Broadcast_fp32(void *stream, float *dst, int dst_stride,
                                 int size);
 
 template <class T>
-const RocBlasType_t<T>* const* complex_cast(const DeviceAddress<T*>& a) {
+const RocBlasType_t<T> *const *complex_cast(const DeviceAddress<T *> &a) {
   return reinterpret_cast<const RocBlasType_t<T> *const *>(GpuMemory(a));
 }
 
 template <class T>
-RocBlasType_t<T>* const* complex_cast(DeviceAddress<T*>& a) {
+RocBlasType_t<T> *const *complex_cast(DeviceAddress<T *> &a) {
   return reinterpret_cast<RocBlasType_t<T> *const *>(GpuMemory(a));
 }
 
 template <class T>
-const RocBlasType_t<T>* complex_cast(const DeviceAddress<T>& a) {
+const RocBlasType_t<T> *complex_cast(const DeviceAddress<T> &a) {
   return reinterpret_cast<const RocBlasType_t<T> *>(GpuMemory(a));
 }
 
@@ -142,7 +142,7 @@ const RocBlasType_t<T> *complex_cast(const T &a) {
   return reinterpret_cast<const RocBlasType_t<T> *>(&a);
 }
 template <class T>
-RocBlasType_t<T>* complex_cast(DeviceAddress<T>* a) {
+RocBlasType_t<T> *complex_cast(DeviceAddress<T> *a) {
   return reinterpret_cast<RocBlasType_t<T> *>(GpuMemoryMutable(a));
 }
 
@@ -183,12 +183,10 @@ bool ROCMBlas::Init() {
     return false;
   }
 
-#if TF_HIPBLASLT
   if (!blas_lt_.Init().ok()) {
     LOG(ERROR) << "Failed to initialize hipblasLt";
     return false;
   }
-#endif
 
   int dev = 0;
   hipError_t result = hipGetDevice(&dev);
@@ -204,14 +202,7 @@ bool ROCMBlas::Init() {
 }
 
 ROCMBlas::ROCMBlas(StreamExecutor *parent)
-    : parent_(CHECK_NOTNULL(parent)),
-      blas_(nullptr)
-#if TF_HIPBLASLT
-      ,
-      blas_lt_(parent)
-#endif
-{
-}
+    : parent_(CHECK_NOTNULL(parent)), blas_(nullptr), blas_lt_(parent) {}
 
 ROCMBlas::~ROCMBlas() {
   if (blas_ != nullptr) {
@@ -466,8 +457,8 @@ absl::Status ROCMBlas::DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
 }
 
 #define Impl_DoBlasScal(Fun, T, Ta)                                         \
-  bool ROCMBlas::DoBlasScal(Stream* stream, uint64_t elem_count, Ta alpha,  \
-                            DeviceAddress<T>* x, int incx) {                \
+  bool ROCMBlas::DoBlasScal(Stream *stream, uint64_t elem_count, Ta alpha,  \
+                            DeviceAddress<T> *x, int incx) {                \
     return DoBlasInternal(Fun, stream, /* pointer_mode_host = */ true,      \
                           elem_count, complex_cast(alpha), complex_cast(x), \
                           incx);                                            \
@@ -482,10 +473,10 @@ Impl_DoBlasScal(wrap::rocblas_sscal, float, float)
                     Impl_DoBlasScal(wrap::rocblas_zscal, std::complex<double>,
                                     std::complex<double>)
 #define Impl_DoBlasGemv(fun, T)                                                \
-  bool ROCMBlas::DoBlasGemv(Stream* stream, blas::Transpose trans, uint64_t m, \
-                            uint64_t n, T alpha, const DeviceAddress<T>& a,    \
-                            int lda, const DeviceAddress<T>& x, int incx,      \
-                            T beta, DeviceAddress<T>* y, int incy) {           \
+  bool ROCMBlas::DoBlasGemv(Stream *stream, blas::Transpose trans, uint64_t m, \
+                            uint64_t n, T alpha, const DeviceAddress<T> &a,    \
+                            int lda, const DeviceAddress<T> &x, int incx,      \
+                            T beta, DeviceAddress<T> *y, int incy) {           \
     return DoBlasInternal(fun, stream, /* pointer_mode_host = */ true,         \
                           ROCMBlasTranspose(trans), m, n, complex_cast(alpha), \
                           complex_cast(a), lda, complex_cast(x), incx,         \
@@ -523,13 +514,13 @@ void ROCMBlas::MaybeLogGemmOp(GemmCallTrace::GemmType op,
       parent_->RecordApiTrace(GemmCallTrace{op, (int)context, size1, size2});
 }
 
-absl::Status ROCMBlas::DoBlasGemm(Stream* stream, blas::Transpose transa,
+absl::Status ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
                                   blas::Transpose transb, uint64_t m,
                                   uint64_t n, uint64_t k, blas::DataType dtype,
-                                  const void* alpha, const DeviceAddressBase& a,
-                                  int lda, const DeviceAddressBase& b, int ldb,
-                                  const void* beta, DeviceAddressBase* c,
-                                  int ldc, const EngineOptions& engine_options,
+                                  const void *alpha, const DeviceAddressBase &a,
+                                  int lda, const DeviceAddressBase &b, int ldb,
+                                  const void *beta, DeviceAddressBase *c,
+                                  int ldc, const EngineOptions &engine_options,
                                   blas::CallContext context) {
   MaybeLogGemmOp(GemmCallTrace::GemmType::kPlain, context,
                  m * k * DtypeSize(dtype), n * k * DtypeSize(dtype));
@@ -611,13 +602,13 @@ absl::Status ROCMBlas::DoBlasGemm(Stream* stream, blas::Transpose transa,
 }
 
 absl::Status ROCMBlas::DoBlasGemmWithAlgorithm(
-    Stream* stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64_t k, const void* alpha, const DeviceAddressBase& a,
-    blas::DataType type_a, int lda, const DeviceAddressBase& b,
-    blas::DataType type_b, int ldb, const void* beta, DeviceAddressBase* c,
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    uint64_t n, uint64_t k, const void *alpha, const DeviceAddressBase &a,
+    blas::DataType type_a, int lda, const DeviceAddressBase &b,
+    blas::DataType type_b, int ldb, const void *beta, DeviceAddressBase *c,
     blas::DataType type_c, int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, const EngineOptions& engine_options,
-    blas::ProfileResult* profile_result, blas::CallContext context) {
+    blas::AlgorithmType algorithm, const EngineOptions &engine_options,
+    blas::ProfileResult *profile_result, blas::CallContext context) {
   if (type_a != type_b) {
     return absl::InternalError(absl::StrFormat(
         "DoBlasGemmWithAlgorithm: different "
@@ -671,14 +662,14 @@ absl::Status ROCMBlas::DoBlasGemmWithAlgorithm(
 }
 
 absl::Status ROCMBlas::DoBlasGemmStridedBatchedWithAlgorithm(
-    Stream* stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64_t k, const void* alpha, const DeviceAddressBase& a,
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    uint64_t n, uint64_t k, const void *alpha, const DeviceAddressBase &a,
     blas::DataType type_a, int lda, int64_t stride_a,
-    const DeviceAddressBase& b, blas::DataType type_b, int ldb,
-    int64_t stride_b, const void* beta, DeviceAddressBase* c,
+    const DeviceAddressBase &b, blas::DataType type_b, int ldb,
+    int64_t stride_b, const void *beta, DeviceAddressBase *c,
     blas::DataType type_c, int ldc, int64_t stride_c, int batch_count,
     blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-    const EngineOptions& engine_options, blas::ProfileResult* profile_result,
+    const EngineOptions &engine_options, blas::ProfileResult *profile_result,
     blas::CallContext context) {
   if (type_a != type_b) {
     return absl::InternalError(absl::StrFormat(
@@ -872,9 +863,9 @@ bool MemCopyOpsFold(MemoryCopyOp &y, const MemoryCopyOp &x) {
 // The below algorithm tries to minimize the number of memcpy by consolidating
 // neighboring memcpy into a single request.
 template <typename MAPPED_T>
-absl::Status ReorganizeMemory(Stream* stream,
-                              DeviceAddress<MAPPED_T>* device_memory,
-                              const std::vector<MAPPED_T*>& raw_ptrs,
+absl::Status ReorganizeMemory(Stream *stream,
+                              DeviceAddress<MAPPED_T> *device_memory,
+                              const std::vector<MAPPED_T *> &raw_ptrs,
                               int batch_count, uint64_t batch_stride,
                               bool gather) {
   if (gather == false) {
@@ -985,12 +976,12 @@ absl::StatusOr<AllocateStridedResult<T>> AllocateStridedBuffer(
 
 template <typename T, typename FuncT>
 absl::Status ROCMBlas::DoBlasGemmBatchedInternal(
-    FuncT rocblas_func, Stream* stream, blas::Transpose transa,
+    FuncT rocblas_func, Stream *stream, blas::Transpose transa,
     blas::Transpose transb, uint64_t m, uint64_t n, uint64_t k, T alpha,
     DeviceAddressSlice<T> a_ptrs_to_wrappers, int lda,
     DeviceAddressSlice<T> b_ptrs_to_wrappers, int ldb, T beta,
     DeviceAddressSlice<T> c_ptrs_to_wrappers, int ldc, int batch_count,
-    ScratchAllocator* scratch_allocator) {
+    ScratchAllocator *scratch_allocator) {
   using MAPPED_T = RocBlasType_t<T>;
 
   // Sanity checks before making any further progress
@@ -1124,11 +1115,11 @@ class rocblas_gemm_strided_batched_bf16 {
 const char *rocblas_gemm_strided_batched_bf16::kName =
     "rocblas_gemm_strided_batched_bf16";
 bool ROCMBlas::DoBlasGemmBatched(
-    Stream* stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
     uint64_t n, uint64_t k, float alpha, DeviceAddressSlice<Eigen::half> a,
     int lda, DeviceAddressSlice<Eigen::half> b, int ldb, float beta,
     DeviceAddressSlice<Eigen::half> c, int ldc, int batch_count,
-    const EngineOptions& engine_options, ScratchAllocator* scratch_allocator,
+    const EngineOptions &engine_options, ScratchAllocator *scratch_allocator,
     blas::CallContext context) {
   MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a.size(),
                  b.size());
@@ -1159,12 +1150,12 @@ bool ROCMBlas::DoBlasGemmBatched(
 }
 
 bool ROCMBlas::DoBlasGemmBatched(
-    Stream* stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
     uint64_t n, uint64_t k, float alpha,
     DeviceAddressSlice<Eigen::bfloat16> a_array, int lda,
     DeviceAddressSlice<Eigen::bfloat16> b_array, int ldb, float beta,
     DeviceAddressSlice<Eigen::bfloat16> c_array, int ldc, int batch_count,
-    const EngineOptions& engine_options, ScratchAllocator* scratch_allocator,
+    const EngineOptions &engine_options, ScratchAllocator *scratch_allocator,
     blas::CallContext context) {
   MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a_array.size(),
                  b_array.size());
@@ -1183,12 +1174,12 @@ bool ROCMBlas::DoBlasGemmBatched(
 
 #define IMPL_DoBlasGemmBatched(T, Fun)                                         \
   bool ROCMBlas::DoBlasGemmBatched(                                            \
-      Stream* stream, blas::Transpose transa, blas::Transpose transb,          \
+      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64_t m, uint64_t n, uint64_t k, T alpha,                             \
       DeviceAddressSlice<T> a_array, int lda, DeviceAddressSlice<T> b_array,   \
       int ldb, T beta, DeviceAddressSlice<T> c_array, int ldc,                 \
-      int batch_count, const EngineOptions& engine_options,                    \
-      ScratchAllocator* scratch_allocator, blas::CallContext context) {        \
+      int batch_count, const EngineOptions &engine_options,                    \
+      ScratchAllocator *scratch_allocator, blas::CallContext context) {        \
     MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a_array.size(), \
                    b_array.size());                                            \
     absl::Status status = DoBlasGemmBatchedInternal(                           \
@@ -1206,29 +1197,29 @@ IMPL_DoBlasGemmBatched(float, wrap::rocblas_sgemm_strided_batched)
                                wrap::rocblas_cgemm_strided_batched)
             IMPL_DoBlasGemmBatched(std::complex<double>,
                                    wrap::rocblas_zgemm_strided_batched)
-#define IMPL_DoBlasTrsm(T, Fun, Fun2)                                        \
-  bool ROCMBlas::DoBlasTrsm(Stream* stream, blas::Side side,                 \
-                            blas::UpperLower uplo, blas::Transpose transa,   \
-                            blas::Diagonal diag, uint64_t m, uint64_t n,     \
-                            T alpha, const DeviceAddress<T>& a, int lda,     \
-                            DeviceAddress<T>* b, int ldb) {                  \
-    return DoBlasInternal(Fun, stream, /* pointer_mode_host = */ true,       \
-                          ROCMBlasSide(side), ROCMBlasUpperLower(uplo),      \
-                          ROCMBlasTranspose(transa), ROCMBlasDiagonal(diag), \
-                          m, n, complex_cast(alpha), complex_cast(a), lda,   \
-                          complex_cast(b), ldb);                             \
-  }                                                                          \
-                                                                             \
-  bool ROCMBlas::DoBlasTrsmBatched(                                          \
-      Stream* stream, blas::Side side, blas::UpperLower uplo,                \
-      blas::Transpose transa, blas::Diagonal diag, uint64_t m, uint64_t n,   \
-      T alpha, const DeviceAddress<T*>& as, int lda, DeviceAddress<T*>* bs,  \
-      int ldb, int batch_count) {                                            \
-    return DoBlasInternal(Fun2, stream, true /* = pointer_mode_host */,      \
-                          ROCMBlasSide(side), ROCMBlasUpperLower(uplo),      \
-                          ROCMBlasTranspose(transa), ROCMBlasDiagonal(diag), \
-                          m, n, complex_cast(alpha), complex_cast(as), lda,  \
-                          complex_cast(*bs), ldb, batch_count);              \
+#define IMPL_DoBlasTrsm(T, Fun, Fun2)                                         \
+  bool ROCMBlas::DoBlasTrsm(Stream *stream, blas::Side side,                  \
+                            blas::UpperLower uplo, blas::Transpose transa,    \
+                            blas::Diagonal diag, uint64_t m, uint64_t n,      \
+                            T alpha, const DeviceAddress<T> &a, int lda,      \
+                            DeviceAddress<T> *b, int ldb) {                   \
+    return DoBlasInternal(Fun, stream, /* pointer_mode_host = */ true,        \
+                          ROCMBlasSide(side), ROCMBlasUpperLower(uplo),       \
+                          ROCMBlasTranspose(transa), ROCMBlasDiagonal(diag),  \
+                          m, n, complex_cast(alpha), complex_cast(a), lda,    \
+                          complex_cast(b), ldb);                              \
+  }                                                                           \
+                                                                              \
+  bool ROCMBlas::DoBlasTrsmBatched(                                           \
+      Stream *stream, blas::Side side, blas::UpperLower uplo,                 \
+      blas::Transpose transa, blas::Diagonal diag, uint64_t m, uint64_t n,    \
+      T alpha, const DeviceAddress<T *> &as, int lda, DeviceAddress<T *> *bs, \
+      int ldb, int batch_count) {                                             \
+    return DoBlasInternal(Fun2, stream, true /* = pointer_mode_host */,       \
+                          ROCMBlasSide(side), ROCMBlasUpperLower(uplo),       \
+                          ROCMBlasTranspose(transa), ROCMBlasDiagonal(diag),  \
+                          m, n, complex_cast(alpha), complex_cast(as), lda,   \
+                          complex_cast(*bs), ldb, batch_count);               \
   }
 
                 IMPL_DoBlasTrsm(float, wrap::rocblas_strsm,
@@ -1244,12 +1235,12 @@ IMPL_DoBlasGemmBatched(float, wrap::rocblas_sgemm_strided_batched)
 
                                 absl::Status
     ROCMBlas::DoBlasGemmStridedBatched(
-        Stream* stream, blas::Transpose transa, blas::Transpose transb,
+        Stream *stream, blas::Transpose transa, blas::Transpose transb,
         uint64_t m, uint64_t n, uint64_t k, blas::DataType dtype,
-        const void* alpha, const DeviceAddressBase& a, int lda,
-        int64_t stride_a, const DeviceAddressBase& b, int ldb, int64_t stride_b,
-        const void* beta, DeviceAddressBase* c, int ldc, int64_t stride_c,
-        int batch_count, const EngineOptions& engine_options,
+        const void *alpha, const DeviceAddressBase &a, int lda,
+        int64_t stride_a, const DeviceAddressBase &b, int ldb, int64_t stride_b,
+        const void *beta, DeviceAddressBase *c, int ldc, int64_t stride_c,
+        int batch_count, const EngineOptions &engine_options,
         blas::CallContext context) {
   VLOG(1) << absl::StreamFormat(
       "doing rocBLAS GEMM Strided Batched: at=%d bt=%d m=%u n=%u "

--- a/xla/stream_executor/rocm/rocm_blas.h
+++ b/xla/stream_executor/rocm/rocm_blas.h
@@ -30,9 +30,7 @@ limitations under the License.
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/gpu/gpu_blas_lt.h"
 #include "xla/stream_executor/plugin_registry.h"
-#if TF_HIPBLASLT
 #include "xla/stream_executor/rocm/hip_blas_lt.h"
-#endif
 #include "xla/stream_executor/stream_executor.h"
 
 namespace stream_executor {
@@ -93,11 +91,7 @@ class ROCMBlas : public blas::BlasSupport {
   TENSORFLOW_STREAM_EXECUTOR_GPU_BLAS_SUPPORT_OVERRIDES
 
   gpu::BlasLt *GetBlasLt() override {
-#if TF_HIPBLASLT
     return &blas_lt_;
-#else
-    return nullptr;
-#endif
   }
 
  private:
@@ -194,9 +188,7 @@ class ROCMBlas : public blas::BlasSupport {
                       blas::CallContext context, uint64_t size1,
                       uint64_t size2);
 
-#if TF_HIPBLASLT
   rocm::BlasLt blas_lt_;
-#endif
 
   ROCMBlas(const ROCMBlas &) = delete;
   void operator=(const ROCMBlas &) = delete;


### PR DESCRIPTION
- TF_HIPBLASLT macro is now always enabled, but it is kept for compatibility with TF builds.
- AMDGPU target options are passed directly to the crosstool through templates, no need some fancy command line options

First PR extracted from https://github.com/openxla/xla/pull/42108