### PR TITLE
[ROCm] Move JAX ROCm Bazel presubmit check to 32-bit mode.

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -93,7 +93,7 @@ jobs:
             --//jax:build_jaxlib=wheel \
             --//jax:build_jax=true \
             --local_test_jobs=4 \
-            --action_env=JAX_ENABLE_X64=1 \
+            --action_env=JAX_ENABLE_X64=0 \
             --repo_env=HERMETIC_PYTHON_VERSION=3.14 \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE=${DOCKER_IMAGE}
 


### PR DESCRIPTION
📝 Summary of Changes
The JAX ROCm Bazel presubmit workflow was originally using 64-bit mode. For now, it is being set to 32-bit mode for broader testing. Eventually, both will be enabled for full testing.

The only change is to the ROCm CI workflow file (`.github/workflows/rocm_ci.yml`). The flag `JAX_ENABLE_X64` is now set to 0 instead of 1.

Please see the associated PR on the JAX side for reference: https://github.com/jax-ml/jax/pull/37475

🎯 Justification
This will help the ROCm JAX tests in XLA align with what is being tested in JAX itself on the ROCm side.

🚀 Kind of Contribution
🧪 Tests

