### PR TITLE
[xla:gpu] Add an API to request multiple symm addrs/slices

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -2501,11 +2501,13 @@ cc_library(
         "//xla/service:buffer_assignment",
         "//xla/service/gpu:buffer_allocations",
         "//xla/stream_executor:device_address",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/xla/backends/gpu/runtime/collective_memory.cc
+++ b/xla/backends/gpu/runtime/collective_memory.cc
@@ -236,17 +236,17 @@ static absl::StatusOr<absl::flat_hash_map<CollectiveMemory::Key,
 AcquireSymmetricMemory(
     const CollectiveParams& params, CollectiveCliques& cliques,
     const BufferAllocations& buffers,
-    absl::Span<const CollectiveMemoryRequests::SymmetricAllocations> allocs,
+    absl::Span<const CollectiveMemoryRequests::CollectiveAllocations> allocs,
     CollectiveMemoryCache& memory_cache) {
   absl::flat_hash_map<CollectiveMemory::Key, std::shared_ptr<SymmetricMemory>>
       sym_memories;
 
-  for (const CollectiveMemoryRequests::SymmetricAllocations& r : allocs) {
-    std::optional<RankId> rank = r.key.rank(params.global_device_id);
+  for (const CollectiveMemoryRequests::CollectiveAllocations& r : allocs) {
+    std::optional<RankId> rank = r.clique.rank(params.global_device_id);
 
     if (!rank.has_value()) {
       return Internal("Can't find global device id %v in clique key %v",
-                      params.global_device_id, r.key);
+                      params.global_device_id, r.clique);
     }
 
     // TODO(ezhulenev): All of the buffer allocations that we make symmetric
@@ -261,21 +261,21 @@ AcquireSymmetricMemory(
     //
     // Currently it's very simple proof of concept.
 
-    ASSIGN_OR_RETURN(GpuCommunicator * comm, cliques.GetComm(r.key, *rank));
+    ASSIGN_OR_RETURN(GpuCommunicator * comm, cliques.GetComm(r.clique, *rank));
     for (BufferAllocation::Index i : r.allocations) {
       se::DeviceAddressBase addr = buffers.GetDeviceAddress(i);
-      CollectiveMemory::Key mem_key = std::make_pair(r.key, i);
+      CollectiveMemory::Key mem_key = std::make_pair(r.clique, i);
       // Check cache first to avoid redundant collective window registration.
-      if (auto cached = memory_cache.FindSymmetricMemory(r.key, addr)) {
+      if (auto cached = memory_cache.FindSymmetricMemory(r.clique, addr)) {
         sym_memories[mem_key] = std::move(cached);
         continue;
       }
       ASSIGN_OR_RETURN(std::unique_ptr<SymmetricMemory> symm,
                        comm->CreateSymmetricMemory(addr));
       ASSIGN_OR_RETURN(tsl::TiedRef<SymmetricMemory> tied_symm,
-                       cliques.Tie(r.key, std::move(symm)));
+                       cliques.Tie(r.clique, std::move(symm)));
       sym_memories[mem_key] =
-          memory_cache.AddSymmetricMemory(r.key, addr, std::move(tied_symm));
+          memory_cache.AddSymmetricMemory(r.clique, addr, std::move(tied_symm));
     }
   }
 
@@ -315,31 +315,31 @@ using MappedMulticastMemoryMap =
 absl::StatusOr<MulticastMemoryMap> AcquireMulticastMemory(
     const CollectiveParams& params, CollectiveCliques& cliques,
     const BufferAllocations& buffers,
-    absl::Span<const CollectiveMemoryRequests::MulticastAllocations> allocs,
+    absl::Span<const CollectiveMemoryRequests::CollectiveAllocations> allocs,
     CollectiveMemoryCache& memory_cache) {
   int32_t device_ordinal = params.executor->device_ordinal();
 
   MulticastMemoryMap mcast_memories;
 
-  for (const CollectiveMemoryRequests::MulticastAllocations& r : allocs) {
-    std::optional<RankId> rank = r.key.rank(params.global_device_id);
+  for (const CollectiveMemoryRequests::CollectiveAllocations& r : allocs) {
+    std::optional<RankId> rank = r.clique.rank(params.global_device_id);
 
     if (!rank.has_value()) {
       return Internal("[%d] Can't find global device id %v in clique key %v",
-                      device_ordinal, params.global_device_id, r.key);
+                      device_ordinal, params.global_device_id, r.clique);
     }
 
     // We rely on in-process rendezvous to allocate the multicast memory and set
     // up memory mapping on all ranks, and don't support multi-process mode.
-    if (!r.key.is_local()) {
+    if (!r.clique.is_local()) {
       return Unimplemented(
           "[%d] Multicast is not supported in multi-process mode in clique %v",
-          device_ordinal, r.key);
+          device_ordinal, r.clique);
     }
 
     std::string rendezvous_name = absl::StrFormat(
         "[%d] [rank=%v] AcquireMulticastMemory for clique %v: allocs=[%s]",
-        device_ordinal, *rank, r.key, absl::StrJoin(r.allocations, ","));
+        device_ordinal, *rank, r.clique, absl::StrJoin(r.allocations, ","));
 
     // Collect device addresses for mapped allocations.
     std::vector<se::DeviceAddressBase> map_to;
@@ -358,7 +358,7 @@ absl::StatusOr<MulticastMemoryMap> AcquireMulticastMemory(
       VLOG(3) << absl::StrFormat(
           "[%s] [ranks=%s] Allocate collective multimem for clique: %v",
           absl::StrJoin(params, ",", DeviceOrdinalFormatter{}),
-          absl::StrJoin(params, ",", RankFormatter{}), r.key);
+          absl::StrJoin(params, ",", RankFormatter{}), r.clique);
 
       // We deterministically choose the first device to create the
       // multicast memory. We will map the rest of participants to it later.
@@ -401,23 +401,23 @@ absl::StatusOr<MulticastMemoryMap> AcquireMulticastMemory(
             "[%s] [ranks=%s] Allocated collective multimem for clique: %v; "
             "mapped_ptrs=[%s]",
             absl::StrJoin(params, ",", DeviceOrdinalFormatter{}),
-            absl::StrJoin(params, ",", RankFormatter{}), r.key,
+            absl::StrJoin(params, ",", RankFormatter{}), r.clique,
             absl::StrJoin(mapped_ptrs, ", ", MappedPtrFormatter{}));
 
         // Tie the lifetime of constructed multicast memory to the clique.
         ASSIGN_OR_RETURN(
             tsl::TiedRef<se::gpu::MulticastMemory> tied_multicast_memory,
-            cliques.Tie(r.key, std::move(multicast_memory)));
+            cliques.Tie(r.clique, std::move(multicast_memory)));
 
         // Add to cache inside the rendezvous (single-threaded) to avoid a race
         // where multiple ranks std::move from the same TiedRef.
         se::DeviceAddressBase mcast_addr =
             params[0]->buffers.GetDeviceAddress(i);
         std::shared_ptr<se::gpu::MulticastMemory> cached =
-            memory_cache.AddMulticastMemory(r.key, mcast_addr,
+            memory_cache.AddMulticastMemory(r.clique, mcast_addr,
                                             std::move(tied_multicast_memory));
 
-        clique_mcast_memories[std::make_pair(r.key, i)] =
+        clique_mcast_memories[std::make_pair(r.clique, i)] =
             MappedMulticastMemory{std::move(cached), std::move(mapped_ptrs)};
       }
       return clique_mcast_memories;
@@ -426,10 +426,10 @@ absl::StatusOr<MulticastMemoryMap> AcquireMulticastMemory(
     // We expect that all local participants will collectively allocate the
     // multicast memory. We do one rendezvous for each clique, and from the
     // rendezvous callback allocate multicast memory for all allocations.
-    RendezvousKey rendezvous_key = {r.key};
+    RendezvousKey rendezvous_key = {r.clique};
     RendezvousParams allocate_params = {*rank, params.executor, buffers};
 
-    int64_t num_participants = r.key.num_local_participants();
+    int64_t num_participants = r.clique.num_local_participants();
     ASSIGN_OR_RETURN(
         std::shared_ptr<MappedMulticastMemoryMap> clique_mcast_memories,
         Rendezvous<MappedMulticastMemoryMap>(rendezvous_name, rendezvous_key,
@@ -460,30 +460,30 @@ using PeerMemoryMap =
 absl::StatusOr<PeerMemoryMap> AcquirePeerMemory(
     const CollectiveParams& params, const CollectiveCliques& cliques,
     const BufferAllocations& buffers,
-    absl::Span<const CollectiveMemoryRequests::PeerAllocations> allocs) {
+    absl::Span<const CollectiveMemoryRequests::CollectiveAllocations> allocs) {
   int32_t device_ordinal = params.executor->device_ordinal();
 
   PeerMemoryMap peer_memories;
 
-  for (const CollectiveMemoryRequests::PeerAllocations& r : allocs) {
-    std::optional<RankId> rank = r.key.rank(params.global_device_id);
+  for (const CollectiveMemoryRequests::CollectiveAllocations& r : allocs) {
+    std::optional<RankId> rank = r.clique.rank(params.global_device_id);
 
     if (!rank.has_value()) {
       return Internal("[%d] Can't find global device id %v in clique key %v",
-                      device_ordinal, params.global_device_id, r.key);
+                      device_ordinal, params.global_device_id, r.clique);
     }
 
     // We rely on in-process rendezvous to exchange peer memory with all ranks.
-    if (!r.key.is_local()) {
+    if (!r.clique.is_local()) {
       return Unimplemented(
           "[%d] Peer memory is not supported in multi-process mode in clique "
           "%v",
-          device_ordinal, r.key);
+          device_ordinal, r.clique);
     }
 
     std::string rendezvous_name = absl::StrFormat(
         "[%d] [rank=%v] AcquirePeerMemory for clique %v: allocs=[%s]",
-        device_ordinal, *rank, r.key, absl::StrJoin(r.allocations, ","));
+        device_ordinal, *rank, r.clique, absl::StrJoin(r.allocations, ","));
 
     // A callback for rendezvous to exchange peer allocation addresses with
     // all participating ranks.
@@ -495,7 +495,7 @@ absl::StatusOr<PeerMemoryMap> AcquirePeerMemory(
       VLOG(3) << absl::StrFormat(
           "[%s] [ranks=%s] Exchange collective peer memory for clique: %v",
           absl::StrJoin(params, ",", DeviceOrdinalFormatter{}),
-          absl::StrJoin(params, ",", RankFormatter{}), r.key);
+          absl::StrJoin(params, ",", RankFormatter{}), r.clique);
 
       PeerMemoryMap clique_peer_memories;
       for (BufferAllocation::Index i : r.allocations) {
@@ -504,7 +504,7 @@ absl::StatusOr<PeerMemoryMap> AcquirePeerMemory(
         for (const RendezvousParams* param : params) {
           addrs[param->rank] = param->buffers.GetDeviceAddress(i);
         }
-        clique_peer_memories[std::make_pair(r.key, i)] =
+        clique_peer_memories[std::make_pair(r.clique, i)] =
             CollectiveMemory::PeerMemory{std::move(addrs)};
       }
       return clique_peer_memories;
@@ -513,10 +513,10 @@ absl::StatusOr<PeerMemoryMap> AcquirePeerMemory(
     // We expect that all local participants will collectively allocate the
     // multicast memory. We do one rendezvous for each clique, and from the
     // rendezvous callback allocate multicast memory for all allocations.
-    RendezvousKey rendezvous_key = {r.key};
+    RendezvousKey rendezvous_key = {r.clique};
     RendezvousParams allocate_params = {*rank, params.executor, buffers};
 
-    int64_t num_participants = r.key.num_local_participants();
+    int64_t num_participants = r.clique.num_local_participants();
     ASSIGN_OR_RETURN(
         std::shared_ptr<PeerMemoryMap> clique_mcast_memories,
         Rendezvous<PeerMemoryMap>(rendezvous_name, rendezvous_key,
@@ -542,11 +542,11 @@ absl::StatusOr<CollectiveMemory> AcquireCollectiveMemory(
   // We rely on deterministic order of memory requests, to guarantee that all
   // ranks create collective memory in identical order, otherwise we can get
   // a deadlock.
-  std::vector<CollectiveMemoryRequests::SymmetricAllocations> sym_allocs =
+  std::vector<CollectiveMemoryRequests::CollectiveAllocations> sym_allocs =
       requests.OrderedSymmetricAllocations();
-  std::vector<CollectiveMemoryRequests::MulticastAllocations> mcast_allocs =
+  std::vector<CollectiveMemoryRequests::CollectiveAllocations> mcast_allocs =
       requests.OrderedMulticastAllocations();
-  std::vector<CollectiveMemoryRequests::PeerAllocations> peer_allocs =
+  std::vector<CollectiveMemoryRequests::CollectiveAllocations> peer_allocs =
       requests.OrderedPeerAllocations();
 
   // Short-circuit if we have nothing to allocate.
@@ -563,29 +563,29 @@ absl::StatusOr<CollectiveMemory> AcquireCollectiveMemory(
   absl::Time start = absl::Now();
 
   for (size_t i = 0; i < sym_allocs.size(); ++i) {
-    const CollectiveMemoryRequests::SymmetricAllocations& r = sym_allocs[i];
+    const CollectiveMemoryRequests::CollectiveAllocations& r = sym_allocs[i];
     XLA_VLOG_DEVICE(2, params.executor->device_ordinal()) << absl::StreamFormat(
         "    symmetric memory #%d (global device %v): id=%d; clique=%v; "
         "allocations=[%s]",
-        i, params.global_device_id, r.id, r.key,
+        i, params.global_device_id, r.id, r.clique,
         absl::StrJoin(r.allocations, ", "));
   }
 
   for (size_t i = 0; i < mcast_allocs.size(); ++i) {
-    const CollectiveMemoryRequests::MulticastAllocations& r = mcast_allocs[i];
+    const CollectiveMemoryRequests::CollectiveAllocations& r = mcast_allocs[i];
     XLA_VLOG_DEVICE(2, params.executor->device_ordinal()) << absl::StreamFormat(
         "    multicast memory #%d (global device %v): id=%d; clique=%v; "
         "allocations=[%s]",
-        i, params.global_device_id, r.id, r.key,
+        i, params.global_device_id, r.id, r.clique,
         absl::StrJoin(r.allocations, ", "));
   }
 
   for (size_t i = 0; i < peer_allocs.size(); ++i) {
-    const CollectiveMemoryRequests::PeerAllocations& r = peer_allocs[i];
+    const CollectiveMemoryRequests::CollectiveAllocations& r = peer_allocs[i];
     XLA_VLOG_DEVICE(2, params.executor->device_ordinal()) << absl::StreamFormat(
         "    peer memory #%d (global device %v): id=%d; clique=%v; "
         "allocations=[%s]",
-        i, params.global_device_id, r.id, r.key,
+        i, params.global_device_id, r.id, r.clique,
         absl::StrJoin(r.allocations, ", "));
   }
 

--- a/xla/backends/gpu/runtime/collective_memory_requests.cc
+++ b/xla/backends/gpu/runtime/collective_memory_requests.cc
@@ -15,12 +15,13 @@ limitations under the License.
 
 #include "xla/backends/gpu/runtime/collective_memory_requests.h"
 
-#include <utility>
 #include <vector>
 
 #include "absl/algorithm/container.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/types/span.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/buffer_allocations.h"
@@ -34,14 +35,13 @@ CollectiveMemoryRequests::CollectiveMemoryRequests(
     : buffers_(buffers) {}
 
 absl::Status CollectiveMemoryRequests::RequestSymmetricAllocation(
-    const GpuCliqueKey& clique_key, BufferAllocation::Index allocation) {
-  VLOG(5) << "Add collective allocation request: " << clique_key
+    const GpuCliqueKey& clique, BufferAllocation::Index allocation) {
+  VLOG(5) << "Add collective allocation request: " << clique
           << "; allocation=" << allocation;
 
   // If symmetric allocation requests already exists add allocation index to it.
-  if (auto it = sym_allocations_.find(clique_key);
-      it != sym_allocations_.end()) {
-    SymmetricAllocations& allocs = it->second;
+  if (auto it = sym_allocations_.find(clique); it != sym_allocations_.end()) {
+    CollectiveAllocations& allocs = it->second;
     allocs.allocations.insert(allocation);
     return absl::OkStatus();
   }
@@ -49,132 +49,148 @@ absl::Status CollectiveMemoryRequests::RequestSymmetricAllocation(
   // XLA compiler guarantees that all collective operations have the same
   // order on all replicas. We rely on this property to assign unique id to
   // symmetric allocation requests to guarantee deterministic execution order.
-  SymmetricAllocations alloc{
-      /*id=*/sym_allocations_.size(), clique_key, {allocation}};
+  CollectiveAllocations alloc{
+      /*id=*/sym_allocations_.size(), clique, {allocation}};
 
-  sym_allocations_.try_emplace(clique_key, std::move(alloc));
+  sym_allocations_.try_emplace(clique, std::move(alloc));
   return absl::OkStatus();
 }
 
 absl::Status CollectiveMemoryRequests::RequestSymmetricAllocationSlice(
-    const GpuCliqueKey& clique_key, BufferAllocation::Slice slice) {
-  return RequestSymmetricAllocation(clique_key, slice.index());
+    const GpuCliqueKey& clique, BufferAllocation::Slice slice) {
+  return RequestSymmetricAllocation(clique, slice.index());
+}
+
+absl::Status CollectiveMemoryRequests::RequestSymmetricAllocationSlices(
+    const GpuCliqueKey& clique,
+    absl::Span<const BufferAllocation::Slice> slices) {
+  for (const BufferAllocation::Slice& slice : slices) {
+    RETURN_IF_ERROR(RequestSymmetricAllocationSlice(clique, slice));
+  }
+  return absl::OkStatus();
 }
 
 absl::Status CollectiveMemoryRequests::RequestSymmetricAddress(
-    const GpuCliqueKey& clique_key, const se::DeviceAddressBase& addr) {
-  VLOG(5) << "Add collective address request: " << clique_key
+    const GpuCliqueKey& clique, const se::DeviceAddressBase& addr) {
+  VLOG(5) << "Add collective address request: " << clique
           << "; address=" << addr.opaque();
 
   if (auto allocation = buffers_.FindAllocationIndex(addr)) {
-    return RequestSymmetricAllocation(clique_key, *allocation);
+    return RequestSymmetricAllocation(clique, *allocation);
   }
   return Internal("Can't find buffer allocation index for a device address");
 }
 
+absl::Status CollectiveMemoryRequests::RequestSymmetricAddresses(
+    const GpuCliqueKey& clique, absl::Span<const se::DeviceAddressBase> addrs) {
+  for (const se::DeviceAddressBase& addr : addrs) {
+    RETURN_IF_ERROR(RequestSymmetricAddress(clique, addr));
+  }
+  return absl::OkStatus();
+}
+
 absl::Status CollectiveMemoryRequests::RequestMulticastAllocation(
-    const GpuCliqueKey& clique_key, BufferAllocation::Index allocation) {
-  VLOG(5) << "Add multicast allocation request: " << clique_key
+    const GpuCliqueKey& clique, BufferAllocation::Index allocation) {
+  VLOG(5) << "Add multicast allocation request: " << clique
           << "; allocation=" << allocation;
 
   // If multicast allocation requests already exists add allocation index to it.
-  if (auto it = mcast_allocations_.find(clique_key);
+  if (auto it = mcast_allocations_.find(clique);
       it != mcast_allocations_.end()) {
-    MulticastAllocations& allocs = it->second;
+    CollectiveAllocations& allocs = it->second;
     allocs.allocations.insert(allocation);
   }
 
   // XLA compiler guarantees that all collective operations have the same
   // order on all replicas. We rely on this property to assign unique id to
   // multicast allocation requests to guarantee deterministic execution order.
-  MulticastAllocations alloc{
-      /*id=*/mcast_allocations_.size(), clique_key, {allocation}};
+  CollectiveAllocations alloc{
+      /*id=*/mcast_allocations_.size(), clique, {allocation}};
 
-  mcast_allocations_.try_emplace(clique_key, std::move(alloc));
+  mcast_allocations_.try_emplace(clique, std::move(alloc));
   return absl::OkStatus();
 }
 
 absl::Status CollectiveMemoryRequests::RequestMulticastAllocationSlice(
-    const GpuCliqueKey& clique_key, BufferAllocation::Slice slice) {
-  return RequestMulticastAllocation(clique_key, slice.index());
+    const GpuCliqueKey& clique, BufferAllocation::Slice slice) {
+  return RequestMulticastAllocation(clique, slice.index());
 }
 
 absl::Status CollectiveMemoryRequests::RequestMulticastAddress(
-    const GpuCliqueKey& clique_key, const se::DeviceAddressBase& addr) {
-  VLOG(5) << "Add multicast address request: " << clique_key.ToString()
+    const GpuCliqueKey& clique, const se::DeviceAddressBase& addr) {
+  VLOG(5) << "Add multicast address request: " << clique.ToString()
           << "; address=" << addr.opaque();
 
   if (auto allocation = buffers_.FindAllocationIndex(addr)) {
-    return RequestMulticastAllocation(clique_key, *allocation);
+    return RequestMulticastAllocation(clique, *allocation);
   }
   return Internal("Can't find buffer allocation index for a device address");
 }
 
 absl::Status CollectiveMemoryRequests::RequestPeerAllocation(
-    const GpuCliqueKey& clique_key, BufferAllocation::Index allocation) {
-  VLOG(5) << "Add peer allocation request: " << clique_key
+    const GpuCliqueKey& clique, BufferAllocation::Index allocation) {
+  VLOG(5) << "Add peer allocation request: " << clique
           << "; allocation=" << allocation;
 
   // If peer allocation requests already exists add allocation index to it.
-  if (auto it = peer_allocations_.find(clique_key);
-      it != peer_allocations_.end()) {
-    PeerAllocations& allocs = it->second;
+  if (auto it = peer_allocations_.find(clique); it != peer_allocations_.end()) {
+    CollectiveAllocations& allocs = it->second;
     allocs.allocations.insert(allocation);
   }
 
   // XLA compiler guarantees that all collective operations have the same
   // order on all replicas. We rely on this property to assign unique id to
   // peer allocation requests to guarantee deterministic execution order.
-  PeerAllocations alloc{
-      /*id=*/peer_allocations_.size(), clique_key, {allocation}};
+  CollectiveAllocations alloc{
+      /*id=*/peer_allocations_.size(), clique, {allocation}};
 
-  peer_allocations_.try_emplace(clique_key, std::move(alloc));
+  peer_allocations_.try_emplace(clique, std::move(alloc));
   return absl::OkStatus();
 }
 
 absl::Status CollectiveMemoryRequests::RequestPeerAllocationSlice(
-    const GpuCliqueKey& clique_key, BufferAllocation::Slice slice) {
-  return RequestPeerAllocation(clique_key, slice.index());
+    const GpuCliqueKey& clique, BufferAllocation::Slice slice) {
+  return RequestPeerAllocation(clique, slice.index());
 }
 
 absl::Status CollectiveMemoryRequests::RequestPeerAddress(
-    const GpuCliqueKey& clique_key, const se::DeviceAddressBase& addr) {
-  VLOG(5) << "Add peer address request: " << clique_key.ToString()
+    const GpuCliqueKey& clique, const se::DeviceAddressBase& addr) {
+  VLOG(5) << "Add peer address request: " << clique.ToString()
           << "; address=" << addr.opaque();
 
   if (auto allocation = buffers_.FindAllocationIndex(addr)) {
-    return RequestPeerAllocation(clique_key, *allocation);
+    return RequestPeerAllocation(clique, *allocation);
   }
   return Internal("Can't find buffer allocation index for a device address");
 }
 
 std::vector<GpuCliqueKey> CollectiveMemoryRequests::RequestedCliques() const {
-  std::vector<GpuCliqueKey> clique_keys;
-  clique_keys.reserve(sym_allocations_.size() + mcast_allocations_.size());
-  for (const auto& [key, _] : sym_allocations_) {
-    clique_keys.push_back(key);
+  std::vector<GpuCliqueKey> cliques;
+  cliques.reserve(sym_allocations_.size() + mcast_allocations_.size());
+  for (const auto& [clique, _] : sym_allocations_) {
+    cliques.push_back(clique);
   }
-  for (const auto& [key, _] : mcast_allocations_) {
-    clique_keys.push_back(key);
+  for (const auto& [clique, _] : mcast_allocations_) {
+    cliques.push_back(clique);
   }
-  return clique_keys;
+  return cliques;
 }
 
-std::vector<CollectiveMemoryRequests::SymmetricAllocations>
+std::vector<CollectiveMemoryRequests::CollectiveAllocations>
 CollectiveMemoryRequests::OrderedSymmetricAllocations() const {
-  std::vector<SymmetricAllocations> sym_allocations;
+  std::vector<CollectiveAllocations> sym_allocations;
   sym_allocations.reserve(sym_allocations_.size());
   for (const auto& [_, allocs] : sym_allocations_) {
     sym_allocations.push_back(allocs);
   }
 
-  absl::c_sort(sym_allocations, [](const SymmetricAllocations& a,
-                                   const SymmetricAllocations& b) {
+  absl::c_sort(sym_allocations, [](const CollectiveAllocations& a,
+                                   const CollectiveAllocations& b) {
     // Create symmetric memory for larger cliques first.
-    if (a.key.devices().size() > b.key.devices().size()) {
+    if (a.clique.devices().size() > b.clique.devices().size()) {
       return true;
     }
-    if (b.key.devices().size() > a.key.devices().size()) {
+    if (b.clique.devices().size() > a.clique.devices().size()) {
       return false;
     }
 
@@ -185,21 +201,21 @@ CollectiveMemoryRequests::OrderedSymmetricAllocations() const {
   return sym_allocations;
 }
 
-std::vector<CollectiveMemoryRequests::MulticastAllocations>
+std::vector<CollectiveMemoryRequests::CollectiveAllocations>
 CollectiveMemoryRequests::OrderedMulticastAllocations() const {
-  std::vector<MulticastAllocations> mcast_allocations;
+  std::vector<CollectiveAllocations> mcast_allocations;
   mcast_allocations.reserve(mcast_allocations_.size());
   for (const auto& [_, allocs] : mcast_allocations_) {
     mcast_allocations.push_back(allocs);
   }
 
-  absl::c_sort(mcast_allocations, [](const MulticastAllocations& a,
-                                     const MulticastAllocations& b) {
+  absl::c_sort(mcast_allocations, [](const CollectiveAllocations& a,
+                                     const CollectiveAllocations& b) {
     // Create multicast memory for larger cliques first.
-    if (a.key.devices().size() > b.key.devices().size()) {
+    if (a.clique.devices().size() > b.clique.devices().size()) {
       return true;
     }
-    if (b.key.devices().size() > a.key.devices().size()) {
+    if (b.clique.devices().size() > a.clique.devices().size()) {
       return false;
     }
 
@@ -210,28 +226,28 @@ CollectiveMemoryRequests::OrderedMulticastAllocations() const {
   return mcast_allocations;
 }
 
-std::vector<CollectiveMemoryRequests::PeerAllocations>
+std::vector<CollectiveMemoryRequests::CollectiveAllocations>
 CollectiveMemoryRequests::OrderedPeerAllocations() const {
-  std::vector<PeerAllocations> peer_allocations;
+  std::vector<CollectiveAllocations> peer_allocations;
   peer_allocations.reserve(peer_allocations_.size());
   for (const auto& [_, allocs] : peer_allocations_) {
     peer_allocations.push_back(allocs);
   }
 
-  absl::c_sort(peer_allocations,
-               [](const PeerAllocations& a, const PeerAllocations& b) {
-                 // Create multicast memory for larger cliques first.
-                 if (a.key.devices().size() > b.key.devices().size()) {
-                   return true;
-                 }
-                 if (b.key.devices().size() > a.key.devices().size()) {
-                   return false;
-                 }
+  absl::c_sort(peer_allocations, [](const CollectiveAllocations& a,
+                                    const CollectiveAllocations& b) {
+    // Create multicast memory for larger cliques first.
+    if (a.clique.devices().size() > b.clique.devices().size()) {
+      return true;
+    }
+    if (b.clique.devices().size() > a.clique.devices().size()) {
+      return false;
+    }
 
-                 // Prefer cliques with smaller id (comes earlier in execution
-                 // order).
-                 return a.id < b.id;
-               });
+    // Prefer cliques with smaller id (comes earlier in execution
+    // order).
+    return a.id < b.id;
+  });
 
   return peer_allocations;
 }

--- a/xla/backends/gpu/runtime/collective_memory_requests.h
+++ b/xla/backends/gpu/runtime/collective_memory_requests.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
+#include "absl/types/span.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/buffer_allocations.h"
@@ -67,95 +68,87 @@ class CollectiveMemoryRequests {
  public:
   explicit CollectiveMemoryRequests(const BufferAllocations& buffers);
 
-  // For both kinds of collective memory we use a synthetic id that is
+  // For all kinds of collective memory we use a synthetic id that is
   // generated automatically when collective allocations is requested, and
   // guarantees deterministic iteration order across all ranks. See
   // `collective_clique_requests` for more details on how exactly this id
   // is generated and why it provides a deterministic iteration order.
 
-  // A set of buffer allocations that must have a corresponding symmetric memory
-  // on the given clique. Allocations must be allocated from a compatible
-  // collective memory allocator (typically have a memory space S(1) in the HLO
-  // program).
-  struct SymmetricAllocations {
-    size_t id;  // see synthetic id documentation above
-    GpuCliqueKey key;
-    absl::btree_set<BufferAllocation::Index> allocations;
-  };
-
-  // A set of buffer allocation that must be mapped for multicast access.
+  // A set of buffer allocations requested for collective memory on a clique.
   // Allocations must be allocated from a compatible collective memory allocator
   // (typically have a memory space S(1) in the HLO program).
-  struct MulticastAllocations {
-    // See synthetic id documentation above.
-    size_t id;
-    GpuCliqueKey key;
-    absl::btree_set<BufferAllocation::Index> allocations;
-  };
-
-  // A set of buffer allocation that must be exchanged with clique peers.
-  struct PeerAllocations {
+  struct CollectiveAllocations {
     size_t id;  // see synthetic id documentation above
-    GpuCliqueKey key;
+    GpuCliqueKey clique;
     absl::btree_set<BufferAllocation::Index> allocations;
   };
 
   // Adds a request to make the given allocation symmetric on the given clique.
-  absl::Status RequestSymmetricAllocation(const GpuCliqueKey& clique_key,
+  absl::Status RequestSymmetricAllocation(const GpuCliqueKey& clique,
                                           BufferAllocation::Index allocation);
 
   // Adds a request to make the given allocation slice symmetric on the given
   // clique.
-  absl::Status RequestSymmetricAllocationSlice(const GpuCliqueKey& clique_key,
+  absl::Status RequestSymmetricAllocationSlice(const GpuCliqueKey& clique,
                                                BufferAllocation::Slice slice);
+
+  // Same as above but for multiple slices.
+  absl::Status RequestSymmetricAllocationSlices(
+      const GpuCliqueKey& clique,
+      absl::Span<const BufferAllocation::Slice> slices);
 
   // Adds a request to make the given address range symmetric on the given
   // clique. If address does not correspond to any of the buffer allocations in
   // the `buffers_`, it will return an error.
-  absl::Status RequestSymmetricAddress(const GpuCliqueKey& clique_key,
+  absl::Status RequestSymmetricAddress(const GpuCliqueKey& clique,
                                        const se::DeviceAddressBase& addr);
+
+  // Same as above but for multiple addresses.
+  absl::Status RequestSymmetricAddresses(
+      const GpuCliqueKey& clique,
+      absl::Span<const se::DeviceAddressBase> addrs);
 
   // Adds a request to map the given allocation to multicast object on the given
   // clique.
-  absl::Status RequestMulticastAllocation(const GpuCliqueKey& clique_key,
+  absl::Status RequestMulticastAllocation(const GpuCliqueKey& clique,
                                           BufferAllocation::Index allocation);
 
   // Adds a request to map the given allocation slice to multicast object on the
   // given clique.
-  absl::Status RequestMulticastAllocationSlice(const GpuCliqueKey& clique_key,
+  absl::Status RequestMulticastAllocationSlice(const GpuCliqueKey& clique,
                                                BufferAllocation::Slice slice);
 
   // Adds a request to map the given address to multicast object on the given
   // clique. If address does not correspond to any of the buffer allocations in
   // the `buffers_`, it will return an error.
-  absl::Status RequestMulticastAddress(const GpuCliqueKey& clique_key,
+  absl::Status RequestMulticastAddress(const GpuCliqueKey& clique,
                                        const se::DeviceAddressBase& addr);
 
   // Adds a request to exchange the given allocation with clique peers.
-  absl::Status RequestPeerAllocation(const GpuCliqueKey& clique_key,
+  absl::Status RequestPeerAllocation(const GpuCliqueKey& clique,
                                      BufferAllocation::Index allocation);
 
   // Adds a request to exchange the given allocation slice with clique peers.
-  absl::Status RequestPeerAllocationSlice(const GpuCliqueKey& clique_key,
+  absl::Status RequestPeerAllocationSlice(const GpuCliqueKey& clique,
                                           BufferAllocation::Slice slice);
 
   // Adds a request to exchange the given address with clique peers. If address
   // does not correspond to any of the buffer allocations in the `buffers_`, it
   // will return an error.
-  absl::Status RequestPeerAddress(const GpuCliqueKey& clique_key,
+  absl::Status RequestPeerAddress(const GpuCliqueKey& clique,
                                   const se::DeviceAddressBase& addr);
 
   // Returns all cliques that have symmetric or multicast allocation requests.
   std::vector<GpuCliqueKey> RequestedCliques() const;
 
   // Returns all requested symmetric allocations ordered by clique.
-  std::vector<SymmetricAllocations> OrderedSymmetricAllocations() const;
+  std::vector<CollectiveAllocations> OrderedSymmetricAllocations() const;
 
   // Returns all requested multicast allocations ordered by clique.
-  std::vector<MulticastAllocations> OrderedMulticastAllocations() const;
+  std::vector<CollectiveAllocations> OrderedMulticastAllocations() const;
 
   // Returns all requested peer allocations ordered by clique.
-  std::vector<PeerAllocations> OrderedPeerAllocations() const;
+  std::vector<CollectiveAllocations> OrderedPeerAllocations() const;
 
   size_t symmetric_size() const { return sym_allocations_.size(); }
   size_t multicast_size() const { return mcast_allocations_.size(); }
@@ -165,9 +158,9 @@ class CollectiveMemoryRequests {
 
  private:
   const BufferAllocations& buffers_;
-  absl::flat_hash_map<GpuCliqueKey, SymmetricAllocations> sym_allocations_;
-  absl::flat_hash_map<GpuCliqueKey, MulticastAllocations> mcast_allocations_;
-  absl::flat_hash_map<GpuCliqueKey, PeerAllocations> peer_allocations_;
+  absl::flat_hash_map<GpuCliqueKey, CollectiveAllocations> sym_allocations_;
+  absl::flat_hash_map<GpuCliqueKey, CollectiveAllocations> mcast_allocations_;
+  absl::flat_hash_map<GpuCliqueKey, CollectiveAllocations> peer_allocations_;
 };
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/collective_memory_requests_test.cc
+++ b/xla/backends/gpu/runtime/collective_memory_requests_test.cc
@@ -53,9 +53,9 @@ TEST(CollectiveMemoryRequestsTest, OrderedSymmetricRequests) {
   // ordering.
   auto ordered_requests = requests.OrderedSymmetricAllocations();
   ASSERT_EQ(ordered_requests.size(), 3);
-  EXPECT_EQ(ordered_requests[0].key, k2);
-  EXPECT_EQ(ordered_requests[1].key, k0);
-  EXPECT_EQ(ordered_requests[2].key, k1);
+  EXPECT_EQ(ordered_requests[0].clique, k2);
+  EXPECT_EQ(ordered_requests[1].clique, k0);
+  EXPECT_EQ(ordered_requests[2].clique, k1);
 }
 
 TEST(CollectiveMemoryRequestsTest, OrderedMulticastRequests) {
@@ -79,9 +79,9 @@ TEST(CollectiveMemoryRequestsTest, OrderedMulticastRequests) {
   // ordering.
   auto ordered_requests = requests.OrderedMulticastAllocations();
   ASSERT_EQ(ordered_requests.size(), 3);
-  EXPECT_EQ(ordered_requests[0].key, k2);
-  EXPECT_EQ(ordered_requests[1].key, k0);
-  EXPECT_EQ(ordered_requests[2].key, k1);
+  EXPECT_EQ(ordered_requests[0].clique, k2);
+  EXPECT_EQ(ordered_requests[1].clique, k0);
+  EXPECT_EQ(ordered_requests[2].clique, k1);
 }
 
 TEST(CollectiveMemoryRequestsTest, OrderedPeerRequests) {
@@ -105,9 +105,28 @@ TEST(CollectiveMemoryRequestsTest, OrderedPeerRequests) {
   // ordering.
   auto ordered_requests = requests.OrderedPeerAllocations();
   ASSERT_EQ(ordered_requests.size(), 3);
-  EXPECT_EQ(ordered_requests[0].key, k2);
-  EXPECT_EQ(ordered_requests[1].key, k0);
-  EXPECT_EQ(ordered_requests[2].key, k1);
+  EXPECT_EQ(ordered_requests[0].clique, k2);
+  EXPECT_EQ(ordered_requests[1].clique, k0);
+  EXPECT_EQ(ordered_requests[2].clique, k1);
+}
+
+TEST(CollectiveMemoryRequestsTest, RequestSymmetricAddresses) {
+  GpuCliqueKey k0({kD0, kD1}, 2);
+
+  std::array<char, 10> data0;
+  std::array<char, 10> data1;
+  se::DeviceAddressBase buf0(data0.data(), 10);
+  se::DeviceAddressBase buf1(data1.data(), 10);
+
+  BufferAllocations buffers({buf0, buf1}, /*device_ordinal=*/0, nullptr);
+  CollectiveMemoryRequests requests(buffers);
+
+  std::vector<se::DeviceAddressBase> addrs = {buf0, buf1};
+  TF_ASSERT_OK(requests.RequestSymmetricAddresses(k0, addrs));
+
+  auto ordered = requests.OrderedSymmetricAllocations();
+  ASSERT_EQ(ordered.size(), 1);
+  EXPECT_EQ(ordered[0].allocations.size(), 2);
 }
 
 }  // namespace xla::gpu


### PR DESCRIPTION
Small usability improvement for collective memory requests, add an API that takes `absl::Span` of buffer addresses or allocation slices. Also collapse 3 identical structs into one.