### PR TITLE
[XLA:CPU][oneDNN] Use if_onednn_async instead of if_onednn in onednn_cc_test bazel functions

### DIFF
--- a/xla/service/cpu/tests/BUILD
+++ b/xla/service/cpu/tests/BUILD
@@ -429,7 +429,7 @@ onednn_cc_test(
     ],
 )
 
-xla_cc_test(
+onednn_cc_test(
     name = "onednn_layer_norm_test",
     srcs = ["onednn_layer_norm_test.cc"],
     copts = tsl_copts(),
@@ -449,7 +449,7 @@ xla_cc_test(
     ],
 )
 
-xla_cc_test(
+onednn_cc_test(
     name = "onednn_softmax_test",
     srcs = ["onednn_softmax_test.cc"],
     copts = tsl_copts(),

--- a/xla/service/cpu/tests/BUILD
+++ b/xla/service/cpu/tests/BUILD
@@ -365,7 +365,6 @@ onednn_cc_test(
     copts = tsl_copts(),
     shard_count = 4,
     tags = [
-        "manual",
         "no_oss",
         "notap",
         "pjrt_migration_candidate",
@@ -387,7 +386,6 @@ onednn_cc_test(
     copts = tsl_copts(),
     tags = [
         # TODO: reenable once onednn is supported by the thunk runtime.
-        "manual",
         "no_oss",
         "notap",
         "pjrt_migration_candidate",
@@ -437,7 +435,6 @@ xla_cc_test(
     copts = tsl_copts(),
     tags = [
         # TODO: reenable once onednn is supported by the thunk runtime.
-        "manual",
         "no_oss",
         "notap",
         "pjrt_migration_candidate",

--- a/xla/tsl/mkl/graph.bzl
+++ b/xla/tsl/mkl/graph.bzl
@@ -10,7 +10,7 @@ TODO(penporn): Rename this file to build_rules.bzl since it's not just about gra
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//xla:xla.default.bzl", "xla_cc_test")
 load("//xla/tsl:package_groups.bzl", "DEFAULT_LOAD_VISIBILITY")
-load("//xla/tsl/mkl:build_defs.bzl", "if_graph_api", "if_onednn_async")
+load("//xla/tsl/mkl:build_defs.bzl", "if_graph_api", "if_onednn", "if_onednn_async")
 
 visibility(DEFAULT_LOAD_VISIBILITY)
 
@@ -41,9 +41,9 @@ def onednn_graph_cc_test(
 def onednn_cc_library(srcs = [], hdrs = [], deps = [], **kwargs):
     """cc_library rule with empty src/hdrs/deps if not building with oneDNN."""
     cc_library(
-        srcs = if_onednn_async(srcs),
-        hdrs = if_onednn_async(hdrs),
-        deps = if_onednn_async(deps),
+        srcs = if_onednn(srcs),
+        hdrs = if_onednn(hdrs),
+        deps = if_onednn(deps),
         # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
         **kwargs
     )

--- a/xla/tsl/mkl/graph.bzl
+++ b/xla/tsl/mkl/graph.bzl
@@ -10,7 +10,7 @@ TODO(penporn): Rename this file to build_rules.bzl since it's not just about gra
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//xla:xla.default.bzl", "xla_cc_test")
 load("//xla/tsl:package_groups.bzl", "DEFAULT_LOAD_VISIBILITY")
-load("//xla/tsl/mkl:build_defs.bzl", "if_graph_api", "if_onednn")
+load("//xla/tsl/mkl:build_defs.bzl", "if_graph_api", "if_onednn_async")
 
 visibility(DEFAULT_LOAD_VISIBILITY)
 
@@ -41,9 +41,9 @@ def onednn_graph_cc_test(
 def onednn_cc_library(srcs = [], hdrs = [], deps = [], **kwargs):
     """cc_library rule with empty src/hdrs/deps if not building with oneDNN."""
     cc_library(
-        srcs = if_onednn(srcs),
-        hdrs = if_onednn(hdrs),
-        deps = if_onednn(deps),
+        srcs = if_onednn_async(srcs),
+        hdrs = if_onednn_async(hdrs),
+        deps = if_onednn_async(deps),
         # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
         **kwargs
     )
@@ -55,8 +55,8 @@ def onednn_cc_test(
     """xla_cc_test rule with empty src and deps if not building with oneDNN."""
     xla_cc_test(
         # CC_TEST_OK=This rule is used in XLA.
-        srcs = if_onednn(srcs),
-        deps = if_onednn(if_true = deps, if_false = ["//xla/tsl/platform:test_main"]),
+        srcs = if_onednn_async(srcs),
+        deps = if_onednn_async(if_true = deps, if_false = ["//xla/tsl/platform:test_main"]),
         # If not building with Graph API, we don't have any tests linked.
         fail_if_no_test_linked = False,
         # If not building with Graph API, we don't have any tests defined either.


### PR DESCRIPTION
A [commit](https://github.com/openxla/xla/commit/b49f469068abe70c0631ebb472992ff8fce99c57) recently added the `manual` tag to oneDNN unit tests, since they were failing when `ENABLE_ONEDNN_ASYNC` is not defined, which does not work when one wants to run these tests via wildcard patterns like `bazel test //xla/service/cpu/tests/....`.

Instead of unconditionally adding the `manual` tag, this PR switches `onednn_cc_test` to use `if_onednn_async` so these targets only build when the oneDNN async runtime is enabled (`--define=build_with_onednn_async=true`), rather than for all oneDNN-enabled platforms.