### PR TITLE
[XLA:GPU] Recompute autotuner reference output per candidate on AMDGPU.

### DIFF
--- a/xla/backends/autotuner/autotuner.cc
+++ b/xla/backends/autotuner/autotuner.cc
@@ -645,8 +645,11 @@ absl::StatusOr<std::vector<Autotuner::ConfigResult>> Autotuner::ProfileAll(
       std::unique_ptr<InputBuffers> input_buffers,
       profiler_->CreateInputBuffers(candidates[0].executable.get(), instr));
 
+  // Compute the reference output once, unless the caller asked to recompute
+  // it per candidate (see AutotuneConfig::recompute_reference_per_candidate).
   std::optional<ScopedShapedBuffer> reference_output;
-  if (autotune_config_.check_buffers) {
+  if (autotune_config_.check_buffers &&
+      !autotune_config_.recompute_reference_per_candidate) {
     VLOG(2) << "Checking buffers";
     reference_output = GetReferenceOutput(candidates, *input_buffers);
     if (!reference_output.has_value()) {
@@ -655,6 +658,14 @@ absl::StatusOr<std::vector<Autotuner::ConfigResult>> Autotuner::ProfileAll(
   }
 
   for (int i = 0; i < candidates.size(); ++i) {
+    if (autotune_config_.check_buffers &&
+        autotune_config_.recompute_reference_per_candidate) {
+      reference_output = GetReferenceOutput(candidates, *input_buffers);
+      if (!reference_output.has_value()) {
+        LOG(WARNING) << "No reference output found even though buffer checking ";
+      }
+    }
+
     absl::StatusOr<ProfileResult> profile_result =
         profiler_->Profile(candidates[i].executable.get(), *input_buffers);
 
@@ -917,7 +928,8 @@ std::string AutotuneConfig::ToString() const {
       "  \"select_first_config\": %s,\n"
       "  \"use_default_config\": %s,\n"
       "  \"dump_hlos\": %s,\n"
-      "  \"allow_reg_spills\": %s\n"
+      "  \"allow_reg_spills\": %s,\n"
+      "  \"recompute_reference_per_candidate\": %s\n"
       "}",
       check_buffers ? "true" : "false", relative_tolerance,
       crash_on_check_failure ? "true" : "false",
@@ -926,7 +938,8 @@ std::string AutotuneConfig::ToString() const {
       exclude_cublas_config ? "true" : "false",
       select_first_config ? "true" : "false",
       use_default_config ? "true" : "false", dump_hlos ? "true" : "false",
-      allow_reg_spills ? "true" : "false");
+      allow_reg_spills ? "true" : "false",
+      recompute_reference_per_candidate ? "true" : "false");
 }
 
 AutotunerCacheInterface::CacheStats Autotuner::GetCacheStats() {

--- a/xla/backends/autotuner/autotuner.h
+++ b/xla/backends/autotuner/autotuner.h
@@ -90,6 +90,11 @@ struct AutotuneConfig {
   bool dump_hlos = false;
   // Whether to allow or discard configs that ptxas warns will spill registers.
   bool allow_reg_spills = false;
+  // If true, recompute the reference output before each candidate compare
+  // instead of computing it once and reusing it. Mitigates a multi-process
+  // race on AMDGPU where the hoisted reference buffer can be perturbed
+  // between compares.
+  bool recompute_reference_per_candidate = false;
 
   std::string ToString() const;
 };

--- a/xla/service/gpu/autotuning/BUILD
+++ b/xla/service/gpu/autotuning/BUILD
@@ -267,6 +267,7 @@ cc_library(
         "//xla/stream_executor:device_address_allocator",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor/rocm:rocm_platform_id",
         "//xla/stream_executor/sycl:sycl_platform_id",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:errors",

--- a/xla/service/gpu/autotuning/autotuner_pass.cc
+++ b/xla/service/gpu/autotuning/autotuner_pass.cc
@@ -38,6 +38,7 @@ limitations under the License.
 #include "xla/service/compiler.h"
 #include "xla/stream_executor/device_address_allocator.h"
 #include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/stream_executor/sycl/sycl_platform_id.h"
 #include "xla/tsl/platform/errors.h"
@@ -126,6 +127,12 @@ absl::StatusOr<std::unique_ptr<AutotunerPass>> AutotunerPass::Create(
       // BufferComparatorKernel and RedzoneAllocatorKernel are registered for
       // SYCL platform.
       autotune_config.check_buffers = false;
+    }
+    if (stream_executor->GetPlatform()->id() ==
+        stream_executor::rocm::kROCmPlatformId) {
+      // Workaround for a multi-process race on AMDGPU where the hoisted
+      // reference buffer can be perturbed between candidate compares.
+      autotune_config.recompute_reference_per_candidate = true;
     }
     profiler = GpuProfiler::Create(
         stream_executor, GetProfileOptions(debug_options, autotune_config),


### PR DESCRIPTION
The fusion autotuner exhibits a multi-process race on AMDGPU when several XLA processes share one physical GPU and concurrently run the autotuner pass: the hoisted reference output buffer in Autotuner::ProfileAll can be perturbed between candidate compares, causing every candidate to fail with WRONG RESULTS in a single failed pass and surfacing as

  jax.errors.JaxRuntimeError: INTERNAL: Autotuning failed for HLO ...
    All configs failed during profiling. Failures (N): WRONG RESULTS

under "pytest -n N". The race is at the reference-buffer level (cross- process flock on the pass eliminates the loud failure but introduces other timing pathologies; --xla_gpu_fusion_autotune_top_k_configs=1 does not cure since the race fires with even one candidate).

Add an AutotuneConfig knob, recompute_reference_per_candidate, that moves the GetReferenceOutput call inside Autotuner::ProfileAll's candidate loop, shrinking the contamination window to a single compute+compare pair. Enabled in AutotunerPass::Create when the StreamExecutor's platform is ROCm; default-off for CUDA and SYCL. Cost on AMDGPU is up to ~2x autotuner profile time, paid once at compile.

Verified on gfx950 / ROCm 7.2: 0 autotuner WRONG RESULTS across 10,079 tests in a CI-density pytest -n 16 sweep (vs ~3 per 8-proc run before the patch).

📝 Summary of Changes
Please provide a clear and concise summary of the changes you've made.

🎯 Justification
Explain why this change is important and which workload benefits from this
change.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement,
✨ New Feature, ♻️ Cleanup, 📚 Documentation, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
