### PR TITLE
[xla:gpu] Disable fabric handles in CudaExecutor::Init if not needed

### DIFF
--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -1334,6 +1334,7 @@ xla_test(
     tags = ["cuda-only"],
     deps = [
         ":cuda_compute_capability",
+        ":cuda_executor",
         ":cuda_platform",
         ":cuda_vmm_allocator",
         "//xla/stream_executor:device_address",

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -29,7 +29,6 @@ limitations under the License.
 #include <utility>
 #include <variant>
 
-#include "cub/version.cuh"
 #include "absl/algorithm/container.h"
 #include "absl/base/call_once.h"
 #include "absl/base/casts.h"
@@ -52,6 +51,7 @@ limitations under the License.
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/gpus/cuda/include/driver_types.h"
 #include "third_party/gpus/cuda/nvml/include/nvml.h"
+#include "cub/version.cuh"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/core/collectives/collectives.h"
 #include "xla/core/collectives/collectives_registry.h"
@@ -958,6 +958,21 @@ absl::Status CudaExecutor::Init() {
   TF_ASSIGN_OR_RETURN(vmm_options_, QueryVmmOptions(device_));
   vmm_options_.enable_peer_access = absl::c_any_of(
       peer_access_cache_, [](const auto& p) { return p.second; });
+
+  // Disable fabric handle if there are no active P2P NVLinks — using
+  // FABRIC+POSIX_FD without a cluster causes allocation failures.
+  if (vmm_options_.enable_fabric_handle) {
+    absl::MutexLock l(GetNVMLLock());
+    if (auto nvml_device = GetNvmlDevice(GetPCIBusID(device_));
+        nvml_device.ok()) {
+      auto p2p_links = GetNumberOfActiveP2PNvlinks(*nvml_device);
+      if (!p2p_links.ok() || *p2p_links == 0) {
+        XLA_VLOG_DEVICE(2, device_ordinal())
+            << "Disabling fabric handle: no active P2P NVLinks detected.";
+        vmm_options_.enable_fabric_handle = false;
+      }
+    }
+  }
 
   device_allocator_ = std::make_unique<CudaDeviceAllocator>(this);
   host_allocator_ = std::make_unique<CudaHostAllocator>(this, numa_node_);

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -961,17 +961,11 @@ absl::Status CudaExecutor::Init() {
 
   // Disable fabric handle if there are no active P2P NVLinks — using
   // FABRIC+POSIX_FD without a cluster causes allocation failures.
-  if (vmm_options_.enable_fabric_handle) {
-    absl::MutexLock l(GetNVMLLock());
-    if (auto nvml_device = GetNvmlDevice(GetPCIBusID(device_));
-        nvml_device.ok()) {
-      auto p2p_links = GetNumberOfActiveP2PNvlinks(*nvml_device);
-      if (!p2p_links.ok() || *p2p_links == 0) {
-        XLA_VLOG_DEVICE(2, device_ordinal())
-            << "Disabling fabric handle: no active P2P NVLinks detected.";
-        vmm_options_.enable_fabric_handle = false;
-      }
-    }
+  if (vmm_options_.enable_fabric_handle &&
+      GetDeviceDescription().device_interconnect_info().active_links == 0) {
+    XLA_VLOG_DEVICE(2, device_ordinal())
+        << "Disabling fabric handle: no active P2P NVLinks detected.";
+    vmm_options_.enable_fabric_handle = false;
   }
 
   device_allocator_ = std::make_unique<CudaDeviceAllocator>(this);

--- a/xla/stream_executor/cuda/cuda_vmm_allocator.cc
+++ b/xla/stream_executor/cuda/cuda_vmm_allocator.cc
@@ -65,8 +65,7 @@ static CUmemAllocationProp GetAllocationProp(
 // properties and falls back through progressively simpler handle types:
 //   FABRIC+POSIX_FD -> POSIX_FD -> NONE
 static absl::StatusOr<CUmemGenericAllocationHandle> CreatePhysicalAllocation(
-    CUmemAllocationProp properties, uint64_t padded_size,
-    bool enable_fabric_handle) {
+    CUmemAllocationProp properties, uint64_t padded_size) {
   CUmemGenericAllocationHandle handle;
 
   auto try_create = [&](const char* description)
@@ -87,9 +86,7 @@ static absl::StatusOr<CUmemGenericAllocationHandle> CreatePhysicalAllocation(
     return cuda::ToStatus(result);
   };
 
-  bool has_fabric =
-      properties.requestedHandleTypes & CU_MEM_HANDLE_TYPE_FABRIC &&
-      enable_fabric_handle;
+  bool has_fabric = properties.requestedHandleTypes & CU_MEM_HANDLE_TYPE_FABRIC;
   bool has_posix_fd = properties.requestedHandleTypes &
                       CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
 
@@ -142,17 +139,8 @@ VmmAllocate(StreamExecutor* executor, const CudaVmmAllocator::Options& options,
   size_t effective_alignment = std::max(options.alignment, granularity);
   uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, effective_alignment);
 
-  const bool enable_fabric_handle =
-      executor->GetDeviceDescription().device_interconnect_info().active_links >
-      0;
-
-  XLA_VLOG_DEVICE(3, executor->device_ordinal())
-      << "Creating physical allocation with handle types: "
-      << properties.requestedHandleTypes
-      << ". Enable fabric handle: " << enable_fabric_handle;
-  ASSIGN_OR_RETURN(
-      CUmemGenericAllocationHandle handle,
-      CreatePhysicalAllocation(properties, padded_size, enable_fabric_handle));
+  ASSIGN_OR_RETURN(CUmemGenericAllocationHandle handle,
+                   CreatePhysicalAllocation(properties, padded_size));
 
   absl::Cleanup release_handle = [&] {
     absl::Status status = cuda::ToStatus(cuMemRelease(handle));

--- a/xla/stream_executor/cuda/cuda_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_vmm_allocator_test.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "absl/log/scoped_mock_log.h"
 #include "absl/types/span.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
+#include "xla/stream_executor/cuda/cuda_executor.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/memory_allocation.h"
@@ -136,8 +137,10 @@ TEST_P(CudaVmmAllocatorTest, HopperNoWarningCheck) {
     GTEST_SKIP() << "Test only runs on H100+";
   }
 
+  auto* cuda_executor = static_cast<CudaExecutor*>(executor);
+
   CudaVmmAllocator::Options options = MakeTestOptions(GetParam());
-  options.enable_fabric_handle = true;
+  options.enable_fabric_handle = cuda_executor->is_fabric_supported();
   options.enable_posix_fd_handle = true;
 
   absl::ScopedMockLog log(absl::MockLogDefault::kIgnoreUnexpected);


### PR DESCRIPTION
Instead of ignoring the flag in allocator set it to false in `CudaExecutor::Init` if device doesn't have P2P links