### PR TITLE
[DOCS] Reorganize ToC with granular & topical sections

### DIFF
--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -1,111 +1,128 @@
 toc:
-- heading: XLA developer guide
+- heading: XLA documentation
 - title: Getting started
-  # These should be in alphabetical order unless otherwise noted.
-  section:
   # This is the default tab for the Getting started section.
-  - title: Overview
+  section:
+  - title: Introduction
     path: /xla
-  - title: Operation semantics
-    path: /xla/operation_semantics
-  - title: XLA architecture
+  - title: XLA architecture overview
     path: /xla/architecture
   - title: XLA terminology
     path: /xla/terminology
-  - title: HLO to Thunks
-    path: /xla/hlo_to_thunks
-- title: Developer details
-  # These should be in alphabetical order unless otherwise noted.
+  - title: XLA flags guidance
+    path: /xla/flags_guidance
+
+- title: Topical guides
+  # This is the default tab for the Topical guides section.
   section:
+  - title: Journey from HLO to executable
+    path: /xla/hlo_to_thunks
+  # XLA Ops sub-section
+  - heading: XLA Ops
+  - title: Operation semantics
+    path: /xla/operation_semantics
+  - title: HLO Passes
+    path: /xla/hlo_passes
   - title: Aliasing
     path: /xla/aliasing
   - title: Async HLO instructions
     path: /xla/async_ops
-  - title: Broadcasting
-    path: /xla/broadcasting
-  - title: Copybara quirks
-    path: /xla/copybara
-  - title: Determinism
-    path: /xla/determinism
-  - title: Effort Levels
-    path: /xla/effort_levels
-  - title: Emitters
-    path: /xla/emitters
-  - title: GPU architecture
-    path: /xla/gpu_architecture
-  - title: Hermetic CUDA overview
-    path: /xla/hermetic_cuda
-  - title: HLO Passes
-    path: /xla/hlo_passes
-  - title: Indexing Analysis
-    path: /xla/indexing
-  - title: LHS Cost Model
-    path: /xla/lhs_cost_model
-  - title: Megascale
-    path: /xla/megascale/overview
-  - title: Multi-host HLO runner
-    path: /xla/tools_multihost_hlo_runner
-  - title: Persisted autotuning
-    path: /xla/persisted_autotuning
+  # Data representation sub-section
+  - heading: Data representation
   - title: Shapes and layout
     path: /xla/shapes
-  - title: SparseCore
-    path: /xla/sparsecore
-  - title: Symbolic expressions and maps
-    path: /xla/symbolic_expression
-  - title: Testing HLO passes
-    path: /xla/test_hlo_passes
   - title: Tiled layout
     path: /xla/tiled_layout
-  - title: Setting Up Developer Environment
-    path: /xla/developer_environment
-  - title: Writing custom calls
+  - title: Symbolic expressions and maps
+    path: /xla/symbolic_expression
+  - title: Indexing Analysis
+    path: /xla/indexing
+  - title: Broadcasting
+    path: /xla/broadcasting
+  # GPU backend sub-section
+  - heading: GPU backend
+  - title: GPU architecture
+    path: /xla/gpu_architecture
+  - title: GPU Emitters
+    path: /xla/emitters
+  - title: Persisted autotuning
+    path: /xla/persisted_autotuning
+  - title: Determinism (GPU)
+    path: /xla/determinism
+  # TPU backend sub-section
+  - heading: TPU backend
+  - title: Sparsecore (embeddings)
+    path: /xla/sparsecore
+  - title: Megascale
+    path: /xla/megascale/overview
+  # Performance sub-section
+  - heading: Performance
+  - title: LHS Cost Model
+    path: /xla/lhs_cost_model
+  - title: Effort Levels
+    path: /xla/effort_levels
+  # Advanced guides sub-section
+  - heading: Advanced guides
+  - title: Write custom calls
     path: /xla/custom_call
-  - title: XLA Flags guidance
-    path: /xla/flags_guidance
-  - title: XLA Tooling
-    path: /xla/tools
+  - title: Develop a new backend for XLA
+    path: /xla/developing_new_backend
+
 - title: Debugging
   section:
   # This is the default tab for the Debugging section.
-  - title: Dump HLO Computations
+  - heading: XLA tooling
+  - title: Dump HLO computations
     path: /xla/hlo_dumps
-  - title: Errors Overview
+  - title: Errors overview
     path: /xla/errors_overview
-  - title: Error Codes
+  - title: Error codes
     path: /xla/error_codes
   - title: Debug OOM errors with XProf
     path: /xla/oom_debugging
   - title: Debug Megascale
     path: /xla/megascale/debugging_workflow
+    # XLA Tools sub-section
+  - heading: XLA tools
+  - title: XLA tooling
+    path: /xla/tools
+  - title: Multi-host HLO runner
+    path: /xla/tools_multihost_hlo_runner
+
 - title: Contributing
-  # These should be in alphabetical order unless otherwise noted.
-  section:
   # This is the default tab for the Contributing section.
-  - title: Contributing
-    path: /xla/contributing
-  - title: Build from source
-    path: /xla/build_from_source
-  - title: Develop a new backend for XLA
-    path: /xla/developing_new_backend
+  section:
   - title: Developer guide
     path: /xla/developer_guide
-- title: PJRT Plugins
+  - title: Set up development environment
+    path: /xla/developer_environment
+  - title: Build from source
+    path: /xla/build_from_source
+  - title: Testing HLO passes
+    path: /xla/test_hlo_passes
+  - title: Copybara quirks
+    path: /xla/copybara
+
+- title: PJRT plugins
+  # This is the default tab for the PJRT section.
   section:
+  - title: "PJRT - Uniform Device API"
+    path: /xla/pjrt/overview
+  - title: PJRT C++ API overview
+    path: /xla/pjrt/cpp_api_overview
   - title: Develop a new PJRT plugin
     path: /xla/pjrt/pjrt_integration
-  - title: PJRT C++ API Overview
-    path: /xla/pjrt/cpp_api_overview
-  - title: PJRT Examples
+  - title: PJRT examples
     path: /xla/pjrt/examples
-- title: Using XLA in TensorFlow
-  # These should be in alphabetical order unless otherwise noted.
+
+- title: XLA frontends
+  # This is the default tab for the XLA frontends section.
   section:
-  - title: Using XLA in TensorFlow
+  - title: Use XLA in TensorFlow
     path: /xla/tf2xla
-  - title: Use tfcompile
-    path: /xla/tf2xla/tfcompile
-  - title: Autoclustering tutorial
-    path: /xla/tf2xla/tutorials/autoclustering_xla
-  - title: Use XLA with tf.function
-    path: /xla/tf2xla/tutorials/jit_compile
+  - title: Use XLA in JAX
+    path: https://docs.jax.dev/en/latest/notebooks/thinking_in_jax.html
+    status: external
+  - title: Use XLA in PyTorch
+    path: https://docs.pytorch.org/xla/release/r2.8/index.html#pytorch-xla-documentation
+    status: external

--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -118,11 +118,16 @@ toc:
 - title: XLA frontends
   # This is the default tab for the XLA frontends section.
   section:
-  - title: Use XLA in TensorFlow
-    path: /xla/tf2xla
-  - title: Use XLA in JAX
+  - title: JAX
     path: https://docs.jax.dev/en/latest/notebooks/thinking_in_jax.html
     status: external
-  - title: Use XLA in PyTorch
+  - title: "PyTorch/XLA"
     path: https://docs.pytorch.org/xla/release/r2.8/index.html#pytorch-xla-documentation
     status: external
+  - heading: TensorFlow
+  - title: Use XLA in TensorFlow
+    path: /xla/tf2xla
+  - title: Autoclustering tutorial
+    path: /xla/tf2xla/tutorials/autoclustering_xla
+  - title: Use XLA with tf.function
+    path: /xla/tf2xla/tutorials/jit_compile


### PR DESCRIPTION
**📝 Summary of Changes**

- Table of contents is re-organized with the following sections and subsections:

```
- Getting started
- Topical guides
    - XLA Ops
    - Data representation
    - GPU backend
    - TPU backend
    - Performance
    - Advanced guides
- Debugging
  - XLA tools
- Contributing
- PJRT plugins
- XLA frontends
  - Tensorflow # to group all tensorflow-specific pages together
```

- Some pages titles were updated:
  - Re-phrased for more clarity
  - Sentence case capitalization (per the [google developer docs style-guide](https://developers.google.com/style/highlights))

**🎯 Justification**

Currently, a large portion of docs are grouped in the "Developer details" section, and presented in alphabetical order. 
This section also includes some contribution-related docs like setting up development environment.

Re-organizing the pages to group similar topics together can help users better navigate the docs, and gives a little more context to some topics.

**🚀 Kind of Contribution**

📚 Documentation