### PR TITLE
[xla:ffi] When setting opaque state require TypeInfo

### DIFF
--- a/xla/ffi/execution_state.cc
+++ b/xla/ffi/execution_state.cc
@@ -31,19 +31,14 @@ limitations under the License.
 
 namespace xla::ffi {
 
-absl::Status ExecutionState::Set(TypeId type_id, void* state) {
-  TF_ASSIGN_OR_RETURN(auto type_info, TypeRegistry::GetTypeInfo(type_id));
-  if (type_info.deleter == nullptr) {
-    return InvalidArgument(
-        "Type id %d does not have a registered type info with a deleter",
-        type_id.value());
-  }
-  return Set(type_id, type_info, state);
-}
-
 absl::Status ExecutionState::Set(TypeId type_id, TypeInfo type_info,
                                  void* state) {
-  DCHECK(state && type_info.deleter) << "State and deleter must not be null";
+  if (state == nullptr) {
+    return InvalidArgument("State must be not null");
+  }
+  if (type_info.deleter == nullptr) {
+    return InvalidArgument("Type info must have a deleter");
+  }
 
   if (state_ != nullptr) {
     return FailedPrecondition("State is already set with a type id %v",

--- a/xla/ffi/execution_state.h
+++ b/xla/ffi/execution_state.h
@@ -54,9 +54,9 @@ class ExecutionState {
   using TypeId = TypeRegistry::TypeId;
   using TypeInfo = TypeRegistry::TypeInfo;
 
-  // Sets opaque state with a given type id. Returns an error if state is
-  // already set, or if type id is not supported as a state.
-  absl::Status Set(TypeId type_id, void* state);
+  // Sets opaque state with a given type id and type info. Returns an error if
+  // state is already set.
+  absl::Status Set(TypeId type_id, TypeInfo type_info, void* state);
 
   // Returns opaque state of the given type id. If set state type id does not
   // match the requested one, returns an error.
@@ -85,8 +85,6 @@ class ExecutionState {
     TypeId type_id;
     TypeInfo type_info;
   };
-
-  absl::Status Set(TypeId type_id, TypeInfo type_info, void* state);
 
   std::unique_ptr<void, Deleter> state_;
 };

--- a/xla/ffi/execution_state_test.cc
+++ b/xla/ffi/execution_state_test.cc
@@ -80,7 +80,7 @@ TEST(ExecutionStateTest, SetAndGetForExternalType) {
   int32_t* value = new int32_t(42);
 
   // Once set, state can be retrieved.
-  TF_ASSERT_OK(state.Set(type_id, value));
+  TF_ASSERT_OK(state.Set(type_id, type_info, value));
   EXPECT_TRUE(state.IsSet());
 
   TF_ASSERT_OK_AND_ASSIGN(void* data, state.Get(type_id));
@@ -112,7 +112,7 @@ TEST(ExecutionStateTest, Serialization) {
       TypeRegistry::AssignTypeId("my_state_type", type_info));
 
   ExecutionState state;
-  TF_ASSERT_OK(state.Set(type_id, new MyState{"some_state_data"}));
+  TF_ASSERT_OK(state.Set(type_id, type_info, new MyState{"some_state_data"}));
 
   TF_ASSERT_OK_AND_ASSIGN(ExecutionStateProto proto, state.ToProto());
 

--- a/xla/ffi/ffi.h
+++ b/xla/ffi/ffi.h
@@ -747,8 +747,9 @@ struct ResultEncoding<stage, absl::StatusOr<std::unique_ptr<T>>> {
               ctx, static_cast<XLA_FFI_ExecutionStage>(stage)));
       DCHECK(execution_state) << "ExecutionState must be set";
 
-      absl::Status status =
-          execution_state->Set(internal::GetTypeId<T>(api), state->release());
+      absl::Status status = execution_state->Set(internal::GetTypeId<T>(api),
+                                                 TypeRegistry::GetTypeInfo<T>(),
+                                                 state->release());
       if (ABSL_PREDICT_TRUE(status.ok())) {
         return nullptr;
       }

--- a/xla/ffi/ffi_api.cc
+++ b/xla/ffi/ffi_api.cc
@@ -370,8 +370,14 @@ static XLA_FFI_Error* XLA_FFI_State_Set(XLA_FFI_State_Set_Args* args) {
   ExecutionState* execution_state = GetExecutionState(args->ctx, args->stage);
   DCHECK(execution_state) << "ExecutionState must be set";
 
-  absl::Status status = execution_state->Set(
-      TypeRegistry::TypeId(args->type_id->type_id), args->state);
+  TypeRegistry::TypeId type_id(args->type_id->type_id);
+
+  auto type_info = TypeRegistry::GetTypeInfo(type_id);
+  if (!type_info.ok()) {
+    return new XLA_FFI_Error{type_info.status()};
+  }
+
+  absl::Status status = execution_state->Set(type_id, *type_info, args->state);
   if (!status.ok()) {
     return new XLA_FFI_Error{std::move(status)};
   }


### PR DESCRIPTION
When setting FFI state via `TypeId` require passing `TypeInfo` as well. Templated APIs are supposed to be used in statically linked binaries, and when different FFI handlers can be in separate object files we rely on opaque type ids and state, and always lookup them through FFI API.

This is one more fix required for making "internal" FFI headers "safe" when linked as multiple object files. This is still not safe in general and not recommended, but this is an escape hatch that makes it work correctly when XLA and FFI handler compiled with the same toolchain.