### PR TITLE
Avoid normalizing batched gathers with overlapping batching dims and start_index_map

### DIFF
--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -6090,6 +6090,7 @@ xla_cc_test(
     srcs = ["batched_gather_scatter_normalizer_test.cc"],
     deps = [
         ":batched_gather_scatter_normalizer",
+        "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "//xla/tests:xla_internal_test_main",
         "@com_google_absl//absl/strings:string_view",

--- a/xla/service/batched_gather_scatter_normalizer.cc
+++ b/xla/service/batched_gather_scatter_normalizer.cc
@@ -38,9 +38,24 @@ limitations under the License.
 namespace xla {
 
 namespace {
+bool HasOverlap(absl::Span<const int64_t> lhs, absl::Span<const int64_t> rhs) {
+  return absl::c_any_of(lhs, [&](int64_t value) {
+    return absl::c_linear_search(rhs, value);
+  });
+}
+
 bool IsBatchGather(const HloGatherInstruction* gather) {
   const auto& dims = gather->gather_dimension_numbers();
   return !dims.operand_batching_dims().empty();
+}
+
+bool CanNormalizeBatchGather(const HloGatherInstruction* gather) {
+  const auto& dims = gather->gather_dimension_numbers();
+  // The normalized non-batch gather prepends operand_batching_dims to
+  // start_index_map. If the two lists overlap, the rewritten ordinary gather
+  // would have duplicate start_index_map entries and fail HLO validation.
+  return IsBatchGather(gather) &&
+         !HasOverlap(dims.operand_batching_dims(), dims.start_index_map());
 }
 
 bool IsBatchScatter(const HloScatterInstruction* scatter) {
@@ -219,7 +234,7 @@ bool BatchedGatherScatterNormalizer::InstructionMatchesPattern(
     HloInstruction* inst) {
   if (inst->opcode() == HloOpcode::kGather) {
     auto* gather = DynCast<HloGatherInstruction>(inst);
-    return IsBatchGather(gather);
+    return CanNormalizeBatchGather(gather);
   }
   if (inst->opcode() == HloOpcode::kScatter) {
     auto* scatter = DynCast<HloScatterInstruction>(inst);

--- a/xla/service/batched_gather_scatter_normalizer_test.cc
+++ b/xla/service/batched_gather_scatter_normalizer_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 
 namespace xla {
@@ -224,6 +225,40 @@ ENTRY %Gather (input_tensor: f32[50,49,48,47,46,0], start_indices: s64[10,9,8,7,
     CHECK-SAME:     index_vector_dim=4,
     CHECK-SAME:     slice_sizes={30,29,28,27,26,0}
   )");
+}
+
+TEST_F(BatchedGatherScatterNormalizerTest,
+       DoNotNormalizeBatchGatherWhenBatchingDimsOverlapStartIndexMap) {
+  constexpr absl::string_view kModuleStr = R"(
+HloModule overlap_batch_gather, entry_computation_layout={(s32[4,40,1]{2,1,0})->s32[4,40,2]{2,1,0}}
+
+ENTRY %entry (start_indices: s32[4,40,1]) -> s32[4,40,2] {
+  %iota = s32[4,1]{1,0} iota(), iota_dimension=0
+  %zero = s32[] constant(0)
+  %pad = s32[4,2]{1,0} pad(s32[4,1]{1,0} %iota, s32[] %zero), padding=0_0x0_1
+  %start_indices = s32[4,40,1]{2,1,0} parameter(0)
+  ROOT %gather = s32[4,40,2]{2,1,0}
+    gather(s32[4,2]{1,0} %pad, s32[4,40,1]{2,1,0} %start_indices),
+    offset_dims={2}, collapsed_slice_dims={}, start_index_map={0},
+    operand_batching_dims={0}, start_indices_batching_dims={0},
+    index_vector_dim=2, slice_sizes={1,2}
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      RunAndCheckHloRewrite(kModuleStr, BatchedGatherScatterNormalizer(),
+                            /*expect_change=*/false));
+
+  auto* gather = DynCast<HloGatherInstruction>(
+      module->entry_computation()->root_instruction());
+  ASSERT_NE(gather, nullptr);
+  const auto& dims = gather->gather_dimension_numbers();
+  EXPECT_EQ(dims.start_index_map_size(), 1);
+  EXPECT_EQ(dims.start_index_map(0), 0);
+  EXPECT_EQ(dims.operand_batching_dims_size(), 1);
+  EXPECT_EQ(dims.operand_batching_dims(0), 0);
+  EXPECT_EQ(dims.start_indices_batching_dims_size(), 1);
+  EXPECT_EQ(dims.start_indices_batching_dims(0), 0);
 }
 
 TEST_F(BatchedGatherScatterNormalizerTest, NormalizeBatchScatter) {


### PR DESCRIPTION
**Summary of Changes**

Fixes BatchedGatherScatterNormalizer so it does not rewrite a valid batched gather when operand_batching_dims overlaps start_index_map.

The normalizer rewrites a batched gather into an ordinary gather by prepending operand_batching_dims to start_index_map. If the same operand dimension is present in both lists, the rewritten ordinary gather has duplicate start_index_map entries, for example {0, 0}. Ordinary gather validation requires those entries to be distinct, so the pass can emit invalid HLO.

The patch adds a small disjointness guard before matching batched gathers for normalization. When the overlap case appears, the pass now leaves the original valid batched gather unchanged.

**Justification**

This is a correctness fix for invalid IR generation in an HLO pass. A legal batched gather can encode one dimension as both an explicit batching dimension and an indexed dimension. XLA's batched gather semantics handle that case by giving explicit batching dims precedence, but the current normalization loses that distinction and constructs an ordinary gather whose metadata is rejected by the ordinary gather verifier.

A minimal poc:

```hlo
ROOT %gather = s32[4,40,2]{2,1,0}
  gather(s32[4,2]{1,0} %pad, s32[4,40,1]{2,1,0} %start_indices),
  offset_dims={2}, collapsed_slice_dims={}, start_index_map={0},
  operand_batching_dims={0}, start_indices_batching_dims={0},
  index_vector_dim=2, slice_sizes={1,2}
```

Before this patch, normalization prepends operand_batching_dims={0} to start_index_map={0}, producing start_index_map={0,0} for an ordinary gather. After this patch, the pass recognizes that this normalization would be
ill-formed and skips the rewrite.


**Kind of Contribution**

Bug Fix, Tests

**Unit Tests:**

Added
`BatchedGatherScatterNormalizerTest.DoNotNormalizeBatchGatherWhenBatchingDimsOverlapStartIndexMap`.

The test builds a minimal HLO module with overlapping `operand_batching_dims={0}` and `start_index_map={0}`, runs
`BatchedGatherScatterNormalizer`, and asserts that the pass reports no change and preserves the original batched gather metadata.

**Execution Tests:**

No new execution test. This is a pass-level IR validity fix covered by the unit test above.