### PR TITLE
Gpu profiler deadlock ending up in DelayKernel timeout when autotuning in parallel

### DIFF
--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -526,6 +526,44 @@ GpuExecutable::GpuExecutable(
 }
 
 GpuExecutable::~GpuExecutable() {
+  // Take reader locks on the per-device GPU mutex for all executors this
+  // executable has been run on. This prevents cuModuleUnload (triggered by
+  // kernel/thunk destruction below) from racing with the DelayKernel used
+  // during autotuning profiling. The profiler holds the writer lock while the
+  // DelayKernel is active; taking reader locks here ensures we wait for
+  // profiling to finish before unloading modules.
+  std::vector<se::StreamExecutor*> executors;
+  executors.reserve(module_handles_.size());
+  {
+    absl::MutexLock lock(&module_handle_mutex_);
+    for (const auto& module_handle : module_handles_) {
+      executors.push_back(module_handle.first);
+    }
+  }
+
+  std::vector<std::unique_ptr<absl::ReaderMutexLock>> gpu_locks;
+  gpu_locks.reserve(executors.size());
+  // Prevent deadlocks by taking the locks in a deterministic order.
+  absl::c_sort(executors, [](se::StreamExecutor* lhs,
+                             se::StreamExecutor* rhs) {
+    return reinterpret_cast<uintptr_t>(lhs) <
+           reinterpret_cast<uintptr_t>(rhs);
+  });
+  for (se::StreamExecutor* executor : executors) {
+    gpu_locks.push_back(
+        std::make_unique<absl::ReaderMutexLock>(&GetGpuMutex(executor)));
+  }
+
+  // Explicitly destroy thunks and module handles under the reader locks.
+  // Thunk destruction triggers kernel unloading (CudaExecutor::UnloadKernel ->
+  // cuModuleUnload). This must happen while we hold reader locks to prevent
+  // cuModuleUnload from racing with the DelayKernel on another thread.
+  thunk_executor_.reset();
+  {
+    absl::MutexLock lock(&module_handle_mutex_);
+    module_handles_.clear();
+  }
+
   if (has_module() && enable_debug_info_manager_) {
     XlaDebugInfoManager::Get()->UnregisterModule(module().unique_id());
   }


### PR DESCRIPTION
📝 Summary of Changes
This PR improves parallel compilation with PJRT_Cient_Compile when autotuning is enabled. It includes a patch for the identified bug here https://github.com/openxla/xla/pull/41399#discussion_r3167394394.

Autotuning relies on a DelayKernel to ensure that the start event is recorded just before the profiled kernel. It's a simple spin loop that keeps the GPU busy until the host could schedule the start & end recording and the profiled kernel launches. Once that's done the host changes a semaphore to signal that the spin loop can stop. This works fine when a single PJRT_Cient_Compile is called. But when calling in parallel, we're seeing DelayKernel timing out all the time.

After some investigation, it's due to CUDA calls such as cuMemcpyDtoHAsync that block while the DelayKernel spins in the same stream. The problem is that this then blocks further calls like cuRecordEvent, and now the start/end event recording cannot be scheduled and we end up in a deadlock between a thread that wants to profile and another one that intends to check input or output buffers. The deadlock is only "solved" through the timeout mechanism.

The first commit takes the gpu lock in shared mode to avoid the checks to execute simultaneously with the profiling. That solves almost all deadlocks. But I still noticed a few deadlocks because of cuModuleUnloadwithin the ScopedModuleHandle desctructor. It's more complicated to prevent any conflicts here. So I propose here one fairly minimal solution that ensures we have a shared lock before calling the destructors, but I'm not sure whether that's acceptable.

🎯 Justification
Today compiling multiple program in parallel with PJRT_Cient_Compile is slower for us than compiling them sequentially. Given that auto-tuning takes a significant amount of time and needs to happen at start-up we want to minimize it as much as possible.

I've tested on the 5090 (CUDA 13.1 / 590.48.01) and 4090 (CUDA 13 / 580.95.05).

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix