### PR TITLE
[XLA:GPU] Disable transfer buffer coalescing

### DIFF
--- a/xla/backends/gpu/host_offloading/BUILD
+++ b/xla/backends/gpu/host_offloading/BUILD
@@ -60,13 +60,17 @@ xla_test(
     backends = ["gpu"],
     deps = [
         ":gpu_host_offloading_allocator",
+        "//xla/core/host_offloading:host_offloading_allocator",
         "//xla/service:platform_util",
+        "//xla/stream_executor:device_address",
         "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:status_matchers",
     ],
 )

--- a/xla/backends/gpu/host_offloading/gpu_host_offloading_allocator.cc
+++ b/xla/backends/gpu/host_offloading/gpu_host_offloading_allocator.cc
@@ -124,7 +124,11 @@ class TransferBufferSubAllocator : public tsl::SubAllocator {
   void* Alloc(size_t alignment, size_t num_bytes, size_t* bytes_received) final;
   void Free(void* ptr, size_t num_bytes) final;
 
-  bool SupportsCoalescing() const final { return true; }
+  // Transfer buffers are passed directly to D2H/H2D copies. Coalescing
+  // adjacent HostMemoryAllocate regions into one logical BFC range can trigger
+  // CUDA_ERROR_INVALID_VALUE during transfers, so keep each chunk within a
+  // single HostMemoryAllocate region.
+  bool SupportsCoalescing() const final { return false; }
 
  private:
   stream_executor::StreamExecutor* executor_;

--- a/xla/backends/gpu/host_offloading/gpu_host_offloading_allocator_test.cc
+++ b/xla/backends/gpu/host_offloading/gpu_host_offloading_allocator_test.cc
@@ -15,14 +15,23 @@ limitations under the License.
 
 #include "xla/backends/gpu/host_offloading/gpu_host_offloading_allocator.h"
 
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include <gtest/gtest.h>
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
+#include "xla/core/host_offloading/host_offloading_allocator.h"
 #include "xla/service/platform_util.h"
+#include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/platform/statusor.h"
+#include "tsl/platform/status_matchers.h"
 
 namespace xla::gpu {
 
@@ -58,6 +67,45 @@ TEST(GpuHostOffloadingAllocatorTest, AllocateStagingBuffer) {
   // Staging buffers are allocated with operators new/delete, so they will be
   // considered invalid arguments to stream calls.
   EXPECT_TRUE(absl::IsInternal(memory_type_or_status.status()));
+}
+
+TEST(GpuHostOffloadingAllocatorTest, LargeTransferBufferCanBeCopied) {
+  constexpr size_t kSmallBufferSize = 32 << 10;
+  constexpr int kNumSmallBuffers = 32;
+  constexpr size_t kLargeBufferSize = 4 << 20;
+
+  se::StreamExecutor* executor = GpuExecutor();
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<se::Stream> stream,
+                       executor->CreateStream());
+  std::unique_ptr<HostOffloadingAllocator> allocator =
+      CreateGpuHostOffloadingAllocator(executor);
+
+  // Fill 1 MiB of BFC's initial 2 MiB region, leaving a free tail. With
+  // suballocator coalescing enabled, BFC can combine that tail with the next
+  // 4 MiB HostMemoryAllocate region and return a large transfer buffer spanning
+  // two independently registered pinned host allocations.
+  std::vector<std::unique_ptr<HostOffloadingAllocator::Buffer>> small_buffers;
+  small_buffers.reserve(kNumSmallBuffers);
+  for (int i = 0; i < kNumSmallBuffers; ++i) {
+    ASSERT_OK_AND_ASSIGN(
+        std::unique_ptr<HostOffloadingAllocator::Buffer> buffer,
+        allocator->AllocateTransferBuffer(kSmallBufferSize));
+    small_buffers.push_back(std::move(buffer));
+  }
+
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<HostOffloadingAllocator::Buffer> large_buffer,
+      allocator->AllocateTransferBuffer(kLargeBufferSize));
+  se::DeviceAddressBase device_buffer = executor->Allocate(kLargeBufferSize);
+  ASSERT_FALSE(device_buffer.is_null());
+
+  ASSERT_OK(stream->Memcpy(&device_buffer, large_buffer->untyped_data(),
+                           kLargeBufferSize));
+  ASSERT_OK(stream->Memcpy(large_buffer->untyped_data(), device_buffer,
+                           kLargeBufferSize));
+  ASSERT_OK(stream->BlockHostUntilDone());
+
+  executor->Deallocate(&device_buffer);
 }
 
 }  // namespace


### PR DESCRIPTION
📝 Summary of Changes

Disable coalescing in `TransferBufferSubAllocator`. Transfer buffers are backed by pinned host allocations and are passed directly to D2H/H2D copies. Allowing BFC to coalesce adjacent regions can produce transfer ranges that do not correspond to a single underlying pinned allocation, which can trigger intermittent `CUDA_ERROR_INVALID_VALUE` failures during host offloading (`_xla_compute_type=host`).

This seems to match the CUDA host-allocation documentation, which notes that the driver tracks the virtual memory ranges allocated by `cuMemHostAlloc`. Keeping each transfer buffer within a single `HostMemoryAllocate` region avoids constructing coalesced ranges that were never explicitly allocated as one pinned host region.

🎯 Justification
Host offloading memory transfers would fail with `CUDA_ERROR_INVALID_VALUE`. I'm seeing this when offloading on the 5090 with fairly large buffers.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix
