### PR TITLE
[TSL]: Internal Retries for GCE Metadata Authentication

### DIFF
--- a/xla/tsl/platform/cloud/google_auth_provider.cc
+++ b/xla/tsl/platform/cloud/google_auth_provider.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include <utility>
 
 #include "absl/strings/match.h"
+#include "absl/strings/numbers.h"
 #include "absl/synchronization/mutex.h"
 #include "json/json.h"
 #include "xla/tsl/platform/env.h"
@@ -63,8 +64,8 @@ constexpr char kCloudSdkConfig[] = "CLOUDSDK_CONFIG";
 // the GCE metadata service.
 constexpr char kNoGceCheck[] = "NO_GCE_CHECK";
 
-// The environment variable to set the maximum number of retries for GCE auth.
-constexpr char kGcsAuthMaxRetries[] = "TF_GCS_AUTH_MAX_RETRIES";
+// The environment variable to set the maximum number of requests for GCE auth.
+constexpr char kGcsAuthMaxRequests[] = "TF_GCS_AUTH_MAX_REQUESTS";
 
 // The environment variable to set the delay in seconds between GCE auth retries.
 constexpr char kGcsAuthRetryDelaySec[] = "TF_GCS_AUTH_RETRY_DELAY_SEC";
@@ -139,6 +140,24 @@ absl::Status GetWellKnownFileName(std::string* filename) {
   return absl::OkStatus();
 }
 
+absl::Status ParseNonNegativeIntEnvVar(const char* env_var_name,
+                                       int default_value, int* result) {
+  if (!result) {
+    return absl::FailedPreconditionError("'result' cannot be nullptr.");
+  }
+  const char* env_value = std::getenv(env_var_name);
+  if (!env_value) {
+    *result = default_value;
+    return absl::OkStatus();
+  }
+  if (!absl::SimpleAtoi(env_value, result) || *result < 0) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Failed to parse $", env_var_name,
+                     " as a non-negative integer: ", env_value));
+  }
+  return absl::OkStatus();
+}
+
 }  // namespace
 
 GoogleAuthProvider::GoogleAuthProvider(
@@ -186,19 +205,23 @@ absl::Status GoogleAuthProvider::GetToken(std::string* t) {
                      absl::StrCat("GCE check skipped due to presence of $",
                                   kNoGceCheck, " environment variable."));
   } else {
-    const char* max_retries_env = std::getenv(kGcsAuthMaxRetries);
-    const char* retry_delay_env = std::getenv(kGcsAuthRetryDelaySec);
-    int max_retries = max_retries_env ? std::atoi(max_retries_env) : 1;
-    int retry_delay_sec = retry_delay_env ? std::atoi(retry_delay_env) : 5;
+    int max_requests;
+    TF_RETURN_IF_ERROR(
+        ParseNonNegativeIntEnvVar(kGcsAuthMaxRequests, 1, &max_requests));
+    int retry_delay_sec;
+    TF_RETURN_IF_ERROR(
+        ParseNonNegativeIntEnvVar(kGcsAuthRetryDelaySec, 5, &retry_delay_sec));
 
-    for (int i = 0; i < max_retries; ++i) {
+    for (int i = 0; i < max_requests; ++i) {
       token_from_gce_status = GetTokenFromGce();
       if (token_from_gce_status.ok()) {
         break;
       }
-      if (i < max_retries - 1) {
-        LOG(INFO) << "GCE auth failed with status: " << token_from_gce_status.ToString()
-                  << ". Retrying in " << retry_delay_sec << " seconds... (Attempt " << i + 1 << " of " << max_retries << ")";
+      if (i < max_requests - 1) {
+        LOG(INFO) << "GCE auth failed with status: "
+                  << token_from_gce_status.ToString() << ". Retrying in "
+                  << retry_delay_sec << " seconds... (Request " << i + 2
+                  << " of " << max_requests << ")";
         env_->SleepForMicroseconds(retry_delay_sec * 1000000);
       }
     }

--- a/xla/tsl/platform/cloud/google_auth_provider.cc
+++ b/xla/tsl/platform/cloud/google_auth_provider.cc
@@ -67,7 +67,8 @@ constexpr char kNoGceCheck[] = "NO_GCE_CHECK";
 // The environment variable to set the maximum number of requests for GCE auth.
 constexpr char kGcsAuthMaxRequests[] = "TF_GCS_AUTH_MAX_REQUESTS";
 
-// The environment variable to set the delay in seconds between GCE auth retries.
+// The environment variable to set the delay in seconds between GCE auth
+// retries.
 constexpr char kGcsAuthRetryDelaySec[] = "TF_GCS_AUTH_RETRY_DELAY_SEC";
 
 // The default path to the gcloud config folder, relative to the home folder.

--- a/xla/tsl/platform/cloud/google_auth_provider.cc
+++ b/xla/tsl/platform/cloud/google_auth_provider.cc
@@ -63,6 +63,12 @@ constexpr char kCloudSdkConfig[] = "CLOUDSDK_CONFIG";
 // the GCE metadata service.
 constexpr char kNoGceCheck[] = "NO_GCE_CHECK";
 
+// The environment variable to set the maximum number of retries for GCE auth.
+constexpr char kGcsAuthMaxRetries[] = "TF_GCS_AUTH_MAX_RETRIES";
+
+// The environment variable to set the delay in seconds between GCE auth retries.
+constexpr char kGcsAuthRetryDelaySec[] = "TF_GCS_AUTH_RETRY_DELAY_SEC";
+
 // The default path to the gcloud config folder, relative to the home folder.
 constexpr char kGCloudConfigFolder[] = ".config/gcloud/";
 
@@ -180,7 +186,22 @@ absl::Status GoogleAuthProvider::GetToken(std::string* t) {
                      absl::StrCat("GCE check skipped due to presence of $",
                                   kNoGceCheck, " environment variable."));
   } else {
-    token_from_gce_status = GetTokenFromGce();
+    const char* max_retries_env = std::getenv(kGcsAuthMaxRetries);
+    const char* retry_delay_env = std::getenv(kGcsAuthRetryDelaySec);
+    int max_retries = max_retries_env ? std::atoi(max_retries_env) : 1;
+    int retry_delay_sec = retry_delay_env ? std::atoi(retry_delay_env) : 5;
+
+    for (int i = 0; i < max_retries; ++i) {
+      token_from_gce_status = GetTokenFromGce();
+      if (token_from_gce_status.ok()) {
+        break;
+      }
+      if (i < max_retries - 1) {
+        LOG(INFO) << "GCE auth failed with status: " << token_from_gce_status.ToString()
+                  << ". Retrying in " << retry_delay_sec << " seconds... (Attempt " << i + 1 << " of " << max_retries << ")";
+        env_->SleepForMicroseconds(retry_delay_sec * 1000000);
+      }
+    }
   }
 
   if (token_from_gce_status.ok()) {

--- a/xla/tsl/platform/cloud/google_auth_provider_test.cc
+++ b/xla/tsl/platform/cloud/google_auth_provider_test.cc
@@ -15,8 +15,6 @@ limitations under the License.
 
 #include "xla/tsl/platform/cloud/google_auth_provider.h"
 
-#include <stdlib.h>
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -25,6 +23,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "json/json.h"
+#include <stdlib.h>
 #include "xla/tsl/lib/core/status_test_util.h"
 #include "xla/tsl/platform/cloud/compute_engine_metadata_client.h"
 #include "xla/tsl/platform/cloud/http_request.h"
@@ -99,32 +98,32 @@ class GoogleAuthProviderTest : public ::testing::Test {
 
 TEST_F(GoogleAuthProviderTest, InternalRetriesOnGceFailure) {
   setenv("TF_GCS_AUTH_MAX_REQUESTS", "3", 1);
-  setenv("TF_GCS_AUTH_RETRY_DELAY_SEC", "0", 1);  // 0s delay for fast test execution
+  setenv("TF_GCS_AUTH_RETRY_DELAY_SEC", "0",
+         1);  // 0s delay for fast test execution
 
   auto oauth_client = new FakeOAuthClient;
 
   // Provide 3 requests: first 2 fail, 3rd succeeds!
-  std::vector<HttpRequest*> requests({
-      new FakeHttpRequest(
-          "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
-          "/service-accounts/default/token\n"
-          "Header Metadata-Flavor: Google\n",
-          "", absl::UnavailableError("503"), 503),
-      new FakeHttpRequest(
-          "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
-          "/service-accounts/default/token\n"
-          "Header Metadata-Flavor: Google\n",
-          "", absl::NotFoundError("404"), 404),
-      new FakeHttpRequest(
-          "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
-          "/service-accounts/default/token\n"
-          "Header Metadata-Flavor: Google\n",
-          R"({
+  std::vector<HttpRequest*> requests(
+      {new FakeHttpRequest(
+           "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
+           "/service-accounts/default/token\n"
+           "Header Metadata-Flavor: Google\n",
+           "", absl::UnavailableError("503"), 503),
+       new FakeHttpRequest(
+           "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
+           "/service-accounts/default/token\n"
+           "Header Metadata-Flavor: Google\n",
+           "", absl::NotFoundError("404"), 404),
+       new FakeHttpRequest(
+           "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
+           "/service-accounts/default/token\n"
+           "Header Metadata-Flavor: Google\n",
+           R"({
             "access_token":"fake-recovered-token",
             "expires_in": 3600,
             "token_type":"Bearer"
-          })")
-  });
+          })")});
 
   FakeEnv env;
   std::shared_ptr<HttpRequest::Factory> fakeHttpRequestFactory =
@@ -146,18 +145,17 @@ TEST_F(GoogleAuthProviderTest, InternalRetriesExhausted) {
   auto oauth_client = new FakeOAuthClient;
 
   // Provide exactly two 404 requests to match the 2 requests
-  std::vector<HttpRequest*> requests({
-      new FakeHttpRequest(
-          "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
-          "/service-accounts/default/token\n"
-          "Header Metadata-Flavor: Google\n",
-          "", absl::NotFoundError("404"), 404),
-      new FakeHttpRequest(
-          "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
-          "/service-accounts/default/token\n"
-          "Header Metadata-Flavor: Google\n",
-          "", absl::NotFoundError("404"), 404)
-  });
+  std::vector<HttpRequest*> requests(
+      {new FakeHttpRequest(
+           "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
+           "/service-accounts/default/token\n"
+           "Header Metadata-Flavor: Google\n",
+           "", absl::NotFoundError("404"), 404),
+       new FakeHttpRequest(
+           "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
+           "/service-accounts/default/token\n"
+           "Header Metadata-Flavor: Google\n",
+           "", absl::NotFoundError("404"), 404)});
 
   FakeEnv env;
   std::shared_ptr<HttpRequest::Factory> fakeHttpRequestFactory =

--- a/xla/tsl/platform/cloud/google_auth_provider_test.cc
+++ b/xla/tsl/platform/cloud/google_auth_provider_test.cc
@@ -92,13 +92,13 @@ class GoogleAuthProviderTest : public ::testing::Test {
     unsetenv("GOOGLE_APPLICATION_CREDENTIALS");
     unsetenv("GOOGLE_AUTH_TOKEN_FOR_TESTING");
     unsetenv("NO_GCE_CHECK");
-    unsetenv("TF_GCS_AUTH_MAX_RETRIES");
+    unsetenv("TF_GCS_AUTH_MAX_REQUESTS");
     unsetenv("TF_GCS_AUTH_RETRY_DELAY_SEC");
   }
 };
 
 TEST_F(GoogleAuthProviderTest, InternalRetriesOnGceFailure) {
-  setenv("TF_GCS_AUTH_MAX_RETRIES", "3", 1);
+  setenv("TF_GCS_AUTH_MAX_REQUESTS", "3", 1);
   setenv("TF_GCS_AUTH_RETRY_DELAY_SEC", "0", 1);  // 0s delay for fast test execution
 
   auto oauth_client = new FakeOAuthClient;
@@ -140,12 +140,12 @@ TEST_F(GoogleAuthProviderTest, InternalRetriesOnGceFailure) {
 }
 
 TEST_F(GoogleAuthProviderTest, InternalRetriesExhausted) {
-  setenv("TF_GCS_AUTH_MAX_RETRIES", "2", 1);
+  setenv("TF_GCS_AUTH_MAX_REQUESTS", "2", 1);
   setenv("TF_GCS_AUTH_RETRY_DELAY_SEC", "0", 1);
 
   auto oauth_client = new FakeOAuthClient;
 
-  // Provide exactly two 404 requests to match the 2 attempts without internal GetMetadata retries
+  // Provide exactly two 404 requests to match the 2 requests
   std::vector<HttpRequest*> requests({
       new FakeHttpRequest(
           "Uri: http://metadata.google.internal/computeMetadata/v1/instance"

--- a/xla/tsl/platform/cloud/google_auth_provider_test.cc
+++ b/xla/tsl/platform/cloud/google_auth_provider_test.cc
@@ -25,7 +25,6 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "json/json.h"
-#include "third_party/jsoncpp/include/json/value.h"
 #include "xla/tsl/lib/core/status_test_util.h"
 #include "xla/tsl/platform/cloud/compute_engine_metadata_client.h"
 #include "xla/tsl/platform/cloud/http_request.h"
@@ -93,8 +92,52 @@ class GoogleAuthProviderTest : public ::testing::Test {
     unsetenv("GOOGLE_APPLICATION_CREDENTIALS");
     unsetenv("GOOGLE_AUTH_TOKEN_FOR_TESTING");
     unsetenv("NO_GCE_CHECK");
+    unsetenv("TF_GCS_AUTH_MAX_RETRIES");
+    unsetenv("TF_GCS_AUTH_RETRY_DELAY_SEC");
   }
 };
+
+TEST_F(GoogleAuthProviderTest, InternalRetriesOnGceFailure) {
+  setenv("TF_GCS_AUTH_MAX_RETRIES", "3", 1);
+  setenv("TF_GCS_AUTH_RETRY_DELAY_SEC", "0", 1);  // 0s delay for fast test execution
+
+  auto oauth_client = new FakeOAuthClient;
+
+  // Provide 3 requests: first 2 fail, 3rd succeeds!
+  std::vector<HttpRequest*> requests({
+      new FakeHttpRequest(
+          "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
+          "/service-accounts/default/token\n"
+          "Header Metadata-Flavor: Google\n",
+          "", absl::UnavailableError("503"), 503),
+      new FakeHttpRequest(
+          "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
+          "/service-accounts/default/token\n"
+          "Header Metadata-Flavor: Google\n",
+          "", absl::NotFoundError("404"), 404),
+      new FakeHttpRequest(
+          "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
+          "/service-accounts/default/token\n"
+          "Header Metadata-Flavor: Google\n",
+          R"({
+            "access_token":"fake-recovered-token",
+            "expires_in": 3600,
+            "token_type":"Bearer"
+          })")
+  });
+
+  FakeEnv env;
+  std::shared_ptr<HttpRequest::Factory> fakeHttpRequestFactory =
+      std::make_shared<FakeHttpRequestFactory>(&requests);
+  auto metadataClient = std::make_shared<ComputeEngineMetadataClient>(
+      fakeHttpRequestFactory, RetryConfig(0 /* init_delay_time_us */));
+  GoogleAuthProvider provider(std::unique_ptr<OAuthClient>(oauth_client),
+                              metadataClient, &env);
+
+  std::string token;
+  TF_EXPECT_OK(provider.GetToken(&token));
+  EXPECT_EQ("fake-recovered-token", token);
+}
 
 TEST_F(GoogleAuthProviderTest, EnvironmentVariable_Caching) {
   setenv("GOOGLE_APPLICATION_CREDENTIALS",

--- a/xla/tsl/platform/cloud/google_auth_provider_test.cc
+++ b/xla/tsl/platform/cloud/google_auth_provider_test.cc
@@ -139,6 +139,39 @@ TEST_F(GoogleAuthProviderTest, InternalRetriesOnGceFailure) {
   EXPECT_EQ("fake-recovered-token", token);
 }
 
+TEST_F(GoogleAuthProviderTest, InternalRetriesExhausted) {
+  setenv("TF_GCS_AUTH_MAX_RETRIES", "2", 1);
+  setenv("TF_GCS_AUTH_RETRY_DELAY_SEC", "0", 1);
+
+  auto oauth_client = new FakeOAuthClient;
+
+  // Provide exactly two 404 requests to match the 2 attempts without internal GetMetadata retries
+  std::vector<HttpRequest*> requests({
+      new FakeHttpRequest(
+          "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
+          "/service-accounts/default/token\n"
+          "Header Metadata-Flavor: Google\n",
+          "", absl::NotFoundError("404"), 404),
+      new FakeHttpRequest(
+          "Uri: http://metadata.google.internal/computeMetadata/v1/instance"
+          "/service-accounts/default/token\n"
+          "Header Metadata-Flavor: Google\n",
+          "", absl::NotFoundError("404"), 404)
+  });
+
+  FakeEnv env;
+  std::shared_ptr<HttpRequest::Factory> fakeHttpRequestFactory =
+      std::make_shared<FakeHttpRequestFactory>(&requests);
+  auto metadataClient = std::make_shared<ComputeEngineMetadataClient>(
+      fakeHttpRequestFactory, RetryConfig(0 /* init_delay_time_us */));
+  GoogleAuthProvider provider(std::unique_ptr<OAuthClient>(oauth_client),
+                              metadataClient, &env);
+
+  std::string token;
+  TF_EXPECT_OK(provider.GetToken(&token));
+  EXPECT_EQ("", token);  // Graceful fallback to empty token
+}
+
 TEST_F(GoogleAuthProviderTest, EnvironmentVariable_Caching) {
   setenv("GOOGLE_APPLICATION_CREDENTIALS",
          io::JoinPath(TestData(), "service_account_credentials.json").c_str(),


### PR DESCRIPTION
### 📝 Summary of Changes

This PR introduces an optional retry loop directly inside the C++ GCE authentication flow (GoogleAuthProvider::GetToken).
The retry behavior is fully configurable via environment variables (with sensible defaults):
- TF_GCS_AUTH_MAX_REQUESTS: Maximum number of attempts to contact the GCE metadata server (default: 1).
- TF_GCS_AUTH_RETRY_DELAY_SEC: Delay in seconds between retry attempts (default: 5).

### 🎯 Justification
When running TensorFlow workloads on GKE (or GCE), the local metadata server (`gke-metadata-server` or `metadata.google.internal`) can experience delayed startup or temporary unresponsiveness under heavy node load.

Currently, if GoogleAuthProvider::GetToken attempts to contact the metadata server during this transient window and fails, it would:
- Log a warning about GCE metadata failure.
- Cache an empty bearer token ("").
- Disable future GCE checks for the lifetime of the process (expiration_timestamp_sec_ = 0 or UINT64_MAX depending on flags).

As a result, transient node startup delays caused permanent PermissionDenied ("Anonymous caller does not have storage.objects.get access...") errors for any subsequent GCS read/write operations, forcing entire pipeline tasks to fail and restart. **For example**, this essentially bricks any container using a tensorflow `epath` backend that has one bad auth try.

### 🚀 Kind of Contribution
🐛 Bug Fix, ⚡️ Performance Improvement

### 📊 Benchmark (for Performance Improvements)
Not applicable.

### 🧪 Unit Tests:
Added a unit test to `google_auth_provider_test.cc`

### 🧪 Execution Tests:

Not applicable. 