### PR TITLE
[ROCm] xla/pjrt: honor XLA_PYTHON_CLIENT_ALLOCATOR=platform

### DIFF
--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -140,6 +140,7 @@ cc_library(
         "//xla/stream_executor:memory_space",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_address_allocator",
         "//xla/stream_executor:stream_executor_h",
         "//xla/stream_executor/cuda:cuda_compute_capability",
         "//xla/stream_executor/integrations:device_mem_allocator",

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -112,6 +112,7 @@ limitations under the License.
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/stream_executor_address_allocator.h"
 #include "xla/tsl/concurrency/async_value.h"
 #include "xla/tsl/concurrency/async_value_ref.h"
 #include "xla/tsl/concurrency/ref_count.h"
@@ -1532,16 +1533,21 @@ GetStreamExecutorGpuDeviceAllocator(
       break;
     }
 
-    case GpuAllocatorConfig::Kind::kPlatform:
+    case GpuAllocatorConfig::Kind::kPlatform: {
       LOG(INFO) << "Using platform allocator.";
       if (allocator_config.collective_memory_size != 0) {
         LOG(WARNING)
             << "collective_memory_size is non-zero, but allocator kind is set "
                "to \"platform\". Collective memory will not be allocated.";
       }
-      // Returning null will cause the client to use the default backend
-      // allocator.
-      return nullptr;
+      std::vector<se::StreamExecutor*> executors;
+      executors.reserve(addressable_devices.size());
+      for (const auto& [ordinal, device] : addressable_devices) {
+        executors.push_back(device->executor());
+      }
+      return std::make_unique<se::StreamExecutorAddressAllocator>(platform,
+                                                                  executors);
+    }
 
     case GpuAllocatorConfig::Kind::kVmm: {
 #if GOOGLE_CUDA


### PR DESCRIPTION
📝 Summary of Changes
Make GpuAllocatorConfig::Kind::kPlatform actually deliver a synchronous passthrough allocator instead of returning nullptr. Previously the env var XLA_PYTHON_CLIENT_ALLOCATOR=platform was silently overridden by the BFC allocator that Backend::Backend() builds unconditionally for CUDA/ROCm platforms.

🎯 Justification
without this fix 

🚀 Kind of Contribution
🐛 Bug Fix, 

🧪 Execution Tests:
setting this XLA_PYTHON_CLIENT_ALLOCATOR= flag from JAX now working after the fix and honoring the flag value.
