### PR TITLE
[ROCm] Fix tf build due to undefined reference

### DIFF
--- a/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -88,8 +88,7 @@ def get_rbe_amdgpu_pool(is_single_gpu = False):
 def rocm_lib_import(name, interface_library, data, deps):
     cc_import(
         name = name + "_interface",
-        interface_library = interface_library,
-        system_provided = True,
+        shared_library = interface_library,
         visibility = ["//visibility:private"],
     )
     cc_library(


### PR DESCRIPTION
📝 Summary of Changes
use shared_library instead of interface_library for rocm libs

🎯 Justification
Fix tf build failure due to undefined reference

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
