### PR TITLE
Add SM103 HLO op profiles for B300 and GB300

### DIFF
--- a/xla/service/gpu/model/hlo_op_profiles_data.h
+++ b/xla/service/gpu/model/hlo_op_profiles_data.h
@@ -24,6 +24,1200 @@ namespace gpu {
 
 inline constexpr char kDeviceHloOpProfiles[] = R"pb(
   entries {
+    key: "sm_103"  # "GB300"
+    value {
+      entries {
+        instruction {
+          opcode: "popcnt"
+          shape {
+            element_type: S8
+          }
+        }
+        clock_cycles: 37
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: S8
+          }
+        }
+        clock_cycles: 4
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: S8
+          }
+        }
+        clock_cycles: 372
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: S8
+          }
+        }
+        clock_cycles: 8
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: S8
+          }
+        }
+        clock_cycles: 4
+      }
+      entries {
+        instruction {
+          opcode: "popcnt"
+          shape {
+            element_type: S16
+          }
+        }
+        clock_cycles: 37
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: S16
+          }
+        }
+        clock_cycles: 4
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: S16
+          }
+        }
+        clock_cycles: 380
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: S16
+          }
+        }
+        clock_cycles: 8
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: S16
+          }
+        }
+        clock_cycles: 4
+      }
+      entries {
+        instruction {
+          opcode: "popcnt"
+          shape {
+            element_type: S32
+          }
+        }
+        clock_cycles: 37
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: S32
+          }
+        }
+        clock_cycles: 4
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: S32
+          }
+        }
+        clock_cycles: 302
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: S32
+          }
+        }
+        clock_cycles: 8
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: S32
+          }
+        }
+        clock_cycles: 4
+      }
+      entries {
+        instruction {
+          opcode: "popcnt"
+          shape {
+            element_type: S64
+          }
+        }
+        clock_cycles: 37
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: S64
+          }
+        }
+        clock_cycles: 12
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: S64
+          }
+        }
+        clock_cycles: 1068
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: S64
+          }
+        }
+        clock_cycles: 12
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: S64
+          }
+        }
+        clock_cycles: 12
+      }
+      entries {
+        instruction {
+          opcode: "popcnt"
+          shape {
+            element_type: U8
+          }
+        }
+        clock_cycles: 37
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: U8
+          }
+        }
+        clock_cycles: 4
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: U8
+          }
+        }
+        clock_cycles: 298
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: U8
+          }
+        }
+        clock_cycles: 8
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: U8
+          }
+        }
+        clock_cycles: 4
+      }
+      entries {
+        instruction {
+          opcode: "popcnt"
+          shape {
+            element_type: U16
+          }
+        }
+        clock_cycles: 37
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: U16
+          }
+        }
+        clock_cycles: 4
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: U16
+          }
+        }
+        clock_cycles: 293
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: U16
+          }
+        }
+        clock_cycles: 8
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: U16
+          }
+        }
+        clock_cycles: 4
+      }
+      entries {
+        instruction {
+          opcode: "popcnt"
+          shape {
+            element_type: U32
+          }
+        }
+        clock_cycles: 37
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: U32
+          }
+        }
+        clock_cycles: 4
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: U32
+          }
+        }
+        clock_cycles: 136
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: U32
+          }
+        }
+        clock_cycles: 8
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: U32
+          }
+        }
+        clock_cycles: 4
+      }
+      entries {
+        instruction {
+          opcode: "popcnt"
+          shape {
+            element_type: U64
+          }
+        }
+        clock_cycles: 33
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: U64
+          }
+        }
+        clock_cycles: 12
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: U64
+          }
+        }
+        clock_cycles: 890
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: U64
+          }
+        }
+        clock_cycles: 12
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: U64
+          }
+        }
+        clock_cycles: 12
+      }
+      entries {
+        instruction {
+          opcode: "cbrt"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 198
+      }
+      entries {
+        instruction {
+          opcode: "cosine"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 442
+      }
+      entries {
+        instruction {
+          opcode: "erf"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 235
+      }
+      entries {
+        instruction {
+          opcode: "exponential"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 111
+      }
+      entries {
+        instruction {
+          opcode: "exponential-minus-one"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 186
+      }
+      entries {
+        instruction {
+          opcode: "log"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 120
+      }
+      entries {
+        instruction {
+          opcode: "log-plus-one"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 219
+      }
+      entries {
+        instruction {
+          opcode: "logistic"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 244
+      }
+      entries {
+        instruction {
+          opcode: "round-nearest-afz"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 66
+      }
+      entries {
+        instruction {
+          opcode: "round-nearest-even"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 62
+      }
+      entries {
+        instruction {
+          opcode: "rsqrt"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 111
+      }
+      entries {
+        instruction {
+          opcode: "sine"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 372
+      }
+      entries {
+        instruction {
+          opcode: "sqrt"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 111
+      }
+      entries {
+        instruction {
+          opcode: "tan"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 372
+      }
+      entries {
+        instruction {
+          opcode: "tanh"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 149
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 8
+      }
+      entries {
+        instruction {
+          opcode: "atan2"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 451
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 49
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 8
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: F16
+          }
+        }
+        clock_cycles: 8
+      }
+      entries {
+        instruction {
+          opcode: "cbrt"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 173
+      }
+      entries {
+        instruction {
+          opcode: "cosine"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 347
+      }
+      entries {
+        instruction {
+          opcode: "erf"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 190
+      }
+      entries {
+        instruction {
+          opcode: "exponential"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 86
+      }
+      entries {
+        instruction {
+          opcode: "exponential-minus-one"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 144
+      }
+      entries {
+        instruction {
+          opcode: "log"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 186
+      }
+      entries {
+        instruction {
+          opcode: "log-plus-one"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 211
+      }
+      entries {
+        instruction {
+          opcode: "logistic"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 202
+      }
+      entries {
+        instruction {
+          opcode: "round-nearest-afz"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 57
+      }
+      entries {
+        instruction {
+          opcode: "round-nearest-even"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 33
+      }
+      entries {
+        instruction {
+          opcode: "rsqrt"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 78
+      }
+      entries {
+        instruction {
+          opcode: "sine"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 376
+      }
+      entries {
+        instruction {
+          opcode: "sqrt"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 78
+      }
+      entries {
+        instruction {
+          opcode: "tan"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 405
+      }
+      entries {
+        instruction {
+          opcode: "tanh"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 140
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 8
+      }
+      entries {
+        instruction {
+          opcode: "atan2"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 438
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 24
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 8
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: F32
+          }
+        }
+        clock_cycles: 8
+      }
+      entries {
+        instruction {
+          opcode: "cbrt"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 2248
+      }
+      entries {
+        instruction {
+          opcode: "cosine"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 2782
+      }
+      entries {
+        instruction {
+          opcode: "erf"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 6276
+      }
+      entries {
+        instruction {
+          opcode: "exponential"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 2322
+      }
+      entries {
+        instruction {
+          opcode: "exponential-minus-one"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 2802
+      }
+      entries {
+        instruction {
+          opcode: "log"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 488
+      }
+      entries {
+        instruction {
+          opcode: "log-plus-one"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 3369
+      }
+      entries {
+        instruction {
+          opcode: "logistic"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 3142
+      }
+      entries {
+        instruction {
+          opcode: "round-nearest-afz"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 364
+      }
+      entries {
+        instruction {
+          opcode: "round-nearest-even"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 136
+      }
+      entries {
+        instruction {
+          opcode: "rsqrt"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 939
+      }
+      entries {
+        instruction {
+          opcode: "sine"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 2761
+      }
+      entries {
+        instruction {
+          opcode: "sqrt"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 1465
+      }
+      entries {
+        instruction {
+          opcode: "tan"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 3502
+      }
+      entries {
+        instruction {
+          opcode: "tanh"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 2094
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 136
+      }
+      entries {
+        instruction {
+          opcode: "atan2"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 5464
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 2028
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 132
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: F64
+          }
+        }
+        clock_cycles: 132
+      }
+      entries {
+        instruction {
+          opcode: "cosine"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 761
+      }
+      entries {
+        instruction {
+          opcode: "exponential"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 823
+      }
+      entries {
+        instruction {
+          opcode: "exponential-minus-one"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 894
+      }
+      entries {
+        instruction {
+          opcode: "log"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 695
+      }
+      entries {
+        instruction {
+          opcode: "log-plus-one"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 741
+      }
+      entries {
+        instruction {
+          opcode: "logistic"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 2852
+      }
+      entries {
+        instruction {
+          opcode: "rsqrt"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 2976
+      }
+      entries {
+        instruction {
+          opcode: "sine"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 790
+      }
+      entries {
+        instruction {
+          opcode: "sqrt"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 4375
+      }
+      entries {
+        instruction {
+          opcode: "tan"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 1771
+      }
+      entries {
+        instruction {
+          opcode: "tanh"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 1668
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 12
+      }
+      entries {
+        instruction {
+          opcode: "atan2"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 6582
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 335
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 33
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: C64
+          }
+        }
+        clock_cycles: 12
+      }
+      entries {
+        instruction {
+          opcode: "cosine"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 10312
+      }
+      entries {
+        instruction {
+          opcode: "exponential"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 11749
+      }
+      entries {
+        instruction {
+          opcode: "exponential-minus-one"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 10076
+      }
+      entries {
+        instruction {
+          opcode: "log"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 14022
+      }
+      entries {
+        instruction {
+          opcode: "log-plus-one"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 16025
+      }
+      entries {
+        instruction {
+          opcode: "logistic"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 27390
+      }
+      entries {
+        instruction {
+          opcode: "rsqrt"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 18369
+      }
+      entries {
+        instruction {
+          opcode: "sine"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 10399
+      }
+      entries {
+        instruction {
+          opcode: "sqrt"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 29046
+      }
+      entries {
+        instruction {
+          opcode: "tan"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 16137
+      }
+      entries {
+        instruction {
+          opcode: "tanh"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 16191
+      }
+      entries {
+        instruction {
+          opcode: "add"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 277
+      }
+      entries {
+        instruction {
+          opcode: "atan2"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 63780
+      }
+      entries {
+        instruction {
+          opcode: "divide"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 14299
+      }
+      entries {
+        instruction {
+          opcode: "multiply"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 832
+      }
+      entries {
+        instruction {
+          opcode: "subtract"
+          shape {
+            element_type: C128
+          }
+        }
+        clock_cycles: 285
+      }
+    }
+  }
+
+  entries {
     key: "sm_100_B200"
     value {
       entries {

--- a/xla/service/gpu/model/hlo_op_profiles_test.cc
+++ b/xla/service/gpu/model/hlo_op_profiles_test.cc
@@ -130,6 +130,23 @@ TEST_F(HloOpProfilesTest, GetProfileH100) {
       3);
 }
 
+TEST_F(HloOpProfilesTest, GetProfileSm103) {
+  auto hlo_op_profiles =
+      HloOpProfiles::Load(kDeviceHloOpProfiles,
+                          /*default_profile_name=*/"sm_80");
+  stream_executor::DeviceDescription device_info;
+  device_info.set_gpu_compute_capability(stream_executor::GpuComputeCapability(
+      stream_executor::CudaComputeCapability(10, 3)));
+
+  EXPECT_EQ(HloOpProfiles::GetProfileName(device_info), "sm_103");
+  const auto& op_profile = hlo_op_profiles->GetProfile(device_info);
+  ASSERT_TRUE(op_profile.contains(
+      std::make_pair(HloOpcode::kDivide, PrimitiveType::S8)));
+  EXPECT_EQ(
+      op_profile.at(std::make_pair(HloOpcode::kDivide, PrimitiveType::S8)),
+      372);
+}
+
 TEST_F(HloOpProfilesTest, GetProfileMI210) {
   auto hlo_op_profiles = HloOpProfiles::Load(kDeviceHloOpProfilesTest,
                                              /*default_profile_name=*/"sm_80");


### PR DESCRIPTION
📝 Summary of Changes
Adds a generated SM103 HLO op profile table keyed as sm_103, using GB300 profiling data. This lets the GPU cost model select SM103-specific scalar op costs through the existing compute-capability profile naming path.

🧪 Unit Tests:
Adds `TEST_F(HloOpProfilesTest, GetProfileSm103)` in xla/service/gpu/model/hlo_op_profiles_test.cc that verifies:
1. Profile name for CUDA compute capability (10, 3) returns `"sm_103"`
2. The SM103 profile loads correctly from `kDeviceHloOpProfiles`
3. Profile contains expected data: `kDivide` for `S8` type returns 372 clock cycles