### PR TITLE
Fix std::min template deduction on darwin arm64

### DIFF
--- a/xla/backends/gpu/runtime/buffers_float_check_thunk.cc
+++ b/xla/backends/gpu/runtime/buffers_float_check_thunk.cc
@@ -173,7 +173,7 @@ absl::Status CheckFloatsAndLog(
   // results of the previous FloatCheck operation are available.
   TF_RETURN_IF_ERROR(reduce_append_kernel.Launch(
       thread_dim, se::BlockDim(1, 1, 1), stream, tmp_ptr,
-      std::min(tmp_ptr.ElementCount(), num_blocks), entry_id,
+      std::min<uint64_t>(tmp_ptr.ElementCount(), num_blocks), entry_id,
       buffer_debug_log.GetDeviceHeader(), buffer_debug_log.GetDeviceEntries()));
 
   return absl::OkStatus();


### PR DESCRIPTION
## Summary

On macOS arm64, `size_t` (`unsigned long`) and `uint64_t` (`unsigned long long`) are distinct integer types. On Linux they both alias to `unsigned long`, so the template argument deduction for `std::min` succeeds. Apple-clang rejects the call site at `buffers_float_check_thunk.cc:176` with:

```
no matching function for call to 'min(uint64_t, size_t)'
```

Pinning the explicit template argument (`std::min<uint64_t>(...)`) fixes the build on Mac and is a no-op on Linux.

## Test plan

- [x] Builds cleanly on darwin_arm64 (Mac Studio M-series, macOS 26, apple-clang 21).
- [x] Build on Linux x86_64 is unchanged (template arg deduction would have succeeded with the same result type).
- [x] No behavior change — same call, same arguments, just explicit on the template parameter.