### PR TITLE
[XLA:CPU] Add xtile.extract_aligned / xtile.insert_aligned

### DIFF
--- a/xla/backends/gpu/runtime/buffers_float_check_thunk.cc
+++ b/xla/backends/gpu/runtime/buffers_float_check_thunk.cc
@@ -173,7 +173,7 @@ absl::Status CheckFloatsAndLog(
   // results of the previous FloatCheck operation are available.
   TF_RETURN_IF_ERROR(reduce_append_kernel.Launch(
       thread_dim, se::BlockDim(1, 1, 1), stream, tmp_ptr,
-      std::min(tmp_ptr.ElementCount(), num_blocks), entry_id,
+      std::min<uint64_t>(tmp_ptr.ElementCount(), num_blocks), entry_id,
       buffer_debug_log.GetDeviceHeader(), buffer_debug_log.GetDeviceEntries()));
 
   return absl::OkStatus();

--- a/xla/codegen/xtile/codegen/emitter_helpers.cc
+++ b/xla/codegen/xtile/codegen/emitter_helpers.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "xla/codegen/xtile/codegen/emitter_helpers.h"
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <utility>
@@ -642,11 +644,39 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
                   minor_to_major_layout, storage_type);
 }
 
+// Returns true if every dim of `original_shape` is statically divisible by
+// `padded_tile_sizes[i] * tile_strides[i]`. Under the standard loop-emitter
+// iteration pattern (step = padded_tile_sizes * tile_strides), this implies
+// every tile access stays in-range, so the bufferization-time boundary check
+// can be elided. Unit-size dims of `padded_tile_sizes` are skipped: such dims
+// are rank-reduced from the tile tensor (and trivially in-range).
+bool TileInfoIsAlwaysFull(const TileInfo& tile_info) {
+  auto shape = tile_info.original_shape();
+  auto tile = tile_info.padded_tile_sizes();
+  auto strides = tile_info.tile_strides();
+  if (shape.size() != tile.size() || shape.size() != strides.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < shape.size(); ++i) {
+    // Rank-reduced unit dim; trivially safe.
+    if (tile[i] == 1) continue;
+    int64_t step = tile[i] * std::max<int64_t>(strides[i], 1);
+    if (step <= 0) return false;
+    if (shape[i] % step != 0) return false;
+  }
+  return true;
+}
+
 TensorValue EmitParameterExtract(mlir::ImplicitLocOpBuilder& b,
                                  const TileInfo& tile_info, Value arg) {
   auto tensor_type = mlir::RankedTensorType::get(tile_info.padded_tile_sizes(),
                                                  tile_info.storage_type());
 
+  if (TileInfoIsAlwaysFull(tile_info)) {
+    return xla::xtile::ExtractAlignedTileOp::create(
+        b, tensor_type, arg, tile_info.offsets(), tile_info.padded_tile_sizes(),
+        tile_info.tile_strides());
+  }
   return xla::xtile::ExtractTileOp::create(
       b, tensor_type, arg, tile_info.offsets(), tile_info.padded_tile_sizes(),
       tile_info.tile_strides());

--- a/xla/codegen/xtile/codegen/emitter_helpers.h
+++ b/xla/codegen/xtile/codegen/emitter_helpers.h
@@ -299,7 +299,13 @@ absl::StatusOr<mlir::Value> EmitElementwise(mlir::ImplicitLocOpBuilder& b,
 mlir::Value Bitcast(mlir::ImplicitLocOpBuilder& b, mlir::Value value,
                     mlir::Type type);
 
-// Emits an xtile::ExtractTileOp for the given tile info and argument.
+// Returns true if every tile access described by `tile_info` is statically
+// guaranteed to fit inside the buffer (no boundary clamp needed). Used by the
+// emitter to choose between aligned and unconstrained Extract/Insert ops.
+bool TileInfoIsAlwaysFull(const TileInfo& tile_info);
+
+// Emits an xtile::ExtractTileOp (or ExtractAlignedTileOp when the tile is
+// provably always in-range) for the given tile info and argument.
 TensorValue EmitParameterExtract(mlir::ImplicitLocOpBuilder& b,
                                  const TileInfo& tile_info, mlir::Value arg);
 

--- a/xla/codegen/xtile/codegen/fusion_emitter.cc
+++ b/xla/codegen/xtile/codegen/fusion_emitter.cc
@@ -1168,9 +1168,15 @@ absl::Status EmitGeneric(mlir::OpBuilder builder,
         auto tile_info,
         TileInfo::Construct(b, tile_id, /*runtime_values=*/{}, *root));
 
-    xtile::InsertTileOp::create(b, result, arg, tile_info.offsets(),
-                                tile_info.padded_tile_sizes(),
-                                tile_info.tile_strides());
+    if (TileInfoIsAlwaysFull(tile_info)) {
+      xtile::InsertAlignedTileOp::create(b, result, arg, tile_info.offsets(),
+                                         tile_info.padded_tile_sizes(),
+                                         tile_info.tile_strides());
+    } else {
+      xtile::InsertTileOp::create(b, result, arg, tile_info.offsets(),
+                                  tile_info.padded_tile_sizes(),
+                                  tile_info.tile_strides());
+    }
   }
 
   return absl::OkStatus();

--- a/xla/codegen/xtile/ir/transforms/tests/bufferize.mlir
+++ b/xla/codegen/xtile/ir/transforms/tests/bufferize.mlir
@@ -147,3 +147,38 @@ func.func @extract_static(%source: memref<16xf32>) -> tensor<8xf32> {
   %tile = xtile.extract %source[%c0][8][1] : memref<16xf32> -> tensor<8xf32>
   return %tile : tensor<8xf32>
 }
+
+// -----
+
+// xtile.extract_aligned promises offsets are in-range, so bufferization
+// emits the unguarded subview+alloc+copy chain (no scf.if, no else-branch
+// padded-tile alloc). The alloc remains because the dynamic-offset subview
+// has a non-identity (strided) layout that still needs the layout fixup.
+// CHECK-LABEL: @extract_aligned_dynamic_offset(
+// CHECK-SAME: %[[SOURCE:.*]]: memref<1024xf32>, %[[OFFSET:.*]]: index)
+func.func @extract_aligned_dynamic_offset(%source: memref<1024xf32>, %tile_id: index) -> tensor<16xf32> {
+  // CHECK-NOT: scf.if
+  // CHECK: %[[SUBVIEW:.*]] = memref.subview %[[SOURCE]][%[[OFFSET]]] [16] [1] : memref<1024xf32> to memref<16xf32, strided<[1], offset: ?>>
+  // CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<16xf32>
+  // CHECK: memref.copy %[[SUBVIEW]], %[[ALLOC]]
+  // CHECK: %[[TILE:.*]] = bufferization.to_tensor %[[ALLOC]]
+  // CHECK: return %[[TILE]]
+  %tile = xtile.extract_aligned %source[%tile_id][16][1] : memref<1024xf32> -> tensor<16xf32>
+  return %tile : tensor<16xf32>
+}
+
+// -----
+
+// xtile.insert_aligned promises offsets are in-range, so bufferization
+// emits the unguarded subview+copy chain (no scf.if).
+// CHECK-LABEL: @insert_aligned_dynamic_offset(
+// CHECK-SAME: %[[SOURCE:.*]]: tensor<16xf32>,
+// CHECK-SAME: %[[DEST:.*]]: memref<1024xf32>,
+// CHECK-SAME: %[[OFFSET:.*]]: index)
+func.func @insert_aligned_dynamic_offset(%source: tensor<16xf32>, %destination: memref<1024xf32>, %tile_id: index) {
+  // CHECK-NOT: scf.if
+  // CHECK: %[[SUBVIEW:.*]] = memref.subview %[[DEST]][%[[OFFSET]]] [16] [1] : memref<1024xf32> to memref<16xf32, strided<[1], offset: ?>>
+  // CHECK: memref.copy {{.*}}, %[[SUBVIEW]]
+  xtile.insert_aligned %source into %destination[%tile_id][16][1] : tensor<16xf32> -> memref<1024xf32>
+  return
+}

--- a/xla/codegen/xtile/ir/xtile_bufferization.cc
+++ b/xla/codegen/xtile/ir/xtile_bufferization.cc
@@ -362,4 +362,118 @@ llvm::LogicalResult InsertTileOp::bufferize(
   return mlir::success();
 }
 
+bool ExtractAlignedTileOp::bufferizesToMemoryRead(
+    mlir::OpOperand& operand, const mlir::bufferization::AnalysisState& state) {
+  return true;
+}
+
+bool ExtractAlignedTileOp::bufferizesToMemoryWrite(
+    mlir::OpOperand& operand, const mlir::bufferization::AnalysisState& state) {
+  return true;
+}
+
+bool ExtractAlignedTileOp::bufferizesToAllocation(mlir::Value value) {
+  // As we don't know if we will emit an allocation at compile time we must be
+  // conservative.
+  return true;
+}
+
+mlir::bufferization::AliasingValueList ExtractAlignedTileOp::getAliasingValues(
+    mlir::OpOperand& operand, const mlir::bufferization::AnalysisState& state) {
+  return {};
+}
+
+mlir::bufferization::AliasingOpOperandList
+ExtractAlignedTileOp::getAliasingOpOperands(
+    mlir::Value value, const mlir::bufferization::AnalysisState& state) {
+  DCHECK_EQ(value, getResult());
+  mlir::bufferization::AliasingOpOperand result(
+      &getSourceMutable(), mlir::bufferization::BufferRelation::Equivalent,
+      false);
+  return {result};
+}
+
+bool ExtractAlignedTileOp::isWritable(
+    mlir::Value value, const mlir::bufferization::AnalysisState& state) {
+  return false;
+}
+
+llvm::LogicalResult ExtractAlignedTileOp::bufferize(
+    mlir::RewriterBase& rewriter,
+    const mlir::bufferization::BufferizationOptions& options,
+    mlir::bufferization::BufferizationState& state) {
+  mlir::ImplicitLocOpBuilder builder(getLoc(), rewriter);
+  auto buffer = GetFullTileSubView(builder, *this);
+  if (buffer.getType().getLayout().isIdentity()) {
+    auto to_tensor_op =
+        mlir::bufferization::ToTensorOp::create(builder, getType(), buffer);
+    rewriter.replaceOp(getOperation(), {to_tensor_op.getResult()});
+    return mlir::success();
+  }
+  // Non-identity layout fixup: still need alloc+copy to give downstream ops
+  // an identity-layout memref. No scf.if guard though.
+  mlir::MemRefType default_buffer_type =
+      mlir::MemRefType::Builder(buffer.getType()).setLayout(nullptr);
+  auto default_buffer =
+      mlir::memref::AllocOp::create(builder, default_buffer_type);
+  mlir::memref::CopyOp::create(builder, buffer, default_buffer);
+  auto to_tensor_op = mlir::bufferization::ToTensorOp::create(
+      builder, getType(), default_buffer);
+  to_tensor_op.setWritable(true);
+  to_tensor_op.setRestrict(true);
+  rewriter.replaceOp(getOperation(), {to_tensor_op.getResult()});
+  return mlir::success();
+}
+
+bool InsertAlignedTileOp::bufferizesToMemoryRead(
+    mlir::OpOperand& operand, const mlir::bufferization::AnalysisState& state) {
+  return true;
+}
+
+bool InsertAlignedTileOp::bufferizesToMemoryWrite(
+    mlir::OpOperand& operand, const mlir::bufferization::AnalysisState& state) {
+  DCHECK_EQ(operand.getOperandNumber(), 0)
+      << "This should only be called on the tensor operand.";
+  return false;
+}
+
+bool InsertAlignedTileOp::bufferizesToAllocation(mlir::Value value) {
+  // As we don't know if we will emit an allocation at compile time we must be
+  // conservative.
+  return true;
+}
+
+mlir::bufferization::AliasingValueList InsertAlignedTileOp::getAliasingValues(
+    mlir::OpOperand& operand, const mlir::bufferization::AnalysisState& state) {
+  return {};
+}
+
+mlir::bufferization::AliasingOpOperandList
+InsertAlignedTileOp::getAliasingOpOperands(
+    mlir::Value value, const mlir::bufferization::AnalysisState& state) {
+  return {};
+}
+
+bool InsertAlignedTileOp::isWritable(
+    mlir::Value value, const mlir::bufferization::AnalysisState& state) {
+  if (value == getDestination()) {
+    return true;
+  }
+
+  return false;
+}
+
+llvm::LogicalResult InsertAlignedTileOp::bufferize(
+    mlir::RewriterBase& rewriter,
+    const mlir::bufferization::BufferizationOptions& options,
+    mlir::bufferization::BufferizationState& state) {
+  mlir::ImplicitLocOpBuilder builder(getLoc(), rewriter);
+  auto target_buffer_subview = GetFullTileSubView(builder, *this);
+  auto materialize_op = mlir::bufferization::MaterializeInDestinationOp::create(
+      builder, getSource(), target_buffer_subview);
+  materialize_op.setWritable(true);
+  rewriter.eraseOp(getOperation());
+  return mlir::success();
+}
+
 }  // namespace xla::xtile

--- a/xla/codegen/xtile/ir/xtile_ops.cc
+++ b/xla/codegen/xtile/ir/xtile_ops.cc
@@ -198,6 +198,30 @@ mlir::TypedValue<mlir::RankedTensorType> InsertTileOp::getTile() {
 
 mlir::LogicalResult InsertTileOp::verify() { return VerifyBufferOp(*this); }
 
+mlir::TypedValue<mlir::MemRefType> ExtractAlignedTileOp::getBuffer() {
+  return getSource();
+}
+
+mlir::TypedValue<mlir::RankedTensorType> ExtractAlignedTileOp::getTile() {
+  return getResult();
+}
+
+mlir::LogicalResult ExtractAlignedTileOp::verify() {
+  return VerifyBufferOp(*this);
+}
+
+mlir::TypedValue<mlir::MemRefType> InsertAlignedTileOp::getBuffer() {
+  return getDestination();
+}
+
+mlir::TypedValue<mlir::RankedTensorType> InsertAlignedTileOp::getTile() {
+  return getSource();
+}
+
+mlir::LogicalResult InsertAlignedTileOp::verify() {
+  return VerifyBufferOp(*this);
+}
+
 llvm::SmallVector<int64_t> MaskOp::getMaskedDimensions() {
   llvm::SmallVector<int64_t> masked_dimensions;
 

--- a/xla/codegen/xtile/ir/xtile_ops.td
+++ b/xla/codegen/xtile/ir/xtile_ops.td
@@ -221,6 +221,72 @@ def InsertTileOp : XTile_Op<"insert", [TiledBufferInterface]> {
   let hasVerifier = 1;
 }
 
+def ExtractAlignedTileOp : XTile_Op<"extract_aligned", [TiledBufferInterface]> {
+  let summary = "Extract a full tile from a memref, assuming offsets are in range.";
+  let description = [{
+    Identical semantics to xtile.extract, with an additional precondition:
+    the caller guarantees that for every dim i,
+      offsets[i] + (full_tile_shape[i] - 1) * strides[i] < source.shape[i].
+    Under this precondition the partial-tile case cannot occur, so
+    bufferization elides the runtime boundary check.
+  }];
+
+  let arguments = (ins
+    AnyMemRef:$source,
+    Variadic<Index>:$offsets,
+    DenseI64ArrayAttr:$full_tile_shape,
+    DenseI64ArrayAttr:$strides
+  );
+
+
+  let results = (outs AnyRankedTensor:$result);
+
+  let assemblyFormat = [{
+    $source `[` $offsets `]` $full_tile_shape $strides
+    `:` type($source) `->` type($result) attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    mlir::TypedValue<mlir::MemRefType> getBuffer();
+    mlir::TypedValue<mlir::RankedTensorType> getTile();
+  }];
+
+  let hasVerifier = 1;
+}
+
+def InsertAlignedTileOp : XTile_Op<"insert_aligned", [TiledBufferInterface]> {
+  let summary = "Insert a full tile into a memref, assuming offsets are in range.";
+  let description = [{
+    Identical semantics to xtile.insert, with an additional precondition:
+    the caller guarantees that for every dim i,
+      offsets[i] + (full_tile_shape[i] - 1) * strides[i] < destination.shape[i].
+    Under this precondition the partial-tile case cannot occur, so
+    bufferization elides the runtime boundary check.
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$source,
+    AnyMemRef:$destination,
+    Variadic<Index>:$offsets,
+    DenseI64ArrayAttr:$full_tile_shape,
+    DenseI64ArrayAttr:$strides
+  );
+
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $source `into` $destination `[` $offsets `]` $full_tile_shape $strides
+    `:` type($source) `->` type($destination) attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    mlir::TypedValue<mlir::MemRefType> getBuffer();
+    mlir::TypedValue<mlir::RankedTensorType> getTile();
+  }];
+
+  let hasVerifier = 1;
+}
+
 def MaskOp : XTile_Op<"mask",
                       [Pure,
                        AllTypesMatch<["source", "result"]>,


### PR DESCRIPTION
## Summary

Adds two new ops to the xtile dialect — `xtile.extract_aligned` and `xtile.insert_aligned` — that mirror `xtile.extract` / `xtile.insert` but carry an explicit precondition: for every dim `i`,

```
offsets[i] + (full_tile_shape[i] - 1) * strides[i] < buffer_shape[i]
```

Under this precondition the partial-tile case cannot occur, so bufferization emits the unguarded subview chain — no `scf.if`, no padded-buffer alloc on the boundary path. This lets LLVM SROA/DSE fold the per-iteration scratch buffers in the common case.

The loop emitter (`emitter_helpers.cc::EmitParameterExtract` and the `InsertTileOp::create` site in `fusion_emitter.cc`) chooses the aligned variant when `buffer_shape[i]` is statically divisible by `padded_tile_size[i] * tile_stride[i]` on every non-reduced dim. Under the standard `step = padded_tile_size * tile_stride` iteration pattern this implies every tile access is in-range.

## Measured impact

On a JAX-emitted `f32[1024] add` fusion:

| | baseline | this PR |
|---|---|---|
| pre-opt LLVM IR allocas | 5 | 3 |
| post-opt LLVM IR allocas | 2 | **0** |
| post-opt LLVM IR memcpys | 3 | **0** |
| loop body instructions/iter | ~25 | ~10 |

Generated loop body becomes the canonical SIMD add: 4× `ldp q,q`, 4× `fadd.4s`, 2× `stp q,q`, branch.

CPU microbenchmarks (Mac Studio M-series, 3-rep median, 7-rep for outlier re-check):

| Benchmark family | Δ vs baseline |
|---|---|
| `BM_AddF32/{128,1024,8192,32768}` | **−24% to −27%** |
| `BM_FusionF32/*` | flat to −5% |
| `BM_ReduceAddF32/*` | within noise (±2%) |
| `BM_BatchedDot_F32_F32_*` | within noise (−3.5% to +2.4%) |

## Dependency note

This PR's head branch was developed off `mac-fix/std-min-uint64-deduction` for Mac build access; it includes that one-line commit as a prerequisite. See #42431 (the same author's std::min fix). Once #42431 lands, this PR's diff will reduce to just the xtile changes.

## Follow-ups (not in this PR)

- `ShapedType::isDynamic()` guard in `TileInfoIsAlwaysFull` for dynamic-shape robustness.
- `xla/codegen/xtile/codegen/experimental_fusion_emitter.cc` has a matching `InsertTileOp` site (line ~1037) used by the Triton/GPU `xtile_compiler` path; intentionally not touched here (different emitter, would need separate validation).
- The layout-fixup alloc still fires inside `ExtractAlignedTile` when the subview has a non-identity (`strided<[1], offset:?>`) layout from a dynamic offset. Relaxing `to_tensor`'s identity-layout precondition (or moving to `vector.transfer_read` directly) would eliminate it. See accompanying design doc.

## Test plan

- [x] New lit cases in `xla/codegen/xtile/ir/transforms/tests/bufferize.mlir` cover both ops:
  - `@extract_aligned_dynamic_offset` asserts `CHECK-NOT: scf.if` + alloc+copy fixup for non-identity layout
  - `@insert_aligned_dynamic_offset` asserts `CHECK-NOT: scf.if` + direct subview/copy
- [x] `bazel test //xla/codegen/xtile/ir/transforms/tests:bufferize.mlir.test` passes
- [x] Existing tests in the same file (which exercise the unconstrained ops with bare offsets) continue to pass
- [x] Spot-check of CPU benchmarks (dot, reduce, fusion, elementwise) shows no regressions on darwin_arm64
- [ ] CI sweep on Linux x86_64