### PR TITLE
[XLA:GPU] Use generic SM100 keys for op profiles

### DIFF
--- a/xla/service/gpu/model/collective_interpolator.cc
+++ b/xla/service/gpu/model/collective_interpolator.cc
@@ -396,7 +396,7 @@ HloOpcode AsyncToSyncOpcode(const HloCollectiveInstruction& instr) {
 
 absl::StatusOr<HloInstructionProfileList> ReadDefaultProfiles(
     const se::DeviceDescription& device_info) {
-  std::string key = HloOpProfiles::GetProfileName(device_info);
+  std::string key = HloOpProfiles::GetDeviceSpecificProfileName(device_info);
 
   if (!Profile().entries().contains(key)) {
     return absl::NotFoundError(absl::StrCat("Cannot find key: ", key));

--- a/xla/service/gpu/model/collective_ptable_stats_collection.cc
+++ b/xla/service/gpu/model/collective_ptable_stats_collection.cc
@@ -54,7 +54,7 @@ absl::StatusOr<HloInstructionProfileList> CollectProfiles(
   TF_RETURN_IF_ERROR(tsl::Env::Default()->FileExists(perf_table_path));
   TF_RETURN_IF_ERROR(tsl::ReadTextOrBinaryProto(tsl::Env::Default(),
                                                 perf_table_path, &profile));
-  std::string key = HloOpProfiles::GetProfileName(device_info);
+  std::string key = HloOpProfiles::GetDeviceSpecificProfileName(device_info);
 
   if (!profile.entries().contains(key)) {
     return absl::NotFoundError(absl::StrCat("Cannot find key: ", key));

--- a/xla/service/gpu/model/collective_ptable_stats_collection_test.cc
+++ b/xla/service/gpu/model/collective_ptable_stats_collection_test.cc
@@ -69,7 +69,8 @@ DeviceHloInstructionProfiles TestProfiles(
 
   *profile_list.add_entries() = std::move(profile_entry);
   profiles.mutable_entries()->insert(
-      {HloOpProfiles::GetProfileName(device_info), std::move(profile_list)});
+      {HloOpProfiles::GetDeviceSpecificProfileName(device_info),
+       std::move(profile_list)});
 
   return profiles;
 }

--- a/xla/service/gpu/model/hlo_op_profiles.cc
+++ b/xla/service/gpu/model/hlo_op_profiles.cc
@@ -49,23 +49,25 @@ namespace gpu {
     const se::DeviceDescription& device_info) {
   if (auto* ptr =
           device_info.gpu_compute_capability().cuda_compute_capability()) {
-    std::string profile_name = absl::StrCat("sm_", ptr->major, ptr->minor);
-    // For sm_100, append device name to distinguish B200 vs GB200.
-    if (profile_name == "sm_100") {
-      CHECK(device_info.name() != se::DeviceDescription::kUndefinedString)
-          << "Device name must be set for sm_100 devices to distinguish "
-             "B200 vs GB200. Use B200SXMDeviceInfo() in tests.";
-      std::vector<std::string> full_name =
-          absl::StrSplit(device_info.name(), ' ');
-      return absl::StrCat(profile_name, "_", full_name.back());
-    }
-    return profile_name;
+    return absl::StrCat("sm_", ptr->major, ptr->minor);
   }
   if (auto* ptr =
           device_info.gpu_compute_capability().rocm_compute_capability()) {
     return ptr->gfx_version();
   }
   return "<unknown>";
+}
+
+/*static*/ std::string HloOpProfiles::GetDeviceSpecificProfileName(
+    const se::DeviceDescription& device_info) {
+  std::string profile_name = GetProfileName(device_info);
+  if (profile_name == "sm_100") {
+    CHECK(device_info.name() != se::DeviceDescription::kUndefinedString)
+        << "Device name must be set for sm_100 device-specific profiles.";
+    std::vector<std::string> full_name = absl::StrSplit(device_info.name(), ' ');
+    return absl::StrCat(profile_name, "_", full_name.back());
+  }
+  return profile_name;
 }
 
 /*static*/ std::unique_ptr<HloOpProfiles> HloOpProfiles::Load(

--- a/xla/service/gpu/model/hlo_op_profiles.h
+++ b/xla/service/gpu/model/hlo_op_profiles.h
@@ -49,6 +49,10 @@ class HloOpProfiles {
   // Returns "<unknown>" for unknown devices.
   static std::string GetProfileName(const se::DeviceDescription& device_info);
 
+  // Returns profile name for performance tables that need device-specific data.
+  static std::string GetDeviceSpecificProfileName(
+      const se::DeviceDescription& device_info);
+
   // Loads profiles from the given text proto data.
   static std::unique_ptr<HloOpProfiles> Load(
       absl::string_view profiles_text_proto,

--- a/xla/service/gpu/model/hlo_op_profiles_data.h
+++ b/xla/service/gpu/model/hlo_op_profiles_data.h
@@ -954,7 +954,7 @@ inline constexpr char kDeviceHloOpProfiles[] = R"pb(
   }
 
   entries {
-    key: "sm_100_B200"
+    key: "sm_100"  # "B200"
     value {
       entries {
         instruction {

--- a/xla/service/gpu/model/hlo_op_profiles_test.cc
+++ b/xla/service/gpu/model/hlo_op_profiles_test.cc
@@ -118,7 +118,7 @@ TEST_F(HloOpProfilesTest, GetProfileA6000) {
 TEST_F(HloOpProfilesTest, GetProfileH100) {
   auto hlo_op_profiles =
       HloOpProfiles::Load(kDeviceHloOpProfiles,
-                          /*default_profile_name=*/"sm_100_B200");
+                          /*default_profile_name=*/"sm_100");
   auto device_info_sm_85 = TestGpuDeviceInfo::H100SXMDeviceInfo(
       stream_executor::CudaComputeCapability(9, 0));
 
@@ -144,6 +144,34 @@ TEST_F(HloOpProfilesTest, GetProfileSm103) {
   EXPECT_EQ(
       op_profile.at(std::make_pair(HloOpcode::kDivide, PrimitiveType::S8)),
       372);
+}
+
+TEST_F(HloOpProfilesTest, GetProfileSm100) {
+  auto hlo_op_profiles =
+      HloOpProfiles::Load(kDeviceHloOpProfiles,
+                          /*default_profile_name=*/"sm_80");
+  stream_executor::DeviceDescription b200_device_info;
+  b200_device_info.set_name("NVIDIA B200");
+  b200_device_info.set_gpu_compute_capability(
+      stream_executor::GpuComputeCapability(
+          stream_executor::CudaComputeCapability(10, 0)));
+  stream_executor::DeviceDescription gb200_device_info;
+  gb200_device_info.set_name("NVIDIA GB200");
+  gb200_device_info.set_gpu_compute_capability(
+      stream_executor::GpuComputeCapability(
+          stream_executor::CudaComputeCapability(10, 0)));
+
+  EXPECT_EQ(HloOpProfiles::GetProfileName(b200_device_info), "sm_100");
+  EXPECT_EQ(HloOpProfiles::GetDeviceSpecificProfileName(b200_device_info),
+            "sm_100_B200");
+  EXPECT_EQ(HloOpProfiles::GetProfileName(gb200_device_info), "sm_100");
+  EXPECT_EQ(HloOpProfiles::GetDeviceSpecificProfileName(gb200_device_info),
+            "sm_100_GB200");
+  const auto& op_profile = hlo_op_profiles->GetProfile(b200_device_info);
+  ASSERT_TRUE(op_profile.contains(
+      std::make_pair(HloOpcode::kDivide, PrimitiveType::S8)));
+  EXPECT_EQ(op_profile.at(std::make_pair(HloOpcode::kDivide, PrimitiveType::S8)),
+            373);
 }
 
 TEST_F(HloOpProfilesTest, GetProfileMI210) {

--- a/xla/service/gpu/model/matmul_interpolator.cc
+++ b/xla/service/gpu/model/matmul_interpolator.cc
@@ -175,7 +175,7 @@ InterpolationSpecification Spec(const HloFusionInstruction& dot_fusion,
 
 absl::StatusOr<GemmPerfTableEntryValues> ReadDefaultProfile(
     const se::DeviceDescription& device_info) {
-  std::string key = HloOpProfiles::GetProfileName(device_info);
+  std::string key = HloOpProfiles::GetDeviceSpecificProfileName(device_info);
 
   if (!Profile().entries().contains(key)) {
     return absl::NotFoundError(absl::StrCat("Cannot find key: ", key));

--- a/xla/service/gpu/model/matmul_ptable_stats_collection.cc
+++ b/xla/service/gpu/model/matmul_ptable_stats_collection.cc
@@ -57,7 +57,7 @@ absl::StatusOr<HloInstructionProfileList> CollectProfiles(
   TF_RETURN_IF_ERROR(tsl::Env::Default()->FileExists(perf_table_path));
   TF_RETURN_IF_ERROR(tsl::ReadTextOrBinaryProto(tsl::Env::Default(),
                                                 perf_table_path, &profile));
-  std::string key = HloOpProfiles::GetProfileName(device_info);
+  std::string key = HloOpProfiles::GetDeviceSpecificProfileName(device_info);
 
   if (!profile.entries().contains(key)) {
     return absl::NotFoundError(absl::StrCat("Cannot find key: ", key));

--- a/xla/service/gpu/model/sol_latency_estimator.cc
+++ b/xla/service/gpu/model/sol_latency_estimator.cc
@@ -96,7 +96,7 @@ absl::StatusOr<HloInstructionProfileList> ReadProfiles(
   TF_RETURN_IF_ERROR(tsl::Env::Default()->FileExists(perf_table_path));
   TF_RETURN_IF_ERROR(tsl::ReadTextOrBinaryProto(tsl::Env::Default(),
                                                 perf_table_path, &profile));
-  std::string key = HloOpProfiles::GetProfileName(device_info);
+  std::string key = HloOpProfiles::GetDeviceSpecificProfileName(device_info);
 
   if (!profile.entries().contains(key)) {
     return absl::FailedPreconditionError(

--- a/xla/tools/collective_perf_table_gen.cc
+++ b/xla/tools/collective_perf_table_gen.cc
@@ -557,7 +557,7 @@ DeviceHloInstructionProfiles CollectivePerfTableGen::ComputeTable() {
 
   GpuTargetConfig gpu_target_config =
       GetGpuTargetConfig(GetPjRtEnv().client.get());
-  std::string device_key = HloOpProfiles::GetProfileName(
+  std::string device_key = HloOpProfiles::GetDeviceSpecificProfileName(
       /*device_info=*/gpu_target_config.device_description);
   profiles.mutable_entries()->insert({device_key, profile_list});
   return profiles;

--- a/xla/tools/matmul_perf_table_gen.cc
+++ b/xla/tools/matmul_perf_table_gen.cc
@@ -562,7 +562,7 @@ DeviceHloInstructionProfiles MatmulPerfTableGen::ComputeTable() {
     ReportProgress("Profiling progress", i + 1, specs.size());
   }
   std::string device_key =
-      gpu::HloOpProfiles::GetProfileName(device_description_);
+      gpu::HloOpProfiles::GetDeviceSpecificProfileName(device_description_);
   device_profiles.mutable_entries()->insert({device_key, profile_list});
   return device_profiles;
 }

--- a/xla/tools/matmul_perf_table_gen_run.cc
+++ b/xla/tools/matmul_perf_table_gen_run.cc
@@ -91,7 +91,8 @@ int RunPerfTableCollection(int argc, char** argv) {
       },
   };
   cfg.output =
-      FilepathOutput(HloOpProfiles::GetProfileName(device_description));
+      FilepathOutput(
+          HloOpProfiles::GetDeviceSpecificProfileName(device_description));
   MatmulPerfTableGen table_gen(runner.get(), &device_description,
                                std::move(cfg));
 


### PR DESCRIPTION
📝 Summary of Changes
This changes SM100 HLO math op profiles to use the generic sm_100 profile key instead of distinguishing
B200 and GB200.

For profile tables where GPU-level/device-level characteristics matter, this keeps device-specific
profile keys via GetDeviceSpecificProfileName(). Matmul and collective profile lookup/generation now use
that path, preserving keys such as sm_100_B200 and sm_100_GB200.

🎯 Justification
For scalar/math HLO op profiles, B200 and GB200 should not need separate entries within the same SM100 architecture.

Matmul profiles are different: they are measured for the whole GPU rather than a single SM, so sharing
one model across B200 and GB200 is likely inaccurate because the devices differ in SM count, DRAM
bandwidth, and other hardware details.

Collective profiles also remain device-specific because topology matters, and topology depends on the
GPU/system variant.

🧪 Unit Tests:
//xla/service/gpu/model:hlo_op_profiles_test `TEST_F(HloOpProfilesTest, GetProfileSm100)`

