### PR TITLE
make mx type unit tests shared by triton and hipblaslt backends

### DIFF
--- a/xla/backends/gpu/autotuner/BUILD
+++ b/xla/backends/gpu/autotuner/BUILD
@@ -688,8 +688,8 @@ cc_library(
 )
 
 xla_test(
-    name = "hipblaslt_mx_execution_test",
-    srcs = ["hipblaslt_mx_execution_test.cc"],
+    name = "mx_scaled_dot_execution_test",
+    srcs = ["mx_scaled_dot_execution_test.cc"],
     backends = [
         "amdgpu_any",
     ],

--- a/xla/backends/gpu/autotuner/hipblaslt.cc
+++ b/xla/backends/gpu/autotuner/hipblaslt.cc
@@ -119,6 +119,15 @@ bool IsValidMxScaledDot(const HloInstruction* scaled_dot) {
     return false;
   }
 
+  int64_t batch_size = 1;
+  for (int64_t dim : dot_dims.lhs_batch_dimensions()) {
+    batch_size *= lhs_shape.dimensions(dim);
+  }
+  if (batch_size != 1) {
+    VLOG(2) << "hipBLASLt MX: batch_size > 1 not supported, got " << batch_size;
+    return false;
+  }
+
   int64_t m = 1;
   for (int64_t i = 0; i < lhs_shape.dimensions().size(); ++i) {
     if (!absl::c_linear_search(dot_dims.lhs_batch_dimensions(), i) &&

--- a/xla/backends/gpu/autotuner/mx_scaled_dot_execution_test.cc
+++ b/xla/backends/gpu/autotuner/mx_scaled_dot_execution_test.cc
@@ -81,9 +81,8 @@ class MxScaledDotExecutionTest : public HloPjRtGpuTestBase {
     TF_ASSERT_OK_AND_ASSIGN(auto test_optimized,
                             GetOptimizedModule(hlo_string, test_config));
     EXPECT_THAT(
-        RunFileCheck(
-            test_optimized->ToString(),
-            "CHECK: {{(__cublas\\$lt\\$matmul\\$mx)|(scaled-dot)}}"),
+        RunFileCheck(test_optimized->ToString(),
+                     "CHECK: {{(__cublas\\$lt\\$matmul\\$mx)|(scaled-dot)}}"),
         absl_testing::IsOkAndHolds(true));
   }
 };

--- a/xla/backends/gpu/autotuner/mx_scaled_dot_execution_test.cc
+++ b/xla/backends/gpu/autotuner/mx_scaled_dot_execution_test.cc
@@ -29,7 +29,7 @@ limitations under the License.
 namespace xla::gpu {
 namespace {
 
-class HipblasLtMxExecutionTest : public HloPjRtGpuTestBase {
+class MxScaledDotExecutionTest : public HloPjRtGpuTestBase {
  protected:
   void SetUp() override {
     const auto& gpu_cc = device_description().gpu_compute_capability();
@@ -39,8 +39,6 @@ class HipblasLtMxExecutionTest : public HloPjRtGpuTestBase {
     }
   }
 
-  // Runs numerical correctness (hipBLASLt MX vs decomposed reference) and
-  // verifies that the optimized HLO uses the expected custom call target.
   void RunMxCorrectnessTest(absl::string_view hlo_string,
                             const ErrorSpec& error_spec) {
     TF_ASSERT_OK_AND_ASSIGN(auto reference_module,
@@ -82,9 +80,11 @@ class HipblasLtMxExecutionTest : public HloPjRtGpuTestBase {
     test_config.mutable_debug_options().set_xla_gpu_enable_triton_gemm(true);
     TF_ASSERT_OK_AND_ASSIGN(auto test_optimized,
                             GetOptimizedModule(hlo_string, test_config));
-    EXPECT_THAT(RunFileCheck(test_optimized->ToString(),
-                             "CHECK: __cublas$lt$matmul$mx"),
-                absl_testing::IsOkAndHolds(true));
+    EXPECT_THAT(
+        RunFileCheck(
+            test_optimized->ToString(),
+            "CHECK: {{(__cublas\\$lt\\$matmul\\$mx)|(scaled-dot)}}"),
+        absl_testing::IsOkAndHolds(true));
   }
 };
 
@@ -99,7 +99,7 @@ ENTRY main {
       lhs_contracting_dims={1}, rhs_contracting_dims={1}
 })";
 
-TEST_F(HipblasLtMxExecutionTest, MxFp8Correctness) {
+TEST_F(MxScaledDotExecutionTest, MxFp8Correctness) {
   RunMxCorrectnessTest(kMxFp8Hlo, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5));
 }
 
@@ -115,7 +115,7 @@ ENTRY main {
       lhs_contracting_dims={2}, rhs_contracting_dims={2}
 })";
 
-TEST_F(HipblasLtMxExecutionTest, MxFp8BatchedCorrectness) {
+TEST_F(MxScaledDotExecutionTest, MxFp8BatchedCorrectness) {
   RunMxCorrectnessTest(kMxFp8BatchedHlo,
                        ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5));
 }
@@ -132,7 +132,7 @@ ENTRY main {
       lhs_contracting_dims={2}, rhs_contracting_dims={2}
 })";
 
-TEST_F(HipblasLtMxExecutionTest, MxFp8MixedTypesBatchedCorrectness) {
+TEST_F(MxScaledDotExecutionTest, MxFp8MixedTypesBatchedCorrectness) {
   RunMxCorrectnessTest(kMxFp8MixedTypesBatchedHlo,
                        ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5));
 }
@@ -148,7 +148,7 @@ ENTRY main {
       lhs_contracting_dims={1}, rhs_contracting_dims={1}
 })";
 
-TEST_F(HipblasLtMxExecutionTest, MxFp4Correctness) {
+TEST_F(MxScaledDotExecutionTest, MxFp4Correctness) {
   RunMxCorrectnessTest(kMxFp4Hlo, ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5));
 }
 
@@ -164,7 +164,7 @@ ENTRY main {
       lhs_contracting_dims={2}, rhs_contracting_dims={2}
 })";
 
-TEST_F(HipblasLtMxExecutionTest, MxFp4BatchedCorrectness) {
+TEST_F(MxScaledDotExecutionTest, MxFp4BatchedCorrectness) {
   RunMxCorrectnessTest(kMxFp4BatchedHlo,
                        ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5));
 }
@@ -181,7 +181,7 @@ ENTRY main {
       lhs_contracting_dims={2}, rhs_contracting_dims={2}
 })";
 
-TEST_F(HipblasLtMxExecutionTest, MxFp4Fp8MixedBatchedCorrectness) {
+TEST_F(MxScaledDotExecutionTest, MxFp4Fp8MixedBatchedCorrectness) {
   RunMxCorrectnessTest(kMxFp4Fp8MixedBatchedHlo,
                        ErrorSpec(/*aabs=*/1e-4, /*arel=*/1e-5));
 }

--- a/xla/backends/gpu/autotuner/mx_scaled_dot_execution_test.cc
+++ b/xla/backends/gpu/autotuner/mx_scaled_dot_execution_test.cc
@@ -39,6 +39,8 @@ class MxScaledDotExecutionTest : public HloPjRtGpuTestBase {
     }
   }
 
+  // Runs numerical correctness verifies that the optimized HLO uses the
+  // expected custom call target.
   void RunMxCorrectnessTest(absl::string_view hlo_string,
                             const ErrorSpec& error_spec) {
     TF_ASSERT_OK_AND_ASSIGN(auto reference_module,

--- a/xla/backends/gpu/autotuner/mx_scaled_dot_execution_test.cc
+++ b/xla/backends/gpu/autotuner/mx_scaled_dot_execution_test.cc
@@ -39,7 +39,7 @@ class MxScaledDotExecutionTest : public HloPjRtGpuTestBase {
     }
   }
 
-  // Runs numerical correctness verifies that the optimized HLO uses the
+  // Runs numerical correctness and verifies that the optimized HLO uses the
   // expected custom call target.
   void RunMxCorrectnessTest(absl::string_view hlo_string,
                             const ErrorSpec& error_spec) {

--- a/xla/backends/gpu/autotuner/mx_scaled_dot_execution_test.cc
+++ b/xla/backends/gpu/autotuner/mx_scaled_dot_execution_test.cc
@@ -64,28 +64,6 @@ class MxScaledDotExecutionTest : public HloPjRtGpuTestBase {
     EXPECT_TRUE(RunAndCompareTwoModules(std::move(test_module),
                                         std::move(reference_module), error_spec,
                                         /*run_hlo_passes=*/true));
-
-    HloModuleConfig ref_config = GetModuleConfigForTest();
-    ref_config.mutable_debug_options()
-        .set_xla_gpu_experimental_scaled_dot_with_triton(false);
-    ref_config.mutable_debug_options().set_xla_gpu_enable_triton_gemm(false);
-    TF_ASSERT_OK_AND_ASSIGN(auto ref_optimized,
-                            GetOptimizedModule(hlo_string, ref_config));
-    EXPECT_THAT(
-        RunFileCheck(ref_optimized->ToString(),
-                     "CHECK-NOT: __cublas$lt$matmul$mx\nCHECK-NOT: scaled-dot"),
-        absl_testing::IsOkAndHolds(true));
-
-    HloModuleConfig test_config = GetModuleConfigForTest();
-    test_config.mutable_debug_options()
-        .set_xla_gpu_experimental_scaled_dot_with_triton(true);
-    test_config.mutable_debug_options().set_xla_gpu_enable_triton_gemm(true);
-    TF_ASSERT_OK_AND_ASSIGN(auto test_optimized,
-                            GetOptimizedModule(hlo_string, test_config));
-    EXPECT_THAT(
-        RunFileCheck(test_optimized->ToString(),
-                     "CHECK: {{(__cublas\\$lt\\$matmul\\$mx)|(scaled-dot)}}"),
-        absl_testing::IsOkAndHolds(true));
   }
 };
 

--- a/xla/backends/gpu/autotuner/mx_scaled_dot_execution_test.cc
+++ b/xla/backends/gpu/autotuner/mx_scaled_dot_execution_test.cc
@@ -43,27 +43,36 @@ class MxScaledDotExecutionTest : public HloPjRtGpuTestBase {
   // expected custom call target.
   void RunMxCorrectnessTest(absl::string_view hlo_string,
                             const ErrorSpec& error_spec) {
-    TF_ASSERT_OK_AND_ASSIGN(auto reference_module,
-                            ParseAndReturnUnverifiedModule(hlo_string));
-    reference_module->mutable_config()
-        .mutable_debug_options()
+    HloModuleConfig ref_config = GetModuleConfigForTest();
+    ref_config.mutable_debug_options()
         .set_xla_gpu_experimental_scaled_dot_with_triton(false);
-    reference_module->mutable_config()
-        .mutable_debug_options()
-        .set_xla_gpu_enable_triton_gemm(false);
+    ref_config.mutable_debug_options().set_xla_gpu_enable_triton_gemm(false);
+    TF_ASSERT_OK_AND_ASSIGN(auto ref_optimized,
+                            GetOptimizedModule(hlo_string, ref_config));
+    EXPECT_THAT(
+        RunFileCheck(ref_optimized->ToString(),
+                     R"(CHECK: {{__cublas\$lt\$matmul|__cublas\$gemm}})"),
+        absl_testing::IsOkAndHolds(true));
 
-    TF_ASSERT_OK_AND_ASSIGN(auto test_module,
-                            ParseAndReturnUnverifiedModule(hlo_string));
-    test_module->mutable_config()
-        .mutable_debug_options()
+    HloModuleConfig test_config = GetModuleConfigForTest();
+    test_config.mutable_debug_options()
         .set_xla_gpu_experimental_scaled_dot_with_triton(true);
-    test_module->mutable_config()
-        .mutable_debug_options()
-        .set_xla_gpu_enable_triton_gemm(true);
+    test_config.mutable_debug_options().set_xla_gpu_enable_triton_gemm(true);
+    TF_ASSERT_OK_AND_ASSIGN(auto test_optimized,
+                            GetOptimizedModule(hlo_string, test_config));
+    // The autotuner may pick any of the MX-aware ROCm backends:
+    //   __triton_nested_gemm_fusion -> Triton
+    //   __cublas$lt$matmul$mx       -> hipBLASLt
+    //   __cublas$lt$matmul          -> HIPBLASLT_FISSION (should never win)
+    EXPECT_THAT(
+        RunFileCheck(
+            test_optimized->ToString(),
+            R"(CHECK: {{__triton_nested_gemm_fusion|__cublas\$lt\$matmul\$mx}})"),
+        absl_testing::IsOkAndHolds(true));
 
-    EXPECT_TRUE(RunAndCompareTwoModules(std::move(test_module),
-                                        std::move(reference_module), error_spec,
-                                        /*run_hlo_passes=*/true));
+    EXPECT_TRUE(RunAndCompareTwoModules(std::move(test_optimized),
+                                        std::move(ref_optimized), error_spec,
+                                        /*run_hlo_passes=*/false));
   }
 };
 

--- a/xla/backends/gpu/autotuner/triton.cc
+++ b/xla/backends/gpu/autotuner/triton.cc
@@ -175,6 +175,20 @@ TritonBackend::GetSupportedConfigsForDot(const HloInstruction* instr) {
 
 absl::StatusOr<std::vector<std::unique_ptr<BackendConfig>>>
 TritonBackend::GetSupportedConfigsForScaledDot(const HloInstruction* instr) {
+  // The ROCm Triton backend does not support mixed FP4/FP8 scaled-dot inputs.
+  const auto& gpu_cc =
+      target_config().device_description.gpu_compute_capability();
+  if (gpu_cc.IsRocm()) {
+    PrimitiveType lhs_type = instr->operand(0)->shape().element_type();
+    PrimitiveType rhs_type = instr->operand(1)->shape().element_type();
+    auto is_fp4 = [](PrimitiveType t) { return t == F4E2M1FN; };
+    auto is_fp8 = [](PrimitiveType t) { return t == F8E4M3FN || t == F8E5M2; };
+    if ((is_fp4(lhs_type) && is_fp8(rhs_type)) ||
+        (is_fp8(lhs_type) && is_fp4(rhs_type))) {
+      return std::vector<std::unique_ptr<BackendConfig>>();
+    }
+  }
+
   std::vector<std::unique_ptr<BackendConfig>> configs;
 
   const bool exhaustive_search =


### PR DESCRIPTION
After https://github.com/openxla/xla/pull/40557, ROCm has two backends that supports scaled dot, so we adjust the test to be shared by both backends.

In addition:
- I disable Triton backend for ROCm for mixed type, i.e., FP8 * FP4
- I revert the hipblaslt limitation for the batch size