### PR TITLE
[XLA/TSL] Three macOS arm64 build fixes

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -325,6 +325,7 @@ common:nonccl --define=no_nccl_support=true
 # Don't trigger --config=<host platform> when cross-compiling.
 common:linux --host_copt=-w
 common:macos --copt=-w
+common:macos --host_copt=-w
 common:windows --copt=/W0
 common:windows --host_copt=/W0
 

--- a/xla/backends/gpu/runtime/buffers_float_check_thunk.cc
+++ b/xla/backends/gpu/runtime/buffers_float_check_thunk.cc
@@ -173,7 +173,7 @@ absl::Status CheckFloatsAndLog(
   // results of the previous FloatCheck operation are available.
   TF_RETURN_IF_ERROR(reduce_append_kernel.Launch(
       thread_dim, se::BlockDim(1, 1, 1), stream, tmp_ptr,
-      std::min(tmp_ptr.ElementCount(), num_blocks), entry_id,
+      std::min<uint64_t>(tmp_ptr.ElementCount(), num_blocks), entry_id,
       buffer_debug_log.GetDeviceHeader(), buffer_debug_log.GetDeviceEntries()));
 
   return absl::OkStatus();

--- a/xla/tsl/tsl.bzl
+++ b/xla/tsl/tsl.bzl
@@ -682,6 +682,11 @@ def tsl_pybind_extension_opensource(
                     # not being exported.  There should be a better way to deal with this.
                     "-Wl,-w",
                     "-Wl,-exported_symbols_list,$(location %s)" % exported_symbols_file,
+                    # Resolve Python C API symbols at module load time. Without
+                    # this the link fails on macOS because libpython is not
+                    # available at link time for the extension .so.
+                    "-undefined",
+                    "dynamic_lookup",
                 ],
                 clean_dep("//xla/tsl:windows"): [],
                 "//conditions:default": [
@@ -721,6 +726,11 @@ def tsl_pybind_extension_opensource(
                     # not being exported.  There should be a better way to deal with this.
                     "-Wl,-w",
                     "-Wl,-exported_symbols_list,$(location %s)" % exported_symbols_file,
+                    # Resolve Python C API symbols at module load time. Without
+                    # this the link fails on macOS because libpython is not
+                    # available at link time for the extension .so.
+                    "-undefined",
+                    "dynamic_lookup",
                 ],
                 clean_dep("//xla/tsl:windows"): [],
                 "//conditions:default": [


### PR DESCRIPTION
## Summary

Three small, independent fixes that together unblock building XLA on macOS arm64 (Apple Silicon) without ad-hoc workaround flags. Commits are self-contained and can be reviewed or cherry-picked in isolation.

### 1. `std::min` template deduction in `buffers_float_check_thunk.cc`

On darwin arm64 `size_t` is `unsigned long` and `uint64_t` is `unsigned long long` — distinct types. On Linux they alias to the same underlying type, so `std::min(tmp_ptr.ElementCount(), num_blocks)` deduces successfully; Apple-clang rejects it as ambiguous (`no matching function for call to 'min(uint64_t, size_t)'`). Pin the explicit template argument.

### 2. Host-config warning suppression on macOS

`tensorflow.bazelrc` already sets `common:linux --host_copt=-w` and `common:windows --host_copt=/W0`, but `:macos` only had the target-config `--copt=-w`. As a result, `-Werror` from `warnings.bazelrc` fires in exec-config (host/tool) compiles on Mac whenever a `--copt=-Wno-*` suppression doesn't have a matching `--host_copt`. Most visible trip: `-Wdeprecated-declarations` on `ABSL_DEPRECATE_AND_INLINE` self-calls in `xla/tsl/platform/file_system.h`. Restore symmetry by adding `common:macos --host_copt=-w`.

### 3. `-undefined dynamic_lookup` for pybind extensions on macOS

`tsl_pybind_extension_opensource` (in `xla/tsl/tsl.bzl`) doesn't pass `-undefined dynamic_lookup` to the linker on macOS, so undefined Python C API symbols (`_PyErr_Fetch`, `_PyFrame_GetCode`, …) from nanobind's wrappers fail at link time. The standard fix for Python C extensions on macOS (used by pybind11/nanobind upstream in their CMake builds) is to defer those symbols to module load time, where libpython is available. Affects `//xla/codegen/testlib:_extension.so` and `//xla/backends/cpu/testlib:_extension.so`, which transitively gate `//xla/backends/cpu/codegen:fusion_emitter_test` and `//xla/backends/cpu/codegen:computation_kernel_emitter_test` from being buildable on Mac.

## Net effect

Before this PR, building any non-trivial XLA target on Mac required:
```
bazel build --config=macos --config=macos_arm64 --macos_sdk_version=15.4 \
  --copt=-Wno-error --host_copt=-Wno-error \
  //target
```

After this PR:
```
bazel build --config=macos --config=macos_arm64 --macos_sdk_version=15.4 \
  //target
```

The remaining `--macos_sdk_version=15.4` workaround addresses an upstream apple_support issue (`default_macos_sdk_version = "10.11"` hardcoded in `xcode_version.bzl`), not in scope for this PR.

## Test plan

- [x] \`bazel build //xla/codegen/xtile/ir:xtile --config=macos --config=macos_arm64 --macos_sdk_version=15.4\` builds clean — verifies host_copt fix removes the workaround need.
- [x] \`bazel build //xla/codegen/testlib:_extension.so\` builds clean — verifies pybind dynamic_lookup fix.
- [x] \`bazel build //xla/tools:run_hlo_module\` builds clean — verifies std::min fix (transitively pulls \`buffers_float_check_thunk.cc\`).
- [ ] CI sweep on Linux x86_64 / Linux aarch64 (no behavior change expected — each fix is either gated on macOS \`select()\` or a no-op on non-Mac compilers).

## Reviewer notes

Each commit is independently sensible. If you'd prefer to land them in stages, they can be cherry-picked individually.