### PR TITLE
[ROCm][Triton] Extend collective memory support (PR 1/5)

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -750,6 +750,57 @@ cc_library(
     ],
 )
 
+
+xla_cc_test(
+    name = "rccl_symmetric_memory_test",
+    srcs = ["rccl_symmetric_memory_test.cc"],
+    tags = [
+        "gpu",
+        "no-oneapi",
+        "rocm-only",
+        "requires-gpu-amd",
+    ],
+    deps = [
+        ":rccl_errors",
+        ":rccl_symmetric_memory",
+        "//xla/stream_executor:device_address",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
+cc_library(
+    name = "rccl_symmetric_memory",
+    srcs = ["rccl_symmetric_memory.cc"],
+    hdrs = ["rccl_symmetric_memory.h"],
+    tags = [
+        "gpu",
+        "no-oneapi",
+        "rocm-only",
+    ],
+    visibility = [
+        "//xla/backends/gpu/runtime:__subpackages__",
+    ],
+    deps = [
+        ":rccl_errors",
+        "//xla:util",
+        "//xla/core/collectives:rank_id",
+        "//xla/core/collectives:symmetric_memory",
+        "//xla/stream_executor:device_address",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@local_config_rocm//rocm:rccl",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
 cc_library(
     name = "rccl_communicator",
     srcs = ["rccl_communicator.cc"],
@@ -765,6 +816,7 @@ cc_library(
         ":gpu_collectives",
         ":gpu_communicator",
         ":rccl_errors",
+        ":rccl_symmetric_memory",
         ":single_threaded_executor",
         "//xla:future",
         "//xla:shape_util",

--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -769,6 +769,7 @@ xla_cc_test(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest_main",
         "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_config",
         "@local_config_rocm//rocm:rocm_headers",
     ],
 )

--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -40,6 +40,7 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/backends/gpu/collectives/rccl_errors.h"
+#include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
 #include "xla/backends/gpu/collectives/single_threaded_executor.h"
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
@@ -680,6 +681,11 @@ absl::Status RcclCommunicator::LaunchRecv(se::DeviceAddressBase recv_buffer,
     TF_RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<SymmetricMemory>>
+RcclCommunicator::CreateSymmetricMemory(se::DeviceAddressBase addr) {
+  return RcclSymmetricMemory::Create(comm_, addr);
 }
 
 std::string RcclCommunicator::ToString() const {

--- a/xla/backends/gpu/collectives/rccl_communicator.h
+++ b/xla/backends/gpu/collectives/rccl_communicator.h
@@ -119,6 +119,9 @@ class RcclCommunicator : public GpuCommunicator {
   Future<> Recv(se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
                 size_t count, RankId peer, const Executor& executor) final;
 
+  absl::StatusOr<std::unique_ptr<SymmetricMemory>> CreateSymmetricMemory(
+      se::DeviceAddressBase addr) final;
+
   std::string ToString() const final;
 
   ncclComm_t comm() const { return comm_; }

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory.cc
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory.cc
@@ -1,0 +1,70 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
+
+#include <memory>
+#include <string>
+
+#include "absl/log/log.h"
+#include "absl/memory/memory.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "xla/backends/gpu/collectives/rccl_errors.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/util.h"
+
+namespace xla::gpu {
+
+RcclSymmetricMemory::RcclSymmetricMemory(
+    ncclComm_t comm, ncclWindow_t win, stream_executor::DeviceAddressBase addr)
+    : comm_(comm), win_(win), addr_(addr) {}
+
+absl::StatusOr<std::unique_ptr<RcclSymmetricMemory>>
+RcclSymmetricMemory::Create(ncclComm_t comm,
+                            stream_executor::DeviceAddressBase addr) {
+  VLOG(3) << absl::StrFormat(
+      "Create RCCL symmetric memory on comm=%p from: ptr=%p; size=%ld", comm,
+      addr.opaque(), addr.size());
+
+  ncclWindow_t win;
+  XLA_RCCL_RETURN_IF_ERROR(ncclCommWindowRegister(
+      comm, addr.opaque(), addr.size(), &win, NCCL_WIN_COLL_SYMMETRIC));
+
+  return absl::WrapUnique(new RcclSymmetricMemory(comm, win, addr));
+}
+
+RcclSymmetricMemory::~RcclSymmetricMemory() {
+  VLOG(3) << absl::StrFormat("Destroy %v", *this);
+  XLA_RCCL_LOG_IF_ERROR(ncclCommWindowDeregister(comm_, win_));
+}
+
+stream_executor::DeviceAddressBase RcclSymmetricMemory::addr() const {
+  return addr_;
+}
+
+std::string RcclSymmetricMemory::ToString() const {
+  return absl::StrFormat(
+      "RcclSymmetricMemory(comm=%p, win=%p, ptr=%p, size=%ld)", comm_, win_,
+      addr_.opaque(), addr_.size());
+}
+
+RcclSymmetricMemory::PackedKernelArg RcclSymmetricMemory::PackKernelArg()
+    const {
+  return win_;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory.h
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory.h
@@ -1,0 +1,67 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_RCCL_SYMMETRIC_MEMORY_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_RCCL_SYMMETRIC_MEMORY_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "rocm/rocm_config.h"  // IWYU pragma: keep  (defines TF_ROCM_VERSION)
+#include "xla/core/collectives/symmetric_memory.h"
+#include "xla/stream_executor/device_address.h"
+
+#if (TF_ROCM_VERSION >= 50200)
+#include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif  // TF_ROCM_VERSION >= 50200
+
+namespace xla::gpu {
+
+// An RCCL window registration handle that makes local buffers accessible from
+// remote peers via symmetric memory registration. Analogous to
+// NcclSymmetricMemory for the ROCm/RCCL platform.
+class RcclSymmetricMemory final : public SymmetricMemory {
+ public:
+  ~RcclSymmetricMemory() final;
+
+  static absl::StatusOr<std::unique_ptr<RcclSymmetricMemory>> Create(
+      ncclComm_t comm, stream_executor::DeviceAddressBase addr);
+
+  stream_executor::DeviceAddressBase addr() const final;
+
+  // multimem_addr() and peer_addr() are not supported by RCCL; the base-class
+  // defaults (returning Unimplemented) are used.
+
+  ncclWindow_t win() const { return win_; }
+
+  std::string ToString() const final;
+
+  PackedKernelArg PackKernelArg() const final;
+
+ private:
+  RcclSymmetricMemory(ncclComm_t comm, ncclWindow_t win,
+                      stream_executor::DeviceAddressBase addr);
+
+  ncclComm_t comm_;
+  ncclWindow_t win_;
+  stream_executor::DeviceAddressBase addr_;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_RCCL_SYMMETRIC_MEMORY_H_

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory_test.cc
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory_test.cc
@@ -1,0 +1,178 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/device_address.h"
+
+#if (TF_ROCM_VERSION >= 50200)
+#include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif  // TF_ROCM_VERSION >= 50200
+
+namespace xla::gpu {
+namespace {
+
+namespace se = stream_executor;
+
+using ::absl_testing::IsOk;
+using ::testing::HasSubstr;
+using ::testing::Not;
+
+// Test fixture that creates a single-rank RCCL communicator and allocates a
+// small GPU buffer. Tests are skipped if no ROCm device or RCCL is available.
+class RcclSymmetricMemoryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Skip if no ROCm/HIP GPU is present.
+    int device_count = 0;
+    if (hipGetDeviceCount(&device_count) != hipSuccess || device_count < 1) {
+      GTEST_SKIP() << "No ROCm/HIP GPU device available";
+    }
+    if (hipSetDevice(0) != hipSuccess) {
+      GTEST_SKIP() << "hipSetDevice(0) failed";
+    }
+
+    // Initialise a single-rank RCCL communicator on device 0.
+    int device_ids[] = {0};
+    ncclResult_t nccl_err = ncclCommInitAll(&comm_, 1, device_ids);
+    if (nccl_err != ncclSuccess) {
+      GTEST_SKIP() << "RCCL communicator initialisation failed: "
+                   << ncclGetErrorString(nccl_err);
+    }
+
+    // Allocate a 4 KiB symmetric memory buffer via RCCL. ncclMemAlloc ensures
+    // the buffer is mapped at the same virtual address on all ranks, which is
+    // required for ncclCommWindowRegister with NCCL_WIN_COLL_SYMMETRIC.
+    constexpr size_t kBufSize = 4096;
+    buf_size_ = kBufSize;
+    if (ncclMemAlloc(&buf_ptr_, buf_size_) != ncclSuccess) {
+      ncclCommDestroy(comm_);
+      comm_ = nullptr;
+      GTEST_SKIP() << "ncclMemAlloc(" << kBufSize << ") failed";
+    }
+  }
+
+  void TearDown() override {
+    if (buf_ptr_ != nullptr) {
+      (void)ncclMemFree(buf_ptr_);
+      buf_ptr_ = nullptr;
+    }
+    if (comm_ != nullptr) {
+      ncclCommDestroy(comm_);
+      comm_ = nullptr;
+    }
+  }
+
+  ncclComm_t comm_ = nullptr;
+  void* buf_ptr_ = nullptr;
+  size_t buf_size_ = 0;
+};
+
+// Verifies that RcclSymmetricMemory::Create succeeds for a valid buffer.
+TEST_F(RcclSymmetricMemoryTest, CreateSucceeds) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  ASSERT_NE(symm_mem, nullptr);
+}
+
+// Verifies that addr() returns exactly the pointer and size that were
+// registered.
+TEST_F(RcclSymmetricMemoryTest, AddrMatchesRegisteredBuffer) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  EXPECT_EQ(symm_mem->addr().opaque(), buf_ptr_);
+  EXPECT_EQ(symm_mem->addr().size(), buf_size_);
+}
+
+// Verifies that ToString() contains key diagnostic fields.
+TEST_F(RcclSymmetricMemoryTest, ToStringContainsExpectedFields) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  const std::string str = symm_mem->ToString();
+  EXPECT_THAT(str, HasSubstr("RcclSymmetricMemory"));
+  EXPECT_THAT(str, HasSubstr("comm="));
+  EXPECT_THAT(str, HasSubstr("win="));
+  EXPECT_THAT(str, HasSubstr("ptr="));
+}
+
+// Verifies that PackKernelArg() returns a non-null handle, and that the
+// win() accessor returns the same underlying ncclWindow_t.
+// NOTE: RCCL returns a null ncclWindow_t for single-rank communicators (no
+// remote peers to establish a window with). This test is skipped in that case.
+TEST_F(RcclSymmetricMemoryTest, PackKernelArgReturnsValidWindowHandle) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  if (symm_mem->win() == nullptr) {
+    GTEST_SKIP()
+        << "RCCL returned a null ncclWindow_t (expected on single-rank "
+           "communicators or RCCL versions without window support); "
+           "skipping window-handle assertions.";
+  }
+  // PackKernelArg() returns a void* (PackedKernelArg) wrapping the window.
+  auto packed = symm_mem->PackKernelArg();
+  EXPECT_NE(packed, nullptr);
+  // win() returns the typed ncclWindow_t handle directly.
+  EXPECT_NE(symm_mem->win(), nullptr);
+}
+
+// Verifies that multimem_addr() returns Unimplemented — RCCL does not support
+// multimem, so the base-class default is expected.
+TEST_F(RcclSymmetricMemoryTest, MultimemAddrNotSupported) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  auto result = symm_mem->multimem_addr();
+  EXPECT_THAT(result, Not(IsOk()));
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kUnimplemented);
+}
+
+// Verifies that two independent windows created from the same communicator
+// on different buffers have distinct ncclWindow_t handles.
+// NOTE: Skipped when RCCL returns null windows (e.g. single-rank communicator).
+TEST_F(RcclSymmetricMemoryTest, TwoWindowsHaveDistinctHandles) {
+  void* buf2_ptr = nullptr;
+  ASSERT_EQ(ncclMemAlloc(&buf2_ptr, buf_size_), ncclSuccess);
+
+  se::DeviceAddressBase addr1(buf_ptr_, buf_size_);
+  se::DeviceAddressBase addr2(buf2_ptr, buf_size_);
+
+  ASSERT_OK_AND_ASSIGN(auto symm1, RcclSymmetricMemory::Create(comm_, addr1));
+  ASSERT_OK_AND_ASSIGN(auto symm2, RcclSymmetricMemory::Create(comm_, addr2));
+
+  if (symm1->win() == nullptr || symm2->win() == nullptr) {
+    (void)ncclMemFree(buf2_ptr);
+    GTEST_SKIP() << "RCCL returned null ncclWindow_t handle(s) (expected on "
+                    "single-rank communicators); skipping distinctness check.";
+  }
+
+  EXPECT_NE(symm1->win(), symm2->win());
+  EXPECT_EQ(symm1->addr().opaque(), buf_ptr_);
+  EXPECT_EQ(symm2->addr().opaque(), buf2_ptr);
+
+  (void)ncclMemFree(buf2_ptr);
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory_test.cc
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory_test.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "rocm/include/hip/hip_runtime.h"
+#include "rocm/rocm_config.h"
 #include "xla/stream_executor/device_address.h"
 
 #if (TF_ROCM_VERSION >= 50200)
@@ -162,6 +163,8 @@ TEST_F(RcclSymmetricMemoryTest, TwoWindowsHaveDistinctHandles) {
   ASSERT_OK_AND_ASSIGN(auto symm2, RcclSymmetricMemory::Create(comm_, addr2));
 
   if (symm1->win() == nullptr || symm2->win() == nullptr) {
+    symm2.reset();
+    symm1.reset();
     (void)ncclMemFree(buf2_ptr);
     GTEST_SKIP() << "RCCL returned null ncclWindow_t handle(s) (expected on "
                     "single-rank communicators); skipping distinctness check.";
@@ -171,6 +174,9 @@ TEST_F(RcclSymmetricMemoryTest, TwoWindowsHaveDistinctHandles) {
   EXPECT_EQ(symm1->addr().opaque(), buf_ptr_);
   EXPECT_EQ(symm2->addr().opaque(), buf2_ptr);
 
+  // Deregister windows before freeing the underlying memory.
+  symm2.reset();
+  symm1.reset();
   (void)ncclMemFree(buf2_ptr);
 }
 


### PR DESCRIPTION
📝 Summary of Changes
This PR is the first in a series of five. 
PR 1/5 : https://github.com/openxla/xla/pull/42531  <= This PR
PR 2/5: https://github.com/openxla/xla/pull/42533  
PR 3/5: https://github.com/openxla/xla/pull/42540  
PR 4/5: https://github.com/openxla/xla/pull/42541 
PR 5/5: https://github.com/openxla/xla/pull/42543  
These PRs aim to enable the Triton backend for the All-Gather collective operation.

This PR adds `RcclSymmetricMemory` class for P2P IPC buffer allocation and exchange across ranks, which is required by the AllGather Triton kernel at runtime.

🎯 Justification
Lowering All-Gather through the triton backend significantly improves performance of this operation for AMD target (compared to RCCL backend) and could allow us to take greater advantage of kernel-level fusion.

Example of 5 Triton Performance Improvements — All-Gather 1D on MI350
| dtype | shape | num_replicas | input_size_kb | output_size_kb | RCCL mean_us | Triton mean_us | Triton/RCCL | Improvement
| -- | -- | -- | -- | -- | -- | -- | -- | --
| bf16 | 2097152 | 4 | 4096 | 16384 | 148.106 | 52.740 | 0.356 | 64.4%
| f16 | 2097152 | 4 | 4096 | 16384 | 126.587 | 51.817 | 0.409 | 59.1%
| bf16 | 2097152 | 2 | 4096 | 8192 | 124.716 | 51.393 | 0.412 | 58.8%
| bf16 | 4194304 | 2 | 8192 | 16384 | 206.720 | 86.595 | 0.419 | 58.1%
| bf16 | 4194304 | 4 | 8192 | 32768 | 223.113 | 95.644 | 0.429 | 57.1%

Example of 5 Triton Performance Improvements — All-Gather 2D on MI350
| dtype | shape     | gather_dim | num_replicas | input_size_kb | output_size_kb | RCCL mean_us | Triton mean_us | Triton/RCCL | Improvement |
| ----- | --------- | ---------: | -----------: | ------------: | -------------: | -----------: | -------------: | ----------: | ----------: |
| bf16  | 1024x1024 |          0 |            2 |          2048 |           4096 |       81.743 |         28.737 |       0.352 |       64.8% |
| u4    | 1024x1024 |          0 |            2 |           512 |           1024 |       49.423 |         21.110 |       0.427 |       57.3% |
| u4    | 256x256   |          1 |            2 |            32 |             64 |       43.142 |         19.736 |       0.457 |       54.3% |
| u4    | 1024x512  |          1 |            2 |           256 |            512 |       39.583 |         20.909 |       0.528 |       47.2% |
| u4    | 2048x2048 |          1 |            2 |          2048 |           4096 |       83.845 |         32.911 |       0.392 |       60.8% |


🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement,✨ New Feature

🧪 Execution Tests:
Tests included in this PR.
