### PR TITLE
[ROCm][Triton]  AllGather build info (PR 3/5)

### DIFF
--- a/xla/backends/gpu/codegen/triton/fusion.cc
+++ b/xla/backends/gpu/codegen/triton/fusion.cc
@@ -132,12 +132,28 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
   std::string suggested_kernel_name = std::string(fusion.name());
   llvm::IRBuilder builder(*ir_emitter_context.llvm_context());
   VLOG(3) << fusion.ToString();
-  TF_ASSIGN_OR_RETURN(
-      auto kernel_arguments,
-      emitters::KernelArguments::Create(
-          ir_emitter_context.buffer_assignment(), GetDefaultBufferAlignment(),
-          instr_override != nullptr ? instr_override : &fusion,
-          unmanaged_arguments));
+
+  // Special handling for AllGather with tuple unpacking
+  absl::StatusOr<emitters::KernelArguments> kernel_arguments_or;
+  if (instr_override != nullptr &&
+      instr_override->opcode() == HloOpcode::kAllGatherStart &&
+      instr_override->shape().IsTuple() && !fusion.shape().IsTuple()) {
+    // Use the new overload: fusion for shapes, AllGather for buffers at index
+    // {1}
+    kernel_arguments_or = emitters::KernelArguments::Create(
+        ir_emitter_context.buffer_assignment(), GetDefaultBufferAlignment(),
+        &fusion,         // shape_instruction
+        instr_override,  // buffer_instruction
+        ShapeIndex{1},   // output_index (element 1 of AllGather tuple)
+        unmanaged_arguments);
+  } else {
+    // Regular path for AllReduce and other operations
+    kernel_arguments_or = emitters::KernelArguments::Create(
+        ir_emitter_context.buffer_assignment(), GetDefaultBufferAlignment(),
+        instr_override != nullptr ? instr_override : &fusion,
+        unmanaged_arguments);
+  }
+  TF_ASSIGN_OR_RETURN(auto kernel_arguments, std::move(kernel_arguments_or));
 
   const HloComputation* hlo_computation =
       fusion.fused_instructions_computation();
@@ -158,7 +174,6 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
             ir_emitter_context.data_layout(), ir_emitter_context.llvm_context(),
             ir_emitter_context.mlir_context()));
     local_module = std::move(triton_wrapper_result.llvm_module);
-
     auto backend_config =
         fusion.backend_config<GpuBackendConfig>()->fusion_backend_config();
     absl::string_view fusion_kind = backend_config.kind();
@@ -172,7 +187,6 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
         kTritonNestedGemmFusionKind,
         kTritonCollectiveFusionKind,
     };
-
     if (!absl::c_linear_search(kSupportedFusionKinds, fusion_kind)) {
       return Internal("Unsupported fusion kind: %s", fusion_kind);
     }
@@ -251,25 +265,45 @@ std::optional<TritonFusion::LaunchConfig> TritonFusion::GetLaunchConfig(
 
     // We expect all roots to have the same number of blocks. Otherwise we
     // cannot codegen it.
+    LOG(INFO) << "GetLaunchConfig: fusion_root_count="
+              << analysis_.fusion_root_count();
+
+    if (analysis_.fusion_root_count() == 0) {
+      LOG(ERROR) << "GetLaunchConfig: No fusion roots found!";
+      return std::nullopt;
+    }
+
     int64_t num_blocks =
         GetNumberOfBlocks(analysis_.fusion_root(0).shape().dimensions(),
                           block_level_parameters.output_tile_sizes[0]);
     for (int64_t i = 1; i < analysis_.fusion_root_count(); ++i) {
-      CHECK_EQ(GetNumberOfBlocks(analysis_.fusion_root(i).shape().dimensions(),
-                                 block_level_parameters.output_tile_sizes[i]),
-               num_blocks);
-    }
+      if (i >= block_level_parameters.output_tile_sizes.size()) {
+        LOG(ERROR)
+            << "GetLaunchConfig: output_tile_sizes index out of bounds! i=" << i
+            << ", size=" << block_level_parameters.output_tile_sizes.size();
+        return std::nullopt;
+      }
 
+      int64_t blocks_for_root =
+          GetNumberOfBlocks(analysis_.fusion_root(i).shape().dimensions(),
+                            block_level_parameters.output_tile_sizes[i]);
+
+      CHECK_EQ(blocks_for_root, num_blocks);
+    }
     LaunchConfig launch_config;
     // TODO(b/451901200): We eventually also want to be able to predict this
     // value without compiling so the cost model can rely on it. Currently, we
     // need the override for auto warp specialization.
+    LOG(INFO) << "GetLaunchConfig: thread_dims_override.has_value()="
+              << thread_dims_override.has_value();
+
     if (thread_dims_override) {
       launch_config.launch_dimensions = LaunchDimensions{
           se::BlockDim(num_blocks), thread_dims_override.value()};
     } else {
+      int64_t warp_size = WarpSize(analysis_.device_info());
       int64_t estimated_threads_per_block =
-          block_level_parameters.num_warps * WarpSize(analysis_.device_info());
+          block_level_parameters.num_warps * warp_size;
       launch_config.launch_dimensions =
           LaunchDimensions{static_cast<uint64_t>(num_blocks),
                            static_cast<uint64_t>(estimated_threads_per_block)};

--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -750,6 +750,57 @@ cc_library(
     ],
 )
 
+
+xla_cc_test(
+    name = "rccl_symmetric_memory_test",
+    srcs = ["rccl_symmetric_memory_test.cc"],
+    tags = [
+        "gpu",
+        "no-oneapi",
+        "rocm-only",
+        "requires-gpu-amd",
+    ],
+    deps = [
+        ":rccl_errors",
+        ":rccl_symmetric_memory",
+        "//xla/stream_executor:device_address",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
+cc_library(
+    name = "rccl_symmetric_memory",
+    srcs = ["rccl_symmetric_memory.cc"],
+    hdrs = ["rccl_symmetric_memory.h"],
+    tags = [
+        "gpu",
+        "no-oneapi",
+        "rocm-only",
+    ],
+    visibility = [
+        "//xla/backends/gpu/runtime:__subpackages__",
+    ],
+    deps = [
+        ":rccl_errors",
+        "//xla:util",
+        "//xla/core/collectives:rank_id",
+        "//xla/core/collectives:symmetric_memory",
+        "//xla/stream_executor:device_address",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@local_config_rocm//rocm:rccl",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
 cc_library(
     name = "rccl_communicator",
     srcs = ["rccl_communicator.cc"],
@@ -765,6 +816,7 @@ cc_library(
         ":gpu_collectives",
         ":gpu_communicator",
         ":rccl_errors",
+        ":rccl_symmetric_memory",
         ":single_threaded_executor",
         "//xla:future",
         "//xla:shape_util",

--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "xla/backends/gpu/collectives/rccl_communicator.h"
+#include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
 
 #include <atomic>
 #include <cstddef>
@@ -680,6 +681,11 @@ absl::Status RcclCommunicator::LaunchRecv(se::DeviceAddressBase recv_buffer,
     TF_RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<SymmetricMemory>>
+RcclCommunicator::CreateSymmetricMemory(se::DeviceAddressBase addr) {
+  return RcclSymmetricMemory::Create(comm_, addr);
 }
 
 std::string RcclCommunicator::ToString() const {

--- a/xla/backends/gpu/collectives/rccl_communicator.h
+++ b/xla/backends/gpu/collectives/rccl_communicator.h
@@ -119,6 +119,9 @@ class RcclCommunicator : public GpuCommunicator {
   Future<> Recv(se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
                 size_t count, RankId peer, const Executor& executor) final;
 
+  absl::StatusOr<std::unique_ptr<SymmetricMemory>> CreateSymmetricMemory(
+      se::DeviceAddressBase addr) final;
+
   std::string ToString() const final;
 
   ncclComm_t comm() const { return comm_; }

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory.cc
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory.cc
@@ -1,0 +1,70 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
+
+#include <memory>
+#include <string>
+
+#include "absl/log/log.h"
+#include "absl/memory/memory.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "xla/backends/gpu/collectives/rccl_errors.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/util.h"
+
+namespace xla::gpu {
+
+RcclSymmetricMemory::RcclSymmetricMemory(
+    ncclComm_t comm, ncclWindow_t win, stream_executor::DeviceAddressBase addr)
+    : comm_(comm), win_(win), addr_(addr) {}
+
+absl::StatusOr<std::unique_ptr<RcclSymmetricMemory>>
+RcclSymmetricMemory::Create(ncclComm_t comm,
+                            stream_executor::DeviceAddressBase addr) {
+  VLOG(3) << absl::StrFormat(
+      "Create RCCL symmetric memory on comm=%p from: ptr=%p; size=%ld", comm,
+      addr.opaque(), addr.size());
+
+  ncclWindow_t win;
+  XLA_RCCL_RETURN_IF_ERROR(ncclCommWindowRegister(
+      comm, addr.opaque(), addr.size(), &win, NCCL_WIN_COLL_SYMMETRIC));
+
+  return absl::WrapUnique(new RcclSymmetricMemory(comm, win, addr));
+}
+
+RcclSymmetricMemory::~RcclSymmetricMemory() {
+  VLOG(3) << absl::StrFormat("Destroy %v", *this);
+  XLA_RCCL_LOG_IF_ERROR(ncclCommWindowDeregister(comm_, win_));
+}
+
+stream_executor::DeviceAddressBase RcclSymmetricMemory::addr() const {
+  return addr_;
+}
+
+std::string RcclSymmetricMemory::ToString() const {
+  return absl::StrFormat(
+      "RcclSymmetricMemory(comm=%p, win=%p, ptr=%p, size=%ld)", comm_, win_,
+      addr_.opaque(), addr_.size());
+}
+
+RcclSymmetricMemory::PackedKernelArg RcclSymmetricMemory::PackKernelArg()
+    const {
+  return win_;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory.h
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory.h
@@ -1,0 +1,67 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_RCCL_SYMMETRIC_MEMORY_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_RCCL_SYMMETRIC_MEMORY_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "rocm/rocm_config.h"  // IWYU pragma: keep  (defines TF_ROCM_VERSION)
+#include "xla/core/collectives/symmetric_memory.h"
+#include "xla/stream_executor/device_address.h"
+
+#if (TF_ROCM_VERSION >= 50200)
+#include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif  // TF_ROCM_VERSION >= 50200
+
+namespace xla::gpu {
+
+// An RCCL window registration handle that makes local buffers accessible from
+// remote peers via symmetric memory registration. Analogous to
+// NcclSymmetricMemory for the ROCm/RCCL platform.
+class RcclSymmetricMemory final : public SymmetricMemory {
+ public:
+  ~RcclSymmetricMemory() final;
+
+  static absl::StatusOr<std::unique_ptr<RcclSymmetricMemory>> Create(
+      ncclComm_t comm, stream_executor::DeviceAddressBase addr);
+
+  stream_executor::DeviceAddressBase addr() const final;
+
+  // multimem_addr() and peer_addr() are not supported by RCCL; the base-class
+  // defaults (returning Unimplemented) are used.
+
+  ncclWindow_t win() const { return win_; }
+
+  std::string ToString() const final;
+
+  PackedKernelArg PackKernelArg() const final;
+
+ private:
+  RcclSymmetricMemory(ncclComm_t comm, ncclWindow_t win,
+                      stream_executor::DeviceAddressBase addr);
+
+  ncclComm_t comm_;
+  ncclWindow_t win_;
+  stream_executor::DeviceAddressBase addr_;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_RCCL_SYMMETRIC_MEMORY_H_

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory_test.cc
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory_test.cc
@@ -1,0 +1,177 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/device_address.h"
+
+#if (TF_ROCM_VERSION >= 50200)
+#include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif  // TF_ROCM_VERSION >= 50200
+
+namespace xla::gpu {
+namespace {
+
+namespace se = stream_executor;
+
+using ::absl_testing::IsOk;
+using ::testing::HasSubstr;
+using ::testing::Not;
+
+// Test fixture that creates a single-rank RCCL communicator and allocates a
+// small GPU buffer. Tests are skipped if no ROCm device or RCCL is available.
+class RcclSymmetricMemoryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Skip if no ROCm/HIP GPU is present.
+    int device_count = 0;
+    if (hipGetDeviceCount(&device_count) != hipSuccess || device_count < 1) {
+      GTEST_SKIP() << "No ROCm/HIP GPU device available";
+    }
+    if (hipSetDevice(0) != hipSuccess) {
+      GTEST_SKIP() << "hipSetDevice(0) failed";
+    }
+
+    // Initialise a single-rank RCCL communicator on device 0.
+    int device_ids[] = {0};
+    ncclResult_t nccl_err = ncclCommInitAll(&comm_, 1, device_ids);
+    if (nccl_err != ncclSuccess) {
+      GTEST_SKIP() << "RCCL communicator initialisation failed: "
+                   << ncclGetErrorString(nccl_err);
+    }
+
+    // Allocate a 4 KiB symmetric memory buffer via RCCL. ncclMemAlloc ensures
+    // the buffer is mapped at the same virtual address on all ranks, which is
+    // required for ncclCommWindowRegister with NCCL_WIN_COLL_SYMMETRIC.
+    constexpr size_t kBufSize = 4096;
+    buf_size_ = kBufSize;
+    if (ncclMemAlloc(&buf_ptr_, buf_size_) != ncclSuccess) {
+      ncclCommDestroy(comm_);
+      comm_ = nullptr;
+      GTEST_SKIP() << "ncclMemAlloc(" << kBufSize << ") failed";
+    }
+  }
+
+  void TearDown() override {
+    if (buf_ptr_ != nullptr) {
+      (void)ncclMemFree(buf_ptr_);
+      buf_ptr_ = nullptr;
+    }
+    if (comm_ != nullptr) {
+      ncclCommDestroy(comm_);
+      comm_ = nullptr;
+    }
+  }
+
+  ncclComm_t comm_ = nullptr;
+  void* buf_ptr_ = nullptr;
+  size_t buf_size_ = 0;
+};
+
+// Verifies that RcclSymmetricMemory::Create succeeds for a valid buffer.
+TEST_F(RcclSymmetricMemoryTest, CreateSucceeds) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  ASSERT_NE(symm_mem, nullptr);
+}
+
+// Verifies that addr() returns exactly the pointer and size that were
+// registered.
+TEST_F(RcclSymmetricMemoryTest, AddrMatchesRegisteredBuffer) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  EXPECT_EQ(symm_mem->addr().opaque(), buf_ptr_);
+  EXPECT_EQ(symm_mem->addr().size(), buf_size_);
+}
+
+// Verifies that ToString() contains key diagnostic fields.
+TEST_F(RcclSymmetricMemoryTest, ToStringContainsExpectedFields) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  const std::string str = symm_mem->ToString();
+  EXPECT_THAT(str, HasSubstr("RcclSymmetricMemory"));
+  EXPECT_THAT(str, HasSubstr("comm="));
+  EXPECT_THAT(str, HasSubstr("win="));
+  EXPECT_THAT(str, HasSubstr("ptr="));
+}
+
+// Verifies that PackKernelArg() returns a non-null handle, and that the
+// win() accessor returns the same underlying ncclWindow_t.
+// NOTE: RCCL returns a null ncclWindow_t for single-rank communicators (no
+// remote peers to establish a window with). This test is skipped in that case.
+TEST_F(RcclSymmetricMemoryTest, PackKernelArgReturnsValidWindowHandle) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  if (symm_mem->win() == nullptr) {
+    GTEST_SKIP() << "RCCL returned a null ncclWindow_t (expected on single-rank "
+                    "communicators or RCCL versions without window support); "
+                    "skipping window-handle assertions.";
+  }
+  // PackKernelArg() returns a void* (PackedKernelArg) wrapping the window.
+  auto packed = symm_mem->PackKernelArg();
+  EXPECT_NE(packed, nullptr);
+  // win() returns the typed ncclWindow_t handle directly.
+  EXPECT_NE(symm_mem->win(), nullptr);
+}
+
+// Verifies that multimem_addr() returns Unimplemented — RCCL does not support
+// multimem, so the base-class default is expected.
+TEST_F(RcclSymmetricMemoryTest, MultimemAddrNotSupported) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  auto result = symm_mem->multimem_addr();
+  EXPECT_THAT(result, Not(IsOk()));
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kUnimplemented);
+}
+
+// Verifies that two independent windows created from the same communicator
+// on different buffers have distinct ncclWindow_t handles.
+// NOTE: Skipped when RCCL returns null windows (e.g. single-rank communicator).
+TEST_F(RcclSymmetricMemoryTest, TwoWindowsHaveDistinctHandles) {
+  void* buf2_ptr = nullptr;
+  ASSERT_EQ(ncclMemAlloc(&buf2_ptr, buf_size_), ncclSuccess);
+
+  se::DeviceAddressBase addr1(buf_ptr_, buf_size_);
+  se::DeviceAddressBase addr2(buf2_ptr, buf_size_);
+
+  ASSERT_OK_AND_ASSIGN(auto symm1, RcclSymmetricMemory::Create(comm_, addr1));
+  ASSERT_OK_AND_ASSIGN(auto symm2, RcclSymmetricMemory::Create(comm_, addr2));
+
+  if (symm1->win() == nullptr || symm2->win() == nullptr) {
+    (void)ncclMemFree(buf2_ptr);
+    GTEST_SKIP() << "RCCL returned null ncclWindow_t handle(s) (expected on "
+                    "single-rank communicators); skipping distinctness check.";
+  }
+
+  EXPECT_NE(symm1->win(), symm2->win());
+  EXPECT_EQ(symm1->addr().opaque(), buf_ptr_);
+  EXPECT_EQ(symm2->addr().opaque(), buf2_ptr);
+
+  (void)ncclMemFree(buf2_ptr);
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -3724,6 +3724,49 @@ xla_test(
 )
 
 cc_library(
+    name = "all_gather",
+    srcs = ["all_gather.cc"],
+    hdrs = ["all_gather.h"],
+    deps = [
+        "//xla:shape_util",
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/service/gpu:launch_dimensions",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/gpu:all_reduce_kernel",
+        "//xla/tsl/platform:errors",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+xla_cc_test(
+    name = "all_gather_build_info_test",
+    srcs = ["all_gather_build_info_test.cc"],
+    deps = [
+        ":all_gather",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service/gpu:gpu_device_info_for_tests",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/host:host_platform",
+        "//xla/tsl/lib/gtl:int_type",
+        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:test",
+        "//xla/tsl/platform:test_main",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
     name = "all_reduce",
     srcs = ["all_reduce.cc"],
     hdrs = ["all_reduce.h"],

--- a/xla/backends/gpu/runtime/all_gather.cc
+++ b/xla/backends/gpu/runtime/all_gather.cc
@@ -1,0 +1,148 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/all_gather.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "llvm/ADT/bit.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/primitive_util.h"
+#include "xla/service/gpu/launch_dimensions.h"
+#include "xla/shape_util.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/gpu/all_reduce_kernel.h"
+#include "xla/tsl/platform/errors.h"
+#include "xla/util.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+
+absl::Status IsAllGatherKernelSupported(int64_t num_ranks, int64_t num_elements,
+                                        PrimitiveType element_type) {
+  // Unsigned integer types are not supported by the Triton all-gather kernel.
+  if (element_type == U32 || element_type == U16 || element_type == U64) {
+    return absl::UnimplementedError(
+        absl::StrCat("Element type (",
+                     primitive_util::LowercasePrimitiveTypeName(element_type),
+                     ") is not supported for all-gather kernel."));
+  }
+  // The number of elements must be aligned to kNumElementsPerThread.
+  if (num_elements % se::gpu::kNumElementsPerThread != 0) {
+    return absl::UnimplementedError(
+        absl::StrCat("Number of elements (", num_elements,
+                     ") is not aligned to the alignment requirement (",
+                     se::gpu::kNumElementsPerThread, ")."));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status IsAllGatherKernelSupported(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    int32_t num_operands, int64_t num_devices, int64_t num_elements,
+    PrimitiveType element_type, bool is_local,
+    const std::vector<ReplicaGroup>& replica_groups) {
+  if (!is_collective_kernel_enabled) {
+    return absl::UnimplementedError("Collective kernel is not enabled.");
+  }
+  // Check if the device supports Triton collective codegen:
+  // CUDA: Requires compute capability 9.0+ (Hopper or newer)
+  // ROCm: All versions with Triton support are enabled
+  if (!device_info.cuda_compute_capability().IsAtLeastHopper() &&
+      !device_info.gpu_compute_capability().IsRocm()) {
+    return absl::UnimplementedError(absl::StrCat(
+        "Triton collective codegen requires CUDA compute capability >= 9.0 "
+        "(Hopper or newer) or a ROCm device with Triton support. "
+        "Got: ",
+        device_info.gpu_compute_capability().ToString(), "."));
+  }
+  // TODO(b/383125489): Support variadic arguments.
+  if (num_operands != 1) {
+    return absl::UnimplementedError(
+        absl::StrCat("Collective kernel is not supported for number of "
+                     "operands not equal to 1. Got ",
+                     num_operands, "."));
+  }
+  if (replica_groups.empty()) {
+    return absl::UnimplementedError(
+        "Replica groups must be explicitly provided for collective kernels.");
+  }
+  if (!is_local) {
+    return absl::UnimplementedError(
+        "Cross-host symmetric memory collectives are not supported.");
+  }
+  if (!llvm::has_single_bit(static_cast<uint64_t>(num_devices))) {
+    return absl::UnimplementedError(
+        absl::StrCat("Collective kernels are only supported for power of 2 "
+                     "number of devices. Got ",
+                     num_devices, "."));
+  }
+  return IsAllGatherKernelSupported(num_devices, num_elements, element_type);
+}
+
+absl::StatusOr<AllGatherInfo> BuildAllGatherInfo(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    const HloAllGatherInstruction* all_gather) {
+  if (!all_gather->device_list()) {
+    return absl::UnimplementedError(
+        "Replica groups must be explicitly provided for collective kernels.");
+  }
+  const int64_t num_devices =
+      all_gather->device_list()->num_devices_per_group();
+  const int64_t num_elements =
+      ShapeUtil::ElementsIn(all_gather->operand(0)->shape());
+  const PrimitiveType element_type =
+      all_gather->operand(0)->shape().element_type();
+  const int32_t num_operands = all_gather->operand_count();
+  TF_RETURN_IF_ERROR(IsAllGatherKernelSupported(
+      is_collective_kernel_enabled, device_info, num_operands, num_devices,
+      num_elements, element_type, /*is_local=*/true,
+      all_gather->replica_groups()));
+  return AllGatherInfo{
+      /*.num_devices =*/num_devices,
+      /*.num_elements =*/num_elements,
+      /*.element_type =*/element_type,
+  };
+}
+
+namespace {
+// All-gather always uses a one-shot strategy: every rank reads its peers'
+// slices directly, so the work is proportional to the full element count
+// with no rank-based partitioning.
+static constexpr int64_t kMaxBlocksPerGrid = 32;
+static constexpr uint64_t kMaxThreadsPerBlock = 512;
+static constexpr int64_t kWarpSize = 32;
+}  // namespace
+
+LaunchDimensions AllGatherLaunchDimensions(int64_t elements,
+                                           int64_t num_ranks) {
+  // Maximum number of threads such that each thread has elements to process.
+  const int64_t total_threads = RoundUpTo(
+      CeilOfRatio(elements, se::gpu::kNumElementsPerThread), kWarpSize);
+  // Triton expects power of 2 for threads_per_block / threads_per_warp.
+  const int64_t threads_per_block =
+      std::min(kMaxThreadsPerBlock,
+               llvm::bit_ceil(static_cast<uint64_t>(total_threads)));
+  const int64_t blocks_per_grid = std::min(
+      kMaxBlocksPerGrid, CeilOfRatio(total_threads, threads_per_block));
+  return LaunchDimensions(blocks_per_grid, threads_per_block);
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/all_gather.h
+++ b/xla/backends/gpu/runtime/all_gather.h
@@ -1,0 +1,66 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_
+#define XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/service/gpu/launch_dimensions.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+
+// Encapsulates the information needed to perform an all-gather.
+struct AllGatherInfo {
+  int64_t num_devices;
+  int64_t num_elements;
+  PrimitiveType element_type;
+};
+
+// Returns absl::OkStatus() if the all-gather kernel is supported for the given
+// element type and number of elements, or an error status detailing why it is
+// not supported.
+absl::Status IsAllGatherKernelSupported(int64_t num_ranks, int64_t num_elements,
+                                        PrimitiveType element_type);
+
+// A broader check for all-gather kernel support.
+// Returns absl::OkStatus() if supported, or an error status detailing why
+// it is not supported.
+absl::Status IsAllGatherKernelSupported(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    int32_t num_operands, int64_t num_devices, int64_t num_elements,
+    PrimitiveType element_type, bool is_local,
+    const std::vector<ReplicaGroup>& replica_groups);
+
+// Constructs an AllGatherInfo object for the given all-gather instruction.
+// Returns an error status if the all-gather kernel is not supported.
+absl::StatusOr<AllGatherInfo> BuildAllGatherInfo(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    const HloAllGatherInstruction* all_gather);
+
+// Returns the launch dimensions for the all-gather kernel.
+// All-gather uses a fixed one-shot tiling strategy: each rank contributes its
+// local slice to the output.
+LaunchDimensions AllGatherLaunchDimensions(int64_t elements, int64_t num_ranks);
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_

--- a/xla/backends/gpu/runtime/all_gather_build_info_test.cc
+++ b/xla/backends/gpu/runtime/all_gather_build_info_test.cc
@@ -1,0 +1,177 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/gpu/runtime/all_gather.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/primitive_util.h"
+#include "xla/service/gpu/gpu_device_info_for_tests.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/tsl/lib/gtl/int_type.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/test.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+namespace {
+
+using ::absl_testing::IsOkAndHolds;
+using ::absl_testing::StatusIs;
+using ::testing::AllOf;
+using ::testing::Field;
+using ::testing::HasSubstr;
+
+TSL_LIB_GTL_DEFINE_INT_TYPE(CollectiveKernelEnabled, bool);
+
+class BuildAllGatherInfoTest : public HloHardwareIndependentTestBase {
+ protected:
+  // Builds an all-gather HLO module and invokes BuildAllGatherInfo.
+  //
+  // `num_elements` is the number of elements in the input operand (per
+  // replica). The all-gather is 1-D along dimension 0.
+  //
+  // `replica_groups` is a flat list of device IDs forming a single replica
+  // group. An empty list means replica_groups={} (empty) in the HLO, which
+  // will trigger the "replica groups must be provided" error path.
+  absl::StatusOr<AllGatherInfo> BuildInfo(
+      CollectiveKernelEnabled collective_kernel_enabled,
+      PrimitiveType element_type, int64_t num_elements,
+      std::vector<int32_t> replica_groups) {
+    const int num_replicas =
+        replica_groups.empty() ? 1 : static_cast<int>(replica_groups.size());
+    const std::string element_type_str =
+        primitive_util::LowercasePrimitiveTypeName(element_type);
+    const std::string input_shape_str = absl::StrFormat("%d", num_elements);
+    const std::string output_shape_str =
+        absl::StrFormat("%d", num_elements * num_replicas);
+    const std::string replica_groups_str =
+        replica_groups.empty()
+            ? ""
+            : absl::StrFormat("{%s}", absl::StrJoin(replica_groups, ","));
+
+    // The all-gather gathers along dimension 0: output_dim0 = num_replicas *
+    // input_dim0.
+    constexpr absl::string_view kModuleStr = R"(
+    HloModule test
+    ENTRY test_computation {
+      param_0 = %1$s[%2$s] parameter(0)
+      ROOT all-gather = %1$s[%3$s] all-gather(param_0),
+          dimensions={0}, replica_groups={%4$s}
+    }
+    )";
+    const std::string module_str =
+        absl::StrFormat(kModuleStr, element_type_str, input_shape_str,
+                        output_shape_str, replica_groups_str);
+
+    SCOPED_TRACE(testing::Message() << "module_str: " << module_str);
+
+    se::DeviceDescription device_info =
+        TestGpuDeviceInfo::H100SXMDeviceInfo();
+
+    TF_ASSIGN_OR_RETURN(
+        std::unique_ptr<HloModule> module,
+        ParseAndReturnVerifiedModule(module_str, num_replicas));
+
+    const HloInstruction* hlo_instr =
+        HloHardwareIndependentTestBase::FindInstruction(
+            module.get(), HloOpcode::kAllGather);
+    return BuildAllGatherInfo(collective_kernel_enabled.value(), device_info,
+                              Cast<HloAllGatherInstruction>(hlo_instr));
+  }
+};
+
+TEST_F(BuildAllGatherInfoTest, SucceedsForSupportedF32) {
+  EXPECT_THAT(BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                        /*replica_groups=*/{0, 1}),
+              IsOkAndHolds(AllOf(
+                  Field(&AllGatherInfo::num_devices, 2),
+                  Field(&AllGatherInfo::num_elements, 512),
+                  Field(&AllGatherInfo::element_type, F32))));
+}
+
+TEST_F(BuildAllGatherInfoTest, SucceedsForSupportedBF16) {
+  EXPECT_THAT(BuildInfo(CollectiveKernelEnabled(true), BF16,
+                        /*num_elements=*/512, /*replica_groups=*/{0, 1}),
+              IsOkAndHolds(AllOf(
+                  Field(&AllGatherInfo::num_devices, 2),
+                  Field(&AllGatherInfo::num_elements, 512),
+                  Field(&AllGatherInfo::element_type, BF16))));
+}
+
+TEST_F(BuildAllGatherInfoTest, SucceedsForFourDevices) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1, 2, 3}),
+      IsOkAndHolds(AllOf(Field(&AllGatherInfo::num_devices, 4),
+                         Field(&AllGatherInfo::num_elements, 512),
+                         Field(&AllGatherInfo::element_type, F32))));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsIfCollectiveKernelDisabled) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(false), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1}),
+      StatusIs(absl::StatusCode::kUnimplemented, HasSubstr("not enabled")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForNonPowerOfTwoDevices) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1, 2}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("only supported for power of 2")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForUnsupportedUnsignedType) {
+  // U32 is not supported by the Triton all-gather kernel.
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), U32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("is not supported for all-gather kernel")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForUnalignedElements) {
+  // 7 is not divisible by kNumElementsPerThread (which is >= 2).
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/7,
+                /*replica_groups=*/{0, 1}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("not aligned to the alignment requirement")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsIfReplicaGroupsEmpty) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("Replica groups must be explicitly provided")));
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/codegen/emitters/kernel_arguments.cc
+++ b/xla/codegen/emitters/kernel_arguments.cc
@@ -190,6 +190,61 @@ absl::StatusOr<KernelArguments> KernelArguments::Create(
                                hlo_instruction, unmanaged_arguments);
 }
 
+// Special overload for AllGather with tuple unpacking
+absl::StatusOr<KernelArguments> KernelArguments::Create(
+    const BufferAssignment& buffer_assignment,
+    const BufferAlignment& buffer_alignment,
+    const HloInstruction* shape_instruction,
+    const HloInstruction* buffer_instruction, const ShapeIndex& output_index,
+    absl::Span<const Shape> unmanaged_arguments) {
+  std::vector<KernelArgument> kernel_arguments;
+
+  // Input arguments: use shape_instruction's operands for shapes,
+  // but buffer_instruction's operands for buffer lookups
+  for (int i = 0; i < shape_instruction->operand_count(); ++i) {
+    const HloInstruction* shape_operand = shape_instruction->operand(i);
+    const HloInstruction* buffer_operand = buffer_instruction->operand(i);
+    TF_ASSIGN_OR_RETURN(BufferAllocation::Slice slice,
+                        buffer_assignment.GetUniqueSlice(buffer_operand, {}));
+    kernel_arguments.emplace_back(
+        KernelArgument(shape_operand->shape(), slice));
+  }
+
+  // Output arguments: use shape_instruction's shape,
+  // but look up buffer from buffer_instruction at output_index
+  absl::flat_hash_set<BufferAllocation::Slice> buffers_written;
+  TF_RETURN_IF_ERROR(ShapeUtil::ForEachSubshapeWithStatus(
+      shape_instruction->shape(),
+      [&](const Shape& subshape, const ShapeIndex& index) {
+        if (!subshape.IsArray()) return absl::OkStatus();
+
+        // For output buffers, look them up from buffer_instruction at
+        // output_index
+        ShapeIndex buffer_index = output_index;
+        // Append the current index to output_index for nested shapes
+        for (int64_t i : index) {
+          buffer_index.push_back(i);
+        }
+
+        TF_ASSIGN_OR_RETURN(
+            BufferAllocation::Slice slice,
+            buffer_assignment.GetUniqueSlice(buffer_instruction, buffer_index));
+
+        kernel_arguments.emplace_back(KernelArgument(subshape, slice));
+        buffers_written.insert(slice);
+        return absl::OkStatus();
+      }));
+
+  // Add unmanaged arguments
+  for (const Shape& unmanaged_argument : unmanaged_arguments) {
+    kernel_arguments.emplace_back(unmanaged_argument);
+  }
+
+  FillKernelArgumentAttributes(kernel_arguments, buffer_alignment,
+                               buffers_written);
+  return KernelArguments(std::move(kernel_arguments));
+}
+
 absl::StatusOr<KernelArguments> KernelArguments::Create(
     const BufferAssignment& buffer_assignment,
     const BufferAlignment& buffer_alignment,

--- a/xla/codegen/emitters/kernel_arguments.h
+++ b/xla/codegen/emitters/kernel_arguments.h
@@ -111,6 +111,22 @@ class KernelArguments {
       const BufferAlignment& buffer_alignment,
       const HloInstruction* hlo_instruction);
 
+  // Special overload for collective operations where the fusion has a different
+  // output shape than the original instruction (e.g., AllGather with tuple
+  // unpacking).
+  // - shape_instruction: Used to determine argument shapes (typically the
+  // fusion)
+  // - buffer_instruction: Used to look up buffer assignments (typically the
+  // original instruction)
+  // - output_index: ShapeIndex to use when looking up output buffers from
+  // buffer_instruction
+  static absl::StatusOr<KernelArguments> Create(
+      const BufferAssignment& buffer_assignment,
+      const BufferAlignment& buffer_alignment,
+      const HloInstruction* shape_instruction,
+      const HloInstruction* buffer_instruction, const ShapeIndex& output_index,
+      absl::Span<const Shape> unmanaged_arguments);
+
   // Certain kernels require output arguments to be interleaved with input
   // arguments. This function creates a KernelArguments object where the output
   // arguments are interleaved with the input arguments according to the

--- a/xla/hlo/analysis/indexing_analysis.cc
+++ b/xla/hlo/analysis/indexing_analysis.cc
@@ -1550,14 +1550,15 @@ void AssignValuesToRTVars(IndexingMap* indexing_map) {
 
 HloInstructionIndexing ComputeOutputToInputAllGatherOpIndexing(
     const HloAllGatherInstruction* instr, MLIRContext* mlir_context) {
-  // CHECK_EQ(instr->all_gather_dimension(), 0);
-  // if (instr->all_gather_dimension() != 0) {
-  //   return CreateUnknownIndexing(instr->operand_count());
-  // }
+  // For AllGather-start, the shape is a tuple (input, output)
+  // We need to use the output element (index 1) for indexing
+  const Shape& output_shape =
+      instr->shape().IsTuple()
+          ? ShapeUtil::GetTupleElementShape(instr->shape(), 1)
+          : instr->shape();
 
   int64_t all_gather_dim = instr->all_gather_dimension();
-
-  auto output_rank = instr->shape().dimensions().size();
+  auto output_rank = output_shape.dimensions().size();
 
   llvm::SmallVector<SymbolicExpr> exprs;
   exprs.reserve(output_rank);
@@ -1573,14 +1574,14 @@ HloInstructionIndexing ComputeOutputToInputAllGatherOpIndexing(
 
   IndexingMap indexing_map = IndexingMap::FromTensorSizes(
       SymbolicMap::Get(mlir_context, output_rank, 0, exprs),
-      instr->shape().dimensions(), {});
+      output_shape.dimensions(), {});
 
   SymbolicExpr replica_id_expr = CreateDimExpr(all_gather_dim, mlir_context)
                                      .floorDiv(all_gather_input_dim_size);
 
   IndexingMap replica_id_map = IndexingMap::FromTensorSizes(
       SymbolicMap::Get(mlir_context, output_rank, 0, {replica_id_expr}),
-      instr->shape().dimensions(), {});
+      output_shape.dimensions(), {});
 
   OperandIndexing operand_indexing(indexing_map, {}, replica_id_map);
 
@@ -1665,6 +1666,37 @@ HloInstructionIndexing ComputeOutputToInputIndexing(const HloInstruction* instr,
   }
   if (auto transpose = DynCast<HloTransposeInstruction>(instr)) {
     return ComputeOutputToInputTransposeOpIndexing(transpose, mlir_context);
+  }
+  // GetTupleElement extracts an element from a tuple operand.
+  // An identity mapping is only valid when the tuple operand's extracted
+  // element has the same shape as the GTE output. This is the case for
+  // AllGather fusion tiling where GTE acts as a pass-through.
+  if (instr->opcode() == HloOpcode::kGetTupleElement) {
+    auto* gte = Cast<HloGetTupleElementInstruction>(instr);
+    const HloInstruction* tuple_operand = gte->operand(0);
+    const Shape& tuple_shape = tuple_operand->shape();
+    const Shape& output_shape = gte->shape();
+
+    // Verify the operand is a tuple and the extracted element shape matches
+    if (tuple_shape.IsTuple() &&
+        gte->tuple_index() < tuple_shape.tuple_shapes_size()) {
+      const Shape& element_shape = tuple_shape.tuple_shapes(gte->tuple_index());
+
+      // Only use identity mapping if the extracted element shape matches
+      // the GTE output shape
+      if (ShapeUtil::Equal(output_shape, element_shape)) {
+        IndexingMap identity_map =
+            CreateIdentityMap(output_shape, mlir_context);
+        HloInstructionIndexing indexing;
+        indexing.indexing_maps.resize(instr->operand_count());
+        indexing.indexing_maps[0].insert(
+            OperandIndexing{identity_map, /*runtime_variables=*/{}});
+        return indexing;
+      }
+    }
+
+    // If shapes don't match or context is invalid, return unknown indexing
+    return CreateUnknownIndexing(instr->operand_count());
   }
   // go/keep-sorted end
   LOG(ERROR) << "ComputeOutputToInputIndexing is not implemented for opcode "


### PR DESCRIPTION
📝 Summary of Changes
This PR is the third in a series of five. 
PR 1/5 : https://github.com/openxla/xla/pull/42531
PR 2/5: https://github.com/openxla/xla/pull/42533
PR 3/5: https://github.com/openxla/xla/pull/42540  <= This PR
PR 4/5: https://github.com/openxla/xla/pull/42541 
PR 5/5: https://github.com/openxla/xla/pull/42543  
These PRs aim to enable the Triton backend for the All-Gather collective operation.

This PR adds a dedicated all_gather.cc/.h module with the metadata and tiling logic needed to decide whether and how to run an AllGather via the Triton backend (similar to all_reduce.cc/h).

🎯 Justification
Lowering All-Gather through the triton backend significantly improves performance of this operation for AMD target (compared to RCCL backend) and could allow us to take greater advantage of kernel-level fusion.

Example of 5 Triton Performance Improvements — All-Gather 1D on MI350
| dtype | shape | num_replicas | input_size_kb | output_size_kb | RCCL mean_us | Triton mean_us | Triton/RCCL | Improvement
| -- | -- | -- | -- | -- | -- | -- | -- | --
| bf16 | 2097152 | 4 | 4096 | 16384 | 148.106 | 52.740 | 0.356 | 64.4%
| f16 | 2097152 | 4 | 4096 | 16384 | 126.587 | 51.817 | 0.409 | 59.1%
| bf16 | 2097152 | 2 | 4096 | 8192 | 124.716 | 51.393 | 0.412 | 58.8%
| bf16 | 4194304 | 2 | 8192 | 16384 | 206.720 | 86.595 | 0.419 | 58.1%
| bf16 | 4194304 | 4 | 8192 | 32768 | 223.113 | 95.644 | 0.429 | 57.1%

Example of 5 Triton Performance Improvements — All-Gather 2D on MI350
| dtype | shape     | gather_dim | num_replicas | input_size_kb | output_size_kb | RCCL mean_us | Triton mean_us | Triton/RCCL | Improvement |
| ----- | --------- | ---------: | -----------: | ------------: | -------------: | -----------: | -------------: | ----------: | ----------: |
| bf16  | 1024x1024 |          0 |            2 |          2048 |           4096 |       81.743 |         28.737 |       0.352 |       64.8% |
| u4    | 1024x1024 |          0 |            2 |           512 |           1024 |       49.423 |         21.110 |       0.427 |       57.3% |
| u4    | 256x256   |          1 |            2 |            32 |             64 |       43.142 |         19.736 |       0.457 |       54.3% |
| u4    | 1024x512  |          1 |            2 |           256 |            512 |       39.583 |         20.909 |       0.528 |       47.2% |
| u4    | 2048x2048 |          1 |            2 |          2048 |           4096 |       83.845 |         32.911 |       0.392 |       60.8% |


🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement,✨ New Feature

🧪 Execution Tests:
Tests included in this PR.