### PR TITLE
[ROCm][Triton] Enable AllGather path for the Triton collective backend (PR 4/5)

### DIFF
--- a/xla/backends/gpu/codegen/triton/fusion.cc
+++ b/xla/backends/gpu/codegen/triton/fusion.cc
@@ -132,12 +132,28 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
   std::string suggested_kernel_name = std::string(fusion.name());
   llvm::IRBuilder builder(*ir_emitter_context.llvm_context());
   VLOG(3) << fusion.ToString();
-  TF_ASSIGN_OR_RETURN(
-      auto kernel_arguments,
-      emitters::KernelArguments::Create(
-          ir_emitter_context.buffer_assignment(), GetDefaultBufferAlignment(),
-          instr_override != nullptr ? instr_override : &fusion,
-          unmanaged_arguments));
+
+  // Special handling for AllGather with tuple unpacking
+  absl::StatusOr<emitters::KernelArguments> kernel_arguments_or;
+  if (instr_override != nullptr &&
+      instr_override->opcode() == HloOpcode::kAllGatherStart &&
+      instr_override->shape().IsTuple() && !fusion.shape().IsTuple()) {
+    // Use the new overload: fusion for shapes, AllGather for buffers at index
+    // {1}
+    kernel_arguments_or = emitters::KernelArguments::Create(
+        ir_emitter_context.buffer_assignment(), GetDefaultBufferAlignment(),
+        &fusion,         // shape_instruction
+        instr_override,  // buffer_instruction
+        ShapeIndex{1},   // output_index (element 1 of AllGather tuple)
+        unmanaged_arguments);
+  } else {
+    // Regular path for AllReduce and other operations
+    kernel_arguments_or = emitters::KernelArguments::Create(
+        ir_emitter_context.buffer_assignment(), GetDefaultBufferAlignment(),
+        instr_override != nullptr ? instr_override : &fusion,
+        unmanaged_arguments);
+  }
+  TF_ASSIGN_OR_RETURN(auto kernel_arguments, std::move(kernel_arguments_or));
 
   const HloComputation* hlo_computation =
       fusion.fused_instructions_computation();
@@ -158,7 +174,6 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
             ir_emitter_context.data_layout(), ir_emitter_context.llvm_context(),
             ir_emitter_context.mlir_context()));
     local_module = std::move(triton_wrapper_result.llvm_module);
-
     auto backend_config =
         fusion.backend_config<GpuBackendConfig>()->fusion_backend_config();
     absl::string_view fusion_kind = backend_config.kind();
@@ -172,7 +187,6 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
         kTritonNestedGemmFusionKind,
         kTritonCollectiveFusionKind,
     };
-
     if (!absl::c_linear_search(kSupportedFusionKinds, fusion_kind)) {
       return Internal("Unsupported fusion kind: %s", fusion_kind);
     }
@@ -251,25 +265,45 @@ std::optional<TritonFusion::LaunchConfig> TritonFusion::GetLaunchConfig(
 
     // We expect all roots to have the same number of blocks. Otherwise we
     // cannot codegen it.
+    LOG(INFO) << "GetLaunchConfig: fusion_root_count="
+              << analysis_.fusion_root_count();
+
+    if (analysis_.fusion_root_count() == 0) {
+      LOG(ERROR) << "GetLaunchConfig: No fusion roots found!";
+      return std::nullopt;
+    }
+
     int64_t num_blocks =
         GetNumberOfBlocks(analysis_.fusion_root(0).shape().dimensions(),
                           block_level_parameters.output_tile_sizes[0]);
     for (int64_t i = 1; i < analysis_.fusion_root_count(); ++i) {
-      CHECK_EQ(GetNumberOfBlocks(analysis_.fusion_root(i).shape().dimensions(),
-                                 block_level_parameters.output_tile_sizes[i]),
-               num_blocks);
-    }
+      if (i >= block_level_parameters.output_tile_sizes.size()) {
+        LOG(ERROR)
+            << "GetLaunchConfig: output_tile_sizes index out of bounds! i=" << i
+            << ", size=" << block_level_parameters.output_tile_sizes.size();
+        return std::nullopt;
+      }
 
+      int64_t blocks_for_root =
+          GetNumberOfBlocks(analysis_.fusion_root(i).shape().dimensions(),
+                            block_level_parameters.output_tile_sizes[i]);
+
+      CHECK_EQ(blocks_for_root, num_blocks);
+    }
     LaunchConfig launch_config;
     // TODO(b/451901200): We eventually also want to be able to predict this
     // value without compiling so the cost model can rely on it. Currently, we
     // need the override for auto warp specialization.
+    LOG(INFO) << "GetLaunchConfig: thread_dims_override.has_value()="
+              << thread_dims_override.has_value();
+
     if (thread_dims_override) {
       launch_config.launch_dimensions = LaunchDimensions{
           se::BlockDim(num_blocks), thread_dims_override.value()};
     } else {
+      int64_t warp_size = WarpSize(analysis_.device_info());
       int64_t estimated_threads_per_block =
-          block_level_parameters.num_warps * WarpSize(analysis_.device_info());
+          block_level_parameters.num_warps * warp_size;
       launch_config.launch_dimensions =
           LaunchDimensions{static_cast<uint64_t>(num_blocks),
                            static_cast<uint64_t>(estimated_threads_per_block)};

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -365,6 +365,50 @@ CodegenDecision IsTritonSupportedAllReduce(
   return CodegenDecision::Allow();
 }
 
+CodegenDecision IsTritonSupportedAllGather(
+    const HloAllGatherInstruction& all_gather,
+    const se::GpuComputeCapability& gpu_version) {
+  // Check if the flag is enabled
+  bool flag_enabled = all_gather.GetModule()
+                          ->config()
+                          .debug_options()
+                          .xla_gpu_unsupported_use_all_gather_triton_backend();
+
+  VLOG(1) << "IsTritonSupportedAllGather called for: " << all_gather.name()
+          << ", flag_enabled=" << flag_enabled;
+
+  if (!flag_enabled) {
+    VLOG(1) << "AllGather Triton backend is DISABLED for: "
+            << all_gather.name();
+    return CodegenDecision::Forbid(
+        "Triton backend for all-gather is disabled. Enable with "
+        "--xla_gpu_unsupported_use_all_gather_triton_backend=true");
+  }
+
+  VLOG(1) << "AllGather Triton backend is ENABLED for: " << all_gather.name();
+  PrimitiveType element_type = all_gather.operand(0)->shape().element_type();
+  if (element_type == F8E4M3FN || element_type == F8E5M2 ||
+      element_type == S4) {
+    VLOG(1) << "AllGather rejected due to unsupported data type: "
+            << all_gather.shape().element_type();
+    return CodegenDecision::Forbid(
+        "S4, F8E4M3FN and F8E5M2 are not supported for all-gathers.");
+  }
+
+  // TODO(allgather-triton): Add additional validation checks similar to
+  // AllReduce
+  // - Check replica groups
+  // - Check gather dimension constraints
+  // - Check size thresholds
+
+  VLOG(1) << "AllGather Triton backend ALLOWED for: " << all_gather.name()
+          << " (but fusion wrapping may not happen - check thunk_emitter.cc)";
+
+  // Allow codegen to proceed - the actual "not implemented" error will be
+  // generated in collective_emitter.cc::RewriteAllGather()
+  return CodegenDecision::Allow();
+}
+
 bool IsInTritonNestedGemmFusion(const HloInstruction& hlo) {
   if (!hlo.parent()->IsFusionComputation()) {
     return false;
@@ -741,6 +785,12 @@ CodegenDecision IsTritonSupportedInstructionImpl(
     case HloOpcode::kAllReduceDone:
       return IsTritonSupportedAllReduce(
           *Cast<HloAllReduceInstruction>(instr.operand(0)), gpu_version);
+    case HloOpcode::kAllGatherStart:
+      return IsTritonSupportedAllGather(*Cast<HloAllGatherInstruction>(&instr),
+                                        gpu_version);
+    case HloOpcode::kAllGatherDone:
+      return IsTritonSupportedAllGather(
+          *Cast<HloAllGatherInstruction>(instr.operand(0)), gpu_version);
     default:
       // Not all instructions have a special handling.
       break;

--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -750,6 +750,57 @@ cc_library(
     ],
 )
 
+
+xla_cc_test(
+    name = "rccl_symmetric_memory_test",
+    srcs = ["rccl_symmetric_memory_test.cc"],
+    tags = [
+        "gpu",
+        "no-oneapi",
+        "rocm-only",
+        "requires-gpu-amd",
+    ],
+    deps = [
+        ":rccl_errors",
+        ":rccl_symmetric_memory",
+        "//xla/stream_executor:device_address",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
+cc_library(
+    name = "rccl_symmetric_memory",
+    srcs = ["rccl_symmetric_memory.cc"],
+    hdrs = ["rccl_symmetric_memory.h"],
+    tags = [
+        "gpu",
+        "no-oneapi",
+        "rocm-only",
+    ],
+    visibility = [
+        "//xla/backends/gpu/runtime:__subpackages__",
+    ],
+    deps = [
+        ":rccl_errors",
+        "//xla:util",
+        "//xla/core/collectives:rank_id",
+        "//xla/core/collectives:symmetric_memory",
+        "//xla/stream_executor:device_address",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@local_config_rocm//rocm:rccl",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
 cc_library(
     name = "rccl_communicator",
     srcs = ["rccl_communicator.cc"],
@@ -765,6 +816,7 @@ cc_library(
         ":gpu_collectives",
         ":gpu_communicator",
         ":rccl_errors",
+        ":rccl_symmetric_memory",
         ":single_threaded_executor",
         "//xla:future",
         "//xla:shape_util",

--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "xla/backends/gpu/collectives/rccl_communicator.h"
+#include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
 
 #include <atomic>
 #include <cstddef>
@@ -680,6 +681,11 @@ absl::Status RcclCommunicator::LaunchRecv(se::DeviceAddressBase recv_buffer,
     TF_RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<SymmetricMemory>>
+RcclCommunicator::CreateSymmetricMemory(se::DeviceAddressBase addr) {
+  return RcclSymmetricMemory::Create(comm_, addr);
 }
 
 std::string RcclCommunicator::ToString() const {

--- a/xla/backends/gpu/collectives/rccl_communicator.h
+++ b/xla/backends/gpu/collectives/rccl_communicator.h
@@ -119,6 +119,9 @@ class RcclCommunicator : public GpuCommunicator {
   Future<> Recv(se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
                 size_t count, RankId peer, const Executor& executor) final;
 
+  absl::StatusOr<std::unique_ptr<SymmetricMemory>> CreateSymmetricMemory(
+      se::DeviceAddressBase addr) final;
+
   std::string ToString() const final;
 
   ncclComm_t comm() const { return comm_; }

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory.cc
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory.cc
@@ -1,0 +1,70 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
+
+#include <memory>
+#include <string>
+
+#include "absl/log/log.h"
+#include "absl/memory/memory.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "xla/backends/gpu/collectives/rccl_errors.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/util.h"
+
+namespace xla::gpu {
+
+RcclSymmetricMemory::RcclSymmetricMemory(
+    ncclComm_t comm, ncclWindow_t win, stream_executor::DeviceAddressBase addr)
+    : comm_(comm), win_(win), addr_(addr) {}
+
+absl::StatusOr<std::unique_ptr<RcclSymmetricMemory>>
+RcclSymmetricMemory::Create(ncclComm_t comm,
+                            stream_executor::DeviceAddressBase addr) {
+  VLOG(3) << absl::StrFormat(
+      "Create RCCL symmetric memory on comm=%p from: ptr=%p; size=%ld", comm,
+      addr.opaque(), addr.size());
+
+  ncclWindow_t win;
+  XLA_RCCL_RETURN_IF_ERROR(ncclCommWindowRegister(
+      comm, addr.opaque(), addr.size(), &win, NCCL_WIN_COLL_SYMMETRIC));
+
+  return absl::WrapUnique(new RcclSymmetricMemory(comm, win, addr));
+}
+
+RcclSymmetricMemory::~RcclSymmetricMemory() {
+  VLOG(3) << absl::StrFormat("Destroy %v", *this);
+  XLA_RCCL_LOG_IF_ERROR(ncclCommWindowDeregister(comm_, win_));
+}
+
+stream_executor::DeviceAddressBase RcclSymmetricMemory::addr() const {
+  return addr_;
+}
+
+std::string RcclSymmetricMemory::ToString() const {
+  return absl::StrFormat(
+      "RcclSymmetricMemory(comm=%p, win=%p, ptr=%p, size=%ld)", comm_, win_,
+      addr_.opaque(), addr_.size());
+}
+
+RcclSymmetricMemory::PackedKernelArg RcclSymmetricMemory::PackKernelArg()
+    const {
+  return win_;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory.h
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory.h
@@ -1,0 +1,67 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_RCCL_SYMMETRIC_MEMORY_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_RCCL_SYMMETRIC_MEMORY_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "rocm/rocm_config.h"  // IWYU pragma: keep  (defines TF_ROCM_VERSION)
+#include "xla/core/collectives/symmetric_memory.h"
+#include "xla/stream_executor/device_address.h"
+
+#if (TF_ROCM_VERSION >= 50200)
+#include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif  // TF_ROCM_VERSION >= 50200
+
+namespace xla::gpu {
+
+// An RCCL window registration handle that makes local buffers accessible from
+// remote peers via symmetric memory registration. Analogous to
+// NcclSymmetricMemory for the ROCm/RCCL platform.
+class RcclSymmetricMemory final : public SymmetricMemory {
+ public:
+  ~RcclSymmetricMemory() final;
+
+  static absl::StatusOr<std::unique_ptr<RcclSymmetricMemory>> Create(
+      ncclComm_t comm, stream_executor::DeviceAddressBase addr);
+
+  stream_executor::DeviceAddressBase addr() const final;
+
+  // multimem_addr() and peer_addr() are not supported by RCCL; the base-class
+  // defaults (returning Unimplemented) are used.
+
+  ncclWindow_t win() const { return win_; }
+
+  std::string ToString() const final;
+
+  PackedKernelArg PackKernelArg() const final;
+
+ private:
+  RcclSymmetricMemory(ncclComm_t comm, ncclWindow_t win,
+                      stream_executor::DeviceAddressBase addr);
+
+  ncclComm_t comm_;
+  ncclWindow_t win_;
+  stream_executor::DeviceAddressBase addr_;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_RCCL_SYMMETRIC_MEMORY_H_

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory_test.cc
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory_test.cc
@@ -1,0 +1,177 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/device_address.h"
+
+#if (TF_ROCM_VERSION >= 50200)
+#include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif  // TF_ROCM_VERSION >= 50200
+
+namespace xla::gpu {
+namespace {
+
+namespace se = stream_executor;
+
+using ::absl_testing::IsOk;
+using ::testing::HasSubstr;
+using ::testing::Not;
+
+// Test fixture that creates a single-rank RCCL communicator and allocates a
+// small GPU buffer. Tests are skipped if no ROCm device or RCCL is available.
+class RcclSymmetricMemoryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Skip if no ROCm/HIP GPU is present.
+    int device_count = 0;
+    if (hipGetDeviceCount(&device_count) != hipSuccess || device_count < 1) {
+      GTEST_SKIP() << "No ROCm/HIP GPU device available";
+    }
+    if (hipSetDevice(0) != hipSuccess) {
+      GTEST_SKIP() << "hipSetDevice(0) failed";
+    }
+
+    // Initialise a single-rank RCCL communicator on device 0.
+    int device_ids[] = {0};
+    ncclResult_t nccl_err = ncclCommInitAll(&comm_, 1, device_ids);
+    if (nccl_err != ncclSuccess) {
+      GTEST_SKIP() << "RCCL communicator initialisation failed: "
+                   << ncclGetErrorString(nccl_err);
+    }
+
+    // Allocate a 4 KiB symmetric memory buffer via RCCL. ncclMemAlloc ensures
+    // the buffer is mapped at the same virtual address on all ranks, which is
+    // required for ncclCommWindowRegister with NCCL_WIN_COLL_SYMMETRIC.
+    constexpr size_t kBufSize = 4096;
+    buf_size_ = kBufSize;
+    if (ncclMemAlloc(&buf_ptr_, buf_size_) != ncclSuccess) {
+      ncclCommDestroy(comm_);
+      comm_ = nullptr;
+      GTEST_SKIP() << "ncclMemAlloc(" << kBufSize << ") failed";
+    }
+  }
+
+  void TearDown() override {
+    if (buf_ptr_ != nullptr) {
+      (void)ncclMemFree(buf_ptr_);
+      buf_ptr_ = nullptr;
+    }
+    if (comm_ != nullptr) {
+      ncclCommDestroy(comm_);
+      comm_ = nullptr;
+    }
+  }
+
+  ncclComm_t comm_ = nullptr;
+  void* buf_ptr_ = nullptr;
+  size_t buf_size_ = 0;
+};
+
+// Verifies that RcclSymmetricMemory::Create succeeds for a valid buffer.
+TEST_F(RcclSymmetricMemoryTest, CreateSucceeds) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  ASSERT_NE(symm_mem, nullptr);
+}
+
+// Verifies that addr() returns exactly the pointer and size that were
+// registered.
+TEST_F(RcclSymmetricMemoryTest, AddrMatchesRegisteredBuffer) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  EXPECT_EQ(symm_mem->addr().opaque(), buf_ptr_);
+  EXPECT_EQ(symm_mem->addr().size(), buf_size_);
+}
+
+// Verifies that ToString() contains key diagnostic fields.
+TEST_F(RcclSymmetricMemoryTest, ToStringContainsExpectedFields) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  const std::string str = symm_mem->ToString();
+  EXPECT_THAT(str, HasSubstr("RcclSymmetricMemory"));
+  EXPECT_THAT(str, HasSubstr("comm="));
+  EXPECT_THAT(str, HasSubstr("win="));
+  EXPECT_THAT(str, HasSubstr("ptr="));
+}
+
+// Verifies that PackKernelArg() returns a non-null handle, and that the
+// win() accessor returns the same underlying ncclWindow_t.
+// NOTE: RCCL returns a null ncclWindow_t for single-rank communicators (no
+// remote peers to establish a window with). This test is skipped in that case.
+TEST_F(RcclSymmetricMemoryTest, PackKernelArgReturnsValidWindowHandle) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  if (symm_mem->win() == nullptr) {
+    GTEST_SKIP() << "RCCL returned a null ncclWindow_t (expected on single-rank "
+                    "communicators or RCCL versions without window support); "
+                    "skipping window-handle assertions.";
+  }
+  // PackKernelArg() returns a void* (PackedKernelArg) wrapping the window.
+  auto packed = symm_mem->PackKernelArg();
+  EXPECT_NE(packed, nullptr);
+  // win() returns the typed ncclWindow_t handle directly.
+  EXPECT_NE(symm_mem->win(), nullptr);
+}
+
+// Verifies that multimem_addr() returns Unimplemented — RCCL does not support
+// multimem, so the base-class default is expected.
+TEST_F(RcclSymmetricMemoryTest, MultimemAddrNotSupported) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  auto result = symm_mem->multimem_addr();
+  EXPECT_THAT(result, Not(IsOk()));
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kUnimplemented);
+}
+
+// Verifies that two independent windows created from the same communicator
+// on different buffers have distinct ncclWindow_t handles.
+// NOTE: Skipped when RCCL returns null windows (e.g. single-rank communicator).
+TEST_F(RcclSymmetricMemoryTest, TwoWindowsHaveDistinctHandles) {
+  void* buf2_ptr = nullptr;
+  ASSERT_EQ(ncclMemAlloc(&buf2_ptr, buf_size_), ncclSuccess);
+
+  se::DeviceAddressBase addr1(buf_ptr_, buf_size_);
+  se::DeviceAddressBase addr2(buf2_ptr, buf_size_);
+
+  ASSERT_OK_AND_ASSIGN(auto symm1, RcclSymmetricMemory::Create(comm_, addr1));
+  ASSERT_OK_AND_ASSIGN(auto symm2, RcclSymmetricMemory::Create(comm_, addr2));
+
+  if (symm1->win() == nullptr || symm2->win() == nullptr) {
+    (void)ncclMemFree(buf2_ptr);
+    GTEST_SKIP() << "RCCL returned null ncclWindow_t handle(s) (expected on "
+                    "single-rank communicators); skipping distinctness check.";
+  }
+
+  EXPECT_NE(symm1->win(), symm2->win());
+  EXPECT_EQ(symm1->addr().opaque(), buf_ptr_);
+  EXPECT_EQ(symm2->addr().opaque(), buf2_ptr);
+
+  (void)ncclMemFree(buf2_ptr);
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -3724,6 +3724,49 @@ xla_test(
 )
 
 cc_library(
+    name = "all_gather",
+    srcs = ["all_gather.cc"],
+    hdrs = ["all_gather.h"],
+    deps = [
+        "//xla:shape_util",
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/service/gpu:launch_dimensions",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/gpu:all_reduce_kernel",
+        "//xla/tsl/platform:errors",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+xla_cc_test(
+    name = "all_gather_build_info_test",
+    srcs = ["all_gather_build_info_test.cc"],
+    deps = [
+        ":all_gather",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service/gpu:gpu_device_info_for_tests",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/host:host_platform",
+        "//xla/tsl/lib/gtl:int_type",
+        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:test",
+        "//xla/tsl/platform:test_main",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
     name = "all_reduce",
     srcs = ["all_reduce.cc"],
     hdrs = ["all_reduce.h"],

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1857,6 +1857,7 @@ cc_library(
     srcs = ["all_gather_thunk.cc"],
     hdrs = ["all_gather_thunk.h"],
     deps = [
+        ":collective_kernel_thunk",
         ":collective_thunk",
         ":thunk",
         ":thunk_proto_cc",
@@ -1905,6 +1906,7 @@ cc_library(
     srcs = ["collective_kernel_thunk.cc"],
     hdrs = ["collective_kernel_thunk.h"],
     deps = [
+        ":all_gather",
         ":all_reduce",
         ":collective_kernel_api",
         ":collective_params",

--- a/xla/backends/gpu/runtime/all_gather.cc
+++ b/xla/backends/gpu/runtime/all_gather.cc
@@ -1,0 +1,148 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/all_gather.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "llvm/ADT/bit.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/primitive_util.h"
+#include "xla/service/gpu/launch_dimensions.h"
+#include "xla/shape_util.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/gpu/all_reduce_kernel.h"
+#include "xla/tsl/platform/errors.h"
+#include "xla/util.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+
+absl::Status IsAllGatherKernelSupported(int64_t num_ranks, int64_t num_elements,
+                                        PrimitiveType element_type) {
+  // Unsigned integer types are not supported by the Triton all-gather kernel.
+  if (element_type == U32 || element_type == U16 || element_type == U64) {
+    return absl::UnimplementedError(
+        absl::StrCat("Element type (",
+                     primitive_util::LowercasePrimitiveTypeName(element_type),
+                     ") is not supported for all-gather kernel."));
+  }
+  // The number of elements must be aligned to kNumElementsPerThread.
+  if (num_elements % se::gpu::kNumElementsPerThread != 0) {
+    return absl::UnimplementedError(
+        absl::StrCat("Number of elements (", num_elements,
+                     ") is not aligned to the alignment requirement (",
+                     se::gpu::kNumElementsPerThread, ")."));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status IsAllGatherKernelSupported(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    int32_t num_operands, int64_t num_devices, int64_t num_elements,
+    PrimitiveType element_type, bool is_local,
+    const std::vector<ReplicaGroup>& replica_groups) {
+  if (!is_collective_kernel_enabled) {
+    return absl::UnimplementedError("Collective kernel is not enabled.");
+  }
+  // Check if the device supports Triton collective codegen:
+  // CUDA: Requires compute capability 9.0+ (Hopper or newer)
+  // ROCm: All versions with Triton support are enabled
+  if (!device_info.cuda_compute_capability().IsAtLeastHopper() &&
+      !device_info.gpu_compute_capability().IsRocm()) {
+    return absl::UnimplementedError(absl::StrCat(
+        "Triton collective codegen requires CUDA compute capability >= 9.0 "
+        "(Hopper or newer) or a ROCm device with Triton support. "
+        "Got: ",
+        device_info.gpu_compute_capability().ToString(), "."));
+  }
+  // TODO(b/383125489): Support variadic arguments.
+  if (num_operands != 1) {
+    return absl::UnimplementedError(
+        absl::StrCat("Collective kernel is not supported for number of "
+                     "operands not equal to 1. Got ",
+                     num_operands, "."));
+  }
+  if (replica_groups.empty()) {
+    return absl::UnimplementedError(
+        "Replica groups must be explicitly provided for collective kernels.");
+  }
+  if (!is_local) {
+    return absl::UnimplementedError(
+        "Cross-host symmetric memory collectives are not supported.");
+  }
+  if (!llvm::has_single_bit(static_cast<uint64_t>(num_devices))) {
+    return absl::UnimplementedError(
+        absl::StrCat("Collective kernels are only supported for power of 2 "
+                     "number of devices. Got ",
+                     num_devices, "."));
+  }
+  return IsAllGatherKernelSupported(num_devices, num_elements, element_type);
+}
+
+absl::StatusOr<AllGatherInfo> BuildAllGatherInfo(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    const HloAllGatherInstruction* all_gather) {
+  if (!all_gather->device_list()) {
+    return absl::UnimplementedError(
+        "Replica groups must be explicitly provided for collective kernels.");
+  }
+  const int64_t num_devices =
+      all_gather->device_list()->num_devices_per_group();
+  const int64_t num_elements =
+      ShapeUtil::ElementsIn(all_gather->operand(0)->shape());
+  const PrimitiveType element_type =
+      all_gather->operand(0)->shape().element_type();
+  const int32_t num_operands = all_gather->operand_count();
+  TF_RETURN_IF_ERROR(IsAllGatherKernelSupported(
+      is_collective_kernel_enabled, device_info, num_operands, num_devices,
+      num_elements, element_type, /*is_local=*/true,
+      all_gather->replica_groups()));
+  return AllGatherInfo{
+      /*.num_devices =*/num_devices,
+      /*.num_elements =*/num_elements,
+      /*.element_type =*/element_type,
+  };
+}
+
+namespace {
+// All-gather always uses a one-shot strategy: every rank reads its peers'
+// slices directly, so the work is proportional to the full element count
+// with no rank-based partitioning.
+static constexpr int64_t kMaxBlocksPerGrid = 32;
+static constexpr uint64_t kMaxThreadsPerBlock = 512;
+static constexpr int64_t kWarpSize = 32;
+}  // namespace
+
+LaunchDimensions AllGatherLaunchDimensions(int64_t elements,
+                                           int64_t num_ranks) {
+  // Maximum number of threads such that each thread has elements to process.
+  const int64_t total_threads = RoundUpTo(
+      CeilOfRatio(elements, se::gpu::kNumElementsPerThread), kWarpSize);
+  // Triton expects power of 2 for threads_per_block / threads_per_warp.
+  const int64_t threads_per_block =
+      std::min(kMaxThreadsPerBlock,
+               llvm::bit_ceil(static_cast<uint64_t>(total_threads)));
+  const int64_t blocks_per_grid = std::min(
+      kMaxBlocksPerGrid, CeilOfRatio(total_threads, threads_per_block));
+  return LaunchDimensions(blocks_per_grid, threads_per_block);
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/all_gather.h
+++ b/xla/backends/gpu/runtime/all_gather.h
@@ -1,0 +1,66 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_
+#define XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/service/gpu/launch_dimensions.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+
+// Encapsulates the information needed to perform an all-gather.
+struct AllGatherInfo {
+  int64_t num_devices;
+  int64_t num_elements;
+  PrimitiveType element_type;
+};
+
+// Returns absl::OkStatus() if the all-gather kernel is supported for the given
+// element type and number of elements, or an error status detailing why it is
+// not supported.
+absl::Status IsAllGatherKernelSupported(int64_t num_ranks, int64_t num_elements,
+                                        PrimitiveType element_type);
+
+// A broader check for all-gather kernel support.
+// Returns absl::OkStatus() if supported, or an error status detailing why
+// it is not supported.
+absl::Status IsAllGatherKernelSupported(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    int32_t num_operands, int64_t num_devices, int64_t num_elements,
+    PrimitiveType element_type, bool is_local,
+    const std::vector<ReplicaGroup>& replica_groups);
+
+// Constructs an AllGatherInfo object for the given all-gather instruction.
+// Returns an error status if the all-gather kernel is not supported.
+absl::StatusOr<AllGatherInfo> BuildAllGatherInfo(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    const HloAllGatherInstruction* all_gather);
+
+// Returns the launch dimensions for the all-gather kernel.
+// All-gather uses a fixed one-shot tiling strategy: each rank contributes its
+// local slice to the output.
+LaunchDimensions AllGatherLaunchDimensions(int64_t elements, int64_t num_ranks);
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_

--- a/xla/backends/gpu/runtime/all_gather_build_info_test.cc
+++ b/xla/backends/gpu/runtime/all_gather_build_info_test.cc
@@ -1,0 +1,177 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/gpu/runtime/all_gather.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/primitive_util.h"
+#include "xla/service/gpu/gpu_device_info_for_tests.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/tsl/lib/gtl/int_type.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/test.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+namespace {
+
+using ::absl_testing::IsOkAndHolds;
+using ::absl_testing::StatusIs;
+using ::testing::AllOf;
+using ::testing::Field;
+using ::testing::HasSubstr;
+
+TSL_LIB_GTL_DEFINE_INT_TYPE(CollectiveKernelEnabled, bool);
+
+class BuildAllGatherInfoTest : public HloHardwareIndependentTestBase {
+ protected:
+  // Builds an all-gather HLO module and invokes BuildAllGatherInfo.
+  //
+  // `num_elements` is the number of elements in the input operand (per
+  // replica). The all-gather is 1-D along dimension 0.
+  //
+  // `replica_groups` is a flat list of device IDs forming a single replica
+  // group. An empty list means replica_groups={} (empty) in the HLO, which
+  // will trigger the "replica groups must be provided" error path.
+  absl::StatusOr<AllGatherInfo> BuildInfo(
+      CollectiveKernelEnabled collective_kernel_enabled,
+      PrimitiveType element_type, int64_t num_elements,
+      std::vector<int32_t> replica_groups) {
+    const int num_replicas =
+        replica_groups.empty() ? 1 : static_cast<int>(replica_groups.size());
+    const std::string element_type_str =
+        primitive_util::LowercasePrimitiveTypeName(element_type);
+    const std::string input_shape_str = absl::StrFormat("%d", num_elements);
+    const std::string output_shape_str =
+        absl::StrFormat("%d", num_elements * num_replicas);
+    const std::string replica_groups_str =
+        replica_groups.empty()
+            ? ""
+            : absl::StrFormat("{%s}", absl::StrJoin(replica_groups, ","));
+
+    // The all-gather gathers along dimension 0: output_dim0 = num_replicas *
+    // input_dim0.
+    constexpr absl::string_view kModuleStr = R"(
+    HloModule test
+    ENTRY test_computation {
+      param_0 = %1$s[%2$s] parameter(0)
+      ROOT all-gather = %1$s[%3$s] all-gather(param_0),
+          dimensions={0}, replica_groups={%4$s}
+    }
+    )";
+    const std::string module_str =
+        absl::StrFormat(kModuleStr, element_type_str, input_shape_str,
+                        output_shape_str, replica_groups_str);
+
+    SCOPED_TRACE(testing::Message() << "module_str: " << module_str);
+
+    se::DeviceDescription device_info =
+        TestGpuDeviceInfo::H100SXMDeviceInfo();
+
+    TF_ASSIGN_OR_RETURN(
+        std::unique_ptr<HloModule> module,
+        ParseAndReturnVerifiedModule(module_str, num_replicas));
+
+    const HloInstruction* hlo_instr =
+        HloHardwareIndependentTestBase::FindInstruction(
+            module.get(), HloOpcode::kAllGather);
+    return BuildAllGatherInfo(collective_kernel_enabled.value(), device_info,
+                              Cast<HloAllGatherInstruction>(hlo_instr));
+  }
+};
+
+TEST_F(BuildAllGatherInfoTest, SucceedsForSupportedF32) {
+  EXPECT_THAT(BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                        /*replica_groups=*/{0, 1}),
+              IsOkAndHolds(AllOf(
+                  Field(&AllGatherInfo::num_devices, 2),
+                  Field(&AllGatherInfo::num_elements, 512),
+                  Field(&AllGatherInfo::element_type, F32))));
+}
+
+TEST_F(BuildAllGatherInfoTest, SucceedsForSupportedBF16) {
+  EXPECT_THAT(BuildInfo(CollectiveKernelEnabled(true), BF16,
+                        /*num_elements=*/512, /*replica_groups=*/{0, 1}),
+              IsOkAndHolds(AllOf(
+                  Field(&AllGatherInfo::num_devices, 2),
+                  Field(&AllGatherInfo::num_elements, 512),
+                  Field(&AllGatherInfo::element_type, BF16))));
+}
+
+TEST_F(BuildAllGatherInfoTest, SucceedsForFourDevices) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1, 2, 3}),
+      IsOkAndHolds(AllOf(Field(&AllGatherInfo::num_devices, 4),
+                         Field(&AllGatherInfo::num_elements, 512),
+                         Field(&AllGatherInfo::element_type, F32))));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsIfCollectiveKernelDisabled) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(false), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1}),
+      StatusIs(absl::StatusCode::kUnimplemented, HasSubstr("not enabled")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForNonPowerOfTwoDevices) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1, 2}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("only supported for power of 2")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForUnsupportedUnsignedType) {
+  // U32 is not supported by the Triton all-gather kernel.
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), U32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("is not supported for all-gather kernel")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForUnalignedElements) {
+  // 7 is not divisible by kNumElementsPerThread (which is >= 2).
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/7,
+                /*replica_groups=*/{0, 1}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("not aligned to the alignment requirement")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsIfReplicaGroupsEmpty) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("Replica groups must be explicitly provided")));
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/all_gather_thunk.cc
+++ b/xla/backends/gpu/runtime/all_gather_thunk.cc
@@ -40,6 +40,7 @@ limitations under the License.
 #include "xla/shape_util.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "tsl/platform/casts.h"
 
@@ -78,6 +79,19 @@ AllGatherThunk::AllGatherThunk(ThunkInfo thunk_info,
     : CollectiveThunk(Thunk::kAllGather, thunk_info, std::move(buffers)),
       config_(GetAllGatherConfig(inst)) {
   CHECK_EQ(config_.config.operand_element_type.size(), this->buffers().size());
+}
+
+AllGatherThunk::AllGatherThunk(
+    ThunkInfo thunk_info, const HloAllGatherInstruction* inst,
+    std::vector<Buffer> buffers,
+    std::unique_ptr<CollectiveKernelThunk> collective_kernel_thunk,
+    bool p2p_memcpy_enabled)
+    : CollectiveThunk(Thunk::kAllGather, thunk_info, std::move(buffers)),
+      config_(GetAllGatherConfig(inst)),
+      collective_kernel_thunk_(std::move(collective_kernel_thunk)) {
+  CHECK_EQ(config_.config.operand_element_type.size(), this->buffers().size());
+  VLOG(3) << "AllGatherStartThunk created with CollectiveKernelThunk for: "
+          << inst->name();
 }
 
 AllGatherThunk::AllGatherThunk(ThunkInfo thunk_info, CollectiveConfig config,
@@ -128,13 +142,55 @@ absl::StatusOr<ThunkProto> AllGatherThunk::ToProto() const {
   return proto;
 }
 
+absl::Status AllGatherThunk::Prepare(const PrepareParams& params) {
+  TF_RETURN_IF_ERROR(CollectiveThunk::Prepare(params));
+  if (collective_kernel_thunk_) {
+    return collective_kernel_thunk_->Prepare(params);
+  }
+  return absl::OkStatus();
+}
+
+absl::Status AllGatherThunk::Initialize(const InitializeParams& params) {
+  TF_RETURN_IF_ERROR(CollectiveThunk::Initialize(params));
+  if (collective_kernel_thunk_) {
+    TF_ASSIGN_OR_RETURN(GpuCliqueKey clique_key,
+                        GetCollectiveGpuCliqueKey(*params.collective_params,
+                                                  config()));
+    TF_ASSIGN_OR_RETURN(
+        bool use_collective_kernel,
+        collective_kernel_thunk_->IsSupported(clique_key, *params.executor,
+                                              *params.collective_params));
+    if (use_collective_kernel) {
+      TF_RETURN_IF_ERROR(collective_kernel_thunk_->Initialize(params));
+    }
+  }
+  return absl::OkStatus();
+}
+
 absl::Status AllGatherThunk::RunCollective(const ExecuteParams& params,
-                                           const GpuCliqueKey& clique_key,
-                                           se::Stream& stream,
-                                           Communicator& comm) {
+                                                const GpuCliqueKey& clique_key,
+                                                se::Stream& stream,
+                                                Communicator& comm) {
   ASSIGN_OR_RETURN(std::vector<DeviceBufferPair> device_buffers,
                    ConvertToDeviceBuffers(params.buffer_allocations, buffers(),
                                           config_.config.operand_element_type));
+
+  // Try to use Triton collective kernel if available
+  if (collective_kernel_thunk_) {
+    TF_ASSIGN_OR_RETURN(
+        bool use_collective_kernel,
+        collective_kernel_thunk_->IsSupported(
+            clique_key, *params.stream->parent(), *params.collective_params));
+
+    if (use_collective_kernel) {
+      return collective_kernel_thunk_->ExecuteOnStream(params);
+    }
+    LOG(WARNING) << "AllGatherThunk: Triton backend was requested but the "
+                    "Triton kernel is not supported for this configuration "
+                    "at runtime. Falling back to NCCL/RCCL.";
+  }
+
+  // Fallback to NCCL/RCCL
   return xla::gpu::RunAllGather(device_buffers, stream, comm,
                                 config_.config.use_symmetric_buffer);
 }

--- a/xla/backends/gpu/runtime/all_gather_thunk.h
+++ b/xla/backends/gpu/runtime/all_gather_thunk.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
+#include "xla/backends/gpu/runtime/collective_kernel_thunk.h"
 #include "xla/backends/gpu/runtime/collective_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/core/collectives/communicator.h"
@@ -46,6 +47,11 @@ class AllGatherThunk : public CollectiveThunk {
                  std::vector<Buffer> buffers, bool p2p_memcpy_enabled = false);
   AllGatherThunk(ThunkInfo thunk_info, CollectiveConfig config,
                  std::vector<Buffer> buffers);
+  AllGatherThunk(
+      ThunkInfo thunk_info, const HloAllGatherInstruction* inst,
+      std::vector<Buffer> buffers,
+      std::unique_ptr<CollectiveKernelThunk> collective_kernel_thunk,
+      bool p2p_memcpy_enabled = false);
 
   static const char* GetHloOpName() { return "all-gather-start"; }
 
@@ -67,6 +73,8 @@ class AllGatherThunk : public CollectiveThunk {
  protected:
   bool RequiresRendezvous() const override { return true; }
 
+  absl::Status Prepare(const PrepareParams& params) override;
+  absl::Status Initialize(const InitializeParams& params) override;
   absl::Status RunCollective(const ExecuteParams& params,
                              const GpuCliqueKey& clique_key, se::Stream& stream,
                              Communicator& comm) override;
@@ -75,6 +83,7 @@ class AllGatherThunk : public CollectiveThunk {
 
  private:
   const AllGatherConfig config_;
+  std::unique_ptr<CollectiveKernelThunk> collective_kernel_thunk_;
 };
 
 absl::Status RunAllGather(std::vector<DeviceBufferPair>& buffers,

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.cc
@@ -36,6 +36,7 @@ limitations under the License.*/
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
+#include "xla/backends/gpu/runtime/all_gather.h"
 #include "xla/backends/gpu/runtime/all_reduce.h"
 #include "xla/backends/gpu/runtime/collective_kernel_api.h"
 #include "xla/backends/gpu/runtime/collective_params.h"
@@ -153,25 +154,54 @@ absl::Status CopyCollectiveMetadataToDevice(
 absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
     const GpuCliqueKey& clique_key, se::StreamExecutor& executor,
     const CollectiveParams& collective_params) const {
-  absl::Status status = IsAllReduceKernelSupported(
-      collective_kernel_enabled_, executor.GetDeviceDescription(),
-      /*num_operands= */ buffers_.size(), reduction_kind_,
-      clique_key.num_local_participants(), buffers_[0].element_count,
-      collective_config_.operand_element_type[0], clique_key.is_local(),
-      is_multimem_enabled_, collective_config_.replica_groups);
-  if (absl::IsUnimplemented(status)) {
-    VLOG(3) << "Collective kernel not supported: " << status.message();
-    return false;
+  const bool is_all_gather =
+      (collective_op_kind_ == CollectiveOpKind::kAllGather);
+
+  if (!is_all_gather) {
+    absl::Status status = IsAllReduceKernelSupported(
+        collective_kernel_enabled_, executor.GetDeviceDescription(),
+        /*num_operands= */ buffers_.size(), reduction_kind_,
+        clique_key.num_local_participants(), buffers_[0].element_count,
+        collective_config_.operand_element_type[0], clique_key.is_local(),
+        is_multimem_enabled_, collective_config_.replica_groups);
+    if (absl::IsUnimplemented(status)) {
+      VLOG(3) << "Collective kernel not supported: " << status.message();
+      return false;
+    }
+    TF_RETURN_IF_ERROR(status);
+  } else {
+    absl::Status status = IsAllGatherKernelSupported(
+        collective_kernel_enabled_, executor.GetDeviceDescription(),
+        /*num_operands=*/buffers_.size(), clique_key.num_local_participants(),
+        buffers_[0].element_count, collective_config_.operand_element_type[0],
+        clique_key.is_local(), collective_config_.replica_groups);
+    if (absl::IsUnimplemented(status)) {
+      VLOG(3) << "Collective kernel not supported: " << status.message();
+      return false;
+    }
+    TF_RETURN_IF_ERROR(status);
   }
-  TF_RETURN_IF_ERROR(status);
+
   for (const GlobalDeviceId& device : clique_key.devices()) {
     TF_ASSIGN_OR_RETURN(const int peer_device_id,
                         GetLocalDeviceId(device, collective_params));
     if (!executor.CanEnablePeerAccessTo(peer_device_id)) {
       XLA_VLOG_DEVICE(3, executor.device_ordinal())
           << "Peer access is not supported with device " << peer_device_id;
+      VLOG(3) << "CollectiveKernelThunk::IsSupported: peer access not "
+                 "supported to device "
+              << peer_device_id;
       return false;
     }
+  }
+  // All-reduce has a built-in custom kernel (RunAllReduceKernel) that
+  // ExecuteOnStream can fall back to when no Triton kernel was emitted
+  // (i.e., kernel_name_ is empty and state->kernel == nullptr). All-gather
+  // has no such built-in fallback: reaching the kernel_name_-empty path in
+  // ExecuteOnStream would hit CHECK(kAllReduce) and crash. We therefore only
+  // return true for all-gather when a Triton kernel was actually emitted.
+  if (is_all_gather) {
+    return !kernel_name_.empty();
   }
   return true;
 }
@@ -208,18 +238,31 @@ absl::Status CollectiveKernelThunk::Prepare(const PrepareParams& params) {
   absl::MutexLock lock(mutex_);
   if (!per_stream_memory_.contains(params.executor)) {
     // Allocate scratch buffers.
+    const bool is_all_gather =
+        (collective_op_kind_ == CollectiveOpKind::kAllGather);
     const AllReduceStrategy strategy =
         GetAllReduceStrategy(GetInputSizeBytes(), is_multimem_enabled_);
-    const LaunchDimensions launch_dimensions =
-        launch_dimensions_.value_or(AllReduceLaunchDimensions(
-            buffers_[0].element_count, clique_key.num_local_participants(),
-            strategy));
+    const LaunchDimensions launch_dimensions = launch_dimensions_.value_or(
+        is_all_gather
+            ? AllGatherLaunchDimensions(buffers_[0].element_count,
+                                        clique_key.num_local_participants())
+            : AllReduceLaunchDimensions(buffers_[0].element_count,
+                                        clique_key.num_local_participants(),
+                                        strategy));
     const int64_t kNumSignalFlags =
         clique_key.num_local_participants() * launch_dimensions.num_blocks();
     const int64_t kSignalBufferSize = xla::RoundUpTo<uint64_t>(
         kNumSignalFlags * sizeof(int32_t), kXlaAllocatedBufferAlignBytes);
+
+    // For AllGather, we need to allocate buffers based on the destination size
+    // (which is num_replicas * source_size), not the source size.
+    // For AllReduce, source and destination sizes are the same.
+    const int64_t buffer_size_to_allocate =
+        is_all_gather ? buffers_[0].destination_buffer.slice.size()
+                      : buffers_[0].source_buffer.slice.size();
+
     const int64_t kLocalBufferSize = xla::RoundUpTo<uint64_t>(
-        buffers_[0].source_buffer.slice.size(), kXlaAllocatedBufferAlignBytes);
+        buffer_size_to_allocate, kXlaAllocatedBufferAlignBytes);
     TF_ASSIGN_OR_RETURN(
         se::DeviceAddressHandle local_buffers_handle,
         AllocateMemory(params.executor, kLocalBufferSize * kNumBuffers,
@@ -395,12 +438,15 @@ absl::Status CollectiveKernelThunk::Initialize(const InitializeParams& params) {
           tsl::safe_reinterpret_cast<char*>(dst_mmem) + dst_mmem_offset;
 
       XLA_VLOG_DEVICE(3, params.executor->device_ordinal())
-          << "Constructed device state {"
-          << " metadata rank: " << metadata.rank << ", param_to_peers: ("
+          << "Constructed device state {" << " metadata rank: " << metadata.rank
+          << ", param_to_peers: ("
           << absl::StrJoin(param_to_peers_ptrs, ", ", PtrFormatter{})
           << "), multimem_addresses: ("
           << absl::StrJoin(multimem_addresses, ", ", PtrFormatter{}) << ")}";
     } else {
+      // For both AllReduce and AllGather, we exchange 2 buffers via P2P:
+      // - Parameter 0: Data symmetric buffer (local_buffers)
+      // - Parameter 1: Signal/synchronization buffer (signal_buffers)
       std::vector<se::DeviceAddressBase> parameters{
           memory_state->local_buffers_handle.address(),
           memory_state->signal_buffers_handle.address()};
@@ -513,19 +559,23 @@ absl::Status CollectiveKernelThunk::ExecuteOnStream(
                                  launch_dimensions_.value(),
                                  /*cluster_dim=*/std::nullopt, stream);
   }
+  // TODO(b/407736956): Change this to emitted kernel.
+  CHECK(collective_op_kind_ == CollectiveOpKind::kAllReduce)
+      << "RunAllReduceKernel should only be called for AllReduce operations, "
+      << "not for AllGather. AllGather requires an emitted Triton kernel.";
+  TF_RET_CHECK(reduction_kind_.has_value())
+      << "reduction_kind_ must be set for AllReduce operations";
   const LaunchDimensions launch_dimensions =
       AllReduceLaunchDimensions(buffer.element_count, num_devices, strategy);
   XLA_VLOG_DEVICE(3, device_ordinal)
       << "CUDA kernel launch dimensions: " << launch_dimensions.num_blocks()
       << "x" << launch_dimensions.num_threads_per_block()
       << "(block x threadsPerBlock)";
-
-  // TODO(b/407736956): Change this to emitted kernel.
   return RunAllReduceKernel(
       /*stream=*/stream,
       /*launch_dimensions=*/launch_dimensions,
       /*element_type=*/element_type,
-      /*reduction_kind=*/reduction_kind_,
+      /*reduction_kind=*/*reduction_kind_,
       /*all_reduce_strategy=*/strategy,
       /*symmetric_input_buffer=*/input_buffer_ptr,
       /*local_input_buffer=*/source_buffer,

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.h
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.h
@@ -58,12 +58,17 @@ namespace xla::gpu {
 // must be set.
 class CollectiveKernelThunk : public Thunk {
  public:
+  enum class CollectiveOpKind {
+    kAllReduce,
+    kAllGather,
+  };
+
   static constexpr auto kMaxNumExecutors =
       ::stream_executor::gpu::kMaxNumAllReduceInputPtrs;
 
   CollectiveKernelThunk(
       ThunkInfo info, CollectiveConfig collective_config,                //
-      ReductionKind reduction_kind,                                      //
+      std::optional<ReductionKind> reduction_kind,                       //
       bool is_async,                                                     //
       std::vector<CollectiveThunk::Buffer> buffers,                      //
       bool is_collective_kernel_enabled,                                 //
@@ -72,7 +77,8 @@ class CollectiveKernelThunk : public Thunk {
       int32_t shmem_bytes = 0,                                           //
       bool is_multimem_enabled = false,
       std::optional<std::vector<uint8_t>> cubin = std::nullopt,
-      bool use_pdl = false)
+      bool use_pdl = false,
+      CollectiveOpKind collective_op_kind = CollectiveOpKind::kAllReduce)
       : Thunk{Thunk::kCollectiveKernel, info},
         collective_kernel_enabled_(is_collective_kernel_enabled),
         is_async_(is_async),
@@ -84,7 +90,8 @@ class CollectiveKernelThunk : public Thunk {
         shmem_bytes_(shmem_bytes),
         buffers_(std::move(buffers)),
         is_multimem_enabled_(is_multimem_enabled),
-        use_pdl_(use_pdl) {
+        use_pdl_(use_pdl),
+        collective_op_kind_(collective_op_kind) {
     per_stream_state_.reserve(kMaxNumExecutors);
   }
 
@@ -188,7 +195,8 @@ class CollectiveKernelThunk : public Thunk {
   // Collective config being used. Copied over to avoid lifetime issues.
   const CollectiveConfig collective_config_;
   // Reduction kind being to use for AllReduce collective.
-  const ReductionKind reduction_kind_;
+  // Optional because AllGather does not use reduction.
+  const std::optional<ReductionKind> reduction_kind_;
   // Launch dimensions for the kernel. Only relevant when the codegen kernel
   // is used.
   std::optional<LaunchDimensions> launch_dimensions_;
@@ -214,6 +222,8 @@ class CollectiveKernelThunk : public Thunk {
 
   // Programmatic Dependent Launch.
   const bool use_pdl_;
+
+  const CollectiveOpKind collective_op_kind_;
 };
 }  // namespace xla::gpu
 

--- a/xla/codegen/emitters/kernel_arguments.cc
+++ b/xla/codegen/emitters/kernel_arguments.cc
@@ -190,6 +190,61 @@ absl::StatusOr<KernelArguments> KernelArguments::Create(
                                hlo_instruction, unmanaged_arguments);
 }
 
+// Special overload for AllGather with tuple unpacking
+absl::StatusOr<KernelArguments> KernelArguments::Create(
+    const BufferAssignment& buffer_assignment,
+    const BufferAlignment& buffer_alignment,
+    const HloInstruction* shape_instruction,
+    const HloInstruction* buffer_instruction, const ShapeIndex& output_index,
+    absl::Span<const Shape> unmanaged_arguments) {
+  std::vector<KernelArgument> kernel_arguments;
+
+  // Input arguments: use shape_instruction's operands for shapes,
+  // but buffer_instruction's operands for buffer lookups
+  for (int i = 0; i < shape_instruction->operand_count(); ++i) {
+    const HloInstruction* shape_operand = shape_instruction->operand(i);
+    const HloInstruction* buffer_operand = buffer_instruction->operand(i);
+    TF_ASSIGN_OR_RETURN(BufferAllocation::Slice slice,
+                        buffer_assignment.GetUniqueSlice(buffer_operand, {}));
+    kernel_arguments.emplace_back(
+        KernelArgument(shape_operand->shape(), slice));
+  }
+
+  // Output arguments: use shape_instruction's shape,
+  // but look up buffer from buffer_instruction at output_index
+  absl::flat_hash_set<BufferAllocation::Slice> buffers_written;
+  TF_RETURN_IF_ERROR(ShapeUtil::ForEachSubshapeWithStatus(
+      shape_instruction->shape(),
+      [&](const Shape& subshape, const ShapeIndex& index) {
+        if (!subshape.IsArray()) return absl::OkStatus();
+
+        // For output buffers, look them up from buffer_instruction at
+        // output_index
+        ShapeIndex buffer_index = output_index;
+        // Append the current index to output_index for nested shapes
+        for (int64_t i : index) {
+          buffer_index.push_back(i);
+        }
+
+        TF_ASSIGN_OR_RETURN(
+            BufferAllocation::Slice slice,
+            buffer_assignment.GetUniqueSlice(buffer_instruction, buffer_index));
+
+        kernel_arguments.emplace_back(KernelArgument(subshape, slice));
+        buffers_written.insert(slice);
+        return absl::OkStatus();
+      }));
+
+  // Add unmanaged arguments
+  for (const Shape& unmanaged_argument : unmanaged_arguments) {
+    kernel_arguments.emplace_back(unmanaged_argument);
+  }
+
+  FillKernelArgumentAttributes(kernel_arguments, buffer_alignment,
+                               buffers_written);
+  return KernelArguments(std::move(kernel_arguments));
+}
+
 absl::StatusOr<KernelArguments> KernelArguments::Create(
     const BufferAssignment& buffer_assignment,
     const BufferAlignment& buffer_alignment,

--- a/xla/codegen/emitters/kernel_arguments.h
+++ b/xla/codegen/emitters/kernel_arguments.h
@@ -111,6 +111,22 @@ class KernelArguments {
       const BufferAlignment& buffer_alignment,
       const HloInstruction* hlo_instruction);
 
+  // Special overload for collective operations where the fusion has a different
+  // output shape than the original instruction (e.g., AllGather with tuple
+  // unpacking).
+  // - shape_instruction: Used to determine argument shapes (typically the
+  // fusion)
+  // - buffer_instruction: Used to look up buffer assignments (typically the
+  // original instruction)
+  // - output_index: ShapeIndex to use when looking up output buffers from
+  // buffer_instruction
+  static absl::StatusOr<KernelArguments> Create(
+      const BufferAssignment& buffer_assignment,
+      const BufferAlignment& buffer_alignment,
+      const HloInstruction* shape_instruction,
+      const HloInstruction* buffer_instruction, const ShapeIndex& output_index,
+      absl::Span<const Shape> unmanaged_arguments);
+
   // Certain kernels require output arguments to be interleaved with input
   // arguments. This function creates a KernelArguments object where the output
   // arguments are interleaved with the input arguments according to the

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -462,6 +462,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_unsupported_enable_all_reduce_decomposer(false);
   opts.set_xla_gpu_unsupported_enable_ragged_all_to_all_decomposer(false);
   opts.set_xla_gpu_unsupported_use_all_reduce_one_shot_kernel(true);
+  opts.set_xla_gpu_unsupported_use_all_gather_triton_backend(false);
   opts.set_xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel(true);
   opts.set_xla_gpu_experimental_enable_fusion_autotuner(true);
   opts.set_xla_gpu_experimental_max_unroll_factor(32);
@@ -2780,6 +2781,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_unsupported_use_all_reduce_one_shot_kernel(),
       "Internal: Enable the one-shot kernel for single-host all-reduce "
       "operations."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_unsupported_use_all_gather_triton_backend",
+      bool_setter_for(
+          &DebugOptions::
+              set_xla_gpu_unsupported_use_all_gather_triton_backend),
+      debug_options->xla_gpu_unsupported_use_all_gather_triton_backend(),
+      "Internal: Enable Triton backend for all-gather operations."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel",
       bool_setter_for(

--- a/xla/hlo/analysis/indexing_analysis.cc
+++ b/xla/hlo/analysis/indexing_analysis.cc
@@ -1550,14 +1550,15 @@ void AssignValuesToRTVars(IndexingMap* indexing_map) {
 
 HloInstructionIndexing ComputeOutputToInputAllGatherOpIndexing(
     const HloAllGatherInstruction* instr, MLIRContext* mlir_context) {
-  // CHECK_EQ(instr->all_gather_dimension(), 0);
-  // if (instr->all_gather_dimension() != 0) {
-  //   return CreateUnknownIndexing(instr->operand_count());
-  // }
+  // For AllGather-start, the shape is a tuple (input, output)
+  // We need to use the output element (index 1) for indexing
+  const Shape& output_shape =
+      instr->shape().IsTuple()
+          ? ShapeUtil::GetTupleElementShape(instr->shape(), 1)
+          : instr->shape();
 
   int64_t all_gather_dim = instr->all_gather_dimension();
-
-  auto output_rank = instr->shape().dimensions().size();
+  auto output_rank = output_shape.dimensions().size();
 
   llvm::SmallVector<SymbolicExpr> exprs;
   exprs.reserve(output_rank);
@@ -1573,14 +1574,14 @@ HloInstructionIndexing ComputeOutputToInputAllGatherOpIndexing(
 
   IndexingMap indexing_map = IndexingMap::FromTensorSizes(
       SymbolicMap::Get(mlir_context, output_rank, 0, exprs),
-      instr->shape().dimensions(), {});
+      output_shape.dimensions(), {});
 
   SymbolicExpr replica_id_expr = CreateDimExpr(all_gather_dim, mlir_context)
                                      .floorDiv(all_gather_input_dim_size);
 
   IndexingMap replica_id_map = IndexingMap::FromTensorSizes(
       SymbolicMap::Get(mlir_context, output_rank, 0, {replica_id_expr}),
-      instr->shape().dimensions(), {});
+      output_shape.dimensions(), {});
 
   OperandIndexing operand_indexing(indexing_map, {}, replica_id_map);
 
@@ -1665,6 +1666,37 @@ HloInstructionIndexing ComputeOutputToInputIndexing(const HloInstruction* instr,
   }
   if (auto transpose = DynCast<HloTransposeInstruction>(instr)) {
     return ComputeOutputToInputTransposeOpIndexing(transpose, mlir_context);
+  }
+  // GetTupleElement extracts an element from a tuple operand.
+  // An identity mapping is only valid when the tuple operand's extracted
+  // element has the same shape as the GTE output. This is the case for
+  // AllGather fusion tiling where GTE acts as a pass-through.
+  if (instr->opcode() == HloOpcode::kGetTupleElement) {
+    auto* gte = Cast<HloGetTupleElementInstruction>(instr);
+    const HloInstruction* tuple_operand = gte->operand(0);
+    const Shape& tuple_shape = tuple_operand->shape();
+    const Shape& output_shape = gte->shape();
+
+    // Verify the operand is a tuple and the extracted element shape matches
+    if (tuple_shape.IsTuple() &&
+        gte->tuple_index() < tuple_shape.tuple_shapes_size()) {
+      const Shape& element_shape = tuple_shape.tuple_shapes(gte->tuple_index());
+
+      // Only use identity mapping if the extracted element shape matches
+      // the GTE output shape
+      if (ShapeUtil::Equal(output_shape, element_shape)) {
+        IndexingMap identity_map =
+            CreateIdentityMap(output_shape, mlir_context);
+        HloInstructionIndexing indexing;
+        indexing.indexing_maps.resize(instr->operand_count());
+        indexing.indexing_maps[0].insert(
+            OperandIndexing{identity_map, /*runtime_variables=*/{}});
+        return indexing;
+      }
+    }
+
+    // If shapes don't match or context is invalid, return unknown indexing
+    return CreateUnknownIndexing(instr->operand_count());
   }
   // go/keep-sorted end
   LOG(ERROR) << "ComputeOutputToInputIndexing is not implemented for opcode "

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -173,6 +173,7 @@ limitations under the License.
 #include "xla/tools/hlo_decomposer.h"
 #include "xla/tsl/concurrency/future.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/dnn.pb.h"
 #include "xla/util.h"
@@ -230,18 +231,27 @@ static constexpr bool kRequiresCollectiveKernelThunk =
                             const HloAllReduceInstruction*,
                             std::vector<CollectiveThunk::Buffer>,
                             std::unique_ptr<CollectiveKernelThunk>,
+                            /*p2p_memcpy_enabled=*/bool> ||
+    std::is_constructible_v<ThunkType, Thunk::ThunkInfo,
+                            const HloAllGatherInstruction*,
+                            std::vector<CollectiveThunk::Buffer>,
+                            std::unique_ptr<CollectiveKernelThunk>,
                             /*p2p_memcpy_enabled=*/bool>;
 
 // The signature of this function would change to absl::Status once we lift the
 // CollectiveKernelThunk out as a top level thunk. It would then become a member
 // function of ThunkEmitter.
 // As it stands now the collective kernel thunk is wrapped inside other
-// collective thunks such as AllReduceStart. So this function is only
-// responsible for emitting the collective kernel thunk and its dependencies.
+// collective thunks such as AllReduceStart and AllGatherStart. So this function
+// is only responsible for emitting the collective kernel thunk and its
+// dependencies.
 absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     IrEmitterContext* ir_emitter_context, const CallGraph* call_graph,
     Thunk::ThunkInfo thunk_info, std::vector<CollectiveThunk::Buffer> buffers,
     const HloAllReduceInstruction* instr, const AllReduceConfig& config) {
+  VLOG(3) << "EmitCollectiveKernelThunk called for AllReduce: "
+          << instr->name();
+
   std::unique_ptr<HloModule> fused_module =
       NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
   HloFusionInstruction* fusion_instr = Cast<HloFusionInstruction>(
@@ -270,11 +280,14 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   TF_ASSIGN_OR_RETURN(bool did_set_config, TrySetGpuBackendConfigForCollective(
                                                device_info, fusion_instr));
   if (!did_set_config) {
+    VLOG(3) << "TrySetGpuBackendConfigForCollective returned false - not using "
+               "Triton";
     return make_thunk(/*kernel_name=*/"",
                       /*shmem_bytes=*/0,
                       /*launch_dimensions=*/std::nullopt,
                       /*local_module=*/nullptr);
   }
+  VLOG(3) << "TrySetGpuBackendConfigForCollective succeeded - using Triton!";
   const HloFusionAnalysis fusion_analysis =
       HloFusionAnalysis::Create(*fusion_instr, device_info);
   auto emitter = std::make_unique<TritonFusion>(fusion_analysis);
@@ -314,12 +327,88 @@ ThunkSequence FlattenThunkSequence(std::vector<ThunkSequence>&& sequences) {
   return result;
 }
 
+// Overload for AllGather
+absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
+    IrEmitterContext* ir_emitter_context, const CallGraph* call_graph,
+    Thunk::ThunkInfo thunk_info, std::vector<CollectiveThunk::Buffer> buffers,
+    const HloAllGatherInstruction* instr) {
+  VLOG(3) << "EmitCollectiveKernelThunk called for AllGather: "
+          << instr->name();
+
+  std::unique_ptr<HloModule> fused_module =
+      NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
+  HloFusionInstruction* fusion_instr = Cast<HloFusionInstruction>(
+      fused_module->entry_computation()->root_instruction());
+  const se::DeviceDescription& device_info =
+      ir_emitter_context->gpu_device_info();
+
+  // For AllGather, we don't have a reduction, so we pass nullopt
+  const auto make_thunk = [&](absl::string_view kernel_name,
+                              int32_t shmem_bytes,
+                              std::optional<LaunchDimensions> launch_dimensions,
+                              std::unique_ptr<llvm::Module> local_module) {
+    // AllGather doesn't have reduction, pass nullopt
+    return EmitCollectiveResult{
+        std::make_unique<CollectiveKernelThunk>(
+            thunk_info,
+            GetCollectiveConfig(instr, instr->use_global_device_ids()),
+            std::nullopt,  // No reduction for AllGather
+            /*is_async=*/!IsGPUSyncCollective(*instr), std::move(buffers),
+            /*is_collective_kernel_enabled=*/
+            instr->GetModule()
+                ->config()
+                .debug_options()
+                .xla_gpu_unsupported_use_all_gather_triton_backend(),
+            /*kernel_name=*/kernel_name,
+            /*launch_dimensions=*/launch_dimensions,
+            /*shmem_bytes=*/shmem_bytes,
+            /*is_multimem_enabled=*/false,
+            /*cubin =*/ std::nullopt,
+            /*use_pdl =*/ false,
+            /*collective_op_kind=*/
+            CollectiveKernelThunk::CollectiveOpKind::kAllGather),
+        std::move(local_module)};
+  };
+
+  TF_ASSIGN_OR_RETURN(bool did_set_config, TrySetGpuBackendConfigForCollective(
+                                               device_info, fusion_instr));
+  if (!did_set_config) {
+    VLOG(3) << "TrySetGpuBackendConfigForCollective returned false for "
+               "AllGather - not using Triton";
+    return make_thunk(/*kernel_name=*/"",
+                      /*shmem_bytes=*/0,
+                      /*launch_dimensions=*/std::nullopt,
+                      /*local_module=*/nullptr);
+  }
+  VLOG(3) << "TrySetGpuBackendConfigForCollective succeeded for AllGather - "
+             "using Triton!";
+  const HloFusionAnalysis fusion_analysis =
+      HloFusionAnalysis::Create(*fusion_instr, device_info);
+  auto emitter = std::make_unique<TritonFusion>(fusion_analysis);
+  TritonFusion::EmitResult result;
+  {
+    XLA_SCOPED_LOGGING_TIMER("Emit collective kernel thunk for AllGather");
+    TF_ASSIGN_OR_RETURN(std::vector<Shape> unmanaged_arguments,
+                        GetCollectiveUnmanagedKernelArguments(fusion_instr));
+    VLOG(3) << "EmitCollectiveKernelThunk before emit!";
+
+    // For AllGather, use instr_override to get correct buffer assignments.
+    // The special KernelArguments::Create overload in fusion.cc handles
+    // the tuple unpacking, using fusion for shapes and AllGather for buffers.
+    TF_ASSIGN_OR_RETURN(
+        result, emitter->Emit(*ir_emitter_context, *fusion_instr,
+                              /*instr_override=*/instr, unmanaged_arguments));
+  }
+  return make_thunk(
+      result.kernel_thunk->kernel_name(), result.kernel_thunk->shmem_bytes(),
+      result.kernel_thunk->launch_dimensions(), std::move(result.llvm_module));
+}
+
 }  // namespace
 
-ThunkEmitter::ThunkEmitter(
-    IrEmitterContext* absl_nonnull ir_emitter_context,
-    llvm_ir::LLVMCommandLineOptionsReleasableLock* absl_nonnull
-        llvm_options_lock)
+ThunkEmitter::ThunkEmitter(IrEmitterContext* absl_nonnull ir_emitter_context,
+                           llvm_ir::LLVMCommandLineOptionsReleasableLock*
+                               absl_nonnull llvm_options_lock)
     : ir_emitter_context_(ir_emitter_context),
       send_recv_events_(std::make_shared<HostSendRecvAsyncEvents>()),
       nvshmem_buffer_addresses_(std::make_shared<NvshmemBufferAddresses>()),
@@ -1786,18 +1875,35 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectiveThunk(
   // TODO(b/828435206) Remove this constexpr once collective kernel thunk is
   // lifted out of the all reduce thunk.
   if constexpr (kRequiresCollectiveKernelThunk<CollectiveThunkType>) {
-    TF_ASSIGN_OR_RETURN(
-        auto emit_result,
-        EmitCollectiveKernelThunk(
-            ir_emitter_context_, call_graph_.get(), thunk_info, buffers,
-            Cast<HloAllReduceInstruction>(inst), GetAllReduceConfigInst(inst)));
-    if (emit_result.llvm_module != nullptr) {
-      kernel_modules_.push_back(std::move(emit_result.llvm_module));
+    // Check if this is AllReduce or AllGather and call appropriate overload
+    if constexpr (std::is_same_v<HloInstType, HloAllReduceInstruction>) {
+      TF_ASSIGN_OR_RETURN(
+          auto emit_result,
+          EmitCollectiveKernelThunk(ir_emitter_context_, call_graph_.get(),
+                                    thunk_info, buffers, inst,
+                                    GetAllReduceConfigInst(inst)));
+      if (emit_result.llvm_module != nullptr) {
+        kernel_modules_.push_back(std::move(emit_result.llvm_module));
+      }
+      thunk = std::make_unique<CollectiveThunkType>(
+          thunk_info, inst, /*buffers=*/std::move(buffers),
+          std::move(emit_result.thunk),
+          ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p());
+    } else if constexpr (std::is_same_v<HloInstType, HloAllGatherInstruction>) {
+      TF_ASSIGN_OR_RETURN(
+          auto emit_result,
+          EmitCollectiveKernelThunk(ir_emitter_context_, call_graph_.get(),
+                                    thunk_info, buffers, inst));
+      if (emit_result.llvm_module != nullptr) {
+        kernel_modules_.push_back(std::move(emit_result.llvm_module));
+      }
+      thunk = std::make_unique<CollectiveThunkType>(
+          thunk_info, inst, /*buffers=*/std::move(buffers),
+          std::move(emit_result.thunk),
+          ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p());
+    } else {
+      return Internal("Unsupported collective instruction type");
     }
-    thunk = std::make_unique<CollectiveThunkType>(
-        thunk_info, inst, /*buffers=*/std::move(buffers),
-        std::move(emit_result.thunk),
-        ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p());
   } else {
     thunk = std::make_unique<CollectiveThunkType>(
         thunk_info, inst, /*buffers=*/std::move(buffers),

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1128,6 +1128,9 @@ message DebugOptions {
   // all-reduce operations.
   optional bool xla_gpu_unsupported_use_all_reduce_one_shot_kernel = 387;
 
+  // Internal testing flag to enable Triton backend for all-gather operations.
+  optional bool xla_gpu_unsupported_use_all_gather_triton_backend = 478;
+
   // Internal testing flag to enable one-shot kernel for single-host
   // ragged-all-to-all operations.
   optional bool xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel = 375;
@@ -1532,7 +1535,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 478
+  // Next id: 479
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
📝 Summary of Changes
This PR is the fourth in a series of five. 
PR 1/5 : https://github.com/openxla/xla/pull/42531
PR 2/5: https://github.com/openxla/xla/pull/42533
PR 3/5: https://github.com/openxla/xla/pull/42540
PR 4/5: https://github.com/openxla/xla/pull/42541 <= This PR
PR 5/5: https://github.com/openxla/xla/pull/42543  
These PRs aim to enable the Triton backend for the All-Gather collective operation.

This PR wire the full `AllGather` dispatch chain so that `AllGather` ops are routed through `CollectiveKernelThunk` at runtime. The Triton kernel emitter is not yet implemented (`GetBlockLevelFusionConfigForAllGather` in the base `collective_emitter` returns `nullopt` for `AllGather` fusions), so every `AllGather` falls back to NCCL/RCCL cleanly at this stage.

🎯 Justification
Lowering All-Gather through the triton backend significantly improves performance of this operation for AMD target (compared to RCCL backend) and could allow us to take greater advantage of kernel-level fusion.

Example of 5 Triton Performance Improvements — All-Gather 1D on MI350
| dtype | shape | num_replicas | input_size_kb | output_size_kb | RCCL mean_us | Triton mean_us | Triton/RCCL | Improvement
| -- | -- | -- | -- | -- | -- | -- | -- | --
| bf16 | 2097152 | 4 | 4096 | 16384 | 148.106 | 52.740 | 0.356 | 64.4%
| f16 | 2097152 | 4 | 4096 | 16384 | 126.587 | 51.817 | 0.409 | 59.1%
| bf16 | 2097152 | 2 | 4096 | 8192 | 124.716 | 51.393 | 0.412 | 58.8%
| bf16 | 4194304 | 2 | 8192 | 16384 | 206.720 | 86.595 | 0.419 | 58.1%
| bf16 | 4194304 | 4 | 8192 | 32768 | 223.113 | 95.644 | 0.429 | 57.1%

Example of 5 Triton Performance Improvements — All-Gather 2D on MI350
| dtype | shape     | gather_dim | num_replicas | input_size_kb | output_size_kb | RCCL mean_us | Triton mean_us | Triton/RCCL | Improvement |
| ----- | --------- | ---------: | -----------: | ------------: | -------------: | -----------: | -------------: | ----------: | ----------: |
| bf16  | 1024x1024 |          0 |            2 |          2048 |           4096 |       81.743 |         28.737 |       0.352 |       64.8% |
| u4    | 1024x1024 |          0 |            2 |           512 |           1024 |       49.423 |         21.110 |       0.427 |       57.3% |
| u4    | 256x256   |          1 |            2 |            32 |             64 |       43.142 |         19.736 |       0.457 |       54.3% |
| u4    | 1024x512  |          1 |            2 |           256 |            512 |       39.583 |         20.909 |       0.528 |       47.2% |
| u4    | 2048x2048 |          1 |            2 |          2048 |           4096 |       83.845 |         32.911 |       0.392 |       60.8% |


🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement,✨ New Feature
