### PR TITLE
[ROCm][Triton] Emit the All-Gather Triton kernel (PR 5/5)

### DIFF
--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -703,6 +703,7 @@ cc_library(
         "//xla:util",
         "//xla:xla_data_proto_cc",
         "//xla/backends/gpu/codegen/triton/ir:triton_xla",
+        "//xla/backends/gpu/runtime:all_gather",
         "//xla/backends/gpu/runtime:all_reduce",
         "//xla/codegen/emitters/ir:xla",
         "//xla/codegen/xtile/codegen:emitter_helpers",

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -54,6 +54,7 @@ limitations under the License.
 #include "stablehlo/dialect/StablehloOps.h"
 #include "xla/backends/gpu/codegen/triton/ir/triton_xla_ops.h"
 #include "xla/backends/gpu/codegen/triton/lowering_util.h"
+#include "xla/backends/gpu/runtime/all_gather.h"
 #include "xla/backends/gpu/runtime/all_reduce.h"
 #include "xla/codegen/emitters/ir/xla_ops.h"  // IWYU pragma: keep
 #include "xla/codegen/xtile/codegen/emitter_helpers.h"
@@ -86,6 +87,15 @@ namespace xla::gpu {
 namespace {
 
 using ::xla::se::gpu::AllReduceStrategy;
+
+// Maximum number of blocks per grid for collective operations.
+// This constant is used for:
+// 1. Launch dimension calculations in GetBlockLevelFusionConfigForAllGather
+// 2. Signal buffer shape sizing in GetAllReduceUnmanagedKernelArguments
+// 3. Signal buffer shape sizing in GetAllGatherUnmanagedKernelArguments
+// Note: The runtime signal buffer allocation in collective_kernel_thunk.cc
+// sizes based on actual launch dimensions, not this shape constant.
+static constexpr int64_t kMaxBlocksPerGrid = 24;
 
 namespace ttir = ::mlir::triton;
 namespace mtx = ::mlir::triton::xla;
@@ -267,7 +277,6 @@ absl::StatusOr<std::vector<Shape>> GetAllReduceUnmanagedKernelArguments(
   // - num_devices * num_blocks for the signal buffer.
   // - num_devices * shape of the parameter for scratch buffers.
   // Since number of blocks is not known in this context we use a constant.
-  static constexpr int32_t kMaxBlocksPerGrid = 24;
   unmanaged_arguments.push_back(
       ShapeUtil::MakeShape(S32, {num_devices, kMaxBlocksPerGrid}));
   // Scratch buffers
@@ -919,13 +928,35 @@ class AllReduceEmitter {
 llvm::SmallVector<int64_t> GreedyPowerOfTwoTiles(const Shape& output_shape,
                                                  int32_t num_blocks) {
   CHECK_GT(num_blocks, 0) << "num_blocks must be positive. Was " << num_blocks;
+
+  // Triton has a hard limit of 1048576 elements per tensor
+  constexpr int64_t kMaxTensorNumElements = 1048576;
+
   // Rank fits in int32_t.
   const auto rank = static_cast<int32_t>(output_shape.dimensions().size());
   const llvm::ArrayRef<const int64_t> minor_to_major =
       LayoutUtil::MinorToMajor(output_shape);
   llvm::SmallVector<int64_t, 4> tile_sizes(rank);
+
+  // Calculate minimum blocks needed to respect the element limit
+  int64_t total_elements = ShapeUtil::ElementsIn(output_shape);
+  int64_t min_blocks_for_limit =
+      CeilOfRatio(total_elements, kMaxTensorNumElements);
+
+  // Use at least enough blocks to stay under the element limit
+  uint64_t effective_num_blocks =
+      std::max(static_cast<uint64_t>(num_blocks),
+               static_cast<uint64_t>(min_blocks_for_limit));
+
+  VLOG(3) << "GreedyPowerOfTwoTiles: shape=" << output_shape.ToString()
+          << " requested_blocks=" << num_blocks
+          << " total_elements=" << total_elements
+          << " min_blocks_for_limit=" << min_blocks_for_limit
+          << " effective_blocks=" << effective_num_blocks;
+
   // NB: Unsigned because llvm::bit_<> functions expect unsigned.
-  uint64_t remaining_blocks = num_blocks;
+  uint64_t remaining_blocks = effective_num_blocks;
+
   // Iterate from most major to most minor to keep memory contiguous for each
   // block.
   for (int32_t i = rank - 1; i >= 0; --i) {
@@ -939,19 +970,116 @@ llvm::SmallVector<int64_t> GreedyPowerOfTwoTiles(const Shape& output_shape,
         static_cast<int64_t>(llvm::bit_ceil(xla::CeilOfRatio(dim_size, k)));
     const uint64_t blocks_used =
         xla::CeilOfRatio(dim_size, static_cast<uint64_t>(tile_sizes[dim]));
+
+    VLOG(3) << "  dim=" << dim << " dim_size=" << dim_size << " k=" << k
+            << " tile_size=" << tile_sizes[dim]
+            << " blocks_used=" << blocks_used
+            << " remaining_blocks_before=" << remaining_blocks;
+
     remaining_blocks = xla::FloorOfRatio(remaining_blocks, blocks_used);
+
+    VLOG(3) << "  remaining_blocks_after=" << remaining_blocks;
   }
+
+  // Final check
+  int64_t tile_num_elements = Product(tile_sizes);
+  VLOG(3) << "Final tile_sizes: [" << absl::StrJoin(tile_sizes, ", ") << "]"
+          << " total_tile_elements=" << tile_num_elements;
+
+  if (tile_num_elements > kMaxTensorNumElements) {
+    LOG(ERROR) << "Generated tile with " << tile_num_elements << " elements, "
+               << "which exceeds Triton's limit of " << kMaxTensorNumElements
+               << ". This will cause compilation to fail.";
+  }
+
   return tile_sizes;
+}
+
+// Returns the block level fusion config for all-gather if supported.
+absl::StatusOr<std::optional<BlockLevelFusionConfig>>
+GetBlockLevelFusionConfigForAllGather(
+    const se::DeviceDescription& device_info,
+    const HloAllGatherInstruction* all_gather) {
+  const bool triton_backend_requested = all_gather->GetModule()
+                                            ->config()
+                                            .debug_options()
+                                            .xla_gpu_unsupported_use_all_gather_triton_backend();
+  absl::StatusOr<AllGatherInfo> maybe_all_gather_info = BuildAllGatherInfo(
+      /*is_collective_kernel_enabled=*/triton_backend_requested, device_info,
+      all_gather);
+  if (absl::IsUnimplemented(maybe_all_gather_info.status())) {
+    if (triton_backend_requested) {
+      // The Triton backend was explicitly requested via debug flag but cannot
+      // handle this all-gather configuration (e.g., unsupported element type,
+      // misaligned element count, or unsupported device). The operation will
+      // fall back to NCCL/RCCL. This warning helps diagnose silent fallbacks.
+      LOG(WARNING) << "Triton backend was requested for all-gather '"
+                   << all_gather->name()
+                   << "' but the configuration is not supported: "
+                   << maybe_all_gather_info.status().message()
+                   << ". Falling back to NCCL/RCCL.";
+    } else {
+      VLOG(3) << "Codegen for all-gather is not supported: "
+              << maybe_all_gather_info.status();
+    }
+    return std::nullopt;
+  }
+  TF_ASSIGN_OR_RETURN(AllGatherInfo all_gather_info,
+                      std::move(maybe_all_gather_info));
+
+  const Shape& input_shape = all_gather->operand(0)->shape();
+  static constexpr int64_t kWarpSize = 32;
+  static constexpr uint64_t kMaxThreadsPerBlock = 512;
+
+  const int64_t total_threads =
+      RoundUpTo(all_gather_info.num_elements / se::gpu::kNumElementsPerThread,
+                kWarpSize);
+  // Triton expects power of 2 for threads_per_block / threads_per_warp.
+  const int64_t threads_per_block =
+      std::min(kMaxThreadsPerBlock,
+               static_cast<uint64_t>(llvm::PowerOf2Ceil(total_threads)));
+  const int64_t blocks_per_grid = std::min(
+      kMaxBlocksPerGrid, CeilOfRatio(total_threads, threads_per_block));
+  const LaunchDimensions launch_dims(blocks_per_grid, threads_per_block);
+
+  BlockLevelFusionConfig block_level_config;
+  const int64_t num_warps = std::max(
+      int64_t{1}, static_cast<int64_t>(launch_dims.num_threads_per_block() /
+                                       WarpSize(device_info)));
+  block_level_config.set_num_warps(num_warps);
+  block_level_config.set_num_ctas(1);    // No block-level clustering.
+  block_level_config.set_num_stages(1);  // No pipelining of loops.
+
+  Tile* output_tile = block_level_config.add_output_tiles();
+  const llvm::SmallVector<int64_t> tile_sizes =
+      GreedyPowerOfTwoTiles(input_shape, launch_dims.num_blocks());
+  output_tile->mutable_sizes()->Assign(tile_sizes.begin(), tile_sizes.end());
+
+  VLOG(3) << "Block level fusion config for " << all_gather->name() << ": "
+          << block_level_config;
+  return block_level_config;
 }
 
 absl::StatusOr<std::optional<BlockLevelFusionConfig>>
 GetCollectiveBlockLevelFusionConfig(const se::DeviceDescription& device_info,
                                     const HloFusionInstruction* fusion_instr) {
   const HloInstruction* root = fusion_instr->fused_expression_root();
+
+  // For AllGather-start, the fusion root is a GetTupleElement that extracts
+  // the output from the AllGather-start tuple
+  if (root->opcode() == HloOpcode::kGetTupleElement &&
+      root->operand(0)->opcode() == HloOpcode::kAllGatherStart) {
+    return GetBlockLevelFusionConfigForAllGather(
+        device_info, Cast<HloAllGatherInstruction>(root->operand(0)));
+  }
+
   switch (root->opcode()) {
     case HloOpcode::kAllReduceStart:
       return GetBlockLevelFusionConfigForAllReduce(
           device_info, Cast<HloAllReduceInstruction>(root));
+    case HloOpcode::kAllGatherStart:
+      return GetBlockLevelFusionConfigForAllGather(
+          device_info, Cast<HloAllGatherInstruction>(root));
     default:
       return std::nullopt;
   }
@@ -980,14 +1108,77 @@ absl::StatusOr<bool> TrySetGpuBackendConfigForCollective(
   return true;
 }
 
+// Returns unmanaged kernel arguments for all-gather (similar to all-reduce).
+absl::StatusOr<std::vector<Shape>> GetAllGatherUnmanagedKernelArguments(
+    const HloComputation* computation,
+    const HloAllGatherInstruction* all_gather) {
+  // Check if device_list is valid to prevent segfault
+  if (!all_gather->device_list()) {
+    return absl::InternalError(absl::StrCat(
+        "AllGather instruction ", all_gather->name(),
+        " has null device_list. Cannot generate Triton kernel arguments."));
+  }
+
+  const int32_t num_devices =
+      all_gather->device_list()->num_devices_per_group();
+
+  std::vector<Shape> unmanaged_arguments;
+  unmanaged_arguments.reserve(computation->num_parameters() +
+                              kNumCollectiveMetadataArgs);
+  // rank and signal_value
+  unmanaged_arguments.push_back(ShapeUtil::MakeShape(S32, {}));
+  unmanaged_arguments.push_back(ShapeUtil::MakeShape(S32, {}));
+
+  // Signal and scratch buffers (same as AllReduce)
+  unmanaged_arguments.push_back(
+      ShapeUtil::MakeShape(S32, {num_devices, kMaxBlocksPerGrid}));
+
+  // Scratch buffers for AllGather
+  // Note: For AllGather, we need buffers to hold the gathered data
+  if (!computation) {
+    return absl::InternalError(
+        "Computation is null in GetAllGatherUnmanagedKernelArguments");
+  }
+
+  for (const HloInstruction* instr : computation->parameter_instructions()) {
+    if (!instr) {
+      return absl::InternalError(
+          "Null parameter instruction in GetAllGatherUnmanagedKernelArguments");
+    }
+    Shape shape =
+        ShapeUtil::InsertDimensionAtIndex(instr->shape(), 0, num_devices);
+    unmanaged_arguments.push_back(shape);
+  }
+
+  if (unmanaged_arguments.size() !=
+      computation->num_parameters() + kNumCollectiveMetadataArgs) {
+    return absl::InternalError(
+        absl::StrCat("AllGather unmanaged arguments size mismatch. Expected: ",
+                     computation->num_parameters() + kNumCollectiveMetadataArgs,
+                     ", Got: ", unmanaged_arguments.size()));
+  }
+  return unmanaged_arguments;
+}
+
 absl::StatusOr<std::vector<Shape>> GetCollectiveUnmanagedKernelArguments(
     const HloFusionInstruction* fusion) {
   const HloComputation* computation = fusion->fused_instructions_computation();
   const HloInstruction* root = computation->root_instruction();
+
+  // For AllGather-start wrapped in GetTupleElement
+  if (root->opcode() == HloOpcode::kGetTupleElement &&
+      root->operand(0)->opcode() == HloOpcode::kAllGatherStart) {
+    return GetAllGatherUnmanagedKernelArguments(
+        computation, Cast<HloAllGatherInstruction>(root->operand(0)));
+  }
+
   switch (root->opcode()) {
     case HloOpcode::kAllReduceStart:
       return GetAllReduceUnmanagedKernelArguments(
           computation, Cast<HloAllReduceInstruction>(root));
+    case HloOpcode::kAllGatherStart:
+      return GetAllGatherUnmanagedKernelArguments(
+          computation, Cast<HloAllGatherInstruction>(root));
     default:
       return std::vector<Shape>();
   }
@@ -1040,6 +1231,327 @@ mlir::LogicalResult RewriteAllReduce(mlir::stablehlo::AllReduceOp op,
   VLOG(3) << "AllReduceEmitter::Emit using strategy: "
           << maybe_context->strategy;
   return AllReduceEmitter::Emit(maybe_context.value(), rewriter);
+}
+
+// Context for AllGather emitter
+struct AllGatherEmitterContext {
+  mlir::stablehlo::AllGatherOp op;
+  int32_t num_input_output_args{0};
+  int32_t num_scratch_buffers{0};
+  xtile::EntryFuncOp xtile_entry_fn;
+  xtile::TensorValue input_tile;
+  xtile::ExtractTileOp input_extract;
+  llvm::SmallVector<int64_t, 4> non_tiled_input_shape;
+  PrimitiveType element_type;
+  int64_t world_size{0};
+  int64_t num_elements{0};
+  int64_t all_gather_dimension{0};
+};
+
+absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
+    mlir::stablehlo::AllGatherOp op) {
+  AllGatherEmitterContext ctx;
+  if (op.getOperands().size() != 1) {
+    return absl::InvalidArgumentError(
+        "AllGather op must have exactly one operand in order to be lowered "
+        "to triton.");
+  }
+
+  mlir::Type element_type =
+      mlir::cast<mlir::ShapedType>(op.getOperand(0).getType()).getElementType();
+  ctx.element_type = xla::ConvertMlirTypeToPrimitiveType(element_type);
+  if (ctx.element_type == PrimitiveType::PRIMITIVE_TYPE_INVALID) {
+    std::string type_string;
+    llvm::raw_string_ostream stream(type_string);
+    op.getOperand(0).print(stream);
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Could not convert operand type to a valid PrimitiveType. "
+        "Operand Type: %s",
+        type_string));
+  }
+
+  ctx.xtile_entry_fn = op->getParentOfType<xtile::EntryFuncOp>();
+  if (!ctx.xtile_entry_fn) {
+    return absl::InvalidArgumentError(
+        "AllGather op must be in an XTile entry function in order to be "
+        "lowered to triton.");
+  }
+
+  ctx.num_input_output_args = op->getNumOperands() * 2;
+  ctx.num_scratch_buffers = op->getNumOperands();
+  const int32_t expected_num_args =
+      ctx.num_input_output_args + ctx.num_scratch_buffers +
+      kNumCollectiveMetadataArgs + kNumTileIndexArgs;
+  if (ctx.xtile_entry_fn.getNumArguments() != expected_num_args) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("AllGather op must have ", expected_num_args,
+                     " arguments in order to "
+                     "be lowered to triton, but it has ",
+                     ctx.xtile_entry_fn.getNumArguments()));
+  }
+
+  ctx.input_tile = mlir::cast<xtile::TensorValue>(op->getOperand(0));
+  ctx.input_extract =
+      llvm::dyn_cast<xtile::ExtractTileOp>(ctx.input_tile.getDefiningOp());
+  if (!ctx.input_extract &&
+      ctx.input_tile.getDefiningOp()->getNumOperands() > 0) {
+    ctx.input_extract = llvm::dyn_cast<xtile::ExtractTileOp>(
+        ctx.input_tile.getDefiningOp()->getOperand(0).getDefiningOp());
+  }
+  if (!ctx.input_extract) {
+    return absl::InvalidArgumentError(
+        "AllGather op must have an extract tile op as operand in order to be "
+        "lowered to triton.");
+  }
+
+  ctx.non_tiled_input_shape = llvm::SmallVector<int64_t, 4>(
+      ctx.input_extract.getSource().getType().getShape());
+  ctx.num_elements = Product(ctx.non_tiled_input_shape);
+  // Get world_size from replica_groups, not from getAllGatherDim()
+  // getAllGatherDim() returns the dimension to gather along (e.g., 0)
+  // world_size is the number of devices in the group
+  ctx.world_size = mlir::cast<mlir::DenseIntElementsAttr>(op.getReplicaGroups()).getType().getDimSize(1);
+  ctx.all_gather_dimension = op.getAllGatherDim();
+  ctx.op = op;
+
+  return ctx;
+}
+
+class AllGatherEmitter {
+ public:
+  static mlir::LogicalResult Emit(AllGatherEmitterContext ctx,
+                                  mlir::PatternRewriter& rewriter) {
+    AllGatherEmitter emitter(std::move(ctx), rewriter);
+    if (auto result = emitter.Initialize(); !result.ok()) {
+      LOG(ERROR) << "Failed to initialize AllGatherEmitter: "
+                 << result.message();
+      return mlir::failure();
+    }
+    return emitter.EmitAllGather();
+  }
+
+ private:
+  AllGatherEmitter(AllGatherEmitterContext ctx, mlir::PatternRewriter& rewriter)
+      : ctx_(std::move(ctx)),
+        rewriter_(rewriter),
+        builder_(ctx_.op->getLoc(), rewriter) {}
+
+  absl::Status Initialize() {
+    CHECK(!initialized_);
+
+    // 1. Opaque arguments
+    const int32_t start_idx = ctx_.num_input_output_args;
+    device_rank_ = ctx_.xtile_entry_fn.getArgument(start_idx);
+    CHECK(device_rank_.getType().isInteger(32));
+    signal_value_ = ctx_.xtile_entry_fn.getArgument(start_idx + 1);
+    CHECK(signal_value_.getType().isInteger(32));
+    signal_buffers_ = ctx_.xtile_entry_fn.getArgument(start_idx + 2);
+    remote_input_buffers_ = ctx_.xtile_entry_fn.getArgument(start_idx + 3);
+
+    // 2. Constants and types
+    elem_type_ = mlir::getElementTypeOrSelf(ctx_.input_tile.getType());
+    elem_storage_type_ = xtile::StorageType(elem_type_);
+    ptr_to_i64_type_ =
+        ttir::PointerType::get(builder_.getI64Type(), kGlobalAddressSpace);
+    ptr_to_elem_type_ =
+        ttir::PointerType::get(elem_storage_type_, kGlobalAddressSpace);
+    TF_ASSIGN_OR_RETURN(layout_, xtile::GetPermutationMinorToMajor(
+                                     ctx_.input_extract.getSource().getType()));
+
+    // 3. Emit setup IR
+    remote_input_buffers_i64_ = ttir::BitcastOp::create(
+        builder_, ptr_to_i64_type_, remote_input_buffers_);
+    const mlir::Type i64_type = builder_.getI64Type();
+
+    mlir::Value buffer_index = arith::AndIOp::create(
+        builder_, i64_type,
+        arith::ExtSIOp::create(builder_, i64_type, signal_value_),
+        arith::ConstantOp::create(builder_, i64_type,
+                                  builder_.getI64IntegerAttr(1)));
+
+    const int64_t buffer_size = xla::RoundUpTo<uint64_t>(
+        ctx_.num_elements *
+            ShapeUtil::ByteSizeOfPrimitiveType(ctx_.element_type),
+        kXlaAllocatedBufferAlignBytes);
+    const int64_t elements_per_buffer =
+        buffer_size / ShapeUtil::ByteSizeOfPrimitiveType(ctx_.element_type);
+    buffer_offset_ = arith::MulIOp::create(
+        builder_, i64_type, buffer_index,
+        arith::ConstantOp::create(
+            builder_, i64_type,
+            builder_.getI64IntegerAttr(elements_per_buffer)));
+
+    initialized_ = true;
+    return absl::OkStatus();
+  }
+
+  mlir::Value GetRemoteBufferPtr(mlir::Value rank_idx) {
+    CHECK(initialized_);
+    mlir::Value remote_buf_ptr_addr = ttir::AddPtrOp::create(
+        builder_, ptr_to_i64_type_, remote_input_buffers_i64_, rank_idx);
+    mlir::Value remote_buf_i64 = ttir::LoadOp::create(
+        builder_, remote_buf_ptr_addr, ttir::CacheModifier::NONE,
+        ttir::EvictionPolicy::NORMAL,
+        /*isVolatile=*/false);
+    mlir::Value remote_buf_ptr_base =
+        ttir::IntToPtrOp::create(builder_, ptr_to_elem_type_, remote_buf_i64,
+                                 llvm::ArrayRef<mlir::NamedAttribute>{
+                                     xtile::GetDivisibilityAttr(builder_)});
+    mlir::Value remote_buf_ptr = ttir::AddPtrOp::create(
+        builder_, ptr_to_elem_type_, remote_buf_ptr_base, buffer_offset_);
+    return remote_buf_ptr;
+  }
+
+  xtile::TensorValue LoadTileForRank(mlir::Value rank_idx,
+                                     mlir::ValueRange offsets,
+                                     llvm::ArrayRef<int64_t> shape) {
+    CHECK(initialized_);
+    mlir::Value remote_buf_ptr = GetRemoteBufferPtr(rank_idx);
+    auto [ptrs, mask] = triton::CreateTensorOfPointersAndMask(
+        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_, offsets,
+        shape, ctx_.input_extract.getStrides(),
+        /*reduced_dims=*/{}, shape);
+
+    auto next_tile = mlir::cast<xtile::TensorValue>(
+        ttir::LoadOp::create(builder_, ptrs, mask, /*other=*/mlir::Value(),
+                             ttir::CacheModifier::NONE,
+                             ttir::EvictionPolicy::NORMAL,
+                             /*isVolatile=*/false)
+            .getResult());
+
+    if (elem_storage_type_ != elem_type_) {
+      next_tile = mlir::cast<xtile::TensorValue>(
+          xtile::Cast(builder_, next_tile, elem_type_));
+    }
+    return next_tile;
+  }
+
+  mlir::LogicalResult EmitCopyToSymmetric(mlir::Value tile_to_store,
+                                          mlir::ValueRange offsets,
+                                          llvm::ArrayRef<int64_t> shape) {
+    CHECK(initialized_);
+    mlir::Value remote_buf_ptr = GetRemoteBufferPtr(device_rank_);
+
+    mlir::Value storage_tile = tile_to_store;
+    if (elem_storage_type_ != elem_type_) {
+      storage_tile = mlir::cast<xtile::TensorValue>(
+          xtile::Cast(builder_, tile_to_store, elem_storage_type_));
+    }
+
+    auto [ptrs, mask] = triton::CreateTensorOfPointersAndMask(
+        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_, offsets,
+        shape, ctx_.input_extract.getStrides(),
+        /*reduced_dims=*/{}, shape);
+
+    ttir::StoreOp::create(builder_, ptrs, storage_tile, mask,
+                          ttir::CacheModifier::NONE,
+                          ttir::EvictionPolicy::NORMAL);
+    return mlir::success();
+  }
+
+  mlir::LogicalResult EmitSync(mlir::Value signal_value) {
+    CHECK(initialized_);
+    mlir::triton::gpu::BarrierOp::create(builder_,
+                                         mlir::triton::gpu::AddrSpace::Local);
+    mtx::BlockBarrierOp::create(builder_, signal_buffers_, device_rank_,
+                                signal_value,
+                                builder_.getI32IntegerAttr(ctx_.world_size));
+    return mlir::success();
+  }
+
+  mlir::LogicalResult EmitAllGather() {
+    CHECK(initialized_);
+
+    llvm::ArrayRef<int64_t> shape = ctx_.input_tile.getType().getShape();
+
+    // Get the block/program ID
+    mlir::Value program_id = ttir::GetProgramIdOp::create(builder_, 0);
+
+    // Calculate source rank: program_id % world_size
+    // The modulo operation guarantees the result is in [0, world_size-1]
+    mlir::Value world_size_i32 =
+        arith::ConstantOp::create(builder_, builder_.getI32Type(),
+                                  builder_.getI32IntegerAttr(ctx_.world_size));
+    mlir::Value source_rank_i32 =
+        arith::RemSIOp::create(builder_, program_id, world_size_i32);
+    mlir::Value source_rank = arith::ExtSIOp::create(
+        builder_, builder_.getI64Type(), source_rank_i32);
+
+    // 1. Copy local tile to symmetric buffer (all ranks do this)
+    if (mlir::failed(EmitCopyToSymmetric(
+            ctx_.input_tile, ctx_.input_extract.getOffsets(),
+            ctx_.input_tile.getType().getShape()))) {
+      return rewriter_.notifyMatchFailure(ctx_.op,
+                                          "Failed to emit copy to symmetric");
+    }
+
+    // 2. Synchronization: Wait for all ranks to complete the copy
+    if (mlir::failed(EmitSync(signal_value_))) {
+      return rewriter_.notifyMatchFailure(ctx_.op,
+                                          "Failed to emit sync for all-gather");
+    }
+
+    // 3. Load the appropriate rank's data based on this block's program ID
+    // Calculate the local offset within the source rank's buffer
+    // For the gather dimension, offset is always 0 (we load the full input
+    // size) For other dimensions, use the tile offset from input_extract
+    mlir::ValueRange tile_offsets = ctx_.input_extract.getOffsets();
+    llvm::SmallVector<mlir::Value> local_offsets;
+    for (size_t i = 0; i < ctx_.non_tiled_input_shape.size(); ++i) {
+      if (i == ctx_.all_gather_dimension) {
+        // For gather dimension, always start at 0 in the source rank's buffer
+        local_offsets.push_back(arith::ConstantOp::create(
+            builder_, builder_.getIndexType(), builder_.getIndexAttr(0)));
+      } else {
+        // For other dimensions, use the tile offset
+        local_offsets.push_back(tile_offsets[i]);
+      }
+    }
+
+    xtile::TensorValue result =
+        LoadTileForRank(source_rank, local_offsets, shape);
+
+    // Replace the AllGather op with the loaded result
+    rewriter_.replaceOp(ctx_.op, result);
+
+    return mlir::success();
+  }
+
+  AllGatherEmitterContext ctx_;
+  mlir::PatternRewriter& rewriter_;
+  mlir::ImplicitLocOpBuilder builder_;
+
+  mlir::Value device_rank_;
+  mlir::Value signal_value_;
+  mlir::Value signal_buffers_;
+  mlir::Value remote_input_buffers_;
+  mlir::Value remote_input_buffers_i64_;
+  mlir::Value buffer_offset_;
+
+  llvm::SmallVector<int64_t> layout_;
+  mlir::Type elem_type_;
+  mlir::Type elem_storage_type_;
+  ttir::PointerType ptr_to_i64_type_;
+  ttir::PointerType ptr_to_elem_type_;
+
+  bool initialized_ = false;
+};
+
+mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
+                                     mlir::PatternRewriter& rewriter) {
+  const mlir::Location loc = op->getLoc();
+  absl::StatusOr<AllGatherEmitterContext> maybe_context =
+      CreateAllGatherEmitterContext(op);
+  if (!maybe_context.ok()) {
+    VLOG(3) << "Failed to create AllGatherEmitterContext: "
+            << maybe_context.status().message();
+    return rewriter.notifyMatchFailure(
+        loc, absl::StrCat("Failed to create AllGatherEmitterContext: ",
+                          maybe_context.status().message()));
+  }
+
+  VLOG(3) << "AllGatherEmitter::Emit for all-gather";
+  return AllGatherEmitter::Emit(maybe_context.value(), rewriter);
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/codegen/triton/collective_emitter.h
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.h
@@ -84,5 +84,9 @@ absl::StatusOr<std::vector<Shape>> GetCollectiveUnmanagedKernelArguments(
 mlir::LogicalResult RewriteAllReduce(mlir::stablehlo::AllReduceOp op,
                                      mlir::PatternRewriter& rewriter);
 
+// Rewrites stablehlo all-gather op to a triton implementation.
+mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
+                                     mlir::PatternRewriter& rewriter);
+
 }  // namespace xla::gpu
 #endif  // XLA_BACKENDS_GPU_CODEGEN_TRITON_COLLECTIVE_EMITTER_H_

--- a/xla/backends/gpu/codegen/triton/fusion.cc
+++ b/xla/backends/gpu/codegen/triton/fusion.cc
@@ -132,12 +132,28 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
   std::string suggested_kernel_name = std::string(fusion.name());
   llvm::IRBuilder builder(*ir_emitter_context.llvm_context());
   VLOG(3) << fusion.ToString();
-  TF_ASSIGN_OR_RETURN(
-      auto kernel_arguments,
-      emitters::KernelArguments::Create(
-          ir_emitter_context.buffer_assignment(), GetDefaultBufferAlignment(),
-          instr_override != nullptr ? instr_override : &fusion,
-          unmanaged_arguments));
+
+  // Special handling for AllGather with tuple unpacking
+  absl::StatusOr<emitters::KernelArguments> kernel_arguments_or;
+  if (instr_override != nullptr &&
+      instr_override->opcode() == HloOpcode::kAllGatherStart &&
+      instr_override->shape().IsTuple() && !fusion.shape().IsTuple()) {
+    // Use the new overload: fusion for shapes, AllGather for buffers at index
+    // {1}
+    kernel_arguments_or = emitters::KernelArguments::Create(
+        ir_emitter_context.buffer_assignment(), GetDefaultBufferAlignment(),
+        &fusion,         // shape_instruction
+        instr_override,  // buffer_instruction
+        ShapeIndex{1},   // output_index (element 1 of AllGather tuple)
+        unmanaged_arguments);
+  } else {
+    // Regular path for AllReduce and other operations
+    kernel_arguments_or = emitters::KernelArguments::Create(
+        ir_emitter_context.buffer_assignment(), GetDefaultBufferAlignment(),
+        instr_override != nullptr ? instr_override : &fusion,
+        unmanaged_arguments);
+  }
+  TF_ASSIGN_OR_RETURN(auto kernel_arguments, std::move(kernel_arguments_or));
 
   const HloComputation* hlo_computation =
       fusion.fused_instructions_computation();
@@ -158,7 +174,6 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
             ir_emitter_context.data_layout(), ir_emitter_context.llvm_context(),
             ir_emitter_context.mlir_context()));
     local_module = std::move(triton_wrapper_result.llvm_module);
-
     auto backend_config =
         fusion.backend_config<GpuBackendConfig>()->fusion_backend_config();
     absl::string_view fusion_kind = backend_config.kind();
@@ -172,7 +187,6 @@ absl::StatusOr<TritonFusion::EmitResult> TritonFusion::Emit(
         kTritonNestedGemmFusionKind,
         kTritonCollectiveFusionKind,
     };
-
     if (!absl::c_linear_search(kSupportedFusionKinds, fusion_kind)) {
       return Internal("Unsupported fusion kind: %s", fusion_kind);
     }
@@ -251,25 +265,45 @@ std::optional<TritonFusion::LaunchConfig> TritonFusion::GetLaunchConfig(
 
     // We expect all roots to have the same number of blocks. Otherwise we
     // cannot codegen it.
+    LOG(INFO) << "GetLaunchConfig: fusion_root_count="
+              << analysis_.fusion_root_count();
+
+    if (analysis_.fusion_root_count() == 0) {
+      LOG(ERROR) << "GetLaunchConfig: No fusion roots found!";
+      return std::nullopt;
+    }
+
     int64_t num_blocks =
         GetNumberOfBlocks(analysis_.fusion_root(0).shape().dimensions(),
                           block_level_parameters.output_tile_sizes[0]);
     for (int64_t i = 1; i < analysis_.fusion_root_count(); ++i) {
-      CHECK_EQ(GetNumberOfBlocks(analysis_.fusion_root(i).shape().dimensions(),
-                                 block_level_parameters.output_tile_sizes[i]),
-               num_blocks);
-    }
+      if (i >= block_level_parameters.output_tile_sizes.size()) {
+        LOG(ERROR)
+            << "GetLaunchConfig: output_tile_sizes index out of bounds! i=" << i
+            << ", size=" << block_level_parameters.output_tile_sizes.size();
+        return std::nullopt;
+      }
 
+      int64_t blocks_for_root =
+          GetNumberOfBlocks(analysis_.fusion_root(i).shape().dimensions(),
+                            block_level_parameters.output_tile_sizes[i]);
+
+      CHECK_EQ(blocks_for_root, num_blocks);
+    }
     LaunchConfig launch_config;
     // TODO(b/451901200): We eventually also want to be able to predict this
     // value without compiling so the cost model can rely on it. Currently, we
     // need the override for auto warp specialization.
+    LOG(INFO) << "GetLaunchConfig: thread_dims_override.has_value()="
+              << thread_dims_override.has_value();
+
     if (thread_dims_override) {
       launch_config.launch_dimensions = LaunchDimensions{
           se::BlockDim(num_blocks), thread_dims_override.value()};
     } else {
+      int64_t warp_size = WarpSize(analysis_.device_info());
       int64_t estimated_threads_per_block =
-          block_level_parameters.num_warps * WarpSize(analysis_.device_info());
+          block_level_parameters.num_warps * warp_size;
       launch_config.launch_dimensions =
           LaunchDimensions{static_cast<uint64_t>(num_blocks),
                            static_cast<uint64_t>(estimated_threads_per_block)};

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -365,6 +365,50 @@ CodegenDecision IsTritonSupportedAllReduce(
   return CodegenDecision::Allow();
 }
 
+CodegenDecision IsTritonSupportedAllGather(
+    const HloAllGatherInstruction& all_gather,
+    const se::GpuComputeCapability& gpu_version) {
+  // Check if the flag is enabled
+  bool flag_enabled = all_gather.GetModule()
+                          ->config()
+                          .debug_options()
+                          .xla_gpu_unsupported_use_all_gather_triton_backend();
+
+  VLOG(1) << "IsTritonSupportedAllGather called for: " << all_gather.name()
+          << ", flag_enabled=" << flag_enabled;
+
+  if (!flag_enabled) {
+    VLOG(1) << "AllGather Triton backend is DISABLED for: "
+            << all_gather.name();
+    return CodegenDecision::Forbid(
+        "Triton backend for all-gather is disabled. Enable with "
+        "--xla_gpu_unsupported_use_all_gather_triton_backend=true");
+  }
+
+  VLOG(1) << "AllGather Triton backend is ENABLED for: " << all_gather.name();
+  PrimitiveType element_type = all_gather.operand(0)->shape().element_type();
+  if (element_type == F8E4M3FN || element_type == F8E5M2 ||
+      element_type == S4) {
+    VLOG(1) << "AllGather rejected due to unsupported data type: "
+            << all_gather.shape().element_type();
+    return CodegenDecision::Forbid(
+        "S4, F8E4M3FN and F8E5M2 are not supported for all-gathers.");
+  }
+
+  // TODO(allgather-triton): Add additional validation checks similar to
+  // AllReduce
+  // - Check replica groups
+  // - Check gather dimension constraints
+  // - Check size thresholds
+
+  VLOG(1) << "AllGather Triton backend ALLOWED for: " << all_gather.name()
+          << " (but fusion wrapping may not happen - check thunk_emitter.cc)";
+
+  // Allow codegen to proceed - the actual "not implemented" error will be
+  // generated in collective_emitter.cc::RewriteAllGather()
+  return CodegenDecision::Allow();
+}
+
 bool IsInTritonNestedGemmFusion(const HloInstruction& hlo) {
   if (!hlo.parent()->IsFusionComputation()) {
     return false;
@@ -741,6 +785,12 @@ CodegenDecision IsTritonSupportedInstructionImpl(
     case HloOpcode::kAllReduceDone:
       return IsTritonSupportedAllReduce(
           *Cast<HloAllReduceInstruction>(instr.operand(0)), gpu_version);
+    case HloOpcode::kAllGatherStart:
+      return IsTritonSupportedAllGather(*Cast<HloAllGatherInstruction>(&instr),
+                                        gpu_version);
+    case HloOpcode::kAllGatherDone:
+      return IsTritonSupportedAllGather(
+          *Cast<HloAllGatherInstruction>(instr.operand(0)), gpu_version);
     default:
       // Not all instructions have a special handling.
       break;

--- a/xla/backends/gpu/codegen/triton/transforms/stablehlo_lower_to_triton.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/stablehlo_lower_to_triton.cc
@@ -796,6 +796,18 @@ class LowerAllReduce : public mlir::OpRewritePattern<stablehlo::AllReduceOp> {
   }
 };
 
+class LowerAllGather : public mlir::OpRewritePattern<stablehlo::AllGatherOp> {
+ public:
+  using OpRewritePattern::OpRewritePattern;
+
+ private:
+  mlir::LogicalResult matchAndRewrite(
+      stablehlo::AllGatherOp op,
+      mlir::PatternRewriter& rewriter) const override {
+    return ::xla::gpu::RewriteAllGather(op, rewriter);
+  }
+};
+
 class StableHLOLowerToTritonPass
     : public impl::StableHLOLowerToTritonPassBase<StableHLOLowerToTritonPass> {
  public:
@@ -808,7 +820,8 @@ class StableHLOLowerToTritonPass
     {
       mlir::RewritePatternSet patterns(mlir_context);
       patterns.add<LowerTranspose, LowerIotaToMakeRange, LowerBroadcastInDim,
-                   LowerReduce, LowerReshape, LowerAllReduce>(mlir_context);
+                   LowerReduce, LowerReshape, LowerAllReduce, LowerAllGather>(
+          mlir_context);
       patterns.add<CanonicalizeDotGeneral>(mlir_context);
       patterns.add<LowerDotGeneral>(mlir_context, warp_specialization_allowed_);
       if (mlir::failed(mlir::applyPatternsGreedily(getOperation(),

--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -750,6 +750,57 @@ cc_library(
     ],
 )
 
+
+xla_cc_test(
+    name = "rccl_symmetric_memory_test",
+    srcs = ["rccl_symmetric_memory_test.cc"],
+    tags = [
+        "gpu",
+        "no-oneapi",
+        "rocm-only",
+        "requires-gpu-amd",
+    ],
+    deps = [
+        ":rccl_errors",
+        ":rccl_symmetric_memory",
+        "//xla/stream_executor:device_address",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
+cc_library(
+    name = "rccl_symmetric_memory",
+    srcs = ["rccl_symmetric_memory.cc"],
+    hdrs = ["rccl_symmetric_memory.h"],
+    tags = [
+        "gpu",
+        "no-oneapi",
+        "rocm-only",
+    ],
+    visibility = [
+        "//xla/backends/gpu/runtime:__subpackages__",
+    ],
+    deps = [
+        ":rccl_errors",
+        "//xla:util",
+        "//xla/core/collectives:rank_id",
+        "//xla/core/collectives:symmetric_memory",
+        "//xla/stream_executor:device_address",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@local_config_rocm//rocm:rccl",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
 cc_library(
     name = "rccl_communicator",
     srcs = ["rccl_communicator.cc"],
@@ -765,6 +816,7 @@ cc_library(
         ":gpu_collectives",
         ":gpu_communicator",
         ":rccl_errors",
+        ":rccl_symmetric_memory",
         ":single_threaded_executor",
         "//xla:future",
         "//xla:shape_util",

--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "xla/backends/gpu/collectives/rccl_communicator.h"
+#include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
 
 #include <atomic>
 #include <cstddef>
@@ -680,6 +681,11 @@ absl::Status RcclCommunicator::LaunchRecv(se::DeviceAddressBase recv_buffer,
     TF_RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<SymmetricMemory>>
+RcclCommunicator::CreateSymmetricMemory(se::DeviceAddressBase addr) {
+  return RcclSymmetricMemory::Create(comm_, addr);
 }
 
 std::string RcclCommunicator::ToString() const {

--- a/xla/backends/gpu/collectives/rccl_communicator.h
+++ b/xla/backends/gpu/collectives/rccl_communicator.h
@@ -119,6 +119,9 @@ class RcclCommunicator : public GpuCommunicator {
   Future<> Recv(se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
                 size_t count, RankId peer, const Executor& executor) final;
 
+  absl::StatusOr<std::unique_ptr<SymmetricMemory>> CreateSymmetricMemory(
+      se::DeviceAddressBase addr) final;
+
   std::string ToString() const final;
 
   ncclComm_t comm() const { return comm_; }

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory.cc
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory.cc
@@ -1,0 +1,70 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
+
+#include <memory>
+#include <string>
+
+#include "absl/log/log.h"
+#include "absl/memory/memory.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "xla/backends/gpu/collectives/rccl_errors.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/util.h"
+
+namespace xla::gpu {
+
+RcclSymmetricMemory::RcclSymmetricMemory(
+    ncclComm_t comm, ncclWindow_t win, stream_executor::DeviceAddressBase addr)
+    : comm_(comm), win_(win), addr_(addr) {}
+
+absl::StatusOr<std::unique_ptr<RcclSymmetricMemory>>
+RcclSymmetricMemory::Create(ncclComm_t comm,
+                            stream_executor::DeviceAddressBase addr) {
+  VLOG(3) << absl::StrFormat(
+      "Create RCCL symmetric memory on comm=%p from: ptr=%p; size=%ld", comm,
+      addr.opaque(), addr.size());
+
+  ncclWindow_t win;
+  XLA_RCCL_RETURN_IF_ERROR(ncclCommWindowRegister(
+      comm, addr.opaque(), addr.size(), &win, NCCL_WIN_COLL_SYMMETRIC));
+
+  return absl::WrapUnique(new RcclSymmetricMemory(comm, win, addr));
+}
+
+RcclSymmetricMemory::~RcclSymmetricMemory() {
+  VLOG(3) << absl::StrFormat("Destroy %v", *this);
+  XLA_RCCL_LOG_IF_ERROR(ncclCommWindowDeregister(comm_, win_));
+}
+
+stream_executor::DeviceAddressBase RcclSymmetricMemory::addr() const {
+  return addr_;
+}
+
+std::string RcclSymmetricMemory::ToString() const {
+  return absl::StrFormat(
+      "RcclSymmetricMemory(comm=%p, win=%p, ptr=%p, size=%ld)", comm_, win_,
+      addr_.opaque(), addr_.size());
+}
+
+RcclSymmetricMemory::PackedKernelArg RcclSymmetricMemory::PackKernelArg()
+    const {
+  return win_;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory.h
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory.h
@@ -1,0 +1,67 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_RCCL_SYMMETRIC_MEMORY_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_RCCL_SYMMETRIC_MEMORY_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "rocm/rocm_config.h"  // IWYU pragma: keep  (defines TF_ROCM_VERSION)
+#include "xla/core/collectives/symmetric_memory.h"
+#include "xla/stream_executor/device_address.h"
+
+#if (TF_ROCM_VERSION >= 50200)
+#include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif  // TF_ROCM_VERSION >= 50200
+
+namespace xla::gpu {
+
+// An RCCL window registration handle that makes local buffers accessible from
+// remote peers via symmetric memory registration. Analogous to
+// NcclSymmetricMemory for the ROCm/RCCL platform.
+class RcclSymmetricMemory final : public SymmetricMemory {
+ public:
+  ~RcclSymmetricMemory() final;
+
+  static absl::StatusOr<std::unique_ptr<RcclSymmetricMemory>> Create(
+      ncclComm_t comm, stream_executor::DeviceAddressBase addr);
+
+  stream_executor::DeviceAddressBase addr() const final;
+
+  // multimem_addr() and peer_addr() are not supported by RCCL; the base-class
+  // defaults (returning Unimplemented) are used.
+
+  ncclWindow_t win() const { return win_; }
+
+  std::string ToString() const final;
+
+  PackedKernelArg PackKernelArg() const final;
+
+ private:
+  RcclSymmetricMemory(ncclComm_t comm, ncclWindow_t win,
+                      stream_executor::DeviceAddressBase addr);
+
+  ncclComm_t comm_;
+  ncclWindow_t win_;
+  stream_executor::DeviceAddressBase addr_;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_RCCL_SYMMETRIC_MEMORY_H_

--- a/xla/backends/gpu/collectives/rccl_symmetric_memory_test.cc
+++ b/xla/backends/gpu/collectives/rccl_symmetric_memory_test.cc
@@ -1,0 +1,177 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/device_address.h"
+
+#if (TF_ROCM_VERSION >= 50200)
+#include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif  // TF_ROCM_VERSION >= 50200
+
+namespace xla::gpu {
+namespace {
+
+namespace se = stream_executor;
+
+using ::absl_testing::IsOk;
+using ::testing::HasSubstr;
+using ::testing::Not;
+
+// Test fixture that creates a single-rank RCCL communicator and allocates a
+// small GPU buffer. Tests are skipped if no ROCm device or RCCL is available.
+class RcclSymmetricMemoryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Skip if no ROCm/HIP GPU is present.
+    int device_count = 0;
+    if (hipGetDeviceCount(&device_count) != hipSuccess || device_count < 1) {
+      GTEST_SKIP() << "No ROCm/HIP GPU device available";
+    }
+    if (hipSetDevice(0) != hipSuccess) {
+      GTEST_SKIP() << "hipSetDevice(0) failed";
+    }
+
+    // Initialise a single-rank RCCL communicator on device 0.
+    int device_ids[] = {0};
+    ncclResult_t nccl_err = ncclCommInitAll(&comm_, 1, device_ids);
+    if (nccl_err != ncclSuccess) {
+      GTEST_SKIP() << "RCCL communicator initialisation failed: "
+                   << ncclGetErrorString(nccl_err);
+    }
+
+    // Allocate a 4 KiB symmetric memory buffer via RCCL. ncclMemAlloc ensures
+    // the buffer is mapped at the same virtual address on all ranks, which is
+    // required for ncclCommWindowRegister with NCCL_WIN_COLL_SYMMETRIC.
+    constexpr size_t kBufSize = 4096;
+    buf_size_ = kBufSize;
+    if (ncclMemAlloc(&buf_ptr_, buf_size_) != ncclSuccess) {
+      ncclCommDestroy(comm_);
+      comm_ = nullptr;
+      GTEST_SKIP() << "ncclMemAlloc(" << kBufSize << ") failed";
+    }
+  }
+
+  void TearDown() override {
+    if (buf_ptr_ != nullptr) {
+      (void)ncclMemFree(buf_ptr_);
+      buf_ptr_ = nullptr;
+    }
+    if (comm_ != nullptr) {
+      ncclCommDestroy(comm_);
+      comm_ = nullptr;
+    }
+  }
+
+  ncclComm_t comm_ = nullptr;
+  void* buf_ptr_ = nullptr;
+  size_t buf_size_ = 0;
+};
+
+// Verifies that RcclSymmetricMemory::Create succeeds for a valid buffer.
+TEST_F(RcclSymmetricMemoryTest, CreateSucceeds) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  ASSERT_NE(symm_mem, nullptr);
+}
+
+// Verifies that addr() returns exactly the pointer and size that were
+// registered.
+TEST_F(RcclSymmetricMemoryTest, AddrMatchesRegisteredBuffer) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  EXPECT_EQ(symm_mem->addr().opaque(), buf_ptr_);
+  EXPECT_EQ(symm_mem->addr().size(), buf_size_);
+}
+
+// Verifies that ToString() contains key diagnostic fields.
+TEST_F(RcclSymmetricMemoryTest, ToStringContainsExpectedFields) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  const std::string str = symm_mem->ToString();
+  EXPECT_THAT(str, HasSubstr("RcclSymmetricMemory"));
+  EXPECT_THAT(str, HasSubstr("comm="));
+  EXPECT_THAT(str, HasSubstr("win="));
+  EXPECT_THAT(str, HasSubstr("ptr="));
+}
+
+// Verifies that PackKernelArg() returns a non-null handle, and that the
+// win() accessor returns the same underlying ncclWindow_t.
+// NOTE: RCCL returns a null ncclWindow_t for single-rank communicators (no
+// remote peers to establish a window with). This test is skipped in that case.
+TEST_F(RcclSymmetricMemoryTest, PackKernelArgReturnsValidWindowHandle) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  if (symm_mem->win() == nullptr) {
+    GTEST_SKIP() << "RCCL returned a null ncclWindow_t (expected on single-rank "
+                    "communicators or RCCL versions without window support); "
+                    "skipping window-handle assertions.";
+  }
+  // PackKernelArg() returns a void* (PackedKernelArg) wrapping the window.
+  auto packed = symm_mem->PackKernelArg();
+  EXPECT_NE(packed, nullptr);
+  // win() returns the typed ncclWindow_t handle directly.
+  EXPECT_NE(symm_mem->win(), nullptr);
+}
+
+// Verifies that multimem_addr() returns Unimplemented — RCCL does not support
+// multimem, so the base-class default is expected.
+TEST_F(RcclSymmetricMemoryTest, MultimemAddrNotSupported) {
+  se::DeviceAddressBase addr(buf_ptr_, buf_size_);
+  ASSERT_OK_AND_ASSIGN(auto symm_mem, RcclSymmetricMemory::Create(comm_, addr));
+  auto result = symm_mem->multimem_addr();
+  EXPECT_THAT(result, Not(IsOk()));
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kUnimplemented);
+}
+
+// Verifies that two independent windows created from the same communicator
+// on different buffers have distinct ncclWindow_t handles.
+// NOTE: Skipped when RCCL returns null windows (e.g. single-rank communicator).
+TEST_F(RcclSymmetricMemoryTest, TwoWindowsHaveDistinctHandles) {
+  void* buf2_ptr = nullptr;
+  ASSERT_EQ(ncclMemAlloc(&buf2_ptr, buf_size_), ncclSuccess);
+
+  se::DeviceAddressBase addr1(buf_ptr_, buf_size_);
+  se::DeviceAddressBase addr2(buf2_ptr, buf_size_);
+
+  ASSERT_OK_AND_ASSIGN(auto symm1, RcclSymmetricMemory::Create(comm_, addr1));
+  ASSERT_OK_AND_ASSIGN(auto symm2, RcclSymmetricMemory::Create(comm_, addr2));
+
+  if (symm1->win() == nullptr || symm2->win() == nullptr) {
+    (void)ncclMemFree(buf2_ptr);
+    GTEST_SKIP() << "RCCL returned null ncclWindow_t handle(s) (expected on "
+                    "single-rank communicators); skipping distinctness check.";
+  }
+
+  EXPECT_NE(symm1->win(), symm2->win());
+  EXPECT_EQ(symm1->addr().opaque(), buf_ptr_);
+  EXPECT_EQ(symm2->addr().opaque(), buf2_ptr);
+
+  (void)ncclMemFree(buf2_ptr);
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -3724,6 +3724,49 @@ xla_test(
 )
 
 cc_library(
+    name = "all_gather",
+    srcs = ["all_gather.cc"],
+    hdrs = ["all_gather.h"],
+    deps = [
+        "//xla:shape_util",
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/service/gpu:launch_dimensions",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/gpu:all_reduce_kernel",
+        "//xla/tsl/platform:errors",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+xla_cc_test(
+    name = "all_gather_build_info_test",
+    srcs = ["all_gather_build_info_test.cc"],
+    deps = [
+        ":all_gather",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service/gpu:gpu_device_info_for_tests",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/host:host_platform",
+        "//xla/tsl/lib/gtl:int_type",
+        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:test",
+        "//xla/tsl/platform:test_main",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
     name = "all_reduce",
     srcs = ["all_reduce.cc"],
     hdrs = ["all_reduce.h"],

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1857,6 +1857,7 @@ cc_library(
     srcs = ["all_gather_thunk.cc"],
     hdrs = ["all_gather_thunk.h"],
     deps = [
+        ":collective_kernel_thunk",
         ":collective_thunk",
         ":thunk",
         ":thunk_proto_cc",
@@ -1905,6 +1906,7 @@ cc_library(
     srcs = ["collective_kernel_thunk.cc"],
     hdrs = ["collective_kernel_thunk.h"],
     deps = [
+        ":all_gather",
         ":all_reduce",
         ":collective_kernel_api",
         ":collective_params",

--- a/xla/backends/gpu/runtime/all_gather.cc
+++ b/xla/backends/gpu/runtime/all_gather.cc
@@ -1,0 +1,148 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/all_gather.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "llvm/ADT/bit.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/primitive_util.h"
+#include "xla/service/gpu/launch_dimensions.h"
+#include "xla/shape_util.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/gpu/all_reduce_kernel.h"
+#include "xla/tsl/platform/errors.h"
+#include "xla/util.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+
+absl::Status IsAllGatherKernelSupported(int64_t num_ranks, int64_t num_elements,
+                                        PrimitiveType element_type) {
+  // Unsigned integer types are not supported by the Triton all-gather kernel.
+  if (element_type == U32 || element_type == U16 || element_type == U64) {
+    return absl::UnimplementedError(
+        absl::StrCat("Element type (",
+                     primitive_util::LowercasePrimitiveTypeName(element_type),
+                     ") is not supported for all-gather kernel."));
+  }
+  // The number of elements must be aligned to kNumElementsPerThread.
+  if (num_elements % se::gpu::kNumElementsPerThread != 0) {
+    return absl::UnimplementedError(
+        absl::StrCat("Number of elements (", num_elements,
+                     ") is not aligned to the alignment requirement (",
+                     se::gpu::kNumElementsPerThread, ")."));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status IsAllGatherKernelSupported(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    int32_t num_operands, int64_t num_devices, int64_t num_elements,
+    PrimitiveType element_type, bool is_local,
+    const std::vector<ReplicaGroup>& replica_groups) {
+  if (!is_collective_kernel_enabled) {
+    return absl::UnimplementedError("Collective kernel is not enabled.");
+  }
+  // Check if the device supports Triton collective codegen:
+  // CUDA: Requires compute capability 9.0+ (Hopper or newer)
+  // ROCm: All versions with Triton support are enabled
+  if (!device_info.cuda_compute_capability().IsAtLeastHopper() &&
+      !device_info.gpu_compute_capability().IsRocm()) {
+    return absl::UnimplementedError(absl::StrCat(
+        "Triton collective codegen requires CUDA compute capability >= 9.0 "
+        "(Hopper or newer) or a ROCm device with Triton support. "
+        "Got: ",
+        device_info.gpu_compute_capability().ToString(), "."));
+  }
+  // TODO(b/383125489): Support variadic arguments.
+  if (num_operands != 1) {
+    return absl::UnimplementedError(
+        absl::StrCat("Collective kernel is not supported for number of "
+                     "operands not equal to 1. Got ",
+                     num_operands, "."));
+  }
+  if (replica_groups.empty()) {
+    return absl::UnimplementedError(
+        "Replica groups must be explicitly provided for collective kernels.");
+  }
+  if (!is_local) {
+    return absl::UnimplementedError(
+        "Cross-host symmetric memory collectives are not supported.");
+  }
+  if (!llvm::has_single_bit(static_cast<uint64_t>(num_devices))) {
+    return absl::UnimplementedError(
+        absl::StrCat("Collective kernels are only supported for power of 2 "
+                     "number of devices. Got ",
+                     num_devices, "."));
+  }
+  return IsAllGatherKernelSupported(num_devices, num_elements, element_type);
+}
+
+absl::StatusOr<AllGatherInfo> BuildAllGatherInfo(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    const HloAllGatherInstruction* all_gather) {
+  if (!all_gather->device_list()) {
+    return absl::UnimplementedError(
+        "Replica groups must be explicitly provided for collective kernels.");
+  }
+  const int64_t num_devices =
+      all_gather->device_list()->num_devices_per_group();
+  const int64_t num_elements =
+      ShapeUtil::ElementsIn(all_gather->operand(0)->shape());
+  const PrimitiveType element_type =
+      all_gather->operand(0)->shape().element_type();
+  const int32_t num_operands = all_gather->operand_count();
+  TF_RETURN_IF_ERROR(IsAllGatherKernelSupported(
+      is_collective_kernel_enabled, device_info, num_operands, num_devices,
+      num_elements, element_type, /*is_local=*/true,
+      all_gather->replica_groups()));
+  return AllGatherInfo{
+      /*.num_devices =*/num_devices,
+      /*.num_elements =*/num_elements,
+      /*.element_type =*/element_type,
+  };
+}
+
+namespace {
+// All-gather always uses a one-shot strategy: every rank reads its peers'
+// slices directly, so the work is proportional to the full element count
+// with no rank-based partitioning.
+static constexpr int64_t kMaxBlocksPerGrid = 32;
+static constexpr uint64_t kMaxThreadsPerBlock = 512;
+static constexpr int64_t kWarpSize = 32;
+}  // namespace
+
+LaunchDimensions AllGatherLaunchDimensions(int64_t elements,
+                                           int64_t num_ranks) {
+  // Maximum number of threads such that each thread has elements to process.
+  const int64_t total_threads = RoundUpTo(
+      CeilOfRatio(elements, se::gpu::kNumElementsPerThread), kWarpSize);
+  // Triton expects power of 2 for threads_per_block / threads_per_warp.
+  const int64_t threads_per_block =
+      std::min(kMaxThreadsPerBlock,
+               llvm::bit_ceil(static_cast<uint64_t>(total_threads)));
+  const int64_t blocks_per_grid = std::min(
+      kMaxBlocksPerGrid, CeilOfRatio(total_threads, threads_per_block));
+  return LaunchDimensions(blocks_per_grid, threads_per_block);
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/all_gather.h
+++ b/xla/backends/gpu/runtime/all_gather.h
@@ -1,0 +1,66 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_
+#define XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/service/gpu/launch_dimensions.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+
+// Encapsulates the information needed to perform an all-gather.
+struct AllGatherInfo {
+  int64_t num_devices;
+  int64_t num_elements;
+  PrimitiveType element_type;
+};
+
+// Returns absl::OkStatus() if the all-gather kernel is supported for the given
+// element type and number of elements, or an error status detailing why it is
+// not supported.
+absl::Status IsAllGatherKernelSupported(int64_t num_ranks, int64_t num_elements,
+                                        PrimitiveType element_type);
+
+// A broader check for all-gather kernel support.
+// Returns absl::OkStatus() if supported, or an error status detailing why
+// it is not supported.
+absl::Status IsAllGatherKernelSupported(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    int32_t num_operands, int64_t num_devices, int64_t num_elements,
+    PrimitiveType element_type, bool is_local,
+    const std::vector<ReplicaGroup>& replica_groups);
+
+// Constructs an AllGatherInfo object for the given all-gather instruction.
+// Returns an error status if the all-gather kernel is not supported.
+absl::StatusOr<AllGatherInfo> BuildAllGatherInfo(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    const HloAllGatherInstruction* all_gather);
+
+// Returns the launch dimensions for the all-gather kernel.
+// All-gather uses a fixed one-shot tiling strategy: each rank contributes its
+// local slice to the output.
+LaunchDimensions AllGatherLaunchDimensions(int64_t elements, int64_t num_ranks);
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_

--- a/xla/backends/gpu/runtime/all_gather_build_info_test.cc
+++ b/xla/backends/gpu/runtime/all_gather_build_info_test.cc
@@ -1,0 +1,177 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/gpu/runtime/all_gather.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/primitive_util.h"
+#include "xla/service/gpu/gpu_device_info_for_tests.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/tsl/lib/gtl/int_type.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/test.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+namespace {
+
+using ::absl_testing::IsOkAndHolds;
+using ::absl_testing::StatusIs;
+using ::testing::AllOf;
+using ::testing::Field;
+using ::testing::HasSubstr;
+
+TSL_LIB_GTL_DEFINE_INT_TYPE(CollectiveKernelEnabled, bool);
+
+class BuildAllGatherInfoTest : public HloHardwareIndependentTestBase {
+ protected:
+  // Builds an all-gather HLO module and invokes BuildAllGatherInfo.
+  //
+  // `num_elements` is the number of elements in the input operand (per
+  // replica). The all-gather is 1-D along dimension 0.
+  //
+  // `replica_groups` is a flat list of device IDs forming a single replica
+  // group. An empty list means replica_groups={} (empty) in the HLO, which
+  // will trigger the "replica groups must be provided" error path.
+  absl::StatusOr<AllGatherInfo> BuildInfo(
+      CollectiveKernelEnabled collective_kernel_enabled,
+      PrimitiveType element_type, int64_t num_elements,
+      std::vector<int32_t> replica_groups) {
+    const int num_replicas =
+        replica_groups.empty() ? 1 : static_cast<int>(replica_groups.size());
+    const std::string element_type_str =
+        primitive_util::LowercasePrimitiveTypeName(element_type);
+    const std::string input_shape_str = absl::StrFormat("%d", num_elements);
+    const std::string output_shape_str =
+        absl::StrFormat("%d", num_elements * num_replicas);
+    const std::string replica_groups_str =
+        replica_groups.empty()
+            ? ""
+            : absl::StrFormat("{%s}", absl::StrJoin(replica_groups, ","));
+
+    // The all-gather gathers along dimension 0: output_dim0 = num_replicas *
+    // input_dim0.
+    constexpr absl::string_view kModuleStr = R"(
+    HloModule test
+    ENTRY test_computation {
+      param_0 = %1$s[%2$s] parameter(0)
+      ROOT all-gather = %1$s[%3$s] all-gather(param_0),
+          dimensions={0}, replica_groups={%4$s}
+    }
+    )";
+    const std::string module_str =
+        absl::StrFormat(kModuleStr, element_type_str, input_shape_str,
+                        output_shape_str, replica_groups_str);
+
+    SCOPED_TRACE(testing::Message() << "module_str: " << module_str);
+
+    se::DeviceDescription device_info =
+        TestGpuDeviceInfo::H100SXMDeviceInfo();
+
+    TF_ASSIGN_OR_RETURN(
+        std::unique_ptr<HloModule> module,
+        ParseAndReturnVerifiedModule(module_str, num_replicas));
+
+    const HloInstruction* hlo_instr =
+        HloHardwareIndependentTestBase::FindInstruction(
+            module.get(), HloOpcode::kAllGather);
+    return BuildAllGatherInfo(collective_kernel_enabled.value(), device_info,
+                              Cast<HloAllGatherInstruction>(hlo_instr));
+  }
+};
+
+TEST_F(BuildAllGatherInfoTest, SucceedsForSupportedF32) {
+  EXPECT_THAT(BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                        /*replica_groups=*/{0, 1}),
+              IsOkAndHolds(AllOf(
+                  Field(&AllGatherInfo::num_devices, 2),
+                  Field(&AllGatherInfo::num_elements, 512),
+                  Field(&AllGatherInfo::element_type, F32))));
+}
+
+TEST_F(BuildAllGatherInfoTest, SucceedsForSupportedBF16) {
+  EXPECT_THAT(BuildInfo(CollectiveKernelEnabled(true), BF16,
+                        /*num_elements=*/512, /*replica_groups=*/{0, 1}),
+              IsOkAndHolds(AllOf(
+                  Field(&AllGatherInfo::num_devices, 2),
+                  Field(&AllGatherInfo::num_elements, 512),
+                  Field(&AllGatherInfo::element_type, BF16))));
+}
+
+TEST_F(BuildAllGatherInfoTest, SucceedsForFourDevices) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1, 2, 3}),
+      IsOkAndHolds(AllOf(Field(&AllGatherInfo::num_devices, 4),
+                         Field(&AllGatherInfo::num_elements, 512),
+                         Field(&AllGatherInfo::element_type, F32))));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsIfCollectiveKernelDisabled) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(false), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1}),
+      StatusIs(absl::StatusCode::kUnimplemented, HasSubstr("not enabled")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForNonPowerOfTwoDevices) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1, 2}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("only supported for power of 2")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForUnsupportedUnsignedType) {
+  // U32 is not supported by the Triton all-gather kernel.
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), U32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("is not supported for all-gather kernel")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForUnalignedElements) {
+  // 7 is not divisible by kNumElementsPerThread (which is >= 2).
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/7,
+                /*replica_groups=*/{0, 1}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("not aligned to the alignment requirement")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsIfReplicaGroupsEmpty) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("Replica groups must be explicitly provided")));
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/all_gather_thunk.cc
+++ b/xla/backends/gpu/runtime/all_gather_thunk.cc
@@ -40,6 +40,7 @@ limitations under the License.
 #include "xla/shape_util.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "tsl/platform/casts.h"
 
@@ -78,6 +79,19 @@ AllGatherThunk::AllGatherThunk(ThunkInfo thunk_info,
     : CollectiveThunk(Thunk::kAllGather, thunk_info, std::move(buffers)),
       config_(GetAllGatherConfig(inst)) {
   CHECK_EQ(config_.config.operand_element_type.size(), this->buffers().size());
+}
+
+AllGatherThunk::AllGatherThunk(
+    ThunkInfo thunk_info, const HloAllGatherInstruction* inst,
+    std::vector<Buffer> buffers,
+    std::unique_ptr<CollectiveKernelThunk> collective_kernel_thunk,
+    bool p2p_memcpy_enabled)
+    : CollectiveThunk(Thunk::kAllGather, thunk_info, std::move(buffers)),
+      config_(GetAllGatherConfig(inst)),
+      collective_kernel_thunk_(std::move(collective_kernel_thunk)) {
+  CHECK_EQ(config_.config.operand_element_type.size(), this->buffers().size());
+  VLOG(3) << "AllGatherStartThunk created with CollectiveKernelThunk for: "
+          << inst->name();
 }
 
 AllGatherThunk::AllGatherThunk(ThunkInfo thunk_info, CollectiveConfig config,
@@ -128,13 +142,55 @@ absl::StatusOr<ThunkProto> AllGatherThunk::ToProto() const {
   return proto;
 }
 
+absl::Status AllGatherThunk::Prepare(const PrepareParams& params) {
+  TF_RETURN_IF_ERROR(CollectiveThunk::Prepare(params));
+  if (collective_kernel_thunk_) {
+    return collective_kernel_thunk_->Prepare(params);
+  }
+  return absl::OkStatus();
+}
+
+absl::Status AllGatherThunk::Initialize(const InitializeParams& params) {
+  TF_RETURN_IF_ERROR(CollectiveThunk::Initialize(params));
+  if (collective_kernel_thunk_) {
+    TF_ASSIGN_OR_RETURN(GpuCliqueKey clique_key,
+                        GetCollectiveGpuCliqueKey(*params.collective_params,
+                                                  config()));
+    TF_ASSIGN_OR_RETURN(
+        bool use_collective_kernel,
+        collective_kernel_thunk_->IsSupported(clique_key, *params.executor,
+                                              *params.collective_params));
+    if (use_collective_kernel) {
+      TF_RETURN_IF_ERROR(collective_kernel_thunk_->Initialize(params));
+    }
+  }
+  return absl::OkStatus();
+}
+
 absl::Status AllGatherThunk::RunCollective(const ExecuteParams& params,
-                                           const GpuCliqueKey& clique_key,
-                                           se::Stream& stream,
-                                           Communicator& comm) {
+                                                const GpuCliqueKey& clique_key,
+                                                se::Stream& stream,
+                                                Communicator& comm) {
   ASSIGN_OR_RETURN(std::vector<DeviceBufferPair> device_buffers,
                    ConvertToDeviceBuffers(params.buffer_allocations, buffers(),
                                           config_.config.operand_element_type));
+
+  // Try to use Triton collective kernel if available
+  if (collective_kernel_thunk_) {
+    TF_ASSIGN_OR_RETURN(
+        bool use_collective_kernel,
+        collective_kernel_thunk_->IsSupported(
+            clique_key, *params.stream->parent(), *params.collective_params));
+
+    if (use_collective_kernel) {
+      return collective_kernel_thunk_->ExecuteOnStream(params);
+    }
+    LOG(WARNING) << "AllGatherThunk: Triton backend was requested but the "
+                    "Triton kernel is not supported for this configuration "
+                    "at runtime. Falling back to NCCL/RCCL.";
+  }
+
+  // Fallback to NCCL/RCCL
   return xla::gpu::RunAllGather(device_buffers, stream, comm,
                                 config_.config.use_symmetric_buffer);
 }

--- a/xla/backends/gpu/runtime/all_gather_thunk.h
+++ b/xla/backends/gpu/runtime/all_gather_thunk.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
+#include "xla/backends/gpu/runtime/collective_kernel_thunk.h"
 #include "xla/backends/gpu/runtime/collective_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/core/collectives/communicator.h"
@@ -46,6 +47,11 @@ class AllGatherThunk : public CollectiveThunk {
                  std::vector<Buffer> buffers, bool p2p_memcpy_enabled = false);
   AllGatherThunk(ThunkInfo thunk_info, CollectiveConfig config,
                  std::vector<Buffer> buffers);
+  AllGatherThunk(
+      ThunkInfo thunk_info, const HloAllGatherInstruction* inst,
+      std::vector<Buffer> buffers,
+      std::unique_ptr<CollectiveKernelThunk> collective_kernel_thunk,
+      bool p2p_memcpy_enabled = false);
 
   static const char* GetHloOpName() { return "all-gather-start"; }
 
@@ -67,6 +73,8 @@ class AllGatherThunk : public CollectiveThunk {
  protected:
   bool RequiresRendezvous() const override { return true; }
 
+  absl::Status Prepare(const PrepareParams& params) override;
+  absl::Status Initialize(const InitializeParams& params) override;
   absl::Status RunCollective(const ExecuteParams& params,
                              const GpuCliqueKey& clique_key, se::Stream& stream,
                              Communicator& comm) override;
@@ -75,6 +83,7 @@ class AllGatherThunk : public CollectiveThunk {
 
  private:
   const AllGatherConfig config_;
+  std::unique_ptr<CollectiveKernelThunk> collective_kernel_thunk_;
 };
 
 absl::Status RunAllGather(std::vector<DeviceBufferPair>& buffers,

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.cc
@@ -36,6 +36,7 @@ limitations under the License.*/
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
+#include "xla/backends/gpu/runtime/all_gather.h"
 #include "xla/backends/gpu/runtime/all_reduce.h"
 #include "xla/backends/gpu/runtime/collective_kernel_api.h"
 #include "xla/backends/gpu/runtime/collective_params.h"
@@ -153,25 +154,54 @@ absl::Status CopyCollectiveMetadataToDevice(
 absl::StatusOr<bool> CollectiveKernelThunk::IsSupported(
     const GpuCliqueKey& clique_key, se::StreamExecutor& executor,
     const CollectiveParams& collective_params) const {
-  absl::Status status = IsAllReduceKernelSupported(
-      collective_kernel_enabled_, executor.GetDeviceDescription(),
-      /*num_operands= */ buffers_.size(), reduction_kind_,
-      clique_key.num_local_participants(), buffers_[0].element_count,
-      collective_config_.operand_element_type[0], clique_key.is_local(),
-      is_multimem_enabled_, collective_config_.replica_groups);
-  if (absl::IsUnimplemented(status)) {
-    VLOG(3) << "Collective kernel not supported: " << status.message();
-    return false;
+  const bool is_all_gather =
+      (collective_op_kind_ == CollectiveOpKind::kAllGather);
+
+  if (!is_all_gather) {
+    absl::Status status = IsAllReduceKernelSupported(
+        collective_kernel_enabled_, executor.GetDeviceDescription(),
+        /*num_operands= */ buffers_.size(), reduction_kind_,
+        clique_key.num_local_participants(), buffers_[0].element_count,
+        collective_config_.operand_element_type[0], clique_key.is_local(),
+        is_multimem_enabled_, collective_config_.replica_groups);
+    if (absl::IsUnimplemented(status)) {
+      VLOG(3) << "Collective kernel not supported: " << status.message();
+      return false;
+    }
+    TF_RETURN_IF_ERROR(status);
+  } else {
+    absl::Status status = IsAllGatherKernelSupported(
+        collective_kernel_enabled_, executor.GetDeviceDescription(),
+        /*num_operands=*/buffers_.size(), clique_key.num_local_participants(),
+        buffers_[0].element_count, collective_config_.operand_element_type[0],
+        clique_key.is_local(), collective_config_.replica_groups);
+    if (absl::IsUnimplemented(status)) {
+      VLOG(3) << "Collective kernel not supported: " << status.message();
+      return false;
+    }
+    TF_RETURN_IF_ERROR(status);
   }
-  TF_RETURN_IF_ERROR(status);
+
   for (const GlobalDeviceId& device : clique_key.devices()) {
     TF_ASSIGN_OR_RETURN(const int peer_device_id,
                         GetLocalDeviceId(device, collective_params));
     if (!executor.CanEnablePeerAccessTo(peer_device_id)) {
       XLA_VLOG_DEVICE(3, executor.device_ordinal())
           << "Peer access is not supported with device " << peer_device_id;
+      VLOG(3) << "CollectiveKernelThunk::IsSupported: peer access not "
+                 "supported to device "
+              << peer_device_id;
       return false;
     }
+  }
+  // All-reduce has a built-in custom kernel (RunAllReduceKernel) that
+  // ExecuteOnStream can fall back to when no Triton kernel was emitted
+  // (i.e., kernel_name_ is empty and state->kernel == nullptr). All-gather
+  // has no such built-in fallback: reaching the kernel_name_-empty path in
+  // ExecuteOnStream would hit CHECK(kAllReduce) and crash. We therefore only
+  // return true for all-gather when a Triton kernel was actually emitted.
+  if (is_all_gather) {
+    return !kernel_name_.empty();
   }
   return true;
 }
@@ -208,18 +238,31 @@ absl::Status CollectiveKernelThunk::Prepare(const PrepareParams& params) {
   absl::MutexLock lock(mutex_);
   if (!per_stream_memory_.contains(params.executor)) {
     // Allocate scratch buffers.
+    const bool is_all_gather =
+        (collective_op_kind_ == CollectiveOpKind::kAllGather);
     const AllReduceStrategy strategy =
         GetAllReduceStrategy(GetInputSizeBytes(), is_multimem_enabled_);
-    const LaunchDimensions launch_dimensions =
-        launch_dimensions_.value_or(AllReduceLaunchDimensions(
-            buffers_[0].element_count, clique_key.num_local_participants(),
-            strategy));
+    const LaunchDimensions launch_dimensions = launch_dimensions_.value_or(
+        is_all_gather
+            ? AllGatherLaunchDimensions(buffers_[0].element_count,
+                                        clique_key.num_local_participants())
+            : AllReduceLaunchDimensions(buffers_[0].element_count,
+                                        clique_key.num_local_participants(),
+                                        strategy));
     const int64_t kNumSignalFlags =
         clique_key.num_local_participants() * launch_dimensions.num_blocks();
     const int64_t kSignalBufferSize = xla::RoundUpTo<uint64_t>(
         kNumSignalFlags * sizeof(int32_t), kXlaAllocatedBufferAlignBytes);
+
+    // For AllGather, we need to allocate buffers based on the destination size
+    // (which is num_replicas * source_size), not the source size.
+    // For AllReduce, source and destination sizes are the same.
+    const int64_t buffer_size_to_allocate =
+        is_all_gather ? buffers_[0].destination_buffer.slice.size()
+                      : buffers_[0].source_buffer.slice.size();
+
     const int64_t kLocalBufferSize = xla::RoundUpTo<uint64_t>(
-        buffers_[0].source_buffer.slice.size(), kXlaAllocatedBufferAlignBytes);
+        buffer_size_to_allocate, kXlaAllocatedBufferAlignBytes);
     TF_ASSIGN_OR_RETURN(
         se::DeviceAddressHandle local_buffers_handle,
         AllocateMemory(params.executor, kLocalBufferSize * kNumBuffers,
@@ -395,12 +438,15 @@ absl::Status CollectiveKernelThunk::Initialize(const InitializeParams& params) {
           tsl::safe_reinterpret_cast<char*>(dst_mmem) + dst_mmem_offset;
 
       XLA_VLOG_DEVICE(3, params.executor->device_ordinal())
-          << "Constructed device state {"
-          << " metadata rank: " << metadata.rank << ", param_to_peers: ("
+          << "Constructed device state {" << " metadata rank: " << metadata.rank
+          << ", param_to_peers: ("
           << absl::StrJoin(param_to_peers_ptrs, ", ", PtrFormatter{})
           << "), multimem_addresses: ("
           << absl::StrJoin(multimem_addresses, ", ", PtrFormatter{}) << ")}";
     } else {
+      // For both AllReduce and AllGather, we exchange 2 buffers via P2P:
+      // - Parameter 0: Data symmetric buffer (local_buffers)
+      // - Parameter 1: Signal/synchronization buffer (signal_buffers)
       std::vector<se::DeviceAddressBase> parameters{
           memory_state->local_buffers_handle.address(),
           memory_state->signal_buffers_handle.address()};
@@ -513,19 +559,23 @@ absl::Status CollectiveKernelThunk::ExecuteOnStream(
                                  launch_dimensions_.value(),
                                  /*cluster_dim=*/std::nullopt, stream);
   }
+  // TODO(b/407736956): Change this to emitted kernel.
+  CHECK(collective_op_kind_ == CollectiveOpKind::kAllReduce)
+      << "RunAllReduceKernel should only be called for AllReduce operations, "
+      << "not for AllGather. AllGather requires an emitted Triton kernel.";
+  TF_RET_CHECK(reduction_kind_.has_value())
+      << "reduction_kind_ must be set for AllReduce operations";
   const LaunchDimensions launch_dimensions =
       AllReduceLaunchDimensions(buffer.element_count, num_devices, strategy);
   XLA_VLOG_DEVICE(3, device_ordinal)
       << "CUDA kernel launch dimensions: " << launch_dimensions.num_blocks()
       << "x" << launch_dimensions.num_threads_per_block()
       << "(block x threadsPerBlock)";
-
-  // TODO(b/407736956): Change this to emitted kernel.
   return RunAllReduceKernel(
       /*stream=*/stream,
       /*launch_dimensions=*/launch_dimensions,
       /*element_type=*/element_type,
-      /*reduction_kind=*/reduction_kind_,
+      /*reduction_kind=*/*reduction_kind_,
       /*all_reduce_strategy=*/strategy,
       /*symmetric_input_buffer=*/input_buffer_ptr,
       /*local_input_buffer=*/source_buffer,

--- a/xla/backends/gpu/runtime/collective_kernel_thunk.h
+++ b/xla/backends/gpu/runtime/collective_kernel_thunk.h
@@ -58,12 +58,17 @@ namespace xla::gpu {
 // must be set.
 class CollectiveKernelThunk : public Thunk {
  public:
+  enum class CollectiveOpKind {
+    kAllReduce,
+    kAllGather,
+  };
+
   static constexpr auto kMaxNumExecutors =
       ::stream_executor::gpu::kMaxNumAllReduceInputPtrs;
 
   CollectiveKernelThunk(
       ThunkInfo info, CollectiveConfig collective_config,                //
-      ReductionKind reduction_kind,                                      //
+      std::optional<ReductionKind> reduction_kind,                       //
       bool is_async,                                                     //
       std::vector<CollectiveThunk::Buffer> buffers,                      //
       bool is_collective_kernel_enabled,                                 //
@@ -72,7 +77,8 @@ class CollectiveKernelThunk : public Thunk {
       int32_t shmem_bytes = 0,                                           //
       bool is_multimem_enabled = false,
       std::optional<std::vector<uint8_t>> cubin = std::nullopt,
-      bool use_pdl = false)
+      bool use_pdl = false,
+      CollectiveOpKind collective_op_kind = CollectiveOpKind::kAllReduce)
       : Thunk{Thunk::kCollectiveKernel, info},
         collective_kernel_enabled_(is_collective_kernel_enabled),
         is_async_(is_async),
@@ -84,7 +90,8 @@ class CollectiveKernelThunk : public Thunk {
         shmem_bytes_(shmem_bytes),
         buffers_(std::move(buffers)),
         is_multimem_enabled_(is_multimem_enabled),
-        use_pdl_(use_pdl) {
+        use_pdl_(use_pdl),
+        collective_op_kind_(collective_op_kind) {
     per_stream_state_.reserve(kMaxNumExecutors);
   }
 
@@ -188,7 +195,8 @@ class CollectiveKernelThunk : public Thunk {
   // Collective config being used. Copied over to avoid lifetime issues.
   const CollectiveConfig collective_config_;
   // Reduction kind being to use for AllReduce collective.
-  const ReductionKind reduction_kind_;
+  // Optional because AllGather does not use reduction.
+  const std::optional<ReductionKind> reduction_kind_;
   // Launch dimensions for the kernel. Only relevant when the codegen kernel
   // is used.
   std::optional<LaunchDimensions> launch_dimensions_;
@@ -214,6 +222,8 @@ class CollectiveKernelThunk : public Thunk {
 
   // Programmatic Dependent Launch.
   const bool use_pdl_;
+
+  const CollectiveOpKind collective_op_kind_;
 };
 }  // namespace xla::gpu
 

--- a/xla/backends/gpu/tests/collective_ops_e2e_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_e2e_test.cc
@@ -359,6 +359,53 @@ TEST_P(AsyncCollectiveOps, AsyncAllGather) {
   }
 }
 
+TEST_P(AsyncCollectiveOps, AsyncAllGatherTritonBackend) {
+  const absl::string_view kModuleStr = R"(
+  HloModule test
+  ENTRY test_computation {
+    id = u32[] replica-id()
+    id_f32 = f32[] convert(id)
+    id2 = f32[1, 4] broadcast(id_f32), dimensions={}
+    a0 = f32[1, 4] constant({{10, 15, 20, 25}})
+    a1 = f32[1, 4] add(id2, a0)
+    allgather = f32[2, 4] all-gather(a1), replica_groups={{0,1}}, dimensions={0}
+    ROOT out = f32[8] reshape(allgather)
+  }
+  )";
+  const int64_t kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "Test requires at least " << kNumReplicas << " devices ("
+      << device_count() << " available)";
+
+  const bool enable_async_all_gather = GetParam();
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  config.mutable_debug_options()
+      .set_xla_gpu_unsupported_use_all_gather_triton_backend(true);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, config));
+
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
+                          ExecuteReplicated(std::move(module)));
+
+  const HloModule* hlo_module = execution_result.optimized_module;
+  HloInstruction* all_gather_start =
+      FindInstruction(hlo_module, HloOpcode::kAllGatherStart);
+  HloInstruction* all_gather_done =
+      FindInstruction(hlo_module, HloOpcode::kAllGatherDone);
+  EXPECT_THAT(all_gather_start, NotNull());
+  EXPECT_THAT(all_gather_done, NotNull());
+  EXPECT_EQ(IsAsync(all_gather_start), enable_async_all_gather);
+
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (const Literal& result : results) {
+    LiteralTestUtil::ExpectR1Equal<float>({10.0, 15.0, 20.0, 25.0, 11.0, 16.0, 21.0, 26.0}, result);
+  }
+}
+
 TEST_P(AsyncCollectiveOps, AsyncAllGatherMixedTypes) {
   const absl::string_view kModuleStr = R"(
   HloModule test
@@ -2934,6 +2981,48 @@ TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim0OutputIsCorrect) {
   }
 }
 
+TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim0OutputIsCorrectTritonBackend) {
+  constexpr int kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "Test requires at least " << kNumReplicas << " devices ("
+      << device_count() << " available)";
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  config.mutable_debug_options()
+      .set_xla_gpu_unsupported_use_all_gather_triton_backend(true);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto unoptimized_module,
+                          ParseAndReturnVerifiedModule(R"(
+    HloModule m, replica_count=2
+
+    e {
+      a = s4[2,4]{1,0:E(4)} constant({{0,1,2,3},{4,5,5,4}})
+      b = s4[4,4]{1,0:E(4)} all-gather(a), replica_groups={{0,1}}, dimensions={0}
+    })",
+                                                       config));
+
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
+                          ExecuteReplicated(std::move(unoptimized_module)));
+
+  const HloModule* module = execution_result.optimized_module;
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              GmockMatch(m::Bitcast(m::AllGatherDone().WithShape(S8, {4, 2}))));
+
+  const Literal expected_result =
+      LiteralUtil::CreateR2<s4>({{s4(0), s4(1), s4(2), s4(3)},
+                                 {s4(4), s4(5), s4(5), s4(4)},
+                                 {s4(0), s4(1), s4(2), s4(3)},
+                                 {s4(4), s4(5), s4(5), s4(4)}});
+
+  const std::vector<Literal>& result = execution_result.results;
+  ASSERT_EQ(result.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    EXPECT_TRUE(LiteralTestUtil::Equal(expected_result, result[i]))
+        << "Results differ at replica " << i;
+  }
+}
+
 TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim1OutputIsCorrect) {
   constexpr int kNumReplicas = 2;
   ASSERT_GE(device_count(), kNumReplicas)
@@ -2949,6 +3038,51 @@ TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim1OutputIsCorrect) {
       b = s4[4,4]{1,0:E(4)} all-gather(a), dimensions={1}
     })",
                                                        kNumReplicas));
+
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
+                          ExecuteReplicated(std::move(unoptimized_module)));
+
+  const HloModule* module = execution_result.optimized_module;
+  const HloInstruction* root = module->entry_computation()->root_instruction();
+  EXPECT_THAT(root, GmockMatch(m::Fusion(
+                        m::Bitcast(m::AllGatherDone().WithShape(S8, {2, 4})))));
+  EXPECT_THAT(root->fused_expression_root(),
+              GmockMatch(m::Transpose(m::Parameter())));
+
+  const Literal expected_result =
+      LiteralUtil::CreateR2<s4>({{s4(0), s4(1), s4(0), s4(1)},
+                                 {s4(2), s4(3), s4(2), s4(3)},
+                                 {s4(4), s4(5), s4(4), s4(5)},
+                                 {s4(5), s4(4), s4(5), s4(4)}});
+
+  const std::vector<Literal>& result = execution_result.results;
+  ASSERT_EQ(result.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    EXPECT_TRUE(LiteralTestUtil::Equal(expected_result, result[i]))
+        << "Results differ at replica " << i;
+  }
+}
+
+TEST_F(CollectiveOpsTestE2E, OptimizedSubByteAllGatherOnDim1OutputIsCorrectTritonBackend) {
+  constexpr int kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "Test requires at least " << kNumReplicas << " devices ("
+      << device_count() << " available)";
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  config.mutable_debug_options()
+      .set_xla_gpu_unsupported_use_all_gather_triton_backend(true);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto unoptimized_module,
+                          ParseAndReturnVerifiedModule(R"(
+    HloModule m, replica_count=2
+
+    e {
+      a = s4[4,2]{1,0:E(4)} constant({{0,1},{2,3},{4,5},{5,4}})
+      b = s4[4,4]{1,0:E(4)} all-gather(a), replica_groups={{0,1}}, dimensions={1}
+    })",
+                                                       config));
 
   TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
                           ExecuteReplicated(std::move(unoptimized_module)));
@@ -3003,6 +3137,47 @@ TEST_F(CollectiveOpsTestE2E, AllGatherOnChangedDimensionIsCorrect) {
                           ExecuteReplicated(executable.get(), {{}, {}}));
   ASSERT_EQ(results.size(), kNumReplicas);
   Literal expected = LiteralUtil::CreateR3<uint32_t>(
+      {{{0, 1, 2}, {3, 4, 5}, {0, 1, 2}, {3, 4, 5}},
+       {{6, 7, 8}, {9, 10, 11}, {6, 7, 8}, {9, 10, 11}}});
+  for (const Literal& result : results) {
+    EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
+  }
+}
+
+TEST_F(CollectiveOpsTestE2E, AllGatherOnChangedDimensionIsCorrectTritonBackend) {
+  const int64_t kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "The test requires at least " << kNumReplicas << " devices";
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  config.mutable_debug_options()
+      .set_xla_gpu_unsupported_use_all_gather_triton_backend(true);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto unoptimized_module,
+                          ParseAndReturnVerifiedModule(R"(
+  HloModule m, replica_count=2
+  e {
+    a = f32[2,2,3] constant({{{0,1,2},{3,4,5}},{{6,7,8},{9,10,11}}})
+    g = f32[2,4,3] all-gather(a), replica_groups={{0,1}}, dimensions={1}
+  })",
+                                                       config));
+  TF_ASSERT_OK_AND_ASSIGN(auto executable,
+                          CreateExecutable(std::move(unoptimized_module),
+                                           /*run_hlo_passes=*/true));
+  TF_ASSERT_OK_AND_ASSIGN(const HloModule* module,
+                          test_runner().HloModuleFromWrapped(executable.get()));
+  const HloInstruction* root = module->entry_computation()->root_instruction();
+
+  EXPECT_THAT(root, GmockMatch(m::Fusion(m::AllGatherDone(
+                        m::AllGatherStart(m::Bitcast(m::Constant()))))));
+  EXPECT_THAT(root->fused_expression_root(),
+              GmockMatch(m::Transpose(m::Bitcast(m::Parameter()))));
+
+  TF_ASSERT_OK_AND_ASSIGN(std::vector<Literal> results,
+                          ExecuteReplicated(executable.get(), {{}, {}}));
+  ASSERT_EQ(results.size(), kNumReplicas);
+  Literal expected = LiteralUtil::CreateR3<float>(
       {{{0, 1, 2}, {3, 4, 5}, {0, 1, 2}, {3, 4, 5}},
        {{6, 7, 8}, {9, 10, 11}, {6, 7, 8}, {9, 10, 11}}});
   for (const Literal& result : results) {

--- a/xla/codegen/emitters/kernel_arguments.cc
+++ b/xla/codegen/emitters/kernel_arguments.cc
@@ -190,6 +190,61 @@ absl::StatusOr<KernelArguments> KernelArguments::Create(
                                hlo_instruction, unmanaged_arguments);
 }
 
+// Special overload for AllGather with tuple unpacking
+absl::StatusOr<KernelArguments> KernelArguments::Create(
+    const BufferAssignment& buffer_assignment,
+    const BufferAlignment& buffer_alignment,
+    const HloInstruction* shape_instruction,
+    const HloInstruction* buffer_instruction, const ShapeIndex& output_index,
+    absl::Span<const Shape> unmanaged_arguments) {
+  std::vector<KernelArgument> kernel_arguments;
+
+  // Input arguments: use shape_instruction's operands for shapes,
+  // but buffer_instruction's operands for buffer lookups
+  for (int i = 0; i < shape_instruction->operand_count(); ++i) {
+    const HloInstruction* shape_operand = shape_instruction->operand(i);
+    const HloInstruction* buffer_operand = buffer_instruction->operand(i);
+    TF_ASSIGN_OR_RETURN(BufferAllocation::Slice slice,
+                        buffer_assignment.GetUniqueSlice(buffer_operand, {}));
+    kernel_arguments.emplace_back(
+        KernelArgument(shape_operand->shape(), slice));
+  }
+
+  // Output arguments: use shape_instruction's shape,
+  // but look up buffer from buffer_instruction at output_index
+  absl::flat_hash_set<BufferAllocation::Slice> buffers_written;
+  TF_RETURN_IF_ERROR(ShapeUtil::ForEachSubshapeWithStatus(
+      shape_instruction->shape(),
+      [&](const Shape& subshape, const ShapeIndex& index) {
+        if (!subshape.IsArray()) return absl::OkStatus();
+
+        // For output buffers, look them up from buffer_instruction at
+        // output_index
+        ShapeIndex buffer_index = output_index;
+        // Append the current index to output_index for nested shapes
+        for (int64_t i : index) {
+          buffer_index.push_back(i);
+        }
+
+        TF_ASSIGN_OR_RETURN(
+            BufferAllocation::Slice slice,
+            buffer_assignment.GetUniqueSlice(buffer_instruction, buffer_index));
+
+        kernel_arguments.emplace_back(KernelArgument(subshape, slice));
+        buffers_written.insert(slice);
+        return absl::OkStatus();
+      }));
+
+  // Add unmanaged arguments
+  for (const Shape& unmanaged_argument : unmanaged_arguments) {
+    kernel_arguments.emplace_back(unmanaged_argument);
+  }
+
+  FillKernelArgumentAttributes(kernel_arguments, buffer_alignment,
+                               buffers_written);
+  return KernelArguments(std::move(kernel_arguments));
+}
+
 absl::StatusOr<KernelArguments> KernelArguments::Create(
     const BufferAssignment& buffer_assignment,
     const BufferAlignment& buffer_alignment,

--- a/xla/codegen/emitters/kernel_arguments.h
+++ b/xla/codegen/emitters/kernel_arguments.h
@@ -111,6 +111,22 @@ class KernelArguments {
       const BufferAlignment& buffer_alignment,
       const HloInstruction* hlo_instruction);
 
+  // Special overload for collective operations where the fusion has a different
+  // output shape than the original instruction (e.g., AllGather with tuple
+  // unpacking).
+  // - shape_instruction: Used to determine argument shapes (typically the
+  // fusion)
+  // - buffer_instruction: Used to look up buffer assignments (typically the
+  // original instruction)
+  // - output_index: ShapeIndex to use when looking up output buffers from
+  // buffer_instruction
+  static absl::StatusOr<KernelArguments> Create(
+      const BufferAssignment& buffer_assignment,
+      const BufferAlignment& buffer_alignment,
+      const HloInstruction* shape_instruction,
+      const HloInstruction* buffer_instruction, const ShapeIndex& output_index,
+      absl::Span<const Shape> unmanaged_arguments);
+
   // Certain kernels require output arguments to be interleaved with input
   // arguments. This function creates a KernelArguments object where the output
   // arguments are interleaved with the input arguments according to the

--- a/xla/codegen/tiling/tiled_hlo_instruction.cc
+++ b/xla/codegen/tiling/tiled_hlo_instruction.cc
@@ -48,8 +48,13 @@ absl::Status VerifyTiledHloInstructionConstructorPreconditions(
     std::optional<IndexingMap> tile_offsets_indexing,
     const llvm::SmallVector<const TiledHloInstruction*>& runtime_variables) {
   // * Number of tile sizes, strides should match the rank of the HLO.
+  const Shape& shape_for_tiling =
+      (hlo->opcode() == HloOpcode::kAllGatherStart && hlo->shape().IsTuple())
+          ? ShapeUtil::GetTupleElementShape(hlo->shape(), 1)
+          : hlo->shape();
+
   const int rank =
-      hlo->shape().IsArray() ? hlo->shape().dimensions().size() : 0;
+      shape_for_tiling.IsArray() ? shape_for_tiling.dimensions().size() : 0;
 
   if (tile_sizes.size() != rank) {
     return absl::InvalidArgumentError(

--- a/xla/codegen/xtile/codegen/emitter_helpers.cc
+++ b/xla/codegen/xtile/codegen/emitter_helpers.cc
@@ -694,10 +694,14 @@ absl::StatusOr<TensorValue> EmitScope(
                hlo->opcode() == HloOpcode::kTranspose ||
                hlo->opcode() == HloOpcode::kSlice ||
                hlo->opcode() == HloOpcode::kReshape ||
-               hlo->opcode() == HloOpcode::kPad) {
+               hlo->opcode() == HloOpcode::kPad ||
+               hlo->opcode() == HloOpcode::kGetTupleElement ||
+               hlo->opcode() == HloOpcode::kAllGatherStart) {
       // All these are currently supported only as operations on indices
       // which are pushed to loads and stores. No operations on tiles are
       // performed here.
+      // For GetTupleElement and AllGatherStart, we pass through the operand
+      // value
       result = values[hlo->operand(0)];
     } else if (hlo->opcode() == HloOpcode::kFusion) {
       const auto* fusion_instruction = ::xla::Cast<HloFusionInstruction>(hlo);

--- a/xla/codegen/xtile/codegen/fusion_emitter.cc
+++ b/xla/codegen/xtile/codegen/fusion_emitter.cc
@@ -100,6 +100,7 @@ limitations under the License.
 #include "xla/tools/hlo_decomposer.h"
 #include "xla/tsl/framework/mlir/status_scoped_diagnostic_handler.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 #include "xla/xla.pb.h"
@@ -890,6 +891,75 @@ absl::StatusOr<TensorValue> EmitAllReduce(
   return mlir::cast<TensorValue>(all_reduce_op.getResult(0));
 }
 
+absl::StatusOr<TensorValue> EmitAllGather(
+    mlir::ImplicitLocOpBuilder& b, const HloComputation* computation,
+    const HloAllGatherInstruction& all_gather,
+    const TiledHloInstruction& tiled_hlo_gather,
+    absl::flat_hash_map<const TiledHloInstruction*, TensorValue>& values) {
+  llvm::SmallVector<mlir::Value> operands;
+  operands.reserve(tiled_hlo_gather.operands().size());
+
+  for (const auto operand : tiled_hlo_gather.operands()) {
+    if (!values.contains(operand)) {
+      return Internal("Operand %s not found in the values map.",
+                      operand->ToString());
+    }
+    operands.push_back(values[operand]);
+  }
+
+  if (all_gather.device_list()->replica_groups().empty()) {
+    return Internal(
+        "Triton emitting AllGather without replica groups is not supported.");
+  }
+
+  llvm::SmallVector<int64_t> flattened_replica_group_ids;
+  for (const auto& replica_group : all_gather.replica_groups()) {
+    for (const auto& replica_id : replica_group.replica_ids()) {
+      flattened_replica_group_ids.push_back(replica_id);
+    }
+  }
+
+  std::optional<int64_t> channel_handle = all_gather.channel_id();
+  bool use_global_device_ids = all_gather.use_global_device_ids();
+  int64_t all_gather_dimension = all_gather.all_gather_dimension();
+
+  // AllGather-start returns a tuple (input, output), but we need the output
+  // shape (element 1)
+  const Shape& all_gather_output_shape =
+      all_gather.shape().IsTuple()
+          ? ShapeUtil::GetTupleElementShape(all_gather.shape(), 1)
+          : all_gather.shape();
+
+  TF_ASSIGN_OR_RETURN(auto output_element_type,
+                      xtile::PrimitiveTypeToMlirType(
+                          b, all_gather_output_shape.element_type()));
+
+  // Use the tiled output shape
+  llvm::SmallVector<int64_t> output_shape(tiled_hlo_gather.tile_sizes().begin(),
+                                          tiled_hlo_gather.tile_sizes().end());
+
+  auto output_type =
+      mlir::RankedTensorType::get(output_shape, output_element_type);
+
+  auto replica_groups_type = mlir::RankedTensorType::get(
+      {static_cast<int64_t>(all_gather.replica_groups().size()),
+       static_cast<int64_t>(all_gather.replica_groups()[0].replica_ids_size())},
+      b.getI64Type());
+  auto replica_groups_attr = mlir::DenseIntElementsAttr::get(
+      replica_groups_type, flattened_replica_group_ids);
+  auto channel_handle_attr =
+      channel_handle ? mlir::stablehlo::ChannelHandleAttr::get(b.getContext(),
+                                                               *channel_handle,
+                                                               /*type=*/0)
+                     : nullptr;
+
+  auto all_gather_op = mlir::stablehlo::AllGatherOp::create(
+      b, b.getLoc(), output_type, mlir::ValueRange(operands),
+      all_gather_dimension, replica_groups_attr, channel_handle_attr,
+      use_global_device_ids);
+  return mlir::cast<TensorValue>(all_gather_op.getResult(0));
+}
+
 absl::StatusOr<TensorValue> EmitTiledHloInstruction(
     mlir::ImplicitLocOpBuilder& b, const HloFusionInstruction& fusion,
     const TiledHloInstruction& tiled_hlo, mlir::FunctionOpInterface fn,
@@ -993,6 +1063,29 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
     return values[tiled_hlo.operand(0)];
   }
 
+  if (hlo->opcode() == HloOpcode::kAllGatherStart) {
+    const HloComputation* computation =
+        fusion.fused_instructions_computation();
+    const HloInstruction* root_instruction = computation->root_instruction();
+
+    // Handle GetTupleElement wrapping
+    if (root_instruction->opcode() == HloOpcode::kGetTupleElement &&
+        root_instruction->operand(0)->opcode() == HloOpcode::kAllGatherStart) {
+      root_instruction = root_instruction->operand(0);
+    }
+    if (root_instruction->opcode() == HloOpcode::kAllGatherDone) {
+      root_instruction = root_instruction->operand(0);
+    }
+
+    return EmitAllGather(b, computation,
+                         *xla::Cast<HloAllGatherInstruction>(root_instruction),
+                         tiled_hlo, values);
+  }
+
+  if (hlo->opcode() == HloOpcode::kAllGatherDone) {
+    return values[tiled_hlo.operand(0)];
+  }
+
   if (hlo->IsElementwise()) {
     std::vector<Value> operands;
     operands.reserve(hlo->operands().size());
@@ -1030,6 +1123,11 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
   if (hlo->opcode() == HloOpcode::kDynamicSlice) {
     // Dynamic slice is implemented as a load and does not require any further
     // processing.
+    return values[tiled_hlo.operand(0)];
+  }
+
+  // GetTupleElement is a pass-through operation
+  if (hlo->opcode() == HloOpcode::kGetTupleElement) {
     return values[tiled_hlo.operand(0)];
   }
 

--- a/xla/codegen/xtile/ir/transforms/verify_legal_xtile_ops.cc
+++ b/xla/codegen/xtile/ir/transforms/verify_legal_xtile_ops.cc
@@ -83,13 +83,13 @@ std::optional<absl::string_view> IsLegalTensorOp(mlir::Operation* op) {
 std::optional<absl::string_view> IsLegalStablehloOp(mlir::Operation* op) {
   if (mlir::isa<
           // go/keep-sorted start
-          mlir::stablehlo::AllReduceOp, mlir::stablehlo::AddOp,
-          mlir::stablehlo::AndOp, mlir::stablehlo::BroadcastInDimOp,
-          mlir::stablehlo::CompareOp, mlir::stablehlo::ConvertOp,
-          mlir::stablehlo::DivOp, mlir::stablehlo::DotGeneralOp,
-          mlir::stablehlo::MaxOp, mlir::stablehlo::MinOp,
-          mlir::stablehlo::MulOp, mlir::stablehlo::ReduceOp,
-          mlir::stablehlo::OrOp, mlir::stablehlo::RemOp,
+          mlir::stablehlo::AddOp, mlir::stablehlo::AllGatherOp,
+          mlir::stablehlo::AllReduceOp, mlir::stablehlo::AndOp,
+          mlir::stablehlo::BroadcastInDimOp, mlir::stablehlo::CompareOp,
+          mlir::stablehlo::ConvertOp, mlir::stablehlo::DivOp,
+          mlir::stablehlo::DotGeneralOp, mlir::stablehlo::MaxOp,
+          mlir::stablehlo::MinOp, mlir::stablehlo::MulOp, mlir::stablehlo::OrOp,
+          mlir::stablehlo::ReduceOp, mlir::stablehlo::RemOp,
           mlir::stablehlo::ReshapeOp, mlir::stablehlo::ReturnOp,
           mlir::stablehlo::SubtractOp, mlir::stablehlo::TransposeOp,
           mlir::stablehlo::XorOp

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -462,6 +462,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_unsupported_enable_all_reduce_decomposer(false);
   opts.set_xla_gpu_unsupported_enable_ragged_all_to_all_decomposer(false);
   opts.set_xla_gpu_unsupported_use_all_reduce_one_shot_kernel(true);
+  opts.set_xla_gpu_unsupported_use_all_gather_triton_backend(false);
   opts.set_xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel(true);
   opts.set_xla_gpu_experimental_enable_fusion_autotuner(true);
   opts.set_xla_gpu_experimental_max_unroll_factor(32);
@@ -2780,6 +2781,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_unsupported_use_all_reduce_one_shot_kernel(),
       "Internal: Enable the one-shot kernel for single-host all-reduce "
       "operations."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_unsupported_use_all_gather_triton_backend",
+      bool_setter_for(
+          &DebugOptions::
+              set_xla_gpu_unsupported_use_all_gather_triton_backend),
+      debug_options->xla_gpu_unsupported_use_all_gather_triton_backend(),
+      "Internal: Enable Triton backend for all-gather operations."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel",
       bool_setter_for(

--- a/xla/hlo/analysis/indexing_analysis.cc
+++ b/xla/hlo/analysis/indexing_analysis.cc
@@ -1550,14 +1550,15 @@ void AssignValuesToRTVars(IndexingMap* indexing_map) {
 
 HloInstructionIndexing ComputeOutputToInputAllGatherOpIndexing(
     const HloAllGatherInstruction* instr, MLIRContext* mlir_context) {
-  // CHECK_EQ(instr->all_gather_dimension(), 0);
-  // if (instr->all_gather_dimension() != 0) {
-  //   return CreateUnknownIndexing(instr->operand_count());
-  // }
+  // For AllGather-start, the shape is a tuple (input, output)
+  // We need to use the output element (index 1) for indexing
+  const Shape& output_shape =
+      instr->shape().IsTuple()
+          ? ShapeUtil::GetTupleElementShape(instr->shape(), 1)
+          : instr->shape();
 
   int64_t all_gather_dim = instr->all_gather_dimension();
-
-  auto output_rank = instr->shape().dimensions().size();
+  auto output_rank = output_shape.dimensions().size();
 
   llvm::SmallVector<SymbolicExpr> exprs;
   exprs.reserve(output_rank);
@@ -1573,14 +1574,14 @@ HloInstructionIndexing ComputeOutputToInputAllGatherOpIndexing(
 
   IndexingMap indexing_map = IndexingMap::FromTensorSizes(
       SymbolicMap::Get(mlir_context, output_rank, 0, exprs),
-      instr->shape().dimensions(), {});
+      output_shape.dimensions(), {});
 
   SymbolicExpr replica_id_expr = CreateDimExpr(all_gather_dim, mlir_context)
                                      .floorDiv(all_gather_input_dim_size);
 
   IndexingMap replica_id_map = IndexingMap::FromTensorSizes(
       SymbolicMap::Get(mlir_context, output_rank, 0, {replica_id_expr}),
-      instr->shape().dimensions(), {});
+      output_shape.dimensions(), {});
 
   OperandIndexing operand_indexing(indexing_map, {}, replica_id_map);
 
@@ -1665,6 +1666,37 @@ HloInstructionIndexing ComputeOutputToInputIndexing(const HloInstruction* instr,
   }
   if (auto transpose = DynCast<HloTransposeInstruction>(instr)) {
     return ComputeOutputToInputTransposeOpIndexing(transpose, mlir_context);
+  }
+  // GetTupleElement extracts an element from a tuple operand.
+  // An identity mapping is only valid when the tuple operand's extracted
+  // element has the same shape as the GTE output. This is the case for
+  // AllGather fusion tiling where GTE acts as a pass-through.
+  if (instr->opcode() == HloOpcode::kGetTupleElement) {
+    auto* gte = Cast<HloGetTupleElementInstruction>(instr);
+    const HloInstruction* tuple_operand = gte->operand(0);
+    const Shape& tuple_shape = tuple_operand->shape();
+    const Shape& output_shape = gte->shape();
+
+    // Verify the operand is a tuple and the extracted element shape matches
+    if (tuple_shape.IsTuple() &&
+        gte->tuple_index() < tuple_shape.tuple_shapes_size()) {
+      const Shape& element_shape = tuple_shape.tuple_shapes(gte->tuple_index());
+
+      // Only use identity mapping if the extracted element shape matches
+      // the GTE output shape
+      if (ShapeUtil::Equal(output_shape, element_shape)) {
+        IndexingMap identity_map =
+            CreateIdentityMap(output_shape, mlir_context);
+        HloInstructionIndexing indexing;
+        indexing.indexing_maps.resize(instr->operand_count());
+        indexing.indexing_maps[0].insert(
+            OperandIndexing{identity_map, /*runtime_variables=*/{}});
+        return indexing;
+      }
+    }
+
+    // If shapes don't match or context is invalid, return unknown indexing
+    return CreateUnknownIndexing(instr->operand_count());
   }
   // go/keep-sorted end
   LOG(ERROR) << "ComputeOutputToInputIndexing is not implemented for opcode "

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -173,6 +173,7 @@ limitations under the License.
 #include "xla/tools/hlo_decomposer.h"
 #include "xla/tsl/concurrency/future.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/dnn.pb.h"
 #include "xla/util.h"
@@ -230,18 +231,27 @@ static constexpr bool kRequiresCollectiveKernelThunk =
                             const HloAllReduceInstruction*,
                             std::vector<CollectiveThunk::Buffer>,
                             std::unique_ptr<CollectiveKernelThunk>,
+                            /*p2p_memcpy_enabled=*/bool> ||
+    std::is_constructible_v<ThunkType, Thunk::ThunkInfo,
+                            const HloAllGatherInstruction*,
+                            std::vector<CollectiveThunk::Buffer>,
+                            std::unique_ptr<CollectiveKernelThunk>,
                             /*p2p_memcpy_enabled=*/bool>;
 
 // The signature of this function would change to absl::Status once we lift the
 // CollectiveKernelThunk out as a top level thunk. It would then become a member
 // function of ThunkEmitter.
 // As it stands now the collective kernel thunk is wrapped inside other
-// collective thunks such as AllReduceStart. So this function is only
-// responsible for emitting the collective kernel thunk and its dependencies.
+// collective thunks such as AllReduceStart and AllGatherStart. So this function
+// is only responsible for emitting the collective kernel thunk and its
+// dependencies.
 absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
     IrEmitterContext* ir_emitter_context, const CallGraph* call_graph,
     Thunk::ThunkInfo thunk_info, std::vector<CollectiveThunk::Buffer> buffers,
     const HloAllReduceInstruction* instr, const AllReduceConfig& config) {
+  VLOG(3) << "EmitCollectiveKernelThunk called for AllReduce: "
+          << instr->name();
+
   std::unique_ptr<HloModule> fused_module =
       NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
   HloFusionInstruction* fusion_instr = Cast<HloFusionInstruction>(
@@ -270,11 +280,14 @@ absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
   TF_ASSIGN_OR_RETURN(bool did_set_config, TrySetGpuBackendConfigForCollective(
                                                device_info, fusion_instr));
   if (!did_set_config) {
+    VLOG(3) << "TrySetGpuBackendConfigForCollective returned false - not using "
+               "Triton";
     return make_thunk(/*kernel_name=*/"",
                       /*shmem_bytes=*/0,
                       /*launch_dimensions=*/std::nullopt,
                       /*local_module=*/nullptr);
   }
+  VLOG(3) << "TrySetGpuBackendConfigForCollective succeeded - using Triton!";
   const HloFusionAnalysis fusion_analysis =
       HloFusionAnalysis::Create(*fusion_instr, device_info);
   auto emitter = std::make_unique<TritonFusion>(fusion_analysis);
@@ -314,12 +327,88 @@ ThunkSequence FlattenThunkSequence(std::vector<ThunkSequence>&& sequences) {
   return result;
 }
 
+// Overload for AllGather
+absl::StatusOr<EmitCollectiveResult> EmitCollectiveKernelThunk(
+    IrEmitterContext* ir_emitter_context, const CallGraph* call_graph,
+    Thunk::ThunkInfo thunk_info, std::vector<CollectiveThunk::Buffer> buffers,
+    const HloAllGatherInstruction* instr) {
+  VLOG(3) << "EmitCollectiveKernelThunk called for AllGather: "
+          << instr->name();
+
+  std::unique_ptr<HloModule> fused_module =
+      NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
+  HloFusionInstruction* fusion_instr = Cast<HloFusionInstruction>(
+      fused_module->entry_computation()->root_instruction());
+  const se::DeviceDescription& device_info =
+      ir_emitter_context->gpu_device_info();
+
+  // For AllGather, we don't have a reduction, so we pass nullopt
+  const auto make_thunk = [&](absl::string_view kernel_name,
+                              int32_t shmem_bytes,
+                              std::optional<LaunchDimensions> launch_dimensions,
+                              std::unique_ptr<llvm::Module> local_module) {
+    // AllGather doesn't have reduction, pass nullopt
+    return EmitCollectiveResult{
+        std::make_unique<CollectiveKernelThunk>(
+            thunk_info,
+            GetCollectiveConfig(instr, instr->use_global_device_ids()),
+            std::nullopt,  // No reduction for AllGather
+            /*is_async=*/!IsGPUSyncCollective(*instr), std::move(buffers),
+            /*is_collective_kernel_enabled=*/
+            instr->GetModule()
+                ->config()
+                .debug_options()
+                .xla_gpu_unsupported_use_all_gather_triton_backend(),
+            /*kernel_name=*/kernel_name,
+            /*launch_dimensions=*/launch_dimensions,
+            /*shmem_bytes=*/shmem_bytes,
+            /*is_multimem_enabled=*/false,
+            /*cubin =*/ std::nullopt,
+            /*use_pdl =*/ false,
+            /*collective_op_kind=*/
+            CollectiveKernelThunk::CollectiveOpKind::kAllGather),
+        std::move(local_module)};
+  };
+
+  TF_ASSIGN_OR_RETURN(bool did_set_config, TrySetGpuBackendConfigForCollective(
+                                               device_info, fusion_instr));
+  if (!did_set_config) {
+    VLOG(3) << "TrySetGpuBackendConfigForCollective returned false for "
+               "AllGather - not using Triton";
+    return make_thunk(/*kernel_name=*/"",
+                      /*shmem_bytes=*/0,
+                      /*launch_dimensions=*/std::nullopt,
+                      /*local_module=*/nullptr);
+  }
+  VLOG(3) << "TrySetGpuBackendConfigForCollective succeeded for AllGather - "
+             "using Triton!";
+  const HloFusionAnalysis fusion_analysis =
+      HloFusionAnalysis::Create(*fusion_instr, device_info);
+  auto emitter = std::make_unique<TritonFusion>(fusion_analysis);
+  TritonFusion::EmitResult result;
+  {
+    XLA_SCOPED_LOGGING_TIMER("Emit collective kernel thunk for AllGather");
+    TF_ASSIGN_OR_RETURN(std::vector<Shape> unmanaged_arguments,
+                        GetCollectiveUnmanagedKernelArguments(fusion_instr));
+    VLOG(3) << "EmitCollectiveKernelThunk before emit!";
+
+    // For AllGather, use instr_override to get correct buffer assignments.
+    // The special KernelArguments::Create overload in fusion.cc handles
+    // the tuple unpacking, using fusion for shapes and AllGather for buffers.
+    TF_ASSIGN_OR_RETURN(
+        result, emitter->Emit(*ir_emitter_context, *fusion_instr,
+                              /*instr_override=*/instr, unmanaged_arguments));
+  }
+  return make_thunk(
+      result.kernel_thunk->kernel_name(), result.kernel_thunk->shmem_bytes(),
+      result.kernel_thunk->launch_dimensions(), std::move(result.llvm_module));
+}
+
 }  // namespace
 
-ThunkEmitter::ThunkEmitter(
-    IrEmitterContext* absl_nonnull ir_emitter_context,
-    llvm_ir::LLVMCommandLineOptionsReleasableLock* absl_nonnull
-        llvm_options_lock)
+ThunkEmitter::ThunkEmitter(IrEmitterContext* absl_nonnull ir_emitter_context,
+                           llvm_ir::LLVMCommandLineOptionsReleasableLock*
+                               absl_nonnull llvm_options_lock)
     : ir_emitter_context_(ir_emitter_context),
       send_recv_events_(std::make_shared<HostSendRecvAsyncEvents>()),
       nvshmem_buffer_addresses_(std::make_shared<NvshmemBufferAddresses>()),
@@ -1786,18 +1875,35 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectiveThunk(
   // TODO(b/828435206) Remove this constexpr once collective kernel thunk is
   // lifted out of the all reduce thunk.
   if constexpr (kRequiresCollectiveKernelThunk<CollectiveThunkType>) {
-    TF_ASSIGN_OR_RETURN(
-        auto emit_result,
-        EmitCollectiveKernelThunk(
-            ir_emitter_context_, call_graph_.get(), thunk_info, buffers,
-            Cast<HloAllReduceInstruction>(inst), GetAllReduceConfigInst(inst)));
-    if (emit_result.llvm_module != nullptr) {
-      kernel_modules_.push_back(std::move(emit_result.llvm_module));
+    // Check if this is AllReduce or AllGather and call appropriate overload
+    if constexpr (std::is_same_v<HloInstType, HloAllReduceInstruction>) {
+      TF_ASSIGN_OR_RETURN(
+          auto emit_result,
+          EmitCollectiveKernelThunk(ir_emitter_context_, call_graph_.get(),
+                                    thunk_info, buffers, inst,
+                                    GetAllReduceConfigInst(inst)));
+      if (emit_result.llvm_module != nullptr) {
+        kernel_modules_.push_back(std::move(emit_result.llvm_module));
+      }
+      thunk = std::make_unique<CollectiveThunkType>(
+          thunk_info, inst, /*buffers=*/std::move(buffers),
+          std::move(emit_result.thunk),
+          ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p());
+    } else if constexpr (std::is_same_v<HloInstType, HloAllGatherInstruction>) {
+      TF_ASSIGN_OR_RETURN(
+          auto emit_result,
+          EmitCollectiveKernelThunk(ir_emitter_context_, call_graph_.get(),
+                                    thunk_info, buffers, inst));
+      if (emit_result.llvm_module != nullptr) {
+        kernel_modules_.push_back(std::move(emit_result.llvm_module));
+      }
+      thunk = std::make_unique<CollectiveThunkType>(
+          thunk_info, inst, /*buffers=*/std::move(buffers),
+          std::move(emit_result.thunk),
+          ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p());
+    } else {
+      return Internal("Unsupported collective instruction type");
     }
-    thunk = std::make_unique<CollectiveThunkType>(
-        thunk_info, inst, /*buffers=*/std::move(buffers),
-        std::move(emit_result.thunk),
-        ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p());
   } else {
     thunk = std::make_unique<CollectiveThunkType>(
         thunk_info, inst, /*buffers=*/std::move(buffers),

--- a/xla/service/hlo_creation_utils.cc
+++ b/xla/service/hlo_creation_utils.cc
@@ -991,6 +991,21 @@ std::unique_ptr<HloModule> NewModuleWithFusion(
     });
   }
 
+  // For AllGather-start, extract the output element from the tuple.
+  // AllGather-start returns (input, output) tuple, but Triton backend
+  // cannot handle tuple results. We extract element 1 (the output).
+  Shape fusion_output_shape = instruction->shape();
+  if (instruction->opcode() == HloOpcode::kAllGatherStart &&
+      instruction->shape().IsTuple()) {
+    // Extract just the output element (index 1) from the tuple
+    HloInstruction* gte =
+        fusion_builder.AddInstruction(HloInstruction::CreateGetTupleElement(
+            ShapeUtil::GetTupleElementShape(instruction->shape(), 1),
+            fused_root, 1));
+    fused_root = gte;
+    fusion_output_shape = fused_root->shape();
+  }
+
   HloComputation* fused_computation =
       hlo_module->AddEmbeddedComputation(fusion_builder.Build(fused_root));
 
@@ -1000,7 +1015,7 @@ std::unique_ptr<HloModule> NewModuleWithFusion(
       build_parameter_instructions(entry_builder);
   HloInstruction* fusion_instruction =
       entry_builder.AddInstruction(HloInstruction::CreateFusion(
-          instruction->shape(), fusion_kind, entry_parameters,
+          fusion_output_shape, fusion_kind, entry_parameters,
           fused_computation,
           /*prefix=*/absl::StrCat(instruction->name(), "-")));
 

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -3586,3 +3586,42 @@ xla_test(
         "//xla/tsl/platform:statusor",
     ],
 )
+
+xla_test(
+    name = "all_gather_e2e_test",
+    srcs = ["all_gather_e2e_test.cc"],
+    backend_tags = {
+        "gpu": [
+            "multi_gpu",
+        ],
+    },
+    backends = [
+        "gpu",
+    ],
+    deps = [
+        ":literal_test_util",
+        "//xla:array",
+        "//xla:error_spec",
+        "//xla:literal",
+        "//xla:literal_util",
+        "//xla:shape_util",
+        "//xla:types",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service:collective_ops_utils",
+        "//xla/backends/gpu/tests:collective_ops_e2e_test_base",
+        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:test",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/log:scoped_mock_log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/xla/tests/all_gather_e2e_test.cc
+++ b/xla/tests/all_gather_e2e_test.cc
@@ -1,0 +1,1132 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstddef>
+#include <cstdint>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/log/scoped_mock_log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "xla/array.h"
+#include "xla/error_spec.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/literal.h"
+#include "xla/literal_util.h"
+#include "xla/primitive_util.h"
+#include "xla/service/collective_ops_utils.h"
+#include "xla/backends/gpu/tests/collective_ops_e2e_test_base.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+#include "xla/tests/literal_test_util.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/test.h"
+#include "xla/types.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla {
+namespace {
+
+std::string GetAsyncTestName(bool is_async) {
+  return is_async ? "async" : "sync";
+}
+
+void VerifyAllGatherType(const HloModule* module, PrimitiveType expected_type) {
+  bool found = false;
+  for (auto* comp : module->computations()) {
+    for (auto* instr : comp->instructions()) {
+      if (instr->opcode() == HloOpcode::kAllGather ||
+          instr->opcode() == HloOpcode::kAllGatherStart) {
+        PrimitiveType actual_type = instr->operand(0)->shape().element_type();
+        ASSERT_EQ(actual_type, expected_type)
+            << "Expected AllGather type " << PrimitiveType_Name(expected_type)
+            << " but got " << PrimitiveType_Name(actual_type);
+        found = true;
+      }
+    }
+  }
+  ASSERT_TRUE(found) << "No AllGather found in module";
+}
+
+class AllGatherTestNoParams : public CollectiveOpsWithFlagsBase {
+ public:
+  explicit AllGatherTestNoParams(bool is_async = false)
+      : CollectiveOpsWithFlagsBase(/*enable_async=*/is_async,
+                                   /*enable_p2p_memcpy=*/false,
+                                   /*enable_symmetric_buffer=*/false,
+                                   /*memory_size=*/32 * kMB,
+                                   /*collectives_memory_size=*/0) {}
+
+  void SetUp() override {
+    CollectiveOpsE2ETestBase::SetUp();
+    // Check for Triton support: Ampere+ for CUDA, any supported GPU for ROCm
+    if (Capability().IsCuda() && !IsAmpereAndHigher()) {
+      GTEST_SKIP() << "Test requires Ampere or newer architecture for CUDA "
+                      "since it's using triton.";
+    }
+  }
+
+  // Receives a required device count and asserts or skips the test if the
+  // device count is less than the required device count.
+  //
+  // Tap presubmits have only 2 GPUs available. This is the minimum required
+  // device count below which we fail the test.
+  // If the required device count is more than 2 and not enough devices are
+  // available, the test is marked as skipped when running on TAP.
+  //
+  // Returns false if the test should be skipped or has failed. Otherwise,
+  // returns true.
+  bool CheckDeviceCount(int32_t required_device_count) {
+    [&]() -> void {
+      const int32_t current_device_count = device_count();
+      if (current_device_count < required_device_count) {
+        ASSERT_GE(current_device_count, 2)
+            << "Test requires at least 2 devices but only "
+            << current_device_count << " available";
+        if (current_device_count < required_device_count) {
+          GTEST_SKIP() << "Test requires at least " << required_device_count
+                       << " devices but only " << current_device_count
+                       << " available.";
+        }
+      }
+    }();
+    return !IsSkipped() && !HasFatalFailure();
+  }
+
+  // Returns true if the current device supports Triton collective kernels.
+  // Triton collectives require Hopper+ for CUDA or any supported ROCm device.
+  bool IsTritonCapable() {
+    return IsHopperAndHigher() || Capability().IsRocm();
+  }
+
+  // Activates a log monitor that fails the test if a "Falling back to
+  // NCCL/RCCL" WARNING is emitted while the Triton flag is set.
+  // Call this just before ExecuteReplicated() in tests using
+  // Triton-compatible shapes. Has no effect when use_triton_backend is false
+  // or the hardware is not Triton-capable.
+  //
+  // The ScopedMockLog expectation is verified automatically when the fixture
+  // is torn down (i.e., when triton_mock_log_ is destroyed).
+  void CheckNoTritonFallback(bool use_triton_backend) {
+    if (!use_triton_backend || !IsTritonCapable()) return;
+    triton_mock_log_ = std::make_unique<absl::ScopedMockLog>(
+        absl::MockLogDefault::kIgnoreUnexpected);
+    EXPECT_CALL(*triton_mock_log_,
+                Log(absl::LogSeverity::kWarning, ::testing::_,
+                    ::testing::HasSubstr("Falling back to NCCL/RCCL")))
+        .Times(0);
+    triton_mock_log_->StartCapturingLogs();
+  }
+
+ private:
+  // Holds the ScopedMockLog set up by CheckNoTritonFallback().
+  // Null when not in use. Expectations are verified when this is destroyed.
+  std::unique_ptr<absl::ScopedMockLog> triton_mock_log_;
+};
+
+struct AllGatherTestParams {
+  // If true uses the async stream for the collective.
+  bool is_async;
+  // If true, uses the Triton backend for all-gather.
+  // If false, uses the NCCL backend.
+  bool use_all_gather_triton_backend;
+
+  // Returns the shape for the given element type and rank.
+  std::vector<int64_t> GetShape(PrimitiveType element_type,
+                                int32_t rank = 1) const {
+    // Use a reasonable size for testing
+    int64_t total = 1024;
+    if (rank <= 1) {
+      return {total};
+    }
+    std::vector<int64_t> dims;
+    for (int32_t i = 0; i < rank - 1; ++i) {
+      dims.push_back(rank);
+      total /= rank;
+    }
+    dims.push_back(total);
+    return dims;
+  }
+
+  static std::vector<AllGatherTestParams> Generate() {
+    std::vector<AllGatherTestParams> params;
+    for (bool is_async : {true, false}) {
+      for (bool use_all_gather_triton_backend : {true, false}) {
+        params.push_back({is_async, use_all_gather_triton_backend});
+      }
+    }
+    return params;
+  }
+
+  // Convert to string for test naming.
+  [[maybe_unused]] friend void PrintTo(const AllGatherTestParams& params,
+                                       std::ostream* os) {
+    *os << "{ .is_async=" << params.is_async
+        << ", .use_all_gather_triton_backend="
+        << params.use_all_gather_triton_backend << " }";
+  }
+};
+
+struct AllGatherTypesTestParams : public AllGatherTestParams {
+  // The element type of the all-gather.
+  PrimitiveType element_type;
+
+  static std::vector<AllGatherTypesTestParams> Generate() {
+    std::vector<AllGatherTypesTestParams> params;
+    for (auto& all_gather_test_params : AllGatherTestParams::Generate()) {
+      // Test common types used in ML workloads
+      for (const PrimitiveType element_type : {F32, F16, BF16, S32, S8, PRED}) {
+        params.push_back({all_gather_test_params, element_type});
+      }
+    }
+    return params;
+  }
+};
+
+struct InputsOutputs {
+  std::vector<Literal> inputs;
+  std::vector<Literal> expected_outputs;
+
+  [[nodiscard]] std::vector<std::vector<Literal*>> InputLiteralPtrs() {
+    std::vector<std::vector<Literal*>> result;
+    for (auto& input : inputs) {
+      result.push_back(std::vector<Literal*>{&input});
+    }
+    return result;
+  }
+};
+
+template <typename T>
+static void FillRandom(Array<T>& array, int64_t seed) {
+  constexpr PrimitiveType primitive_type =
+      primitive_util::NativeToPrimitiveType<T>();
+  if constexpr (primitive_util::IsFloatingPointType(primitive_type)) {
+    array.FillRandom(T{1.0f}, T{10.0}, seed);
+  } else if constexpr (primitive_type == PRED) {
+    array.FillRandomBool(seed);
+  } else if constexpr (primitive_util::IsIntegralType(primitive_type)) {
+    array.FillRandomUniform(T{0}, T{100}, seed);
+  } else {
+    GTEST_FAIL() << "Unsupported element type: "
+                 << absl::StrFormat("%v",
+                                    primitive_util::NativeToPrimitiveType<T>());
+  }
+}
+
+template <PrimitiveType kElementType>
+static absl::StatusOr<InputsOutputs> BuildTestInputsOutputs(
+    const HloModule& module, int64_t num_replicas,
+    int64_t all_gather_dimension) {
+  using ElementType = primitive_util::NativeTypeOf<kElementType>;
+
+  std::vector<Array<ElementType>> inputs;
+  std::vector<Literal> input_literals;
+  const HloInstruction* const hlo_instr =
+      HloHardwareIndependentTestBase::FindInstruction(&module,
+                                                      HloOpcode::kAllGather);
+  if (hlo_instr == nullptr) {
+    return absl::InvalidArgumentError(
+        "Instruction 'all-gather' not found in module.");
+  }
+  const HloAllGatherInstruction* instr =
+      Cast<HloAllGatherInstruction>(hlo_instr);
+  const Shape& input_shape = instr->operand(0)->shape();
+
+  // Create inputs for each replica
+  for (int i = 0; i < num_replicas; ++i) {
+    auto& input =
+        inputs.emplace_back(Array<ElementType>(input_shape.dimensions()));
+    FillRandom<ElementType>(input, i);
+    input_literals.push_back(LiteralUtil::CreateFromArray(input));
+  }
+
+  std::vector<Literal> expected_output_literals;
+
+  const std::vector<ReplicaGroup>& replica_groups =
+      instr->device_list()->replica_groups();
+
+  // Map each device to set of replica groups it belongs to.
+  std::vector<std::vector<int64_t>> device_to_groups(num_replicas);
+  for (const auto& replica_group : replica_groups) {
+    const auto& replica_ids = replica_group.replica_ids();
+    for (int64_t replica : replica_group.replica_ids()) {
+      CHECK_EQ(device_to_groups[replica].size(), 0);
+      device_to_groups[replica].assign(replica_ids.begin(), replica_ids.end());
+    }
+  }
+
+  // Build expected outputs by concatenating inputs along the all-gather
+  // dimension For all-gather, each replica in a group receives the
+  // concatenation of all inputs from replicas in that group along the specified
+  // dimension.
+  const Shape& output_shape = instr->shape();
+  for (int i = 0; i < num_replicas; ++i) {
+    const std::vector<int64_t>& group = device_to_groups[i];
+
+    // Create output literal with the concatenated shape
+    Literal output(output_shape);
+
+    // Manually concatenate by copying slices from each replica in the group
+    // along the all-gather dimension
+    int64_t offset = 0;
+    for (int64_t replica : group) {
+      const Literal& input = input_literals[replica];
+      const int64_t slice_size = input_shape.dimensions(all_gather_dimension);
+
+      // Set up source and destination bases
+      std::vector<int64_t> src_base(input_shape.dimensions_size(), 0);
+      std::vector<int64_t> dest_base(output_shape.dimensions_size(), 0);
+      dest_base[all_gather_dimension] = offset;
+
+      // Copy data from input to output at the appropriate offset
+      TF_RETURN_IF_ERROR(output.CopySliceFrom(
+          input, src_base, dest_base, /*copy_size=*/input_shape.dimensions()));
+      offset += slice_size;
+    }
+
+    expected_output_literals.push_back(std::move(output));
+  }
+
+  return InputsOutputs{std::move(input_literals),
+                       std::move(expected_output_literals)};
+}
+
+absl::StatusOr<InputsOutputs> BuildTestInputsOutputs(
+    PrimitiveType element_type, const HloModule& module, int64_t num_replicas,
+    int64_t all_gather_dimension) {
+  const auto dispatch = [&](auto type) {
+    return BuildTestInputsOutputs<type>(module, num_replicas,
+                                        all_gather_dimension);
+  };
+  return primitive_util::ArrayTypeSwitch(dispatch, element_type);
+}
+
+class AllGatherTest
+    : public AllGatherTestNoParams,
+      public ::testing::WithParamInterface<AllGatherTestParams> {
+ public:
+  AllGatherTest() : AllGatherTestNoParams(/*is_async=*/GetParam().is_async) {}
+
+ protected:
+  DebugOptions GetDebugOptionsForTest() const override {
+    DebugOptions opts = CollectiveOpsWithFlagsBase::GetDebugOptionsForTest();
+    opts.set_xla_gpu_unsupported_use_all_gather_triton_backend(
+        GetParam().use_all_gather_triton_backend);
+    return opts;
+  }
+
+  // Calls the base CheckNoTritonFallback() with this test's Triton flag.
+  void CheckNoTritonFallback() {
+    AllGatherTestNoParams::CheckNoTritonFallback(
+        GetParam().use_all_gather_triton_backend);
+  }
+};
+
+class AllGatherTypesTest
+    : public AllGatherTestNoParams,
+      public ::testing::WithParamInterface<AllGatherTypesTestParams> {
+ public:
+  AllGatherTypesTest()
+      : AllGatherTestNoParams(/*is_async=*/GetParam().is_async) {}
+
+ protected:
+  DebugOptions GetDebugOptionsForTest() const override {
+    DebugOptions opts = CollectiveOpsWithFlagsBase::GetDebugOptionsForTest();
+    opts.set_xla_gpu_unsupported_use_all_gather_triton_backend(
+        GetParam().use_all_gather_triton_backend);
+    return opts;
+  }
+
+  // Calls the base CheckNoTritonFallback() with this test's Triton flag.
+  void CheckNoTritonFallback() {
+    AllGatherTestNoParams::CheckNoTritonFallback(
+        GetParam().use_all_gather_triton_backend);
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    AllGatherTest, AllGatherTest,
+    ::testing::ValuesIn(AllGatherTestParams::Generate()),
+    [](const ::testing::TestParamInfo<AllGatherTestParams>& info) {
+      return absl::StrCat(
+          GetAsyncTestName(info.param.is_async), "_",
+          info.param.use_all_gather_triton_backend ? "triton" : "nccl");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    AllGatherTypesTest, AllGatherTypesTest,
+    ::testing::ValuesIn(AllGatherTypesTestParams::Generate()),
+    [](const ::testing::TestParamInfo<AllGatherTypesTestParams>& info) {
+      return absl::StrCat(
+          GetAsyncTestName(info.param.is_async), "_",
+          primitive_util::LowercasePrimitiveTypeName(info.param.element_type),
+          "_", info.param.use_all_gather_triton_backend ? "triton" : "nccl");
+    });
+
+TEST_P(AllGatherTypesTest, SupportedTypes2GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = %1$s[%2$s] parameter(0)
+    ROOT all-gather = %1$s[%3$s] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  const PrimitiveType element_type = GetParam().element_type;
+  const std::vector<int64_t> input_shape = GetParam().GetShape(element_type);
+
+  // Calculate output shape (dimension 0 multiplied by num replicas in group)
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  const std::string module_str = absl::StrFormat(
+      kModuleStr, primitive_util::LowercasePrimitiveTypeName(element_type),
+      absl::StrJoin(input_shape, ","), absl::StrJoin(output_shape, ","));
+  SCOPED_TRACE(::testing::Message() << "module_str: " << module_str);
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(module_str, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs(element_type, *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Equal(test_io.expected_outputs[i], results[i]))
+        << "ExpectedOutput != Result at rank " << i;
+  }
+}
+
+TEST_P(AllGatherTest, F32_8GPUs_AllReplicasOneGroup) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,1,2,3,4,5,6,7}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 8;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  const std::vector<int64_t> input_shape =
+      GetParam().GetShape(PrimitiveType::F32);
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      ParseAndReturnVerifiedModule(
+          absl::StrFormat(kModuleStr, absl::StrJoin(input_shape, ","),
+                          absl::StrJoin(output_shape, ",")),
+          kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+TEST_P(AllGatherTest, F32_8GPUs_2ReplicasPerGroup) {
+  const std::vector<int64_t> input_shape =
+      GetParam().GetShape(PrimitiveType::F32);
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= 2;  // 2 replicas per group
+
+  const auto kModuleStr = absl::StrFormat(
+      R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,4},{1,5},{2,6},{3,7}}, dimensions={0}
+  }
+  )",
+      absl::StrJoin(input_shape, ","), absl::StrJoin(output_shape, ","));
+
+  constexpr int64_t kNumReplicas = 8;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Equal(test_io.expected_outputs[i], results[i]))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+TEST_P(AllGatherTest, F32TwoD4GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,1,2,3}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 4;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  const std::vector<int64_t> input_shape =
+      GetParam().GetShape(PrimitiveType::F32, /*rank=*/2);
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      ParseAndReturnVerifiedModule(
+          absl::StrFormat(kModuleStr, absl::StrJoin(input_shape, ","),
+                          absl::StrJoin(output_shape, ",")),
+          kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// This test uses a 3D shape with non-power-of-2 dimensions (e.g., [3,3,113] =
+// 1017 elements) which doesn't meet Triton's alignment requirements (must be
+// divisible by 4). The test verifies that the system correctly falls back to
+// NCCL/RCCL when Triton is not supported.
+TEST_P(AllGatherTest, F32_3D_2GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+  const std::vector<int64_t> input_shape =
+      GetParam().GetShape(PrimitiveType::F32, /*rank=*/3);
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      ParseAndReturnVerifiedModule(
+          absl::StrFormat(kModuleStr, absl::StrJoin(input_shape, ","),
+                          absl::StrJoin(output_shape, ",")),
+          kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// 3D test with power-of-2 dimensions that work with Triton tiling
+TEST_P(AllGatherTest, F32_3D_2GPUs_PowerOf2) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+  // Use power-of-2 dimensions: [8, 8, 16] = 1024 elements (aligned)
+  const std::vector<int64_t> input_shape = {8, 8, 16};
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      ParseAndReturnVerifiedModule(
+          absl::StrFormat(kModuleStr, absl::StrJoin(input_shape, ","),
+                          absl::StrJoin(output_shape, ",")),
+          kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// Test gathering on dimension 1 for 2D data
+TEST_P(AllGatherTest, F32TwoD4GPUs_Dim1) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[32,32] parameter(0)
+    ROOT all-gather = f32[32,128] all-gather(param_0),
+      replica_groups={{0,1,2,3}}, dimensions={1}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 4;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/1)));
+
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// Test gathering on dimension 1 for 3D data
+TEST_P(AllGatherTest, F32_3D_2GPUs_Dim1) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[8,8,16] parameter(0)
+    ROOT all-gather = f32[8,16,16] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={1}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/1)));
+
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// Test gathering on dimension 2 for 3D data
+TEST_P(AllGatherTest, F32_3D_2GPUs_Dim2) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[8,8,16] parameter(0)
+    ROOT all-gather = f32[8,8,32] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={2}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/2)));
+
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()))
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// Large BF16 test matching the Python test configuration
+// Tests 1024 elements (2KB) with 2 GPUs to verify Triton output correctness
+TEST_P(AllGatherTest, BF16_1024Elements_2GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = bf16[1024] parameter(0)
+    ROOT all-gather = bf16[2048] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+
+  // Build test inputs and expected outputs
+  TF_ASSERT_OK_AND_ASSIGN(InputsOutputs test_io,
+                          (BuildTestInputsOutputs<PrimitiveType::BF16>(
+                              *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+
+  CheckNoTritonFallback();
+  // Execute the all-gather operation
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+
+  // Verify outputs match expected
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-3}))
+        << "ExpectedOutput != Result at replica " << i
+        << "\nThis test verifies that AllGather output matches the expected "
+        << "concatenation of inputs. Failure indicates incorrect Triton "
+           "implementation.";
+  }
+}
+
+// Large BF16 test with 4 GPUs
+// Tests 1024 elements per replica (2KB) -> 4096 elements output (8KB)
+TEST_P(AllGatherTest, BF16_1024Elements_4GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = bf16[1024] parameter(0)
+    ROOT all-gather = bf16[4096] all-gather(param_0),
+      replica_groups={{0,1,2,3}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 4;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+
+  // Build test inputs and expected outputs
+  TF_ASSERT_OK_AND_ASSIGN(InputsOutputs test_io,
+                          (BuildTestInputsOutputs<PrimitiveType::BF16>(
+                              *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+
+  CheckNoTritonFallback();
+  // Execute the all-gather operation
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+
+  // Verify outputs match expected
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-3}))
+        << "ExpectedOutput != Result at replica " << i
+        << "\nThis test verifies that AllGather output matches the expected "
+        << "concatenation of inputs. Failure indicates incorrect Triton "
+           "implementation.";
+  }
+}
+
+// Large BF16 test with 8 GPUs
+// Tests 1024 elements per replica (2KB) -> 8192 elements output (16KB)
+TEST_P(AllGatherTest, BF16_1024Elements_8GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = bf16[1024] parameter(0)
+    ROOT all-gather = bf16[8192] all-gather(param_0),
+      replica_groups={{0,1,2,3,4,5,6,7}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 8;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+
+  // Build test inputs and expected outputs
+  TF_ASSERT_OK_AND_ASSIGN(InputsOutputs test_io,
+                          (BuildTestInputsOutputs<PrimitiveType::BF16>(
+                              *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+
+  CheckNoTritonFallback();
+  // Execute the all-gather operation
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+
+  // Verify outputs match expected
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-3}))
+        << "ExpectedOutput != Result at replica " << i
+        << "\nThis test verifies that AllGather output matches the expected "
+        << "concatenation of inputs. Failure indicates incorrect Triton "
+           "implementation.";
+  }
+}
+
+// Test fixture for verifying that the Triton backend actually executes when
+// the Triton flag is set. Uses ScopedMockLog to detect silent NCCL fallbacks.
+//
+// The key insight: when xla_gpu_unsupported_use_all_gather_triton_backend=true
+// but the Triton kernel cannot run (either because the shape is not supported
+// at compile time or because runtime checks fail), a LOG(WARNING) containing
+// "Falling back to NCCL/RCCL" is emitted. Tests in this fixture use
+// ScopedMockLog to assert that this warning is absent (Triton ran) or present
+// (expected fallback).
+class AllGatherTritonVerificationTest : public AllGatherTestNoParams {
+ protected:
+  DebugOptions GetDebugOptionsForTest() const override {
+    DebugOptions opts = CollectiveOpsWithFlagsBase::GetDebugOptionsForTest();
+    opts.set_xla_gpu_unsupported_use_all_gather_triton_backend(true);
+    return opts;
+  }
+};
+
+// Verifies that the Triton backend actually runs (no NCCL/RCCL fallback) when:
+//  - The Triton flag is explicitly set, AND
+//  - The all-gather shape is compatible with Triton
+//    (1024 bf16 elements: aligned to kNumElementsPerThread=4, power-of-2 GPUs)
+//
+// If Triton silently falls back to NCCL/RCCL, this test fails because the
+// "Falling back to NCCL/RCCL" WARNING would be emitted and detected.
+TEST_F(AllGatherTritonVerificationTest, TritonActuallyRuns_BF16_1024Elements_2GPUs) {
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+  if (!IsTritonCapable()) {
+    GTEST_SKIP() << "Test requires Hopper+ CUDA or ROCm for Triton backend. "
+                    "Skipping Triton execution verification.";
+  }
+
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = bf16[1024] parameter(0)
+    ROOT all-gather = bf16[2048] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(InputsOutputs test_io,
+                          (BuildTestInputsOutputs<PrimitiveType::BF16>(
+                              *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+
+  // Monitor logs during execution to verify Triton backend actually ran.
+  // A "Falling back to NCCL/RCCL" WARNING indicates a silent fallback, which
+  // would mean the test was not actually validating Triton behavior.
+  absl::ScopedMockLog mock_log(absl::MockLogDefault::kIgnoreUnexpected);
+  EXPECT_CALL(mock_log,
+              Log(absl::LogSeverity::kWarning, ::testing::_,
+                  ::testing::HasSubstr("Falling back to NCCL/RCCL")))
+      .Times(0);  // No fallback expected — Triton should run.
+  mock_log.StartCapturingLogs();
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module), test_io.InputLiteralPtrs()));
+
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-3}))
+        << "Triton all-gather result mismatch at replica " << i;
+  }
+}
+
+// Verifies that when the Triton flag is set but the shape is not supported by
+// Triton (1017 elements = 3*3*113, not divisible by kNumElementsPerThread=4),
+// a WARNING containing "Falling back to NCCL/RCCL" is emitted.
+//
+// This test serves two purposes:
+//  1. Confirms the warning mechanism works correctly.
+//  2. Documents that NCCL/RCCL still produces a correct result on fallback.
+TEST_F(AllGatherTritonVerificationTest,
+       NcclFallbackWarningEmitted_NonAlignedShape_2GPUs) {
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+  if (!IsTritonCapable()) {
+    GTEST_SKIP() << "Test requires Hopper+ CUDA or ROCm for Triton backend. "
+                    "Skipping NCCL fallback warning verification.";
+  }
+
+  // Shape has 1017 elements (3*3*113): not divisible by kNumElementsPerThread
+  // (4), so Triton cannot emit a kernel and falls back to NCCL/RCCL.
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[3,3,113] parameter(0)
+    ROOT all-gather = f32[6,3,113] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(InputsOutputs test_io,
+                          (BuildTestInputsOutputs<PrimitiveType::F32>(
+                              *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+
+  // Expect the fallback warning to be emitted exactly because Triton cannot
+  // handle this shape.
+  absl::ScopedMockLog mock_log(absl::MockLogDefault::kIgnoreUnexpected);
+  EXPECT_CALL(mock_log,
+              Log(absl::LogSeverity::kWarning, ::testing::_,
+                  ::testing::HasSubstr("Falling back to NCCL/RCCL")))
+      .Times(::testing::AtLeast(1));  // Fallback warning must be emitted.
+  mock_log.StartCapturingLogs();
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module), test_io.InputLiteralPtrs()));
+
+  // NCCL/RCCL fallback must still produce the correct result.
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "NCCL/RCCL fallback result mismatch at replica " << i;
+  }
+}
+
+// FP8 vs FP16 all-gather comparison.
+TEST_F(AllGatherTestNoParams, AsyncAllGather_F8E4M3FN_2GPUs) {
+  bool has_fp8_support = false;
+  if (Capability().IsCuda()) {
+    has_fp8_support = Capability().cuda_compute_capability()->IsAtLeast(9, 0);
+  } else if (Capability().IsRocm()) {
+    has_fp8_support =
+        Capability().rocm_compute_capability()->has_ocp_fp8_support();
+  }
+
+  if (!has_fp8_support) {
+    GTEST_SKIP() << "FP8 requires GPU with OCP FP8 support (CUDA Hopper+ or "
+                    "ROCm MI350/gfx12xx with ROCm 7.0+).";
+  }
+
+  // FP16 baseline
+  constexpr absl::string_view kF16ModuleStr = R"(
+  HloModule f16_allgather
+  ENTRY test {
+    param = f16[32,64] parameter(0)
+    ROOT all-gather = f16[64,64] all-gather(param), replica_groups={{0,1}}, dimensions={0}
+  })";
+
+  // FP8 version
+  constexpr absl::string_view kF8ModuleStr = R"(
+  HloModule fp8_allgather
+  ENTRY test {
+    param = f16[32,64] parameter(0)
+    param_f8 = f8e4m3fn[32,64] convert(param)
+    all-gather_f8 = f8e4m3fn[64,64] all-gather(param_f8), replica_groups={{0,1}}, dimensions={0}
+    ROOT result = f16[64,64] convert(all-gather_f8)
+  })";
+
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  Array<Eigen::half> input1({32, 64}), input2({32, 64});
+  input1.FillRandom(Eigen::half(0.1f), 0.5f, /*seed=*/0);
+  input2.FillRandom(Eigen::half(0.1f), 0.5f, /*seed=*/1);
+
+  Literal input_lit1 = LiteralUtil::CreateFromArray(input1);
+  Literal input_lit2 = LiteralUtil::CreateFromArray(input2);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto f16_module, ParseAndReturnVerifiedModule(
+                                               kF16ModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult f16_result,
+                          ExecuteReplicated(std::move(f16_module),
+                                            std::vector<std::vector<Literal*>>{
+                                                {&input_lit1}, {&input_lit2}}));
+  // Verify FP16 all-gather type in optimized module
+  VerifyAllGatherType(f16_result.optimized_module, F16);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto f8_module, ParseAndReturnVerifiedModule(kF8ModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult f8_result,
+                          ExecuteReplicated(std::move(f8_module),
+                                            std::vector<std::vector<Literal*>>{
+                                                {&input_lit1}, {&input_lit2}}));
+  // Verify FP8 all-gather type in optimized module
+  VerifyAllGatherType(f8_result.optimized_module, F8E4M3FN);
+
+  ASSERT_EQ(f16_result.results.size(), kNumReplicas);
+  ASSERT_EQ(f8_result.results.size(), kNumReplicas);
+
+  // FP8 vs FP16 comparison: should be close but not identical
+  // Note: Using 6% tolerance due to cumulative FP16 and FP8 precision loss
+  EXPECT_TRUE(LiteralTestUtil::Near(f16_result.results[0], f8_result.results[0],
+                                    ErrorSpec{6e-2, 6e-2}));
+}
+
+}  // namespace
+}  // namespace xla

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1128,6 +1128,9 @@ message DebugOptions {
   // all-reduce operations.
   optional bool xla_gpu_unsupported_use_all_reduce_one_shot_kernel = 387;
 
+  // Internal testing flag to enable Triton backend for all-gather operations.
+  optional bool xla_gpu_unsupported_use_all_gather_triton_backend = 478;
+
   // Internal testing flag to enable one-shot kernel for single-host
   // ragged-all-to-all operations.
   optional bool xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel = 375;
@@ -1532,7 +1535,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 478
+  // Next id: 479
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
📝 Summary of Changes
This PR is the fifth in a series of five. 
PR 1/5 : https://github.com/openxla/xla/pull/42531
PR 2/5: https://github.com/openxla/xla/pull/42533
PR 3/5: https://github.com/openxla/xla/pull/42540
PR 4/5: https://github.com/openxla/xla/pull/42541
PR 5/5: https://github.com/openxla/xla/pull/42543  <= This PR

These PRs aim to enable the Triton backend for the All-Gather collective operation.

This PR implements the full Triton MLIR emitter for all-gather and wires it end-to-end. Activates when `xla_gpu_unsupported_use_all_gather_triton_backend` is set to `true` (default `false` for safe rollout).

🎯 Justification
Lowering All-Gather through the triton backend significantly improves performance of this operation for AMD target (compared to RCCL backend) and could allow us to take greater advantage of kernel-level fusion.

Example of 5 Triton Performance Improvements — All-Gather 1D on MI350
| dtype | shape | num_replicas | input_size_kb | output_size_kb | RCCL mean_us | Triton mean_us | Triton/RCCL | Improvement
| -- | -- | -- | -- | -- | -- | -- | -- | --
| bf16 | 2097152 | 4 | 4096 | 16384 | 148.106 | 52.740 | 0.356 | 64.4%
| f16 | 2097152 | 4 | 4096 | 16384 | 126.587 | 51.817 | 0.409 | 59.1%
| bf16 | 2097152 | 2 | 4096 | 8192 | 124.716 | 51.393 | 0.412 | 58.8%
| bf16 | 4194304 | 2 | 8192 | 16384 | 206.720 | 86.595 | 0.419 | 58.1%
| bf16 | 4194304 | 4 | 8192 | 32768 | 223.113 | 95.644 | 0.429 | 57.1%

Example of 5 Triton Performance Improvements — All-Gather 2D on MI350
| dtype | shape     | gather_dim | num_replicas | input_size_kb | output_size_kb | RCCL mean_us | Triton mean_us | Triton/RCCL | Improvement |
| ----- | --------- | ---------: | -----------: | ------------: | -------------: | -----------: | -------------: | ----------: | ----------: |
| bf16  | 1024x1024 |          0 |            2 |          2048 |           4096 |       81.743 |         28.737 |       0.352 |       64.8% |
| u4    | 1024x1024 |          0 |            2 |           512 |           1024 |       49.423 |         21.110 |       0.427 |       57.3% |
| u4    | 256x256   |          1 |            2 |            32 |             64 |       43.142 |         19.736 |       0.457 |       54.3% |
| u4    | 1024x512  |          1 |            2 |           256 |            512 |       39.583 |         20.909 |       0.528 |       47.2% |
| u4    | 2048x2048 |          1 |            2 |          2048 |           4096 |       83.845 |         32.911 |       0.392 |       60.8% |


🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement,✨ New Feature
