### PR TITLE
[ROCm] Disable multigpu tests and use singlegpu runner

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -101,7 +101,7 @@ jobs:
   xla:
     needs: rocm-config
     name: XLA Linux x86 AMD Instinct GPU
-    runs-on: linux-x86-64-4gpu-amd
+    runs-on: linux-x86-64-1gpu-amd
     env:
       DOCKER_IMAGE: ${{ needs.rocm-config.outputs.docker-image }}
       EXECUTE_CI_BUILD_URL: https://raw.githubusercontent.com/ROCm/xla/refs/heads/rocm-dev-infra/build_tools/rocm/execute_ci_build_upstream.sh
@@ -135,15 +135,4 @@ jobs:
             --config=ci_single_gpu \
             --local_test_jobs=4 \
             --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a \
-            --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${DOCKER_IMAGE}"
-
-      - name: Test XLA [multi_gpu]
-        timeout-minutes: 120
-        run: |
-          build_tools/rocm/execute_ci_build_upstream.sh \
-            --config=rocm_ci \
-            --config=rocm_rbe \
-            --config=ci_multi_gpu \
-            --local_test_jobs=1 \
-            --strategy=TestRunner=local \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${DOCKER_IMAGE}"


### PR DESCRIPTION
📝 Summary of Changes
Run only single gpu tests on PR checks for rocm

🎯 Justification
ROCm needs to increase the amount of CI workers, hence we switch to singlegpu runners only

🚀 Kind of Contribution
Please remove what does not apply:  ⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
Note relevant.

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
