### PR TITLE
[oneAPI] Fix the Postsubmit failures for Intel GPU

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -26,4 +26,4 @@ self-hosted-runner:
     - "linux-x86-64-4gpu-amd" # AMD runner with 4 GPUs.
     - "linux-x86-a4-224-b200-1gpu" # Linux X86 GPU runner using 1 B200 GPU and 1/8 the resources of a a4-highgpu-8g machine
     - "linux-x86-a3-8g-h100-8gpu" # Linux X86 GPU runner using a3-highgpu-8g machine with 8 NVIDIA H100 GPUs attached.
-    - "linux-x86-intel-emr4148-1gpu-02" # Linux X86 GPU runner using an EMR4148 machine with 2 Intel BMG GPUs attached.
+    - "linux-x64-battlemage-256-1gpu-intel" # Linux X86 GPU runner using an EMR4148 machine with 2 Intel BMG GPUs attached.

--- a/.github/workflows/oneAPI_Postsubmit.yml
+++ b/.github/workflows/oneAPI_Postsubmit.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   Tests:
     name: XLA Linux X86 GPU ONEAPI POSTSUBMIT
-    runs-on: linux-x86-intel-emr4148-1gpu-02
+    runs-on: linux-x64-battlemage-256-1gpu-intel
     container: 
       image: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest  # zizmor: ignore[unpinned-images]
       options: --device=/dev/dri


### PR DESCRIPTION
Added the linux-x64-battlemage-256-1gpu-intel self-hosted runner label to .github/actionlint.yml to resolve the actionlint warning for the Intel GPU runner used in oneAPI/XLA workflows.
Changed the runner configuration to use the pool name instead of the machine-specific name.

These commits were not included when the changes from my branch were merged into the Google XLA repository.