### PR TITLE
[ROCm] Fix DeterminismTest.CublasDot on AMD GPUs.

### DIFF
--- a/xla/service/gpu/determinism_test.cc
+++ b/xla/service/gpu/determinism_test.cc
@@ -188,6 +188,9 @@ ENTRY e {
     if (!HasHipblasLt()) {
       GTEST_SKIP() << "No hipblas-lt support on this architecture!";
     }
+    debug_options_.clear_xla_gpu_experimental_autotune_backends();
+    debug_options_.add_xla_gpu_experimental_autotune_backends(
+        autotuner::Backend::ROCBLAS);
   }
   debug_options_.set_xla_gpu_enable_triton_gemm(false);
 


### PR DESCRIPTION
The CUBLAS-only autotune allowlist leaves zero backends on ROCm, failing Autotuner::Create. Use ROCBLAS instead.
