### PR TITLE
[ROCm] Drop gfx900 (MI25) and gfx906 (MI50/MI60) support

### DIFF
--- a/xla/stream_executor/device_description_test.cc
+++ b/xla/stream_executor/device_description_test.cc
@@ -70,7 +70,8 @@ TEST(RocmComputeCapability, GfxVersion) {
 }
 
 TEST(RocmComputeCapability, IsSupportedGfxVersion) {
-  ASSERT_TRUE(RocmComputeCapability{"gfx900"}.is_supported_gfx_version());
+  ASSERT_FALSE(RocmComputeCapability{"gfx900"}.is_supported_gfx_version());
+  ASSERT_FALSE(RocmComputeCapability{"gfx906"}.is_supported_gfx_version());
   ASSERT_TRUE(RocmComputeCapability{"gfx1201"}.is_supported_gfx_version());
   ASSERT_TRUE(RocmComputeCapability{"gfx942"}.is_supported_gfx_version());
   ASSERT_TRUE(RocmComputeCapability{"gfx1250"}.is_supported_gfx_version());
@@ -117,12 +118,6 @@ TEST(RocmComputeCapability, Accessors) {
   EXPECT_TRUE(RocmComputeCapability{"gfx12xx"}.gfx12());
   EXPECT_TRUE(RocmComputeCapability{"gfx12xxblabla"}.gfx12());
 
-  EXPECT_TRUE(RocmComputeCapability{"gfx12"}.fence_before_barrier());
-  EXPECT_TRUE(RocmComputeCapability{"anything"}.fence_before_barrier());
-  EXPECT_FALSE(RocmComputeCapability{"gfx900"}.fence_before_barrier());
-  EXPECT_FALSE(RocmComputeCapability{"gfx906"}.fence_before_barrier());
-
-  EXPECT_FALSE(RocmComputeCapability{"gfx900"}.has_hipblaslt());
   EXPECT_TRUE(RocmComputeCapability{"gfx942"}.has_hipblaslt());
   EXPECT_TRUE(RocmComputeCapability{"gfx90a"}.has_hipblaslt());
   EXPECT_TRUE(RocmComputeCapability{"gfx1200"}.has_hipblaslt());
@@ -152,8 +147,8 @@ TEST(GpuComputeCapability, ProtoConversion) {
       IsOkAndHolds(GpuComputeCapability(CudaComputeCapability::Volta())));
   EXPECT_THAT(
       GpuComputeCapability::FromProto(
-          GpuComputeCapability(RocmComputeCapability("gfx900")).ToProto()),
-      IsOkAndHolds(GpuComputeCapability(RocmComputeCapability("gfx900"))));
+          GpuComputeCapability(RocmComputeCapability("gfx908")).ToProto()),
+      IsOkAndHolds(GpuComputeCapability(RocmComputeCapability("gfx908"))));
 }
 
 TEST(ExecutionUnitDescription, ProtoConversion) {

--- a/xla/stream_executor/rocm/rocm_compute_capability.h
+++ b/xla/stream_executor/rocm/rocm_compute_capability.h
@@ -87,8 +87,6 @@ class RocmComputeCapability {
   // hurt since they are immutable, but keeping them close to methods simplifies
   // maintanance.
   static constexpr absl::string_view kSupportedGfxVersions[]{
-      "gfx900",   // MI25
-      "gfx906",   // MI50 / MI60
       "gfx908",   // MI100
       "gfx90a",   // MI200
       "gfx942",   // MI300
@@ -181,11 +179,6 @@ class RocmComputeCapability {
 
   bool has_packed_bf16_atomics_support() const {
     return gfx9_mi300_series() || gfx12();
-  }
-
-  bool fence_before_barrier() const {
-    static constexpr absl::string_view kList[] = {"gfx900", "gfx906"};
-    return !IsThisGfxInAnyList(kList);
   }
 
   bool has_hipblaslt() const {

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -121,16 +121,6 @@ absl::uint128 Fingerprint128(const absl::string_view s) {
   return absl::MakeUint128(fp.high64, fp.low64);
 }
 
-int fpus_per_core(std::string gcn_arch_name) {
-  // Source:
-  // https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/white-papers/amd-cdna2-white-paper.pdf
-  int n = 128;  // gfx90a and gfx908 -> 128
-  if (gcn_arch_name.substr(0, 6) == "gfx906") {
-    n = 64;
-  }
-  return n;
-}
-
 // ROCM driver routines may require a large amount of stack (particularly
 // hipModuleLoadDataEx, in our experience). To avoid stack overflow when using
 // stack-limited threads (such as those spawned by a default-argument
@@ -1240,7 +1230,10 @@ RocmExecutor::CreateDeviceDescription(int device_ordinal) {
       GetMaxSharedMemoryPerBlock(device).value());
   int core_count = GetMultiprocessorCount(device).value();
   desc.set_core_count(core_count);
-  desc.set_fpus_per_core(fpus_per_core(gcn_arch_name));
+  // TODO(ROCm): replace this hardcoded value with a per-arch lookup table and
+  // populate scalar_unit_description / matrix_unit_description so the perf
+  // model picks the right FP32 path (vector vs. matrix).
+  desc.set_fpus_per_core(128);
   desc.set_threads_per_core_limit(
       GetMaxThreadsPerMultiprocessor(device).value());
   desc.set_registers_per_block_limit(GetMaxRegistersPerBlock(device).value());


### PR DESCRIPTION
📝 Summary of Changes
Remove gfx900 (MI25) and gfx906 (MI50/MI60) support

🎯 Justification
These targets are no longer supported by ROCm.

🚀 Kind of Contribution
♻️ Cleanup