### PR TITLE
[XLA:CPU] Avoid unconditional work on the thunk-execution hot path

### DIFF
--- a/xla/backends/cpu/runtime/copy_thunk.cc
+++ b/xla/backends/cpu/runtime/copy_thunk.cc
@@ -159,14 +159,17 @@ tsl::AsyncValueRef<Thunk::ExecuteEvent> CopyThunk::Execute(
   // TODO(ezhulenev): Add extra checks for buffer aliasing, as we rely on the
   // fact that buffers do not alias each other to run copy in parallel.
 
-  VLOG(3) << absl::StreamFormat("Copy buffer: use_transpose=%s",
-                                transpose_plan_ ? "true" : "false");
-  VLOG(3) << absl::StreamFormat("  src: %s in slice %s (%p)",
-                                src_shape_.ToString(true),
-                                src_buffer_.ToString(), src_data.opaque());
-  VLOG(3) << absl::StreamFormat("  dst: %s in slice %s (%p)",
-                                dst_shape_.ToString(true),
-                                dst_buffer_.ToString(), dst_data.opaque());
+  // ToString operands to operator<< allocate even when VLOG is off.
+  if (ABSL_PREDICT_FALSE(VLOG_IS_ON(3))) {
+    VLOG(3) << absl::StreamFormat("Copy buffer: use_transpose=%s",
+                                  transpose_plan_ ? "true" : "false");
+    VLOG(3) << absl::StreamFormat("  src: %s in slice %s (%p)",
+                                  src_shape_.ToString(true),
+                                  src_buffer_.ToString(), src_data.opaque());
+    VLOG(3) << absl::StreamFormat("  dst: %s in slice %s (%p)",
+                                  dst_shape_.ToString(true),
+                                  dst_buffer_.ToString(), dst_data.opaque());
+  }
 
   // Skip no-op copy operations.
   if (ABSL_PREDICT_FALSE(parallel_block_params_.block_count == 0)) {

--- a/xla/backends/cpu/runtime/thunk_executor.cc
+++ b/xla/backends/cpu/runtime/thunk_executor.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include <cstdint>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -438,7 +439,10 @@ void ThunkExecutor::Execute(std::shared_ptr<ExecuteState> state,
                             Thunk::ExecuteSession::Lock lock) {
   DCHECK(!ready_queue.Empty()) << "Ready queue must not be empty";
 
-  tsl::profiler::TraceMe trace("ThunkExecutor::Execute");
+  std::optional<tsl::profiler::TraceMe> trace;
+  if (ABSL_PREDICT_FALSE(tsl::profiler::TraceMe::Active())) {
+    trace.emplace("ThunkExecutor::Execute");
+  }
   bool has_runner = params.task_runner != nullptr;
   bool has_lock = static_cast<bool>(lock);
 

--- a/xla/service/cpu/cpu_executable.cc
+++ b/xla/service/cpu/cpu_executable.cc
@@ -231,24 +231,33 @@ static int32_t GetDeviceOrdinal(const ExecutableRunOptions* run_options) {
 absl::Status CpuExecutable::ExecuteThunks(
     const ExecutableRunOptions* run_options,
     absl::Span<MaybeOwningDeviceAddress const> buffers) {
-  uint64_t start_ns = tsl::Env::Default()->NowNanos();
+  // NowNanos is otherwise dead work when no execution_profile is set.
+  uint64_t start_ns = 0;
+  if (ABSL_PREDICT_FALSE(run_options->execution_profile() != nullptr)) {
+    start_ns = tsl::Env::Default()->NowNanos();
+  }
 
   size_t profile_counters_size = 0;
   int64_t* profile_counters = nullptr;
 
   BufferAllocations allocations(buffers);
 
-  VLOG(3) << "Executing XLA:CPU thunks:";
-  VLOG(3) << absl::StrFormat("  Number of buffer allocations: %u",
-                             buffers.size());
-  auto mem_printer = [](std::string* out, const MaybeOwningDeviceAddress& mem) {
-    absl::StrAppend(out, absl::StrFormat("%p", mem.AsDeviceAddress().opaque()));
-  };
-  VLOG(3) << absl::StrFormat("  Buffer allocations: [%s]",
-                             absl::StrJoin(buffers, ", ", mem_printer));
-  VLOG(3) << absl::StrFormat("  Number of profile counters: %u",
-                             profile_counters_size);
-  VLOG(3) << absl::StrFormat("  Profile counters: %p", profile_counters);
+  // StrJoin + StrFormat operands to operator<< allocate even when VLOG off.
+  if (ABSL_PREDICT_FALSE(VLOG_IS_ON(3))) {
+    VLOG(3) << "Executing XLA:CPU thunks:";
+    VLOG(3) << absl::StrFormat("  Number of buffer allocations: %u",
+                               buffers.size());
+    auto mem_printer = [](std::string* out,
+                          const MaybeOwningDeviceAddress& mem) {
+      absl::StrAppend(out,
+                      absl::StrFormat("%p", mem.AsDeviceAddress().opaque()));
+    };
+    VLOG(3) << absl::StrFormat("  Buffer allocations: [%s]",
+                               absl::StrJoin(buffers, ", ", mem_printer));
+    VLOG(3) << absl::StrFormat("  Number of profile counters: %u",
+                               profile_counters_size);
+    VLOG(3) << absl::StrFormat("  Profile counters: %p", profile_counters);
+  }
 
   // Prepare for executing XLA program collectively.
   ASSIGN_OR_RETURN(Thunk::CollectiveExecuteParams collective_execute_params,


### PR DESCRIPTION
📝 **Summary of Changes**

Four small overhead removals on the per-`Execute` path in XLA:CPU:

  - `CopyThunk::Execute`
      - Gate the `VLOG(3)` block on `VLOG_IS_ON(3)`. `Shape::ToString` and `Slice::ToString` allocate strings as function-argument operands to `operator<<`, so they ran on every CopyThunk execute regardless of verbosity.
  - `CpuExecutable::ExecuteThunks`
      - Same treatment for the `VLOG(3)` buffer-dump block. `StrJoin` walks every buffer and calls `StrFormat` per element.
  - `CpuExecutable::ExecuteThunks`
      - Only sample `NowNanos()` when `execution_profile` is set, otherwise the vDSO call is dead work.
  - `ThunkExecutor::Execute`
      - Only construct the `TraceMe` when the profiler is `Active()`. Per-thunk `TracedExecute` already covers profiling; the outer span is preserved when profiling is enabled.

🎯 **Justification**

CPU workloads pay these costs on every thunk execute regardless of whether anyone is consuming the output (VLOG off, no profiler attached, no execution profile requested). Gating each on the relevant predicate keeps behavior identical when the consumer is present and removes the work otherwise.

🚀 **Kind of Contribution**

- ⚡️ Performance Improvement

📊 **Benchmark (for Performance Improvements)**

`BM_AsyncThunkExecutor` (10 reps, min 0.5s):

  | Items | Improvement |
  |-------|-------------|
  | 1     | -6.6%       |
  | 2     | -14.6%      |
  | 4     | -12.8%      |
  | 8     | -8.1%       |
  | 16    | -11.0%      |
  | 32    | -2.5%       |
  | 64    | -3.5%       |
  | 256   | -2.2%       |
  | 512   | -2.3%       |
