### PR TITLE
[ROCm] Expose missing ROCm sysdeps headers

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -89,6 +89,15 @@ cc_library(
     ]),
     defines = {"__HIP_DISABLE_CPP_FUNCTIONS__": "1"},
     strip_include_prefix = "%{rocm_root}/include",
+    deps = [":rocm_sysdeps_includes"],
+)
+
+cc_library(
+    name = "rocm_sysdeps_includes",
+    hdrs = glob([
+        "%{rocm_root}/lib/rocm_sysdeps/include/**",
+    ], allow_empty = True),
+    strip_include_prefix = "%{rocm_root}/lib/rocm_sysdeps/include",
 )
 
 cc_library(


### PR DESCRIPTION
This hopefully brings main green again.

Adds a generated `@local_config_rocm//rocm:rocm_sysdeps_includes` target for headers shipped under `lib/rocm_sysdeps/include`, and wires it into `rocm_headers_includes`.

## Why

The hermetic ROCm distribution ships `include/rocm_smi/kfd_ioctl.h`, which includes `<libdrm/drm.h>`. The matching `libdrm` headers are already present in the ROCm distribution under `lib/rocm_sysdeps/include`, but the generated Bazel repository only exposed `%{rocm_root}/include/**` as ROCm headers.

As a result, hermetic ROCm builds can see `rocm_smi/kfd_ioctl.h` but fail to resolve `libdrm/drm.h`.