### PR TITLE
DO NOT REVIEW - Dummy ROCm SVD main check

### DIFF
--- a/xla/hlo/builder/lib/svd_test.cc
+++ b/xla/hlo/builder/lib/svd_test.cc
@@ -39,6 +39,7 @@ limitations under the License.
 
 namespace xla {
 
+// Dummy source touch to verify ROCm SVD presubmit behavior on main.
 class SVDTest : public ClientLibraryTestRunnerMixin<
                     HloPjRtInterpreterReferenceMixin<HloPjRtTestBase>> {
  protected:


### PR DESCRIPTION
Dummy PR to check whether the current ROCm SVD failure reproduces on a branch based directly on main.

What changed:
- Added a no-op source comment in `xla/hlo/builder/lib/svd_test.cc`.

Why:
- The Bazel 8 migration PR is currently failing `//xla/hlo/builder/lib:svd_test_amdgpu_any` in `XLA Linux x86 AMD Instinct GPU`.
- This PR changes an input to that test target without changing behavior, so ROCm CI should rebuild/rerun the relevant graph from current main.

Validation:
- No local test run; this PR exists only to trigger presubmit CI.