### PR TITLE
Fix zstd compressor build.

### DIFF
--- a/xla/tools/BUILD
+++ b/xla/tools/BUILD
@@ -1418,6 +1418,10 @@ sh_test(
 cc_binary(
     name = "zstd_compressor",
     srcs = ["zstd_compressor.cc"],
+    linkopts = select({
+        "//xla/tsl:windows": [],
+        "//conditions:default": ["-lm"],
+    }),
     deps = [
         "//xla/tsl/util:command_line_flags",
         "@com_google_absl//absl/status",


### PR DESCRIPTION
📝 Summary of Changes
The target requires -lm which is added globally by cuda_clang config used by CI but not cuda_nvcc_clang_local for example.

🎯 Justification
🐛 Bug Fix