### PR TITLE
[ROCm] Drop support for ROCm < 7.1

### DIFF
--- a/third_party/gpus/find_rocm_config.py
+++ b/third_party/gpus/find_rocm_config.py
@@ -67,23 +67,26 @@ def _get_header_version(path, name):
                     "  its value is not an integer literal")
 
 
+def _find_version_file(rocm_install_path, candidates, component_name):
+  """Returns the first existing candidate path under rocm_install_path.
+
+  Raises ConfigError if none of the candidates exist.
+  """
+  for candidate in candidates:
+    full_path = os.path.join(rocm_install_path, candidate)
+    if os.path.exists(full_path):
+      return full_path
+  raise ConfigError(
+      "{} version file not found in {}".format(component_name, candidates))
+
+
 def _find_rocm_config(rocm_install_path):
 
   def rocm_version_numbers(path):
     possible_version_files = [
-        "include/rocm-core/rocm_version.h",  # ROCm 5.2
-        "include/rocm_version.h",  # ROCm 5.1 and prior
+        "include/rocm-core/rocm_version.h",
     ]
-    version_file = None
-    for f in possible_version_files:
-      version_file_path = os.path.join(path, f)
-      if os.path.exists(version_file_path):
-        version_file = version_file_path
-        break
-    if not version_file:
-      raise ConfigError(
-          "ROCm version file not found in {}".format(possible_version_files))
-
+    version_file = _find_version_file(path, possible_version_files, "ROCm")
     major = _get_header_version(version_file, "ROCM_VERSION_MAJOR")
     minor = _get_header_version(version_file, "ROCM_VERSION_MINOR")
     patch = _get_header_version(version_file, "ROCM_VERSION_PATCH")
@@ -91,8 +94,14 @@ def _find_rocm_config(rocm_install_path):
 
   major, minor, patch = rocm_version_numbers(rocm_install_path)
 
+  composite_version = _get_composite_version_number(major, minor, patch)
+  if composite_version < 70100:
+    raise ConfigError(
+        "XLA requires ROCm 7.1 or higher, but found {}.{}.{}".format(
+            major, minor, patch))
+
   rocm_config = {
-      "rocm_version_number": _get_composite_version_number(major, minor, patch)
+      "rocm_version_number": composite_version
   }
 
   return rocm_config
@@ -102,19 +111,10 @@ def _find_hipruntime_config(rocm_install_path):
 
   def hipruntime_version_number(path):
     possible_version_files = [
-        "include/hip/hip_version.h",  # ROCm 5.2
-        "hip/include/hip/hip_version.h",  # ROCm 5.1 and prior
+        "include/hip/hip_version.h",
     ]
-    version_file = None
-    for f in possible_version_files:
-      version_file_path = os.path.join(path, f)
-      if os.path.exists(version_file_path):
-        version_file = version_file_path
-        break
-    if not version_file:
-      raise ConfigError("HIP Runtime version file not found in {}".format(
-          possible_version_files))
-
+    version_file = _find_version_file(path, possible_version_files,
+                                      "HIP Runtime")
     # This header file has an explicit #define for HIP_VERSION, whose value
     # is (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR)
     # Retreive the major + minor and re-calculate here, since we do not
@@ -134,18 +134,9 @@ def _find_miopen_config(rocm_install_path):
 
   def miopen_version_numbers(path):
     possible_version_files = [
-        "include/miopen/version.h",  # ROCm 5.2 and prior
-        "miopen/include/miopen/version.h",  # ROCm 5.1 and prior
+        "include/miopen/version.h",
     ]
-    version_file = None
-    for f in possible_version_files:
-      version_file_path = os.path.join(path, f)
-      if os.path.exists(version_file_path):
-        version_file = version_file_path
-        break
-    if not version_file:
-      raise ConfigError(
-          'MIOpen version file "{}" not found'.format(version_file))
+    version_file = _find_version_file(path, possible_version_files, "MIOpen")
     major = _get_header_version(version_file, "MIOPEN_VERSION_MAJOR")
     minor = _get_header_version(version_file, "MIOPEN_VERSION_MINOR")
     patch = _get_header_version(version_file, "MIOPEN_VERSION_PATCH")
@@ -165,19 +156,9 @@ def _find_rocblas_config(rocm_install_path):
 
   def rocblas_version_numbers(path):
     possible_version_files = [
-        "include/rocblas/internal/rocblas-version.h",  # ROCm 5.2
-        "rocblas/include/internal/rocblas-version.h",  # ROCm 5.1 and prior
+        "include/rocblas/internal/rocblas-version.h",
     ]
-    version_file = None
-    for f in possible_version_files:
-      version_file_path = os.path.join(path, f)
-      if os.path.exists(version_file_path):
-        version_file = version_file_path
-        break
-    if not version_file:
-      raise ConfigError(
-          "rocblas version file not found in {}".format(
-              possible_version_files))
+    version_file = _find_version_file(path, possible_version_files, "rocblas")
     major = _get_header_version(version_file, "ROCBLAS_VERSION_MAJOR")
     minor = _get_header_version(version_file, "ROCBLAS_VERSION_MINOR")
     patch = _get_header_version(version_file, "ROCBLAS_VERSION_PATCH")
@@ -197,18 +178,9 @@ def _find_rocrand_config(rocm_install_path):
 
   def rocrand_version_number(path):
     possible_version_files = [
-        "include/rocrand/rocrand_version.h",  # ROCm 5.1
-        "rocrand/include/rocrand_version.h",  # ROCm 5.0 and prior
+        "include/rocrand/rocrand_version.h",
     ]
-    version_file = None
-    for f in possible_version_files:
-      version_file_path = os.path.join(path, f)
-      if os.path.exists(version_file_path):
-        version_file = version_file_path
-        break
-    if not version_file:
-      raise ConfigError(
-          "rocrand version file not found in {}".format(possible_version_files))
+    version_file = _find_version_file(path, possible_version_files, "rocrand")
     version_number = _get_header_version(version_file, "ROCRAND_VERSION")
     return version_number
 
@@ -223,18 +195,9 @@ def _find_rocfft_config(rocm_install_path):
 
   def rocfft_version_numbers(path):
     possible_version_files = [
-        "include/rocfft/rocfft-version.h",  # ROCm 5.2
-        "rocfft/include/rocfft-version.h",  # ROCm 5.1 and prior
+        "include/rocfft/rocfft-version.h",
     ]
-    version_file = None
-    for f in possible_version_files:
-      version_file_path = os.path.join(path, f)
-      if os.path.exists(version_file_path):
-        version_file = version_file_path
-        break
-    if not version_file:
-      raise ConfigError(
-          "rocfft version file not found in {}".format(possible_version_files))
+    version_file = _find_version_file(path, possible_version_files, "rocfft")
     major = _get_header_version(version_file, "rocfft_version_major")
     minor = _get_header_version(version_file, "rocfft_version_minor")
     patch = _get_header_version(version_file, "rocfft_version_patch")
@@ -254,18 +217,9 @@ def _find_hipfft_config(rocm_install_path):
 
   def hipfft_version_numbers(path):
     possible_version_files = [
-        "include/hipfft/hipfft-version.h",  # ROCm 5.2
-        "hipfft/include/hipfft-version.h",  # ROCm 5.1 and prior
+        "include/hipfft/hipfft-version.h",
     ]
-    version_file = None
-    for f in possible_version_files:
-      version_file_path = os.path.join(path, f)
-      if os.path.exists(version_file_path):
-        version_file = version_file_path
-        break
-    if not version_file:
-      raise ConfigError(
-          "hipfft version file not found in {}".format(possible_version_files))
+    version_file = _find_version_file(path, possible_version_files, "hipfft")
     major = _get_header_version(version_file, "hipfftVersionMajor")
     minor = _get_header_version(version_file, "hipfftVersionMinor")
     patch = _get_header_version(version_file, "hipfftVersionPatch")
@@ -285,18 +239,10 @@ def _find_roctracer_config(rocm_install_path):
 
   def roctracer_version_numbers(path):
     possible_version_files = [
-        "include/roctracer/roctracer.h",  # ROCm 5.2
-        "roctracer/include/roctracer.h",  # ROCm 5.1 and prior
+        "include/roctracer/roctracer.h",
     ]
-    version_file = None
-    for f in possible_version_files:
-      version_file_path = os.path.join(path, f)
-      if os.path.exists(version_file_path):
-        version_file = version_file_path
-        break
-    if not version_file:
-      raise ConfigError("roctracer version file not found in {}".format(
-          possible_version_files))
+    version_file = _find_version_file(path, possible_version_files,
+                                      "roctracer")
     major = _get_header_version(version_file, "ROCTRACER_VERSION_MAJOR")
     minor = _get_header_version(version_file, "ROCTRACER_VERSION_MINOR")
     # roctracer header does not have a patch version number
@@ -317,18 +263,10 @@ def _find_hipsparse_config(rocm_install_path):
 
   def hipsparse_version_numbers(path):
     possible_version_files = [
-        "include/hipsparse/hipsparse-version.h",  # ROCm 5.2
-        "hipsparse/include/hipsparse-version.h",  # ROCm 5.1 and prior
+        "include/hipsparse/hipsparse-version.h",
     ]
-    version_file = None
-    for f in possible_version_files:
-      version_file_path = os.path.join(path, f)
-      if os.path.exists(version_file_path):
-        version_file = version_file_path
-        break
-    if not version_file:
-      raise ConfigError("hipsparse version file not found in {}".format(
-          possible_version_files))
+    version_file = _find_version_file(path, possible_version_files,
+                                      "hipsparse")
     major = _get_header_version(version_file, "hipsparseVersionMajor")
     minor = _get_header_version(version_file, "hipsparseVersionMinor")
     patch = _get_header_version(version_file, "hipsparseVersionPatch")
@@ -347,19 +285,10 @@ def _find_hipsolver_config(rocm_install_path):
 
   def hipsolver_version_numbers(path):
     possible_version_files = [
-        "include/hipsolver/internal/hipsolver-version.h",  # ROCm 5.2
-        "hipsolver/include/internal/hipsolver-version.h",  # ROCm 5.1
-        "hipsolver/include/hipsolver-version.h",  # ROCm 5.0 and prior
+        "include/hipsolver/internal/hipsolver-version.h",
     ]
-    version_file = None
-    for f in possible_version_files:
-      version_file_path = os.path.join(path, f)
-      if os.path.exists(version_file_path):
-        version_file = version_file_path
-        break
-    if not version_file:
-      raise ConfigError("hipsolver version file not found in {}".format(
-          possible_version_files))
+    version_file = _find_version_file(path, possible_version_files,
+                                      "hipsolver")
     major = _get_header_version(version_file, "hipsolverVersionMajor")
     minor = _get_header_version(version_file, "hipsolverVersionMinor")
     patch = _get_header_version(version_file, "hipsolverVersionPatch")
@@ -379,18 +308,10 @@ def _find_rocsolver_config(rocm_install_path):
 
   def rocsolver_version_numbers(path):
     possible_version_files = [
-        "include/rocsolver/rocsolver-version.h",  # ROCm 5.2
-        "rocsolver/include/rocsolver-version.h",  # ROCm 5.1 and prior
+        "include/rocsolver/rocsolver-version.h",
     ]
-    version_file = None
-    for f in possible_version_files:
-      version_file_path = os.path.join(path, f)
-      if os.path.exists(version_file_path):
-        version_file = version_file_path
-        break
-    if not version_file:
-      raise ConfigError("rocsolver version file not found in {}".format(
-          possible_version_files))
+    version_file = _find_version_file(path, possible_version_files,
+                                      "rocsolver")
     major = _get_header_version(version_file, "ROCSOLVER_VERSION_MAJOR")
     minor = _get_header_version(version_file, "ROCSOLVER_VERSION_MINOR")
     patch = _get_header_version(version_file, "ROCSOLVER_VERSION_PATCH")
@@ -422,12 +343,10 @@ def find_rocm_config():
   result.update(_find_rocblas_config(rocm_install_path))
   result.update(_find_rocrand_config(rocm_install_path))
   result.update(_find_rocfft_config(rocm_install_path))
-  if result["rocm_version_number"] >= 40100:
-    result.update(_find_hipfft_config(rocm_install_path))
+  result.update(_find_hipfft_config(rocm_install_path))
   result.update(_find_roctracer_config(rocm_install_path))
   result.update(_find_hipsparse_config(rocm_install_path))
-  if result["rocm_version_number"] >= 40500:
-    result.update(_find_hipsolver_config(rocm_install_path))
+  result.update(_find_hipsolver_config(rocm_install_path))
   result.update(_find_rocsolver_config(rocm_install_path))
 
   return result

--- a/third_party/gpus/rocm/rocm_config.h.tpl
+++ b/third_party/gpus/rocm/rocm_config.h.tpl
@@ -24,4 +24,8 @@ limitations under the License.
 // NOTE: HipBlasLt is now always available, this flag is deprecated !
 #define TF_HIPBLASLT 1
 
+#if TF_ROCM_VERSION != 0 && TF_ROCM_VERSION < 70100
+#error "XLA requires ROCm 7.1 or higher. Older versions are no longer supported."
+#endif
+
 #endif  // ROCM_ROCM_CONFIG_H_

--- a/xla/backends/gpu/collectives/rccl_collectives.cc
+++ b/xla/backends/gpu/collectives/rccl_collectives.cc
@@ -66,11 +66,7 @@ limitations under the License.
 #include "tsl/platform/casts.h"
 #include "tsl/platform/numbers.h"
 
-#if (TF_ROCM_VERSION >= 50200)
 #include "rocm/include/rccl/rccl.h"
-#else
-#include "rocm/include/rccl.h"
-#endif  // TF_ROCM_VERSION >= 50200
 
 namespace xla::gpu {
 
@@ -155,9 +151,7 @@ static absl::StatusOr<ncclConfig_t> AsRcclConfig(
     const se::StreamExecutor* stream_executor) {
   ncclConfig_t comm_config = NCCL_CONFIG_INITIALIZER;
   comm_config.blocking = config.blocking_communicators ? 1 : 0;
-#if !defined(TENSORFLOW_USE_ROCM) || TF_ROCM_VERSION > 50700
   comm_config.splitShare = config.split_share;
-#endif
   int nccl_version;
   XLA_RCCL_RETURN_IF_ERROR(ncclGetVersion(&nccl_version));
   if (config.max_nchannels > 0) {
@@ -281,7 +275,6 @@ RcclCollectives::SplitCommunicatorsWithCancel(
   const auto& gpu_config =
       absl::down_cast<const GpuCollectives::Config&>(config);
 
-#if !defined(TENSORFLOW_USE_ROCM) || TF_ROCM_VERSION >= 60000
   auto make_comm = [&](int i) -> absl::StatusOr<ncclComm_t> {
     auto* device = absl::down_cast<GpuCollectives::Device*>(ranks[i].device);
     TF_RET_CHECK(device != nullptr);
@@ -318,11 +311,6 @@ RcclCollectives::SplitCommunicatorsWithCancel(
   }  // pool's destructor blocks until all scheduled work is done.
   RETURN_IF_ERROR(status);
   return split_comms;
-#else
-  return absl::UnimplementedError(
-      absl::StrFormat("%s:%d: NCCL operation ncclCommSplit not implemented",
-                      __FILE__, __LINE__));
-#endif  // !defined(TENSORFLOW_USE_ROCM) || TF_ROCM_VERSION >= 60000
 }
 
 static absl::StatusOr<xla::gpu::GpuCollectives*> GetNvshmemCollectives() {

--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -58,11 +58,7 @@ limitations under the License.
 #include "xla/util.h"
 #include "tsl/platform/casts.h"
 
-#if (TF_ROCM_VERSION >= 50200)
 #include "rocm/include/rccl/rccl.h"
-#else
-#include "rocm/include/rccl.h"
-#endif  // TF_ROCM_VERSION >= 50200
 
 namespace xla::gpu {
 namespace {
@@ -88,17 +84,9 @@ static absl::StatusOr<ncclDataType_t> ToNcclDataType(
     se::RocmComputeCapability rocm_cc) {
   switch (dtype) {
     case F8E5M2:
-#if TF_ROCM_VERSION >= 70000
       return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e5m2 : ncclInt8;
-#else
-      return ncclInt8;
-#endif
     case F8E4M3FN:
-#if TF_ROCM_VERSION >= 70000
       return rocm_cc.has_ocp_fp8_support() ? ncclFloat8e4m3 : ncclInt8;
-#else
-      return ncclInt8;
-#endif
     case S8:
     case F8E5M2FNUZ:
     case F8E4M3FNUZ:

--- a/xla/backends/gpu/collectives/rccl_communicator.h
+++ b/xla/backends/gpu/collectives/rccl_communicator.h
@@ -43,11 +43,7 @@ limitations under the License.
 #include "xla/tsl/platform/env.h"
 #include "xla/xla_data.pb.h"
 
-#if (TF_ROCM_VERSION >= 50200)
 #include "rocm/include/rccl/rccl.h"
-#else
-#include "rocm/include/rccl.h"
-#endif  // TF_ROCM_VERSION >= 50200
 
 namespace xla::gpu {
 

--- a/xla/backends/gpu/collectives/rccl_errors.cc
+++ b/xla/backends/gpu/collectives/rccl_errors.cc
@@ -23,11 +23,7 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/cancellation_token.h"
 #include "xla/util.h"
 
-#if (TF_ROCM_VERSION >= 50200)
 #include "rocm/include/rccl/rccl.h"
-#else
-#include "rocm/include/rccl.h"
-#endif  // TF_ROCM_VERSION >= 50200
 
 namespace xla::gpu {
 

--- a/xla/backends/gpu/collectives/rccl_errors.h
+++ b/xla/backends/gpu/collectives/rccl_errors.h
@@ -21,11 +21,7 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/cancellation_token.h"
 #include "xla/tsl/platform/logging.h"
 
-#if (TF_ROCM_VERSION >= 50200)
 #include "rocm/include/rccl/rccl.h"
-#else
-#include "rocm/include/rccl.h"
-#endif  // TF_ROCM_VERSION >= 50200
 
 //===----------------------------------------------------------------------===//
 // Collection of helper macros for handling RCCL errors.

--- a/xla/stream_executor/rocm/cub_sort_kernel_rocm_impl.cu.cc
+++ b/xla/stream_executor/rocm/cub_sort_kernel_rocm_impl.cu.cc
@@ -23,7 +23,6 @@ limitations under the License.
 #include "rocm/include/hipcub/backend/rocprim/device/device_segmented_radix_sort.hpp"
 #include "rocm/include/rocprim/thread/radix_key_codec.hpp"
 #include "rocm/include/rocprim/type_traits.hpp"
-#include "rocm/rocm_config.h"
 #include "xla/stream_executor/rocm/cub_sort_kernel_rocm.h"
 #include "xla/stream_executor/rocm/rocm_status.h"
 #include "tsl/platform/bfloat16.h"
@@ -31,32 +30,6 @@ limitations under the License.
 // Required for sorting Eigen::half and bfloat16.
 namespace rocprim {
 
-#if (TF_ROCM_VERSION >= 50200 && TF_ROCM_VERSION < 70000)
-namespace detail {
-template <>
-struct float_bit_mask<Eigen::half> {
-  static constexpr uint16_t sign_bit = 0x8000;
-  static constexpr uint16_t exponent = 0x7C00;
-  static constexpr uint16_t mantissa = 0x03FF;
-  using bit_type = uint16_t;
-};
-
-template <>
-struct float_bit_mask<tsl::bfloat16> {
-  static constexpr uint16_t sign_bit = 0x8000;
-  static constexpr uint16_t exponent = 0x7F80;
-  static constexpr uint16_t mantissa = 0x007F;
-  using bit_type = uint16_t;
-};
-
-template <>
-struct radix_key_codec_base<Eigen::half>
-    : radix_key_codec_floating<Eigen::half, uint16_t> {};
-template <>
-struct radix_key_codec_base<tsl::bfloat16>
-    : radix_key_codec_floating<tsl::bfloat16, uint16_t> {};
-}  // namespace detail
-#else   // TF_ROCM_VERSION >= 70000
 namespace traits {
 
 template <>
@@ -78,7 +51,6 @@ struct define<tsl::bfloat16> {
 };
 
 }  // namespace traits
-#endif  // TF_ROCM_VERSION >= 50200 && TF_ROCM_VERSION < 70000
 
 };  // namespace rocprim
 

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -134,20 +134,16 @@ static absl::StatusOr<hipblasLtEpilogue_t> AsHipblasLtEpilogue(
       return HIPBLASLT_EPILOGUE_RELU_BIAS;
     case gpu::BlasLt::Epilogue::kGELU:
       return HIPBLASLT_EPILOGUE_GELU;
-#if TF_ROCM_VERSION >= 60000
     case gpu::BlasLt::Epilogue::kGELUWithAux:
       return HIPBLASLT_EPILOGUE_GELU_AUX;
     case gpu::BlasLt::Epilogue::kBiasThenGELU:
       return HIPBLASLT_EPILOGUE_GELU_BIAS;
     case gpu::BlasLt::Epilogue::kBiasThenGELUWithAux:
       return HIPBLASLT_EPILOGUE_GELU_AUX_BIAS;
-#endif
-#if TF_ROCM_VERSION >= 70000
     case gpu::BlasLt::Epilogue::kSILU:
       return HIPBLASLT_EPILOGUE_SWISH_EXT;
     case gpu::BlasLt::Epilogue::kBiasThenSILU:
       return HIPBLASLT_EPILOGUE_SWISH_BIAS_EXT;
-#endif
     default:
       return absl::InternalError("Unsupported epilogue: " +
                                  std::to_string((int)epilogue));
@@ -276,7 +272,6 @@ auto BlasLt::RegularMatmulPlan::GetAlgorithms(size_t max_algorithm_count,
         break;
       }
       case gpu::ScaleMode::kBlockScaling: {
-#if TF_ROCM_VERSION >= 70000
         static int64_t dummy_pointer = 0xACEBALL;
         RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                 HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
@@ -290,9 +285,6 @@ auto BlasLt::RegularMatmulPlan::GetAlgorithms(size_t max_algorithm_count,
                                 HIPBLASLT_MATMUL_DESC_A_SCALE_MODE, mx_scale));
         RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                                 HIPBLASLT_MATMUL_DESC_B_SCALE_MODE, mx_scale));
-#else
-        return absl::InternalError("Block scaling requires ROCm >= 7.0");
-#endif
         break;
       }
     }
@@ -386,7 +378,6 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
   ASSIGN_OR_RETURN(auto c_desc, MatrixLayout::Create(c_layout));
   ASSIGN_OR_RETURN(auto d_desc, MatrixLayout::Create(output_layout));
 
-#if TF_ROCM_VERSION >= 60000
   // Currently, the default bias data type in hipblasLt is the same with output
   // data type for fp8 matmul, which is different from cublasLt. This is a
   // workaround to match cublasLt behavior.
@@ -401,7 +392,6 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
       }
     }
   }
-#endif  // TF_ROCM_VERSION >= 60000
 
   return std::make_unique<RegularMatmulPlan>(
       *this, std::move(op_desc), std::move(a_desc), std::move(b_desc),
@@ -464,7 +454,6 @@ absl::Status BlasLt::RegularMatmulPlan::DoMatmul(
                               args.bias.opaque()));
     }
 
-#if TF_ROCM_VERSION >= 60000
     if (a_scale != nullptr) {
       RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                               HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
@@ -485,12 +474,6 @@ absl::Status BlasLt::RegularMatmulPlan::DoMatmul(
                               HIPBLASLT_MATMUL_DESC_D_SCALE_POINTER,
                               args.d_scale.opaque()));
     }
-#else
-    if (!(args.a_scale == nullptr && args.b_scale == nullptr &&
-          args.c_scale == nullptr && args.d_scale == nullptr)) {
-      return absl::InternalError("hipblaslt does not support scale");
-    }
-#endif
 
     if (args.d_amax != nullptr) {
       return absl::InternalError("hipblaslt does not support amax");
@@ -553,7 +536,6 @@ absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
 
 // FP8 compatible types combinations (Full table in
 // https://github.com/ROCm/hipBLASLt/blob/develop/docs/api-reference.rst?plain=1)
-#if TF_ROCM_VERSION >= 60000
   TYPED_MATMUL(float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_16F,
                HIP_R_16F)
   TYPED_MATMUL(float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_32F,
@@ -568,9 +550,7 @@ absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
                HIP_R_16F)
   TYPED_MATMUL(float, HIP_R_8F_E5M2_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_32F,
                HIP_R_32F)
-#endif
 
-#if TF_ROCM_VERSION >= 60200
   TYPED_MATMUL(float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_16BF,
                HIP_R_16BF)
   TYPED_MATMUL(float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E5M2_FNUZ, HIP_R_16BF,
@@ -583,9 +563,7 @@ absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
                HIP_R_8F_E5M2_FNUZ, HIP_R_8F_E5M2_FNUZ)
   TYPED_MATMUL(float, HIP_R_8F_E5M2_FNUZ, HIP_R_8F_E4M3_FNUZ,
                HIP_R_8F_E5M2_FNUZ, HIP_R_8F_E5M2_FNUZ)
-#endif
 
-#if TF_ROCM_VERSION >= 60300
   TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_8F_E4M3, HIP_R_16BF, HIP_R_16BF)
   TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_8F_E4M3, HIP_R_16BF, HIP_R_8F_E4M3)
   TYPED_MATMUL(float, HIP_R_8F_E4M3, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_8F_E4M3)
@@ -609,9 +587,7 @@ absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
   TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_8F_E5M2)
   TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_8F_E4M3, HIP_R_16F, HIP_R_16F)
   TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_8F_E4M3, HIP_R_32F, HIP_R_32F)
-#endif
 
-#if TF_ROCM_VERSION >= 70000
   // MX FP4 (F4E2M1FN) type combinations
   TYPED_MATMUL(float, HIP_R_4F_E2M1, HIP_R_4F_E2M1, HIP_R_32F, HIP_R_32F)
   TYPED_MATMUL(float, HIP_R_4F_E2M1, HIP_R_4F_E2M1, HIP_R_32F, HIP_R_16F)
@@ -662,7 +638,6 @@ absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
   TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1, HIP_R_16BF, HIP_R_16BF)
   TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1, HIP_R_16BF, HIP_R_32F)
   TYPED_MATMUL(float, HIP_R_8F_E5M2, HIP_R_4F_E2M1, HIP_R_16BF, HIP_R_16F)
-#endif
 
   // Other data types:
   TYPED_MATMUL(float, HIP_R_16BF, HIP_R_16BF, HIP_R_16BF, HIP_R_16BF)

--- a/xla/stream_executor/rocm/hip_blas_utils.cc
+++ b/xla/stream_executor/rocm/hip_blas_utils.cc
@@ -39,33 +39,16 @@ hipDataType AsHipblasDataType(blas::DataType type) {
     case blas::DataType::kF8E8M0FNU:
       LOG(FATAL) << "hipblaslt does not support F8E4M3, F8E3M4, and F8E8M0FNU "
                     "as matrix data types";
-#if TF_ROCM_VERSION >= 70000
     case blas::DataType::kF4E2M1FN:
       return HIP_R_4F_E2M1;
-#else
-    case blas::DataType::kF4E2M1FN:
-      LOG(FATAL) << "hipblaslt only supports F4E2M1FN in ROCm 7.0 and above";
-#endif
-#if TF_ROCM_VERSION >= 60000
     case blas::DataType::kF8E5M2FNUZ:
       return HIP_R_8F_E5M2_FNUZ;
     case blas::DataType::kF8E4M3FNUZ:
       return HIP_R_8F_E4M3_FNUZ;
-#else
-    case blas::DataType::kF8E5M2FNUZ:
-    case blas::DataType::kF8E4M3FNUZ:
-      LOG(FATAL) << "hipblaslt only supports nanoo F8 in ROCm 6.0 and above";
-#endif
-#if TF_ROCM_VERSION >= 60300
     case blas::DataType::kF8E5M2:
       return HIP_R_8F_E5M2;
     case blas::DataType::kF8E4M3FN:
       return HIP_R_8F_E4M3;
-#else
-    case blas::DataType::kF8E5M2:
-    case blas::DataType::kF8E4M3FN:
-      LOG(FATAL) << "hipblaslt only supports OCP F8 in ROCm 6.3 and above";
-#endif
     case blas::DataType::kHalf:
       return HIP_R_16F;
     case blas::DataType::kBF16:

--- a/xla/stream_executor/rocm/hip_blas_utils.h
+++ b/xla/stream_executor/rocm/hip_blas_utils.h
@@ -26,23 +26,6 @@ limitations under the License.
 #include "xla/stream_executor/blas.h"
 #include "xla/tsl/platform/errors.h"
 
-#if TF_ROCM_VERSION < 60000
-#define hipDataType hipblasDatatype_t
-#define HIP_R_16F HIPBLAS_R_16F
-#define HIP_R_16BF HIPBLAS_R_16B
-#define HIP_R_32F HIPBLAS_R_32F
-#define HIP_R_64F HIPBLAS_R_64F
-#define HIP_R_8I HIPBLAS_R_8I
-#define HIP_R_32I HIPBLAS_R_32I
-#define HIP_C_32F HIPBLAS_C_32F
-#define HIP_C_64F HIPBLAS_C_64F
-
-#define hipblasComputeType_t hipblasLtComputeType_t
-#define HIPBLAS_COMPUTE_32F HIPBLASLT_COMPUTE_F32
-#define HIPBLAS_COMPUTE_64F HIPBLASLT_COMPUTE_F64
-#define HIPBLAS_COMPUTE_32I HIPBLASLT_COMPUTE_I32
-#endif
-
 namespace stream_executor {
 namespace rocm {
 

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -159,7 +159,6 @@ static std::string ToString(rocblas_status status) {
     XVAL(rocblas_status_invalid_size);
     XVAL(rocblas_status_memory_error);
     XVAL(rocblas_status_internal_error);
-#if TF_ROCM_VERSION >= 60000
     XVAL(rocblas_status_perf_degraded);
     XVAL(rocblas_status_size_query_mismatch);
     XVAL(rocblas_status_size_increased);
@@ -169,7 +168,6 @@ static std::string ToString(rocblas_status status) {
     XVAL(rocblas_status_check_numerics_fail);
     XVAL(rocblas_status_excluded_from_build);
     XVAL(rocblas_status_arch_mismatch);
-#endif
     default:
       return absl::StrCat("<invalid rocBLAS status: ", status, ">");
   }

--- a/xla/stream_executor/rocm/rocm_dnn.cc
+++ b/xla/stream_executor/rocm/rocm_dnn.cc
@@ -559,7 +559,7 @@ absl::StatusOr<ScopedTensorDescriptor> scope(
       std::vector<int64_t> dims64 =
           batch_descriptor.full_dims(dnn::DataLayout::kBatchDepthYX);
 
-#if (MIOPEN_BETA_API && TF_ROCM_VERSION >= 60300)
+#if MIOPEN_BETA_API
       status = miopenSetTensorDescriptorV2(obj.handle_, data_type, nd,
                                            (const size_t*)dims64.data(),
                                            (const size_t*)strides64.data());
@@ -640,7 +640,7 @@ absl::StatusOr<ScopedFilterDescriptor> scope(
       std::vector<int64_t> dims64 =
           filter_descriptor.full_dims(dnn::FilterLayout::kOutputInputYX);
 
-#if (MIOPEN_BETA_API && TF_ROCM_VERSION >= 60300)
+#if MIOPEN_BETA_API
       status = miopenSetTensorDescriptorV2(obj.handle_, data_type, nd,
                                            (const size_t*)dims64.data(),
                                            (const size_t*)strides64.data());
@@ -710,7 +710,6 @@ absl::StatusOr<ScopedConvolutionDescriptor> scope(
                << ToString(status);
   }
 
-#if (TF_ROCM_VERSION >= 50300)
   if (RequireMIOpenDeterminism()) {
     status = miopenSetConvolutionAttribute(
         obj.handle_, MIOPEN_CONVOLUTION_ATTRIB_DETERMINISTIC, 1);
@@ -719,7 +718,6 @@ absl::StatusOr<ScopedConvolutionDescriptor> scope(
                  << ToString(status);
     }
   }
-#endif
   return obj;
 }
 
@@ -4331,19 +4329,11 @@ class RocmFusedConvRunner : public dnn::FusedConvRunner {
 
     CHECK(output_profile_result == nullptr);
 
-    miopenStatus_t status;
-#if (TF_ROCM_VERSION >= 70000)
-    status = miopenExecuteFusionPlan_v2(
+    miopenStatus_t status = miopenExecuteFusionPlan_v2(
         miopen.handle(), fusion_plan_.fusion_plan_, input_nd_.handle(),
         input_data.opaque(), output_nd_.handle(), output_data.opaque(),
         fusion_plan_.fusion_args_, scratch_memory.opaque(),
         scratch_memory.size());
-#else
-    status = miopenExecuteFusionPlan(miopen.handle(), fusion_plan_.fusion_plan_,
-                                     input_nd_.handle(), input_data.opaque(),
-                                     output_nd_.handle(), output_data.opaque(),
-                                     fusion_plan_.fusion_args_);
-#endif
 
     if (status != miopenStatusSuccess) {
       LOG(ERROR) << "Failed to enqueue fused convolution on stream: "
@@ -4502,12 +4492,7 @@ absl::Status MIOpenSupport::GetFusedConvolveRunners(
       side_input_scale, leakyrelu_alpha, input_descriptor, filter_descriptor,
       bias_descriptor, output_descriptor, convolution_descriptor,
       activation_mode);
-// No way to invoke fused convs with workspace prior to rocm 7
-#if (TF_ROCM_VERSION >= 70000)
   if (runner_or.ok()) {
-#else
-  if (runner_or.ok() && runner_or.value()->GetWorkspaceSize() == 0) {
-#endif
     out_exec_plans->push_back(std::move(runner_or).value());
   }
 
@@ -4517,7 +4502,6 @@ absl::Status MIOpenSupport::GetFusedConvolveRunners(
 }
 
 bool UseNhwcLayoutForRocm() {
-#if TF_ROCM_VERSION >= 50100
   static bool is_enabled = [] {
     bool is_enabled = false;
     CHECK_OK(tsl::ReadBoolFromEnvVar("TF_USE_ROCM_NHWC",
@@ -4525,9 +4509,6 @@ bool UseNhwcLayoutForRocm() {
     return is_enabled;
   }();
   return is_enabled;
-#else  // TF_ROCM_VERSION < 50000
-  return false;
-#endif
 }
 
 }  // namespace gpu

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -677,16 +677,11 @@ absl::StatusOr<std::unique_ptr<Kernel>> RocmExecutor::LoadKernel(
     VLOG(1) << "Resolve ROCM kernel " << kernel_name
             << " from symbol pointer: " << symbol;
 
-#if TF_ROCM_VERSION >= 60200
     hipFunction_t func;
     RETURN_IF_ERROR(
         ToStatus(hipGetFuncBySymbol(&func, spec.in_process_symbol()->symbol),
                  "Failed call to hipGetFuncBySymbol"));
     rocm_kernel->set_gpu_function(func);
-#else
-    rocm_kernel->set_gpu_function(
-        static_cast<hipFunction_t>(spec.in_process_symbol().symbol()));
-#endif  // TF_ROCM_VERSION >= 60200
 
   } else {
     return absl::InternalError("No method of loading ROCM kernel provided");

--- a/xla/stream_executor/rocm/rocm_fft.h
+++ b/xla/stream_executor/rocm/rocm_fft.h
@@ -22,13 +22,7 @@ limitations under the License.
 
 #include <cstdint>
 
-#include "rocm/rocm_config.h"  // IWYU pragma: keep - needed for TF_ROCM_VERSION
-
-#if (TF_ROCM_VERSION >= 50200)
 #include "rocm/include/hipfft/hipfft.h"
-#else
-#include "rocm/include/hipfft.h"
-#endif
 
 #include "xla/stream_executor/fft.h"
 #include "xla/stream_executor/plugin_registry.h"

--- a/xla/stream_executor/rocm/rocm_status.cc
+++ b/xla/stream_executor/rocm/rocm_status.cc
@@ -58,7 +58,6 @@ std::string ToString(hipError_t result) {
       OSTREAM_ROCM_ERROR(ContextAlreadyInUse)
       OSTREAM_ROCM_ERROR(PeerAccessUnsupported)
       OSTREAM_ROCM_ERROR(Unknown)  // Unknown internal error to ROCM.
-#if TF_ROCM_VERSION >= 60200
       OSTREAM_ROCM_ERROR(LaunchTimeOut)
       OSTREAM_ROCM_ERROR(PeerAccessAlreadyEnabled)
       OSTREAM_ROCM_ERROR(PeerAccessNotEnabled)
@@ -82,7 +81,6 @@ std::string ToString(hipError_t result) {
       OSTREAM_ROCM_ERROR(GraphExecUpdateFailure)
       OSTREAM_ROCM_ERROR(RuntimeMemory)
       OSTREAM_ROCM_ERROR(RuntimeOther)
-#endif  // TF_ROCM_VERSION >= 60200
     default:
       return absl::StrCat("hipError_t(", static_cast<int>(result), ")");
   }

--- a/xla/stream_executor/rocm/rocm_stream.cc
+++ b/xla/stream_executor/rocm/rocm_stream.cc
@@ -320,23 +320,9 @@ absl::Status LaunchRocmKernel(
           << " bdz: " << block_dim_z << " smem: " << shared_mem_bytes
           << " func: " << (const void*)function;
 
-  auto res = hipSuccess;
-#if TF_ROCM_VERSION < 60200
-  // for in-process kernel this function returns mangled kernel function name,
-  // and null otherwise
-  auto name = hipKernelNameRefByPtr((const void*)function, stream);
-  if (name != nullptr) {
-    res = hipLaunchKernel((const void*)function,
-                          dim3(grid_dim_x, grid_dim_y, grid_dim_z),
-                          dim3(block_dim_x, block_dim_y, block_dim_z),
-                          kernel_params, shared_mem_bytes, stream);
-  } else  // NOLINT(readability/braces)
-#endif    // TF_ROCM_VERSION < 60200
-  {
-    res = hipModuleLaunchKernel(function, grid_dim_x, grid_dim_y, grid_dim_z,
-                                block_dim_x, block_dim_y, block_dim_z,
-                                shared_mem_bytes, stream, kernel_params, extra);
-  }
+  auto res = hipModuleLaunchKernel(
+      function, grid_dim_x, grid_dim_y, grid_dim_z, block_dim_x, block_dim_y,
+      block_dim_z, shared_mem_bytes, stream, kernel_params, extra);
   RETURN_IF_ERROR(ToStatus(
       res, absl::StrCat("Failed to launch ROCm kernel: ", kernel_name,
                         "; grid: ", grid_dim_x, "x", grid_dim_y, "x",

--- a/xla/tests/dot_operation_test.cc
+++ b/xla/tests/dot_operation_test.cc
@@ -81,7 +81,7 @@ using TypesF16F32F64CF64 = ::testing::Types<
 #if GOOGLE_CUDA
 using TypesF8 = ::testing::Types<tsl::float8_e4m3fn>;
 #endif
-#if TF_HIPBLASLT && TF_ROCM_VERSION >= 60000
+#if TF_HIPBLASLT
 using TypesF8 = ::testing::Types<tsl::float8_e4m3fnuz>;
 #endif
 
@@ -761,7 +761,7 @@ TYPED_TEST(DotOperationTest_F16F32F64CF64, GeneralMatMul) {
       {&x_data, &y_data}, this->error_spec_);
 }
 
-#if GOOGLE_CUDA || (TF_HIPBLASLT && TF_ROCM_VERSION >= 60000)
+#if GOOGLE_CUDA || TF_HIPBLASLT
 template <typename T>
 class DotOperationTestWithCublasLt_F16F32F64CF64 : public DotOperationTest {
  public:


### PR DESCRIPTION
Reject ROCm older than 7.1 at configure and compile time, and remove all version-gated fallback code for older releases.