### PR TITLE
[ROCm] Update ROCm CI hermetic configuration

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -312,7 +312,7 @@ common:rocm_ci --config=rocm
 common:rocm_ci --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 common:rocm_ci_hermetic --dynamic_mode=off
-common:rocm_ci_hermetic --config=rocm_clang_official
+common:rocm_ci_hermetic --config=rocm_clang_hermetic_local_sysroot
 common:rocm_ci_hermetic --repo_env="ROCM_DISTRO_VERSION=rocm_7.10.0_gfx90X"
 common:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic
 


### PR DESCRIPTION
Fix rocm_ci_hermetic config

📝 Summary of Changes
Update clang configruation for hermetic CI

🎯 Justification
rocm_clang_official doesn't exist anymore. We have to use rocm_clang_hermetic instead

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
