### PR TITLE
[ROCm] Iterate full activity vector in ApiActivityInfoExchange to fix HIP-graph kernel loss

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -571,6 +571,7 @@ xla_cc_test(
         # ":rocm_tracer",
         ":rocm_collector",
         ":rocm_tracer_utils",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_googletest//:gtest_main",
         "//xla/tsl/profiler/utils:xplane_utils",
         "@tsl//tsl/profiler/protobuf:xplane_proto_cc",

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -623,7 +623,11 @@ std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
   */
 
   std::vector<RocmTracerEvent> aggregated_events;
-  aggregated_events.reserve(api_events_map_.size());
+  size_t total_activities = 0;
+  for (const auto& [_, v] : activity_ops_events_map_) {
+    total_activities += v.size();
+  }
+  aggregated_events.reserve(api_events_map_.size() + total_activities);
 
   // Copy info from activity events to API callback events
   for (auto& [key, api_event] : api_events_map_) {
@@ -666,65 +670,79 @@ std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
     }  // switch
   }  // for
 
-  // Make sure for all activity events we have API callback events
+  // Make sure for all activity events we have API callback events.
+  //
+  // `activity_iter.second` is a vector keyed by correlation_id; a single
+  // hipGraphLaunch can produce many kernel-dispatch records sharing one
+  // correlation_id. Iterate the whole vector; the api_event lookup is
+  // invariant across it and hoisted out of the inner loop.
   for (auto& activity_iter : activity_ops_events_map_) {
-    RocmTracerEvent& activity_event = activity_iter.second.front();
+    if (activity_iter.second.empty()) {
+      continue;
+    }
+    const uint32_t corr_id = activity_iter.first;
 
-    auto api_event = api_events_map_.find(activity_event.correlation_id);
-
-    if (api_event == api_events_map_.end()) {
-      api_event = auxiliary_api_events_map_.find(activity_event.correlation_id);
-
-      if (api_event == auxiliary_api_events_map_.end()) {
-        OnEventsDropped(
-            "An event from activity was discarded."
-            "Could not find the counterpart HIP API.",
-            activity_event.correlation_id);
-        PrintRocmTracerEvent(activity_event, ". Dropped!");
-        continue;
-      }
+    const RocmTracerEvent* api_event = nullptr;
+    if (auto it = api_events_map_.find(corr_id); it != api_events_map_.end()) {
+      api_event = &it->second;
+    } else if (auto it_aux = auxiliary_api_events_map_.find(corr_id);
+               it_aux != auxiliary_api_events_map_.end()) {
+      api_event = &it_aux->second;
     }
 
-    switch (activity_event.type) {
-      case RocmTracerEventType::Kernel:
-        activity_event.kernel_info = api_event->second.kernel_info;
-        PrintRocmTracerEvent(activity_event,
-                             ". activity event from api_event.");
-        aggregated_events.push_back(activity_event);
-        break;
+    if (api_event == nullptr) {
+      // Drop the entire vector together; log once per correlation_id
+      // instead of per activity event (the activities all share corr_id).
+      OnEventsDropped(
+          "An event from activity was discarded."
+          "Could not find the counterpart HIP API.",
+          corr_id);
+      PrintRocmTracerEvent(activity_iter.second.front(), ". Dropped!");
+      continue;
+    }
 
-      case RocmTracerEventType::MemcpyD2H:
-      case RocmTracerEventType::MemcpyH2D:
-      case RocmTracerEventType::MemcpyD2D:
-      case RocmTracerEventType::MemcpyOther:
-        // activity_event.memcpy_info = api_event->second.memcpy_info;
-        aggregated_events.push_back(activity_event);
-        break;
-      case RocmTracerEventType::Memset:
-        activity_event.memset_info = api_event->second.memset_info;
-        aggregated_events.push_back(activity_event);
-        break;
+    for (auto& activity_event : activity_iter.second) {
+      switch (activity_event.type) {
+        case RocmTracerEventType::Kernel:
+          activity_event.kernel_info = api_event->kernel_info;
+          PrintRocmTracerEvent(activity_event,
+                               ". activity event from api_event.");
+          aggregated_events.push_back(activity_event);
+          break;
 
-      case RocmTracerEventType::MemoryAlloc:
-      case RocmTracerEventType::MemoryFree:
-        activity_event.device_id = api_event->second.device_id;
-        aggregated_events.push_back(activity_event);
-        break;
+        case RocmTracerEventType::MemcpyD2H:
+        case RocmTracerEventType::MemcpyH2D:
+        case RocmTracerEventType::MemcpyD2D:
+        case RocmTracerEventType::MemcpyOther:
+          // activity_event.memcpy_info = api_event->memcpy_info;
+          aggregated_events.push_back(activity_event);
+          break;
+        case RocmTracerEventType::Memset:
+          activity_event.memset_info = api_event->memset_info;
+          aggregated_events.push_back(activity_event);
+          break;
 
-      case RocmTracerEventType::Synchronization:
-        activity_event.device_id = api_event->second.device_id;
-        aggregated_events.push_back(activity_event);
-        break;
-      default:
-        OnEventsDropped("Missing API-Activity information exchange. Dropped!",
-                        activity_event.correlation_id);
-        PrintRocmTracerEvent(activity_event, ". Dropped!");
-        LOG(WARNING) << "A ROCm activity event with unimplemented API "
-                        "callback merge dropped! "
-                        "Type="
-                     << GetRocmTracerEventTypeName(activity_event.type);
-    }  // switch
-  }  // for
+        case RocmTracerEventType::MemoryAlloc:
+        case RocmTracerEventType::MemoryFree:
+          activity_event.device_id = api_event->device_id;
+          aggregated_events.push_back(activity_event);
+          break;
+
+        case RocmTracerEventType::Synchronization:
+          activity_event.device_id = api_event->device_id;
+          aggregated_events.push_back(activity_event);
+          break;
+        default:
+          OnEventsDropped("Missing API-Activity information exchange. Dropped!",
+                          activity_event.correlation_id);
+          PrintRocmTracerEvent(activity_event, ". Dropped!");
+          LOG(WARNING) << "A ROCm activity event with unimplemented API "
+                          "callback merge dropped! "
+                          "Type="
+                       << GetRocmTracerEventTypeName(activity_event.type);
+      }  // switch
+    }    // for activity_event
+  }      // for activity_iter
 
   return aggregated_events;
 }

--- a/xla/backends/profiler/gpu/rocm_collector_test.cc
+++ b/xla/backends/profiler/gpu/rocm_collector_test.cc
@@ -15,10 +15,13 @@ limitations under the License.
 
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 
+#include <cstddef>
 #include <cstdint>
+#include <string>
 #include <utility>
 
 #include <gtest/gtest.h>
+#include "absl/container/flat_hash_set.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/profiler/utils/xplane_utils.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
@@ -102,6 +105,100 @@ TEST(RocmCollectorTest, TestAddKernelEventAndExport) {
   EXPECT_EQ(event.duration_ps(), (kEndTimeNs - kStartTimeNs) * 1000);
   EXPECT_EQ(gpu_plane->event_metadata().at(event.metadata_id()).name(),
             "test_rocm_kernel");
+}
+
+// Regression test for the .front()-only iteration bug in
+// ApiActivityInfoExchange. When N activity events share one
+// correlation_id (the rocprofiler-sdk pattern for hipGraphLaunch-replayed
+// kernels), all N must reach the exported XPlane, not just the first.
+TEST(RocmCollectorTest, MultipleActivitiesPerCorrelationIdAllExported) {
+  RocmTraceCollectorOptions options;
+  options.max_callback_api_events = 100;
+  options.max_activity_api_events = 100;
+  options.max_annotation_strings = 100;
+  options.num_gpus = 1;
+
+  constexpr uint64_t kStartWallTimeNs = 1000;
+  constexpr uint64_t kStartGpuTimeNs = 2000;
+  RocmTraceCollectorImpl collector(options, kStartWallTimeNs, kStartGpuTimeNs);
+
+  // Single correlation_id shared by all events -- mirrors a hipGraphLaunch
+  // that replays a captured graph: one API call, many kernel-dispatch
+  // records emitted by rocprofiler-sdk under the same correlation_id.
+  constexpr uint32_t kCorrelationId = 7;
+  constexpr uint32_t kDeviceId = 100;
+  constexpr uint64_t kStreamId = 123;
+
+  RocmTracerEvent api_event;
+  api_event.type = RocmTracerEventType::Kernel;
+  api_event.source = RocmTracerEventSource::ApiCallback;
+  api_event.domain = RocmTracerEventDomain::HIP_API;
+  api_event.name = "hipGraphLaunch";
+  api_event.correlation_id = kCorrelationId;
+  api_event.thread_id = 999;
+  api_event.kernel_info = KernelDetails{};
+  api_event.kernel_info.func_ptr = reinterpret_cast<void*>(0xdeadbeef);
+  collector.AddEvent(std::move(api_event), /*is_auxiliary=*/false);
+
+  // Three GPU activity records, same correlation_id, same stream (so
+  // they land on the same XLine), distinct names and timestamps.
+  struct ActivityShape {
+    const char* name;
+    uint64_t start_ns;
+    uint64_t end_ns;
+  };
+  constexpr ActivityShape kActivities[] = {
+      {"kernel_a", 3000, 3500},
+      {"kernel_b", 3500, 4000},
+      {"kernel_c", 4000, 4500},
+  };
+  for (const auto& shape : kActivities) {
+    RocmTracerEvent activity;
+    activity.type = RocmTracerEventType::Kernel;
+    activity.source = RocmTracerEventSource::Activity;
+    activity.domain = RocmTracerEventDomain::HIP_OPS;
+    activity.name = shape.name;
+    activity.correlation_id = kCorrelationId;
+    activity.start_time_ns = shape.start_ns;
+    activity.end_time_ns = shape.end_ns;
+    activity.device_id = kDeviceId;
+    activity.stream_id = kStreamId;
+    collector.AddEvent(std::move(activity), /*is_auxiliary=*/false);
+  }
+
+  collector.Flush();
+  tensorflow::profiler::XSpace space;
+  collector.Export(&space);
+
+  const auto* gpu_plane =
+      FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu_plane, nullptr);
+
+  // Pre-fix (.front()-only) would emit just one event here. The fix
+  // iterates the entire vector, so all three activity records must
+  // appear on the stream line.
+  size_t total_kernel_events = 0;
+  absl::flat_hash_set<std::string> seen_names;
+  for (const auto& line : gpu_plane->lines()) {
+    if (line.id() != static_cast<int64_t>(kStreamId)) {
+      continue;
+    }
+    total_kernel_events += line.events_size();
+    for (const auto& ev : line.events()) {
+      seen_names.insert(
+          gpu_plane->event_metadata().at(ev.metadata_id()).name());
+    }
+  }
+
+  EXPECT_EQ(total_kernel_events, 3u)
+      << "Expected all 3 activity records to be emitted under the same "
+         "correlation_id; got "
+      << total_kernel_events
+      << " (this is the "
+         "regression the .front()-only iteration introduced).";
+  EXPECT_TRUE(seen_names.contains("kernel_a"));
+  EXPECT_TRUE(seen_names.contains("kernel_b"));
+  EXPECT_TRUE(seen_names.contains("kernel_c"));
 }
 
 }  // namespace test


### PR DESCRIPTION
📝 Summary of Changes
- The second half of ApiActivityInfoExchange in `xla/backends/profiler/gpu/rocm_collector.cc` keyed activities by  correlation_id and read only `activity_iter.second.front()`. 
- This is problem with when hipGraphLaunch is involved because single graph launch can have multiple kernels all with same correlation ID. and all that gets recorded only once in xplane because it only reads front()



🎯 Justification
without this change whenever command buffer is ON xla profiler drops events and events in final trace will be missing.
- Iterate the entire activity vector instead of only .front().
- Hoist the API-event lookup out of the inner loop (invariant across the vector since all activities share the correlation_id).


🚀 Kind of Contribution
🐛 Bug Fix


🧪 Unit Tests:
Added `RocmCollectorTest.MultipleActivitiesPerCorrelationIdAllExported` in rocm_collector_test.cc. Inserts one api_event + three activity events all sharing one correlation_id (the hipGraphLaunch shape), runs Flush() + Export(), and asserts all three kernel records appear in the xplane device plane.


