### PR TITLE
[XLA:CPU][oneDNN] Enforce c++17 for async oneDNN build file

### DIFF
--- a/third_party/mkl_dnn/mkldnn_v1_async.BUILD
+++ b/third_party/mkl_dnn/mkldnn_v1_async.BUILD
@@ -127,6 +127,11 @@ _COPTS_LIST = select({
     "-DDNNL_ENABLE_GRAPH_DUMP",
 ] + tf_openmp_copts()
 
+_CXXOPTS_LIST = select({
+    "@xla//xla/tsl:windows": ["/std:c++17"],
+    "//conditions:default": ["-std=c++17"],
+})
+
 _INCLUDES_LIST = [
     "include",
     "src",
@@ -172,7 +177,17 @@ cc_library(
     copts = [
         "-O1",
         "-U_FORTIFY_SOURCE",
-    ] + _COPTS_LIST,
+    ] + _COPTS_LIST + _CXXOPTS_LIST,
+    includes = _INCLUDES_LIST,
+    textual_hdrs = _TEXTUAL_HDRS_LIST,
+    visibility = ["//visibility:public"],
+)
+
+# Separate out the C-library to limit copts.
+cc_library(
+    name = "onednn_ittnotify",
+    srcs = glob(["third_party/ittnotify/*.c"]),
+    copts = _COPTS_LIST,
     includes = _INCLUDES_LIST,
     textual_hdrs = _TEXTUAL_HDRS_LIST,
     visibility = ["//visibility:public"],
@@ -197,7 +212,6 @@ cc_library(
             "src/graph/backend/dnnl/kernels/*.cpp",
             "src/graph/utils/*.cpp",
             "src/graph/utils/pm/*.cpp",
-            "third_party/ittnotify/*.c",
         ],
         exclude = [
             "src/cpu/aarch64/**",
@@ -207,7 +221,7 @@ cc_library(
             "src/cpu/sycl/**",
         ],
     ),
-    copts = _COPTS_LIST,
+    copts = _COPTS_LIST + _CXXOPTS_LIST,
     includes = _INCLUDES_LIST,
     # TODO(penpornk): Use lrt_if_needed from tensorflow.bzl instead.
     linkopts = select({
@@ -219,7 +233,10 @@ cc_library(
     }),
     textual_hdrs = _TEXTUAL_HDRS_LIST,
     visibility = ["//visibility:public"],
-    deps = [":onednn_autogen"] + if_mkl_ml(
+    deps = [
+        ":onednn_autogen",
+        ":onednn_ittnotify",
+    ] + if_mkl_ml(
         ["@xla//xla/tsl/mkl:intel_binary_blob"],
         [],
     ),


### PR DESCRIPTION
This PR replicates the [recent commit](https://github.com/openxla/xla/commit/e01d84e609f1c0329f422575a607e5c6a5d65f36) that enforces C++17 for the oneDNN build (`mkldnn_v1.BUILD`) in `mkldnn_v1_async.BUILD`.