### PR TITLE
[xla:gpu] Add DynamicSliceFusionRewriterV2 targeting V2 DUS-fusions

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1474,6 +1474,62 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "dynamic_slice_fusion_rewriter_v2",
+    srcs = ["dynamic_slice_fusion_rewriter_v2.cc"],
+    hdrs = ["dynamic_slice_fusion_rewriter_v2.h"],
+    tags = ["gpu"],
+    deps = [
+        "//xla:shape_util",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/service/gpu:gpu_constants",
+        "//xla/service/gpu:ir_emission_utils",
+        "//xla/stream_executor:platform_id",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/functional:any_invocable",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+xla_cc_test(
+    name = "dynamic_slice_fusion_rewriter_v2_test",
+    srcs = ["dynamic_slice_fusion_rewriter_v2_test.cc"],
+    tags = [
+        "cuda-only",
+        "gpu",
+    ],
+    deps = [
+        ":dynamic_slice_annotator",
+        ":dynamic_slice_fusion",
+        ":dynamic_slice_fusion_rewriter_v2",
+        "//xla:shape_util",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass_pipeline",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service:platform_util",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/stream_executor:platform_id",
+        "//xla/stream_executor/gpu:gpu_init_impl",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest_main",  # fixdeps: keep
+    ],
+)
+
+cc_library(
     name = "explicit_collectives_group_async_wrapper",
     srcs = ["explicit_collectives_group_async_wrapper.cc"],
     hdrs = ["explicit_collectives_group_async_wrapper.h"],

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
@@ -1,0 +1,646 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/algorithm/container.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/container/inlined_vector.h"
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/gpu_constants.h"
+#include "xla/service/gpu/ir_emission_utils.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+
+namespace xla::gpu {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Data structures
+//===----------------------------------------------------------------------===//
+
+// A hero operand path: slice → noops → hero. Describes a Slice or
+// DynamicSlice instruction feeding the hero through zero or more no-op
+// instructions (bitcasts, GTEs).
+struct SlicedParameter {
+  // The Slice or DynamicSlice instruction at the start of the chain.
+  HloInstruction* slice;
+
+  // Bitcasts/GTEs between the slice and the hero (topological order).
+  std::vector<HloInstruction*> noops;
+};
+
+// A hero result path: hero → [GTE] → [bitcasts] → DUS. Describes how one hero
+// output flows through an optional GTE and bitcasts into a DynamicUpdateSlice
+// that writes it into a target buffer. The `noops` vector holds the full chain
+// (GTE first, then bitcasts). For passthrough results (tuple outputs without
+// DUS), update_slice is nullptr and noops contains only the GTE.
+//
+// For flat tuple-producing heroes, there is one SlicedResult per tuple element.
+struct SlicedResult {
+  // Flat tuple element index within the hero's output shape. Matches
+  // DynamicSliceFusion::Result::result_number. 0 for non-tuple heroes.
+  int64_t result_number = 0;
+
+  // Instructions between the hero output and the DUS: GTE (for tuple heroes)
+  // followed by bitcasts. Empty when the leaf has no users in the original HLO
+  // (dead output) or for non-tuple heroes without bitcasts.
+  std::vector<HloInstruction*> noops;
+
+  // The DynamicUpdateSlice at the end of the chain. nullptr for passthrough
+  // results (tuple outputs that don't flow through a DUS).
+  HloInstruction* update_slice = nullptr;
+};
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+bool IsNoOp(const HloInstruction* instr) {
+  return instr->opcode() == HloOpcode::kBitcast ||
+         instr->opcode() == HloOpcode::kGetTupleElement;
+}
+
+bool HasDynamicSliceConfig(const HloInstruction* instr) {
+  auto config = instr->backend_config<GpuBackendConfig>();
+  if (!config.ok()) {
+    return false;
+  }
+  return config->has_dynamic_slice_config();
+}
+
+bool IsAlignedSlice(const HloInstruction* instr) {
+  if (!IsContiguousSlice(*instr)) {
+    return false;
+  }
+
+  const Shape& slice_shape = instr->opcode() == HloOpcode::kDynamicUpdateSlice
+                                 ? instr->operand(1)->shape()
+                                 : instr->shape();
+
+  auto byte_strides = ShapeUtil::ByteStrides(slice_shape);
+  if (!byte_strides.has_value()) {
+    return false;
+  }
+
+  int64_t slice_bytes = ShapeUtil::ByteSizeOf(slice_shape);
+  return slice_bytes % kXlaAllocatedBufferAlignBytes == 0;
+}
+
+bool HasSupportedShapes(const HloInstruction* hero) {
+  for (const HloInstruction* operand : hero->operands()) {
+    if (operand->shape().IsTuple()) {
+      LOG(WARNING) << "DynamicSliceFusionRewriterV2: skipping " << hero->name()
+                   << " because operand " << operand->name() << " is a tuple";
+      return false;
+    }
+  }
+  if (hero->shape().IsTuple()) {
+    for (const Shape& tuple_shape : hero->shape().tuple_shapes()) {
+      if (tuple_shape.IsTuple()) {
+        LOG(WARNING) << "DynamicSliceFusionRewriterV2: skipping "
+                     << hero->name()
+                     << " because nested tuple results are not supported";
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// Resolve sliced parameters
+//===----------------------------------------------------------------------===//
+
+using OptLevel = DynamicSliceFusionRewriterV2::OptLevel;
+using CaptureSlice = DynamicSliceFusionRewriterV2::CaptureSlice;
+using CaptureUpdateSlice = DynamicSliceFusionRewriterV2::CaptureUpdateSlice;
+
+std::optional<SlicedParameter> ResolveSlicedParameter(HloInstruction* operand,
+                                                      OptLevel opt_level) {
+  HloInstruction* current = operand;
+
+  // Walk backward through no-ops to find the slice. In O2 mode, also look
+  // through tuple→GTE barriers: if a chain of GTEs resolves through
+  // corresponding tuple instructions, we skip the entire GTE/tuple tower and
+  // continue from the innermost tuple operand. These are NOT added to noops.
+  std::vector<HloInstruction*> noops;
+  while (IsNoOp(current)) {
+    if (opt_level == OptLevel::kO2 &&
+        current->opcode() == HloOpcode::kGetTupleElement) {
+      // Collect a chain of GTEs, then try to resolve through
+      // opt-barriers and tuples back to the original operand.
+      std::vector<int64_t> indices;
+      HloInstruction* probe = current;
+      while (probe->opcode() == HloOpcode::kGetTupleElement) {
+        indices.push_back(
+            Cast<HloGetTupleElementInstruction>(probe)->tuple_index());
+        probe = probe->mutable_operand(0);
+      }
+      // Skip through optimization barriers (they pass tuples through
+      // unchanged).
+      while (probe->opcode() == HloOpcode::kOptimizationBarrier) {
+        probe = probe->mutable_operand(0);
+      }
+      // Walk the tuple chain: each index peels one tuple layer.
+      bool resolved = true;
+      for (int64_t idx : indices) {
+        if (probe->opcode() != HloOpcode::kTuple) {
+          resolved = false;
+          break;
+        }
+        probe = probe->mutable_operand(idx);
+      }
+      if (resolved) {
+        current = probe;
+        continue;
+      }
+    }
+    noops.push_back(current);
+    current = current->mutable_operand(0);
+  }
+
+  if (auto* slice = DynCast<HloSliceInstruction>(current)) {
+    if (!IsAlignedSlice(slice)) {
+      return std::nullopt;
+    }
+    absl::c_reverse(noops);
+    return SlicedParameter{slice, std::move(noops)};
+  }
+
+  if (auto* ds = DynCast<HloDynamicSliceInstruction>(current)) {
+    if (!HasDynamicSliceConfig(ds)) {
+      return std::nullopt;
+    }
+    if (!IsAlignedSlice(ds)) {
+      return std::nullopt;
+    }
+    absl::c_reverse(noops);
+    return SlicedParameter{ds, std::move(noops)};
+  }
+
+  return std::nullopt;
+}
+
+std::vector<SlicedParameter> ResolveSlicedParameters(
+    HloInstruction* hero, OptLevel opt_level,
+    const CaptureSlice& capture_slice) {
+  std::vector<SlicedParameter> result;
+  for (int64_t i = 0; i < hero->operand_count(); ++i) {
+    HloInstruction* operand = hero->mutable_operand(i);
+    auto param = ResolveSlicedParameter(operand, opt_level);
+    if (!param.has_value()) {
+      continue;
+    }
+    if (!capture_slice(hero, i, param->slice)) {
+      continue;
+    }
+    // In O2 mode, the chain output may differ from the hero's operand when
+    // we looked through a tuple/GTE barrier. Replace the hero's operand so
+    // BuildFusionPlan sees a connected graph. Safe because the hero will be
+    // replaced by the fusion.
+    HloInstruction* chain_output =
+        param->noops.empty() ? param->slice : param->noops.back();
+    if (chain_output != operand) {
+      CHECK_OK(hero->ReplaceOperandWith(i, chain_output));
+    }
+    result.push_back(std::move(*param));
+  }
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
+// Resolve sliced results
+//===----------------------------------------------------------------------===//
+
+std::optional<SlicedResult> ResolveSlicedResult(HloInstruction* user) {
+  HloInstruction* current = user;
+
+  // Walk forward through no-ops to find the DUS.
+  std::vector<HloInstruction*> noops;
+  while (IsNoOp(current)) {
+    if (current->user_count() != 1) {
+      return std::nullopt;
+    }
+    noops.push_back(current);
+    current = current->users().front();
+  }
+
+  auto* dus = DynCast<HloDynamicUpdateSliceInstruction>(current);
+  if (dus == nullptr) {
+    return std::nullopt;
+  }
+
+  if (!HasDynamicSliceConfig(dus)) {
+    return std::nullopt;
+  }
+
+  if (!IsAlignedSlice(dus)) {
+    return std::nullopt;
+  }
+
+  // DUS must flow into the root: either IS the root, or feeds root tuple.
+  HloComputation* parent = dus->parent();
+  HloInstruction* root = parent->root_instruction();
+  if (dus != root) {
+    if (root->opcode() != HloOpcode::kTuple) {
+      return std::nullopt;
+    }
+    bool feeds_root =
+        absl::c_any_of(root->operands(),
+                       [dus](const HloInstruction* op) { return op == dus; });
+    if (!feeds_root) {
+      return std::nullopt;
+    }
+  }
+
+  return SlicedResult{0, std::move(noops), dus};
+}
+
+// Finds the GTE user of `hero` that extracts the given tuple index.
+HloInstruction* FindGte(HloInstruction* hero, int64_t tuple_index) {
+  for (HloInstruction* user : hero->users()) {
+    auto* gte = DynCast<HloGetTupleElementInstruction>(user);
+    if (gte != nullptr && gte->tuple_index() == tuple_index) {
+      return gte;
+    }
+  }
+  return nullptr;
+}
+
+// Walks forward from `gte` to find a DUS chain. If found, returns a
+// SlicedResult with the GTE prepended into noops.
+std::optional<SlicedResult> ResolveLeafDus(HloInstruction* gte) {
+  for (HloInstruction* user : gte->users()) {
+    if (auto sliced = ResolveSlicedResult(user)) {
+      sliced->noops.insert(sliced->noops.begin(), gte);
+      return sliced;
+    }
+  }
+  return std::nullopt;
+}
+
+// Resolves the sliced result for a non-tuple hero.
+std::vector<SlicedResult> ResolveNonTupleSlicedResult(
+    HloInstruction* hero, const CaptureUpdateSlice& capture_update_slice) {
+  for (HloInstruction* user : hero->users()) {
+    if (auto sliced = ResolveSlicedResult(user)) {
+      if (!capture_update_slice(hero, std::nullopt, sliced->update_slice)) {
+        continue;
+      }
+      return std::vector<SlicedResult>{std::move(*sliced)};
+    }
+  }
+  return {};
+}
+
+// Resolves sliced results for a flat tuple-producing hero. Returns one
+// SlicedResult per tuple element.
+std::vector<SlicedResult> ResolveTupleSlicedResults(
+    HloInstruction* hero, const CaptureUpdateSlice& capture_update_slice) {
+  const int64_t tuple_size = hero->shape().tuple_shapes().size();
+
+  struct LeafInfo {
+    int64_t result_number;
+    HloInstruction* gte;
+    std::optional<SlicedResult> sliced_update;
+  };
+
+  std::vector<LeafInfo> leaf_infos;
+  leaf_infos.reserve(tuple_size);
+  for (int64_t i = 0; i < tuple_size; ++i) {
+    HloInstruction* gte = FindGte(hero, i);
+    std::optional<SlicedResult> sliced_update;
+    if (gte != nullptr) {
+      sliced_update = ResolveLeafDus(gte);
+    }
+    leaf_infos.push_back({i, gte, std::move(sliced_update)});
+  }
+
+  std::vector<SlicedResult> result;
+  result.reserve(tuple_size);
+  for (auto& info : leaf_infos) {
+    if (info.sliced_update.has_value() &&
+        capture_update_slice(hero, info.result_number,
+                             info.sliced_update->update_slice)) {
+      info.sliced_update->result_number = info.result_number;
+      result.push_back(std::move(*info.sliced_update));
+      continue;
+    }
+
+    SlicedResult passthrough;
+    passthrough.result_number = info.result_number;
+    if (info.gte != nullptr) {
+      passthrough.noops.push_back(info.gte);
+    }
+    result.push_back(std::move(passthrough));
+  }
+  return result;
+}
+
+std::vector<SlicedResult> ResolveSlicedResults(
+    HloInstruction* hero, const CaptureUpdateSlice& capture_update_slice) {
+  if (hero->shape().IsTuple()) {
+    return ResolveTupleSlicedResults(hero, capture_update_slice);
+  }
+  return ResolveNonTupleSlicedResult(hero, capture_update_slice);
+}
+
+//===----------------------------------------------------------------------===//
+// Build fusion plan
+//===----------------------------------------------------------------------===//
+
+// Complete plan for creating a dynamic-slice fusion from a hero instruction.
+// Contains all instructions to include in the fusion body and the external
+// operands (captures).
+struct DynamicSliceFusionPlan {
+  // Operands of `instructions` that are not in the set — these become fusion
+  // parameters (e.g., the original buffers, loop induction variable,
+  // constants).
+  std::vector<HloInstruction*> captures;
+
+  // All instructions to clone into the fusion body (topological order):
+  // slices, noops, hero, result noops, DUS instructions. The last instruction
+  // becomes the fusion root (may be a single DUS, or the hero itself when
+  // there are no DUS results). When there are multiple results,
+  // CreateFusionBody appends a tuple instruction as the root.
+  std::vector<HloInstruction*> instructions;
+};
+
+std::optional<DynamicSliceFusionPlan> BuildFusionPlan(
+    HloInstruction* hero, absl::Span<const SlicedParameter> sliced_params,
+    absl::Span<const SlicedResult> sliced_results) {
+  bool has_any_slice = !sliced_params.empty() ||
+                       absl::c_any_of(sliced_results, [](const auto& r) {
+                         return r.update_slice != nullptr;
+                       });
+  if (!has_any_slice) {
+    return std::nullopt;
+  }
+
+  std::vector<HloInstruction*> instructions;
+  absl::flat_hash_set<HloInstruction*> instruction_set;
+
+  auto add_instr = [&](HloInstruction* instr) {
+    if (instruction_set.insert(instr).second) {
+      instructions.push_back(instr);
+    }
+  };
+
+  // Add sliced parameter paths (topological: slice → noops → hero).
+  for (const auto& param : sliced_params) {
+    add_instr(param.slice);
+    for (HloInstruction* noop : param.noops) {
+      add_instr(noop);
+    }
+  }
+
+  add_instr(hero);
+
+  // Add sliced result paths (topological: hero → noops → DUS).
+  // For passthrough results (no DUS), add the GTE chain so the hero output
+  // is accessible inside the fusion.
+  for (const auto& result : sliced_results) {
+    for (HloInstruction* noop : result.noops) {
+      add_instr(noop);
+    }
+    if (result.update_slice != nullptr) {
+      add_instr(result.update_slice);
+    }
+  }
+
+  // Sink constants into the fusion body instead of capturing them as
+  // parameters. Constants have no operands so they go at the front.
+  std::vector<HloInstruction*> constants;
+  for (HloInstruction* instr : instructions) {
+    for (HloInstruction* operand : instr->operands()) {
+      if (operand->opcode() == HloOpcode::kConstant &&
+          instruction_set.insert(operand).second) {
+        constants.push_back(operand);
+      }
+    }
+  }
+  instructions.insert(instructions.begin(), constants.begin(), constants.end());
+
+  // Collect captures: operands of instructions that are not in the set.
+  std::vector<HloInstruction*> captures;
+  absl::flat_hash_set<HloInstruction*> capture_set;
+  for (HloInstruction* instr : instructions) {
+    for (HloInstruction* operand : instr->operands()) {
+      if (!instruction_set.contains(operand) &&
+          capture_set.insert(operand).second) {
+        captures.push_back(operand);
+      }
+    }
+  }
+
+  return DynamicSliceFusionPlan{std::move(captures), std::move(instructions)};
+}
+
+//===----------------------------------------------------------------------===//
+// Create fusion
+//===----------------------------------------------------------------------===//
+
+absl::StatusOr<HloComputation*> CreateFusionBody(
+    HloModule* module, const DynamicSliceFusionPlan& plan,
+    absl::Span<const SlicedResult> sliced_results, HloInstruction* hero) {
+  HloComputation::Builder builder("dynamic-slice-fusion");
+
+  absl::flat_hash_map<const HloInstruction*, HloInstruction*> instr_mapping;
+  instr_mapping.reserve(plan.captures.size() + plan.instructions.size());
+
+  // Create parameters for captures.
+  for (const HloInstruction* capture : plan.captures) {
+    int64_t index = instr_mapping.size();
+    instr_mapping[capture] =
+        builder.AddInstruction(HloInstruction::CreateParameter(
+            index, capture->shape(), absl::StrCat("p", index)));
+  }
+
+  auto mapped_operands = [&](HloInstruction* instr) {
+    absl::InlinedVector<HloInstruction*, 4> operands;
+    operands.reserve(instr->operand_count());
+    for (HloInstruction* operand : instr->operands()) {
+      operands.push_back(instr_mapping.at(operand));
+    }
+    return operands;
+  };
+
+  // Clone instructions in topological order.
+  for (HloInstruction* instr : plan.instructions) {
+    instr_mapping[instr] = builder.AddInstruction(
+        instr->CloneWithNewOperands(instr->shape(), mapped_operands(instr)));
+  }
+
+  // Build root tuple when there are multiple results (DUS and/or passthrough).
+  if (sliced_results.size() > 1) {
+    HloInstruction* cloned_hero = instr_mapping.at(hero);
+    std::vector<HloInstruction*> tuple_operands;
+    tuple_operands.reserve(sliced_results.size());
+    for (const auto& result : sliced_results) {
+      if (result.update_slice != nullptr) {
+        tuple_operands.push_back(instr_mapping.at(result.update_slice));
+      } else if (!result.noops.empty()) {
+        tuple_operands.push_back(instr_mapping.at(result.noops.back()));
+      } else {
+        // Dead output: create a GTE from the cloned hero to extract this tuple
+        // element so the fusion output has a buffer slot for it.
+        tuple_operands.push_back(
+            builder.AddInstruction(HloInstruction::CreateGetTupleElement(
+                cloned_hero, result.result_number)));
+      }
+    }
+    builder.AddInstruction(HloInstruction::CreateTuple(tuple_operands));
+  }
+
+  return module->AddComputationAndUnifyNamesAndIds(builder.Build(), false);
+}
+
+absl::Status SetDsfBackendConfig(HloInstruction* fusion) {
+  GpuBackendConfig gpu_config;
+  FusionBackendConfig& backend_config =
+      *gpu_config.mutable_fusion_backend_config();
+  backend_config.set_kind("__custom_fusion");
+  CustomFusionConfig config;
+  config.set_name(std::string(kDynamicSliceFusionConfigName));
+  *backend_config.mutable_custom_fusion_config() = config;
+  return fusion->set_backend_config(std::move(gpu_config));
+}
+
+//===----------------------------------------------------------------------===//
+// Rewrite sync hero
+//===----------------------------------------------------------------------===//
+
+absl::StatusOr<bool> RewriteHero(
+    HloModule* module, HloInstruction* hero,
+    absl::Span<const SlicedParameter> sliced_params,
+    absl::Span<const SlicedResult> sliced_results) {
+  auto plan = BuildFusionPlan(hero, sliced_params, sliced_results);
+  if (!plan.has_value()) {
+    return false;
+  }
+
+  ASSIGN_OR_RETURN(HloComputation * fusion_body,
+                   CreateFusionBody(module, *plan, sliced_results, hero));
+
+  HloComputation* parent = hero->parent();
+  HloInstruction* fusion = parent->AddInstruction(HloInstruction::CreateFusion(
+      fusion_body->root_instruction()->shape(),
+      HloInstruction::FusionKind::kCustom, plan->captures, fusion_body));
+  module->SetAndUniquifyInstrName(fusion, "dynamic_slice_fusion");
+  RETURN_IF_ERROR(SetDsfBackendConfig(fusion));
+
+  if (sliced_results.size() > 1) {
+    bool any_result_replaced = false;
+    for (int64_t i = 0; i < sliced_results.size(); ++i) {
+      auto* gte = parent->AddInstruction(
+          HloInstruction::CreateGetTupleElement(fusion, i));
+      if (sliced_results[i].update_slice != nullptr) {
+        RETURN_IF_ERROR(
+            parent->ReplaceInstruction(sliced_results[i].update_slice, gte));
+        any_result_replaced = true;
+      } else if (!sliced_results[i].noops.empty()) {
+        HloInstruction* original_leaf = sliced_results[i].noops.back();
+        RETURN_IF_ERROR(parent->ReplaceInstruction(original_leaf, gte));
+        any_result_replaced = true;
+      }
+    }
+    if (!any_result_replaced) {
+      RETURN_IF_ERROR(parent->ReplaceInstruction(hero, fusion));
+    }
+  } else if (sliced_results.size() == 1) {
+    if (sliced_results[0].update_slice != nullptr) {
+      RETURN_IF_ERROR(
+          parent->ReplaceInstruction(sliced_results[0].update_slice, fusion));
+    } else {
+      RETURN_IF_ERROR(parent->ReplaceInstruction(hero, fusion));
+    }
+  } else {
+    RETURN_IF_ERROR(parent->ReplaceInstruction(hero, fusion));
+  }
+
+  return true;
+}
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// RunImpl
+//===----------------------------------------------------------------------===//
+
+absl::StatusOr<bool> DynamicSliceFusionRewriterV2::RunImpl(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool changed = false;
+
+  std::vector<HloComputation*> computations(module->computations().begin(),
+                                            module->computations().end());
+  for (HloComputation* computation : computations) {
+    if (computation->IsFusionComputation()) {
+      continue;
+    }
+
+    std::vector<HloInstruction*> heroes;
+    for (HloInstruction* candidate : computation->instructions()) {
+      if (!options_.predicate(candidate)) {
+        continue;
+      }
+      if (candidate->opcode() == HloOpcode::kAsyncStart) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "DynamicSliceFusionRewriterV2 predicate must not match "
+            "async-start instructions, but matched: ",
+            candidate->name()));
+      }
+      if (HasSupportedShapes(candidate)) {
+        heroes.push_back(candidate);
+      }
+    }
+
+    for (HloInstruction* hero : heroes) {
+      auto sliced_params = ResolveSlicedParameters(hero, options_.opt_level,
+                                                   options_.capture_slice);
+      auto sliced_results =
+          ResolveSlicedResults(hero, options_.capture_update_slice);
+      ASSIGN_OR_RETURN(
+          bool hero_changed,
+          RewriteHero(module, hero, sliced_params, sliced_results));
+      changed |= hero_changed;
+    }
+  }
+
+  return changed;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
@@ -115,7 +115,7 @@ bool IsAlignedSlice(const HloInstruction* instr) {
     return false;
   }
 
-  int64_t slice_bytes = ShapeUtil::ByteSizeOf(slice_shape);
+  int64_t slice_bytes = ShapeUtil::ByteSizeOfElements(slice_shape);
   return slice_bytes % kXlaAllocatedBufferAlignBytes == 0;
 }
 
@@ -528,7 +528,7 @@ absl::StatusOr<HloComputation*> CreateFusionBody(
   return module->AddComputationAndUnifyNamesAndIds(builder.Build(), false);
 }
 
-absl::Status SetDsfBackendConfig(HloInstruction* fusion) {
+absl::Status SetDynamicSliceFusionBackendConfig(HloInstruction* fusion) {
   GpuBackendConfig gpu_config;
   FusionBackendConfig& backend_config =
       *gpu_config.mutable_fusion_backend_config();
@@ -560,7 +560,7 @@ absl::StatusOr<bool> RewriteHero(
       fusion_body->root_instruction()->shape(),
       HloInstruction::FusionKind::kCustom, plan->captures, fusion_body));
   module->SetAndUniquifyInstrName(fusion, "dynamic_slice_fusion");
-  RETURN_IF_ERROR(SetDsfBackendConfig(fusion));
+  RETURN_IF_ERROR(SetDynamicSliceFusionBackendConfig(fusion));
 
   if (sliced_results.size() > 1) {
     bool any_result_replaced = false;
@@ -605,13 +605,9 @@ absl::StatusOr<bool> DynamicSliceFusionRewriterV2::RunImpl(
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
   bool changed = false;
 
-  std::vector<HloComputation*> computations(module->computations().begin(),
-                                            module->computations().end());
+  std::vector<HloComputation*> computations =
+      module->MakeNonfusionComputations(execution_threads);
   for (HloComputation* computation : computations) {
-    if (computation->IsFusionComputation()) {
-      continue;
-    }
-
     std::vector<HloInstruction*> heroes;
     for (HloInstruction* candidate : computation->instructions()) {
       if (!options_.predicate(candidate)) {

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.h
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.h
@@ -1,0 +1,104 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_FUSION_REWRITER_V2_H_
+#define XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_FUSION_REWRITER_V2_H_
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/functional/any_invocable.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+#include "xla/stream_executor/platform_id.h"
+
+namespace xla::gpu {
+
+// Dynamic slice fusion rewriter V2 wraps a hero instruction that reads from
+// sliced buffers (via Slice or DynamicSlice) and/or writes into sliced buffers
+// (via DynamicUpdateSlice) into a custom fusion.
+//
+// Requires that the DynamicSliceAnnotator pass has run first to annotate
+// DynamicSlice/DynamicUpdateSlice instructions with DynamicSliceConfig.
+//
+// The pass is configured with options that select hero instructions and decide
+// which sliced input/output edges to pull into each fusion body.
+//
+class DynamicSliceFusionRewriterV2 : public HloModulePass {
+ public:
+  // Selects instructions that are legal hero candidates for dynamic-slice
+  // fusion wrapping. It is evaluated before input/output slicing analysis.
+  using Predicate = absl::AnyInvocable<bool(const HloInstruction*) const>;
+
+  // Called after the pass has resolved an aligned Slice/DynamicSlice chain
+  // feeding one hero operand. Return true to move that slice chain into the
+  // fusion body; return false to leave it outside. For O2 tuple/GTE
+  // look-through, rejecting an input also prevents the temporary hero operand
+  // rewrite for that input.
+  using CaptureSlice =
+      absl::AnyInvocable<bool(const HloInstruction* hero, int64_t operand_index,
+                              const HloInstruction* slice) const>;
+
+  // Called after the pass has resolved an aligned DynamicUpdateSlice chain
+  // consuming one hero result. `result_index` is absent for non-tuple hero
+  // results and contains the flat tuple result number for tuple hero results.
+  // Return true to move that update chain into the fusion body; return false
+  // to leave it outside.
+  using CaptureUpdateSlice = absl::AnyInvocable<bool(
+      const HloInstruction* hero, std::optional<int64_t> result_index,
+      const HloInstruction* dynamic_update_slice) const>;
+
+  enum class OptLevel {
+    // Follow a sequence of no-op (bitcast, tuple, gte) operations to find the
+    // the sliced source
+    kO1,
+    // Aggressive optimization that passes through optimization barriers to find
+    // the sliced source.
+    kO2,
+  };
+
+  struct Options {
+    Predicate predicate = [](auto...) { return false; };
+    CaptureSlice capture_slice = [](auto...) { return true; };
+    CaptureUpdateSlice capture_update_slice = [](auto...) { return true; };
+    OptLevel opt_level = OptLevel::kO1;
+  };
+
+  DynamicSliceFusionRewriterV2(stream_executor::PlatformId platform_id,
+                               Options options)
+      : platform_id_(std::move(platform_id)), options_(std::move(options)) {}
+
+  absl::string_view name() const override {
+    return "dynamic-slice-fusion-rewriter-v2";
+  }
+
+ protected:
+  absl::StatusOr<bool> RunImpl(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  stream_executor::PlatformId platform_id_;
+  Options options_;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_TRANSFORMS_DYNAMIC_SLICE_FUSION_REWRITER_V2_H_

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
@@ -1,0 +1,1940 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.h"
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/log/check.h"
+#include "absl/strings/match.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/gpu/transforms/dynamic_slice_annotator.h"
+#include "xla/backends/gpu/transforms/dynamic_slice_fusion.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_pipeline.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/platform_util.h"
+#include "xla/shape_util.h"
+#include "xla/stream_executor/platform_id.h"  // IWYU pragma: keep
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+
+using CstOff = DynamicSliceFusion::ConstantOffset;
+using RtOff = DynamicSliceFusion::RuntimeOffset;
+using Param = DynamicSliceFusion::Parameter;
+using Result = DynamicSliceFusion::Result;
+
+static constexpr absl::string_view kFakeTarget = "fake_target";
+
+DynamicSliceConfig MakeConfig(int64_t loop_index, int64_t offset,
+                              int64_t stride) {
+  DynamicSliceConfig config;
+  config.set_loop_index(loop_index);
+  config.set_byte_offset(offset);
+  config.set_byte_stride(stride);
+  return config;
+}
+
+DynamicSliceConfig MakeStaticConfig(int64_t offset) {
+  DynamicSliceConfig config;
+  config.set_byte_offset(offset);
+  config.set_byte_stride(0);
+  return config;
+}
+
+const HloComputation* FindDsfBody(HloModule* module) {
+  for (HloComputation* comp : module->computations()) {
+    if (absl::StrContains(comp->name(), "dynamic-slice-fusion")) {
+      return comp;
+    }
+  }
+  return nullptr;
+}
+
+class DynamicSliceFusionRewriterV2Test : public HloHardwareIndependentTestBase {
+  void SetUp() override {
+    auto maybe_name = PlatformUtil::CanonicalPlatformName("gpu");
+    CHECK_OK(maybe_name);
+    auto maybe_platform_id =
+        PlatformUtil::GetPlatformIdFromCanonicalName(maybe_name.value());
+    CHECK_OK(maybe_platform_id);
+    platform_id_ = maybe_platform_id.value();
+  }
+
+ protected:
+  stream_executor::PlatformId platform_id() const { return platform_id_; }
+
+  using Options = DynamicSliceFusionRewriterV2::Options;
+  using OptLevel = DynamicSliceFusionRewriterV2::OptLevel;
+
+  static Options DefaultOptions(OptLevel opt_level = OptLevel::kO1) {
+    Options options;
+    options.predicate = [](const HloInstruction* instr) {
+      auto* custom_call = DynCast<HloCustomCallInstruction>(instr);
+      return custom_call != nullptr &&
+             custom_call->custom_call_target() == kFakeTarget;
+    };
+    options.opt_level = opt_level;
+    return options;
+  }
+
+  HloPassPipeline MakePipeline(OptLevel opt_level = OptLevel::kO1) {
+    return MakePipeline(DefaultOptions(opt_level));
+  }
+
+  HloPassPipeline MakePipeline(Options options) {
+    HloPassPipeline pipeline("test-pipeline");
+    pipeline.AddPass<DynamicSliceAnnotator>();
+    pipeline.AddPass<DynamicSliceFusionRewriterV2>(platform_id(),
+                                                   std::move(options));
+    return pipeline;
+  }
+
+ private:
+  stream_executor::PlatformId platform_id_;
+};
+
+//===----------------------------------------------------------------------===//
+// Sliced operand tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionRewriterV2Test, SlicedOperands) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[2,8,8]{2,1,0} parameter(0)
+      %p1 = f32[2,8,8]{2,1,0} parameter(1)
+      %slice0 = f32[1,8,8]{2,1,0} slice(%p0), slice={[1:2], [0:8], [0:8]}
+      %bitcast0 = f32[8,8]{1,0} bitcast(%slice0)
+      %slice1 = f32[1,8,8]{2,1,0} slice(%p1), slice={[1:2], [0:8], [0:8]}
+      %bitcast1 = f32[8,8]{1,0} bitcast(%slice1)
+      ROOT %hero = f32[8,8]{1,0} custom-call(%bitcast0, %bitcast1),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK-DAG:   {{.*}} f32[2,8,8]{2,1,0} parameter(0)
+    ; CHECK-DAG:   {{.*}} f32[2,8,8]{2,1,0} parameter(1)
+    ; CHECK-DAG:   {{.*}} f32[1,8,8]{2,1,0} slice(
+    ; CHECK-DAG:   {{.*}} f32[8,8]{1,0} bitcast(
+    ; CHECK-DAG:   {{.*}} f32[1,8,8]{2,1,0} slice(
+    ; CHECK-DAG:   {{.*}} f32[8,8]{1,0} bitcast(
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(%p0, %p1),
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_288 = ShapeUtil::MakeShape(F32, {2, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(
+        params,
+        ElementsAre(
+            Param{0, f32_288, f32_188, MakeStaticConfig(256), std::nullopt},
+            Param{1, f32_288, f32_188, MakeStaticConfig(256), std::nullopt}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, SlicedOperandsDuplicateSlice) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[2,8,8]{2,1,0} parameter(0)
+      %slice0 = f32[1,8,8]{2,1,0} slice(%p0), slice={[1:2], [0:8], [0:8]}
+      %bitcast0 = f32[8,8]{1,0} bitcast(%slice0)
+      %slice1 = f32[1,8,8]{2,1,0} slice(%p0), slice={[0:1], [0:8], [0:8]}
+      %bitcast1 = f32[8,8]{1,0} bitcast(%slice1)
+      ROOT %hero = f32[8,8]{1,0} custom-call(%bitcast0, %bitcast1),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       [[P0:%[^ ]+]] = f32[2,8,8]{2,1,0} parameter(0)
+    ; CHECK:       {{.*}} = f32[1,8,8]{2,1,0} slice([[P0]])
+    ; CHECK-SAME:    slice={[1:2], [0:8], [0:8]}
+    ; CHECK:       {{.*}} = f32[8,8]{1,0} bitcast(
+    ; CHECK:       {{.*}} = f32[1,8,8]{2,1,0} slice([[P0]])
+    ; CHECK-SAME:    slice={[0:1], [0:8], [0:8]}
+    ; CHECK:       {{.*}} = f32[8,8]{1,0} bitcast(
+    ; CHECK:       ROOT {{.*}} = f32[8,8]{1,0} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} = f32[8,8]{1,0} fusion(%p0),
+    ; CHECK:              kind=kCustom
+    ; CHECK:     }
+  )";
+
+  auto f32_288 = ShapeUtil::MakeShape(F32, {2, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(
+        params,
+        ElementsAre(
+            Param{0, f32_288, f32_188, MakeStaticConfig(256), std::nullopt},
+            Param{0, f32_288, f32_188, MakeStaticConfig(0), std::nullopt}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, NotContiguousSliceNotFused) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[8,8]{1,0} parameter(0)
+      %slice0 = f32[4,4]{1,0} slice(%p0), slice={[0:4], [0:4]}
+      ROOT %hero = f32[4,4]{1,0} custom-call(%slice0),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), std::nullopt);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, NonNoOpInSliceChainNotFused) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[2,8,8]{2,1,0} parameter(0)
+      %slice0 = f32[1,8,8]{2,1,0} slice(%p0), slice={[1:2], [0:8], [0:8]}
+      %negate = f32[1,8,8]{2,1,0} negate(%slice0)
+      %bitcast0 = f32[8,8]{1,0} bitcast(%negate)
+      ROOT %hero = f32[8,8]{1,0} custom-call(%bitcast0),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), std::nullopt);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, DSWithConstantOffset) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[4,8,8]{2,1,0} parameter(0)
+      %c0 = s32[] constant(0)
+      %c1 = s32[] constant(1)
+      %ds = f32[1,8,8]{2,1,0} dynamic-slice(%p0, %c1, %c0, %c0),
+        dynamic_slice_sizes={1,8,8}
+      %bitcast = f32[8,8]{1,0} bitcast(%ds)
+      ROOT %hero = f32[8,8]{1,0} custom-call(%bitcast),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} dynamic-slice(
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(%p0),
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    std::vector<DynamicSliceFusion::Offset> offsets = {
+        CstOff{0, 0}, CstOff{0, 1}, CstOff{0, 2}};
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_488, f32_188,
+                                          MakeStaticConfig(256), offsets}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, SlicedOperandWithTupleResult) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[2,8,8]{2,1,0} parameter(0)
+      %p1 = f32[8,8]{1,0} parameter(1)
+      %slice0 = f32[1,8,8]{2,1,0} slice(%p0), slice={[1:2], [0:8], [0:8]}
+      %bitcast0 = f32[8,8]{1,0} bitcast(%slice0)
+      ROOT %hero = (f32[8,8]{1,0}, f32[8,8]{1,0}) custom-call(%bitcast0, %p1),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} = f32[2,8,8]{2,1,0} parameter({{.*}})
+    ; CHECK:       {{.*}} = f32[1,8,8]{2,1,0} slice({{.*}})
+    ; CHECK-SAME:    slice={[1:2], [0:8], [0:8]}
+    ; CHECK:       {{.*}} = f32[8,8]{1,0} bitcast(
+    ; CHECK:       {{.*}} = f32[8,8]{1,0} parameter({{.*}})
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:       {{.*}} get-tuple-element(
+    ; CHECK:       {{.*}} get-tuple-element(
+    ; CHECK:       ROOT {{.*}} tuple(
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(%p0, %p1),
+    ; CHECK:              kind=kCustom
+    ; CHECK:     }
+  )";
+
+  auto f32_288 = ShapeUtil::MakeShape(F32, {2, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(
+        params,
+        ElementsAre(
+            Param{0, f32_288, f32_188, MakeStaticConfig(256), std::nullopt},
+            Param{1, f32_88, f32_88, std::nullopt, std::nullopt}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88,
+                                            std::nullopt, std::nullopt},
+                                     Result{std::nullopt, 1, f32_88, f32_88,
+                                            std::nullopt, std::nullopt}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+//===----------------------------------------------------------------------===//
+// Dynamic slice operand tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionRewriterV2Test, DynamicSlicedOperands) {
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      p0 = (s32[], f32[4,8,8], f32[8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = f32[4,8,8] get-tuple-element(p0), index=1
+      accum = f32[8,8] get-tuple-element(p0), index=2
+      c0 = s32[] constant(0)
+      ds = f32[1,8,8] dynamic-slice(input, ivar, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      bitcast = f32[8,8] bitcast(ds)
+      hero = f32[8,8] custom-call(bitcast, accum),
+          custom_call_target="fake_target"
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], f32[4,8,8], f32[8,8]) tuple(next_ivar, input, hero)
+    }
+
+    condition {
+      p0 = (s32[], f32[4,8,8], f32[8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = f32[4,8,8] parameter(0)
+      accum = f32[8,8] parameter(1)
+      c0 = s32[] constant(0)
+      tuple = (s32[], f32[4,8,8], f32[8,8]) tuple(c0, input, accum)
+      ROOT while = (s32[], f32[4,8,8], f32[8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} dynamic-slice(
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  // Captures: input(p0), ivar(p1), accum(p2). Constants sunk into fusion.
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(
+        params,
+        ElementsAre(Param{0, f32_488, f32_188, MakeConfig(0, 0, 256), offsets},
+                    Param{2, f32_88, f32_88, std::nullopt, std::nullopt}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+//===----------------------------------------------------------------------===//
+// Dynamic update slice result tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionRewriterV2Test, DynamicUpdateSliceResult) {
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      p0 = (s32[], f32[4,8,8], f32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = f32[4,8,8] get-tuple-element(p0), index=1
+      output = f32[4,8,8] get-tuple-element(p0), index=2
+      c0 = s32[] constant(0)
+      ds = f32[1,8,8] dynamic-slice(input, ivar, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      bitcast_in = f32[8,8] bitcast(ds)
+      hero = f32[8,8] custom-call(bitcast_in),
+          custom_call_target="fake_target"
+      bitcast_out = f32[1,8,8] bitcast(hero)
+      dus = f32[4,8,8] dynamic-update-slice(output, bitcast_out, ivar, c0, c0)
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], f32[4,8,8], f32[4,8,8]) tuple(next_ivar, input, dus)
+    }
+
+    condition {
+      p0 = (s32[], f32[4,8,8], f32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = f32[4,8,8] parameter(0)
+      output = f32[4,8,8] parameter(1)
+      c0 = s32[] constant(0)
+      tuple = (s32[], f32[4,8,8], f32[4,8,8]) tuple(c0, input, output)
+      ROOT while = (s32[], f32[4,8,8], f32[4,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} dynamic-slice(
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       ROOT {{.*}} dynamic-update-slice(
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  // Captures: input(p0), ivar(p1), output(p2). Constants sunk into fusion.
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_488, f32_188,
+                                          MakeConfig(0, 0, 256), offsets}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{2, 0, f32_488, f32_188,
+                                            MakeConfig(0, 0, 256), offsets}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, DUSOnlyNoSlicedInput) {
+  // Hero takes an unsliced input and writes output via bitcast → DUS into a
+  // stacked buffer. This mirrors the real-world pattern where a transpose
+  // fusion produces a gradient slice that is DUS-ed into a stacked buffer.
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      p0 = (s32[], f32[8,8], f32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = f32[8,8] get-tuple-element(p0), index=1
+      output = f32[4,8,8] get-tuple-element(p0), index=2
+      c0 = s32[] constant(0)
+      hero = f32[8,8] custom-call(input),
+          custom_call_target="fake_target"
+      bitcast_out = f32[1,8,8] bitcast(hero)
+      dus = f32[4,8,8] dynamic-update-slice(output, bitcast_out, ivar, c0, c0)
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], f32[8,8], f32[4,8,8]) tuple(next_ivar, input, dus)
+    }
+
+    condition {
+      p0 = (s32[], f32[8,8], f32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = f32[8,8] parameter(0)
+      output = f32[4,8,8] parameter(1)
+      c0 = s32[] constant(0)
+      tuple = (s32[], f32[8,8], f32[4,8,8]) tuple(c0, input, output)
+      ROOT while = (s32[], f32[8,8], f32[4,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       ROOT {{.*}} dynamic-update-slice(
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  // Captures: input(p0), output(p1), ivar(p2). Constants sunk into fusion.
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{2, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_88, f32_88, std::nullopt,
+                                          std::nullopt}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{1, 0, f32_488, f32_188,
+                                            MakeConfig(0, 0, 256), offsets}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, DUSWithConstantOffset) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[8,8]{1,0} parameter(0)
+      %p1 = f32[4,8,8]{2,1,0} parameter(1)
+      %hero = f32[8,8]{1,0} custom-call(%p0),
+        custom_call_target="fake_target"
+      %bitcast = f32[1,8,8]{2,1,0} bitcast(%hero)
+      %c0 = s32[] constant(0)
+      ROOT %dus = f32[4,8,8]{2,1,0} dynamic-update-slice(
+        %p1, %bitcast, %c0, %c0, %c0)
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       ROOT {{.*}} dynamic-update-slice(
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(%p0, %p1),
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_88, f32_88, std::nullopt,
+                                          std::nullopt}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    std::vector<DynamicSliceFusion::Offset> offsets = {
+        CstOff{0, 0}, CstOff{0, 1}, CstOff{0, 2}};
+    EXPECT_THAT(results, ElementsAre(Result{1, 0, f32_488, f32_188,
+                                            MakeStaticConfig(0), offsets}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, DUSNotRootNotFused) {
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      p0 = (s32[], f32[4,8,8], f32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = f32[4,8,8] get-tuple-element(p0), index=1
+      output = f32[4,8,8] get-tuple-element(p0), index=2
+      c0 = s32[] constant(0)
+      ds = f32[1,8,8] dynamic-slice(input, ivar, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      bitcast_in = f32[8,8] bitcast(ds)
+      hero = f32[8,8] custom-call(bitcast_in),
+          custom_call_target="fake_target"
+      bitcast_out = f32[1,8,8] bitcast(hero)
+      dus = f32[4,8,8] dynamic-update-slice(output, bitcast_out, ivar, c0, c0)
+      negate = f32[4,8,8] negate(dus)
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], f32[4,8,8], f32[4,8,8]) tuple(
+        next_ivar, input, negate)
+    }
+
+    condition {
+      p0 = (s32[], f32[4,8,8], f32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = f32[4,8,8] parameter(0)
+      output = f32[4,8,8] parameter(1)
+      c0 = s32[] constant(0)
+      tuple = (s32[], f32[4,8,8], f32[4,8,8]) tuple(c0, input, output)
+      ROOT while = (s32[], f32[4,8,8], f32[4,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} dynamic-slice(
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  // Only DS fused (DUS not root). Captures: input(p0), ivar(p1).
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_488, f32_188,
+                                          MakeConfig(0, 0, 256), offsets}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, MixedSlicedAndUnslicedOperands) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[2,8,8]{2,1,0} parameter(0)
+      %p1 = f32[8,8]{1,0} parameter(1)
+      %slice0 = f32[1,8,8]{2,1,0} slice(%p0), slice={[1:2], [0:8], [0:8]}
+      %bitcast0 = f32[8,8]{1,0} bitcast(%slice0)
+      ROOT %hero = f32[8,8]{1,0} custom-call(%bitcast0, %p1),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} = f32[2,8,8]{2,1,0} parameter({{.*}})
+    ; CHECK:       {{.*}} = f32[1,8,8]{2,1,0} slice({{.*}})
+    ; CHECK-SAME:    slice={[1:2], [0:8], [0:8]}
+    ; CHECK:       {{.*}} = f32[8,8]{1,0} bitcast(
+    ; CHECK:       {{.*}} = f32[8,8]{1,0} parameter({{.*}})
+    ; CHECK:       ROOT {{.*}} = f32[8,8]{1,0} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(%p0, %p1),
+    ; CHECK:              kind=kCustom
+    ; CHECK:     }
+  )";
+
+  auto f32_288 = ShapeUtil::MakeShape(F32, {2, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(
+        params,
+        ElementsAre(
+            Param{0, f32_288, f32_188, MakeStaticConfig(256), std::nullopt},
+            Param{1, f32_88, f32_88, std::nullopt, std::nullopt}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+//===----------------------------------------------------------------------===//
+// Predicate tests
+//===----------------------------------------------------------------------===//
+
+// The next four tests use this HLO as input.
+constexpr char kSlicedInputAndDusOutputHlo[] = R"(
+  HloModule test
+
+  body {
+    p0 = (s32[], f32[4,8,8], f32[4,8,8]) parameter(0)
+    ivar = s32[] get-tuple-element(p0), index=0
+    input = f32[4,8,8] get-tuple-element(p0), index=1
+    output = f32[4,8,8] get-tuple-element(p0), index=2
+    c0 = s32[] constant(0)
+    ds = f32[1,8,8] dynamic-slice(input, ivar, c0, c0),
+        dynamic_slice_sizes={1,8,8}
+    bitcast_in = f32[8,8] bitcast(ds)
+    hero = f32[8,8] custom-call(bitcast_in),
+        custom_call_target="fake_target"
+    bitcast_out = f32[1,8,8] bitcast(hero)
+    dus = f32[4,8,8] dynamic-update-slice(output, bitcast_out, ivar, c0, c0)
+    c1 = s32[] constant(1)
+    next_ivar = s32[] add(ivar, c1)
+    ROOT result = (s32[], f32[4,8,8], f32[4,8,8]) tuple(next_ivar, input, dus)
+  }
+
+  condition {
+    p0 = (s32[], f32[4,8,8], f32[4,8,8]) parameter(0)
+    ivar = s32[] get-tuple-element(p0), index=0
+    c4 = s32[] constant(4)
+    ROOT cmp = pred[] compare(ivar, c4), direction=LT
+  }
+
+  ENTRY main {
+    input = f32[4,8,8] parameter(0)
+    output = f32[4,8,8] parameter(1)
+    c0 = s32[] constant(0)
+    tuple = (s32[], f32[4,8,8], f32[4,8,8]) tuple(c0, input, output)
+    ROOT while = (s32[], f32[4,8,8], f32[4,8,8]) while(tuple),
+        condition=condition, body=body,
+        backend_config={"known_trip_count":{"n":"4"},
+                        "known_init_step":{"init":"0","step":"1"},
+                        "known_induction_variable":{"tuple_index":"0"}}
+  }
+)";
+
+TEST_F(DynamicSliceFusionRewriterV2Test, PredicateMismatchNotFused) {
+  Options options = DefaultOptions();
+  options.predicate = [](const HloInstruction*) { return false; };
+
+  const char* expected = R"(
+    ; CHECK: HloModule
+    ; CHECK-NOT: dynamic_slice_fusion
+  )";
+
+  RunAndFilecheckHloRewrite(kSlicedInputAndDusOutputHlo,
+                            MakePipeline(std::move(options)), expected);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test,
+       InputAndOutputPredicatesRejectAllSkipsHero) {
+  Options options = DefaultOptions();
+  options.capture_slice = [](const HloInstruction*, int64_t,
+                             const HloInstruction*) { return false; };
+  options.capture_update_slice = [](const HloInstruction*,
+                                    std::optional<int64_t>,
+                                    const HloInstruction*) { return false; };
+
+  const char* expected = R"(
+    ; CHECK: HloModule
+    ; CHECK-NOT: dynamic_slice_fusion
+  )";
+
+  RunAndFilecheckHloRewrite(kSlicedInputAndDusOutputHlo,
+                            MakePipeline(std::move(options)), expected);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, CanCaptureSlicedInputsOnly) {
+  Options options = DefaultOptions();
+  options.capture_update_slice = [](const HloInstruction*,
+                                    std::optional<int64_t>,
+                                    const HloInstruction*) { return false; };
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} dynamic-slice(
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK-SAME:         custom_call_target="fake_target"
+    ; CHECK-NOT:   dynamic-update-slice(
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK-SAME:         kind=kCustom
+    ; CHECK-SAME:         "name":"dynamic_slice_fusion"
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       {{.*}} dynamic-update-slice(
+    ; CHECK:     }
+  )";
+
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_488, f32_188,
+                                          MakeConfig(0, 0, 256), offsets}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88}));
+  };
+
+  RunAndFilecheckHloRewrite(kSlicedInputAndDusOutputHlo,
+                            MakePipeline(std::move(options)), expected,
+                            fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, CanCaptureSlicedOutputsOnly) {
+  Options options = DefaultOptions();
+  options.capture_slice = [](const HloInstruction*, int64_t,
+                             const HloInstruction*) { return false; };
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK-NOT:   dynamic-slice(
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK-SAME:         custom_call_target="fake_target"
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       ROOT {{.*}} dynamic-update-slice(
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} dynamic-slice(
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK-SAME:         kind=kCustom
+    ; CHECK-SAME:         "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{2, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_88, f32_88}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{1, 0, f32_488, f32_188,
+                                            MakeConfig(0, 0, 256), offsets}));
+  };
+
+  RunAndFilecheckHloRewrite(kSlicedInputAndDusOutputHlo,
+                            MakePipeline(std::move(options)), expected,
+                            fusion_checks);
+}
+
+//===----------------------------------------------------------------------===//
+// Induction variable offset tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionRewriterV2Test, OffsetAsLinearFunctionOfInductionVar) {
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      p0 = (s32[], f32[8,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = f32[8,8,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      c2 = s32[] constant(2)
+      offset = s32[] multiply(ivar, c2)
+      ds = f32[1,8,8] dynamic-slice(input, offset, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      bitcast = f32[8,8] bitcast(ds)
+      hero = f32[8,8] custom-call(bitcast),
+          custom_call_target="fake_target"
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], f32[8,8,8]) tuple(next_ivar, input)
+    }
+
+    condition {
+      p0 = (s32[], f32[8,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = f32[8,8,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], f32[8,8,8]) tuple(c0, input)
+      ROOT while = (s32[], f32[8,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} dynamic-slice(
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  // offset = ivar*2, byte stride dim0 = 256. stride = 2*256 = 512.
+  // Captures: input(p0), offset(p1). Constants sunk into fusion.
+  auto f32_888 = ShapeUtil::MakeShape(F32, {8, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_888, f32_188,
+                                          MakeConfig(0, 0, 512), offsets}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+//===----------------------------------------------------------------------===//
+// Non-parameter source tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionRewriterV2Test, SliceFromNonParameterSource) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[2,8,8]{2,1,0} parameter(0)
+      %negate = f32[2,8,8]{2,1,0} negate(%p0)
+      %slice0 = f32[1,8,8]{2,1,0} slice(%negate), slice={[1:2], [0:8], [0:8]}
+      %bitcast0 = f32[8,8]{1,0} bitcast(%slice0)
+      ROOT %hero = f32[8,8]{1,0} custom-call(%bitcast0),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       [[P0:%[^ ]+]] = f32[2,8,8]{2,1,0} parameter(0)
+    ; CHECK:       [[S0:%[^ ]+]] = f32[1,8,8]{2,1,0} slice([[P0]])
+    ; CHECK-SAME:    slice={[1:2], [0:8], [0:8]}
+    ; CHECK:       [[B0:%[^ ]+]] = f32[8,8]{1,0} bitcast([[S0]])
+    ; CHECK:       ROOT {{.*}} custom-call([[B0]]),
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       %negate = f32[2,8,8]{2,1,0} negate(
+    ; CHECK:       ROOT {{.*}} = f32[8,8]{1,0} fusion(%negate),
+    ; CHECK:              kind=kCustom
+    ; CHECK:     }
+  )";
+
+  auto f32_288 = ShapeUtil::MakeShape(F32, {2, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params,
+                ElementsAre(Param{0, f32_288, f32_188, MakeStaticConfig(256),
+                                  std::nullopt}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+//===----------------------------------------------------------------------===//
+// Multiple heroes tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionRewriterV2Test, TwoHeroesSameComputation) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[2,8,8]{2,1,0} parameter(0)
+      %p1 = f32[8,8]{1,0} parameter(1)
+      %slice0 = f32[1,8,8]{2,1,0} slice(%p0), slice={[0:1], [0:8], [0:8]}
+      %bitcast0 = f32[8,8]{1,0} bitcast(%slice0)
+      %hero0 = f32[8,8]{1,0} custom-call(%bitcast0),
+        custom_call_target="fake_target"
+      %slice1 = f32[1,8,8]{2,1,0} slice(%p0), slice={[1:2], [0:8], [0:8]}
+      %bitcast1 = f32[8,8]{1,0} bitcast(%slice1)
+      %hero1 = f32[8,8]{1,0} custom-call(%bitcast1, %p1),
+        custom_call_target="fake_target"
+      ROOT %tuple = (f32[8,8]{1,0}, f32[8,8]{1,0}) tuple(%hero0, %hero1)
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK-DAG:   {{.*}} fusion(%p0), kind=kCustom
+    ; CHECK-DAG:   {{.*}} fusion(%p0, %p1), kind=kCustom
+    ; CHECK:     }
+  )";
+
+  // Two separate fusions; verify both can be analyzed.
+  auto fusion_checks = [](HloModule* module) {
+    int dsf_count = 0;
+    for (HloComputation* comp : module->computations()) {
+      if (!absl::StrContains(comp->name(), "dynamic-slice-fusion")) {
+        continue;
+      }
+      dsf_count++;
+      auto* hero = DynamicSliceFusion::FindHero(comp);
+      ASSERT_OK_AND_ASSIGN(auto params,
+                           DynamicSliceFusion::ResolveParameters(hero));
+      EXPECT_FALSE(params.empty());
+    }
+    EXPECT_EQ(dsf_count, 2);
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, NestedTupleResultNotFused) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[2,8,8]{2,1,0} parameter(0)
+      %slice0 = f32[1,8,8]{2,1,0} slice(%p0), slice={[1:2], [0:8], [0:8]}
+      %bitcast0 = f32[8,8]{1,0} bitcast(%slice0)
+      ROOT %hero = ((f32[8,8]{1,0}, f32[8,8]{1,0}), f32[8,8]{1,0})
+          custom-call(%bitcast0), custom_call_target="fake_target"
+    }
+  )";
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), std::nullopt);
+}
+
+//===----------------------------------------------------------------------===//
+// Non-standard layout tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionRewriterV2Test, SlicedOperandColumnMajorLayout) {
+  // Layout {0,1,2}: column-major, dim0 most minor, dim2 most major.
+  // Byte strides for f32[8,8,2]{0,1,2}: dim0=4, dim1=32, dim2=256.
+  // Slice along most-major dim2: [0:8,0:8,1:2] → byte offset = 1*256 = 256.
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[8,8,2]{0,1,2} parameter(0)
+      %slice0 = f32[8,8,1]{0,1,2} slice(%p0), slice={[0:8], [0:8], [1:2]}
+      %bitcast0 = f32[8,8]{0,1} bitcast(%slice0)
+      ROOT %hero = f32[8,8]{0,1} custom-call(%bitcast0),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       [[P0:%[^ ]+]] = f32[8,8,2]{0,1,2} parameter(0)
+    ; CHECK:       [[S0:%[^ ]+]] = f32[8,8,1]{0,1,2} slice([[P0]])
+    ; CHECK-SAME:    slice={[0:8], [0:8], [1:2]}
+    ; CHECK:       [[B0:%[^ ]+]] = f32[8,8]{0,1} bitcast([[S0]])
+    ; CHECK:       ROOT {{.*}} = f32[8,8]{0,1} custom-call([[B0]]),
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} = f32[8,8]{0,1} fusion(%p0),
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_882 = ShapeUtil::MakeShapeWithDenseLayout(F32, {8, 8, 2}, {0, 1, 2});
+  auto f32_881 = ShapeUtil::MakeShapeWithDenseLayout(F32, {8, 8, 1}, {0, 1, 2});
+  auto f32_88 = ShapeUtil::MakeShapeWithDenseLayout(F32, {8, 8}, {0, 1});
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params,
+                ElementsAre(Param{0, f32_882, f32_881, MakeStaticConfig(256),
+                                  std::nullopt}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, DynamicSliceNonStandardLayoutWithDUS) {
+  // Layout {1,2,0}: minor_to_major=[1,2,0], so dim1 most minor, dim2 next,
+  // dim0 most major. Byte strides for f32[4,8,8]{1,2,0}: dim1=4, dim2=32,
+  // dim0=256. Slicing dim0 is contiguous because dim0 is most major.
+  // DS/DUS along dim0 → config stride = 256.
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      p0 = (s32[], f32[4,8,8]{1,2,0}, f32[4,8,8]{1,2,0}) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = f32[4,8,8]{1,2,0} get-tuple-element(p0), index=1
+      output = f32[4,8,8]{1,2,0} get-tuple-element(p0), index=2
+      c0 = s32[] constant(0)
+      ds = f32[1,8,8]{1,2,0} dynamic-slice(input, ivar, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      bitcast_in = f32[8,8]{0,1} bitcast(ds)
+      hero = f32[8,8]{0,1} custom-call(bitcast_in),
+          custom_call_target="fake_target"
+      bitcast_out = f32[1,8,8]{1,2,0} bitcast(hero)
+      dus = f32[4,8,8]{1,2,0} dynamic-update-slice(
+          output, bitcast_out, ivar, c0, c0)
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], f32[4,8,8]{1,2,0}, f32[4,8,8]{1,2,0})
+          tuple(next_ivar, input, dus)
+    }
+
+    condition {
+      p0 = (s32[], f32[4,8,8]{1,2,0}, f32[4,8,8]{1,2,0}) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = f32[4,8,8]{1,2,0} parameter(0)
+      output = f32[4,8,8]{1,2,0} parameter(1)
+      c0 = s32[] constant(0)
+      tuple = (s32[], f32[4,8,8]{1,2,0}, f32[4,8,8]{1,2,0})
+          tuple(c0, input, output)
+      ROOT while = (s32[], f32[4,8,8]{1,2,0}, f32[4,8,8]{1,2,0})
+          while(tuple), condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} dynamic-slice(
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       ROOT {{.*}} dynamic-update-slice(
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_488 = ShapeUtil::MakeShapeWithDenseLayout(F32, {4, 8, 8}, {1, 2, 0});
+  auto f32_188 = ShapeUtil::MakeShapeWithDenseLayout(F32, {1, 8, 8}, {1, 2, 0});
+  auto f32_88 = ShapeUtil::MakeShapeWithDenseLayout(F32, {8, 8}, {0, 1});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_488, f32_188,
+                                          MakeConfig(0, 0, 256), offsets}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{2, 0, f32_488, f32_188,
+                                            MakeConfig(0, 0, 256), offsets}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test,
+       NonContiguousSliceNonStandardLayoutNotFused) {
+  // Layout {1,0,2}: dim1 most minor, dim0 next, dim2 most major.
+  // Slicing dim0 [1:2,0:8,0:8] is non-contiguous because dim2 (more major
+  // than sliced dim0) has extent 8 != 1.
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[2,8,8]{1,0,2} parameter(0)
+      %slice0 = f32[1,8,8]{1,0,2} slice(%p0), slice={[1:2], [0:8], [0:8]}
+      %bitcast0 = f32[8,8]{0,1} bitcast(%slice0)
+      ROOT %hero = f32[8,8]{0,1} custom-call(%bitcast0),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), std::nullopt);
+}
+
+//===----------------------------------------------------------------------===//
+// Mixed DUS/passthrough tuple output tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionRewriterV2Test, TupleOutputOneDUS) {
+  // Hero produces (f32[8,8], f32[8,8]). Only the first output flows through
+  // DUS; the second is returned directly (passthrough). The fusion output
+  // must be a tuple containing both the DUS result and the passthrough GTE.
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      p0 = (s32[], f32[4,8,8], f32[8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      buf = f32[4,8,8] get-tuple-element(p0), index=1
+      prev = f32[8,8] get-tuple-element(p0), index=2
+      c0 = s32[] constant(0)
+      hero = (f32[8,8], f32[8,8]) custom-call(),
+          custom_call_target="fake_target"
+      gte0 = f32[8,8] get-tuple-element(hero), index=0
+      gte1 = f32[8,8] get-tuple-element(hero), index=1
+      bc0 = f32[1,8,8] bitcast(gte0)
+      dus = f32[4,8,8] dynamic-update-slice(buf, bc0, ivar, c0, c0)
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], f32[4,8,8], f32[8,8]) tuple(next_ivar, dus, gte1)
+    }
+
+    condition {
+      p0 = (s32[], f32[4,8,8], f32[8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      buf = f32[4,8,8] parameter(0)
+      prev = f32[8,8] parameter(1)
+      c0 = s32[] constant(0)
+      tuple = (s32[], f32[4,8,8], f32[8,8]) tuple(c0, buf, prev)
+      ROOT while = (s32[], f32[4,8,8], f32[8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK-SAME:         custom_call_target="fake_target"
+    ; CHECK:       {{.*}} get-tuple-element(
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       {{.*}} dynamic-update-slice(
+    ; CHECK:       {{.*}} get-tuple-element(
+    ; CHECK:       ROOT {{.*}} tuple(
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK-SAME:         kind=kCustom
+    ; CHECK-SAME:         "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* body = FindDsfBody(module);
+    ASSERT_NE(body, nullptr);
+    auto* hero = DynamicSliceFusion::FindHero(body);
+    ASSERT_NE(hero, nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, IsEmpty());
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{0, 0, f32_488, f32_188,
+                                            MakeConfig(0, 0, 256), offsets},
+                                     Result{std::nullopt, 1, f32_88, f32_88,
+                                            std::nullopt, std::nullopt}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, TupleOutputNoDUS) {
+  // Hero produces (f32[8,8], f32[8,8]). Neither output has DUS — both are
+  // passthrough. With a sliced input, the rewriter should still fuse.
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      p0 = (s32[], f32[4,8,8], f32[8,8], f32[8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = f32[4,8,8] get-tuple-element(p0), index=1
+      prev0 = f32[8,8] get-tuple-element(p0), index=2
+      prev1 = f32[8,8] get-tuple-element(p0), index=3
+      c0 = s32[] constant(0)
+      ds = f32[1,8,8] dynamic-slice(input, ivar, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      bc = f32[8,8] bitcast(ds)
+      hero = (f32[8,8], f32[8,8]) custom-call(bc),
+          custom_call_target="fake_target"
+      gte0 = f32[8,8] get-tuple-element(hero), index=0
+      gte1 = f32[8,8] get-tuple-element(hero), index=1
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], f32[4,8,8], f32[8,8], f32[8,8])
+          tuple(next_ivar, input, gte0, gte1)
+    }
+
+    condition {
+      p0 = (s32[], f32[4,8,8], f32[8,8], f32[8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = f32[4,8,8] parameter(0)
+      prev0 = f32[8,8] parameter(1)
+      prev1 = f32[8,8] parameter(2)
+      c0 = s32[] constant(0)
+      tuple = (s32[], f32[4,8,8], f32[8,8], f32[8,8])
+          tuple(c0, input, prev0, prev1)
+      ROOT while = (s32[], f32[4,8,8], f32[8,8], f32[8,8])
+          while(tuple), condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} dynamic-slice(
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK-SAME:         custom_call_target="fake_target"
+    ; CHECK:       {{.*}} get-tuple-element(
+    ; CHECK:       {{.*}} get-tuple-element(
+    ; CHECK:       ROOT {{.*}} tuple(
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK-SAME:         kind=kCustom
+    ; CHECK-SAME:         "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* body = FindDsfBody(module);
+    ASSERT_NE(body, nullptr);
+    auto* hero = DynamicSliceFusion::FindHero(body);
+    ASSERT_NE(hero, nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_488, f32_188,
+                                          MakeConfig(0, 0, 256), offsets}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88,
+                                            std::nullopt, std::nullopt},
+                                     Result{std::nullopt, 1, f32_88, f32_88,
+                                            std::nullopt, std::nullopt}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, TupleOutputOneDUSOneDeadOutput) {
+  // Hero produces (f32[8,8], f32[8,8]). Only the first output is used (via
+  // DUS). The second output has no GTE users — it is dead. The fusion must
+  // still include both in its output tuple so that buffer allocation has a
+  // slot for the second output.
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      p0 = (s32[], f32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      buf = f32[4,8,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      hero = (f32[8,8], f32[8,8]) custom-call(),
+          custom_call_target="fake_target"
+      gte0 = f32[8,8] get-tuple-element(hero), index=0
+      bc0 = f32[1,8,8] bitcast(gte0)
+      dus = f32[4,8,8] dynamic-update-slice(buf, bc0, ivar, c0, c0)
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], f32[4,8,8]) tuple(next_ivar, dus)
+    }
+
+    condition {
+      p0 = (s32[], f32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      buf = f32[4,8,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], f32[4,8,8]) tuple(c0, buf)
+      ROOT while = (s32[], f32[4,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK-SAME:         custom_call_target="fake_target"
+    ; CHECK:       {{.*}} get-tuple-element(
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       {{.*}} dynamic-update-slice(
+    ; CHECK:       {{.*}} get-tuple-element(
+    ; CHECK:       ROOT {{.*}} tuple(
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK-SAME:         kind=kCustom
+    ; CHECK-SAME:         "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* body = FindDsfBody(module);
+    ASSERT_NE(body, nullptr);
+    auto* hero = DynamicSliceFusion::FindHero(body);
+    ASSERT_NE(hero, nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{0, 0, f32_488, f32_188,
+                                            MakeConfig(0, 0, 256), offsets},
+                                     Result{std::nullopt, 1, f32_88, f32_88,
+                                            std::nullopt, std::nullopt}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, DynamicSliceOnlyNoResult) {
+  const char* hlo = R"(
+    HloModule test
+
+    %body {
+      %p = (s32[], f32[4,8,8]{2,1,0}) parameter(0)
+      %ivar = s32[] get-tuple-element(%p), index=0
+      %input = f32[4,8,8]{2,1,0} get-tuple-element(%p), index=1
+      %zero = s32[] constant(0)
+      %ds = f32[1,8,8]{2,1,0} dynamic-slice(%input, %ivar, %zero, %zero),
+        dynamic_slice_sizes={1,8,8}
+      %bc = f32[8,8]{1,0} bitcast(%ds)
+      %hero = f32[8,8]{1,0} custom-call(%bc),
+        custom_call_target="fake_target"
+      %one = s32[] constant(1)
+      %next = s32[] add(%ivar, %one)
+      ROOT %tuple = (s32[], f32[4,8,8]{2,1,0}) tuple(%next, %input)
+    }
+
+    %cond {
+      %p = (s32[], f32[4,8,8]{2,1,0}) parameter(0)
+      %i = s32[] get-tuple-element(%p), index=0
+      %limit = s32[] constant(4)
+      ROOT %cmp = pred[] compare(%i, %limit), direction=LT
+    }
+
+    ENTRY main {
+      %zero = s32[] constant(0)
+      %buf = f32[4,8,8]{2,1,0} parameter(0)
+      %init = (s32[], f32[4,8,8]{2,1,0}) tuple(%zero, %buf)
+      ROOT %while = (s32[], f32[4,8,8]{2,1,0}) while(%init),
+        body=%body, condition=%cond,
+        backend_config={"known_trip_count":{"n":"4"},
+                        "known_init_step":{"init":"0","step":"1"},
+                        "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK-DAG:   [[P0:%[^ ]+]] = f32[4,8,8]{2,1,0} parameter(0)
+    ; CHECK:       [[DS:%[^ ]+]] = f32[1,8,8]{2,1,0} dynamic-slice([[P0]]
+    ; CHECK:       [[BC:%[^ ]+]] = f32[8,8]{1,0} bitcast([[DS]])
+    ; CHECK:       ROOT {{.*}} = f32[8,8]{1,0} custom-call([[BC]]),
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     %body{{.*}} {
+    ; CHECK:       {{.*}} = f32[8,8]{1,0} fusion(
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_488, f32_188,
+                                          MakeConfig(0, 0, 256), offsets}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+//===----------------------------------------------------------------------===//
+// O2 mode tests — looking through tuples
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionRewriterV2Test, O2LooksThroughTupleGte) {
+  // Pattern: Slice → bitcast → tuple → GTE → hero. In O2 mode the rewriter
+  // should look through the tuple/GTE barrier and fuse the Slice. The tuple
+  // and GTE are NOT captured into the fusion.
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[2,8,8]{2,1,0} parameter(0)
+      %p1 = f32[8,8]{1,0} parameter(1)
+      %slice0 = f32[1,8,8]{2,1,0} slice(%p0), slice={[1:2], [0:8], [0:8]}
+      %bitcast0 = f32[8,8]{1,0} bitcast(%slice0)
+      %tuple = (f32[8,8]{1,0}, f32[8,8]{1,0}) tuple(%bitcast0, %p1)
+      %gte0 = f32[8,8]{1,0} get-tuple-element(%tuple), index=0
+      %gte1 = f32[8,8]{1,0} get-tuple-element(%tuple), index=1
+      ROOT %hero = f32[8,8]{1,0} custom-call(%gte0, %gte1),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  // In O1 mode: GTE→tuple blocks the search, no fusion (only Slice has no
+  // DynamicSliceConfig, so the annotator doesn't change the module either).
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(OptLevel::kO1), std::nullopt);
+
+  // In O2 mode: look through tuple→GTE, find slice, fuse it.
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK-DAG:   [[P0:%[^ ]+]] = f32[2,8,8]{2,1,0} parameter({{.*}})
+    ; CHECK:       [[S0:%[^ ]+]] = f32[1,8,8]{2,1,0} slice([[P0]])
+    ; CHECK-SAME:    slice={[1:2], [0:8], [0:8]}
+    ; CHECK:       [[B0:%[^ ]+]] = f32[8,8]{1,0} bitcast([[S0]])
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_288 = ShapeUtil::MakeShape(F32, {2, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(
+        params,
+        ElementsAre(
+            Param{0, f32_288, f32_188, MakeStaticConfig(256), std::nullopt},
+            Param{1, f32_88, f32_88, std::nullopt, std::nullopt}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(OptLevel::kO2), expected,
+                            fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, O2DynamicSliceThroughTupleGte) {
+  // Pattern in while body: DS → bitcast → tuple → GTE → hero, with dynamic
+  // offsets. O2 mode looks through the tuple barrier and fuses the DS.
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      p0 = (s32[], f32[4,8,8], f32[8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = f32[4,8,8] get-tuple-element(p0), index=1
+      accum = f32[8,8] get-tuple-element(p0), index=2
+      c0 = s32[] constant(0)
+      ds = f32[1,8,8] dynamic-slice(input, ivar, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      bitcast = f32[8,8] bitcast(ds)
+      barrier = (f32[8,8], f32[8,8]) tuple(bitcast, accum)
+      gte_sliced = f32[8,8] get-tuple-element(barrier), index=0
+      gte_accum = f32[8,8] get-tuple-element(barrier), index=1
+      hero = f32[8,8] custom-call(gte_sliced, gte_accum),
+          custom_call_target="fake_target"
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], f32[4,8,8], f32[8,8]) tuple(next_ivar, input, hero)
+    }
+
+    condition {
+      p0 = (s32[], f32[4,8,8], f32[8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = f32[4,8,8] parameter(0)
+      accum = f32[8,8] parameter(1)
+      c0 = s32[] constant(0)
+      tuple = (s32[], f32[4,8,8], f32[8,8]) tuple(c0, input, accum)
+      ROOT while = (s32[], f32[4,8,8], f32[8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  // O1 mode: blocked by tuple barrier — annotator still runs and annotates
+  // the DS, but no fusion is created.
+  const char* o1_expected = R"(
+    ; CHECK:     body
+    ; CHECK-NOT:   fusion(
+    ; CHECK:     ENTRY
+  )";
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(OptLevel::kO1), o1_expected);
+
+  // O2 mode: looks through tuple, fuses DS.
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} dynamic-slice(
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
+                                                     CstOff{0, 2}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(
+        params,
+        ElementsAre(Param{0, f32_488, f32_188, MakeConfig(0, 0, 256), offsets},
+                    Param{2, f32_88, f32_88, std::nullopt, std::nullopt}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(OptLevel::kO2), expected,
+                            fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, O2NestedTupleGteLookthrough) {
+  // Nested tuple barrier: DS → bitcast → tuple → tuple → GTE → GTE → hero.
+  // O2 should look through both levels.
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[2,8,8]{2,1,0} parameter(0)
+      %slice0 = f32[1,8,8]{2,1,0} slice(%p0), slice={[1:2], [0:8], [0:8]}
+      %bitcast0 = f32[8,8]{1,0} bitcast(%slice0)
+      %inner = (f32[8,8]{1,0}) tuple(%bitcast0)
+      %outer = ((f32[8,8]{1,0})) tuple(%inner)
+      %gte_outer = (f32[8,8]{1,0}) get-tuple-element(%outer), index=0
+      %gte_inner = f32[8,8]{1,0} get-tuple-element(%gte_outer), index=0
+      ROOT %hero = f32[8,8]{1,0} custom-call(%gte_inner),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       [[P0:%[^ ]+]] = f32[2,8,8]{2,1,0} parameter(0)
+    ; CHECK:       [[S0:%[^ ]+]] = f32[1,8,8]{2,1,0} slice([[P0]])
+    ; CHECK-SAME:    slice={[1:2], [0:8], [0:8]}
+    ; CHECK:       [[B0:%[^ ]+]] = f32[8,8]{1,0} bitcast([[S0]])
+    ; CHECK:       ROOT {{.*}} custom-call([[B0]]),
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(%p0),
+    ; CHECK:              kind=kCustom
+    ; CHECK:     }
+  )";
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(OptLevel::kO2), expected);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test, O2LooksThroughOptBarrier) {
+  // Pattern: Slice → bitcast → tuple → opt-barrier → GTE → hero.
+  // O2 should look through the optimization barrier and tuple together.
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[2,8,8]{2,1,0} parameter(0)
+      %p1 = f32[8,8]{1,0} parameter(1)
+      %slice0 = f32[1,8,8]{2,1,0} slice(%p0), slice={[1:2], [0:8], [0:8]}
+      %bitcast0 = f32[8,8]{1,0} bitcast(%slice0)
+      %tuple = (f32[8,8]{1,0}, f32[8,8]{1,0}) tuple(%bitcast0, %p1)
+      %barrier = (f32[8,8]{1,0}, f32[8,8]{1,0}) opt-barrier(%tuple)
+      %gte0 = f32[8,8]{1,0} get-tuple-element(%barrier), index=0
+      %gte1 = f32[8,8]{1,0} get-tuple-element(%barrier), index=1
+      ROOT %hero = f32[8,8]{1,0} custom-call(%gte0, %gte1),
+        custom_call_target="fake_target"
+    }
+  )";
+
+  // O1 mode: blocked by opt-barrier + tuple.
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(OptLevel::kO1), std::nullopt);
+
+  // O2 mode: looks through opt-barrier and tuple, finds the slice.
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK-DAG:   [[P0:%[^ ]+]] = f32[2,8,8]{2,1,0} parameter({{.*}})
+    ; CHECK:       [[S0:%[^ ]+]] = f32[1,8,8]{2,1,0} slice([[P0]])
+    ; CHECK-SAME:    slice={[1:2], [0:8], [0:8]}
+    ; CHECK:       [[B0:%[^ ]+]] = f32[8,8]{1,0} bitcast([[S0]])
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_288 = ShapeUtil::MakeShape(F32, {2, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(
+        params,
+        ElementsAre(
+            Param{0, f32_288, f32_188, MakeStaticConfig(256), std::nullopt},
+            Param{1, f32_88, f32_88, std::nullopt, std::nullopt}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(OptLevel::kO2), expected,
+                            fusion_checks);
+}
+
+}  // namespace
+}  // namespace xla::gpu


### PR DESCRIPTION
Add `DynamicSliceFusionRewriterV2` that targets the V2 of the dynamic-slice-fusion library, it wraps a hero instruction that reads from sliced buffers (via Slice or DynamicSlice) and/or writes into sliced buffers (via DynamicUpdateSlice) into a custom fusion.

In contrast to previous (legacy, to-be-deleted) version it allows flexible configs for what slices/update-slices must become a part of the DUS-fusion, in some cases we don't want to pull particular slices into the fusion body as it would create unwanted buffer dependencies and limit scheduler ability to overlap computation/communication.

This is not wired into gpu-compiler, it will come in the followup PRs.