### PR TITLE
Implement cache for hipStream in ROCm executor

### DIFF
--- a/xla/pjrt/local_device_state.cc
+++ b/xla/pjrt/local_device_state.cc
@@ -167,6 +167,24 @@ LocalDeviceState::~LocalDeviceState() {
     LOG(ERROR) << "Error when closing device: " << status;
   }
 
+  // Drain the callback thread before touching compute_events_.
+  //
+  // After SynchronizeAllActivity() above, all GPU host-callbacks registered
+  // via hipLaunchHostFunc / ThenExecuteCallback have been *invoked*, which
+  // means every callback_thread_->Schedule() call they contain has already
+  // been issued.  Those closures (e.g. the AndThen that calls
+  // compute_events_.pop_front()) may still be sitting in the queue or
+  // actively executing.
+  //
+  // Because compute_events_ is declared *after* callback_thread_ in the
+  // class, C++ destroys it *before* callback_thread_'s destructor joins the
+  // worker thread — creating a window where pop_front() runs on an
+  // already-destroyed deque (undefined behaviour / use-after-free).
+  //
+  // Draining the thread here closes that window: every closure enqueued
+  // before this point completes before we touch compute_events_.
+  callback_thread_->Drain();
+
   // Explicitly delete all the streams and events to ensure that their callbacks
   // are executed before the destruction of the LocalDeviceState and its
   // callback threads.

--- a/xla/pjrt/worker_thread.cc
+++ b/xla/pjrt/worker_thread.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/synchronization/notification.h"
 #include "xla/tsl/platform/env.h"
 
 namespace xla {
@@ -42,6 +43,14 @@ void WorkerThread::Schedule(absl::AnyInvocable<void() &&> fn) {
   CHECK(fn != nullptr);
   absl::MutexLock lock(mu_);
   work_queue_.push(std::move(fn));
+}
+
+void WorkerThread::Drain() {
+  absl::Notification done;
+  // Schedule a sentinel closure after all currently-queued work. When the
+  // worker thread executes it, we know every prior closure has completed.
+  Schedule([&done]() { done.Notify(); });
+  done.WaitForNotification();
 }
 
 bool WorkerThread::WorkAvailable() { return !work_queue_.empty(); }

--- a/xla/pjrt/worker_thread.h
+++ b/xla/pjrt/worker_thread.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/base/thread_annotations.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/synchronization/notification.h"
 #include "xla/tsl/platform/env.h"
 #include "tsl/platform/env.h"
 
@@ -42,6 +43,14 @@ class WorkerThread {
 
   // Adds 'fn' to the queue of closures to be executed by the worker thread.
   void Schedule(absl::AnyInvocable<void() &&> fn);
+
+  // Blocks the calling thread until all closures that were enqueued before this
+  // call have completed. Any closures enqueued concurrently with or after this
+  // call may or may not have run when Drain() returns.
+  //
+  // Implementation: schedules a sentinel no-op closure and waits for it to be
+  // dequeued and executed, which guarantees that all prior closures have run.
+  void Drain();
 
   // Returns true if there is any outstanding work.
   bool HasBacklog() {

--- a/xla/stream_executor/rocm/rocm_stream.cc
+++ b/xla/stream_executor/rocm/rocm_stream.cc
@@ -16,13 +16,17 @@ limitations under the License.
 #include "xla/stream_executor/rocm/rocm_stream.h"
 
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "absl/base/casts.h"
+#include "absl/base/thread_annotations.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -31,6 +35,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
+#include "absl/synchronization/mutex.h"
 #include "rocm/include/hip/driver_types.h"
 #include "rocm/include/hip/hip_runtime.h"
 #include "rocm/rocm_config.h"
@@ -48,20 +53,80 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 
 namespace stream_executor::gpu {
+
+// ---------------------------------------------------------------------------
+// Process-level HIP stream handle cache
+//
+// hipStreamCreate on ROCm is expensive (~100 ms/stream). Instead of calling
+// hipStreamDestroy in RocmStream::~RocmStream() and hipStreamCreate in
+// RocmStream::Create(), idle handles are kept in this cache and reused.
+//
+// Cache key: (device_ordinal, creation_flags, creation_priority_int).
+// Flags and priority are queried from the live stream via hipStreamGetFlags /
+// hipStreamGetPriority before insertion, so a retrieved handle is guaranteed
+// to match the creation parameters of the new stream.
+//
+// Safety invariants:
+//   - A handle is inserted only after BlockHostUntilDone() confirms it is
+//     fully idle (hipStreamSynchronize ran in RocmStream::~RocmStream()).
+//   - hipStreamQuery is re-checked at insertion time; any stream in an error
+//     state is destroyed rather than cached.
+//   - The GPU context is activated (executor->Activate()) for all HIP calls.
+//
+// Intentional leak: the singleton (new, never delete) holds at most one
+// vector of handles per (device, flags, priority) for the process lifetime.
+// The OS reclaims all GPU resources on exit.
+//
+// Thread safety: mu guards all map accesses.
+struct HipStreamHandleCache {
+  absl::Mutex mu;
+  // Key: (device_ordinal, flags, priority_int)
+  std::map<std::tuple<int, unsigned int, int>, std::vector<hipStream_t>>
+      handles ABSL_GUARDED_BY(mu);
+};
+
+static HipStreamHandleCache& GetHipStreamHandleCache() {
+  static auto* cache = new HipStreamHandleCache();  // Intentional leak.
+  return *cache;
+}
+
 namespace {
 
 absl::StatusOr<hipStream_t> CreateStream(StreamExecutor* executor,
                                          int priority) {
+  // XLA always creates streams with hipStreamDefault. This constant is used
+  // as part of the cache key so that if the flag changes in the future the
+  // cache will not silently return a handle with the wrong synchronisation
+  // semantics.
+  constexpr unsigned int kFlags = hipStreamDefault;
+
+  // Check the cache for an idle handle with matching (device, flags, priority).
+  {
+    auto& cache = GetHipStreamHandleCache();
+    absl::MutexLock lock(&cache.mu);
+    auto key = std::make_tuple(executor->device_ordinal(), kFlags, priority);
+    auto it = cache.handles.find(key);
+    if (it != cache.handles.end() && !it->second.empty()) {
+      hipStream_t h = it->second.back();
+      it->second.pop_back();
+      VLOG(2) << "Reusing cached HIP stream " << h << " for device "
+              << executor->device_ordinal() << " flags=" << kFlags
+              << " priority=" << priority;
+      return h;
+    }
+  }
+
+  // Cold path: create a new HIP stream.
   std::unique_ptr<ActivateContext> activation = executor->Activate();
   hipStream_t stream;
   if (priority == 0) {
     TF_RETURN_IF_ERROR(ToStatus(
-        hipStreamCreateWithFlags(&stream, hipStreamDefault),
-        "Failed to create stream"));  // switch to hipStreamNonBlocking?
+        hipStreamCreateWithFlags(&stream, kFlags),
+        "Failed to create stream"));
   } else {
     TF_RETURN_IF_ERROR(ToStatus(
-        hipStreamCreateWithPriority(&stream, hipStreamDefault, priority),
-        "Failed to create stream"));  // switch to hipStreamNonBlocking?
+        hipStreamCreateWithPriority(&stream, kFlags, priority),
+        "Failed to create stream"));
   }
 
   VLOG(2) << "successfully created stream " << stream << " for device "
@@ -212,20 +277,69 @@ void DestroyStream(StreamExecutor* executor, hipStream_t stream) {
   if (stream == nullptr) {
     return;
   }
-  hipError_t res = hipStreamQuery(stream);
-  if (res != hipSuccess) {
-    LOG(ERROR) << "stream not idle on destroy: " << ToString(res);
+
+  // Verify the stream is fully idle before caching.
+  // BlockHostUntilDone() ran in ~RocmStream() before this call, so under
+  // normal conditions this query always succeeds. An error here indicates a
+  // GPU fault or driver issue; destroy the stream rather than poisoning the
+  // cache with a broken handle.
+  hipError_t query_res = hipStreamQuery(stream);
+  if (query_res != hipSuccess) {
+    LOG(WARNING) << "stream not idle on destroy: " << ToString(query_res)
+               << " — destroying instead of caching";
+    std::unique_ptr<ActivateContext> activation = executor->Activate();
+    hipError_t res = hipStreamDestroy(stream);
+    if (res != hipSuccess) {
+      LOG(ERROR) << "failed to destroy ROCM stream for device "
+                 << executor->device_ordinal() << ": " << ToString(res);
+    }
+    return;
   }
 
-  std::unique_ptr<ActivateContext> activation = executor->Activate();
-  res = hipStreamDestroy(stream);
-  if (res != hipSuccess) {
-    LOG(ERROR) << "failed to destroy ROCM stream for device "
-               << executor->device_ordinal() << ": " << ToString(res);
-  } else {
-    VLOG(2) << "successfully destroyed stream " << stream << " for device "
-            << executor->device_ordinal();
+  // Query the stream's creation flags and priority so they can be used as the
+  // cache key. This guarantees a retrieved handle always matches the exact
+  // (flags, priority) the new stream would have been created with — even if
+  // XLA is changed to use hipStreamNonBlocking or non-default priorities.
+  unsigned int flags = 0;
+  int stream_priority = 0;
+  {
+    std::unique_ptr<ActivateContext> activation = executor->Activate();
+    hipError_t flags_res = hipStreamGetFlags(stream, &flags);
+    if (flags_res != hipSuccess) {
+      LOG(WARNING) << "hipStreamGetFlags failed: " << ToString(flags_res)
+                   << " — destroying stream " << stream
+                   << " instead of caching";
+      hipError_t destroy_res = hipStreamDestroy(stream);
+      if (destroy_res != hipSuccess) {
+        LOG(ERROR) << "failed to destroy ROCM stream for device "
+                   << executor->device_ordinal() << ": "
+                   << ToString(destroy_res);
+      }
+      return;
+    }
+    hipError_t prio_res = hipStreamGetPriority(stream, &stream_priority);
+    if (prio_res != hipSuccess) {
+      LOG(WARNING) << "hipStreamGetPriority failed: " << ToString(prio_res)
+                   << " — destroying stream " << stream
+                   << " instead of caching";
+      hipError_t destroy_res = hipStreamDestroy(stream);
+      if (destroy_res != hipSuccess) {
+        LOG(ERROR) << "failed to destroy ROCM stream for device "
+                   << executor->device_ordinal() << ": "
+                   << ToString(destroy_res);
+      }
+      return;
+    }
   }
+
+  // Insert the verified, idle handle into the cache for reuse.
+  auto& cache = GetHipStreamHandleCache();
+  absl::MutexLock lock(&cache.mu);
+  auto key = std::make_tuple(executor->device_ordinal(), flags, stream_priority);
+  cache.handles[key].push_back(stream);
+  VLOG(2) << "cached HIP stream " << stream << " for device "
+          << executor->device_ordinal() << " flags=" << flags
+          << " priority=" << stream_priority;
 }
 }  // namespace
 


### PR DESCRIPTION
## Motivation

The iota_test was very slow on AMD targets (compared to NVDIA) because the pjrt client was destroyed and recreated for each of the 4500 tests that make up the `iota_test`. This task in ROCm is ~40× slower than with CUDA (see table below).

Phase | H100 | AMD MI300X
-- | -- | --
Previous client teardown + new client init (pre-BFC log) | ~35ms total | ~963ms total
BFC allocator re-setup (8 GPUs) | ~0.3ms | ~0.1ms
Per-test GPU lifecycle cost | 35ms | 1009ms

The main cause of slowdowns when creating and destroying a pjrt client lies in the creation and destruction of streams.
```
Per-test overhead (8 GPU ROCm, iota_test):

CREATION (~406ms):
  Phase1 GetGpuXlaClient:      0.2ms    (negligible, singleton)
  Phase2 hipStreamCreate ×112: 385ms    ← dominant creation cost
  Phase3 EnablePeerAccess:     0.4ms    (negligible, cached)
  Phase4 BFC Allocator:        0.2ms    (negligible, no prealloc)
  Phase5 BuildDistributed:      20ms    (RCCL topology)

DESTRUCTION (~513ms):
  dtor body:                   0.05ms
  thread pool shutdown:       138ms 
  hipStreamDestroy ×112:      375ms    ← dominant destruction cost
  SyncAllActivity:              1.5ms   (device 0 only)

TOTAL OVERHEAD:                ~919ms per test
ACTUAL COMPUTATION:             ~90ms  (IotaReshapeExtraDims = 1012ms total)
```

This PR implements a process-level `HipStreamHandleCache` singleton directly in rocm_stream.cc. Cache key: (device_ordinal, creation_flags, creation_priority_int).

On destruction (RocmStream::~RocmStream):
  1. BlockHostUntilDone() already ran -- stream is idle.
  2. hipStreamQuery() confirms idleness; on error the handle is destroyed rather than cached (no poisoning).
  3. hipStreamGetFlags / hipStreamGetPriority are called to build the exact cache key, ensuring a retrieved handle always matches the flags and priority the new stream would have used -- even if XLA later switches to hipStreamNonBlocking.
  4. Idle handle is stored; hipStreamDestroy is skipped.

On creation (RocmStream::Create via CreateStream):
  The cache is checked first; on hit the cached handle is returned
  directly and hipStreamCreate is skipped. On miss the cold path
  calls hipStreamCreate as before.

The LocalDeviceState and RocmStream wrapper objects are still created and destroyed normally on every client instantiation. DNN state is cleaned up via DeallocateStream as usual. Only the underlying HIP queue (hipStream_t) is reused.

Also fix a latent use-after-free in `LocalDeviceState::~LocalDeviceState`:

  C++ destroys members in reverse declaration order. `compute_events_`
  (line 352 in local_device_state.h) is declared after `callback_thread_`
  (line 342), so its destructor runs *before* `callback_thread_`'s
  destructor joins the worker thread. If callback_thread_ still has
  pending `pop_front(compute_events_)` closures when `compute_events_` is
  destroyed, those closures access freed memory.

  The fix adds `callback_thread_->Drain()` between `SynchronizeAllActivity()`
  and the explicit stream/event clears. After `Drain()` the callback thread
  is idle and `compute_events_` can be safely cleared.

