### PR TITLE
[XLA:GPU] Run command buffer warmup without requiring collectives

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -760,6 +760,7 @@ xla_test(
     backends = ["gpu"],
     tags = ["cuda-only"],
     deps = [
+        ":collective_params",
         ":command",
         ":command_buffer_cmd",
         ":command_buffer_thunk",
@@ -771,6 +772,7 @@ xla_test(
         "//xla:types",
         "//xla:xla_data_proto_cc",
         "//xla/runtime:buffer_use",
+        "//xla/runtime:device_id",
         "//xla/service:buffer_assignment",
         "//xla/service:executable",
         "//xla/service:platform_util",

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -762,7 +762,6 @@ xla_test(
     deps = [
         ":collective_params",
         ":command",
-        ":command_buffer_cmd",
         ":command_buffer_thunk",
         ":command_executor",
         ":cudnn_thunk",
@@ -787,19 +786,16 @@ xla_test(
         "//xla/stream_executor:kernel_spec",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream_executor_address_allocator",
         "//xla/stream_executor:stream_executor_h",
-        "//xla/stream_executor:stream_executor_memory_allocator",
         "//xla/stream_executor/cuda:cuda_compute_capability",
         "//xla/stream_executor/cuda:cudnn_plugin",
-        "//xla/tsl/lib/core:status_test_util",
-        "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
         "@cudnn_frontend_archive//:cudnn_frontend",
-        "@local_config_cuda//cuda:cuda_headers",
     ],
 )
 

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -206,9 +206,8 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
       GetOrCreateCommandBuffer(params.executor, *params.buffer_allocations));
   absl::MutexLock lock(cmd_buffer->mutex);
 
-  // If there are no thunks, or command buffer does not require initialization,
-  // we can mark warm up as done immediately.
-  if (!thunks_ || !commands_.requires_initialization()) {
+  // If there are no thunks, there is no fallback path to use for warmup.
+  if (!thunks_) {
     cmd_buffer->warmup_done = true;
   }
 
@@ -230,10 +229,10 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
   }
 
   // If command buffer is in `kCreate` state it means that command buffer
-  // sequence was never recorded into it. We initialize all command buffers
-  // before execution, because command buffers when instantiated will allocate
-  // memory on device and this might lead to deadlocks when we have concurrent
-  // NCCL operations in flight.
+  // sequence was never recorded into it. When there is no pending warmup
+  // iteration, we initialize command buffers before execution, because command
+  // buffers when instantiated will allocate memory on device and this might
+  // lead to deadlocks when we have concurrent NCCL operations in flight.
 
   // If commands require initialization (and VA remapping is not enabled), we
   // also record them into the command buffer before execution. This is required

--- a/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
@@ -429,6 +429,63 @@ TEST(CommandBufferThunkTest, Memset32CmdCommandBuffersEnabledDuringProfiling) {
   ASSERT_EQ(dst, std::vector<int32_t>(4, 84));
 }
 
+TEST(CommandBufferThunkTest, InitializedThunkRunsWarmupWithoutCollectives) {
+  se::StreamExecutor* stream_executor = GpuExecutor();
+
+  ASSERT_OK_AND_ASSIGN(auto stream, stream_executor->CreateStream());
+
+  int64_t length = 4;
+  int64_t byte_length = sizeof(int32_t) * length;
+
+  se::DeviceAddress<int32_t> a =
+      stream_executor->AllocateArray<int32_t>(length, 0);
+  ASSERT_OK(stream->MemZero(&a, byte_length));
+
+  BufferAllocation alloc_a(/*index=*/0, byte_length, /*color=*/0);
+  BufferAllocation::Slice slice_a(&alloc_a, 0, byte_length);
+
+  CommandSequence commands;
+  commands.Append(std::make_unique<Memset32BitValueThunk>(
+      Thunk::ThunkInfo(), /*value=*/84, slice_a));
+  ASSERT_OK_AND_ASSIGN(CommandExecutor executor,
+                       CommandExecutor::Create(std::move(commands), serialize));
+
+  ThunkSequence thunks;
+  thunks.push_back(std::make_unique<Memset32BitValueThunk>(
+      Thunk::ThunkInfo(), /*value=*/21, slice_a));
+  auto seq_thunks =
+      std::make_unique<SequentialThunk>(Thunk::ThunkInfo(), std::move(thunks));
+
+  CommandBufferThunk thunk(std::move(executor), Thunk::ThunkInfo(),
+                           std::move(seq_thunks));
+
+  ServiceExecutableRunOptions run_options;
+  stream_executor::StreamExecutorAddressAllocator allocator(stream_executor);
+  BufferAllocations allocations({a}, 0, &allocator);
+
+  Thunk::ExecuteParams params =
+      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
+                                   stream.get(), nullptr, nullptr, nullptr);
+
+  Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
+  ASSERT_OK(thunk.Initialize(
+      {stream_executor, source, &allocations, stream.get(), stream.get()}));
+
+  ASSERT_OK(thunk.ExecuteOnStream(params));
+  ASSERT_OK(stream->BlockHostUntilDone());
+
+  std::vector<int32_t> dst(4, 0);
+  ASSERT_OK(stream->Memcpy(dst.data(), a, byte_length));
+  ASSERT_EQ(dst, std::vector<int32_t>(4, 21));
+
+  ASSERT_OK(thunk.ExecuteOnStream(params));
+  ASSERT_OK(stream->BlockHostUntilDone());
+
+  std::fill(dst.begin(), dst.end(), 0);
+  ASSERT_OK(stream->Memcpy(dst.data(), a, byte_length));
+  ASSERT_EQ(dst, std::vector<int32_t>(4, 84));
+}
+
 TEST(CommandBufferThunkTest, Memset32CmdOnDifferentStreams) {
   se::StreamExecutor* stream_executor = GpuExecutor();
 

--- a/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "third_party/cudnn_frontend/include/cudnn_frontend/graph_properties.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend_utils.h"
 #include "third_party/gpus/cuda/include/cuda.h"
+#include "xla/backends/gpu/runtime/collective_params.h"
 #include "xla/backends/gpu/runtime/command.h"
 #include "xla/backends/gpu/runtime/command_buffer_cmd.h"
 #include "xla/backends/gpu/runtime/command_buffer_thunk.h"
@@ -39,6 +40,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/sequential_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/runtime/buffer_use.h"
+#include "xla/runtime/device_id.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/buffer_allocations.h"
 #include "xla/service/platform_util.h"
@@ -86,7 +88,7 @@ static constexpr auto serialize =
 
 TEST(CommandBufferThunkTest, CuDnnCmd) {
   se::StreamExecutor* stream_executor = GpuExecutor();
-  TF_ASSERT_OK_AND_ASSIGN(auto stream, stream_executor->CreateStream());
+  ASSERT_OK_AND_ASSIGN(auto stream, stream_executor->CreateStream());
   se::dnn::DnnSupport& dnn_support = *stream_executor->AsDnn();
 
   if (dnn_support.GetVersion().value_or(se::dnn::VersionInfo{0, 0, 0}) <
@@ -169,9 +171,8 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
 
   CommandSequence commands;
   commands.Append(cudnn_thunk.get());
-  TF_ASSERT_OK_AND_ASSIGN(
-      CommandExecutor executor,
-      CommandExecutor::Create(std::move(commands), serialize));
+  ASSERT_OK_AND_ASSIGN(CommandExecutor executor,
+                       CommandExecutor::Create(std::move(commands), serialize));
 
   // Construct a thunk with command sequence. A SequentialThunk owns the
   // CuDnnThunk so it outlives the borrowed pointer in CommandSequence.
@@ -203,23 +204,39 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
   }
 
   ServiceExecutableRunOptions run_options;
+  run_options.mutable_run_options()->set_stream(stream.get());
+  ASSERT_OK_AND_ASSIGN(CollectiveParams collective_params,
+                       CollectiveParams::Create(
+                           run_options, /*async_streams=*/{},
+                           LocalDeviceId(stream_executor->device_ordinal())));
   stream_executor::StreamExecutorAddressAllocator allocator(stream_executor);
   BufferAllocations allocations(operands, 0, &allocator);
 
-  Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+  Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
+      run_options, allocations, stream.get(), stream.get(), &collective_params,
+      nullptr, nullptr);
 
   Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
   TF_ASSERT_OK(thunk.Initialize(
       {stream_executor, source, &allocations, stream.get(), stream.get()}));
 
-  // Execute command buffer thunk and verify that it executed a GEMM.
+  // First run warms up by executing the fallback thunk sequence.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
   TF_ASSERT_OK(stream->BlockHostUntilDone());
 
-  // Copy output0 data back to host.
   std::vector<int32_t> dst(kTotalElements, 1);
+  TF_ASSERT_OK(
+      stream->Memcpy(dst.data(), output0, kTotalElements * sizeof(int32_t)));
+
+  ASSERT_EQ(dst, std::vector<int32_t>(kTotalElements, 0));
+
+  TF_ASSERT_OK(stream->Memset32(&output0, 123, output0.size()));
+
+  // Second run records the command buffer and executes it.
+  TF_ASSERT_OK(thunk.ExecuteOnStream(params));
+  TF_ASSERT_OK(stream->BlockHostUntilDone());
+
+  std::fill(dst.begin(), dst.end(), 1);
   TF_ASSERT_OK(
       stream->Memcpy(dst.data(), output0, kTotalElements * sizeof(int32_t)));
 
@@ -233,8 +250,12 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
   // Update buffer allocation
   operands[1] = output1;
   allocations = BufferAllocations(operands, 0, &allocator);
-  // Thunk execution should automatically update underlying command
-  // buffer.
+  params = Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
+                                        stream.get(), &collective_params,
+                                        nullptr, nullptr);
+
+  // Third run updates the command buffer for the new allocation and executes
+  // it.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
   TF_ASSERT_OK(stream->BlockHostUntilDone());
 

--- a/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
@@ -30,10 +30,8 @@ limitations under the License.
 #include "third_party/cudnn_frontend/include/cudnn_frontend/graph_interface.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend/graph_properties.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend_utils.h"
-#include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/backends/gpu/runtime/collective_params.h"
 #include "xla/backends/gpu/runtime/command.h"
-#include "xla/backends/gpu/runtime/command_buffer_cmd.h"
 #include "xla/backends/gpu/runtime/command_buffer_thunk.h"
 #include "xla/backends/gpu/runtime/command_executor.h"
 #include "xla/backends/gpu/runtime/cudnn_thunk.h"
@@ -60,9 +58,7 @@ limitations under the License.
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
 #include "xla/stream_executor/stream_executor.h"
-#include "xla/stream_executor/stream_executor_memory_allocator.h"
-#include "xla/tsl/lib/core/status_test_util.h"
-#include "xla/tsl/platform/statusor.h"
+#include "xla/stream_executor/stream_executor_address_allocator.h"
 #include "xla/types.h"  // IWYU pragma: keep
 #include "xla/xla_data.pb.h"
 
@@ -124,11 +120,11 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
     return graph;
   }());
   int64_t workspace_size = graph.Graph().get_workspace_size();
-  TF_ASSERT_OK(graph.Prepare(
+  ASSERT_OK(graph.Prepare(
       dnn_support, se::EngineOptions{/*require_determinism=*/false,
                                      /*allow_tf32=*/true,
                                      /*require_command_buffer=*/true}));
-  TF_ASSERT_OK(graph.Build(dnn_support, /*plan_id=*/std::nullopt));
+  ASSERT_OK(graph.Build(dnn_support, /*plan_id=*/std::nullopt));
   EXPECT_THAT(graph.SupportsExplicitCommandBufferConstruction(),
               absl_testing::IsOkAndHolds(true));
 
@@ -188,11 +184,11 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
 
   se::DeviceAddress<int8_t> input =
       stream_executor->AllocateArray<int8_t>(kTotalElements);
-  TF_ASSERT_OK(stream->MemZero(&input, input.size()));
+  ASSERT_OK(stream->MemZero(&input, input.size()));
 
   se::DeviceAddress<int32_t> output0 =
       stream_executor->AllocateArray<int32_t>(kTotalElements);
-  TF_ASSERT_OK(stream->Memset32(&output0, 123, output0.size()));
+  ASSERT_OK(stream->Memset32(&output0, 123, output0.size()));
 
   operands.push_back(input);  // multiplying the input by itself
   operands.push_back(output0);
@@ -217,27 +213,27 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
       nullptr, nullptr);
 
   Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
-  TF_ASSERT_OK(thunk.Initialize(
+  ASSERT_OK(thunk.Initialize(
       {stream_executor, source, &allocations, stream.get(), stream.get()}));
 
   // First run warms up by executing the fallback thunk sequence.
-  TF_ASSERT_OK(thunk.ExecuteOnStream(params));
-  TF_ASSERT_OK(stream->BlockHostUntilDone());
+  ASSERT_OK(thunk.ExecuteOnStream(params));
+  ASSERT_OK(stream->BlockHostUntilDone());
 
   std::vector<int32_t> dst(kTotalElements, 1);
-  TF_ASSERT_OK(
+  ASSERT_OK(
       stream->Memcpy(dst.data(), output0, kTotalElements * sizeof(int32_t)));
 
   ASSERT_EQ(dst, std::vector<int32_t>(kTotalElements, 0));
 
-  TF_ASSERT_OK(stream->Memset32(&output0, 123, output0.size()));
+  ASSERT_OK(stream->Memset32(&output0, 123, output0.size()));
 
   // Second run records the command buffer and executes it.
-  TF_ASSERT_OK(thunk.ExecuteOnStream(params));
-  TF_ASSERT_OK(stream->BlockHostUntilDone());
+  ASSERT_OK(thunk.ExecuteOnStream(params));
+  ASSERT_OK(stream->BlockHostUntilDone());
 
   std::fill(dst.begin(), dst.end(), 1);
-  TF_ASSERT_OK(
+  ASSERT_OK(
       stream->Memcpy(dst.data(), output0, kTotalElements * sizeof(int32_t)));
 
   ASSERT_EQ(dst, std::vector<int32_t>(kTotalElements, 0));
@@ -245,7 +241,7 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
   // Prepare buffer allocation for updating command buffer.
   se::DeviceAddress<int32_t> output1 =
       stream_executor->AllocateArray<int32_t>(kTotalElements);
-  TF_ASSERT_OK(stream->Memset32(&output1, 456, output1.size()));
+  ASSERT_OK(stream->Memset32(&output1, 456, output1.size()));
 
   // Update buffer allocation
   operands[1] = output1;
@@ -256,12 +252,12 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
 
   // Third run updates the command buffer for the new allocation and executes
   // it.
-  TF_ASSERT_OK(thunk.ExecuteOnStream(params));
-  TF_ASSERT_OK(stream->BlockHostUntilDone());
+  ASSERT_OK(thunk.ExecuteOnStream(params));
+  ASSERT_OK(stream->BlockHostUntilDone());
 
   // Copy output1 data back to host.
   std::fill(dst.begin(), dst.end(), 1);
-  TF_ASSERT_OK(
+  ASSERT_OK(
       stream->Memcpy(dst.data(), output1, kTotalElements * sizeof(int32_t)));
 
   ASSERT_EQ(dst, std::vector<int32_t>(kTotalElements, 0));


### PR DESCRIPTION

  📝 Summary of Changes
  CommandBufferThunk now keeps the warmup iteration enabled whenever fallback
  thunks are available, instead of only when commands require initialization
  through collective commands.

  Added a regression test covering initialized, non-collective command buffers to
  verify the first execution runs through the fallback thunk and subsequent
  execution uses the command buffer.

  🎯 Justification
  Some custom call library operators also require warmup before command buffer
  execution.  The concrete case is the TE/JAX `CollectiveGemm` external custom call when using
  the cuBLASMp backend. The custom call is marked `kCmdBufferCompatible` and is
  intended to be CUDA graph safe, but cuBLASMp internally uses NCCL for its
  symmetric-memory path. In the failing trace, graph capture was invalidated by an
  `ncclPutSignal` call inside cuBLASMp, producing
  `CUDA_ERROR_STREAM_CAPTURE_INVALIDATED`.

Previously warmup was effectively limited to collective commands via
  `Command::requires_initialization()`. This change enables warmup by default for
  all command-buffered operators with fallback thunks, covering custom call
  library operators and other non-collective cases.




  🚀 Kind of Contribution
  🐛 Bug Fix

  📊 Benchmark (for Performance Improvements)
  N/A

  🧪 Unit Tests:
  Added `CommandBufferThunkTest.InitializedThunkRunsWarmupWithoutCollectives`.

  🧪 Execution Tests:
  Ran:

  `bazel test //xla/backends/gpu/runtime:command_buffer_thunk_test --test_filter=CommandBufferThunkTest.InitializedThunkRunsWarmupWithoutCollectives`
