### PR TITLE
[ROCm] Make rocm-smi logging less verbose

### DIFF
--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -1161,9 +1161,8 @@ RocmExecutor::CreateDeviceDescription(int device_ordinal) {
     if (pcie_bw.has_value()) {
       desc.set_pcie_bandwidth(*pcie_bw);
     } else {
-      LOG(WARNING) << "Could not determine PCIe bandwidth for device "
-                   << device_ordinal
-                   << " via rocm_smi. Assuming PCIe Gen4 x16.";
+      VLOG(2) << "Could not determine PCIe bandwidth for device "
+              << device_ordinal << " via rocm_smi. Assuming PCIe Gen4 x16.";
       desc.set_pcie_bandwidth(32LL * 1024 * 1024 * 1024);
     }
   }

--- a/xla/stream_executor/rocm/rocm_pcie_bandwidth.cc
+++ b/xla/stream_executor/rocm/rocm_pcie_bandwidth.cc
@@ -53,14 +53,13 @@ std::optional<int64_t> GetRocmPcieBandwidth(absl::string_view pci_bus_id) {
 
   std::optional<BdfComponents> bdf = ParseBdf(pci_bus_id);
   if (!bdf.has_value()) {
-    LOG(WARNING) << "Failed to parse PCI bus ID: " << pci_bus_id;
+    VLOG(2) << "Failed to parse PCI bus ID: " << pci_bus_id;
     return std::nullopt;
   }
 
   std::optional<uint32_t> dev_idx = FindDeviceIndex(*bdf);
   if (!dev_idx.has_value()) {
-    LOG(WARNING) << "rocm_smi: could not find device for PCI bus ID "
-                 << pci_bus_id;
+    VLOG(2) << "rocm_smi: could not find device for PCI bus ID " << pci_bus_id;
     return std::nullopt;
   }
 
@@ -69,8 +68,8 @@ std::optional<int64_t> GetRocmPcieBandwidth(absl::string_view pci_bus_id) {
   if (status != RSMI_STATUS_SUCCESS) {
     const char* err_str = nullptr;
     rsmi_status_string(status, &err_str);
-    LOG(WARNING) << "rsmi_dev_gpu_metrics_info_get failed for " << pci_bus_id
-                 << ": " << (err_str ? err_str : "unknown error");
+    VLOG(2) << "rsmi_dev_gpu_metrics_info_get failed for " << pci_bus_id << ": "
+            << (err_str ? err_str : "unknown error");
     return std::nullopt;
   }
 
@@ -79,16 +78,16 @@ std::optional<int64_t> GetRocmPcieBandwidth(absl::string_view pci_bus_id) {
   uint16_t width = gpu_metrics.pcie_link_width;
 
   if (speed_mt_per_sec == 0 || width == 0) {
-    LOG(WARNING) << "rocm_smi gpu_metrics reported zero PCIe speed ("
-                 << speed_mt_per_sec << " MT/s) or width (" << width
-                 << " lanes) for " << pci_bus_id;
+    VLOG(2) << "rocm_smi gpu_metrics reported zero PCIe speed ("
+            << speed_mt_per_sec << " MT/s) or width (" << width
+            << " lanes) for " << pci_bus_id;
     return std::nullopt;
   }
 
   int64_t bandwidth =
       ComputePcieBandwidthFromSpeedAndWidth(speed_mt_per_sec, width);
 
-  VLOG(1) << "PCIe bandwidth for " << pci_bus_id << ": " << speed_mt_per_sec
+  VLOG(2) << "PCIe bandwidth for " << pci_bus_id << ": " << speed_mt_per_sec
           << " MT/s x" << width << " = " << bandwidth / (1024 * 1024 * 1024)
           << " GB/s (" << bandwidth << " bytes/s)";
 

--- a/xla/stream_executor/rocm/rocm_smi_util.cc
+++ b/xla/stream_executor/rocm/rocm_smi_util.cc
@@ -29,8 +29,7 @@ bool InitRocmSmi() {
     if (status != RSMI_STATUS_SUCCESS) {
       const char* err_str = nullptr;
       rsmi_status_string(status, &err_str);
-      LOG(WARNING) << "rsmi_init failed: "
-                   << (err_str ? err_str : "unknown error");
+      VLOG(2) << "rsmi_init failed: " << (err_str ? err_str : "unknown error");
       return false;
     }
     return true;

--- a/xla/stream_executor/rocm/rocm_xgmi_topology.cc
+++ b/xla/stream_executor/rocm/rocm_xgmi_topology.cc
@@ -29,14 +29,14 @@ XgmiTopologyInfo GetRocmXgmiTopology(absl::string_view pci_bus_id) {
 
   std::optional<BdfComponents> bdf = ParseBdf(pci_bus_id);
   if (!bdf.has_value()) {
-    LOG(WARNING) << "Failed to parse PCI bus ID for xGMI query: " << pci_bus_id;
+    VLOG(2) << "Failed to parse PCI bus ID for xGMI query: " << pci_bus_id;
     return info;
   }
 
   std::optional<uint32_t> dev_idx = FindDeviceIndex(*bdf);
   if (!dev_idx.has_value()) {
-    LOG(WARNING) << "rocm_smi: could not find device for PCI bus ID "
-                 << pci_bus_id << " (xGMI query)";
+    VLOG(2) << "rocm_smi: could not find device for PCI bus ID " << pci_bus_id
+            << " (xGMI query)";
     return info;
   }
 
@@ -46,7 +46,7 @@ XgmiTopologyInfo GetRocmXgmiTopology(absl::string_view pci_bus_id) {
   if (status == RSMI_STATUS_SUCCESS) {
     info.hive_id = hive_id;
   } else {
-    VLOG(1) << "rsmi_dev_xgmi_hive_id_get failed for " << pci_bus_id
+    VLOG(2) << "rsmi_dev_xgmi_hive_id_get failed for " << pci_bus_id
             << "; device may not be in an xGMI hive.";
   }
 
@@ -73,7 +73,7 @@ XgmiTopologyInfo GetRocmXgmiTopology(absl::string_view pci_bus_id) {
 
   info.active_links = xgmi_links;
 
-  VLOG(1) << "xGMI topology for " << pci_bus_id << ": " << xgmi_links
+  VLOG(2) << "xGMI topology for " << pci_bus_id << ": " << xgmi_links
           << " active xGMI links"
           << " (hive_id=" << hive_id << ", num_devices=" << num_devices << ")";
 


### PR DESCRIPTION
📝 Summary of Changes
Change from LOG(WARNING) to VLOG(2) in recently introduced rocm-smi integration and related code.

🎯 Justification
The existing warnings are too verbose in environments where metrics queries fail for one reason another, resulting in log spam, and potentially mislead e.g. in diagnosing failing tests. Give the user control over whether to show them.