### PR TITLE
Ignore deleted files in clang-tidy changed file list

### DIFF
--- a/build_tools/ci/run_clang_tidy.sh
+++ b/build_tools/ci/run_clang_tidy.sh
@@ -55,7 +55,8 @@ if [ -z "$MERGE_BASE" ]; then
   echo "Example: git pull --rebase $REMOTE main" >&2
   exit 1
 fi
-CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" | grep -E '\.(cc|h)$' || true)
+CHANGED_FILES=$(git diff --name-only --diff-filter=d "$MERGE_BASE" |
+  grep -E '\.(cc|h)$' || true)
 # Always exit with 0 if no C++ files are changed.
 if [ -z "$CHANGED_FILES" ]; then
   set +x


### PR DESCRIPTION
📝 Summary of Changes
  Update `build_tools/ci/run_clang_tidy.sh` to exclude deleted `.cc` and `.h` files when computing the changed C++ file list for clang-tidy.

  🎯 Justification
  The clang-tidy CI script currently includes deleted C++ files from `git diff --name-only`. When a PR removes a source/header file, the script can pass that deleted path into Bazel target discovery, causing errors like “no such target” before clang-tidy can run.

  Filtering deleted files keeps clang-tidy focused on files that still exist and can be resolved to Bazel targets.

  🚀 Kind of Contribution
  🐛 Bug Fix

  📊 Benchmark (for Performance Improvements)
  N/A

  🧪 Unit Tests:
  N/A. This is a CI script fix.

  🧪 Execution Tests:
  Verified locally:
  - `bash -n build_tools/ci/run_clang_tidy.sh`
  - `git diff --check`