### PR TITLE
[XLA:CPU] Expand the scope of eligible transposes for folding

### DIFF
--- a/xla/hlo/transforms/simplifiers/BUILD
+++ b/xla/hlo/transforms/simplifiers/BUILD
@@ -753,6 +753,7 @@ xla_cc_test(
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/xla/hlo/transforms/simplifiers/gemv_rewriter.cc
+++ b/xla/hlo/transforms/simplifiers/gemv_rewriter.cc
@@ -56,6 +56,9 @@ absl::StatusOr<Layout> GetLayoutWithNewMinorMostDimension(
 
 class GemvRewriterVisitor : public DfsHloRewriteVisitor {
  public:
+  explicit GemvRewriterVisitor(const bool is_layout_sensitive = true)
+      : is_layout_sensitive_(is_layout_sensitive) {}
+
   absl::Status HandleDot(HloInstruction* instr) override {
     HloDotInstruction* dot = Cast<HloDotInstruction>(instr);
     const DotDimensionNumbers& dim_numbers = dot->dot_dimension_numbers();
@@ -87,6 +90,15 @@ class GemvRewriterVisitor : public DfsHloRewriteVisitor {
       return absl::OkStatus();
     }
 
+    // Skip if the layout is not normalized and the pass is not layout
+    // sensitive.
+    if (!is_layout_sensitive_ &&
+        !(LayoutUtil::IsMonotonicWithDim0Major(lhs->shape().layout()) &&
+          LayoutUtil::IsMonotonicWithDim0Major(rhs->shape().layout()) &&
+          LayoutUtil::IsMonotonicWithDim0Major(dot->shape().layout()))) {
+      return absl::OkStatus();
+    }
+
     changed_ = true;
 
     HloComputation* computation = dot->parent();
@@ -102,7 +114,9 @@ class GemvRewriterVisitor : public DfsHloRewriteVisitor {
           *new_lhs_shape.mutable_layout(),
           GetLayoutWithNewMinorMostDimension(lhs_shape.layout()));
       new_lhs = computation->AddInstruction(
-          HloInstruction::CreateBitcast(new_lhs_shape, lhs));
+          is_layout_sensitive_
+              ? HloInstruction::CreateBitcast(new_lhs_shape, lhs)
+              : HloInstruction::CreateReshape(new_lhs_shape, lhs));
     }
 
     HloInstruction* new_rhs = rhs;
@@ -117,7 +131,9 @@ class GemvRewriterVisitor : public DfsHloRewriteVisitor {
           *new_rhs_shape.mutable_layout(),
           GetLayoutWithNewMinorMostDimension(rhs_shape.layout()));
       new_rhs = computation->AddInstruction(
-          HloInstruction::CreateBitcast(new_rhs_shape, rhs));
+          is_layout_sensitive_
+              ? HloInstruction::CreateBitcast(new_rhs_shape, rhs)
+              : HloInstruction::CreateReshape(new_rhs_shape, rhs));
     }
 
     std::vector<int64_t> new_out_dimensions;
@@ -144,15 +160,18 @@ class GemvRewriterVisitor : public DfsHloRewriteVisitor {
         computation->AddInstruction(HloInstruction::CreateDot(
             new_out_shape, new_lhs, new_rhs, dot->dot_dimension_numbers(),
             dot->precision_config()));
-    HloInstruction* bitcast = computation->AddInstruction(
-        HloInstruction::CreateBitcast(dot->shape(), new_dot));
-    return computation->ReplaceInstruction(dot, bitcast);
+    HloInstruction* bitcast_or_reshape = computation->AddInstruction(
+        is_layout_sensitive_
+            ? HloInstruction::CreateBitcast(dot->shape(), new_dot)
+            : HloInstruction::CreateReshape(dot->shape(), new_dot));
+    return computation->ReplaceInstruction(dot, bitcast_or_reshape);
   }
 
   bool changed() const { return changed_; }
 
  private:
   bool changed_ = false;
+  const bool is_layout_sensitive_;
 };
 
 }  // namespace
@@ -160,7 +179,7 @@ class GemvRewriterVisitor : public DfsHloRewriteVisitor {
 absl::StatusOr<bool> GemvRewriter::RunImpl(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
-  GemvRewriterVisitor gemv_rewriter;
+  GemvRewriterVisitor gemv_rewriter(is_layout_sensitive_);
   for (HloComputation* computation :
        module->MakeNonfusionComputations(execution_threads)) {
     TF_RETURN_IF_ERROR(computation->Accept(&gemv_rewriter));

--- a/xla/hlo/transforms/simplifiers/gemv_rewriter.h
+++ b/xla/hlo/transforms/simplifiers/gemv_rewriter.h
@@ -30,12 +30,21 @@ namespace xla {
 // rewritten to [n x 1] @ [m x n].
 class GemvRewriter : public HloModulePass {
  public:
+  explicit GemvRewriter(const bool is_layout_sensitive = true)
+      : is_layout_sensitive_(is_layout_sensitive) {}
+  ~GemvRewriter() override = default;
   absl::string_view name() const override { return "gemv-rewriter"; }
 
  protected:
   absl::StatusOr<bool> RunImpl(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  // Whether the pass should be layout sensitive. If this pass is run before
+  // layout assignment then this value should be set to false, else should be
+  // set to true.
+  const bool is_layout_sensitive_;
 };
 
 }  // namespace xla

--- a/xla/hlo/transforms/simplifiers/gemv_rewriter_test.cc
+++ b/xla/hlo/transforms/simplifiers/gemv_rewriter_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <memory>
 #include <optional>
+#include <string>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/xla/hlo/transforms/simplifiers/gemv_rewriter_test.cc
+++ b/xla/hlo/transforms/simplifiers/gemv_rewriter_test.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/tsl/platform/statusor.h"
@@ -28,9 +29,19 @@ limitations under the License.
 namespace xla {
 namespace {
 
-class GemvRewriterTest : public HloHardwareIndependentTestBase {};
+class GemvRewriterTest : public HloHardwareIndependentTestBase,
+                         public ::testing::WithParamInterface<bool> {
+ protected:
+  GemvRewriterTest() {
+    is_layout_sensitive_ = GetParam();
+    reshape_or_bitcast_ = is_layout_sensitive_ ? "bitcast" : "reshape";
+  }
 
-TEST_F(GemvRewriterTest, RewriteMatrixVectorMultiplicationToGemm) {
+  bool is_layout_sensitive_;
+  const char* reshape_or_bitcast_;
+};
+
+TEST_P(GemvRewriterTest, RewriteMatrixVectorMultiplicationToGemm) {
   const char* hlo = R"(
   HloModule m
 
@@ -41,18 +52,23 @@ TEST_F(GemvRewriterTest, RewriteMatrixVectorMultiplicationToGemm) {
       lhs_contracting_dims={1}, rhs_contracting_dims={0}
   })";
 
-  const char* expected = R"()
+  // clang-format off
+  std::string expected = absl::StrCat(R"(
 // CHECK:  %[[P0:.*]] = f32[32,7]{1,0} parameter(0)
 // CHECK:  %[[P1:.*]] = f32[7]{0} parameter(1)
-// CHECK:  %[[BITCAST:.*]] = f32[7,1]{1,0} bitcast(%[[P1]])
-// CHECK:  %[[DOT:.*]] = f32[32,1]{1,0} dot(%[[P0]], %[[BITCAST]]), lhs_contracting_dims={1}, rhs_contracting_dims={0}
-// CHECK:  ROOT %[[ROOT:.*]] = f32[32]{0} bitcast(%[[DOT]])
-})";
+// CHECK:  %[[RESHAPE_OR_BITCAST:.*]] = f32[7,1]{1,0}
+// CHECK-SAME: )", reshape_or_bitcast_, R"((%[[P1]])
+// CHECK:  %[[DOT:.*]] = f32[32,1]{1,0} dot(%[[P0]], %[[RESHAPE_OR_BITCAST]]),
+// CHECK-SAME: lhs_contracting_dims={1}, rhs_contracting_dims={0}
+// CHECK:  ROOT %[[ROOT:.*]] = f32[32]{0}
+// CHECK-SAME: )", reshape_or_bitcast_, R"((%[[DOT]])
+)");
+  // clang-format on
 
-  RunAndFilecheckHloRewrite(hlo, GemvRewriter(), expected);
+  RunAndFilecheckHloRewrite(hlo, GemvRewriter(is_layout_sensitive_), expected);
 }
 
-TEST_F(GemvRewriterTest, RewriteVectorMatrixMultiplicationToGemm) {
+TEST_P(GemvRewriterTest, RewriteVectorMatrixMultiplicationToGemm) {
   const char* hlo = R"(
   HloModule m
 
@@ -63,18 +79,23 @@ TEST_F(GemvRewriterTest, RewriteVectorMatrixMultiplicationToGemm) {
       lhs_contracting_dims={0}, rhs_contracting_dims={0}
   })";
 
-  const char* expected = R"()
+  // clang-format off
+  std::string expected = absl::StrCat(R"(
 // CHECK:  %[[P0:.*]] = f32[7]{0} parameter(0)
-// CHECK:  %[[BITCAST:.*]] = f32[7,1]{1,0} bitcast(%[[P0]])
+// CHECK:  %[[RESHAPE_OR_BITCAST:.*]] = f32[7,1]{1,0}
+// CHECK-SAME: )", reshape_or_bitcast_, R"((%[[P0]])
 // CHECK:  %[[P1:.*]] = f32[7,32]{1,0} parameter(1)
-// CHECK:  %[[DOT:.*]] = f32[1,32]{1,0} dot(%[[BITCAST]], %[[P1]]), lhs_contracting_dims={0}, rhs_contracting_dims={0}
-// CHECK:  ROOT %[[ROOT:.*]].1 = f32[32]{0} bitcast(%[[DOT]])
-})";
+// CHECK:  %[[DOT:.*]] = f32[1,32]{1,0} dot(%[[RESHAPE_OR_BITCAST]], %[[P1]]),
+// CHECK-SAME: lhs_contracting_dims={0}, rhs_contracting_dims={0}
+// CHECK:  ROOT %[[ROOT:.*]].1 = f32[32]{0}
+// CHECK-SAME: )", reshape_or_bitcast_, R"((%[[DOT]])
+)");
+  // clang-format on
 
-  RunAndFilecheckHloRewrite(hlo, GemvRewriter(), expected);
+  RunAndFilecheckHloRewrite(hlo, GemvRewriter(is_layout_sensitive_), expected);
 }
 
-TEST_F(GemvRewriterTest, RewriteMatrixVectorMultiplicationWithBatch) {
+TEST_P(GemvRewriterTest, RewriteMatrixVectorMultiplicationWithBatch) {
   const char* hlo = R"(
   HloModule m
 
@@ -86,19 +107,23 @@ TEST_F(GemvRewriterTest, RewriteMatrixVectorMultiplicationWithBatch) {
       lhs_contracting_dims={3}, rhs_contracting_dims={2}
   })";
 
-  const char* expected = R"()
+  // clang-format off
+  std::string expected = absl::StrCat(R"(
 // CHECK:  %[[P0:.*]] = f32[2,5,32,7]{3,2,1,0} parameter(0)
 // CHECK:  %[[P1:.*]] = f32[2,5,7]{2,1,0} parameter(1)
-// CHECK:  %[[BITCAST:.*]] = f32[2,5,7,1]{3,2,1,0} bitcast(%[[P1]])
-// CHECK:  %[[DOT:.*]] = f32[2,5,32,1]{3,2,1,0} dot(%[[P0]], %[[BITCAST]]),
+// CHECK:  %[[RESHAPE_OR_BITCAST:.*]] = f32[2,5,7,1]{3,2,1,0}
+// CHECK-SAME: )", reshape_or_bitcast_, R"((%[[P1]])
+// CHECK:  %[[DOT:.*]] = f32[2,5,32,1]{3,2,1,0} dot(%[[P0]], %[[RESHAPE_OR_BITCAST]]),
 // CHECK-SAME: lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
-// CHECK:  ROOT %[[ROOT:.*]] = f32[2,5,32]{2,1,0} bitcast(%[[DOT]])
-})";
+// CHECK:  ROOT %[[ROOT:.*]] = f32[2,5,32]{2,1,0}
+// CHECK-SAME: )", reshape_or_bitcast_, R"((%[[DOT]])
+)");
+  // clang-format on
 
-  RunAndFilecheckHloRewrite(hlo, GemvRewriter(), expected);
+  RunAndFilecheckHloRewrite(hlo, GemvRewriter(is_layout_sensitive_), expected);
 }
 
-TEST_F(GemvRewriterTest, DotNotRewriteVectorVectorMultiplication) {
+TEST_P(GemvRewriterTest, DotNotRewriteVectorVectorMultiplication) {
   const char* hlo = R"(
   HloModule m
 
@@ -109,10 +134,11 @@ TEST_F(GemvRewriterTest, DotNotRewriteVectorVectorMultiplication) {
       lhs_contracting_dims={0}, rhs_contracting_dims={0}
   })";
 
-  RunAndFilecheckHloRewrite(hlo, GemvRewriter(), /*expected=*/std::nullopt);
+  RunAndFilecheckHloRewrite(hlo, GemvRewriter(is_layout_sensitive_),
+                            /*expected=*/std::nullopt);
 }
 
-TEST_F(GemvRewriterTest, DotNotRewriteMatrixMatrixMultiplication) {
+TEST_P(GemvRewriterTest, DotNotRewriteMatrixMatrixMultiplication) {
   const char* hlo = R"(
   HloModule m
 
@@ -123,10 +149,11 @@ TEST_F(GemvRewriterTest, DotNotRewriteMatrixMatrixMultiplication) {
       lhs_contracting_dims={1}, rhs_contracting_dims={0}
   })";
 
-  RunAndFilecheckHloRewrite(hlo, GemvRewriter(), /*expected=*/std::nullopt);
+  RunAndFilecheckHloRewrite(hlo, GemvRewriter(is_layout_sensitive_),
+                            /*expected=*/std::nullopt);
 }
 
-TEST_F(GemvRewriterTest, DoNotRewriteDotsWithNonNormalizedLayout) {
+TEST_P(GemvRewriterTest, DoNotRewriteDotsWithNonNormalizedLayout) {
   const char* hlo = R"(
   HloModule m
 
@@ -140,12 +167,25 @@ TEST_F(GemvRewriterTest, DoNotRewriteDotsWithNonNormalizedLayout) {
 
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(hlo));
-  GemvRewriter rewriter;
+  GemvRewriter rewriter(is_layout_sensitive_);
   absl::StatusOr<bool> result = this->RunHloPass(&rewriter, module.get());
-  EXPECT_FALSE(result.ok());
-  EXPECT_THAT(result.status().message(),
-              ::testing::HasSubstr("Layout is not normalized."));
+  if (is_layout_sensitive_) {
+    EXPECT_FALSE(result.ok());
+    EXPECT_THAT(result.status().message(),
+                ::testing::HasSubstr("Layout is not normalized."));
+  } else {
+    // No rewrite when the layout is not normalized, but the pass should succeed
+    // in this configuration.
+    EXPECT_TRUE(result.ok());
+    EXPECT_FALSE(result.value());
+  }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    GemvRewriterTestSuite, GemvRewriterTest, ::testing::Values(true, false),
+    [](const ::testing::TestParamInfo<GemvRewriterTest::ParamType>& info) {
+      return info.param ? "LayoutSensitive" : "NotLayoutSensitive";
+    });
 
 }  // namespace
 }  // namespace xla

--- a/xla/service/cpu/BUILD
+++ b/xla/service/cpu/BUILD
@@ -220,6 +220,7 @@ cc_library(
         "//xla/hlo/transforms/simplifiers:flatten_call_graph",
         "//xla/hlo/transforms/simplifiers:float_normalization",
         "//xla/hlo/transforms/simplifiers:gather_simplifier",
+        "//xla/hlo/transforms/simplifiers:gemv_rewriter",
         "//xla/hlo/transforms/simplifiers:hlo_computation_deduplicator",
         "//xla/hlo/transforms/simplifiers:hlo_constant_folding",
         "//xla/hlo/transforms/simplifiers:hlo_dce",

--- a/xla/service/cpu/cpu_compiler.cc
+++ b/xla/service/cpu/cpu_compiler.cc
@@ -142,6 +142,7 @@ limitations under the License.
 #include "xla/hlo/transforms/simplifiers/flatten_call_graph.h"
 #include "xla/hlo/transforms/simplifiers/float_normalization.h"
 #include "xla/hlo/transforms/simplifiers/gather_simplifier.h"
+#include "xla/hlo/transforms/simplifiers/gemv_rewriter.h"
 #include "xla/hlo/transforms/simplifiers/hlo_computation_deduplicator.h"
 #include "xla/hlo/transforms/simplifiers/hlo_constant_folding.h"
 #include "xla/hlo/transforms/simplifiers/hlo_dce.h"
@@ -934,6 +935,7 @@ absl::Status CpuCompiler::RunHloPassesThroughLayoutAssn(
   pipeline.AddPass(CreateSimplificationPipeline(
       "post_scatter_expansion_simplification", module, use_fusion_emitters,
       use_onednn_custom_call));
+  pipeline.AddPass<GemvRewriter>(/*is_layout_sensitive=*/false);
 
   pipeline.AddPass<BitcastDtypesExpander>();
 


### PR DESCRIPTION
This PR brings the `gemv_rewriter` pass into the CPU pipeline (it was previously GPU-only), which increases the set of transpose patterns that can be folded during CPU compilation.

What this PR changes:

1. Adds an `is_layout_sensitive` flag to the `gemv_rewrier` pass to control behavior based on whether it runs before or after layout assignment.
2. Expands test coverage to include cases where `is_layout_sensitive` is false.
3. Integrates `gemv_rewriter` to the CPU pipeline.

Enabling this rewrite on CPU improves optimization opportunities and can significantly improve end-to-end performance. Eg: `xla/backends/cpu/benchmarks/e2e/gemma2` tps increase to 2x on Intel Xeons (for F32 and F16) and close to 4x for BF16 batched throughput cases.

Note: 
1. This PR is Part 2/2 of https://github.com/openxla/xla/pull/40320
2. Part 1/2 (merged): https://github.com/openxla/xla/pull/42652