### PR TITLE
[xla:gpu] Support simple scalar expressions in DynamicSliceFusion part #1

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -631,7 +631,7 @@ xla_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/types:span",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest_main",  # fixdeps: keep
     ],
 )
 

--- a/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.cc
@@ -50,6 +50,34 @@ limitations under the License.
 #include "xla/xla_data.pb.h"
 
 namespace xla::gpu {
+namespace {
+
+struct ConstantOffset {
+  int64_t offset;
+  int64_t dimension_number;
+};
+
+struct RuntimeOffset {
+  int64_t parameter_number;
+  int64_t dimension_number;
+};
+
+// Thunk does not fully support dynamic-slice offset expressions and can only
+// verify offsets that come from a known constant or a parameter.
+using Offset = std::variant<ConstantOffset, RuntimeOffset>;
+
+absl::StatusOr<Offset> ConvertOffset(const DynamicSliceFusion::Offset& offset) {
+  using Expr = DynamicSliceFusion::Offset::Expr;
+  if (auto* constant = std::get_if<Expr::Constant>(&offset.expr.value)) {
+    return ConstantOffset{constant->value, offset.dimension_number};
+  }
+  if (auto* parameter = std::get_if<Expr::Parameter>(&offset.expr.value)) {
+    return RuntimeOffset{parameter->parameter_number, offset.dimension_number};
+  }
+  return InvalidArgument("Unsupported offset expression: %v", offset.expr);
+}
+
+}  // namespace
 
 //===----------------------------------------------------------------------===//
 // Helpers
@@ -70,19 +98,23 @@ static int64_t ComputeSliceOffset(const DynamicSliceConfig& config,
 // Computes the raw byte offset from actual offset scalars (D2H-copied from
 // device). Each runtime offset contributes index * byte_stride for its
 // dimension. No clamping is applied here.
-static int64_t ComputeSliceOffsetFromScalars(
-    absl::Span<const int32_t> indices, const Shape& src_shape,
-    absl::Span<const DynamicSliceFusion::Offset> offsets) {
+static int64_t ComputeSliceOffsetFromScalars(absl::Span<const int32_t> indices,
+                                             const Shape& src_shape,
+                                             absl::Span<const Offset> offsets) {
   auto byte_strides = ShapeUtil::ByteStrides(src_shape);
   int64_t byte_offset = 0;
   size_t runtime_idx = 0;
   for (const auto& offset : offsets) {
-    auto* runtime = std::get_if<DynamicSliceFusion::RuntimeOffset>(&offset);
-    if (runtime == nullptr) {
-      continue;
+    int64_t idx = 0;
+    int64_t dim = 0;
+    if (auto* constant = std::get_if<ConstantOffset>(&offset)) {
+      idx = constant->offset;
+      dim = constant->dimension_number;
+    } else {
+      auto& runtime = std::get<RuntimeOffset>(offset);
+      idx = indices[runtime_idx++];
+      dim = runtime.dimension_number;
     }
-    int64_t dim = runtime->dimension_number;
-    int64_t idx = indices[runtime_idx++];
     byte_offset += idx * (*byte_strides)[dim];
   }
   return byte_offset;
@@ -143,11 +175,17 @@ static absl::Status VerifySliceOffset(
     return absl::OkStatus();
   }
 
+  std::vector<Offset> leaf_offsets;
+  leaf_offsets.reserve(offsets->size());
+  for (const DynamicSliceFusion::Offset& offset : *offsets) {
+    ASSIGN_OR_RETURN(leaf_offsets.emplace_back(), ConvertOffset(offset));
+  }
+
   // Collect offsets that depend on runtime values.
-  std::vector<DynamicSliceFusion::RuntimeOffset> runtime_offsets;
-  for (const auto& offset : *offsets) {
-    if (auto* rt = std::get_if<DynamicSliceFusion::RuntimeOffset>(&offset)) {
-      runtime_offsets.push_back(*rt);
+  std::vector<RuntimeOffset> runtime_offsets;
+  for (const auto& offset : leaf_offsets) {
+    if (auto* runtime = std::get_if<RuntimeOffset>(&offset)) {
+      runtime_offsets.push_back(*runtime);
     }
   }
 
@@ -177,8 +215,8 @@ static absl::Status VerifySliceOffset(
   int64_t buffer_size = ShapeUtil::ByteSizeOf(src_shape);
   int64_t slice_size = ShapeUtil::ByteSizeOf(dst_shape);
   int64_t actual_offset = ClampSliceOffset(
-      ComputeSliceOffsetFromScalars(indices, src_shape, *offsets), buffer_size,
-      slice_size);
+      ComputeSliceOffsetFromScalars(indices, src_shape, leaf_offsets),
+      buffer_size, slice_size);
   int64_t annotated_offset = ClampSliceOffset(
       ComputeSliceOffset(*config, loop_nest), buffer_size, slice_size);
 
@@ -313,28 +351,37 @@ absl::Status DynamicSliceFusionV2Thunk::TransformNested(Transformer callback) {
 // Serialization
 //===----------------------------------------------------------------------===//
 
-static DynamicSliceFusionThunkProto::OffsetProto OffsetToProto(
+static absl::StatusOr<DynamicSliceFusionThunkProto::OffsetProto> OffsetToProto(
     const DynamicSliceFusion::Offset& offset) {
+  ASSIGN_OR_RETURN(Offset leaf_offset, ConvertOffset(offset));
+
   DynamicSliceFusionThunkProto::OffsetProto proto;
-  if (auto* c = std::get_if<DynamicSliceFusion::ConstantOffset>(&offset)) {
-    proto.set_dimension_number(c->dimension_number);
-    proto.set_constant_offset(c->offset);
-  } else {
-    auto& r = std::get<DynamicSliceFusion::RuntimeOffset>(offset);
-    proto.set_dimension_number(r.dimension_number);
-    proto.set_runtime_parameter_number(r.parameter_number);
+  if (auto* constant = std::get_if<ConstantOffset>(&leaf_offset)) {
+    proto.set_dimension_number(constant->dimension_number);
+    proto.set_constant_offset(constant->offset);
+    return proto;
   }
-  return proto;
+  if (auto* runtime = std::get_if<RuntimeOffset>(&leaf_offset)) {
+    proto.set_dimension_number(runtime->dimension_number);
+    proto.set_runtime_parameter_number(runtime->parameter_number);
+    return proto;
+  }
+  return InvalidArgument("Unknown dynamic slice fusion offset kind");
 }
 
-static DynamicSliceFusion::Offset OffsetFromProto(
+static absl::StatusOr<DynamicSliceFusion::Offset> OffsetFromProto(
     const DynamicSliceFusionThunkProto::OffsetProto& proto) {
   if (proto.has_constant_offset()) {
-    return DynamicSliceFusion::ConstantOffset{proto.constant_offset(),
-                                              proto.dimension_number()};
+    return DynamicSliceFusion::Offset{
+        proto.dimension_number(),
+        DynamicSliceFusion::Offset::Constant(proto.constant_offset())};
   }
-  return DynamicSliceFusion::RuntimeOffset{proto.runtime_parameter_number(),
-                                           proto.dimension_number()};
+  if (proto.has_runtime_parameter_number()) {
+    return DynamicSliceFusion::Offset{proto.dimension_number(),
+                                      DynamicSliceFusion::Offset::Parameter(
+                                          proto.runtime_parameter_number())};
+  }
+  return InvalidArgument("Offset proto has no value");
 }
 
 absl::StatusOr<ThunkProto> DynamicSliceFusionV2Thunk::ToProto() const {
@@ -353,7 +400,7 @@ absl::StatusOr<ThunkProto> DynamicSliceFusionV2Thunk::ToProto() const {
     }
     if (param.slice_offsets.has_value()) {
       for (const auto& offset : *param.slice_offsets) {
-        *p->add_slice_offsets() = OffsetToProto(offset);
+        ASSIGN_OR_RETURN(*p->add_slice_offsets(), OffsetToProto(offset));
       }
     }
   }
@@ -371,7 +418,7 @@ absl::StatusOr<ThunkProto> DynamicSliceFusionV2Thunk::ToProto() const {
     }
     if (result.update_offsets.has_value()) {
       for (const auto& offset : *result.update_offsets) {
-        *r->add_update_offsets() = OffsetToProto(offset);
+        ASSIGN_OR_RETURN(*r->add_update_offsets(), OffsetToProto(offset));
       }
     }
   }
@@ -417,7 +464,7 @@ DynamicSliceFusionV2Thunk::FromProto(
     if (!p.slice_offsets().empty()) {
       slice_offsets.emplace();
       for (const auto& o : p.slice_offsets()) {
-        slice_offsets->push_back(OffsetFromProto(o));
+        ASSIGN_OR_RETURN(slice_offsets->emplace_back(), OffsetFromProto(o));
       }
     }
     parameters.push_back(DynamicSliceFusion::Parameter{
@@ -442,7 +489,7 @@ DynamicSliceFusionV2Thunk::FromProto(
     if (!r.update_offsets().empty()) {
       update_offsets.emplace();
       for (const auto& o : r.update_offsets()) {
-        update_offsets->push_back(OffsetFromProto(o));
+        ASSIGN_OR_RETURN(update_offsets->emplace_back(), OffsetFromProto(o));
       }
     }
     results.push_back(DynamicSliceFusion::Result{

--- a/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk_test.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk_test.cc
@@ -54,6 +54,7 @@ namespace {
 
 using Parameter = DynamicSliceFusion::Parameter;
 using Result = DynamicSliceFusion::Result;
+using Offset = DynamicSliceFusion::Offset;
 using ::tsl::proto_testing::EqualsProto;
 
 static absl::StatusOr<se::StreamExecutor*> CreateExecutor() {
@@ -575,12 +576,14 @@ TEST(DynamicSliceFusionV2ThunkTest, SerializeDeserializeRoundTrip) {
   Shape res_shape = ShapeUtil::MakeShape(F32, {128});
 
   std::vector<Parameter> parameters = {
-      {0, arg_shape, arg_shape, MakeConfig(0, 0, 1024)},
+      {0, arg_shape, arg_shape, MakeConfig(0, 0, 1024),
+       std::vector<Offset>{{0, Offset::Constant(0)}}},
       {1, arg2_shape, arg2_shape},
   };
 
   std::vector<Result> results = {
-      {1, 0, res_shape, res_shape, MakeConfig(0, 256, 512)},
+      {1, 0, res_shape, res_shape, MakeConfig(0, 256, 512),
+       std::vector<Offset>{{0, Offset::Parameter(1)}}},
   };
 
   ShapedSlice memzero_dest = {

--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1324,15 +1324,20 @@ cc_library(
     srcs = ["dynamic_slice_fusion.cc"],
     hdrs = ["dynamic_slice_fusion.h"],
     deps = [
+        "//xla:comparison_util",
         "//xla:shape_util",
         "//xla:util",
+        "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
         "//xla/service/gpu:backend_configs_cc",
         "//xla/tsl/platform:status_macros",
-        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -1341,13 +1346,13 @@ xla_cc_test(
     srcs = ["dynamic_slice_fusion_test.cc"],
     deps = [
         ":dynamic_slice_fusion",
+        "//xla:comparison_util",
         "//xla:shape_util",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "//xla/service/gpu:backend_configs_cc",
         "@com_google_absl//absl/strings",
-        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",  # fixdeps: keep
     ],
 )

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion.cc
@@ -15,12 +15,22 @@ limitations under the License.
 
 #include "xla/backends/gpu/transforms/dynamic_slice_fusion.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <type_traits>
+#include <utility>
+#include <variant>
 #include <vector>
 
+#include "absl/algorithm/container.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "xla/comparison_util.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -29,40 +39,163 @@ limitations under the License.
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
-#include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
+#include "xla/xla_data.pb.h"
 
 namespace xla::gpu {
 
-const HloInstruction* DynamicSliceFusion::FindHero(const HloComputation* body) {
-  for (const HloInstruction* instr : body->instructions()) {
-    switch (instr->opcode()) {
-      case HloOpcode::kParameter:
-      case HloOpcode::kConstant:
-      case HloOpcode::kSlice:
-      case HloOpcode::kDynamicSlice:
-      case HloOpcode::kDynamicUpdateSlice:
-      case HloOpcode::kBitcast:
-      case HloOpcode::kTuple:
-      case HloOpcode::kGetTupleElement:
-        continue;
-      default:
-        return instr;
-    }
-  }
-  return nullptr;
+using Offset = DynamicSliceFusion::Offset;
+
+Offset::Expr Offset::Constant(int64_t value) {
+  return {Offset::Expr::Constant{value}};
 }
 
-namespace {
+Offset::Expr Offset::Parameter(int64_t parameter_number) {
+  return {Offset::Expr::Parameter{parameter_number}};
+}
 
-const HloInstruction* WalkThroughBitcasts(const HloInstruction* instr) {
-  while (instr->opcode() == HloOpcode::kBitcast) {
+Offset::Expr Offset::Add(Offset::Expr lhs, Offset::Expr rhs) {
+  return {Offset::Expr::Add{{std::move(lhs), std::move(rhs)}}};
+}
+
+Offset::Expr Offset::Subtract(Offset::Expr lhs, Offset::Expr rhs) {
+  return {Offset::Expr::Subtract{{std::move(lhs), std::move(rhs)}}};
+}
+
+Offset::Expr Offset::Multiply(Offset::Expr lhs, Offset::Expr rhs) {
+  return {Offset::Expr::Multiply{{std::move(lhs), std::move(rhs)}}};
+}
+
+Offset::Expr Offset::Compare(ComparisonDirection direction, Offset::Expr lhs,
+                             Offset::Expr rhs) {
+  return {Offset::Expr::Compare{direction, {std::move(lhs), std::move(rhs)}}};
+}
+
+Offset::Expr Offset::Select(Offset::Expr pred, Offset::Expr on_true,
+                            Offset::Expr on_false) {
+  return {Offset::Expr::Select{
+      {std::move(pred), std::move(on_true), std::move(on_false)}}};
+}
+
+static bool IsBitcastOrReshape(const HloInstruction* instr) {
+  return instr->opcode() == HloOpcode::kBitcast ||
+         instr->opcode() == HloOpcode::kReshape;
+}
+
+static const HloInstruction* WalkThroughBitcastsAndReshapes(
+    const HloInstruction* instr) {
+  while (IsBitcastOrReshape(instr)) {
     instr = instr->operand(0);
   }
   return instr;
 }
 
-std::optional<DynamicSliceConfig> ExtractDynamicSliceConfig(
+static bool IsNoOpInstruction(const HloInstruction* instr) {
+  switch (instr->opcode()) {
+    case HloOpcode::kParameter:
+    case HloOpcode::kConstant:
+    case HloOpcode::kBitcast:
+    case HloOpcode::kReshape:
+    case HloOpcode::kTuple:
+    case HloOpcode::kGetTupleElement:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool IsSlicingInstruction(const HloInstruction* instr) {
+  switch (instr->opcode()) {
+    case HloOpcode::kSlice:
+    case HloOpcode::kDynamicSlice:
+    case HloOpcode::kDynamicUpdateSlice:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static const HloInstruction* WalkThroughBitcasts(const HloInstruction* instr) {
+  return WalkThroughBitcastsAndReshapes(instr);
+}
+
+static absl::StatusOr<int64_t> GetScalarIntegerLiteral(
+    const HloConstantInstruction* constant) {
+  if (!ShapeUtil::IsScalar(constant->shape())) {
+    return Internal(
+        "DynamicSliceFusion: expected scalar offset constant, got %s",
+        constant->ToString());
+  }
+
+  switch (constant->shape().element_type()) {
+    case PRED:
+      return constant->literal().GetFirstElement<bool>() ? 1 : 0;
+    case S32:
+      return constant->literal().GetFirstElement<int32_t>();
+    case S64:
+      return constant->literal().GetFirstElement<int64_t>();
+    default:
+      return Internal(
+          "DynamicSliceFusion: expected integer or pred offset constant, "
+          "got %s",
+          constant->ToString());
+  }
+}
+
+static absl::StatusOr<Offset::Expr> BuildOffsetExpr(
+    const HloInstruction* instr) {
+  instr = WalkThroughBitcasts(instr);
+
+  if (auto* parameter = DynCast<HloParameterInstruction>(instr)) {
+    return Offset::Parameter(parameter->parameter_number());
+  }
+
+  if (auto* constant = DynCast<HloConstantInstruction>(instr)) {
+    ASSIGN_OR_RETURN(int64_t value, GetScalarIntegerLiteral(constant));
+    return Offset::Constant(value);
+  }
+
+  switch (instr->opcode()) {
+    case HloOpcode::kAdd: {
+      ASSIGN_OR_RETURN(auto lhs, BuildOffsetExpr(instr->operand(0)));
+      ASSIGN_OR_RETURN(auto rhs, BuildOffsetExpr(instr->operand(1)));
+      return Offset::Add(std::move(lhs), std::move(rhs));
+    }
+    case HloOpcode::kSubtract: {
+      ASSIGN_OR_RETURN(auto lhs, BuildOffsetExpr(instr->operand(0)));
+      ASSIGN_OR_RETURN(auto rhs, BuildOffsetExpr(instr->operand(1)));
+      return Offset::Subtract(std::move(lhs), std::move(rhs));
+    }
+    case HloOpcode::kMultiply: {
+      ASSIGN_OR_RETURN(auto lhs, BuildOffsetExpr(instr->operand(0)));
+      ASSIGN_OR_RETURN(auto rhs, BuildOffsetExpr(instr->operand(1)));
+      return Offset::Multiply(std::move(lhs), std::move(rhs));
+    }
+    case HloOpcode::kCompare: {
+      auto* compare = Cast<HloCompareInstruction>(instr);
+      ASSIGN_OR_RETURN(auto lhs, BuildOffsetExpr(compare->operand(0)));
+      ASSIGN_OR_RETURN(auto rhs, BuildOffsetExpr(compare->operand(1)));
+      return Offset::Compare(compare->direction(), std::move(lhs),
+                             std::move(rhs));
+    }
+    case HloOpcode::kSelect: {
+      ASSIGN_OR_RETURN(auto pred, BuildOffsetExpr(instr->operand(0)));
+      ASSIGN_OR_RETURN(auto on_true, BuildOffsetExpr(instr->operand(1)));
+      ASSIGN_OR_RETURN(auto on_false, BuildOffsetExpr(instr->operand(2)));
+      return Offset::Select(std::move(pred), std::move(on_true),
+                            std::move(on_false));
+    }
+    case HloOpcode::kConvert:
+      return BuildOffsetExpr(instr->operand(0));
+    default:
+      return Internal(
+          "DynamicSliceFusion: expected DS/DUS offset to be a scalar "
+          "expression of fusion parameters and constants, got %s",
+          instr->ToString());
+  }
+}
+
+static std::optional<DynamicSliceConfig> ExtractDynamicSliceConfig(
     const HloInstruction* instr) {
   auto config = instr->backend_config<GpuBackendConfig>();
   if (!config.ok() || !config->has_dynamic_slice_config()) {
@@ -71,14 +204,172 @@ std::optional<DynamicSliceConfig> ExtractDynamicSliceConfig(
   return config->dynamic_slice_config();
 }
 
-std::optional<DynamicSliceConfig> ComputeStaticSliceConfig(
+static absl::Status VerifyArgCount(const Offset::Expr& expr,
+                                   absl::Span<const Offset::Expr> args,
+                                   size_t expected) {
+  if (args.size() != expected) {
+    return InvalidArgument(
+        "Expected offset expression %s to have %d args, got %d",
+        absl::StrCat(expr), expected, args.size());
+  }
+  return absl::OkStatus();
+}
+
+static absl::StatusOr<int64_t> GetParameterValue(
+    int64_t parameter_number,
+    absl::Span<const std::pair<int64_t, int64_t>> parameters) {
+  for (const auto& [candidate, value] : parameters) {
+    if (candidate == parameter_number) {
+      return value;
+    }
+  }
+  return InvalidArgument("Missing value for offset parameter %d",
+                         parameter_number);
+}
+
+static absl::Span<const Offset::Expr> GetArgs(const Offset::Expr& expr) {
+  return std::visit(
+      [](const auto& e) -> absl::Span<const Offset::Expr> {
+        using T = std::decay_t<decltype(e)>;
+        if constexpr (std::is_same_v<T, Offset::Expr::Constant> ||
+                      std::is_same_v<T, Offset::Expr::Parameter>) {
+          return {};
+        } else {
+          return e.args;
+        }
+      },
+      expr.value);
+}
+
+absl::StatusOr<int64_t> DynamicSliceFusion::Evaluate(
+    const Offset::Expr& expr,
+    absl::Span<const std::pair<int64_t, int64_t>> parameters) {
+  auto evaluate_compare = [](ComparisonDirection direction, int64_t lhs,
+                             int64_t rhs) -> absl::StatusOr<int64_t> {
+    switch (direction) {
+      case ComparisonDirection::kEq:
+        return lhs == rhs ? 1 : 0;
+      case ComparisonDirection::kNe:
+        return lhs != rhs ? 1 : 0;
+      case ComparisonDirection::kGe:
+        return lhs >= rhs ? 1 : 0;
+      case ComparisonDirection::kGt:
+        return lhs > rhs ? 1 : 0;
+      case ComparisonDirection::kLe:
+        return lhs <= rhs ? 1 : 0;
+      case ComparisonDirection::kLt:
+        return lhs < rhs ? 1 : 0;
+    }
+    return Internal("Unsupported comparison direction in offset expression");
+  };
+
+  return std::visit(
+      [&](const auto& e) -> absl::StatusOr<int64_t> {
+        using T = std::decay_t<decltype(e)>;
+        if constexpr (std::is_same_v<T, Offset::Expr::Constant>) {
+          return e.value;
+        } else if constexpr (std::is_same_v<T, Offset::Expr::Parameter>) {
+          return GetParameterValue(e.parameter_number, parameters);
+        } else if constexpr (std::is_same_v<T, Offset::Expr::Add>) {
+          RETURN_IF_ERROR(VerifyArgCount(expr, e.args, 2));
+          ASSIGN_OR_RETURN(int64_t lhs, Evaluate(e.args[0], parameters));
+          ASSIGN_OR_RETURN(int64_t rhs, Evaluate(e.args[1], parameters));
+          return lhs + rhs;
+        } else if constexpr (std::is_same_v<T, Offset::Expr::Subtract>) {
+          RETURN_IF_ERROR(VerifyArgCount(expr, e.args, 2));
+          ASSIGN_OR_RETURN(int64_t lhs, Evaluate(e.args[0], parameters));
+          ASSIGN_OR_RETURN(int64_t rhs, Evaluate(e.args[1], parameters));
+          return lhs - rhs;
+        } else if constexpr (std::is_same_v<T, Offset::Expr::Multiply>) {
+          RETURN_IF_ERROR(VerifyArgCount(expr, e.args, 2));
+          ASSIGN_OR_RETURN(int64_t lhs, Evaluate(e.args[0], parameters));
+          ASSIGN_OR_RETURN(int64_t rhs, Evaluate(e.args[1], parameters));
+          return lhs * rhs;
+        } else if constexpr (std::is_same_v<T, Offset::Expr::Compare>) {
+          RETURN_IF_ERROR(VerifyArgCount(expr, e.args, 2));
+          ASSIGN_OR_RETURN(int64_t lhs, Evaluate(e.args[0], parameters));
+          ASSIGN_OR_RETURN(int64_t rhs, Evaluate(e.args[1], parameters));
+          return evaluate_compare(e.direction, lhs, rhs);
+        } else if constexpr (std::is_same_v<T, Offset::Expr::Select>) {
+          RETURN_IF_ERROR(VerifyArgCount(expr, e.args, 3));
+          ASSIGN_OR_RETURN(int64_t pred, Evaluate(e.args[0], parameters));
+          return Evaluate(e.args[pred != 0 ? 1 : 2], parameters);
+        } else {
+          return Internal("Unsupported offset expression kind");
+        }
+      },
+      expr.value);
+}
+
+std::vector<int64_t> DynamicSliceFusion::CollectOffsetParameters(
+    const Offset::Expr& expr) {
+  std::vector<int64_t> parameter_numbers;
+  auto collect = [&](auto& self, const Offset::Expr& expr) -> void {
+    if (auto* e = std::get_if<Offset::Expr::Parameter>(&expr.value);
+        e && !absl::c_contains(parameter_numbers, e->parameter_number)) {
+      parameter_numbers.push_back(e->parameter_number);
+    }
+    for (const Offset::Expr& arg : GetArgs(expr)) {
+      self(self, arg);
+    }
+  };
+  collect(collect, expr);
+  return parameter_numbers;
+}
+
+static absl::flat_hash_set<const HloInstruction*> CollectOffsetInstructions(
+    const HloComputation* body) {
+  absl::flat_hash_set<const HloInstruction*> offsets;
+
+  auto collect = [&](auto& self, const HloInstruction* instr) -> void {
+    instr = WalkThroughBitcasts(instr);
+    if (!offsets.insert(instr).second) {
+      return;
+    }
+    if (instr->opcode() == HloOpcode::kParameter ||
+        instr->opcode() == HloOpcode::kConstant) {
+      return;
+    }
+    for (const HloInstruction* operand : instr->operands()) {
+      self(self, operand);
+    }
+  };
+
+  for (const HloInstruction* hlo : body->instructions()) {
+    if (auto* ds = DynCast<HloDynamicSliceInstruction>(hlo)) {
+      for (int64_t i = 1; i < ds->operand_count(); ++i) {
+        collect(collect, ds->operand(i));
+      }
+    } else if (auto* dus = DynCast<HloDynamicUpdateSliceInstruction>(hlo)) {
+      for (int64_t i = 2; i < dus->operand_count(); ++i) {
+        collect(collect, dus->operand(i));
+      }
+    }
+  }
+
+  return offsets;
+}
+
+const HloInstruction* DynamicSliceFusion::FindHero(const HloComputation* body) {
+  absl::flat_hash_set<const HloInstruction*> offsets =
+      CollectOffsetInstructions(body);
+  for (const HloInstruction* hlo : body->instructions()) {
+    if (!offsets.contains(hlo) && !IsNoOpInstruction(hlo) &&
+        !IsSlicingInstruction(hlo)) {
+      return hlo;
+    }
+  }
+  return nullptr;
+}
+
+static std::optional<DynamicSliceConfig> ComputeStaticSliceConfig(
     const HloSliceInstruction* slice) {
   auto byte_strides = ShapeUtil::ByteStrides(slice->operand(0)->shape());
   if (!byte_strides.has_value()) {
     return std::nullopt;
   }
   int64_t byte_offset = 0;
-  for (int64_t dim = 0; dim < slice->shape().dimensions_size(); ++dim) {
+  for (int64_t dim = 0; dim < slice->shape().dimensions().size(); ++dim) {
     byte_offset += slice->slice_starts(dim) * (*byte_strides)[dim];
   }
   DynamicSliceConfig config;
@@ -87,23 +378,16 @@ std::optional<DynamicSliceConfig> ComputeStaticSliceConfig(
   return config;
 }
 
-// Resolves per-dimension offset info for a DS/DUS. Returns one entry per
-// dimension: RuntimeOffset for fusion parameters, ConstantOffset for
-// constants sunk into the fusion body.
-std::vector<DynamicSliceFusion::Offset> ResolveOffsets(
+// Resolves per-dimension offset info for a DS/DUS. Returns one expression per
+// dimension.
+static absl::StatusOr<std::vector<Offset>> ResolveOffsets(
     const HloInstruction* instr, int32_t first_offset_index) {
-  std::vector<DynamicSliceFusion::Offset> offsets;
+  std::vector<Offset> offsets;
   offsets.reserve(instr->operand_count() - first_offset_index);
   for (int64_t i = first_offset_index; i < instr->operand_count(); ++i) {
     int64_t dim = i - first_offset_index;
-    const HloInstruction* idx = WalkThroughBitcasts(instr->operand(i));
-    auto* idx_param = DynCast<HloParameterInstruction>(idx);
-    if (idx_param != nullptr) {
-      offsets.push_back(DynamicSliceFusion::RuntimeOffset{
-          idx_param->parameter_number(), dim});
-    } else {
-      offsets.push_back(DynamicSliceFusion::ConstantOffset{0, dim});
-    }
+    ASSIGN_OR_RETURN(Offset::Expr expr, BuildOffsetExpr(instr->operand(i)));
+    offsets.push_back(Offset{dim, std::move(expr)});
   }
   return offsets;
 }
@@ -132,9 +416,11 @@ ResolveOneResultChain(const HloInstruction* start, const Shape& hero_shape,
   auto* target_param = DynCast<HloParameterInstruction>(target);
   if (target_param == nullptr) {
     return Internal(
-        "DynamicSliceFusionV2: DUS target must be a fusion parameter, got %s",
+        "DynamicSliceFusion: DUS target must be a fusion parameter, got %s",
         target->ToString());
   }
+
+  ASSIGN_OR_RETURN(auto offsets, ResolveOffsets(dus, 2));
 
   return DynamicSliceFusion::Result{
       std::optional<int64_t>(target_param->parameter_number()),
@@ -142,7 +428,7 @@ ResolveOneResultChain(const HloInstruction* start, const Shape& hero_shape,
       dus->operand(0)->shape(),
       dus->operand(1)->shape(),
       config,
-      std::optional(ResolveOffsets(dus, 2)),
+      std::optional(std::move(offsets)),
   };
 }
 
@@ -150,8 +436,8 @@ ResolveOneResultChain(const HloInstruction* start, const Shape& hero_shape,
 // example, ShapeIndex{0,1} means: find the GTE with index 0 among instr's
 // users, then find the GTE with index 1 among that GTE's users. Returns
 // nullptr if the chain does not exist.
-const HloInstruction* WalkGteChain(const HloInstruction* instr,
-                                   const ShapeIndex& index) {
+static const HloInstruction* WalkGteChain(const HloInstruction* instr,
+                                          const ShapeIndex& index) {
   const HloInstruction* current = instr;
   for (int64_t i = 0; i < index.size(); ++i) {
     const HloInstruction* found = nullptr;
@@ -170,8 +456,6 @@ const HloInstruction* WalkGteChain(const HloInstruction* instr,
   return current;
 }
 
-}  // namespace
-
 absl::StatusOr<std::vector<DynamicSliceFusion::Parameter>>
 DynamicSliceFusion::ResolveParameters(const HloInstruction* hero) {
   std::vector<DynamicSliceFusion::Parameter> result;
@@ -181,13 +465,13 @@ DynamicSliceFusion::ResolveParameters(const HloInstruction* hero) {
     const HloInstruction* walk = WalkThroughBitcasts(operand);
 
     std::optional<DynamicSliceConfig> config;
-    std::optional<std::vector<DynamicSliceFusion::Offset>> offsets;
+    std::optional<std::vector<Offset>> offsets;
     const HloInstruction* source = walk;
     Shape slice_shape = operand->shape();
 
     if (auto* ds = DynCast<HloDynamicSliceInstruction>(walk)) {
       config = ExtractDynamicSliceConfig(ds);
-      offsets = ResolveOffsets(ds, 1);
+      ASSIGN_OR_RETURN(offsets, ResolveOffsets(ds, 1));
       slice_shape = ds->shape();
       source = ds->operand(0);
     } else if (auto* slice = DynCast<HloSliceInstruction>(walk)) {
@@ -200,8 +484,8 @@ DynamicSliceFusion::ResolveParameters(const HloInstruction* hero) {
     auto* parameter = DynCast<HloParameterInstruction>(source);
     if (parameter == nullptr) {
       return Internal(
-          "DynamicSliceFusionV2: expected fusion parameter backing hero "
-          "operand, got %s",
+          "DynamicSliceFusion: expected fusion parameter backing hero operand, "
+          "got %s",
           source->ToString());
     }
 

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion.h
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion.h
@@ -19,6 +19,8 @@ limitations under the License.
 #include <cstdint>
 #include <optional>
 #include <ostream>
+#include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -26,6 +28,8 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
+#include "absl/types/span.h"
+#include "xla/comparison_util.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/service/gpu/backend_configs.pb.h"
@@ -36,48 +40,54 @@ namespace xla::gpu {
 
 // Utilities for analyzing dynamic-slice fusion instructions. These fusions are
 // created by the dynamic-slice fusion rewriter when it can prove that DS/DUS
-// offsets depend only on the while-loop induction variable or are fully static.
+// offsets can be represented in a tiny offset expression language over scalar
+// fusion parameters and constants. The language supports constants, parameter
+// reads, arithmetic, comparisons, and selects that can be evaluated at run
+// time.
 //
 // A dynamic-slice fusion wraps a hero computation (e.g. a custom call or a
 // kernel fusion) with dynamic-slice (DS) inputs and dynamic-update-slice (DUS)
 // outputs. At run time, the DynamicSliceFusionThunk adjusts buffer offsets
 // per while-loop iteration so the hero operates on a different slice each time.
 //
-// Example HLO (a custom call reading and writing one row per iteration of a
-// 4-iteration while loop). The induction variable `ivar` is passed as a fusion
-// parameter so the runtime can verify the annotated offset.
+// Example HLO (a custom call reading and writing row `ivar + 1` per iteration
+// of a 4-iteration while loop). The induction variable `ivar` is passed as a
+// fusion parameter so the annotated offset expression can be verified.
 //
 //   %dsf_computation {
-//     %p0 = f32[4,8,8] parameter(0)         // input buffer
-//     %p1 = s32[] parameter(1)              // ivar (runtime offset)
-//     %p2 = f32[4,8,8] parameter(2)         // output buffer
+//     %p0 = f32[5,8,8] parameter(0)         // input buffer
+//     %p1 = s32[] parameter(1)              // ivar
+//     %p2 = f32[5,8,8] parameter(2)         // output buffer
 //     %c0 = s32[] constant(0)
-//     %ds = f32[1,8,8] dynamic-slice(%p0, %p1, %c0, %c0),
+//     %c1 = s32[] constant(1)
+//     %offset = s32[] add(%p1, %c1)
+//     %ds = f32[1,8,8] dynamic-slice(%p0, %offset, %c0, %c0),
 //       dynamic_slice_sizes={1,8,8},
 //       backend_config={"dynamic_slice_config":{
-//         "loop_index":0, "byte_offset":0, "byte_stride":256}}
+//         "loop_index":0, "byte_offset":256, "byte_stride":256}}
 //     %bc_in = f32[8,8] bitcast(%ds)
 //     %hero = f32[8,8] custom-call(%bc_in),
 //       custom_call_target="fake_target"
 //     %bc_out = f32[1,8,8] bitcast(%hero)
-//     ROOT %dus = f32[4,8,8] dynamic-update-slice(%p2, %bc_out, %p1, %c0, %c0),
+//     ROOT %dus = f32[5,8,8] dynamic-update-slice(
+//       %p2, %bc_out, %offset, %c0, %c0),
 //       backend_config={"dynamic_slice_config":{
-//         "loop_index":0, "byte_offset":0, "byte_stride":256}}
+//         "loop_index":0, "byte_offset":256, "byte_stride":256}}
 //   }
 //
 //   body {
-//     %param = (s32[], f32[4,8,8], f32[4,8,8]) parameter(0)
+//     %param = (s32[], f32[5,8,8], f32[5,8,8]) parameter(0)
 //     %ivar = s32[] get-tuple-element(%param), index=0
-//     %input = f32[4,8,8] get-tuple-element(%param), index=1
-//     %output = f32[4,8,8] get-tuple-element(%param), index=2
-//     %updated = f32[4,8,8] fusion(%input, %ivar, %output),
+//     %input = f32[5,8,8] get-tuple-element(%param), index=1
+//     %output = f32[5,8,8] get-tuple-element(%param), index=2
+//     %updated = f32[5,8,8] fusion(%input, %ivar, %output),
 //       kind=kCustom, calls=%dsf_computation,
 //       backend_config={"fusion_backend_config":{
 //         "kind":"__custom_fusion",
 //         "custom_fusion_config":{"name":"dynamic_slice_fusion"}}}
 //     %one = s32[] constant(1)
 //     %next_ivar = s32[] add(%ivar, %one)
-//     ROOT %result = (s32[], f32[4,8,8], f32[4,8,8])
+//     ROOT %result = (s32[], f32[5,8,8], f32[5,8,8])
 //       tuple(%next_ivar, %input, %updated)
 //   }
 //
@@ -88,29 +98,41 @@ namespace xla::gpu {
 // parameter and result maps to fusion parameters and how offsets are computed
 // at runtime.
 struct DynamicSliceFusion {
-  // A DS/DUS offset for one dimension that is a compile-time constant (e.g.
-  // `s32[] constant(0)` inside the fusion body). The actual byte contribution
-  // for this dimension is `offset * byte_stride_for_dimension`.
-  struct ConstantOffset {
-    int64_t offset;            // Constant index value for this dimension.
-    int64_t dimension_number;  // Which dimension of the DS/DUS this applies to.
-  };
+  // Per-dimension offset for a DS or DUS instruction.
+  struct Offset {
+    // Scalar expression used to compute one DS/DUS offset. Leaves are either
+    // constants or fusion parameters that hold scalar values; internal nodes
+    // are simple arithmetic, comparison, and select operations.
+    struct Expr {
+      // A tiny AST that can express offset computations on scalars inside a
+      // dynamic-slice-fusion operation.
+      // clang-format off
+      struct Constant  { int64_t value;              };
+      struct Parameter { int64_t parameter_number;   };
+      struct Add       { std::vector<Expr> args;     };
+      struct Subtract  { std::vector<Expr> args;     };
+      struct Multiply  { std::vector<Expr> args;     };
+      struct Select    { std::vector<Expr> args;     };
+      struct Compare   { ComparisonDirection direction;
+                         std::vector<Expr> args;     };
+      // clang-format on
 
-  // A DS/DUS offset for one dimension that comes from a fusion parameter
-  // holding a runtime scalar (e.g. the loop induction variable passed as a
-  // fusion operand). At emit time the thunk emitter maps `parameter_number`
-  // to a BufferAllocation::Slice; at runtime the thunk D2H-copies the scalar
-  // to verify that the annotated DynamicSliceConfig offset matches the actual
-  // XLA-computed offset.
-  struct RuntimeOffset {
-    int64_t parameter_number;  // Fusion parameter index of the offset scalar.
-    int64_t dimension_number;  // Which dimension of the DS/DUS this applies to.
-  };
+      using Value = std::variant<Constant, Parameter, Add, Subtract, Multiply,
+                                 Compare, Select>;
+      Value value;
+    };
 
-  // Per-dimension offset for a DS or DUS instruction: either a compile-time
-  // constant (literal inside the fusion) or a reference to a runtime scalar
-  // fusion parameter.
-  using Offset = std::variant<ConstantOffset, RuntimeOffset>;
+    static Expr Constant(int64_t value);
+    static Expr Parameter(int64_t parameter_number);
+    static Expr Add(Expr lhs, Expr rhs);
+    static Expr Subtract(Expr lhs, Expr rhs);
+    static Expr Multiply(Expr lhs, Expr rhs);
+    static Expr Compare(ComparisonDirection direction, Expr lhs, Expr rhs);
+    static Expr Select(Expr pred, Expr on_true, Expr on_false);
+
+    int64_t dimension_number;  // Which dimension of the DS/DUS this applies to.
+    Expr expr;                 // Scalar expression computing the index value.
+  };
 
   // Parameter numbers in the structs below correspond to
   // HloParameterInstruction::parameter_number() inside the fusion body. Note
@@ -183,43 +205,82 @@ struct DynamicSliceFusion {
   // of the dynamic slice fusion (root of the hero, or for each tuple entry).
   static absl::StatusOr<std::vector<Result>> ResolveResults(
       const HloInstruction* hero);
+
+  // Evaluates an offset expression with parameter values represented as
+  // (fusion parameter number, scalar value) pairs.
+  static absl::StatusOr<int64_t> Evaluate(
+      const Offset::Expr& expr,
+      absl::Span<const std::pair<int64_t, int64_t>> parameters);
+
+  // Returns fusion parameters referenced by an offset expression.
+  static std::vector<int64_t> CollectOffsetParameters(const Offset::Expr& expr);
 };
 
 //===----------------------------------------------------------------------===//
 // DynamicSliceFusion comparison and stringification
 //===----------------------------------------------------------------------===//
 
-inline bool operator==(const DynamicSliceFusion::ConstantOffset& a,
-                       const DynamicSliceFusion::ConstantOffset& b) {
-  return a.offset == b.offset && a.dimension_number == b.dimension_number;
+inline bool operator==(const DynamicSliceFusion::Offset::Expr& a,
+                       const DynamicSliceFusion::Offset::Expr& b);
+
+inline bool operator==(const DynamicSliceFusion::Offset::Expr::Constant& a,
+                       const DynamicSliceFusion::Offset::Expr::Constant& b) {
+  return a.value == b.value;
 }
 
-inline bool operator==(const DynamicSliceFusion::RuntimeOffset& a,
-                       const DynamicSliceFusion::RuntimeOffset& b) {
-  return a.parameter_number == b.parameter_number &&
-         a.dimension_number == b.dimension_number;
+inline bool operator==(const DynamicSliceFusion::Offset::Expr::Parameter& a,
+                       const DynamicSliceFusion::Offset::Expr::Parameter& b) {
+  return a.parameter_number == b.parameter_number;
 }
 
-inline bool ConfigsEqual(const std::optional<DynamicSliceConfig>& a,
-                         const std::optional<DynamicSliceConfig>& b) {
-  if (a.has_value() != b.has_value()) {
-    return false;
-  }
-  if (!a.has_value()) {
-    return true;
-  }
-  return a->has_loop_index() == b->has_loop_index() &&
-         a->loop_index() == b->loop_index() &&
-         a->byte_offset() == b->byte_offset() &&
-         a->byte_stride() == b->byte_stride();
+inline bool operator==(const DynamicSliceFusion::Offset::Expr::Add& a,
+                       const DynamicSliceFusion::Offset::Expr::Add& b) {
+  return a.args == b.args;
+}
+
+inline bool operator==(const DynamicSliceFusion::Offset::Expr::Subtract& a,
+                       const DynamicSliceFusion::Offset::Expr::Subtract& b) {
+  return a.args == b.args;
+}
+
+inline bool operator==(const DynamicSliceFusion::Offset::Expr::Multiply& a,
+                       const DynamicSliceFusion::Offset::Expr::Multiply& b) {
+  return a.args == b.args;
+}
+
+inline bool operator==(const DynamicSliceFusion::Offset::Expr::Compare& a,
+                       const DynamicSliceFusion::Offset::Expr::Compare& b) {
+  return a.direction == b.direction && a.args == b.args;
+}
+
+inline bool operator==(const DynamicSliceFusion::Offset::Expr::Select& a,
+                       const DynamicSliceFusion::Offset::Expr::Select& b) {
+  return a.args == b.args;
+}
+
+inline bool operator==(const DynamicSliceFusion::Offset::Expr& a,
+                       const DynamicSliceFusion::Offset::Expr& b) {
+  return a.value == b.value;
+}
+
+inline bool operator==(const DynamicSliceFusion::Offset& a,
+                       const DynamicSliceFusion::Offset& b) {
+  return a.dimension_number == b.dimension_number && a.expr == b.expr;
+}
+
+inline bool operator==(const DynamicSliceConfig& a,
+                       const DynamicSliceConfig& b) {
+  return a.has_loop_index() == b.has_loop_index() &&
+         a.loop_index() == b.loop_index() &&
+         a.byte_offset() == b.byte_offset() &&
+         a.byte_stride() == b.byte_stride();
 }
 
 inline bool operator==(const DynamicSliceFusion::Parameter& a,
                        const DynamicSliceFusion::Parameter& b) {
   return a.parameter_number == b.parameter_number &&
          a.parameter_shape == b.parameter_shape &&
-         a.slice_shape == b.slice_shape &&
-         ConfigsEqual(a.slice_config, b.slice_config) &&
+         a.slice_shape == b.slice_shape && a.slice_config == b.slice_config &&
          a.slice_offsets == b.slice_offsets;
 }
 
@@ -228,23 +289,41 @@ inline bool operator==(const DynamicSliceFusion::Result& a,
   return a.parameter_number == b.parameter_number &&
          a.result_number == b.result_number &&
          a.result_shape == b.result_shape && a.update_shape == b.update_shape &&
-         ConfigsEqual(a.update_config, b.update_config) &&
+         a.update_config == b.update_config &&
          a.update_offsets == b.update_offsets;
 }
 
 template <typename Sink>
-void AbslStringify(Sink& sink, const DynamicSliceFusion::ConstantOffset& o) {
-  absl::Format(&sink, "c(d%d,%d)", o.dimension_number, o.offset);
-}
-
-template <typename Sink>
-void AbslStringify(Sink& sink, const DynamicSliceFusion::RuntimeOffset& o) {
-  absl::Format(&sink, "r(d%d,p%d)", o.dimension_number, o.parameter_number);
+void AbslStringify(Sink& sink, const DynamicSliceFusion::Offset::Expr& expr) {
+  using Expr = DynamicSliceFusion::Offset::Expr;
+  std::visit(
+      [&](const auto& e) {
+        using T = std::decay_t<decltype(e)>;
+        if constexpr (std::is_same_v<T, Expr::Constant>) {
+          absl::Format(&sink, "%d", e.value);
+        } else if constexpr (std::is_same_v<T, Expr::Parameter>) {
+          absl::Format(&sink, "p%d", e.parameter_number);
+        } else if constexpr (std::is_same_v<T, Expr::Add>) {
+          absl::Format(&sink, "add(%v, %v)", e.args[0], e.args[1]);
+        } else if constexpr (std::is_same_v<T, Expr::Subtract>) {
+          absl::Format(&sink, "sub(%v, %v)", e.args[0], e.args[1]);
+        } else if constexpr (std::is_same_v<T, Expr::Multiply>) {
+          absl::Format(&sink, "mul(%v, %v)", e.args[0], e.args[1]);
+        } else if constexpr (std::is_same_v<T, Expr::Compare>) {
+          absl::Format(&sink, "cmp(%s, %v, %v)",
+                       ComparisonDirectionToString(e.direction), e.args[0],
+                       e.args[1]);
+        } else if constexpr (std::is_same_v<T, Expr::Select>) {
+          absl::Format(&sink, "select(%v, %v, %v)", e.args[0], e.args[1],
+                       e.args[2]);
+        }
+      },
+      expr.value);
 }
 
 template <typename Sink>
 void AbslStringify(Sink& sink, const DynamicSliceFusion::Offset& o) {
-  std::visit([&sink](const auto& v) { AbslStringify(sink, v); }, o);
+  absl::Format(&sink, "o(d%d,%s)", o.dimension_number, absl::StrCat(o.expr));
 }
 
 template <typename Sink>
@@ -293,12 +372,7 @@ void AbslStringify(Sink& sink, const DynamicSliceFusion::Result& r) {
 }
 
 inline std::ostream& operator<<(std::ostream& os,
-                                const DynamicSliceFusion::ConstantOffset& o) {
-  return os << absl::StrCat(o);
-}
-
-inline std::ostream& operator<<(std::ostream& os,
-                                const DynamicSliceFusion::RuntimeOffset& o) {
+                                const DynamicSliceFusion::Offset::Expr& o) {
   return os << absl::StrCat(o);
 }
 

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
@@ -46,8 +46,7 @@ namespace {
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 
-using CstOff = DynamicSliceFusion::ConstantOffset;
-using RtOff = DynamicSliceFusion::RuntimeOffset;
+using Offset = DynamicSliceFusion::Offset;
 using Param = DynamicSliceFusion::Parameter;
 using Result = DynamicSliceFusion::Result;
 
@@ -309,8 +308,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, DSWithConstantOffset) {
 
     ASSERT_OK_AND_ASSIGN(auto params,
                          DynamicSliceFusion::ResolveParameters(hero));
-    std::vector<DynamicSliceFusion::Offset> offsets = {
-        CstOff{0, 0}, CstOff{0, 1}, CstOff{0, 2}};
+    std::vector<Offset> offsets = {{0, Offset::Constant(1)},
+                                   {1, Offset::Constant(0)},
+                                   {2, Offset::Constant(0)}};
     EXPECT_THAT(params, ElementsAre(Param{0, f32_488, f32_188,
                                           MakeStaticConfig(256), offsets}));
 
@@ -443,8 +443,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, DynamicSlicedOperands) {
   auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
@@ -526,8 +527,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, DynamicUpdateSliceResult) {
   auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
@@ -606,8 +608,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, DUSOnlyNoSlicedInput) {
   auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{2, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(2)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
@@ -670,8 +673,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, DUSWithConstantOffset) {
 
     ASSERT_OK_AND_ASSIGN(auto results,
                          DynamicSliceFusion::ResolveResults(hero));
-    std::vector<DynamicSliceFusion::Offset> offsets = {
-        CstOff{0, 0}, CstOff{0, 1}, CstOff{0, 2}};
+    std::vector<Offset> offsets = {{0, Offset::Constant(0)},
+                                   {1, Offset::Constant(0)},
+                                   {2, Offset::Constant(0)}};
     EXPECT_THAT(results, ElementsAre(Result{1, 0, f32_488, f32_188,
                                             MakeStaticConfig(0), offsets}));
   };
@@ -741,8 +745,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, DUSNotRootNotFused) {
   auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
@@ -912,8 +917,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, CanCaptureSlicedInputsOnly) {
   auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
@@ -958,8 +964,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, CanCaptureSlicedOutputsOnly) {
   auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{2, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(2)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
@@ -1042,8 +1049,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, OffsetAsLinearFunctionOfInductionVar) {
   auto f32_888 = ShapeUtil::MakeShape(F32, {8, 8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
@@ -1302,8 +1310,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, DynamicSliceNonStandardLayoutWithDUS) {
   auto f32_488 = ShapeUtil::MakeShapeWithDenseLayout(F32, {4, 8, 8}, {1, 2, 0});
   auto f32_188 = ShapeUtil::MakeShapeWithDenseLayout(F32, {1, 8, 8}, {1, 2, 0});
   auto f32_88 = ShapeUtil::MakeShapeWithDenseLayout(F32, {8, 8}, {0, 1});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
@@ -1410,8 +1419,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, TupleOutputOneDUS) {
   auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* body = FindDsfBody(module);
@@ -1502,8 +1512,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, TupleOutputNoDUS) {
   auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* body = FindDsfBody(module);
@@ -1589,8 +1600,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, TupleOutputOneDUSOneDeadOutput) {
   auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* body = FindDsfBody(module);
@@ -1665,8 +1677,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, DynamicSliceOnlyNoResult) {
   auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
@@ -1821,8 +1834,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, O2DynamicSliceThroughTupleGte) {
   auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
-  std::vector<DynamicSliceFusion::Offset> offsets = {RtOff{1, 0}, CstOff{0, 1},
-                                                     CstOff{0, 2}};
+  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_test.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/strings/str_cat.h"
+#include "xla/comparison_util.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
@@ -36,11 +37,9 @@ namespace {
 
 using Parameter = DynamicSliceFusion::Parameter;
 using Result = DynamicSliceFusion::Result;
+using Offset = DynamicSliceFusion::Offset;
 
-using CstOff = DynamicSliceFusion::ConstantOffset;
-using RtOff = DynamicSliceFusion::RuntimeOffset;
-
-using Offsets = std::vector<DynamicSliceFusion::Offset>;
+using Offsets = std::vector<Offset>;
 
 DynamicSliceConfig MakeConfig(int64_t loop_index, int64_t offset,
                               int64_t stride) {
@@ -120,6 +119,36 @@ TEST_F(DynamicSliceFusionTest, FindHeroSkipsInfrastructure) {
   EXPECT_EQ(hero->opcode(), HloOpcode::kDot);
 }
 
+TEST_F(DynamicSliceFusionTest, FindHeroSkipsOffsetExpression) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = s32[4,2] parameter(0)
+      %p1 = s32[] parameter(1)
+      %zero = s32[] constant(0)
+      %one = s32[] constant(1)
+      %offset = s32[] add(%p1, %one)
+      %ds = s32[1,2] dynamic-slice(%p0, %offset, %zero),
+        dynamic_slice_sizes={1,2}
+      ROOT %copy = s32[1,2] copy(%ds)
+    }
+
+    ENTRY main {
+      %input = s32[4,2] parameter(0)
+      %ivar = s32[] parameter(1)
+      ROOT %fusion = s32[1,2] fusion(%input, %ivar), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  const HloComputation* body = module->GetComputationWithName("fused");
+
+  const HloInstruction* hero = DynamicSliceFusion::FindHero(body);
+  ASSERT_NE(hero, nullptr);
+  EXPECT_EQ(hero->opcode(), HloOpcode::kCopy);
+}
+
 TEST_F(DynamicSliceFusionTest, FindHeroReturnsNullWhenNoHero) {
   const char* hlo = R"(
     HloModule test
@@ -172,10 +201,11 @@ TEST_F(DynamicSliceFusionTest, ResolveParamWithDynamicSliceConstantOffsets) {
   ASSERT_OK_AND_ASSIGN(auto params,
                        DynamicSliceFusion::ResolveParameters(hero));
   ASSERT_EQ(params.size(), 1);
-  EXPECT_EQ(params[0],
-            (Parameter{0, ShapeUtil::MakeShape(F32, {4, 4}),
-                       ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
-                       Offsets{CstOff{0, 0}, CstOff{0, 1}}}));
+  EXPECT_EQ(
+      params[0],
+      (Parameter{0, ShapeUtil::MakeShape(F32, {4, 4}),
+                 ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+                 Offsets{{0, Offset::Constant(0)}, {1, Offset::Constant(0)}}}));
 }
 
 TEST_F(DynamicSliceFusionTest, ResolveParamWithDynamicSliceRuntimeOffsets) {
@@ -208,9 +238,95 @@ TEST_F(DynamicSliceFusionTest, ResolveParamWithDynamicSliceRuntimeOffsets) {
                        DynamicSliceFusion::ResolveParameters(hero));
   ASSERT_EQ(params.size(), 1);
   EXPECT_EQ(params[0],
-            (Parameter{0, ShapeUtil::MakeShape(F32, {4, 4}),
-                       ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
-                       Offsets{RtOff{1, 0}, CstOff{0, 1}}}));
+            (Parameter{
+                0, ShapeUtil::MakeShape(F32, {4, 4}),
+                ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+                Offsets{{0, Offset::Parameter(1)}, {1, Offset::Constant(0)}}}));
+}
+
+TEST_F(DynamicSliceFusionTest, ResolveParamWithComputedDynamicSliceOffset) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %p1 = s32[] parameter(1)
+      %one = s32[] constant(1)
+      %zero = s32[] constant(0)
+      %offset = s32[] add(%p1, %one)
+      %ds = f32[1,4] dynamic-slice(%p0, %offset, %zero), dynamic_slice_sizes={1,4},
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+      ROOT %custom = f32[1,4] custom-call(%ds), custom_call_target="hero"
+    }
+
+    ENTRY main {
+      %input = f32[4,4] parameter(0)
+      %ivar = s32[] parameter(1)
+      ROOT %fusion = f32[1,4] fusion(%input, %ivar), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = body->GetInstructionWithName("custom");
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto params,
+                       DynamicSliceFusion::ResolveParameters(hero));
+  ASSERT_EQ(params.size(), 1);
+  EXPECT_EQ(
+      params[0],
+      (Parameter{
+          0, ShapeUtil::MakeShape(F32, {4, 4}),
+          ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+          Offsets{{0, Offset::Add(Offset::Parameter(1), Offset::Constant(1))},
+                  {1, Offset::Constant(0)}}}));
+}
+
+TEST_F(DynamicSliceFusionTest, ResolveParamWithSelectOffsetExpression) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %p1 = s32[] parameter(1)
+      %one = s32[] constant(1)
+      %zero = s32[] constant(0)
+      %is_negative = pred[] compare(%p1, %zero), direction=LT
+      %incremented = s32[] add(%p1, %one)
+      %offset = s32[] select(%is_negative, %zero, %incremented)
+      %ds = f32[1,4] dynamic-slice(%p0, %offset, %zero), dynamic_slice_sizes={1,4},
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+      ROOT %custom = f32[1,4] custom-call(%ds), custom_call_target="hero"
+    }
+
+    ENTRY main {
+      %input = f32[4,4] parameter(0)
+      %ivar = s32[] parameter(1)
+      ROOT %fusion = f32[1,4] fusion(%input, %ivar), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = body->GetInstructionWithName("custom");
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto params,
+                       DynamicSliceFusion::ResolveParameters(hero));
+  ASSERT_EQ(params.size(), 1);
+  EXPECT_EQ(
+      params[0],
+      (Parameter{
+          0, ShapeUtil::MakeShape(F32, {4, 4}),
+          ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+          Offsets{{0, Offset::Select(Offset::Compare(ComparisonDirection::kLt,
+                                                     Offset::Parameter(1),
+                                                     Offset::Constant(0)),
+                                     Offset::Constant(0),
+                                     Offset::Add(Offset::Parameter(1),
+                                                 Offset::Constant(1)))},
+                  {1, Offset::Constant(0)}}}));
 }
 
 TEST_F(DynamicSliceFusionTest, ResolveParamWithStaticSlice) {
@@ -309,10 +425,11 @@ TEST_F(DynamicSliceFusionTest, ResolveResultWithDUSConstantOffsets) {
 
   ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
   ASSERT_EQ(results.size(), 1);
-  EXPECT_EQ(results[0],
-            (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
-                    ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
-                    Offsets{CstOff{0, 0}, CstOff{0, 1}}}));
+  EXPECT_EQ(
+      results[0],
+      (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+              ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+              Offsets{{0, Offset::Constant(0)}, {1, Offset::Constant(0)}}}));
 }
 
 TEST_F(DynamicSliceFusionTest, ResolveResultWithDUSRuntimeOffsets) {
@@ -344,10 +461,50 @@ TEST_F(DynamicSliceFusionTest, ResolveResultWithDUSRuntimeOffsets) {
 
   ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
   ASSERT_EQ(results.size(), 1);
-  EXPECT_EQ(results[0],
-            (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
-                    ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
-                    Offsets{RtOff{1, 0}, CstOff{0, 1}}}));
+  EXPECT_EQ(
+      results[0],
+      (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+              ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+              Offsets{{0, Offset::Parameter(1)}, {1, Offset::Constant(0)}}}));
+}
+
+TEST_F(DynamicSliceFusionTest, ResolveResultWithComputedDusOffset) {
+  const char* hlo = R"(
+    HloModule test
+
+    %fused {
+      %p0 = f32[4,4] parameter(0)
+      %p1 = s32[] parameter(1)
+      %fill = f32[4] custom-call(), custom_call_target="fill"
+      %bitcast = f32[1,4] bitcast(%fill)
+      %one = s32[] constant(1)
+      %zero = s32[] constant(0)
+      %offset = s32[] add(%p1, %one)
+      ROOT %dus = f32[4,4] dynamic-update-slice(%p0, %bitcast, %offset, %zero),
+        backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":0,"byte_stride":16}}
+    }
+
+    ENTRY main {
+      %input = f32[4,4] parameter(0)
+      %ivar = s32[] parameter(1)
+      ROOT %fusion = f32[4,4] fusion(%input, %ivar), kind=kCustom, calls=%fused
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  HloComputation* body = module->GetComputationWithName("fused");
+  const HloInstruction* hero = body->GetInstructionWithName("fill");
+  ASSERT_NE(hero, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
+  ASSERT_EQ(results.size(), 1);
+  EXPECT_EQ(
+      results[0],
+      (Result{
+          0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+          ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+          Offsets{{0, Offset::Add(Offset::Parameter(1), Offset::Constant(1))},
+                  {1, Offset::Constant(0)}}}));
 }
 
 TEST_F(DynamicSliceFusionTest, ResolveResultWithBitcastThenDUS) {
@@ -377,10 +534,11 @@ TEST_F(DynamicSliceFusionTest, ResolveResultWithBitcastThenDUS) {
 
   ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
   ASSERT_EQ(results.size(), 1);
-  EXPECT_EQ(results[0],
-            (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
-                    ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(1, 32, 64),
-                    Offsets{CstOff{0, 0}, CstOff{0, 1}}}));
+  EXPECT_EQ(
+      results[0],
+      (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+              ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(1, 32, 64),
+              Offsets{{0, Offset::Constant(0)}, {1, Offset::Constant(0)}}}));
 }
 
 TEST_F(DynamicSliceFusionTest, ResolveResultNoDUS) {
@@ -436,9 +594,11 @@ TEST_F(DynamicSliceFusionTest, ResolveResultDUSWithoutConfig) {
 
   ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
   ASSERT_EQ(results.size(), 1);
-  EXPECT_EQ(results[0], (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
-                                ShapeUtil::MakeShape(F32, {1, 4}), std::nullopt,
-                                Offsets{CstOff{0, 0}, CstOff{0, 1}}}));
+  EXPECT_EQ(
+      results[0],
+      (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+              ShapeUtil::MakeShape(F32, {1, 4}), std::nullopt,
+              Offsets{{0, Offset::Constant(0)}, {1, Offset::Constant(0)}}}));
 }
 
 //===----------------------------------------------------------------------===//
@@ -480,16 +640,18 @@ TEST_F(DynamicSliceFusionTest, ParamsAndResultsWithRuntimeOffsets) {
                        DynamicSliceFusion::ResolveParameters(hero));
   ASSERT_EQ(params.size(), 1);
   EXPECT_EQ(params[0],
-            (Parameter{0, ShapeUtil::MakeShape(F32, {4, 4}),
-                       ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
-                       Offsets{RtOff{2, 0}, CstOff{0, 1}}}));
+            (Parameter{
+                0, ShapeUtil::MakeShape(F32, {4, 4}),
+                ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+                Offsets{{0, Offset::Parameter(2)}, {1, Offset::Constant(0)}}}));
 
   ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
   ASSERT_EQ(results.size(), 1);
-  EXPECT_EQ(results[0],
-            (Result{1, 0, ShapeUtil::MakeShape(F32, {4, 4}),
-                    ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
-                    Offsets{RtOff{2, 0}, CstOff{0, 1}}}));
+  EXPECT_EQ(
+      results[0],
+      (Result{1, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+              ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+              Offsets{{0, Offset::Parameter(2)}, {1, Offset::Constant(0)}}}));
 }
 
 //===----------------------------------------------------------------------===//
@@ -531,14 +693,16 @@ TEST_F(DynamicSliceFusionTest, ResolveResultsFlatTupleWithDUS) {
 
   ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
   ASSERT_EQ(results.size(), 2);
-  EXPECT_EQ(results[0],
-            (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
-                    ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
-                    Offsets{RtOff{2, 0}, CstOff{0, 1}}}));
-  EXPECT_EQ(results[1],
-            (Result{1, 1, ShapeUtil::MakeShape(F32, {4, 8}),
-                    ShapeUtil::MakeShape(F32, {1, 8}), MakeConfig(0, 0, 32),
-                    Offsets{CstOff{0, 0}, CstOff{0, 1}}}));
+  EXPECT_EQ(
+      results[0],
+      (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
+              ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
+              Offsets{{0, Offset::Parameter(2)}, {1, Offset::Constant(0)}}}));
+  EXPECT_EQ(
+      results[1],
+      (Result{1, 1, ShapeUtil::MakeShape(F32, {4, 8}),
+              ShapeUtil::MakeShape(F32, {1, 8}), MakeConfig(0, 0, 32),
+              Offsets{{0, Offset::Constant(0)}, {1, Offset::Constant(0)}}}));
 }
 
 TEST_F(DynamicSliceFusionTest, ResolveResultsNestedTupleWithDUS) {
@@ -584,7 +748,7 @@ TEST_F(DynamicSliceFusionTest, ResolveResultsNestedTupleWithDUS) {
 
   ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
   ASSERT_EQ(results.size(), 3);
-  Offsets const_2d{CstOff{0, 0}, CstOff{0, 1}};
+  Offsets const_2d{{0, Offset::Constant(0)}, {1, Offset::Constant(0)}};
   EXPECT_EQ(results[0], (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
                                 ShapeUtil::MakeShape(F32, {1, 4}),
                                 MakeConfig(0, 0, 16), const_2d}));
@@ -632,7 +796,7 @@ TEST_F(DynamicSliceFusionTest, ResolveResultsNestedTuplePartialDUS) {
 
   ASSERT_OK_AND_ASSIGN(auto results, DynamicSliceFusion::ResolveResults(hero));
   ASSERT_EQ(results.size(), 3);
-  Offsets const_2d{CstOff{0, 0}, CstOff{0, 1}};
+  Offsets const_2d{{0, Offset::Constant(0)}, {1, Offset::Constant(0)}};
   EXPECT_EQ(results[0], (Result{0, 0, ShapeUtil::MakeShape(F32, {4, 4}),
                                 ShapeUtil::MakeShape(F32, {1, 4}),
                                 MakeConfig(0, 0, 16), const_2d}));
@@ -644,18 +808,86 @@ TEST_F(DynamicSliceFusionTest, ResolveResultsNestedTuplePartialDUS) {
 }
 
 //===----------------------------------------------------------------------===//
+// Offset evaluation tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(DynamicSliceFusionTest, EvaluateOffsetExprConstantAndParameter) {
+  ASSERT_OK_AND_ASSIGN(int64_t constant,
+                       DynamicSliceFusion::Evaluate(Offset::Constant(42), {}));
+  EXPECT_EQ(constant, 42);
+
+  ASSERT_OK_AND_ASSIGN(int64_t parameter, DynamicSliceFusion::Evaluate(
+                                              Offset::Parameter(3), {{3, -7}}));
+  EXPECT_EQ(parameter, -7);
+}
+
+TEST_F(DynamicSliceFusionTest, EvaluateOffsetExprArithmetic) {
+  auto expr = Offset::Subtract(
+      Offset::Multiply(Offset::Add(Offset::Parameter(0), Offset::Constant(2)),
+                       Offset::Parameter(1)),
+      Offset::Constant(5));
+
+  ASSERT_OK_AND_ASSIGN(int64_t result,
+                       DynamicSliceFusion::Evaluate(expr, {{0, 4}, {1, 3}}));
+  EXPECT_EQ(result, 13);
+}
+
+TEST_F(DynamicSliceFusionTest, EvaluateOffsetExprCompareAndSelect) {
+  auto expr = Offset::Select(
+      Offset::Compare(ComparisonDirection::kLt, Offset::Parameter(0),
+                      Offset::Constant(3)),
+      Offset::Add(Offset::Parameter(0), Offset::Constant(1)),
+      Offset::Multiply(Offset::Parameter(1), Offset::Constant(2)));
+
+  ASSERT_OK_AND_ASSIGN(int64_t on_true,
+                       DynamicSliceFusion::Evaluate(expr, {{0, 2}, {1, 9}}));
+  EXPECT_EQ(on_true, 3);
+
+  ASSERT_OK_AND_ASSIGN(int64_t on_false,
+                       DynamicSliceFusion::Evaluate(expr, {{0, 3}, {1, 9}}));
+  EXPECT_EQ(on_false, 18);
+}
+
+TEST_F(DynamicSliceFusionTest, EvaluateOffsetExprMissingParameterFails) {
+  auto status =
+      DynamicSliceFusion::Evaluate(Offset::Parameter(7), {{3, 12}}).status();
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status.message(),
+              ::testing::HasSubstr("Missing value for offset parameter 7"));
+}
+
+TEST_F(DynamicSliceFusionTest, CollectOffsetParameters) {
+  auto expr =
+      Offset::Select(Offset::Parameter(2),
+                     Offset::Add(Offset::Parameter(4), Offset::Parameter(2)),
+                     Offset::Constant(0));
+
+  EXPECT_THAT(DynamicSliceFusion::CollectOffsetParameters(expr),
+              ::testing::ElementsAre(2, 4));
+}
+
+//===----------------------------------------------------------------------===//
 // Stringify tests
 //===----------------------------------------------------------------------===//
 
 TEST_F(DynamicSliceFusionTest, StringifyParameterWithConfig) {
   Parameter p{0, ShapeUtil::MakeShape(F32, {4, 4}),
               ShapeUtil::MakeShape(F32, {1, 4}), MakeConfig(0, 0, 16),
-              Offsets{RtOff{1, 0}, CstOff{0, 1}}};
+              Offsets{{0, Offset::Parameter(1)}, {1, Offset::Constant(0)}}};
   std::string s = absl::StrCat(p);
   EXPECT_EQ(s,
             "Parameter{param=0 f32[4,4]->f32[1,4], "
             "config{loop=0, offset=0, stride=16}, "
-            "offsets=[r(d0,p1), c(d1,0)]}");
+            "offsets=[o(d0,p1), o(d1,0)]}");
+}
+
+TEST_F(DynamicSliceFusionTest, StringifyOffsetExpr) {
+  auto expr =
+      Offset::Select(Offset::Compare(ComparisonDirection::kLt,
+                                     Offset::Parameter(0), Offset::Constant(3)),
+                     Offset::Add(Offset::Parameter(0), Offset::Constant(1)),
+                     Offset::Constant(0));
+  EXPECT_EQ(absl::StrCat(expr), "select(cmp(LT, p0, 3), add(p0, 1), 0)");
 }
 
 TEST_F(DynamicSliceFusionTest, StringifyParameterWithoutConfig) {
@@ -673,12 +905,12 @@ TEST_F(DynamicSliceFusionTest, StringifyResultWithConfig) {
            ShapeUtil::MakeShape(F32, {4, 4}),
            ShapeUtil::MakeShape(F32, {1, 4}),
            MakeConfig(0, 0, 16),
-           Offsets{CstOff{0, 0}, CstOff{0, 1}}};
+           Offsets{{0, Offset::Constant(0)}, {1, Offset::Constant(0)}}};
   std::string s = absl::StrCat(r);
   EXPECT_EQ(s,
             "Result{param=0, result=0 f32[1,4]->f32[4,4], "
             "config{loop=0, offset=0, stride=16}, "
-            "offsets=[c(d0,0), c(d1,0)]}");
+            "offsets=[o(d0,0), o(d1,0)]}");
 }
 
 TEST_F(DynamicSliceFusionTest, StringifyResultWithoutConfig) {


### PR DESCRIPTION
Previously `DynamicSliceFusion` required offset to be a known constant value or a parameter of the fusion. This is suboptimal as it leaves offset calculation outside of fusion and it means that XLA is forced to compile a kernel for it, and it is super wasteful as the kernel operates on scalar value. 

 - Add `DynamicSliceFusion::Offset::Expr`, a small scalar offset expression AST for constants, fusion parameters, arithmetic, comparisons, and selects.
- Extend dynamic-slice fusion analysis and thunk serialization to carry offset expressions instead of only constant or runtime parameter offsets.

Thunk still supports only constant or runtime offsets, runtime support will come in next PR.