### PR TITLE
Fix libdrm include after invalid merge

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -89,15 +89,9 @@ cc_library(
     ]),
     defines = {"__HIP_DISABLE_CPP_FUNCTIONS__": "1"},
     strip_include_prefix = "%{rocm_root}/include",
-    deps = [":rocm_sysdeps_includes"],
-)
-
-cc_library(
-    name = "rocm_sysdeps_includes",
-    hdrs = glob([
-        "%{rocm_root}/lib/rocm_sysdeps/include/**",
-    ], allow_empty = True),
-    strip_include_prefix = "%{rocm_root}/lib/rocm_sysdeps/include",
+    deps = [
+        "@libdrm//:drm_headers",
+    ],
 )
 
 cc_library(
@@ -297,8 +291,8 @@ rocm_lib_import(
     data = glob(["%{rocm_root}/lib/librccl.so*"]),
     interface_library = "%{rocm_root}/lib/librccl.so",
     deps = [
-        ":hip_runtime_libs",
         ":amdsmi_libs",
+        ":hip_runtime_libs",
         ":rocm_smi_libs",
         ":rocprofiler_register_libs",
         ":roctx_libs",


### PR DESCRIPTION
📝 Summary of Changes
Fix libdrm dependency in rocm targets

🎯 Justification
After partial merge of the pr we got a build break with missing libdrm headers,
this PR adds the missing part

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
