### PR TITLE
[xla:gpu] Add support for collective group launch on multiple comms

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -253,6 +253,7 @@ cc_library(
     hdrs = ["gpu_collectives.h"],
     deps = [
         ":cancellation_token",
+        ":gpu_communicator",
         "//xla:shape_util",
         "//xla:util",
         "//xla:xla_data_proto_cc",
@@ -270,14 +271,15 @@ cc_library(
         "//xla/stream_executor:device_interconnect_resource",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
-        "@tsl//tsl/platform:casts",
     ],
 )
 
@@ -294,7 +296,7 @@ xla_cc_test(
         ":gpu_clique_key",
         ":gpu_collectives",
         ":gpu_communicator",
-        ":nccl_or_rccl_collectives",
+        ":nccl_or_rccl_collectives",  # buildcleaner: keep
         "//xla:future",
         "//xla:xla_data_proto_cc",
         "//xla/core/collectives",
@@ -325,7 +327,7 @@ xla_cc_test(
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/types:span",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest_main",  # buildcleaner: keep
     ],
 )
 
@@ -388,14 +390,13 @@ cc_library(
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/container:inlined_vector",
-        "@com_google_absl//absl/functional:any_invocable",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",
-        "@tsl//tsl/platform:casts",
     ],
 )
 
@@ -592,6 +593,28 @@ cc_library(
 )
 
 cc_library(
+    name = "nccl_group",
+    srcs = ["nccl_group.cc"],
+    hdrs = ["nccl_group.h"],
+    tags = [
+        "cuda-only",
+        "gpu",
+        "no-oneapi",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":nccl_errors",
+        "//xla:util",
+        "//xla/tsl/cuda:nccl",
+        "//xla/tsl/platform:logging",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/functional:function_ref",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
     name = "nccl_collectives",
     srcs = ["nccl_collectives.cc"],
     hdrs = ["nccl_collectives.h"],
@@ -605,8 +628,10 @@ cc_library(
         ":cancellation_token",
         ":gpu_clique_key",
         ":gpu_collectives",
+        ":gpu_communicator",
         ":nccl_communicator",
         ":nccl_errors",
+        ":nccl_group",
         "//xla:debug_options_flags",
         "//xla:future",
         "//xla:status_macros",
@@ -630,6 +655,7 @@ cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
@@ -638,11 +664,33 @@ cc_library(
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
-        "@tsl//tsl/platform:casts",
         "@tsl//tsl/platform:numbers",
         "@tsl//tsl/profiler/lib:traceme",
     ],
     alwayslink = True,  # registers collectives implementation
+)
+
+cc_library(
+    name = "rccl_group",
+    srcs = ["rccl_group.cc"],
+    hdrs = ["rccl_group.h"],
+    tags = [
+        "gpu",
+        "no-oneapi",
+        "rocm-only",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":rccl_errors",
+        "//xla:util",
+        "//xla/tsl/platform:logging",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/functional:function_ref",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_rocm//rocm:rccl",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
 )
 
 cc_library(
@@ -659,8 +707,10 @@ cc_library(
         ":cancellation_token",
         ":gpu_clique_key",
         ":gpu_collectives",
+        ":gpu_communicator",
         ":rccl_communicator",
         ":rccl_errors",
+        ":rccl_group",
         "//xla:debug_options_flags",
         "//xla:status_macros",
         "//xla:util",
@@ -684,6 +734,7 @@ cc_library(
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
@@ -694,7 +745,6 @@ cc_library(
         "@com_google_absl//absl/types:span",
         "@local_config_rocm//rocm:rccl",  # buildcleaner: keep
         "@local_config_rocm//rocm:rocm_headers",
-        "@tsl//tsl/platform:casts",
         "@tsl//tsl/platform:numbers",
     ],
     alwayslink = True,  # registers collectives implementation
@@ -739,6 +789,7 @@ cc_library(
         ":gpu_collectives",
         ":gpu_communicator",
         ":nccl_errors",
+        ":nccl_group",
         ":nccl_registered_memory",
         ":nccl_symmetric_memory",
         ":nccl_types",
@@ -753,6 +804,7 @@ cc_library(
         "//xla/core/collectives:registered_memory",
         "//xla/core/collectives:symmetric_memory",
         "//xla/stream_executor:device_address",
+        "//xla/stream_executor:kernel_args",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
         "//xla/stream_executor/cuda:cuda_compute_capability",
@@ -765,9 +817,9 @@ cc_library(
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/functional:any_invocable",
+        "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status",
@@ -778,7 +830,6 @@ cc_library(
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
         "@local_config_cuda//cuda:cuda_headers",
-        "@tsl//tsl/platform:casts",
     ],
 )
 
@@ -847,6 +898,7 @@ cc_library(
         ":gpu_collectives",
         ":gpu_communicator",
         ":rccl_errors",
+        ":rccl_group",
         ":rccl_symmetric_memory",
         ":single_threaded_executor",
         "//xla:future",
@@ -867,9 +919,9 @@ cc_library(
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/functional:any_invocable",
+        "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status",
@@ -880,7 +932,6 @@ cc_library(
         "@com_google_absl//absl/types:span",
         "@local_config_rocm//rocm:rccl",  # buildcleaner: keep
         "@local_config_rocm//rocm:rocm_headers",
-        "@tsl//tsl/platform:casts",
     ],
 )
 

--- a/xla/backends/gpu/collectives/gpu_collectives.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <cstddef>
 #include <optional>
 
+#include "absl/base/casts.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/statusor.h"
@@ -34,7 +35,6 @@ limitations under the License.
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/casts.h"
 
 namespace xla::gpu {
 

--- a/xla/backends/gpu/collectives/gpu_collectives.h
+++ b/xla/backends/gpu/collectives/gpu_collectives.h
@@ -24,11 +24,13 @@ limitations under the License.
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/collectives/cancellation_token.h"
+#include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/core/collectives/clique_id.h"
 #include "xla/core/collectives/clique_key.h"
 #include "xla/core/collectives/collectives.h"
@@ -70,7 +72,8 @@ class GpuCollectives : public Collectives {
   // Initializes the collectives backend with the provided topology information
   // and returns a callback that will generate unique ids for the cliques if
   // topology spans multiple processes and clique id generation requires
-  // multi-process coordination. For local toplogies returns a nullptr callback.
+  // multi-process coordination. For local topologies returns a nullptr
+  // callback.
   virtual absl::StatusOr<CliqueIdCallback> InitializeTopology(
       const Topology& topology) = 0;
 
@@ -149,6 +152,14 @@ class GpuCollectives : public Collectives {
 
   // Returns true if GPU collectives are implemented.
   virtual bool IsImplemented() const = 0;
+
+  // Executes a group of collective launches. All communicators used by the
+  // `group` must be listed in `comms`, otherwise behavior is undefined.
+  virtual absl::Status GroupLaunch(
+      absl::Span<const GpuCommunicator* const> comms,
+      absl::FunctionRef<absl::Status()> group) {
+    return group();
+  }
 
   // Returns minimum alignment requirement for symmetric memory.
   virtual size_t SymmetricMemoryAlignment() const { return 1; }

--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
 
+#include <array>
 #include <cstddef>
 #include <memory>
 #include <utility>
@@ -62,7 +63,7 @@ namespace {
 static constexpr GlobalDeviceId kD0(0);
 static constexpr GlobalDeviceId kD1(1);
 static constexpr GlobalDeviceId kD2(2);
-static constexpr GlobalDeviceId kD3(2);
+static constexpr GlobalDeviceId kD3(3);
 
 static absl::StatusOr<std::vector<se::StreamExecutor*>> CreateExecutors(
     se::Platform* platform, size_t n) {
@@ -265,6 +266,98 @@ TEST(GpuCollectivesTest, SplitCommunicators) {
       SplitCommunicators(executors, comms, {kD0, kD1}, /*blocking=*/true));
   EXPECT_TRUE(split_comms[0]->platform_comm().handle);
   EXPECT_TRUE(split_comms[1]->platform_comm().handle);
+}
+
+TEST(GpuCollectivesTest, GroupLaunchMultipleCommunicators) {
+  ASSERT_OK_AND_ASSIGN(se::Platform * platform,
+                       se::PlatformManager::PlatformWithName("CUDA"));
+
+  if (platform->VisibleDeviceCount() < 4) {
+    GTEST_SKIP() << "Test requires at least 4 GPUs";
+  }
+
+  GpuCollectives* collectives = GpuCollectives::Default("GPU");
+
+  ASSERT_OK_AND_ASSIGN(std::vector<se::StreamExecutor*> executors_vec,
+                       CreateExecutors(platform, 4));
+  absl::Span<se::StreamExecutor*> executors(executors_vec);
+
+  ASSERT_OK_AND_ASSIGN(auto comms01,
+                       CreateCommunicators(executors.first(2), {kD0, kD1}));
+  ASSERT_OK_AND_ASSIGN(auto comms23,
+                       CreateCommunicators(executors.last(2), {kD2, kD3}));
+
+  std::vector<std::unique_ptr<se::Stream>> streams;
+  streams.reserve(executors.size());
+  for (se::StreamExecutor* executor : executors) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<se::Stream> stream,
+                         executor->CreateStream());
+    streams.push_back(std::move(stream));
+  }
+
+  constexpr size_t kCount = 4;
+  constexpr size_t kNumBytes = kCount * sizeof(float);
+  std::vector<std::array<float, kCount>> inputs = {
+      std::array<float, kCount>{1.0f, 2.0f, 3.0f, 4.0f},
+      std::array<float, kCount>{10.0f, 20.0f, 30.0f, 40.0f},
+      std::array<float, kCount>{5.0f, 6.0f, 7.0f, 8.0f},
+      std::array<float, kCount>{50.0f, 60.0f, 70.0f, 80.0f},
+  };
+
+  std::vector<se::DeviceAddress<float>> send_buffers;
+  std::vector<se::DeviceAddress<float>> recv_buffers;
+  send_buffers.reserve(executors.size());
+  recv_buffers.reserve(executors.size());
+  for (size_t i = 0; i < executors.size(); ++i) {
+    send_buffers.push_back(executors[i]->AllocateArray<float>(kCount));
+    recv_buffers.push_back(executors[i]->AllocateArray<float>(kCount));
+    ASSERT_OK(
+        streams[i]->Memcpy(&send_buffers[i], inputs[i].data(), kNumBytes));
+    ASSERT_OK(streams[i]->MemZero(&recv_buffers[i], kNumBytes));
+    ASSERT_OK(streams[i]->BlockHostUntilDone());
+  }
+
+  std::vector<const GpuCommunicator*> group_comms = {
+      comms01[0].get(), comms01[1].get(), comms23[0].get(), comms23[1].get()};
+
+  ASSERT_OK(collectives->GroupLaunch(group_comms, [&]() -> absl::Status {
+    GpuCollectives::Executor executor0(streams[0].get());
+    GpuCollectives::Executor executor1(streams[1].get());
+    GpuCollectives::Executor executor2(streams[2].get());
+    GpuCollectives::Executor executor3(streams[3].get());
+
+    RETURN_IF_ERROR(comms01[0]->LaunchAllReduce(send_buffers[0],
+                                                recv_buffers[0], F32, kCount,
+                                                ReductionKind::SUM, executor0));
+    RETURN_IF_ERROR(comms01[1]->LaunchAllReduce(send_buffers[1],
+                                                recv_buffers[1], F32, kCount,
+                                                ReductionKind::SUM, executor1));
+    RETURN_IF_ERROR(comms23[0]->LaunchAllReduce(send_buffers[2],
+                                                recv_buffers[2], F32, kCount,
+                                                ReductionKind::SUM, executor2));
+    return comms23[1]->LaunchAllReduce(send_buffers[3], recv_buffers[3], F32,
+                                       kCount, ReductionKind::SUM, executor3);
+  }));
+
+  std::vector<std::array<float, kCount>> expected = {
+      std::array<float, kCount>{11.0f, 22.0f, 33.0f, 44.0f},
+      std::array<float, kCount>{11.0f, 22.0f, 33.0f, 44.0f},
+      std::array<float, kCount>{55.0f, 66.0f, 77.0f, 88.0f},
+      std::array<float, kCount>{55.0f, 66.0f, 77.0f, 88.0f},
+  };
+
+  for (size_t i = 0; i < executors.size(); ++i) {
+    ASSERT_OK(streams[i]->BlockHostUntilDone());
+    std::array<float, kCount> output;
+    ASSERT_OK(streams[i]->Memcpy(output.data(), recv_buffers[i], kNumBytes));
+    ASSERT_OK(streams[i]->BlockHostUntilDone());
+    EXPECT_THAT(output, testing::ElementsAreArray(expected[i]));
+  }
+
+  for (size_t i = 0; i < executors.size(); ++i) {
+    executors[i]->Deallocate(&send_buffers[i]);
+    executors[i]->Deallocate(&recv_buffers[i]);
+  }
 }
 
 TEST(GpuCollectivesTest, CreateSymmetricMemory) {

--- a/xla/backends/gpu/collectives/gpu_communicator.h
+++ b/xla/backends/gpu/collectives/gpu_communicator.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 
 #include "absl/container/inlined_vector.h"
 #include "absl/functional/any_invocable.h"
@@ -160,10 +161,12 @@ class GpuCommunicator : public Communicator {
   // Host-side collective communication APIs
   //===--------------------------------------------------------------------===//
 
-  // Executes f in a group. f should invoke synchronous collective methods like
-  // LaunchAllReduce and not asynchronous collective methods like AllReduce.
-  virtual Future<> GroupExecute(
-      absl::AnyInvocable<absl::Status(GpuCommunicator*)> f) = 0;
+  // Executes a group of collective launches on this communicator. All
+  // collective operations in the `group` must use only *this communicator,
+  // otherwise behavior is undefined.
+  virtual Future<> GroupExecute(absl::AnyInvocable<absl::Status() &&> group) {
+    return Future<>(std::move(group)());
+  }
 
   virtual absl::Status LaunchAllReduce(se::DeviceAddressBase send_buffer,
                                        se::DeviceAddressBase recv_buffer,

--- a/xla/backends/gpu/collectives/loopback_communicator.cc
+++ b/xla/backends/gpu/collectives/loopback_communicator.cc
@@ -20,8 +20,8 @@ limitations under the License.
 #include <string>
 #include <utility>
 
+#include "absl/base/casts.h"
 #include "absl/container/inlined_vector.h"
-#include "absl/functional/any_invocable.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -29,18 +29,15 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
-#include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
 #include "xla/future.h"
 #include "xla/primitive_util.h"
-#include "xla/shape_util.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/casts.h"
 
 namespace xla::gpu {
 
@@ -76,11 +73,6 @@ absl::StatusOr<size_t> LoopbackCommunicator::CurrentRank() { return rank_; }
 std::string LoopbackCommunicator::ToString() const {
   return absl::StrFormat("LoopbackCommunicator(rank=%d, num_ranks=%d)", rank_,
                          num_ranks_);
-}
-
-Future<> LoopbackCommunicator::GroupExecute(
-    absl::AnyInvocable<absl::Status(GpuCommunicator*)> f) {
-  return Future<>(f(this));
 }
 
 //===----------------------------------------------------------------------===//

--- a/xla/backends/gpu/collectives/loopback_communicator.h
+++ b/xla/backends/gpu/collectives/loopback_communicator.h
@@ -21,7 +21,6 @@ limitations under the License.
 #include <string>
 
 #include "absl/container/inlined_vector.h"
-#include "absl/functional/any_invocable.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
@@ -53,8 +52,6 @@ class LoopbackCommunicator : public GpuCommunicator {
   absl::StatusOr<size_t> NumRanks() const final;
   absl::StatusOr<size_t> CurrentRank() final;
   std::string ToString() const final;
-  Future<> GroupExecute(
-      absl::AnyInvocable<absl::Status(GpuCommunicator*)> f) final;
 
   Future<> AllReduce(se::DeviceAddressBase send_buffer,
                      se::DeviceAddressBase recv_buffer, PrimitiveType dtype,

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "absl/base/thread_annotations.h"
 #include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
@@ -44,8 +45,10 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/cancellation_token.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
+#include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/backends/gpu/collectives/nccl_communicator.h"
 #include "xla/backends/gpu/collectives/nccl_errors.h"
+#include "xla/backends/gpu/collectives/nccl_group.h"
 #include "xla/core/collectives/clique_id.h"
 #include "xla/core/collectives/clique_key.h"
 #include "xla/core/collectives/collectives.h"
@@ -63,7 +66,6 @@ limitations under the License.
 #include "xla/tsl/platform/logging.h"
 #include "xla/tsl/platform/threadpool.h"
 #include "xla/util.h"
-#include "tsl/platform/casts.h"
 #include "tsl/platform/numbers.h"
 #include "tsl/profiler/lib/traceme.h"
 
@@ -234,7 +236,7 @@ static auto DeviceOrdinal(const Collectives::DeviceRank& rank) {
 static auto DeviceOrdinalsToString(
     absl::Span<const Collectives::DeviceRank> ranks) {
   return absl::StrJoin(ranks, ",", [](std::string* str, auto& rank) {
-    auto* device = tsl::down_cast<const GpuCollectives::Device*>(rank.device);
+    auto* device = absl::down_cast<const GpuCollectives::Device*>(rank.device);
     absl::StrAppend(str, device->stream_executor()->device_ordinal());
   });
 }
@@ -256,6 +258,28 @@ absl::StatusOr<CliqueId> NcclCollectives::CreateUniqueCliqueId() const {
   ncclUniqueId id;
   XLA_NCCL_RETURN_IF_ERROR(ncclGetUniqueId(&id));
   return CliqueId(absl::string_view(id.internal, NCCL_UNIQUE_ID_BYTES));
+}
+
+absl::Status NcclCollectives::GroupLaunch(
+    absl::Span<const GpuCommunicator* const> comms,
+    absl::FunctionRef<absl::Status()> group) {
+  for (const GpuCommunicator* comm : comms) {
+    auto* nccl_comm = absl::down_cast<const NcclCommunicator*>(comm);
+    if (!nccl_comm->IsBlocking()) {
+      return FailedPrecondition(
+          "NCCL multi-communicator group launch requires blocking "
+          "communicators");
+    }
+  }
+
+  ASSIGN_OR_RETURN(bool launched, NcclGroupLaunch(group));
+  if (launched) {
+    for (const GpuCommunicator* comm : comms) {
+      auto* nccl_comm = absl::down_cast<const NcclCommunicator*>(comm);
+      RETURN_IF_ERROR(nccl_comm->PollUntilDone());
+    }
+  }
+  return absl::OkStatus();
 }
 
 size_t NcclCollectives::SymmetricMemoryAlignment() const {
@@ -516,8 +540,7 @@ NcclCollectives::SplitCommunicatorsWithCancel(
 static absl::StatusOr<xla::gpu::GpuCollectives*> GetNvshmemCollectives() {
   ASSIGN_OR_RETURN(xla::Collectives * collectives,
                    xla::CollectivesRegistry::Get("gpu", "nvshmem"));
-  xla::gpu::GpuCollectives* nvshmem_collectives =
-      absl::down_cast<GpuCollectives*>(collectives);
+  auto* nvshmem_collectives = absl::down_cast<GpuCollectives*>(collectives);
   if (nvshmem_collectives == nullptr) {
     return Internal("Failed to get NVSHMEM collectives");
   }

--- a/xla/backends/gpu/collectives/nccl_collectives.h
+++ b/xla/backends/gpu/collectives/nccl_collectives.h
@@ -16,18 +16,19 @@ limitations under the License.
 #ifndef XLA_BACKENDS_GPU_COLLECTIVES_NCCL_COLLECTIVES_H_
 #define XLA_BACKENDS_GPU_COLLECTIVES_NCCL_COLLECTIVES_H_
 
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <vector>
 
+#include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/collectives/cancellation_token.h"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
+#include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/core/collectives/clique_id.h"
 #include "xla/core/collectives/clique_key.h"
 #include "xla/core/collectives/collectives.h"
@@ -42,6 +43,9 @@ class NcclCollectives : public GpuCollectives {
   bool IsImplemented() const final { return true; }
 
   size_t SymmetricMemoryAlignment() const final;
+
+  absl::Status GroupLaunch(absl::Span<const GpuCommunicator* const> comms,
+                           absl::FunctionRef<absl::Status()> group) final;
 
   absl::StatusOr<CliqueId> CreateUniqueCliqueId() const final;
 

--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -27,12 +27,14 @@ limitations under the License.
 #include "absl/base/casts.h"
 #include "absl/container/inlined_vector.h"
 #include "absl/functional/any_invocable.h"
+#include "absl/functional/function_ref.h"
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
-#include "absl/synchronization/mutex.h"
+#include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "third_party/gpus/cuda/include/cuda.h"
@@ -40,6 +42,7 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/backends/gpu/collectives/nccl_errors.h"
+#include "xla/backends/gpu/collectives/nccl_group.h"
 #include "xla/backends/gpu/collectives/nccl_registered_memory.h"
 #include "xla/backends/gpu/collectives/nccl_symmetric_memory.h"
 #include "xla/backends/gpu/collectives/nccl_types.h"
@@ -51,22 +54,19 @@ limitations under the License.
 #include "xla/core/collectives/symmetric_memory.h"
 #include "xla/future.h"
 #include "xla/primitive_util.h"
-#include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/kernel_args.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/concurrency/executor.h"
 #include "xla/tsl/platform/env.h"
-#include "xla/tsl/platform/errors.h"
 #include "xla/tsl/platform/logging.h"
-#include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/casts.h"
 
 // Include NCCL after XLA headers.
-#include "third_party/nccl/nccl.h"
-#include "third_party/nccl/nccl_device.h"
+#include "third_party/nccl/nccl.h"         // IWYU pragma: keep
+#include "third_party/nccl/nccl_device.h"  // IWYU pragma: keep
 
 namespace xla::gpu {
 namespace {
@@ -328,13 +328,19 @@ absl::StatusOr<size_t> NcclCommunicator::NumRanks() const {
 }
 
 Future<> NcclCommunicator::GroupExecute(
-    absl::AnyInvocable<absl::Status(GpuCommunicator*)> f) {
-  return Execute([f = std::move(f), this]() mutable -> absl::Status {
-    RETURN_IF_ERROR(GroupStart());
-    RETURN_IF_ERROR(f(this));
-    RETURN_IF_ERROR(GroupEnd());
-    return absl::OkStatus();
+    absl::AnyInvocable<absl::Status() &&> group) {
+  return Execute([group = std::move(group), this]() mutable {
+    return GroupLaunch([&] { return std::move(group)(); });
   });
+}
+
+absl::Status NcclCommunicator::GroupLaunch(
+    absl::FunctionRef<absl::Status()> group) {
+  ASSIGN_OR_RETURN(bool launched, NcclGroupLaunch(group));
+  if (launched) {
+    return PollUntilDone();
+  }
+  return absl::OkStatus();
 }
 
 Future<> NcclCommunicator::AllReduce(se::DeviceAddressBase send_buffer,
@@ -445,29 +451,6 @@ Future<> NcclCommunicator::WaitSignal(RankId peer, int op_cnt,
   });
 }
 
-absl::Status NcclCommunicator::GroupStart() {
-  VLOG(5) << "Start NCCL group";
-  XLA_NCCL_RETURN_IF_ERROR(ncclGroupStart());
-  group_nesting_level_++;
-  return absl::OkStatus();
-}
-
-absl::Status NcclCommunicator::GroupEnd() {
-  VLOG(5) << "End NCCL group";
-  XLA_NCCL_RETURN_IF_ERROR(ncclGroupEnd());
-  group_nesting_level_--;
-  if (group_nesting_level_ > 0) {
-    // Though NCCL allows groups to be nested, no operations are actually
-    // performed until the outermost group ends. The inner calls to
-    // GroupStart() and GroupEnd() are effectively noops.
-    //
-    // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/groups.html
-    return absl::OkStatus();
-  }
-  // Wait for the communicator to finish.
-  return PollUntilDone();
-}
-
 absl::Status NcclCommunicator::LaunchAllReduce(
     se::DeviceAddressBase send_buffer, se::DeviceAddressBase recv_buffer,
     PrimitiveType dtype, size_t count, ReductionKind reduction_kind,
@@ -495,7 +478,7 @@ absl::Status NcclCommunicator::LaunchAllReduce(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
       nccl_dtype, ToNcclReduction(reduction_kind), comm_,
       AsCudaStream(stream))));
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideNcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -526,7 +509,7 @@ absl::Status NcclCommunicator::LaunchBroadcast(
   RETURN_IF_ERROR(XLA_NCCL_STATUS(ncclBroadcast(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
       nccl_dtype, root.value(), comm_, AsCudaStream(stream))));
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideNcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -559,7 +542,7 @@ absl::Status NcclCommunicator::LaunchReduceScatter(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
       nccl_dtype, ToNcclReduction(reduction_kind), comm_,
       AsCudaStream(stream))));
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideNcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -589,7 +572,7 @@ absl::Status NcclCommunicator::LaunchAllGather(
   RETURN_IF_ERROR(XLA_NCCL_STATUS(ncclAllGather(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
       nccl_dtype, comm_, AsCudaStream(stream))));
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideNcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -676,25 +659,28 @@ absl::Status NcclCommunicator::LaunchAllToAll(
     XLA_NCCL_RETURN_IF_ERROR(ncclAlltoAll(
         send_contiguous->opaque(), recv_contiguous->opaque(),
         ToNcclCount(dtype, count), nccl_dtype, comm_, AsCudaStream(stream)));
+    if (!IsInsideNcclGroupLaunch()) {
+      RETURN_IF_ERROR(PollUntilDone());
+    }
     return absl::OkStatus();
   }
 #endif
 
-  RETURN_IF_ERROR(GroupStart());
-  for (size_t i = 0; i < send_buffers.size(); ++i) {
-    se::DeviceAddressBase send_buffer = send_buffers[i];
-    se::DeviceAddressBase recv_buffer = recv_buffers[i];
+  auto group = [&] {
+    for (size_t i = 0; i < send_buffers.size(); ++i) {
+      se::DeviceAddressBase send_buffer = send_buffers[i];
+      se::DeviceAddressBase recv_buffer = recv_buffers[i];
 
-    XLA_NCCL_RETURN_IF_ERROR(ncclSend(send_buffer.opaque(),
-                                      ToNcclCount(dtype, count), nccl_dtype, i,
-                                      comm_, AsCudaStream(stream)));
-
-    XLA_NCCL_RETURN_IF_ERROR(ncclRecv(recv_buffer.opaque(),
-                                      ToNcclCount(dtype, count), nccl_dtype, i,
-                                      comm_, AsCudaStream(stream)));
-  }
-  RETURN_IF_ERROR(GroupEnd());
-  return absl::OkStatus();
+      XLA_NCCL_RETURN_IF_ERROR(ncclSend(send_buffer.opaque(),
+                                        ToNcclCount(dtype, count), nccl_dtype,
+                                        i, comm_, AsCudaStream(stream)));
+      XLA_NCCL_RETURN_IF_ERROR(ncclRecv(recv_buffer.opaque(),
+                                        ToNcclCount(dtype, count), nccl_dtype,
+                                        i, comm_, AsCudaStream(stream)));
+    }
+    return absl::OkStatus();
+  };
+  return GroupLaunch(group);
 }
 
 absl::Status NcclCommunicator::LaunchCollectivePermute(
@@ -731,23 +717,23 @@ absl::Status NcclCommunicator::LaunchCollectivePermute(
     return absl::OkStatus();
   }
 
-  RETURN_IF_ERROR(GroupStart());
+  auto group = [&] {
+    if (source_rank) {
+      XLA_NCCL_RETURN_IF_ERROR(
+          ncclRecv(recv_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
+                   source_rank->value(), comm_, AsCudaStream(stream)));
+    }
 
-  if (source_rank) {
-    XLA_NCCL_RETURN_IF_ERROR(
-        ncclRecv(recv_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
-                 source_rank->value(), comm_, AsCudaStream(stream)));
-  }
+    for (RankId target_rank : target_ranks) {
+      XLA_NCCL_RETURN_IF_ERROR(
+          ncclSend(send_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
+                   target_rank.value(), comm_, AsCudaStream(stream)));
+    }
 
-  for (auto target_rank : target_ranks) {
-    XLA_NCCL_RETURN_IF_ERROR(
-        ncclSend(send_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
-                 target_rank.value(), comm_, AsCudaStream(stream)));
-  }
+    return absl::OkStatus();
+  };
 
-  RETURN_IF_ERROR(GroupEnd());
-
-  return absl::OkStatus();
+  return GroupLaunch(group);
 }
 
 absl::Status NcclCommunicator::LaunchSend(se::DeviceAddressBase send_buffer,
@@ -775,7 +761,7 @@ absl::Status NcclCommunicator::LaunchSend(se::DeviceAddressBase send_buffer,
   RETURN_IF_ERROR(XLA_NCCL_STATUS(
       ncclSend(send_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
                peer.value(), comm_, AsCudaStream(stream))));
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideNcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -806,7 +792,7 @@ absl::Status NcclCommunicator::LaunchRecv(se::DeviceAddressBase recv_buffer,
   RETURN_IF_ERROR(XLA_NCCL_STATUS(
       ncclRecv(recv_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
                peer.value(), comm_, AsCudaStream(stream))));
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideNcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -840,7 +826,7 @@ absl::Status NcclCommunicator::LaunchPut(se::DeviceAddressBase send_buffer,
 #else
   return Unimplemented("Put requires NCCL >= 2.29.0");
 #endif
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideNcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -872,7 +858,7 @@ absl::Status NcclCommunicator::LaunchSignal(RankId peer,
 #else
   return Unimplemented("Signal requires NCCL >= 2.29.0");
 #endif
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideNcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -909,7 +895,7 @@ absl::Status NcclCommunicator::LaunchWaitSignal(RankId peer, int op_cnt,
 #else
   return Unimplemented("WaitSignal requires NCCL >= 2.29.0");
 #endif
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideNcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();

--- a/xla/backends/gpu/collectives/nccl_communicator.h
+++ b/xla/backends/gpu/collectives/nccl_communicator.h
@@ -23,16 +23,12 @@ limitations under the License.
 #include <string>
 #include <utility>
 
-#include "absl/base/thread_annotations.h"
-#include "absl/container/flat_hash_map.h"
 #include "absl/container/inlined_vector.h"
 #include "absl/functional/any_invocable.h"
-#include "absl/log/log.h"
+#include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
-#include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/collectives/cancellation_token.h"
 #include "xla/backends/gpu/collectives/gpu_communicator.h"
@@ -43,6 +39,7 @@ limitations under the License.
 #include "xla/core/collectives/symmetric_memory.h"
 #include "xla/future.h"
 #include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/kernel_args.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/concurrency/executor.h"
 #include "xla/tsl/platform/env.h"
@@ -112,8 +109,7 @@ class NcclCommunicator : public GpuCommunicator {
   absl::StatusOr<std::unique_ptr<SymmetricMemory>> CreateSymmetricMemory(
       se::DeviceAddressBase addr) final;
 
-  Future<> GroupExecute(
-      absl::AnyInvocable<absl::Status(GpuCommunicator*)> f) final;
+  Future<> GroupExecute(absl::AnyInvocable<absl::Status() &&> group) final;
 
   Future<> AllReduce(se::DeviceAddressBase send_buffer,
                      se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
@@ -167,13 +163,18 @@ class NcclCommunicator : public GpuCommunicator {
 
   se::StreamExecutor* stream_executor() const { return stream_executor_; }
 
+  bool IsBlocking() const { return executor_ == nullptr; }
+
+  // Polls the communicator until any pending non-blocking operations are done
+  // or aborted.
+  absl::Status PollUntilDone() const;
+
  private:
   NcclCommunicator(se::StreamExecutor* stream_executor, ncclComm_t comm,
                    std::unique_ptr<tsl::Executor> executor,
                    std::shared_ptr<CancellationToken> cancel);
 
-  absl::Status GroupStart();
-  absl::Status GroupEnd();
+  absl::Status GroupLaunch(absl::FunctionRef<absl::Status()> group);
 
   absl::Status LaunchAllReduce(se::DeviceAddressBase send_buffer,
                                se::DeviceAddressBase recv_buffer,
@@ -229,10 +230,6 @@ class NcclCommunicator : public GpuCommunicator {
                                 const SignalDesc& signal_desc,
                                 const Executor& executor) final;
 
-  // Polls the communicator until any pending non-blocking operations are "done"
-  // or aborted.
-  absl::Status PollUntilDone() const;
-
   // Executes f on executor_, or calls f directly if executor_ is null.
   Future<> Execute(absl::AnyInvocable<absl::Status() &&> f) const;
 
@@ -280,9 +277,6 @@ class NcclCommunicator : public GpuCommunicator {
 
   // Has comm_ been aborted?
   bool aborted_ = false;
-
-  // Nesting level of current NCCL group
-  int group_nesting_level_ = 0;
 
   NcclCapabilities capabilities_;
 };

--- a/xla/backends/gpu/collectives/nccl_group.cc
+++ b/xla/backends/gpu/collectives/nccl_group.cc
@@ -1,0 +1,75 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/nccl_group.h"
+
+#include <cstdint>
+
+#include "absl/functional/function_ref.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "third_party/nccl/nccl.h"
+#include "xla/backends/gpu/collectives/nccl_errors.h"
+#include "xla/tsl/platform/logging.h"
+#include "xla/util.h"
+
+namespace xla::gpu {
+namespace {
+
+static thread_local int32_t nccl_group_nesting = 0;
+
+absl::Status NcclGroupStart() {
+  VLOG(5) << "Start NCCL group";
+  XLA_NCCL_RETURN_IF_ERROR(ncclGroupStart());
+  nccl_group_nesting++;
+  return absl::OkStatus();
+}
+
+absl::StatusOr<bool> NcclGroupEnd() {
+  VLOG(5) << "End NCCL group";
+  if (nccl_group_nesting <= 0) {
+    return Internal("NCCL group end called without a matching group start");
+  }
+
+  XLA_NCCL_RETURN_IF_ERROR(ncclGroupEnd());
+  nccl_group_nesting--;
+  if (nccl_group_nesting > 0) {
+    // Though NCCL allows groups to be nested, no operations are actually
+    // performed until the outermost group ends. The inner calls to
+    // ncclGroupStart and ncclGroupEnd are effectively noops.
+    //
+    // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/groups.html
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace
+
+bool IsInsideNcclGroupLaunch() { return nccl_group_nesting > 0; }
+
+absl::StatusOr<bool> NcclGroupLaunch(absl::FunctionRef<absl::Status()> group) {
+  RETURN_IF_ERROR(NcclGroupStart());
+  absl::Status group_status = group();
+  absl::StatusOr<bool> launched = NcclGroupEnd();
+  if (!group_status.ok()) {
+    return group_status;
+  }
+  return launched;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/nccl_group.h
+++ b/xla/backends/gpu/collectives/nccl_group.h
@@ -1,0 +1,35 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_NCCL_GROUP_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_NCCL_GROUP_H_
+
+#include "absl/functional/function_ref.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace xla::gpu {
+
+// Executes `group` between ncclGroupStart and ncclGroupEnd. Returns true when
+// this call closes the outermost NCCL group and launches actual operations.
+// Returns false when this call only closes a nested group.
+absl::StatusOr<bool> NcclGroupLaunch(absl::FunctionRef<absl::Status()> group);
+
+// Returns true when the current thread is inside an NCCL group launch.
+bool IsInsideNcclGroupLaunch();
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_NCCL_GROUP_H_

--- a/xla/backends/gpu/collectives/rccl_collectives.cc
+++ b/xla/backends/gpu/collectives/rccl_collectives.cc
@@ -26,8 +26,10 @@ limitations under the License.
 
 #include "absl/algorithm/container.h"
 #include "absl/base/call_once.h"
+#include "absl/base/casts.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
@@ -43,8 +45,10 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/cancellation_token.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
+#include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/backends/gpu/collectives/rccl_communicator.h"
 #include "xla/backends/gpu/collectives/rccl_errors.h"
+#include "xla/backends/gpu/collectives/rccl_group.h"
 #include "xla/core/collectives/clique_id.h"
 #include "xla/core/collectives/clique_key.h"
 #include "xla/core/collectives/collectives.h"
@@ -64,7 +68,6 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/platform/threadpool.h"
 #include "xla/util.h"
-#include "tsl/platform/casts.h"
 #include "tsl/platform/numbers.h"
 
 namespace xla::gpu {
@@ -143,6 +146,28 @@ absl::StatusOr<CliqueId> RcclCollectives::CreateUniqueCliqueId() const {
   ncclUniqueId id;
   XLA_RCCL_RETURN_IF_ERROR(ncclGetUniqueId(&id));
   return CliqueId(absl::string_view(id.internal, NCCL_UNIQUE_ID_BYTES));
+}
+
+absl::Status RcclCollectives::GroupLaunch(
+    absl::Span<const GpuCommunicator* const> comms,
+    absl::FunctionRef<absl::Status()> group) {
+  for (const GpuCommunicator* comm : comms) {
+    auto* rccl_comm = absl::down_cast<const RcclCommunicator*>(comm);
+    if (!rccl_comm->IsBlocking()) {
+      return FailedPrecondition(
+          "RCCL multi-communicator group launch requires blocking "
+          "communicators");
+    }
+  }
+
+  ASSIGN_OR_RETURN(bool launched, RcclGroupLaunch(group));
+  if (launched) {
+    for (const GpuCommunicator* comm : comms) {
+      auto* rccl_comm = absl::down_cast<const RcclCommunicator*>(comm);
+      RETURN_IF_ERROR(rccl_comm->PollUntilDone());
+    }
+  }
+  return absl::OkStatus();
 }
 
 static absl::StatusOr<ncclConfig_t> AsRcclConfig(
@@ -315,8 +340,7 @@ RcclCollectives::SplitCommunicatorsWithCancel(
 static absl::StatusOr<xla::gpu::GpuCollectives*> GetNvshmemCollectives() {
   ASSIGN_OR_RETURN(xla::Collectives * collectives,
                    xla::CollectivesRegistry::Get("gpu", "nvshmem"));
-  xla::gpu::GpuCollectives* nvshmem_collectives =
-      absl::down_cast<GpuCollectives*>(collectives);
+  auto* nvshmem_collectives = absl::down_cast<GpuCollectives*>(collectives);
   if (nvshmem_collectives == nullptr) {
     return absl::InternalError("Failed to get NVSHMEM collectives");
   }

--- a/xla/backends/gpu/collectives/rccl_collectives.h
+++ b/xla/backends/gpu/collectives/rccl_collectives.h
@@ -21,11 +21,13 @@ limitations under the License.
 #include <optional>
 #include <vector>
 
+#include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/collectives/cancellation_token.h"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
+#include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/core/collectives/clique_id.h"
 #include "xla/core/collectives/clique_key.h"
 #include "xla/core/collectives/collectives.h"
@@ -38,6 +40,9 @@ namespace xla::gpu {
 class RcclCollectives : public GpuCollectives {
  public:
   bool IsImplemented() const final { return true; }
+
+  absl::Status GroupLaunch(absl::Span<const GpuCommunicator* const> comms,
+                           absl::FunctionRef<absl::Status()> group) final;
 
   absl::StatusOr<CliqueId> CreateUniqueCliqueId() const final;
 

--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -27,12 +27,12 @@ limitations under the License.
 #include "absl/base/casts.h"
 #include "absl/container/inlined_vector.h"
 #include "absl/functional/any_invocable.h"
+#include "absl/functional/function_ref.h"
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
-#include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "rocm/include/hip/hip_runtime.h"
@@ -42,6 +42,7 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/backends/gpu/collectives/rccl_errors.h"
+#include "xla/backends/gpu/collectives/rccl_group.h"
 #include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
 #include "xla/backends/gpu/collectives/single_threaded_executor.h"
 #include "xla/core/collectives/communicator.h"
@@ -58,7 +59,7 @@ limitations under the License.
 #include "xla/tsl/platform/logging.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
-#include "tsl/platform/casts.h"
+#include "xla/xla_data.pb.h"
 
 namespace xla::gpu {
 namespace {
@@ -256,13 +257,19 @@ absl::StatusOr<size_t> RcclCommunicator::NumRanks() const {
 }
 
 Future<> RcclCommunicator::GroupExecute(
-    absl::AnyInvocable<absl::Status(GpuCommunicator*)> f) {
-  return Execute([f = std::move(f), this]() mutable -> absl::Status {
-    RETURN_IF_ERROR(GroupStart());
-    RETURN_IF_ERROR(f(this));
-    RETURN_IF_ERROR(GroupEnd());
-    return absl::OkStatus();
+    absl::AnyInvocable<absl::Status() &&> group) {
+  return Execute([group = std::move(group), this]() mutable {
+    return GroupLaunch([&] { return std::move(group)(); });
   });
+}
+
+absl::Status RcclCommunicator::GroupLaunch(
+    absl::FunctionRef<absl::Status()> group) {
+  ASSIGN_OR_RETURN(bool launched, RcclGroupLaunch(group));
+  if (launched) {
+    return PollUntilDone();
+  }
+  return absl::OkStatus();
 }
 
 Future<> RcclCommunicator::AllReduce(se::DeviceAddressBase send_buffer,
@@ -348,29 +355,6 @@ Future<> RcclCommunicator::Recv(se::DeviceAddressBase recv_buffer,
   });
 }
 
-absl::Status RcclCommunicator::GroupStart() {
-  VLOG(5) << "Start RCCL group";
-  XLA_RCCL_RETURN_IF_ERROR(ncclGroupStart());
-  group_nesting_level_++;
-  return absl::OkStatus();
-}
-
-absl::Status RcclCommunicator::GroupEnd() {
-  VLOG(5) << "End RCCL group";
-  XLA_RCCL_RETURN_IF_ERROR(ncclGroupEnd());
-  group_nesting_level_--;
-  if (group_nesting_level_ > 0) {
-    // Though NCCL allows groups to be nested, no operations are actually
-    // performed until the outermost group ends. The inner calls to
-    // GroupStart() and GroupEnd() are effectively noops.
-    //
-    // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/groups.html
-    return absl::OkStatus();
-  }
-  // Wait for the communicator to finish.
-  return PollUntilDone();
-}
-
 absl::Status RcclCommunicator::LaunchAllReduce(
     se::DeviceAddressBase send_buffer, se::DeviceAddressBase recv_buffer,
     PrimitiveType dtype, size_t count, ReductionKind reduction_kind,
@@ -398,7 +382,7 @@ absl::Status RcclCommunicator::LaunchAllReduce(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
       nccl_dtype, ToNcclReduction(reduction_kind), comm_,
       AsHipStream(stream))));
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideRcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -429,7 +413,7 @@ absl::Status RcclCommunicator::LaunchBroadcast(
   RETURN_IF_ERROR(XLA_RCCL_STATUS(ncclBroadcast(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
       nccl_dtype, root.value(), comm_, AsHipStream(stream))));
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideRcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -462,7 +446,7 @@ absl::Status RcclCommunicator::LaunchReduceScatter(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
       nccl_dtype, ToNcclReduction(reduction_kind), comm_,
       AsHipStream(stream))));
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideRcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -492,7 +476,7 @@ absl::Status RcclCommunicator::LaunchAllGather(
   RETURN_IF_ERROR(XLA_RCCL_STATUS(ncclAllGather(
       send_buffer.opaque(), recv_buffer.opaque(), ToNcclCount(dtype, count),
       nccl_dtype, comm_, AsHipStream(stream))));
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideRcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -540,21 +524,21 @@ absl::Status RcclCommunicator::LaunchAllToAll(
           dtype, /*is_reduction_op=*/false,
           stream->parent()->GetDeviceDescription().rocm_compute_capability()));
 
-  RETURN_IF_ERROR(GroupStart());
-  for (size_t i = 0; i < send_buffers.size(); ++i) {
-    se::DeviceAddressBase send_buffer = send_buffers[i];
-    se::DeviceAddressBase recv_buffer = recv_buffers[i];
+  auto group = [&] {
+    for (size_t i = 0; i < send_buffers.size(); ++i) {
+      se::DeviceAddressBase send_buffer = send_buffers[i];
+      se::DeviceAddressBase recv_buffer = recv_buffers[i];
 
-    XLA_RCCL_RETURN_IF_ERROR(ncclSend(send_buffer.opaque(),
-                                      ToNcclCount(dtype, count), nccl_dtype, i,
-                                      comm_, AsHipStream(stream)));
-
-    XLA_RCCL_RETURN_IF_ERROR(ncclRecv(recv_buffer.opaque(),
-                                      ToNcclCount(dtype, count), nccl_dtype, i,
-                                      comm_, AsHipStream(stream)));
-  }
-  RETURN_IF_ERROR(GroupEnd());
-  return absl::OkStatus();
+      XLA_RCCL_RETURN_IF_ERROR(ncclSend(send_buffer.opaque(),
+                                        ToNcclCount(dtype, count), nccl_dtype,
+                                        i, comm_, AsHipStream(stream)));
+      XLA_RCCL_RETURN_IF_ERROR(ncclRecv(recv_buffer.opaque(),
+                                        ToNcclCount(dtype, count), nccl_dtype,
+                                        i, comm_, AsHipStream(stream)));
+    }
+    return absl::OkStatus();
+  };
+  return GroupLaunch(group);
 }
 
 absl::Status RcclCommunicator::LaunchCollectivePermute(
@@ -590,23 +574,23 @@ absl::Status RcclCommunicator::LaunchCollectivePermute(
     return absl::OkStatus();
   }
 
-  RETURN_IF_ERROR(GroupStart());
+  auto group = [&] {
+    if (source_rank) {
+      XLA_RCCL_RETURN_IF_ERROR(
+          ncclRecv(recv_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
+                   source_rank->value(), comm_, AsHipStream(stream)));
+    }
 
-  if (source_rank) {
-    XLA_RCCL_RETURN_IF_ERROR(
-        ncclRecv(recv_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
-                 source_rank->value(), comm_, AsHipStream(stream)));
-  }
+    for (RankId target_rank : target_ranks) {
+      XLA_RCCL_RETURN_IF_ERROR(
+          ncclSend(send_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
+                   target_rank.value(), comm_, AsHipStream(stream)));
+    }
 
-  for (auto target_rank : target_ranks) {
-    XLA_RCCL_RETURN_IF_ERROR(
-        ncclSend(send_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
-                 target_rank.value(), comm_, AsHipStream(stream)));
-  }
+    return absl::OkStatus();
+  };
 
-  RETURN_IF_ERROR(GroupEnd());
-
-  return absl::OkStatus();
+  return GroupLaunch(group);
 }
 
 absl::Status RcclCommunicator::LaunchSend(se::DeviceAddressBase send_buffer,
@@ -634,7 +618,7 @@ absl::Status RcclCommunicator::LaunchSend(se::DeviceAddressBase send_buffer,
   RETURN_IF_ERROR(XLA_RCCL_STATUS(
       ncclSend(send_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
                peer.value(), comm_, AsHipStream(stream))));
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideRcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();
@@ -665,7 +649,7 @@ absl::Status RcclCommunicator::LaunchRecv(se::DeviceAddressBase recv_buffer,
   RETURN_IF_ERROR(XLA_RCCL_STATUS(
       ncclRecv(recv_buffer.opaque(), ToNcclCount(dtype, count), nccl_dtype,
                peer.value(), comm_, AsHipStream(stream))));
-  if (group_nesting_level_ == 0) {
+  if (!IsInsideRcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
   return absl::OkStatus();

--- a/xla/backends/gpu/collectives/rccl_communicator.h
+++ b/xla/backends/gpu/collectives/rccl_communicator.h
@@ -22,14 +22,12 @@ limitations under the License.
 #include <string>
 #include <utility>
 
-#include "absl/base/thread_annotations.h"
-#include "absl/container/flat_hash_map.h"
 #include "absl/container/inlined_vector.h"
 #include "absl/functional/any_invocable.h"
+#include "absl/functional/function_ref.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "rocm/include/rccl/rccl.h"
 #include "rocm/rocm_config.h"  // IWYU pragma: keep
@@ -75,8 +73,7 @@ class RcclCommunicator : public GpuCommunicator {
   absl::Status HealthCheck() const final;
   absl::StatusOr<size_t> NumRanks() const final;
 
-  Future<> GroupExecute(
-      absl::AnyInvocable<absl::Status(GpuCommunicator*)> f) final;
+  Future<> GroupExecute(absl::AnyInvocable<absl::Status() &&> group) final;
 
   Future<> AllReduce(se::DeviceAddressBase send_buffer,
                      se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
@@ -121,6 +118,12 @@ class RcclCommunicator : public GpuCommunicator {
 
   ncclComm_t comm() const { return comm_; }
 
+  bool IsBlocking() const { return executor_ == nullptr; }
+
+  // Polls the communicator until any pending non-blocking operations are done
+  // or aborted.
+  absl::Status PollUntilDone() const;
+
  private:
   class RcclRegisteredBufferHandle;
 
@@ -132,8 +135,7 @@ class RcclCommunicator : public GpuCommunicator {
     VLOG(1) << "Created RCCL communicator" << *this;
   }
 
-  absl::Status GroupStart();
-  absl::Status GroupEnd();
+  absl::Status GroupLaunch(absl::FunctionRef<absl::Status()> group);
 
   absl::Status LaunchAllReduce(se::DeviceAddressBase send_buffer,
                                se::DeviceAddressBase recv_buffer,
@@ -177,10 +179,6 @@ class RcclCommunicator : public GpuCommunicator {
                           PrimitiveType dtype, size_t count, RankId peer,
                           const Executor& executor) final;
 
-  // Polls the communicator until any pending non-blocking operations are "done"
-  // or aborted.
-  absl::Status PollUntilDone() const;
-
   // Executes f on executor_, or calls f directly if executor_ is null.
   Future<> Execute(absl::AnyInvocable<absl::Status() &&> f) const;
 
@@ -223,9 +221,6 @@ class RcclCommunicator : public GpuCommunicator {
 
   // Has comm_ been aborted?
   bool aborted_ = false;
-
-  // Nesting level of current RCCL group
-  int group_nesting_level_ = 0;
 };
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/rccl_group.cc
+++ b/xla/backends/gpu/collectives/rccl_group.cc
@@ -1,0 +1,81 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/rccl_group.h"
+
+#include <cstdint>
+
+#include "absl/functional/function_ref.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "rocm/rocm_config.h"
+#include "xla/backends/gpu/collectives/rccl_errors.h"
+#include "xla/tsl/platform/logging.h"
+#include "xla/util.h"
+
+#if (TF_ROCM_VERSION >= 50200)
+#include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif  // TF_ROCM_VERSION >= 50200
+
+namespace xla::gpu {
+namespace {
+
+static thread_local int32_t rccl_group_nesting = 0;
+
+absl::Status RcclGroupStart() {
+  VLOG(5) << "Start RCCL group";
+  XLA_RCCL_RETURN_IF_ERROR(ncclGroupStart());
+  rccl_group_nesting++;
+  return absl::OkStatus();
+}
+
+absl::StatusOr<bool> RcclGroupEnd() {
+  VLOG(5) << "End RCCL group";
+  if (rccl_group_nesting <= 0) {
+    return Internal("RCCL group end called without a matching group start");
+  }
+
+  XLA_RCCL_RETURN_IF_ERROR(ncclGroupEnd());
+  rccl_group_nesting--;
+  if (rccl_group_nesting > 0) {
+    // Though NCCL allows groups to be nested, no operations are actually
+    // performed until the outermost group ends. The inner calls to
+    // ncclGroupStart and ncclGroupEnd are effectively noops.
+    //
+    // https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/groups.html
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace
+
+bool IsInsideRcclGroupLaunch() { return rccl_group_nesting > 0; }
+
+absl::StatusOr<bool> RcclGroupLaunch(absl::FunctionRef<absl::Status()> group) {
+  RETURN_IF_ERROR(RcclGroupStart());
+  absl::Status group_status = group();
+  absl::StatusOr<bool> launched = RcclGroupEnd();
+  if (!group_status.ok()) {
+    return group_status;
+  }
+  return launched;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/rccl_group.h
+++ b/xla/backends/gpu/collectives/rccl_group.h
@@ -1,0 +1,35 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_RCCL_GROUP_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_RCCL_GROUP_H_
+
+#include "absl/functional/function_ref.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace xla::gpu {
+
+// Executes `group` between ncclGroupStart and ncclGroupEnd. Returns true when
+// this call closes the outermost RCCL group and launches actual operations.
+// Returns false when this call only closes a nested group.
+absl::StatusOr<bool> RcclGroupLaunch(absl::FunctionRef<absl::Status()> group);
+
+// Returns true when the current thread is inside an RCCL group launch.
+bool IsInsideRcclGroupLaunch();
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_RCCL_GROUP_H_

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -804,6 +804,7 @@ xla_cc_test(
         ":thunk",
         ":thunk_executor",
         ":thunk_proto_cc",
+        "//xla:future",
         "//xla:shape_util",
         "//xla:xla_data_proto_cc",
         "//xla/service:buffer_assignment",
@@ -886,6 +887,7 @@ cc_library(
         ":shaped_slice",
         ":thunk",
         ":thunk_proto_cc",
+        "//xla:future",
         "//xla:shape_util",
         "//xla:util",
         "//xla/runtime:buffer_use",
@@ -1806,6 +1808,7 @@ cc_library(
         ":shaped_slice",
         ":thunk",
         ":thunk_proto_cc",
+        "//xla:future",
         "//xla:shape_util",
         "//xla:util",
         "//xla:xla_data_proto_cc",
@@ -1880,11 +1883,11 @@ cc_library(
         "//xla/stream_executor:stream",
         "//xla/tsl/platform:logging",
         "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",
-        "@tsl//tsl/platform:casts",
     ],
 )
 
@@ -2100,12 +2103,12 @@ cc_library(
         "//xla/tsl/platform:logging",
         "//xla/tsl/platform:status_macros",
         "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
-        "@tsl//tsl/platform:casts",
     ],
 )
 
@@ -2345,12 +2348,11 @@ xla_test(
         "//xla/tsl/util/proto:proto_matchers",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:inlined_vector",
-        "@com_google_absl//absl/functional:any_invocable",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest_main",  # buildcleaner: keep
     ],
 )
 
@@ -2401,6 +2403,7 @@ cc_library(
         "//xla/tsl/platform:statusor",
         "//xla/tsl/util:tied_ref",
         "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:inlined_vector",
@@ -2415,7 +2418,6 @@ cc_library(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
-        "@tsl//tsl/platform:casts",
     ],
 )
 
@@ -2534,11 +2536,11 @@ cc_library(
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:stream",
         "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
-        "@tsl//tsl/platform:casts",
     ],
 )
 
@@ -2657,6 +2659,7 @@ cc_library(
         "//xla/stream_executor:stream",
         "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
@@ -2664,7 +2667,6 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
-        "@tsl//tsl/platform:casts",
     ],
 )
 
@@ -3282,19 +3284,20 @@ cc_library(
     srcs = ["collective_group_thunk.cc"],
     hdrs = ["collective_group_thunk.h"],
     deps = [
+        ":collective_cliques",
         ":collective_thunk",
         ":thunk",
         ":thunk_executor",
         ":thunk_proto_cc",
         "//xla:future",
         "//xla:util",
-        "//xla/backends/gpu/collectives:gpu_clique_key",
+        "//xla/backends/gpu/collectives:gpu_collectives",
         "//xla/backends/gpu/collectives:gpu_communicator",
-        "//xla/core/collectives:communicator",
+        "//xla/runtime:device_id",
         "//xla/service:buffer_assignment",
         "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base",
-        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",

--- a/xla/backends/gpu/runtime/all_gather_thunk.cc
+++ b/xla/backends/gpu/runtime/all_gather_thunk.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "absl/base/casts.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "absl/types/span.h"
@@ -47,7 +48,6 @@ limitations under the License.
 #include "xla/util.h"
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/casts.h"
 
 namespace xla::gpu {
 
@@ -191,18 +191,15 @@ absl::Status RunAllGather(std::vector<DeviceBufferPair>& buffers,
                           bool use_symmetric_buffer) {
   int device_ordinal = stream.parent()->device_ordinal();
   XLA_VLOG_DEVICE(3, device_ordinal) << "Performing all-gather";
-  auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(&comm);
-  Future<> future = gpu_comm->GroupExecute(
-      [&buffers, &stream](GpuCommunicator* comm) -> absl::Status {
-        for (DeviceBufferPair& buffer : buffers) {
-          RETURN_IF_ERROR(comm->LaunchAllGather(
-              buffer.source_buffer, buffer.destination_buffer,
-              buffer.element_type, buffer.element_count,
-              GpuCollectives::On(stream)));
-        }
-        return absl::OkStatus();
-      });
-
+  auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
+  Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
+    for (DeviceBufferPair& buffer : buffers) {
+      RETURN_IF_ERROR(gpu_comm->LaunchAllGather(
+          buffer.source_buffer, buffer.destination_buffer, buffer.element_type,
+          buffer.element_count, GpuCollectives::On(stream)));
+    }
+    return absl::OkStatus();
+  });
   RETURN_IF_ERROR(future.Await());
   XLA_VLOG_DEVICE(3, device_ordinal) << "Done performing all-gather";
   return absl::OkStatus();
@@ -264,7 +261,8 @@ static absl::Status RunOneSidedAllGather(
   }
 
   // Step 3: Put our source chunk into each peer's destination buffer.
-  auto put_all = [&](GpuCommunicator* c) -> absl::Status {
+  auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
+  auto put_all = [&]() -> absl::Status {
     for (size_t i = 0; i < device_buffers.size(); ++i) {
       const auto& buf = device_buffers[i];
       size_t chunk_size = buf.source_buffer.size();
@@ -293,15 +291,14 @@ static absl::Status RunOneSidedAllGather(
             << "OneSidedAllGather: Put " << chunk_size << " bytes to peer "
             << peer_rank << " at offset " << offset;
 
-        RETURN_IF_ERROR(c->LaunchPut(buf.source_buffer, sym_mem, offset,
-                                     chunk_size, peer_rank,
-                                     GpuCollectives::On(stream)));
+        RETURN_IF_ERROR(gpu_comm->LaunchPut(buf.source_buffer, sym_mem, offset,
+                                            chunk_size, peer_rank,
+                                            GpuCollectives::On(stream)));
       }
     }
     return absl::OkStatus();
   };
 
-  auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(&comm);
   RETURN_IF_ERROR(gpu_comm->GroupExecute(put_all).Await());
 
   // Copy our own source chunk into our destination buffer (local copy).

--- a/xla/backends/gpu/runtime/all_reduce_thunk.cc
+++ b/xla/backends/gpu/runtime/all_reduce_thunk.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "absl/base/casts.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -51,7 +52,6 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/casts.h"
 
 namespace xla {
 namespace gpu {
@@ -96,18 +96,15 @@ absl::Status RunAllReduce(ReductionKind reduction_kind,
                           bool use_symmetric_buffer) {
   int device_ordinal = stream.parent()->device_ordinal();
   XLA_VLOG_DEVICE(3, device_ordinal) << "Performing all-reduce";
-  auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(&comm);
-  Future<> future =
-      gpu_comm->GroupExecute([reduction_kind, &buffers,
-                              &stream](GpuCommunicator* comm) -> absl::Status {
-        for (DeviceBufferPair& buffer : buffers) {
-          RETURN_IF_ERROR(comm->LaunchAllReduce(
-              buffer.source_buffer, buffer.destination_buffer,
-              buffer.element_type, buffer.element_count, reduction_kind,
-              GpuCollectives::On(stream)));
-        }
-        return absl::OkStatus();
-      });
+  auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
+  Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
+    for (DeviceBufferPair& buffer : buffers) {
+      RETURN_IF_ERROR(gpu_comm->LaunchAllReduce(
+          buffer.source_buffer, buffer.destination_buffer, buffer.element_type,
+          buffer.element_count, reduction_kind, GpuCollectives::On(stream)));
+    }
+    return absl::OkStatus();
+  });
   RETURN_IF_ERROR(future.Await());
   XLA_VLOG_DEVICE(3, device_ordinal) << "Done performing all-reduce";
   return absl::OkStatus();
@@ -361,24 +358,22 @@ absl::Status RunReduceScatter(ReductionKind reduction_kind,
 
   ASSIGN_OR_RETURN(int32_t num_ranks, comm.NumRanks());
 
-  auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(&comm);
-  Future<> future =
-      gpu_comm->GroupExecute([num_ranks, reduction_kind, &buffers,
-                              &stream](GpuCommunicator* comm) -> absl::Status {
-        for (DeviceBufferPair& buffer : buffers) {
-          // buffer.element_count is the source buffers element count. For
-          // ncclReduceScatter, we need the destination buffers element count.
-          TF_RET_CHECK(buffer.element_count % num_ranks == 0)
-              << "Source buffer was not an exact multiple of the number of "
-                 "participants.";
+  auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
+  Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
+    for (DeviceBufferPair& buffer : buffers) {
+      // buffer.element_count is the source buffers element count. For
+      // ncclReduceScatter, we need the destination buffers element count.
+      TF_RET_CHECK(buffer.element_count % num_ranks == 0)
+          << "Source buffer was not an exact multiple of the number of "
+             "participants.";
 
-          RETURN_IF_ERROR(comm->LaunchReduceScatter(
-              buffer.source_buffer, buffer.destination_buffer,
-              buffer.element_type, buffer.element_count / num_ranks,
-              reduction_kind, GpuCollectives::On(stream)));
-        }
-        return absl::OkStatus();
-      });
+      RETURN_IF_ERROR(gpu_comm->LaunchReduceScatter(
+          buffer.source_buffer, buffer.destination_buffer, buffer.element_type,
+          buffer.element_count / num_ranks, reduction_kind,
+          GpuCollectives::On(stream)));
+    }
+    return absl::OkStatus();
+  });
   RETURN_IF_ERROR(future.Await());
   XLA_VLOG_DEVICE(3, device_ordinal) << "Done performing reduce-scatter";
   return absl::OkStatus();

--- a/xla/backends/gpu/runtime/all_to_all_thunk_test.cc
+++ b/xla/backends/gpu/runtime/all_to_all_thunk_test.cc
@@ -28,7 +28,6 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "absl/container/btree_map.h"
 #include "absl/container/inlined_vector.h"
-#include "absl/functional/any_invocable.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
@@ -96,11 +95,6 @@ static bool IsAtLeastCuda12900(const se::StreamExecutor* executor) {
 
 class FakeGpuCommunicator : public GpuCommunicator {
  public:
-  Future<> GroupExecute(
-      absl::AnyInvocable<absl::Status(GpuCommunicator*)> f) override {
-    return f(this);
-  }
-
   absl::Status LaunchAllReduce(se::DeviceAddressBase, se::DeviceAddressBase,
                                PrimitiveType, size_t, ReductionKind,
                                const Executor&) override {

--- a/xla/backends/gpu/runtime/collective_broadcast_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_broadcast_thunk.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "absl/base/casts.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
@@ -40,7 +41,6 @@ limitations under the License.
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/casts.h"
 
 namespace xla::gpu {
 
@@ -116,20 +116,19 @@ absl::Status CollectiveBroadcastThunk::RunCollective(
 
 absl::Status RunCollectiveBroadcast(std::vector<DeviceBufferPair>& buffers,
                                     se::Stream& stream, Communicator& comm) {
-  auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(&comm);
-  Future<> future = gpu_comm->GroupExecute(
-      [&buffers, &stream](GpuCommunicator* comm) -> absl::Status {
-        for (auto buffer : buffers) {
-          se::DeviceAddressBase src_addr = buffer.source_buffer;
-          se::DeviceAddressBase dest_addr = buffer.destination_buffer;
-          RETURN_IF_ERROR(comm->LaunchBroadcast(
-              // Always use rank 0 since we always broadcast from the first id
-              // in replica_groups
-              src_addr, dest_addr, buffer.element_type, buffer.element_count,
-              RankId(0), GpuCollectives::On(stream)));
-        }
-        return absl::OkStatus();
-      });
+  auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
+  Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
+    for (auto buffer : buffers) {
+      se::DeviceAddressBase src_addr = buffer.source_buffer;
+      se::DeviceAddressBase dest_addr = buffer.destination_buffer;
+      RETURN_IF_ERROR(gpu_comm->LaunchBroadcast(
+          // Always use rank 0 since we always broadcast from the first id
+          // in replica_groups
+          src_addr, dest_addr, buffer.element_type, buffer.element_count,
+          RankId(0), GpuCollectives::On(stream)));
+    }
+    return absl::OkStatus();
+  });
   return future.Await();
 }
 

--- a/xla/backends/gpu/runtime/collective_group_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_group_thunk.cc
@@ -18,22 +18,24 @@ limitations under the License.
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
+#include "absl/algorithm/container.h"
 #include "absl/base/casts.h"
-#include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
-#include "xla/backends/gpu/collectives/gpu_clique_key.h"
+#include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/backends/gpu/collectives/gpu_communicator.h"
+#include "xla/backends/gpu/runtime/collective_cliques.h"
 #include "xla/backends/gpu/runtime/collective_thunk.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/backends/gpu/runtime/thunk_executor.h"
-#include "xla/core/collectives/communicator.h"
 #include "xla/future.h"
+#include "xla/runtime/device_id.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/util.h"
 
@@ -56,41 +58,38 @@ std::string CollectiveGroupThunk::ToString(int indent) const {
   return absl::StrCat("\n", executor_.thunks().ToString(indent + 1));
 }
 
-absl::StatusOr<GpuCliqueKey> CollectiveGroupThunk::GetCliqueKey(
-    const Thunk& thunk, const Thunk::ExecuteParams& params) {
-  // Gather the set of all cliques. There should be only one.
-  absl::flat_hash_set<GpuCliqueKey> clique_set;
-  RETURN_IF_ERROR(thunk.Walk([&](const Thunk* nested) -> absl::Status {
-    if (auto* collective = dynamic_cast<const CollectiveThunk*>(nested)) {
-      ASSIGN_OR_RETURN(GpuCliqueKey clique_key,
-                       collective->GetCliqueKey(params));
-      clique_set.insert(std::move(clique_key));
-    }
-    return absl::OkStatus();
-  }));
-
-  if (clique_set.empty()) {
-    return InvalidArgument("No clique in NCCL group");
-  }
-  if (clique_set.size() > 1) {
-    return InvalidArgument("More than one clique in NCCL group");
-  }
-
-  return *clique_set.begin();
-}
-
 absl::Status CollectiveGroupThunk::ExecuteOnStream(
     const Thunk::ExecuteParams& params) {
-  ASSIGN_OR_RETURN(GpuCliqueKey clique_key, GetCliqueKey(*this, params));
-  ASSIGN_OR_RETURN(Communicator * comm,
-                   params.collective_cliques->GetComm(
-                       clique_key, params.collective_params->global_device_id));
-  auto* gpu_comm = absl::down_cast<GpuCommunicator*>(comm);
-  Future<> group_future = gpu_comm->GroupExecute(
-      [this, &params](GpuCommunicator* comm) -> absl::Status {
-        return executor_.ExecuteOnStream(params);
-      });
-  return group_future.Await();
+  GlobalDeviceId global_device_id = params.collective_params->global_device_id;
+
+  // Collect all communicators used by nested thunks.
+  std::vector<GpuCommunicator*> comms;
+  for (const std::unique_ptr<Thunk>& thunk : executor_.thunks()) {
+    auto* collective_thunk = absl::down_cast<CollectiveThunk*>(thunk.get());
+    ASSIGN_OR_RETURN(auto clique_key, collective_thunk->GetCliqueKey(params));
+    ASSIGN_OR_RETURN(GpuCommunicator * comm, params.collective_cliques->GetComm(
+                                                 clique_key, global_device_id));
+    if (!absl::c_contains(comms, comm)) {
+      comms.push_back(comm);
+    }
+  }
+
+  // It is a bug if collective group was formed with no collective ops.
+  if (comms.empty()) {
+    return InvalidArgument(
+        "Collective group must have at least one nested collective thunk");
+  }
+
+  // If nested thunks use a single comm, use it directly to execute the group.
+  if (comms.size() == 1) {
+    Future<> executed = comms.front()->GroupExecute(
+        [&] { return executor_.ExecuteOnStream(params); });
+    return executed.Await();
+  }
+
+  // Otherwise use a multi-comm group launch.
+  return params.collective_params->collectives->GroupLaunch(
+      comms, [&] { return executor_.ExecuteOnStream(params); });
 }
 
 absl::Status CollectiveGroupThunk::WalkNested(Walker callback) {

--- a/xla/backends/gpu/runtime/collective_group_thunk.h
+++ b/xla/backends/gpu/runtime/collective_group_thunk.h
@@ -22,7 +22,6 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
-#include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/backends/gpu/runtime/thunk_executor.h"
@@ -55,10 +54,6 @@ class CollectiveGroupThunk : public Thunk {
   std::string ToString(int indent) const override;
 
  private:
-  // Returns the single clique key used by all nested collective thunks.
-  static absl::StatusOr<GpuCliqueKey> GetCliqueKey(
-      const Thunk& thunk, const Thunk::ExecuteParams& params);
-
   ThunkExecutor executor_;
 };
 

--- a/xla/backends/gpu/runtime/collective_permute_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_permute_thunk.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/algorithm/container.h"
+#include "absl/base/casts.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
@@ -60,7 +61,6 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/casts.h"
 
 namespace xla::gpu {
 namespace {
@@ -225,7 +225,6 @@ CollectiveOpGroupMode CollectivePermuteThunk::GetGroupMode(
       .value();
 }
 
-
 absl::StatusOr<std::unique_ptr<CollectivePermuteThunk>>
 CollectivePermuteThunk::FromProto(
     ThunkInfo thunk_info, const CollectivePermuteThunkProto& thunk_proto,
@@ -376,21 +375,18 @@ absl::Status RunCollectivePermute(P2PConfig::SourceTargetRanks source_target,
       RETURN_IF_ERROR(future.Await());
     }
   } else {
-    auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(&comm);
-    auto future = gpu_comm->GroupExecute(
-        [&source_target, &buffers, &src_addrs, &dest_addrs, &target_ranks,
-         &stream](GpuCommunicator* comm) -> absl::Status {
-          for (uint64_t idx = 0; idx < buffers.size(); ++idx) {
-            se::DeviceAddressBase src = src_addrs.at(idx);
-            se::DeviceAddressBase dst = dest_addrs.at(idx);
-            const DeviceBufferPair& buf = buffers.at(idx);
-            RETURN_IF_ERROR(comm->LaunchCollectivePermute(
-                src, dst, buf.element_type, buf.element_count,
-                source_target.source, target_ranks,
-                GpuCollectives::On(stream)));
-          }
-          return absl::OkStatus();
-        });
+    auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
+    auto future = gpu_comm->GroupExecute([&]() -> absl::Status {
+      for (uint64_t idx = 0; idx < buffers.size(); ++idx) {
+        se::DeviceAddressBase src = src_addrs.at(idx);
+        se::DeviceAddressBase dst = dest_addrs.at(idx);
+        const DeviceBufferPair& buf = buffers.at(idx);
+        RETURN_IF_ERROR(gpu_comm->LaunchCollectivePermute(
+            src, dst, buf.element_type, buf.element_count, source_target.source,
+            target_ranks, GpuCollectives::On(stream)));
+      }
+      return absl::OkStatus();
+    });
     RETURN_IF_ERROR(future.Await());
   }
 
@@ -541,7 +537,8 @@ static absl::Status RunOneSidedPermute(
 
     // Fuse multiple Puts into a single NCCL group to avoid per-buffer
     // kernel launch overhead.
-    auto put_all = [&](GpuCommunicator* c) -> absl::Status {
+    auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
+    auto put_all = [&]() -> absl::Status {
       for (size_t i = 0; i < device_buffers.size(); ++i) {
         const auto& buf = device_buffers[i];
         auto [sym_mem, offset] = params.collective_memory->FindSymmetricMemory(
@@ -549,8 +546,8 @@ static absl::Status RunOneSidedPermute(
 
         if (sym_mem == nullptr) {
           return Internal(
-              "Symmetric memory not found for destination "
-              "buffer[%d] (address=%p, size=%d) in clique %v",
+              "Symmetric memory not found for destination buffer[%d] "
+              "(address=%p, size=%d) in clique %v",
               i, buf.destination_buffer.opaque(), buf.destination_buffer.size(),
               clique_key);
         }
@@ -559,14 +556,13 @@ static absl::Status RunOneSidedPermute(
             << "OneSidedPermute: Put " << buf.source_buffer.size()
             << " bytes to peer " << target << " at offset " << offset;
 
-        RETURN_IF_ERROR(c->LaunchPut(buf.source_buffer, sym_mem, offset,
-                                     buf.source_buffer.size(), target,
-                                     GpuCollectives::On(stream)));
+        RETURN_IF_ERROR(gpu_comm->LaunchPut(buf.source_buffer, sym_mem, offset,
+                                            buf.source_buffer.size(), target,
+                                            GpuCollectives::On(stream)));
       }
       return absl::OkStatus();
     };
 
-    auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(&comm);
     RETURN_IF_ERROR(gpu_comm->GroupExecute(put_all).Await());
   }
 

--- a/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
+++ b/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/algorithm/container.h"
+#include "absl/base/casts.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/inlined_vector.h"
 #include "absl/container/node_hash_map.h"
@@ -82,7 +83,6 @@ limitations under the License.
 #include "xla/util.h"
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/casts.h"
 
 namespace xla {
 namespace gpu {
@@ -206,30 +206,28 @@ absl::Status RunAllToAllOnIndexBuffer(
     const se::DeviceAddressBase& destination_buffer, PrimitiveType element_type,
     se::Stream& stream, Communicator& comm) {
   ASSIGN_OR_RETURN(int32_t num_ranks, comm.NumRanks());
+  auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
 
-  auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(&comm);
-  Future<> future = gpu_comm->GroupExecute(
-      [num_ranks, num_updates_per_replica, element_type, &source_buffer,
-       &destination_buffer, &stream](GpuCommunicator* comm) -> absl::Status {
-        for (int peer = 0; peer < num_ranks; ++peer) {
-          int64_t offset = peer * num_updates_per_replica;
-          se::DeviceAddressBase send_slice =
-              GpuCollectives::Slice(source_buffer, element_type, offset,
-                                    /*count=*/num_updates_per_replica);
-          se::DeviceAddressBase recv_slice =
-              GpuCollectives::Slice(destination_buffer, element_type, offset,
-                                    /*count=*/num_updates_per_replica);
-          RETURN_IF_ERROR(comm->LaunchSend(send_slice, element_type,
+  Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
+    for (int peer = 0; peer < num_ranks; ++peer) {
+      int64_t offset = peer * num_updates_per_replica;
+      se::DeviceAddressBase send_slice =
+          GpuCollectives::Slice(source_buffer, element_type, offset,
+                                /*count=*/num_updates_per_replica);
+      se::DeviceAddressBase recv_slice =
+          GpuCollectives::Slice(destination_buffer, element_type, offset,
+                                /*count=*/num_updates_per_replica);
+      RETURN_IF_ERROR(gpu_comm->LaunchSend(send_slice, element_type,
                                            /*count=*/num_updates_per_replica,
                                            RankId(peer),
                                            GpuCollectives::On(stream)));
-          RETURN_IF_ERROR(comm->LaunchRecv(recv_slice, element_type,
+      RETURN_IF_ERROR(gpu_comm->LaunchRecv(recv_slice, element_type,
                                            /*count=*/num_updates_per_replica,
                                            RankId(peer),
                                            GpuCollectives::On(stream)));
-        }
-        return absl::OkStatus();
-      });
+    }
+    return absl::OkStatus();
+  });
   RETURN_IF_ERROR(future.Await());
   return stream.BlockHostUntilDone();
 }
@@ -850,8 +848,6 @@ absl::Status RunRaggedAllToAll(
   const int64_t* send_sizes = ragged_metadata_allocs[1];
   const int64_t* output_offsets = ragged_metadata_allocs[2];
 
-  auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(&comm);
-
   if (use_put_path) {
     XLA_VLOG_DEVICE(3, device_ordinal)
         << "RunRaggedAllToAll: using Put+Signal path";
@@ -859,35 +855,30 @@ absl::Status RunRaggedAllToAll(
     int64_t element_byte_width = primitive_util::ByteWidth(element_type);
     se::DeviceAddressBase input_buffer = buffers[0].source_buffer;
 
-    Future<> future = gpu_comm->GroupExecute(
-        [num_updates_per_replica, num_ranks, input_offsets, send_sizes,
-         output_offsets, ragged_row_element_size, element_type,
-         element_byte_width, output_base_offset, &input_buffer,
-         output_symmetric_memory,
-         &stream](GpuCommunicator* comm) -> absl::Status {
-          for (int peer = 0; peer < num_ranks; ++peer) {
-            for (int64_t i = 0; i < num_updates_per_replica; ++i) {
-              const int64_t idx = peer * num_updates_per_replica + i;
-              const int64_t send_count =
-                  send_sizes[idx] * ragged_row_element_size;
+    auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
+    Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
+      for (int peer = 0; peer < num_ranks; ++peer) {
+        for (int64_t i = 0; i < num_updates_per_replica; ++i) {
+          const int64_t idx = peer * num_updates_per_replica + i;
+          const int64_t send_count = send_sizes[idx] * ragged_row_element_size;
 
-              const se::DeviceAddressBase send_slice = GpuCollectives::Slice(
-                  input_buffer, element_type,
-                  input_offsets[idx] * ragged_row_element_size, send_count);
+          const se::DeviceAddressBase send_slice = GpuCollectives::Slice(
+              input_buffer, element_type,
+              input_offsets[idx] * ragged_row_element_size, send_count);
 
-              const size_t byte_offset =
-                  output_base_offset + output_offsets[idx] *
-                                           ragged_row_element_size *
-                                           element_byte_width;
-              const size_t byte_count = send_count * element_byte_width;
+          const size_t byte_offset =
+              output_base_offset + output_offsets[idx] *
+                                       ragged_row_element_size *
+                                       element_byte_width;
+          const size_t byte_count = send_count * element_byte_width;
 
-              RETURN_IF_ERROR(comm->LaunchPut(
-                  send_slice, output_symmetric_memory, byte_offset, byte_count,
-                  RankId(peer), GpuCollectives::On(stream)));
-            }
-          }
-          return absl::OkStatus();
-        });
+          RETURN_IF_ERROR(gpu_comm->LaunchPut(
+              send_slice, output_symmetric_memory, byte_offset, byte_count,
+              RankId(peer), GpuCollectives::On(stream)));
+        }
+      }
+      return absl::OkStatus();
+    });
     RETURN_IF_ERROR(future.Await());
 
     GpuSignalDesc signal_desc(/*sig_idx=*/0, /*ctx=*/0);
@@ -905,42 +896,38 @@ absl::Status RunRaggedAllToAll(
       << "RunRaggedAllToAll: using Send/Recv path";
   const int64_t* recv_sizes = ragged_metadata_allocs[3];
 
-  Future<> future = gpu_comm->GroupExecute(
-      [num_updates_per_replica, num_ranks, input_offsets, send_sizes,
-       output_offsets, recv_sizes, ragged_row_element_size, &buffers,
-       &stream](GpuCommunicator* comm) -> absl::Status {
-        PrimitiveType element_type = buffers[0].element_type;
+  auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
+  Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
+    PrimitiveType element_type = buffers[0].element_type;
 
-        se::DeviceAddressBase input_buffer = buffers[0].source_buffer;
-        se::DeviceAddressBase output_buffer = buffers[1].destination_buffer;
+    se::DeviceAddressBase input_buffer = buffers[0].source_buffer;
+    se::DeviceAddressBase output_buffer = buffers[1].destination_buffer;
 
-        for (int64_t i = 0; i < num_updates_per_replica; ++i) {
-          for (int peer = 0; peer < num_ranks; ++peer) {
-            int64_t idx = peer * num_updates_per_replica + i;
-            se::DeviceAddressBase send_slice = GpuCollectives::Slice(
-                input_buffer, element_type,
-                input_offsets[idx] * ragged_row_element_size,
-                send_sizes[idx] * ragged_row_element_size);
+    for (int64_t i = 0; i < num_updates_per_replica; ++i) {
+      for (int peer = 0; peer < num_ranks; ++peer) {
+        int64_t idx = peer * num_updates_per_replica + i;
+        se::DeviceAddressBase send_slice =
+            GpuCollectives::Slice(input_buffer, element_type,
+                                  input_offsets[idx] * ragged_row_element_size,
+                                  send_sizes[idx] * ragged_row_element_size);
 
-            se::DeviceAddressBase recv_slice = GpuCollectives::Slice(
-                output_buffer, element_type,
-                output_offsets[idx] * ragged_row_element_size,
-                recv_sizes[idx] * ragged_row_element_size);
+        se::DeviceAddressBase recv_slice =
+            GpuCollectives::Slice(output_buffer, element_type,
+                                  output_offsets[idx] * ragged_row_element_size,
+                                  recv_sizes[idx] * ragged_row_element_size);
 
-            RETURN_IF_ERROR(
-                comm->LaunchSend(send_slice, element_type,
-                                 send_sizes[idx] * ragged_row_element_size,
-                                 RankId(peer), GpuCollectives::On(stream)));
+        RETURN_IF_ERROR(gpu_comm->LaunchSend(
+            send_slice, element_type, send_sizes[idx] * ragged_row_element_size,
+            RankId(peer), GpuCollectives::On(stream)));
 
-            RETURN_IF_ERROR(
-                comm->LaunchRecv(recv_slice, element_type,
-                                 recv_sizes[idx] * ragged_row_element_size,
-                                 RankId(peer), GpuCollectives::On(stream)));
-          }
-        }
+        RETURN_IF_ERROR(gpu_comm->LaunchRecv(
+            recv_slice, element_type, recv_sizes[idx] * ragged_row_element_size,
+            RankId(peer), GpuCollectives::On(stream)));
+      }
+    }
 
-        return absl::OkStatus();
-      });
+    return absl::OkStatus();
+  });
   return future.Await();
 }
 

--- a/xla/backends/gpu/tests/collective_ops_e2e_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_e2e_test.cc
@@ -612,6 +612,94 @@ TEST_P(CollectivesModeOps, CollectivePermuteCombiner) {
   LiteralTestUtil::ExpectR1Equal<uint32_t>({2, 2, 4, 4, 12, 12}, results[3]);
 }
 
+TEST_F(CollectiveOpsTestE2E, CollectiveGroupAllReduceDifferentReplicaGroups) {
+  const absl::string_view kModuleStr = R"(
+  HloModule test
+
+  add {
+    x = f32[] parameter(0)
+    y = f32[] parameter(1)
+    ROOT add = f32[] add(x, y)
+  }
+
+  grouped_all_reduce {
+    p0 = f32[4] parameter(0)
+    p1 = f32[4] parameter(1)
+    all-start = f32[4] all-reduce-start(p0),
+      replica_groups={{0,1,2,3}}, to_apply=add,
+      backend_config={"collective_backend_config":{"is_sync":true}}
+    pair01_23-start = f32[4] all-reduce-start(p1),
+      replica_groups={{0,1},{2,3}}, to_apply=add,
+      backend_config={"collective_backend_config":{"is_sync":true}}
+    all = f32[4] all-reduce-done(all-start)
+    pair01_23 = f32[4] all-reduce-done(pair01_23-start)
+    ROOT tuple = (f32[4], f32[4]) tuple(all, pair01_23)
+  }
+
+  ENTRY main {
+    p0 = f32[4] parameter(0)
+    p1 = f32[4] parameter(1)
+    start = ((f32[4], f32[4]), (f32[4], f32[4])) async-start(p0, p1),
+      calls=grouped_all_reduce, frontend_attributes={_collectives_group=""}
+    ROOT done = (f32[4], f32[4]) async-done(start)
+  }
+  )";
+  const int64_t kNumReplicas = 4;
+  if (device_count() < kNumReplicas) {
+    GTEST_SKIP() << "Test requires at least " << kNumReplicas << " devices ("
+                 << device_count() << " available)";
+  }
+
+  HloModuleConfig config =
+      GetModuleConfigForTest(/*replica_count=*/kNumReplicas);
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kModuleStr, config));
+
+  std::vector<Literal> all_args;
+  std::vector<Literal> pair_args;
+  all_args.reserve(kNumReplicas);
+  pair_args.reserve(kNumReplicas);
+  for (int64_t replica = 0; replica < kNumReplicas; ++replica) {
+    all_args.push_back(LiteralUtil::CreateR1<float>(
+        {static_cast<float>(replica), static_cast<float>(replica),
+         static_cast<float>(replica), static_cast<float>(replica)}));
+    pair_args.push_back(LiteralUtil::CreateR1<float>(
+        {static_cast<float>(replica), static_cast<float>(replica),
+         static_cast<float>(replica), static_cast<float>(replica)}));
+  }
+
+  std::vector<std::vector<Literal*>> args(kNumReplicas);
+  for (int64_t replica = 0; replica < kNumReplicas; ++replica) {
+    args[replica] = {&all_args[replica], &pair_args[replica]};
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
+                          ExecuteReplicated(std::move(module), args));
+
+  std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+
+  std::vector<Literal> replica0 = results[0].DecomposeTuple();
+  ASSERT_EQ(replica0.size(), 2);
+  LiteralTestUtil::ExpectR1Equal<float>({6, 6, 6, 6}, replica0[0]);
+  LiteralTestUtil::ExpectR1Equal<float>({1, 1, 1, 1}, replica0[1]);
+
+  std::vector<Literal> replica1 = results[1].DecomposeTuple();
+  ASSERT_EQ(replica1.size(), 2);
+  LiteralTestUtil::ExpectR1Equal<float>({6, 6, 6, 6}, replica1[0]);
+  LiteralTestUtil::ExpectR1Equal<float>({1, 1, 1, 1}, replica1[1]);
+
+  std::vector<Literal> replica2 = results[2].DecomposeTuple();
+  ASSERT_EQ(replica2.size(), 2);
+  LiteralTestUtil::ExpectR1Equal<float>({6, 6, 6, 6}, replica2[0]);
+  LiteralTestUtil::ExpectR1Equal<float>({5, 5, 5, 5}, replica2[1]);
+
+  std::vector<Literal> replica3 = results[3].DecomposeTuple();
+  ASSERT_EQ(replica3.size(), 2);
+  LiteralTestUtil::ExpectR1Equal<float>({6, 6, 6, 6}, replica3[0]);
+  LiteralTestUtil::ExpectR1Equal<float>({5, 5, 5, 5}, replica3[1]);
+}
+
 TEST_P(AsyncCollectiveOps, AsyncReduceScatter) {
   const absl::string_view kModuleStr = R"(
   HloModule test

--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -63,6 +63,7 @@ cc_library(
         ":gpu_metrics",
         ":se_gpu_pjrt_runtime_abi_version",
         ":se_gpu_topology_description",
+        "@com_google_absl//absl/base",
         "//xla:executable_run_options",
         "//xla:future",
         "//xla:literal",

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/algorithm/container.h"
+#include "absl/base/casts.h"
 #include "absl/container/btree_map.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/inlined_vector.h"
@@ -121,7 +122,6 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/protobuf/coordination_service.pb.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/casts.h"
 #include "tsl/platform/fingerprint.h"
 #include "tsl/platform/numa.h"
 #include "tsl/platform/protobuf.h"
@@ -543,7 +543,7 @@ absl::StatusOr<AcquiredCliqueAndCommunicator> AcquireCliqueAndCommunicator(
 
   return AcquiredCliqueAndCommunicator{
       std::move(clique),
-      tsl::down_cast<gpu::GpuCommunicator*>(*maybe_communicator)};
+      absl::down_cast<gpu::GpuCommunicator*>(*maybe_communicator)};
 }
 
 // Create a `PreparedTransfer` object bundling together state needed to perform
@@ -871,10 +871,10 @@ void StreamExecutorGpuClient::ScheduleTransfersOnLocalDevice(
 
           // Launch the group of transfers.
           group_futures.push_back(gpu_communicator->GroupExecute(
-              [&launch_transfer_group, &curr_transfers = curr_transfers,
-               stream](gpu::GpuCommunicator* gpu_comm) -> absl::Status {
+              [&launch_transfer_group, &curr_transfers = curr_transfers, stream,
+               gpu_communicator]() {
                 return launch_transfer_group(
-                    gpu_comm, absl::MakeSpan(curr_transfers), stream);
+                    gpu_communicator, absl::MakeSpan(curr_transfers), stream);
               }));
         }
 
@@ -950,7 +950,7 @@ void StreamExecutorGpuClient::ScheduleRemoteSend(
     on_done(collectives.status(), /*sends_were_enqueued=*/false);
   }
   gpu::GpuCollectives* gpu_collectives =
-      tsl::down_cast<gpu::GpuCollectives*>(*collectives);
+      absl::down_cast<gpu::GpuCollectives*>(*collectives);
   if (gpu_collectives == nullptr) {
     auto error = absl::InternalError("Failed to get GPU collectives");
     on_done(error, /*sends_were_enqueued=*/false);
@@ -1045,7 +1045,7 @@ StreamExecutorGpuClient::MakeCrossHostReceiveBuffers(
   ASSIGN_OR_RETURN(Collectives * collectives,
                    CollectivesRegistry::Default("gpu"));
   gpu::GpuCollectives* gpu_collectives =
-      tsl::down_cast<gpu::GpuCollectives*>(collectives);
+      absl::down_cast<gpu::GpuCollectives*>(collectives);
   if (gpu_collectives == nullptr) {
     return absl::InternalError("Failed to get GPU collectives");
   }
@@ -1643,7 +1643,7 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
   ASSIGN_OR_RETURN(xla::Collectives * collectives,
                    xla::CollectivesRegistry::Default("gpu"));
   xla::gpu::GpuCollectives* gpu_collectives =
-      tsl::down_cast<xla::gpu::GpuCollectives*>(collectives);
+      absl::down_cast<xla::gpu::GpuCollectives*>(collectives);
 
   if (gpu_collectives == nullptr) {
     return absl::InternalError("Failed to get GPU collectives");


### PR DESCRIPTION
NCCL group API supports grouping multiple collective operation on different communicators together, add `GpuCollectives::GroupLaunch` API for this use case. Add tests to verify that it actually works.

One special case is non-blocking communicators, because of how groups work in nccl (thread local state) and how NCCL communicators must be accessed from the same thread, it makes multi-comm groups incompatible with async communicators. This probably can we improved in followup PRs, but for now we prefer to return an error!