### PR TITLE
[xla:gpu] Switch default CUDA device allocator to VMM

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -4309,6 +4309,9 @@ cc_library(
 xla_test(
     name = "topk_test",
     srcs = ["topk_test.cc"],
+    backend_tags = {
+        "h100": ["full"],
+    },
     backends = ["gpu"],
     deps = [
         ":topk",

--- a/xla/backends/gpu/runtime/host_execute_thunk_test.cc
+++ b/xla/backends/gpu/runtime/host_execute_thunk_test.cc
@@ -160,8 +160,8 @@ TEST(HostExecuteStartThunkTest, SingleArgSingleResult) {
   TF_ASSERT_OK(stream->BlockHostUntilDone());
 
   xla::Literal result_literal(ShapeUtil::MakeShape(S32, {}));
-  TF_ASSERT_OK(
-      stream->Memcpy(result_literal.untyped_data(), result, result.size()));
+  TF_ASSERT_OK(stream->Memcpy(result_literal.untyped_data(), result,
+                              ShapeUtil::ByteSizeOf(result_literal.shape())));
   EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR0<int32_t>(10),
                                      result_literal));
 }
@@ -241,14 +241,14 @@ TEST(HostExecuteStartThunkTest, MultiArgMultipleResult) {
   TF_ASSERT_OK(stream->BlockHostUntilDone());
 
   xla::Literal result_literal0(ShapeUtil::MakeShape(S32, {}));
-  TF_ASSERT_OK(
-      stream->Memcpy(result_literal0.untyped_data(), result0, result0.size()));
+  TF_ASSERT_OK(stream->Memcpy(result_literal0.untyped_data(), result0,
+                              ShapeUtil::ByteSizeOf(result_literal0.shape())));
   EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR0<int32_t>(8),
                                      result_literal0));
 
   xla::Literal result_literal1(ShapeUtil::MakeShape(S32, {}));
-  TF_ASSERT_OK(
-      stream->Memcpy(result_literal1.untyped_data(), result1, result1.size()));
+  TF_ASSERT_OK(stream->Memcpy(result_literal1.untyped_data(), result1,
+                              ShapeUtil::ByteSizeOf(result_literal1.shape())));
   EXPECT_TRUE(LiteralTestUtil::Equal(LiteralUtil::CreateR0<int32_t>(15),
                                      result_literal1));
 }

--- a/xla/pjrt/gpu/gpu_helpers.cc
+++ b/xla/pjrt/gpu/gpu_helpers.cc
@@ -52,6 +52,15 @@ limitations under the License.
 
 namespace xla {
 
+static size_t RoundUpGpuMemoryLimit(size_t allocator_memory) {
+  // GPU device allocations can be rounded up by backend allocation granularity.
+  // BFC accounts the allocator-reported size as usable pool memory, so round
+  // the limit too to keep memory stats consistent and avoid pool_bytes
+  // exceeding bytes_limit.
+  constexpr size_t kGpuMemoryLimitGranularity = 2 * 1024 * 1024;
+  return RoundUpTo<size_t>(allocator_memory, kGpuMemoryLimitGranularity);
+}
+
 // Builds an xla::LocalClient for the GPU platform.
 absl::StatusOr<LocalClient*> GetGpuXlaClient(
     const std::optional<std::string>& platform_name,
@@ -138,6 +147,9 @@ absl::StatusOr<std::shared_ptr<tsl::BFCAllocator>> CreateBFCAllocator(
   if (gpu_system_memory_size.has_value()) {
     allocator_memory = gpu_system_memory_size.value();
   }
+
+  allocator_memory = RoundUpGpuMemoryLimit(allocator_memory);
+
   const std::string allocator_memory_str =
       absl::StrCat(tsl::strings::HumanReadableNumBytes(allocator_memory), " (",
                    allocator_memory, " bytes)");
@@ -179,6 +191,7 @@ absl::StatusOr<std::shared_ptr<tsl::BFCAllocator>> CreateCollectiveBFCAllocator(
   bool preallocate = collective_memory_size != 0;
   size_t allocator_memory =
       preallocate ? collective_memory_size : total_memory * memory_fraction;
+  allocator_memory = RoundUpGpuMemoryLimit(allocator_memory);
 
   if (preallocate) {
     LOG(INFO) << "XLA backend allocating " << allocator_memory

--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -605,6 +605,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/synchronization",

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -969,7 +969,7 @@ absl::Status CudaExecutor::Init() {
     vmm_options_.enable_fabric_handle = false;
   }
 
-  device_allocator_ = std::make_unique<CudaDeviceAllocator>(this);
+  device_allocator_ = std::make_unique<CudaVmmAllocator>(this, vmm_options_);
   host_allocator_ = std::make_unique<CudaHostAllocator>(this, numa_node_);
   vmm_allocator_ = std::make_unique<CudaVmmAllocator>(this, vmm_options_);
 

--- a/xla/stream_executor/cuda/cuda_executor.h
+++ b/xla/stream_executor/cuda/cuda_executor.h
@@ -305,9 +305,9 @@ class CudaExecutor : public GpuExecutor {
       ABSL_GUARDED_BY(alive_gpu_streams_mu_);
 
   // Memory allocators for supported memory spaces.
-  std::unique_ptr<CudaDeviceAllocator> device_allocator_;
+  std::unique_ptr<CudaVmmAllocator> device_allocator_;
   std::unique_ptr<CudaHostAllocator> host_allocator_;
-  std::unique_ptr<CudaVmmAllocator> vmm_allocator_;  // null if VMM unsupported
+  std::unique_ptr<CudaVmmAllocator> vmm_allocator_;
 
   // Tracks allocations made through the memory allocators, bridging the RAII
   // MemoryAllocation API to the raw-pointer Allocate/Deallocate interface.

--- a/xla/stream_executor/cuda/cuda_executor_multigpu_test.cc
+++ b/xla/stream_executor/cuda/cuda_executor_multigpu_test.cc
@@ -150,27 +150,6 @@ TEST(CudaExecutorMultiGpuTest, CudaMulticastMemorySubscribeMoreDevices) {
                        "All devices are already subscribed."));
 }
 
-TEST(CudaExecutorMultiGpuTest, CudaMulticastMemoryUsingNonVmmMemory) {
-  std::vector<CudaExecutor*> executors = {
-      static_cast<CudaExecutor*>(GetGpuExecutor(0)),
-      static_cast<CudaExecutor*>(GetGpuExecutor(1))};
-  if (!executors[0]->is_multicast_supported()) {
-    GTEST_SKIP() << "Test requires multicast support.";
-  }
-  const int64_t kNumDevices = 2;
-  std::unique_ptr<MulticastMemory> multicast_memory;
-  TF_ASSERT_OK_AND_ASSIGN(
-      multicast_memory, executors[0]->CreateMulticastMemory(1024, kNumDevices));
-  EXPECT_THAT(multicast_memory->SubscribeDevice(0), IsOk());
-  EXPECT_THAT(multicast_memory->SubscribeDevice(1), IsOk());
-
-  DeviceAddressBase device_memory = executors[0]->Allocate(8, 0);
-  EXPECT_THAT(
-      multicast_memory->MapMemory(device_memory, executors[0]),
-      StatusIs(absl::StatusCode::kInternal,
-               "CUDA error: : CUDA_ERROR_INVALID_VALUE: invalid argument"));
-}
-
 TEST(CudaExecutorMultiGpuTest, CudaMulticastMemoryUsingVmmMemory) {
   std::vector<CudaExecutor*> executors = {
       static_cast<CudaExecutor*>(GetGpuExecutor(0)),
@@ -304,17 +283,16 @@ TEST(CudaExecutorMultiGpuTest, IsVmmMemoryCheck) {
     GTEST_SKIP() << "Test requires VMM/Multicast support.";
   }
 
-  // Test with VMM memory
-  stream_executor::DeviceAddressBase vmm_mem = executor->Allocate(
-      1024, static_cast<int64_t>(stream_executor::MemorySpace::kCollective));
-  EXPECT_TRUE(executor->IsVmmMemory(vmm_mem));
-  executor->Deallocate(&vmm_mem);
-
-  // Test with non-VMM memory
   stream_executor::DeviceAddressBase device_mem = executor->Allocate(
       1024, static_cast<int64_t>(stream_executor::MemorySpace::kDevice));
-  EXPECT_FALSE(executor->IsVmmMemory(device_mem));
+  EXPECT_TRUE(executor->IsVmmMemory(device_mem));
   executor->Deallocate(&device_mem);
+
+  stream_executor::DeviceAddressBase collective_mem = executor->Allocate(
+      1024, static_cast<int64_t>(stream_executor::MemorySpace::kCollective));
+  EXPECT_TRUE(executor->IsVmmMemory(collective_mem));
+  executor->Deallocate(&collective_mem);
 }
+
 }  // namespace
 }  // namespace stream_executor::gpu

--- a/xla/stream_executor/cuda/cuda_executor_test.cc
+++ b/xla/stream_executor/cuda/cuda_executor_test.cc
@@ -161,6 +161,19 @@ TEST(CudaExecutorTest, CreateCollectiveMemoryAllocatorWorks) {
   EXPECT_GE(allocation->address().size(), 1024);
 }
 
+TEST(CudaExecutorTest, AllocateArrayReturnsRequestedSize) {
+  TF_ASSERT_OK_AND_ASSIGN(Platform * platform,
+                          PlatformManager::PlatformWithName("CUDA"));
+  TF_ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
+                          platform->ExecutorForDevice(0));
+
+  DeviceAddress<uint64_t> buffer = executor->AllocateScalar<uint64_t>();
+  ASSERT_NE(buffer.opaque(), nullptr);
+  EXPECT_EQ(buffer.size(), sizeof(uint64_t));
+  EXPECT_NE(buffer.payload(), 0);
+  executor->Deallocate(&buffer);
+}
+
 // TODO: b/420735471 - Enable test once fixed.
 TEST(CudaExecutorTest,
      DISABLED_CreateCollectiveMemoryAllocatorFailsForExcessiveSize) {
@@ -250,6 +263,7 @@ TEST(CudaExecutorTest, AllocateMemoryWithVmmApi) {
   TF_ASSERT_OK_AND_ASSIGN(CudaExecutor::VmmMemoryHandle handle,
                           cuda_executor->RetainVmmMemoryHandle(ptr.opaque()));
   EXPECT_NE(handle.handle(), 0);
+  cuda_executor->Deallocate(&ptr);
 }
 
 TEST(CudaExecutorTest, MultipleExecutorsForSameDevice) {
@@ -288,8 +302,7 @@ TEST(CudaExecutorTest, MultipleExecutorsForSameDevice) {
   }
 }
 
-TEST(CudaExecutorTest,
-     RetainVmmMemoryHandleForTheMemoryAllocatedWithoutVmmApi) {
+TEST(CudaExecutorTest, RetainVmmMemoryHandleForDefaultDeviceMemory) {
   TF_ASSERT_OK_AND_ASSIGN(Platform * platform,
                           PlatformManager::PlatformWithName("CUDA"));
   TF_ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
@@ -301,10 +314,14 @@ TEST(CudaExecutorTest,
       cuda_executor->Allocate(1024, static_cast<int>(MemorySpace::kDevice));
 
   EXPECT_NE(ptr.opaque(), nullptr);
-  EXPECT_EQ(ptr.size(), 1024);
+  TF_ASSERT_OK_AND_ASSIGN(size_t granularity,
+                          cuda_executor->GetVmmGranularity());
+  EXPECT_EQ(ptr.size(), granularity);
 
-  EXPECT_THAT(cuda_executor->RetainVmmMemoryHandle(ptr.opaque()),
-              absl_testing::StatusIs(absl::StatusCode::kInternal));
+  TF_ASSERT_OK_AND_ASSIGN(CudaExecutor::VmmMemoryHandle handle,
+                          cuda_executor->RetainVmmMemoryHandle(ptr.opaque()));
+  EXPECT_NE(handle.handle(), 0);
+  cuda_executor->Deallocate(&ptr);
 }
 }  // namespace
 }  // namespace stream_executor::gpu

--- a/xla/stream_executor/integrations/BUILD
+++ b/xla/stream_executor/integrations/BUILD
@@ -77,6 +77,7 @@ cc_library(
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/framework:allocator",
         "//xla/tsl/framework:device_id",
+        "@com_google_absl//absl/log:check",
         "@tsl//tsl/profiler/lib:traceme",
     ],
 )

--- a/xla/stream_executor/integrations/device_mem_allocator.h
+++ b/xla/stream_executor/integrations/device_mem_allocator.h
@@ -16,8 +16,10 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_INTEGRATIONS_DEVICE_MEM_ALLOCATOR_H_
 #define XLA_STREAM_EXECUTOR_INTEGRATIONS_DEVICE_MEM_ALLOCATOR_H_
 
+#include <cstddef>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/framework/allocator.h"
@@ -51,7 +53,9 @@ class DeviceMemAllocator : public tsl::SubAllocator {
     void* ptr = nullptr;
     *bytes_received = num_bytes;
     if (num_bytes > 0) {
-      auto result = stream_exec_->AllocateArray<char>(num_bytes);
+      // Propagate the allocator-reported size so BFC can use any backend
+      // padding that is part of the addressable allocation.
+      DeviceAddressBase result = stream_exec_->Allocate(num_bytes);
       ptr = result.opaque();
       *bytes_received = result.size();
       VisitAlloc(ptr, device_id_.value(), *bytes_received);

--- a/xla/stream_executor/memory_allocator.cc
+++ b/xla/stream_executor/memory_allocator.cc
@@ -77,7 +77,6 @@ absl::Status MemoryAllocator::AllocationTracker::Free(DeviceAddressBase addr) {
   {
     absl::MutexLock lock(&mu_);
     uint64_t id = addr.payload();
-
     // If payload is 0, the caller may have reconstructed the DeviceAddressBase
     // using only the void* pointer. We fall back to looking up the unique ID
     // using the pointer, if it is not null.
@@ -107,7 +106,7 @@ absl::Status MemoryAllocator::AllocationTracker::Free(DeviceAddressBase addr) {
           "Address mismatch for payload ID %d: provided %p, tracked %p", id,
           addr.opaque(), tracked_addr.opaque()));
     }
-    if (addr.size() != 0 && addr.size() != tracked_addr.size()) {
+    if (addr.size() > tracked_addr.size()) {
       return absl::InvalidArgumentError(absl::StrFormat(
           "Size mismatch for payload ID %d: provided %d, tracked %d", id,
           addr.size(), tracked_addr.size()));

--- a/xla/stream_executor/memory_allocator.h
+++ b/xla/stream_executor/memory_allocator.h
@@ -55,8 +55,10 @@ class MemoryAllocator {
   //
   // Thread-safe: all methods are synchronized internally.
   //
-  // Only complete address ranges returned by Track() may be freed; passing a
-  // sub-range or an untracked address to Free() is an error.
+  // Free() must receive the base address returned by Track(). Handles with a
+  // payload or handles reconstructed from a base pointer may report zero or any
+  // size no larger than the tracked allocation size. Passing a different base
+  // address, an oversized range, or an untracked address is an error.
   class AllocationTracker {
    public:
     // Takes ownership of `allocation` and returns its address as a

--- a/xla/stream_executor/memory_allocator_test.cc
+++ b/xla/stream_executor/memory_allocator_test.cc
@@ -51,6 +51,64 @@ TEST(AllocationTrackerTest, TrackAndFree) {
   EXPECT_FALSE(tracker.IsTracked(addr));
 }
 
+TEST(AllocationTrackerTest, FreeAllowsBaseAddressWithSmallerSize) {
+  MemoryAllocator::AllocationTracker tracker;
+
+  void* ptr0 = reinterpret_cast<void*>(0x1234);
+  auto alloc0 = std::make_unique<DummyMemoryAllocation>(ptr0);
+  ASSERT_OK_AND_ASSIGN(DeviceAddressBase addr0,
+                       tracker.Track(std::move(alloc0)));
+  EXPECT_OK(tracker.Free(DeviceAddressBase(addr0.opaque(), 8)));
+  EXPECT_FALSE(tracker.IsTracked(addr0));
+
+  void* ptr1 = reinterpret_cast<void*>(0x5678);
+  auto alloc1 = std::make_unique<DummyMemoryAllocation>(ptr1);
+  ASSERT_OK_AND_ASSIGN(DeviceAddressBase addr1,
+                       tracker.Track(std::move(alloc1)));
+  EXPECT_OK(tracker.Free(DeviceAddressBase(addr1.opaque(), 0)));
+  EXPECT_FALSE(tracker.IsTracked(addr1));
+}
+
+TEST(AllocationTrackerTest, FreeAllowsPayloadHandleWithSmallerSize) {
+  MemoryAllocator::AllocationTracker tracker;
+  void* ptr = reinterpret_cast<void*>(0x1234);
+  auto alloc = std::make_unique<DummyMemoryAllocation>(ptr);
+
+  ASSERT_OK_AND_ASSIGN(DeviceAddressBase addr, tracker.Track(std::move(alloc)));
+  DeviceAddressBase mismatched_size(addr.opaque(), 8);
+  mismatched_size.SetPayload(addr.payload());
+
+  EXPECT_OK(tracker.Free(mismatched_size));
+  EXPECT_FALSE(tracker.IsTracked(addr));
+}
+
+TEST(AllocationTrackerTest, FreeRejectsPayloadHandleWithOversizedRange) {
+  MemoryAllocator::AllocationTracker tracker;
+  void* ptr = reinterpret_cast<void*>(0x1234);
+  auto alloc = std::make_unique<DummyMemoryAllocation>(ptr);
+
+  ASSERT_OK_AND_ASSIGN(DeviceAddressBase addr, tracker.Track(std::move(alloc)));
+  DeviceAddressBase oversized(addr.opaque(), 101);
+  oversized.SetPayload(addr.payload());
+
+  EXPECT_FALSE(tracker.Free(oversized).ok());
+  EXPECT_TRUE(tracker.IsTracked(addr));
+
+  EXPECT_OK(tracker.Free(addr));
+}
+
+TEST(AllocationTrackerTest, FreeRejectsBaseAddressWithOversizedRange) {
+  MemoryAllocator::AllocationTracker tracker;
+  void* ptr = reinterpret_cast<void*>(0x1234);
+  auto alloc = std::make_unique<DummyMemoryAllocation>(ptr);
+
+  ASSERT_OK_AND_ASSIGN(DeviceAddressBase addr, tracker.Track(std::move(alloc)));
+  EXPECT_FALSE(tracker.Free(DeviceAddressBase(addr.opaque(), 101)).ok());
+  EXPECT_TRUE(tracker.IsTracked(addr));
+
+  EXPECT_OK(tracker.Free(addr));
+}
+
 // A MemoryAllocation that interacts with the AllocationTracker in its
 // destructor. This is used to test that the tracker does not hold its lock when
 // destroying the allocation, which would otherwise cause a deadlock.

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/functional/function_ref.h"
+#include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -232,7 +233,7 @@ class StreamExecutor {
   virtual void DeallocateStream(Stream* stream) = 0;
 
   // Enables peer access from this StreamExecutor to memory
-  // allocated by other, such that launched device code, memcpies, etc may
+  // allocated by other, such that launched device code, memcopies, etc may
   // access it directly.
   virtual absl::Status EnablePeerAccessTo(StreamExecutor* other) = 0;
 
@@ -419,7 +420,20 @@ inline DeviceAddress<T> StreamExecutor::AllocateArray(uint64_t element_count,
                  << "]";
     return DeviceAddress<T>();
   }
-  return DeviceAddress<T>(Allocate(bytes, memory_space));
+
+  DeviceAddressBase raw_allocation = Allocate(bytes, memory_space);
+  if (raw_allocation.is_null()) {
+    return DeviceAddress<T>();
+  }
+
+  // Raw allocations can report a larger backend allocation size (for example,
+  // CUDA VMM granularity padding). AllocateArray exposes only the logical array
+  // byte range because callers requested exactly `element_count` elements and
+  // should not treat allocator padding as additional array elements.
+  DCHECK_GE(raw_allocation.size(), bytes);
+  DeviceAddressBase logical_allocation(raw_allocation.opaque(), bytes);
+  logical_allocation.SetPayload(raw_allocation.payload());
+  return DeviceAddress<T>(logical_allocation);
 }
 
 }  // namespace stream_executor


### PR DESCRIPTION
VMM APIs are available since CUDA 11 and required for XLA to run. This change must be a no-op migration from legacy memory allocation APIs to the new modern one.

If this lands cleanly, will send a separate cleanup PR to remove kVmm memory space and delete unused memory allocator.

Also update typed `AllocateArray<T>` API to return requested byte size instead of the padded one. Returning full padded byte size is needed only for untype memory allocation wrappers (BFC), that need to know how much memory was actually allocated.

Delete old tests that checked that default device memory is not VMM allocated, as it no longer true.