### PR TITLE
ci: restrict presubmit benchmarks to non-fork PRs

### DIFF
--- a/.github/workflows/bazel_dependency_violations.yml
+++ b/.github/workflows/bazel_dependency_violations.yml
@@ -23,6 +23,8 @@ on:
 
 jobs:
   dependency-violations:
+    # Restrict to non-fork PRs: self-hosted GCE runner loads fork's aspects.bzl via bazel cquery.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       matrix:
         tag: [gpu, cuda-only, rocm-only]

--- a/.github/workflows/bazel_query.yml
+++ b/.github/workflows/bazel_query.yml
@@ -23,6 +23,8 @@ on:
 
 jobs:
   bazel-query:
+    # Restrict to non-fork PRs: self-hosted GCE runner loads fork's WORKSPACE via bazel query.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: "linux-x86-n2-16"
     container:
       image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest" # zizmor: ignore[unpinned-images]

--- a/.github/workflows/bazel_tags.yml
+++ b/.github/workflows/bazel_tags.yml
@@ -23,6 +23,8 @@ on:
 
 jobs:
   bazel-tags:
+    # Restrict to non-fork PRs: runner executes fork's build_tools/lint/tags.py.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: "linux-x86-n2-16"
     container:
       image: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest" # zizmor: ignore[unpinned-images]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ concurrency:
 
 jobs:
   Tests:
+    # Restrict to non-fork PRs: self-hosted GCE runners execute fork's build.py.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       # Don't fail fast - want to see results for all builds even if one fails.
       fail-fast: false

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -28,8 +28,9 @@ jobs:
     timeout-minutes: 30
     continue-on-error: true
     if: |
-      github.event.sender.type == 'User' ||
-      contains(github.event.pull_request.body, 'FORCE_TEST_ACTIONS')
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event.sender.type == 'User' ||
+       contains(github.event.pull_request.body, 'FORCE_TEST_ACTIONS'))
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/presubmit_benchmark.yml
+++ b/.github/workflows/presubmit_benchmark.yml
@@ -44,6 +44,12 @@ jobs:
   # ================================================================
   generate_matrix:
     name: Generate Presubmit Matrix
+    # Restrict to non-fork PRs to prevent untrusted code from running on
+    # privileged self-hosted GCE runners. Benchmarks can be triggered
+    # manually via workflow_dispatch for external contributions.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/generate_benchmark_matrix.yml
     with:
       workflow_type: 'PRESUBMIT'

--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -41,7 +41,8 @@ jobs:
 
   jax:
     needs: rocm-config
-    if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
+    # Restrict to non-fork PRs (existing base_ref check was not a fork guard).
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.base_ref == 'main') }}
     name: JAX Linux x86 AMD Instinct GPU
     runs-on: linux-x86-64-1gpu-amd
     env:
@@ -100,6 +101,8 @@ jobs:
 
   xla:
     needs: rocm-config
+    # Restrict to non-fork PRs: self-hosted AMD GPU runner executes fork's WORKSPACE via bazel.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: XLA Linux x86 AMD Instinct GPU
     runs-on: linux-x86-64-1gpu-amd
     env:


### PR DESCRIPTION
## Summary

Seven CI workflows in openxla/xla trigger on \`pull_request\` events from any fork and execute code from the fork on privileged self-hosted runners (GCE n2/g2/arm64, AMD GPU) without an approval gate.

An attacker who submits a PR from a fork can run arbitrary code on the runners and access GCE service-account credentials via the metadata server (\`http://metadata.google.internal/\`).

| Workflow | Job | Runner(s) | Fork code executed |
|---|---|---|---|
| \`presubmit_benchmark.yml\` | \`generate_matrix\` | \`linux-x86-n2-64\` | \`configure.py\`, Bazel BUILD, benchmark scripts |
| \`ci.yml\` | \`Tests\` | \`linux-x86-n2-16\`, \`linux-x86-g2-16-l4-1gpu\`, \`linux-arm64-c4a-16\`, \`windows-x86-n2-16\` | \`build_tools/ci/build.py\` (Python) |
| \`bazel_tags.yml\` | \`bazel-tags\` | \`linux-x86-n2-16\` | \`build_tools/lint/tags.py\` (Python) |
| \`clang_tidy.yml\` | \`clang-tidy-cuda\` | \`linux-x86-n2-16\` | \`configure.py\`, \`build_tools/ci/run_clang_tidy.sh\` |
| \`bazel_dependency_violations.yml\` | \`dependency-violations\` | \`linux-x86-n2-16\` | \`build_tools/dependencies/aspects.bzl\` (Starlark aspect via \`bazel cquery\`), WORKSPACE repository rules |
| \`bazel_query.yml\` | \`bazel-query\` | \`linux-x86-n2-16\` | Fork WORKSPACE / BUILD files loaded by \`bazel query\` |
| \`rocm_ci.yml\` | \`jax\`, \`xla\` | \`linux-x86-64-1gpu-amd\` | Fork WORKSPACE / BUILD files loaded by Bazel; \`jax\` job had an incomplete guard (\`base_ref==main\` does not exclude fork PRs) |

## Fix

Added \`if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository\` to each affected job. The \`rocm_ci\` \`jax\` job retains its existing \`github.base_ref == 'main'\` constraint, now combined with the fork-origin check.