### PR TITLE
[XLA:GPU][SPIR-V] Add shard suffix to SPV filename

### DIFF
--- a/xla/service/gpu/intel_gpu_compiler.cc
+++ b/xla/service/gpu/intel_gpu_compiler.cc
@@ -82,7 +82,11 @@ IntelGpuCompiler::CompileTargetBinary(
   if (DumpingEnabledForHloModule(debug_module ? debug_module->name() : "",
                                  module_config.debug_options())) {
     if (debug_module) {
-      DumpToFileInDirOrStdout(*debug_module, "", "spv", spirv_str);
+      DumpToFileInDirOrStdout(*debug_module, "",
+                              shard_number.has_value()
+                                  ? (std::to_string(*shard_number) + ".spv")
+                                  : "spv",
+                              spirv_str);
     } else {
       LOG(ERROR) << "Dumping is not implemented since the file name cannot be "
                     "inferred. Please implement (potentially MLIR) module -> "


### PR DESCRIPTION
This PR adds a shard suffix to the generated spv binary file name. Without this change, all subsequent binaries would overwrite the contents of the previous ones.
