### PR TITLE
[ROCm] Fix ragged-dot incorrectly routed to cuDNN instead of hipBLASLt GroupGemm

### DIFF
--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -801,13 +801,11 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     // The cuDNN ragged dot fusion is only available on NVIDIA/CUDA devices.
     // On AMD ROCm, always use hipBLASLt GroupedMatMul instead, regardless of
     // the xla_gpu_experimental_use_ragged_dot_fusion flag value.
-    const bool is_cuda_device =
-        gpu_version_.cuda_compute_capability() != nullptr;
     bool ragged_dot_fusion_enabled =
-        is_cuda_device && instr->GetModule()
-                              ->config()
-                              .debug_options()
-                              .xla_gpu_experimental_use_ragged_dot_fusion();
+        gpu_version_.IsCuda() && instr->GetModule()
+                                     ->config()
+                                     .debug_options()
+                                     .xla_gpu_experimental_use_ragged_dot_fusion();
     if (ragged_dot_fusion_enabled ||
         !IsGpublasLtSupportedGroupedMatMul(*instr)) {
       return absl::OkStatus();

--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -798,11 +798,16 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
   }
 
   absl::Status HandleRaggedDot(HloInstruction* instr) override {
+    // The cuDNN ragged dot fusion is only available on NVIDIA/CUDA devices.
+    // On AMD ROCm, always use hipBLASLt GroupedMatMul instead, regardless of
+    // the xla_gpu_experimental_use_ragged_dot_fusion flag value.
+    const bool is_cuda_device =
+        gpu_version_.cuda_compute_capability() != nullptr;
     bool ragged_dot_fusion_enabled =
-        instr->GetModule()
-            ->config()
-            .debug_options()
-            .xla_gpu_experimental_use_ragged_dot_fusion();
+        is_cuda_device && instr->GetModule()
+                              ->config()
+                              .debug_options()
+                              .xla_gpu_experimental_use_ragged_dot_fusion();
     if (ragged_dot_fusion_enabled ||
         !IsGpublasLtSupportedGroupedMatMul(*instr)) {
       return absl::OkStatus();

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2039,8 +2039,7 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
   // by hipBLASLt GroupedMatMul via GemmRewriter instead.
   if (!debug_options.xla_gpu_experimental_disable_binary_libraries() &&
       debug_options.xla_gpu_experimental_use_ragged_dot_fusion() &&
-      gpu_target_config.device_description.gpu_compute_capability()
-              .cuda_compute_capability() != nullptr) {
+      gpu_target_config.device_description.gpu_compute_capability().IsCuda()) {
     pipeline.AddPass<RaggedDotFusionRewriter>();
   }
 

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2034,8 +2034,13 @@ absl::Status GpuCompiler::OptimizeHloPostLayoutAssignment(
   // f32).
   add_float_normalization(pipeline);
 
+  // RaggedDotFusionRewriter converts ragged dots into cuDNN fusions, which is
+  // only supported on NVIDIA/CUDA devices. On AMD ROCm, ragged dots are handled
+  // by hipBLASLt GroupedMatMul via GemmRewriter instead.
   if (!debug_options.xla_gpu_experimental_disable_binary_libraries() &&
-      debug_options.xla_gpu_experimental_use_ragged_dot_fusion()) {
+      debug_options.xla_gpu_experimental_use_ragged_dot_fusion() &&
+      gpu_target_config.device_description.gpu_compute_capability()
+              .cuda_compute_capability() != nullptr) {
     pipeline.AddPass<RaggedDotFusionRewriter>();
   }
 


### PR DESCRIPTION
📝 Summary of Changes
Add `cuda_compute_capability() != nullptr` guard to all places where the value of `xla_gpu_experimental_use_ragged_dot_fusion` is checked.

🎯 Justification
Since commit 8addd218c7 (PR #42313), `xla_gpu_experimental_use_ragged_dot_fusion` defaults to true. That commit correctly added a CUDA guard to `RaggedDotRewriter` so `ragged_dot_fusion_enabled` stays false on ROCm. However, two other places that check the same flag were NOT updated with a CUDA guard:

1. `GemmRewriter::HandleRaggedDot` (gemm_rewriter.cc): with the flag now true by default, this immediately returns `OkStatus` on ROCm without converting the ragged-dot to `__cublas$lt$groupedMatmul`, leaving it as a raw `kRaggedDot`.

2. gpu_compiler.cc: `RaggedDotFusionRewriter` (a cuDNN-only pass) is now added to the pipeline on ROCm, picks up the unconverted ragged-dot, and emits a cuDNN fusion custom call instead of a `hipBLASLt GroupedMatMul`.

This causes gemm_rewriter_group_gemm_test.cc to fail on ROCm because the optimized HLO contains a cuDNN custom call instead of the expected `__cublas$lt$groupedMatmul`.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix,