### PR TITLE
[ROCM][NFC] CublasLtMatmulThunk refactor part 3

### DIFF
--- a/xla/backends/gpu/autotuner/hipblaslt.cc
+++ b/xla/backends/gpu/autotuner/hipblaslt.cc
@@ -332,9 +332,8 @@ HipblasLtBackend::GetSupportedConfigs(const HloInstruction& instr) {
     ASSIGN_OR_RETURN(BlasLt::Epilogue epilogue,
                      AsBlasLtEpilogue(backend_config.epilogue()));
 
-    ASSIGN_OR_RETURN(
-        BlasLt::MatmulPlanPtr plan,
-        blas_lt->GetGroupedMatmulPlan(grouped_gemm_config, epilogue));
+    ASSIGN_OR_RETURN(BlasLt::MatmulPlanPtr plan,
+                     blas_lt->GetMatmulPlan(grouped_gemm_config, epilogue));
 
     const Shape& output_shape = instr.shape();
     if (!output_shape.IsTuple() || output_shape.tuple_shapes().empty()) {

--- a/xla/backends/gpu/codegen/custom.cc
+++ b/xla/backends/gpu/codegen/custom.cc
@@ -589,6 +589,7 @@ absl::StatusOr<std::unique_ptr<Thunk>> CreateMatmulThunk(
       thunk_info, std::move(canonical_hlo), std::move(config),
       se::gpu::BlasLt::Epilogue::kDefault, algorithm,
       gemm_backend_config.autotune_workspace_size(), a, b, c, d,
+      /*group_sizes=*/std::nullopt,
       /*bias=*/std::nullopt, /*aux=*/std::nullopt,
       /*a_scale=*/std::nullopt, /*b_scale=*/std::nullopt,
       /*c_scale=*/std::nullopt, /*d_scale=*/std::nullopt,

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
@@ -217,17 +217,23 @@ absl::StatusOr<ThunkProto> CublasLtMatmulThunk::ToProto() const {
 
   CublasLtMatmulThunkProto* cublas_lt_matmul_thunk =
       proto.mutable_cublas_lt_matmul_thunk();
-  if (is_grouped()) {
-    auto gemm_config = std::get<se::gpu::GroupedGemmConfig>(gemm_config_);
-    *cublas_lt_matmul_thunk->mutable_grouped_gemm_config() =
-        gemm_config.ToProto();
-    ASSIGN_OR_RETURN(*cublas_lt_matmul_thunk->mutable_group_sizes(),
-                     group_sizes_.value().ToProto());
-  } else {
-    // Serialize regular matmul
-    auto gemm_config = std::get<se::gpu::GemmConfig>(gemm_config_);
-    *cublas_lt_matmul_thunk->mutable_gemm_config() = gemm_config.ToProto();
-  }
+
+  RETURN_IF_ERROR(std::visit(
+      [&](const auto& gemm_config) {
+        using T = std::decay_t<decltype(gemm_config)>;
+        if constexpr (std::is_same_v<T, se::gpu::GroupedGemmConfig>) {
+          *cublas_lt_matmul_thunk->mutable_grouped_gemm_config() =
+              gemm_config.ToProto();
+          ASSIGN_OR_RETURN(*cublas_lt_matmul_thunk->mutable_group_sizes(),
+                           group_sizes_.value().ToProto());
+        } else {
+          *cublas_lt_matmul_thunk->mutable_gemm_config() =
+              gemm_config.ToProto();
+        }
+        return absl::OkStatus();
+      },
+      gemm_config_));
+
   cublas_lt_matmul_thunk->set_epilogue(
       stream_executor::gpu::BlasLt::EpilogueToProto(epilogue_));
   cublas_lt_matmul_thunk->set_algorithm_idx(algorithm_idx_);

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
@@ -235,7 +235,7 @@ absl::StatusOr<ThunkProto> CublasLtMatmulThunk::ToProto() const {
       gemm_config_));
 
   cublas_lt_matmul_thunk->set_epilogue(
-      stream_executor::gpu::BlasLt::EpilogueToProto(epilogue_));
+      se::gpu::BlasLt::EpilogueToProto(epilogue_));
   cublas_lt_matmul_thunk->set_algorithm_idx(algorithm_idx_);
   cublas_lt_matmul_thunk->set_autotune_workspace_size(autotune_workspace_size_);
   cublas_lt_matmul_thunk->set_canonical_hlo(canonical_hlo_);
@@ -280,9 +280,8 @@ absl::StatusOr<ThunkProto> CublasLtMatmulThunk::ToProto() const {
 CublasLtMatmulThunk::FromProto(Thunk::ThunkInfo thunk_info,
                                const CublasLtMatmulThunkProto& proto,
                                absl::Span<const BufferAllocation> allocations) {
-  ASSIGN_OR_RETURN(
-      stream_executor::gpu::BlasLt::Epilogue epilogue,
-      stream_executor::gpu::BlasLt::EpilogueFromProto(proto.epilogue()));
+  ASSIGN_OR_RETURN(se::gpu::BlasLt::Epilogue epilogue,
+                   se::gpu::BlasLt::EpilogueFromProto(proto.epilogue()));
   ASSIGN_OR_RETURN(ShapedSlice a,
                    ShapedSlice::FromProto(proto.a(), allocations));
   ASSIGN_OR_RETURN(ShapedSlice b,

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
@@ -142,11 +142,11 @@ CublasLtMatmulThunk::GetCachedMatmulPlan(const ExecuteParams& params) {
             << " instr: " << canonical_hlo_;
 
     ASSIGN_OR_RETURN(auto plan, std::visit(
-                                       [&](const auto& gemm_config) {
-                                         return blas_lt->GetMatmulPlan(
-                                             gemm_config, epilogue_);
-                                       },
-                                       gemm_config_));
+                                    [&](const auto& gemm_config) {
+                                      return blas_lt->GetMatmulPlan(gemm_config,
+                                                                    epilogue_);
+                                    },
+                                    gemm_config_));
 
     // Set the workspace size to the size that was used for autotuning, so
     // algorithm index will be the same as returned by GetAlgorithms called
@@ -222,7 +222,7 @@ absl::StatusOr<ThunkProto> CublasLtMatmulThunk::ToProto() const {
     *cublas_lt_matmul_thunk->mutable_grouped_gemm_config() =
         gemm_config.ToProto();
     ASSIGN_OR_RETURN(*cublas_lt_matmul_thunk->mutable_group_sizes(),
-                        group_sizes_.value().ToProto());
+                     group_sizes_.value().ToProto());
   } else {
     // Serialize regular matmul
     auto gemm_config = std::get<se::gpu::GemmConfig>(gemm_config_);
@@ -325,34 +325,28 @@ CublasLtMatmulThunk::FromProto(Thunk::ThunkInfo thunk_info,
                      ShapedSlice::FromProto(proto.workspace(), allocations));
   }
 
+  // se::gpu::GemmConfig is not default constructible, so we need to use
+  // optional here to avoid compiler errors.
+  std::optional<VariantConfig> gemm_config;
   std::optional<ShapedSlice> group_sizes;
   // Check if this is grouped or regular matmul
   if (proto.has_grouped_gemm_config()) {
-    // Grouped matmul
-    ASSIGN_OR_RETURN(auto gemm_config, se::gpu::GroupedGemmConfig::FromProto(
-                                              proto.grouped_gemm_config()));
     ASSIGN_OR_RETURN(group_sizes,
                      ShapedSlice::FromProto(proto.group_sizes(), allocations));
-    return std::make_unique<CublasLtMatmulThunk>(
-        std::move(thunk_info), std::move(proto.canonical_hlo()),
-        std::move(gemm_config), std::move(epilogue), proto.algorithm_idx(),
-        proto.autotune_workspace_size(), std::move(a), std::move(b),
-        std::move(c), std::move(d), std::move(group_sizes), std::move(bias),
-        std::move(aux), std::move(a_scale), std::move(b_scale),
-        std::move(c_scale), std::move(d_scale), std::move(d_amax),
-        std::move(workspace));
+    ASSIGN_OR_RETURN(gemm_config, se::gpu::GroupedGemmConfig::FromProto(
+                                      proto.grouped_gemm_config()));
+  } else {
+    ASSIGN_OR_RETURN(gemm_config,
+                     se::gpu::GemmConfig::FromProto(proto.gemm_config()));
   }
-  ASSIGN_OR_RETURN(auto gemm_config,
-                   se::gpu::GemmConfig::FromProto(proto.gemm_config()));
 
   return std::make_unique<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(proto.canonical_hlo()),
-      xla::gpu::GemmConfig(std::move(gemm_config)), std::move(epilogue),
-      proto.algorithm_idx(), proto.autotune_workspace_size(), std::move(a),
-      std::move(b), std::move(c), std::move(d), std::move(group_sizes),
-      std::move(bias), std::move(aux), std::move(a_scale), std::move(b_scale),
-      std::move(c_scale), std::move(d_scale), std::move(d_amax),
-      std::move(workspace));
+      std::move(*gemm_config), std::move(epilogue), proto.algorithm_idx(),
+      proto.autotune_workspace_size(), std::move(a), std::move(b), std::move(c),
+      std::move(d), std::move(group_sizes), std::move(bias), std::move(aux),
+      std::move(a_scale), std::move(b_scale), std::move(c_scale),
+      std::move(d_scale), std::move(d_amax), std::move(workspace));
 }
 
 }  // namespace gpu

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.cc
@@ -46,68 +46,15 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
-CublasLtMatmulThunk::CublasLtMatmulThunk(const CublasLtMatmulThunk& rhs)
-    : TracedCommand(CommandType::kCublasLtCmd, Kind::kCublasLtMatmul, {}),
-      gemm_config_(rhs.gemm_config_),
-      epilogue_(rhs.epilogue_),
-      algorithm_idx_(rhs.algorithm_idx_),
-      autotune_workspace_size_(rhs.autotune_workspace_size_),
-      canonical_hlo_(rhs.canonical_hlo_),
-      a_(rhs.a_),
-      b_(rhs.b_),
-      c_(rhs.c_),
-      d_(rhs.d_),
-      group_sizes_(rhs.group_sizes_),
-      bias_(rhs.bias_),
-      aux_(rhs.aux_),
-      a_scale_(rhs.a_scale_),
-      b_scale_(rhs.b_scale_),
-      c_scale_(rhs.c_scale_),
-      d_scale_(rhs.d_scale_),
-      d_amax_(rhs.d_amax_),
-      workspace_(rhs.workspace_) {}
-
 CublasLtMatmulThunk::CublasLtMatmulThunk(
     Thunk::ThunkInfo thunk_info, std::string canonical_hlo,
-    GemmConfig gemm_config, se::gpu::BlasLt::Epilogue epilogue,
+    VariantConfig gemm_config, se::gpu::BlasLt::Epilogue epilogue,
     int64_t algorithm_idx, int64_t autotune_workspace_size, ShapedSlice a,
     ShapedSlice b, ShapedSlice c, ShapedSlice d,
-    std::optional<ShapedSlice> bias, std::optional<ShapedSlice> aux,
-    std::optional<ShapedSlice> a_scale, std::optional<ShapedSlice> b_scale,
-    std::optional<ShapedSlice> c_scale, std::optional<ShapedSlice> d_scale,
-    std::optional<ShapedSlice> d_amax,
-    std::optional<const ShapedSlice> workspace)
-    : TracedCommand(CommandType::kCublasLtCmd, Kind::kCublasLtMatmul,
-                    std::move(thunk_info)),
-      gemm_config_(std::move(gemm_config)),
-      epilogue_(epilogue),
-      algorithm_idx_(algorithm_idx),
-      autotune_workspace_size_(autotune_workspace_size),
-      canonical_hlo_(std::move(canonical_hlo)),
-      a_(a),
-      b_(b),
-      c_(c),
-      d_(d),
-      group_sizes_(std::nullopt),
-      bias_(bias),
-      aux_(aux),
-      a_scale_(a_scale),
-      b_scale_(b_scale),
-      c_scale_(c_scale),
-      d_scale_(d_scale),
-      d_amax_(d_amax),
-      workspace_(workspace) {}
-
-// Constructor for grouped matmul
-CublasLtMatmulThunk::CublasLtMatmulThunk(
-    Thunk::ThunkInfo thunk_info, std::string canonical_hlo,
-    se::gpu::GroupedGemmConfig gemm_config, se::gpu::BlasLt::Epilogue epilogue,
-    int64_t algorithm_idx, int64_t autotune_workspace_size, ShapedSlice a,
-    ShapedSlice b, ShapedSlice c, ShapedSlice d, ShapedSlice group_sizes,
-    std::optional<ShapedSlice> bias, std::optional<ShapedSlice> aux,
-    std::optional<ShapedSlice> a_scale, std::optional<ShapedSlice> b_scale,
-    std::optional<ShapedSlice> c_scale, std::optional<ShapedSlice> d_scale,
-    std::optional<ShapedSlice> d_amax,
+    std::optional<ShapedSlice> group_sizes, std::optional<ShapedSlice> bias,
+    std::optional<ShapedSlice> aux, std::optional<ShapedSlice> a_scale,
+    std::optional<ShapedSlice> b_scale, std::optional<ShapedSlice> c_scale,
+    std::optional<ShapedSlice> d_scale, std::optional<ShapedSlice> d_amax,
     std::optional<const ShapedSlice> workspace)
     : TracedCommand(CommandType::kCublasLtCmd, Kind::kCublasLtMatmul,
                     std::move(thunk_info)),
@@ -130,8 +77,7 @@ CublasLtMatmulThunk::CublasLtMatmulThunk(
       d_amax_(d_amax),
       workspace_(workspace) {}
 
-absl::Status CublasLtMatmulThunk::ExecuteOnStreamInternal(
-    se::Stream* stream, const ExecuteParams& params) {
+absl::Status CublasLtMatmulThunk::ExecuteOnStream(const ExecuteParams& params) {
   VLOG(3) << "Running cublas_lt matmul thunk";
   const BufferAllocations& allocs = *params.buffer_allocations;
 
@@ -162,64 +108,45 @@ absl::Status CublasLtMatmulThunk::ExecuteOnStreamInternal(
     workspace = allocs.GetDeviceAddress(workspace_->slice);
   }
 
+  ASSIGN_OR_RETURN(auto* plan, GetCachedMatmulPlan(params));
+  se::gpu::BlasLt::MemoryArgs args{allocs.GetDeviceAddress(a_.slice),
+                                   allocs.GetDeviceAddress(b_.slice),
+                                   allocs.GetDeviceAddress(c_.slice),
+                                   allocs.GetDeviceAddress(d_.slice),
+                                   bias,
+                                   aux,
+                                   a_scale,
+                                   b_scale,
+                                   c_scale,
+                                   d_scale,
+                                   {d_amax},
+                                   workspace,
+                                   nullptr};
+
   if (is_grouped()) {
     if (!group_sizes_.has_value()) {
       return absl::InternalError(
           "GroupedMatmul must have a non-empty group_sizes_");
     }
-    // Grouped matmul execution
-    ASSIGN_OR_RETURN(auto* plan, GetCachedGroupedMatmulPlan(params));
-    return plan->ExecuteOnStream(
-        stream,
-        se::gpu::BlasLt::MemoryArgs{
-            allocs.GetDeviceAddress(a_.slice),
-            allocs.GetDeviceAddress(b_.slice),
-            allocs.GetDeviceAddress(c_.slice),
-            allocs.GetDeviceAddress(d_.slice),
-            bias,
-            aux,
-            a_scale,
-            b_scale,
-            c_scale,
-            d_scale,
-            {allocs.GetDeviceAddress(group_sizes_->slice)},
-            workspace},
-        /* profile_result */ nullptr);
+    args.group_sizes = allocs.GetDeviceAddress(group_sizes_->slice);
   }
-  // Regular matmul execution
-  ASSIGN_OR_RETURN(auto* plan, GetCachedMatmulPlan(params));
-  return plan->ExecuteOnStream(
-      stream,
-      se::gpu::BlasLt::MemoryArgs{allocs.GetDeviceAddress(a_.slice),
-                                  allocs.GetDeviceAddress(b_.slice),
-                                  allocs.GetDeviceAddress(c_.slice),
-                                  allocs.GetDeviceAddress(d_.slice),
-                                  bias,
-                                  aux,
-                                  a_scale,
-                                  b_scale,
-                                  c_scale,
-                                  d_scale,
-                                  {d_amax},
-                                  workspace},
-      /* profile_result */ nullptr);
+  return plan->ExecuteOnStream(params.stream, args, /*profile_result*/ nullptr);
 }
-
 absl::StatusOr<se::gpu::BlasLt::MatmulPlan*>
 CublasLtMatmulThunk::GetCachedMatmulPlan(const ExecuteParams& params) {
   ASSIGN_OR_RETURN(auto* blas_lt,
                    se::gpu::BlasLt::Get(params.stream->parent()));
   auto create = [&]() -> absl::StatusOr<se::gpu::BlasLt::MatmulPlanPtr> {
-    VLOG(2) << this << ": Adding new MatmulPlan for stream: " << params.stream
+    VLOG(2) << this << ": Adding new " << (is_grouped() ? "grouped" : "regular")
+            << " MatmulPlan for stream: " << params.stream
             << " instr: " << canonical_hlo_;
 
-    auto* gemm_config = std::get_if<GemmConfig>(&gemm_config_);
-    if (gemm_config == nullptr) {
-      return absl::InternalError(
-          "Expected GemmConfig but gemm_config_ holds a different type");
-    }
-    ASSIGN_OR_RETURN(auto plan,
-                     blas_lt->GetMatmulPlan(*gemm_config, epilogue_));
+    ASSIGN_OR_RETURN(auto plan, std::visit(
+                                       [&](const auto& gemm_config) {
+                                         return blas_lt->GetMatmulPlan(
+                                             gemm_config, epilogue_);
+                                       },
+                                       gemm_config_));
 
     // Set the workspace size to the size that was used for autotuning, so
     // algorithm index will be the same as returned by GetAlgorithms called
@@ -241,45 +168,6 @@ CublasLtMatmulThunk::GetCachedMatmulPlan(const ExecuteParams& params) {
     return std::move(plan);
   };
   return blas_lt->GetOrCreateMatmulPlan(canonical_hlo_, create);
-}
-
-absl::StatusOr<se::gpu::BlasLt::MatmulPlan*>
-CublasLtMatmulThunk::GetCachedGroupedMatmulPlan(const ExecuteParams& params) {
-  ASSIGN_OR_RETURN(auto* blas_lt,
-                   se::gpu::BlasLt::Get(params.stream->parent()));
-  auto create = [&]() -> absl::StatusOr<se::gpu::BlasLt::MatmulPlanPtr> {
-    VLOG(2) << this
-            << ": Adding new Grouped MatmulPlan for stream: " << params.stream
-            << " instr: " << canonical_hlo_;
-
-    auto* gemm_config = std::get_if<se::gpu::GroupedGemmConfig>(&gemm_config_);
-    if (gemm_config == nullptr) {
-      return absl::InternalError(
-          "Expected GroupedGemmConfig but gemm_config_ holds a different type");
-    }
-    ASSIGN_OR_RETURN(auto plan,
-                     blas_lt->GetGroupedMatmulPlan(*gemm_config, epilogue_));
-
-    // Set the workspace size to the size that was used for autotuning, so
-    // algorithm index will be the same as returned by GetAlgorithms called
-    // during autotuning.
-    int64_t max_workspace = autotune_workspace_size_;
-
-    // If autotuning is disabled, there is no point on retrieving all
-    // algorithms, it's enough to get the default one only.
-    int64_t num_algorithms =
-        algorithm_idx_ == 0 ? 1 : GemmConfig::kNumAlgorithms;
-    ASSIGN_OR_RETURN(auto algorithms,
-                     plan->GetAlgorithms(num_algorithms, max_workspace));
-
-    if (algorithms.empty()) {
-      return absl::InternalError(
-          "Failed to get a GroupedMatmulPlan: no valid algorithm found.");
-    }
-    RETURN_IF_ERROR(plan->SetAlgorithm(algorithms[algorithm_idx_]));
-    return std::move(plan);
-  };
-  return blas_lt->GetOrCreateGroupedMatmulPlan(canonical_hlo_, create);
 }
 
 absl::Status CublasLtMatmulThunk::Initialize(const InitializeParams& params) {
@@ -330,23 +218,15 @@ absl::StatusOr<ThunkProto> CublasLtMatmulThunk::ToProto() const {
   CublasLtMatmulThunkProto* cublas_lt_matmul_thunk =
       proto.mutable_cublas_lt_matmul_thunk();
   if (is_grouped()) {
-    auto* gemm_config = std::get_if<se::gpu::GroupedGemmConfig>(&gemm_config_);
-    if (gemm_config == nullptr) {
-      return absl::InternalError(
-          "Expected GroupedGemmConfig but gemm_config_ holds a different type");
-    }
+    auto gemm_config = std::get<se::gpu::GroupedGemmConfig>(gemm_config_);
     *cublas_lt_matmul_thunk->mutable_grouped_gemm_config() =
-        gemm_config->ToProto();
+        gemm_config.ToProto();
     ASSIGN_OR_RETURN(*cublas_lt_matmul_thunk->mutable_group_sizes(),
-                     group_sizes_.value().ToProto());
+                        group_sizes_.value().ToProto());
   } else {
     // Serialize regular matmul
-    auto* gemm_config = std::get_if<GemmConfig>(&gemm_config_);
-    if (gemm_config == nullptr) {
-      return absl::InternalError(
-          "Expected GemmConfig but gemm_config_ holds a different type");
-    }
-    *cublas_lt_matmul_thunk->mutable_gemm_config() = gemm_config->ToProto();
+    auto gemm_config = std::get<se::gpu::GemmConfig>(gemm_config_);
+    *cublas_lt_matmul_thunk->mutable_gemm_config() = gemm_config.ToProto();
   }
   cublas_lt_matmul_thunk->set_epilogue(
       stream_executor::gpu::BlasLt::EpilogueToProto(epilogue_));
@@ -390,9 +270,10 @@ absl::StatusOr<ThunkProto> CublasLtMatmulThunk::ToProto() const {
   return proto;
 }
 
-absl::StatusOr<std::unique_ptr<Thunk>> CublasLtMatmulThunk::FromProto(
-    Thunk::ThunkInfo thunk_info, const CublasLtMatmulThunkProto& proto,
-    absl::Span<const BufferAllocation> allocations) {
+/* static */ absl::StatusOr<std::unique_ptr<Thunk>>
+CublasLtMatmulThunk::FromProto(Thunk::ThunkInfo thunk_info,
+                               const CublasLtMatmulThunkProto& proto,
+                               absl::Span<const BufferAllocation> allocations) {
   ASSIGN_OR_RETURN(
       stream_executor::gpu::BlasLt::Epilogue epilogue,
       stream_executor::gpu::BlasLt::EpilogueFromProto(proto.epilogue()));
@@ -443,13 +324,14 @@ absl::StatusOr<std::unique_ptr<Thunk>> CublasLtMatmulThunk::FromProto(
     ASSIGN_OR_RETURN(workspace,
                      ShapedSlice::FromProto(proto.workspace(), allocations));
   }
+
+  std::optional<ShapedSlice> group_sizes;
   // Check if this is grouped or regular matmul
   if (proto.has_grouped_gemm_config()) {
     // Grouped matmul
-    ASSIGN_OR_RETURN(stream_executor::gpu::GroupedGemmConfig gemm_config,
-                     stream_executor::gpu::GroupedGemmConfig::FromProto(
-                         proto.grouped_gemm_config()));
-    ASSIGN_OR_RETURN(ShapedSlice group_sizes,
+    ASSIGN_OR_RETURN(auto gemm_config, se::gpu::GroupedGemmConfig::FromProto(
+                                              proto.grouped_gemm_config()));
+    ASSIGN_OR_RETURN(group_sizes,
                      ShapedSlice::FromProto(proto.group_sizes(), allocations));
     return std::make_unique<CublasLtMatmulThunk>(
         std::move(thunk_info), std::move(proto.canonical_hlo()),
@@ -460,17 +342,17 @@ absl::StatusOr<std::unique_ptr<Thunk>> CublasLtMatmulThunk::FromProto(
         std::move(c_scale), std::move(d_scale), std::move(d_amax),
         std::move(workspace));
   }
-  ASSIGN_OR_RETURN(
-      stream_executor::gpu::GemmConfig gemm_config,
-      stream_executor::gpu::GemmConfig::FromProto(proto.gemm_config()));
+  ASSIGN_OR_RETURN(auto gemm_config,
+                   se::gpu::GemmConfig::FromProto(proto.gemm_config()));
 
   return std::make_unique<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(proto.canonical_hlo()),
       xla::gpu::GemmConfig(std::move(gemm_config)), std::move(epilogue),
       proto.algorithm_idx(), proto.autotune_workspace_size(), std::move(a),
-      std::move(b), std::move(c), std::move(d), std::move(bias), std::move(aux),
-      std::move(a_scale), std::move(b_scale), std::move(c_scale),
-      std::move(d_scale), std::move(d_amax), std::move(workspace));
+      std::move(b), std::move(c), std::move(d), std::move(group_sizes),
+      std::move(bias), std::move(aux), std::move(a_scale), std::move(b_scale),
+      std::move(c_scale), std::move(d_scale), std::move(d_amax),
+      std::move(workspace));
 }
 
 }  // namespace gpu

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.h
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk.h
@@ -43,36 +43,23 @@ namespace gpu {
 // TracedCommand traces ExecuteOnStream on the trace stream.
 class CublasLtMatmulThunk : public TracedCommand {
  public:
-  // Constructor for regular matmul
+  using VariantConfig =
+      std::variant<se::gpu::GemmConfig, se::gpu::GroupedGemmConfig>;
+
+  // Constructor for both regular and grouped matmul
   CublasLtMatmulThunk(
       Thunk::ThunkInfo thunk_info, std::string canonical_hlo,
-      GemmConfig gemm_config, se::gpu::BlasLt::Epilogue epilogue,
+      VariantConfig gemm_config, se::gpu::BlasLt::Epilogue epilogue,
       int64_t algorithm_idx, int64_t autotune_workspace_size, ShapedSlice a,
       ShapedSlice b, ShapedSlice c, ShapedSlice d,
-      std::optional<ShapedSlice> bias, std::optional<ShapedSlice> aux,
-      std::optional<ShapedSlice> a_scale, std::optional<ShapedSlice> b_scale,
-      std::optional<ShapedSlice> c_scale, std::optional<ShapedSlice> d_scale,
-      std::optional<ShapedSlice> d_amax,
+      std::optional<ShapedSlice> group_sizes, std::optional<ShapedSlice> bias,
+      std::optional<ShapedSlice> aux, std::optional<ShapedSlice> a_scale,
+      std::optional<ShapedSlice> b_scale, std::optional<ShapedSlice> c_scale,
+      std::optional<ShapedSlice> d_scale, std::optional<ShapedSlice> d_amax,
       std::optional<const ShapedSlice> workspace);
 
-  // Constructor for grouped matmul
-  CublasLtMatmulThunk(Thunk::ThunkInfo thunk_info, std::string canonical_hlo,
-                      se::gpu::GroupedGemmConfig gemm_config,
-                      se::gpu::BlasLt::Epilogue epilogue, int64_t algorithm_idx,
-                      int64_t autotune_workspace_size, ShapedSlice a,
-                      ShapedSlice b, ShapedSlice c, ShapedSlice d,
-                      ShapedSlice group_sizes, std::optional<ShapedSlice> bias,
-                      std::optional<ShapedSlice> aux,
-                      std::optional<ShapedSlice> a_scale,
-                      std::optional<ShapedSlice> b_scale,
-                      std::optional<ShapedSlice> c_scale,
-                      std::optional<ShapedSlice> d_scale,
-                      std::optional<ShapedSlice> d_amax,
-                      std::optional<const ShapedSlice> workspace);
+  absl::Status ExecuteOnStream(const ExecuteParams& params) override;
 
-  absl::Status ExecuteOnStream(const ExecuteParams& params) override {
-    return ExecuteOnStreamInternal(params.stream, params);
-  }
   absl::Status Initialize(const InitializeParams& params) override;
   std::optional<const ShapedSlice> workspace() const { return workspace_; }
 
@@ -88,16 +75,10 @@ class CublasLtMatmulThunk : public TracedCommand {
       absl::Span<const BufferAllocation> allocations);
 
  protected:
-  CublasLtMatmulThunk(const CublasLtMatmulThunk& rhs);
-
-  absl::Status ExecuteOnStreamInternal(se::Stream* stream,
-                                       const ExecuteParams& params);
   absl::StatusOr<se::gpu::BlasLt::MatmulPlan*> GetCachedMatmulPlan(
       const ExecuteParams& params);
-  absl::StatusOr<se::gpu::BlasLt::MatmulPlan*> GetCachedGroupedMatmulPlan(
-      const ExecuteParams& params);
 
-  std::variant<GemmConfig, se::gpu::GroupedGemmConfig> gemm_config_;
+  VariantConfig gemm_config_;
   se::gpu::BlasLt::Epilogue epilogue_;
   int64_t algorithm_idx_;
   int64_t autotune_workspace_size_;

--- a/xla/backends/gpu/runtime/thunk.proto
+++ b/xla/backends/gpu/runtime/thunk.proto
@@ -257,8 +257,10 @@ message SelectKThunkProto {
 message CublasLtMatmulThunkProto {
   // For regular matmul, use gemm_config. For grouped matmul, use
   // grouped_gemm_config.
-  optional xla.GemmConfigProto gemm_config = 1;
-  optional xla.GroupedGemmConfigProto grouped_gemm_config = 19;
+  oneof impl { 
+    xla.GemmConfigProto gemm_config = 1;
+    xla.GroupedGemmConfigProto grouped_gemm_config = 19;
+  }
 
   xla.BlasLtEpilogueProto epilogue = 2;
   int64 algorithm_idx = 3;

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -313,10 +313,9 @@ ThunkSequence FlattenThunkSequence(std::vector<ThunkSequence>&& sequences) {
 
 }  // namespace
 
-ThunkEmitter::ThunkEmitter(
-    IrEmitterContext* absl_nonnull ir_emitter_context,
-    llvm_ir::LLVMCommandLineOptionsReleasableLock* absl_nonnull
-        llvm_options_lock)
+ThunkEmitter::ThunkEmitter(IrEmitterContext* absl_nonnull ir_emitter_context,
+                           llvm_ir::LLVMCommandLineOptionsReleasableLock*
+                               absl_nonnull llvm_options_lock)
     : ir_emitter_context_(ir_emitter_context),
       send_recv_events_(std::make_shared<HostSendRecvAsyncEvents>()),
       nvshmem_buffer_addresses_(std::make_shared<NvshmemBufferAddresses>()),
@@ -590,8 +589,8 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunk(
   auto thunk = std::make_unique<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
       blas_lt_epilogue, algorithm, config.autotune_workspace_size(), a, b, c, d,
-      bias, aux, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-      std::nullopt, workspace_buffer);
+      /*group_sizes=*/std::nullopt, bias, aux, std::nullopt, std::nullopt,
+      std::nullopt, std::nullopt, std::nullopt, workspace_buffer);
   return GetThunkSequence(std::move(thunk));
 }
 
@@ -678,8 +677,8 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunkF8(
   auto thunk = std::make_unique<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
       blas_lt_epilogue, algorithm, config.autotune_workspace_size(), a, b, c, d,
-      bias, std::nullopt, a_scale, b_scale, std::nullopt, d_scale, d_amax,
-      workspace_buffer);
+      /*group_sizes=*/std::nullopt, bias, std::nullopt, a_scale, b_scale,
+      std::nullopt, d_scale, d_amax, workspace_buffer);
   return GetThunkSequence(std::move(thunk));
 }
 
@@ -753,8 +752,8 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtGroupedMatmulThunk(
   auto thunk = std::make_unique<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
       blas_lt_epilogue, algorithm, config.autotune_workspace_size(), a, b, c, d,
-      group_sizes, bias, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-      std::nullopt, std::nullopt, workspace_buffer);
+      std::move(group_sizes), bias, std::nullopt, std::nullopt, std::nullopt,
+      std::nullopt, std::nullopt, std::nullopt, workspace_buffer);
   return GetThunkSequence(std::move(thunk));
 }
 
@@ -804,6 +803,7 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunkMx(
   auto thunk = std::make_unique<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
       blas_lt_epilogue, algorithm, config.autotune_workspace_size(), a, b, c, d,
+      /*group_sizes=*/std::nullopt,
       /*bias=*/std::nullopt, /*aux=*/std::nullopt, a_scale, b_scale,
       /*c_scale=*/std::nullopt, /*d_scale=*/std::nullopt,
       /*d_amax=*/std::nullopt, workspace_buffer);
@@ -1691,8 +1691,8 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitReplicaOrPartitionId(
       result_slice));
 }
 
-[[deprecated("Use NCCL 2.28+ primitives instead.")]]
-bool IsNvshmemCollective(const HloInstruction* instr) {
+[[deprecated("Use NCCL 2.28+ primitives instead.")]] bool IsNvshmemCollective(
+    const HloInstruction* instr) {
   if (instr->has_backend_config()) {
     auto gpu_config = instr->backend_config<GpuBackendConfig>();
     const CollectiveBackendConfig& backend_config =
@@ -2068,9 +2068,9 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectiveAsyncDone(
       it->second));
 }
 
-[[deprecated("Use NCCL 2.28+ primitives instead.")]]
-absl::StatusOr<ThunkSequence> ThunkEmitter::EmitNvshmemAsyncDone(
-    const HloInstruction* inst) {
+[[deprecated(
+    "Use NCCL 2.28+ primitives instead.")]] absl::StatusOr<ThunkSequence>
+ThunkEmitter::EmitNvshmemAsyncDone(const HloInstruction* inst) {
   bool is_send_recv =
       inst->opcode() == HloOpcode::kSendDone ||
       inst->opcode() == HloOpcode::kRecvDone ||
@@ -2098,11 +2098,12 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitNvshmemAsyncDone(
 }
 
 template <typename NvshmemAllReduceThunkType, typename HloAllReduceInstruction>
-[[deprecated("Use NCCL 2.28+ primitives instead.")]]
-absl::StatusOr<ThunkSequence> ThunkEmitter::EmitNvshmemThunk(
-    Thunk::Kind kind, const HloInstruction* async_start,
-    const HloAllReduceInstruction* inst,
-    std::optional<bool> use_global_device_ids) {
+[[deprecated(
+    "Use NCCL 2.28+ primitives instead.")]] absl::StatusOr<ThunkSequence>
+ThunkEmitter::EmitNvshmemThunk(Thunk::Kind kind,
+                               const HloInstruction* async_start,
+                               const HloAllReduceInstruction* inst,
+                               std::optional<bool> use_global_device_ids) {
   CHECK(kind == Thunk::Kind::kNvshmemAllReduce);
   const auto& hlo_config = ir_emitter_context_->hlo_module().config();
   int64_t replica_count = hlo_config.replica_count();

--- a/xla/stream_executor/cuda/cuda_blas_lt.h
+++ b/xla/stream_executor/cuda/cuda_blas_lt.h
@@ -129,7 +129,7 @@ class BlasLt : public gpu::BlasLt {
     double beta_;
     bool must_swap_operands_;
     std::optional<MatmulAlgorithm> algorithm_;  // selected algorithm
-  };  // class MatmulPlan
+  };                                            // class MatmulPlan
 
   explicit BlasLt(StreamExecutor* executor)
       : executor_(executor), handle_(nullptr, cublasLtDestroy) {}
@@ -139,8 +139,8 @@ class BlasLt : public gpu::BlasLt {
   absl::StatusOr<MatmulPlanPtr> GetMatmulPlan(const gpu::GemmConfig& cfg,
                                               Epilogue epilogue) const override;
 
-  absl::StatusOr<MatmulPlanPtr> GetGroupedMatmulPlan(
-      const gpu::GroupedGemmConfig& config, Epilogue epilogue) const override {
+  absl::StatusOr<MatmulPlanPtr> GetMatmulPlan(
+      const gpu::GroupedGemmConfig& cfg, Epilogue epilogue) const override {
     return absl::UnimplementedError(
         "Grouped GEMM is not supported for CUDA BlasLt");
   };

--- a/xla/stream_executor/gpu/gpu_blas_lt.cc
+++ b/xla/stream_executor/gpu/gpu_blas_lt.cc
@@ -326,29 +326,6 @@ size_t BlasLt::GetMatmulPlanCacheSize() const {
   return plan_cache_.size();
 }
 
-absl::StatusOr<BlasLt::MatmulPlan*> BlasLt::GetOrCreateGroupedMatmulPlan(
-    const std::string& key, PlanCreateFunc create) {
-  absl::MutexLock lock(plan_cache_mu_);
-  auto res = grouped_plan_cache_.emplace(key, MatmulPlanPtr{});
-  if (res.second || key.empty()) {
-    VLOG(2) << "Creating a grouped plan for: " << key;
-    ASSIGN_OR_RETURN(res.first->second, create());
-    VLOG(2) << "Grouped Plan created: cache size: "
-            << grouped_plan_cache_.size();
-  }
-  return res.first->second.get();
-}
-
-void BlasLt::ClearGroupedMatmulPlanCache() {
-  absl::MutexLock lock(plan_cache_mu_);
-  grouped_plan_cache_.clear();
-}
-
-size_t BlasLt::GetGroupedMatmulPlanCacheSize() const {
-  absl::MutexLock lock(plan_cache_mu_);
-  return grouped_plan_cache_.size();
-}
-
 absl::StatusOr<GemmConfig> GemmConfig::FromProto(
     const xla::GemmConfigProto& proto) {
   ASSIGN_OR_RETURN(MatrixLayout lhs_layout,

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -298,7 +298,7 @@ struct BlasLt {
   virtual absl::StatusOr<MatmulPlanPtr> GetMatmulPlan(
       const GemmConfig& cfg, Epilogue epilogue) const = 0;
 
-  virtual absl::StatusOr<MatmulPlanPtr> GetGroupedMatmulPlan(
+  virtual absl::StatusOr<MatmulPlanPtr> GetMatmulPlan(
       const gpu::GroupedGemmConfig& config, Epilogue epilogue) const = 0;
 
   static absl::StatusOr<BlasLt*> Get(StreamExecutor* executor);
@@ -315,22 +315,14 @@ struct BlasLt {
   absl::StatusOr<MatmulPlan*> GetOrCreateMatmulPlan(const std::string& key,
                                                     PlanCreateFunc create);
 
-  absl::StatusOr<MatmulPlan*> GetOrCreateGroupedMatmulPlan(
-      const std::string& key, PlanCreateFunc create);
-
   void ClearMatmulPlanCache();
   size_t GetMatmulPlanCacheSize() const;
-
-  void ClearGroupedMatmulPlanCache();
-  size_t GetGroupedMatmulPlanCacheSize() const;
 
   virtual ~BlasLt() = default;
 
  protected:
   mutable absl::Mutex plan_cache_mu_;
   absl::flat_hash_map<std::string, MatmulPlanPtr> plan_cache_
-      ABSL_GUARDED_BY(plan_cache_mu_);
-  absl::flat_hash_map<std::string, MatmulPlanPtr> grouped_plan_cache_
       ABSL_GUARDED_BY(plan_cache_mu_);
 };  // class BlasLt
 

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -846,7 +846,7 @@ absl::Status BlasLt::GroupedMatmulPlan::DoInitialize(
   return absl::OkStatus();
 }
 
-absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetGroupedMatmulPlan(
+absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
     const gpu::GroupedGemmConfig& cfg, Epilogue epilogue) const {
   auto compute_type = cfg.compute_type;
   if (!compute_type) {  // obtain compute_type unless provided by the user

--- a/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/xla/stream_executor/rocm/hip_blas_lt.h
@@ -191,8 +191,8 @@ class BlasLt : public gpu::BlasLt {
   absl::StatusOr<MatmulPlanPtr> GetMatmulPlan(const gpu::GemmConfig& cfg,
                                               Epilogue epilogue) const override;
 
-  absl::StatusOr<MatmulPlanPtr> GetGroupedMatmulPlan(
-      const gpu::GroupedGemmConfig& config, Epilogue epilogue) const override;
+  absl::StatusOr<MatmulPlanPtr> GetMatmulPlan(const gpu::GroupedGemmConfig& cfg,
+                                              Epilogue epilogue) const override;
 
   ~BlasLt() override = default;
 

--- a/xla/stream_executor/sycl/sycl_blas_lt.h
+++ b/xla/stream_executor/sycl/sycl_blas_lt.h
@@ -35,8 +35,8 @@ class BlasLt : public gpu::BlasLt {
   absl::StatusOr<BlasLt::MatmulPlanPtr> GetMatmulPlan(
       const gpu::GemmConfig& config, Epilogue epilogue) const override;
 
-  absl::StatusOr<MatmulPlanPtr> GetGroupedMatmulPlan(
-      const gpu::GroupedGemmConfig& config, Epilogue epilogue) const override {
+  absl::StatusOr<MatmulPlanPtr> GetMatmulPlan(
+      const gpu::GroupedGemmConfig& cfg, Epilogue epilogue) const override {
     return absl::UnimplementedError(
         "Grouped GEMM is not supported for Sycl BlasLt");
   }


### PR DESCRIPTION

1. Renamed GetGroupedMatmulPlan -> GetMatmulPlan overload
2. Removed duplicating/unused CublasLtMatmulThunk constructors: pass VariantConfig directly to the constructor 
3. Removed other duplicate code from CublasLtMatmulThunk 
4. Unified grouped & regular matmul plan caches in gpu_blas_lt (since they use different cache keys anyway)
5. Use protobuf 'oneof' to distinguish between gemm_config and grouped_gemm_config 

This is a 3rd refactoring PR extracted from https://github.com/openxla/xla/pull/42239