### PR TITLE
[ROCm] Add librocm_kpack and libclang-cpp to runfiles globs

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -154,6 +154,7 @@ rocm_lib_import(
     data = glob(
         [
             "%{rocm_root}/lib/libamdhip64.so*",
+            "%{rocm_root}/lib/librocm_kpack.so*",
         ],
     ),
     interface_library = "%{rocm_root}/lib/libamdhip64.so",
@@ -201,6 +202,7 @@ cc_library(
             "%{rocm_root}/lib/libamd_comgr_loader.so*",
             "%{rocm_root}/lib/libamd_comgr.so*",
             "%{rocm_root}/lib/llvm/lib/libLLVM.so*",
+            "%{rocm_root}/lib/llvm/lib/libclang-cpp.so*",
         ],
     ),
     deps = [


### PR DESCRIPTION
Two new DT_NEEDED entries appeared in ROCm 7.13 that BUILD.tpl's data globs weren't mirroring into runfiles, causing dlopen failures at runtime:

  - libamdhip64.so.7   -> librocm_kpack.so.0
  - libamd_comgr.so.3  -> libclang-cpp.so