### PR TITLE
[XLA:CPU][oneDNN] Fix onednn_convolution_test build failure after move to restricted directory

### DIFF
--- a/xla/service/cpu/tests/restricted/onednn_convolution_test.cc
+++ b/xla/service/cpu/tests/restricted/onednn_convolution_test.cc
@@ -26,7 +26,6 @@ limitations under the License.
 #include "xla/service/cpu/onednn_util.h"
 #include "xla/shape_util.h"
 #include "xla/tests/restricted/hlo_test_base_legacy.h"
-#include "xla/tsl/platform/cpu_info.h"
 
 namespace xla {
 namespace cpu {


### PR DESCRIPTION
This PR fixes a build failure (error trace below) for `onednn_convolution_test` which started happening after https://github.com/openxla/xla/commit/e1b7988af67dd0c284a41c2ff42ce74021bdd1fb was merged.

```
xla/service/cpu/tests/restricted/onednn_convolution_test.cc:29:10: fatal error: 'xla/tsl/platform/cpu_info.h' file not found
   29 | #include "xla/tsl/platform/cpu_info.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```