### PR TITLE
[ROCM][NFC] Refactor alpha/beta computation for blaslt backends

### DIFF
--- a/xla/stream_executor/cuda/cuda_blas_lt.cc
+++ b/xla/stream_executor/cuda/cuda_blas_lt.cc
@@ -442,6 +442,9 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
   TYPED_MATMUL(float, CUDA_R_8I, CUDA_R_8I, CUDA_R_32F, CUDA_R_32F)
   TYPED_MATMUL(xla::complex64, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F)
   TYPED_MATMUL(xla::complex128, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F)
+  else {
+    return xla::Internal("Unexpected operand types for cublaslt matmul");
+  }
 #undef TYPED_MATMUL
   return plan;
 }

--- a/xla/stream_executor/cuda/cuda_blas_lt.cc
+++ b/xla/stream_executor/cuda/cuda_blas_lt.cc
@@ -366,15 +366,88 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
   ASSIGN_OR_RETURN(auto c_desc, MatrixLayout::Create(c_layout));
   ASSIGN_OR_RETURN(auto d_desc, MatrixLayout::Create(output_layout));
 
-  return std::make_unique<MatmulPlan>(*this, std::move(op_desc),
-                                      std::move(a_desc), std::move(b_desc),
-                                      std::move(c_desc), std::move(d_desc),
-                                      cfg.alpha, cfg.beta, must_swap_operands);
+  std::tuple operand_types{a_desc.type(), b_desc.type(), c_desc.type(),
+                           d_desc.type()};
+
+  auto plan = std::make_unique<MatmulPlan>(*this, std::move(op_desc),
+                                           std::move(a_desc), std::move(b_desc),
+                                           std::move(c_desc), std::move(d_desc),
+                                           cfg.beta == 0.0, must_swap_operands);
+
+  auto assign_alpha_beta = [&](auto scale) {
+    using Scale = decltype(scale);
+    static_assert(sizeof(Scale) <= MatmulPlan::kMaxScaleBytes,
+                  "Scale type must fit in kMaxScaleBytes");
+    auto* palpha = reinterpret_cast<Scale*>(&plan->alpha_[0]);
+    if constexpr (std::is_same_v<Scale, xla::complex64> ||
+                  std::is_same_v<Scale, xla::complex128>) {
+      *palpha = static_cast<Scale>(cfg.alpha);
+    } else {
+      *palpha = static_cast<Scale>(cfg.alpha.real());
+    }
+    auto* pbeta = reinterpret_cast<Scale*>(&plan->beta_[0]);
+    *pbeta = static_cast<Scale>(cfg.beta);
+  };
+
+#define TYPED_MATMUL(Scale, ATYPE, BTYPE, CTYPE, DTYPE)               \
+  else if (operand_types == std::tuple{ATYPE, BTYPE, CTYPE, DTYPE}) { \
+    assign_alpha_beta(Scale{});                                       \
+  }
+
+  if (false) {
+  }  // This is needed to avoid compiler error for the else clause.
+#if CUDA_VERSION >= 11080
+  // FP8 compatible type combinations (see cuBLASLt documentation):
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_16BF)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16BF,
+               CUDA_R_8F_E4M3)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16F,
+               CUDA_R_8F_E4M3)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_16F)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_32F, CUDA_R_32F)
+
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF, CUDA_R_16BF)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF,
+               CUDA_R_8F_E4M3)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF,
+               CUDA_R_8F_E5M2)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F,
+               CUDA_R_8F_E4M3)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F,
+               CUDA_R_8F_E5M2)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F, CUDA_R_16F)
+  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_32F, CUDA_R_32F)
+
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_16BF)
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF,
+               CUDA_R_8F_E4M3)
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF,
+               CUDA_R_8F_E5M2)
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F,
+               CUDA_R_8F_E4M3)
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F,
+               CUDA_R_8F_E5M2)
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_16F)
+  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_32F, CUDA_R_32F)
+#endif
+
+  // Other data types:
+  TYPED_MATMUL(float, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_16BF)
+  TYPED_MATMUL(float, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
+  TYPED_MATMUL(float, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_32F, CUDA_R_32F)
+  TYPED_MATMUL(float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F, CUDA_R_32F)
+  TYPED_MATMUL(float, CUDA_R_32F, CUDA_R_32F, CUDA_R_32F, CUDA_R_32F)
+  TYPED_MATMUL(double, CUDA_R_64F, CUDA_R_64F, CUDA_R_64F, CUDA_R_64F)
+  TYPED_MATMUL(int32_t, CUDA_R_8I, CUDA_R_8I, CUDA_R_32I, CUDA_R_32I)
+  TYPED_MATMUL(float, CUDA_R_8I, CUDA_R_8I, CUDA_R_32F, CUDA_R_32F)
+  TYPED_MATMUL(xla::complex64, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F)
+  TYPED_MATMUL(xla::complex128, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F)
+#undef TYPED_MATMUL
+  return plan;
 }
 
-absl::Status BlasLt::MatmulPlan::DoMatmul(
-    Stream* stream, const void* alpha, const void* beta,
-    const gpu::BlasLt::MemoryArgs& args,
+absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
+    Stream* stream, const gpu::BlasLt::MemoryArgs& args,
     blas::ProfileResult* profile_result) const {
   if (!algorithm_.has_value()) {
     return absl::InternalError(
@@ -476,12 +549,13 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     std::unique_ptr<ActivateContext> activation =
         blas_lt_.executor_->Activate();
 
-    void* c_ptr = beta_ == 0.0 ? nullptr : args.c.opaque();
+    void* c_ptr = zero_beta_ ? nullptr : args.c.opaque();
     if (palgo != nullptr) {
       SE_CUBLAS_RETURN_IF_ERROR(cublasLtMatmul(
-          blas_lt_.handle_.get(), op_desc_.get(), alpha, a.opaque(),
-          a_desc_.get(), b.opaque(), b_desc_.get(), beta, c_ptr, c_desc_.get(),
-          args.d.opaque(), d_desc_.get(), palgo, workspace_addr, workspace_size,
+          blas_lt_.handle_.get(), op_desc_.get(), &alpha_[0], a.opaque(),
+          a_desc_.get(), b.opaque(), b_desc_.get(), &beta_[0], c_ptr,
+          c_desc_.get(), args.d.opaque(), d_desc_.get(), palgo, workspace_addr,
+          workspace_size,
           absl::bit_cast<CUstream>(stream->platform_specific_handle().stream)));
     } else {
       return absl::InternalError("cublaslt: Invalid algorithm type");
@@ -496,82 +570,6 @@ absl::Status BlasLt::MatmulPlan::DoMatmul(
     profile_result->set_elapsed_time_in_ms(absl::ToDoubleMilliseconds(elapsed));
   }
   return absl::OkStatus();
-}
-
-absl::Status BlasLt::MatmulPlan::ExecuteOnStream(
-    Stream* stream, const gpu::BlasLt::MemoryArgs& args,
-    blas::ProfileResult* profile_result) const {
-  auto wrapped_matmul = [&](auto scale) {
-    using Scale = decltype(scale);
-    Scale salpha;
-    if constexpr (std::is_same_v<Scale, xla::complex64> ||
-                  std::is_same_v<Scale, xla::complex128>) {
-      salpha = static_cast<Scale>(alpha_);
-    } else {
-      salpha = static_cast<Scale>(alpha_.real());
-    }
-    Scale sbeta = static_cast<Scale>(beta_);
-    return DoMatmul(stream, &salpha, &sbeta, args, profile_result);
-  };
-
-  std::tuple operand_types{a_desc_.type(), b_desc_.type(), c_desc_.type(),
-                           d_desc_.type()};
-
-#define TYPED_MATMUL(Scale, ATYPE, BTYPE, CTYPE, DTYPE)          \
-  if (operand_types == std::tuple{ATYPE, BTYPE, CTYPE, DTYPE}) { \
-    return wrapped_matmul(Scale{});                              \
-  }
-
-#if CUDA_VERSION >= 11080
-  // FP8 compatible type combinations (see cuBLASLt documentation):
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_16BF)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16BF,
-               CUDA_R_8F_E4M3)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16F,
-               CUDA_R_8F_E4M3)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_16F)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E4M3, CUDA_R_32F, CUDA_R_32F)
-
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF, CUDA_R_16BF)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF,
-               CUDA_R_8F_E4M3)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16BF,
-               CUDA_R_8F_E5M2)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F,
-               CUDA_R_8F_E4M3)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F,
-               CUDA_R_8F_E5M2)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_16F, CUDA_R_16F)
-  TYPED_MATMUL(float, CUDA_R_8F_E4M3, CUDA_R_8F_E5M2, CUDA_R_32F, CUDA_R_32F)
-
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF, CUDA_R_16BF)
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF,
-               CUDA_R_8F_E4M3)
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16BF,
-               CUDA_R_8F_E5M2)
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F,
-               CUDA_R_8F_E4M3)
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F,
-               CUDA_R_8F_E5M2)
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_16F, CUDA_R_16F)
-  TYPED_MATMUL(float, CUDA_R_8F_E5M2, CUDA_R_8F_E4M3, CUDA_R_32F, CUDA_R_32F)
-#endif
-
-  // Other data types:
-  TYPED_MATMUL(float, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_16BF)
-  TYPED_MATMUL(float, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
-  TYPED_MATMUL(float, CUDA_R_16BF, CUDA_R_16BF, CUDA_R_32F, CUDA_R_32F)
-  TYPED_MATMUL(float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F, CUDA_R_32F)
-  TYPED_MATMUL(float, CUDA_R_32F, CUDA_R_32F, CUDA_R_32F, CUDA_R_32F)
-  TYPED_MATMUL(double, CUDA_R_64F, CUDA_R_64F, CUDA_R_64F, CUDA_R_64F)
-  TYPED_MATMUL(int32_t, CUDA_R_8I, CUDA_R_8I, CUDA_R_32I, CUDA_R_32I)
-  TYPED_MATMUL(float, CUDA_R_8I, CUDA_R_8I, CUDA_R_32F, CUDA_R_32F)
-  TYPED_MATMUL(xla::complex64, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F, CUDA_C_32F)
-  TYPED_MATMUL(xla::complex128, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F, CUDA_C_64F)
-
-#undef TYPED_MATMUL
-
-  return xla::Internal("Unexpected dtype");
 }
 
 }  // namespace cuda

--- a/xla/stream_executor/cuda/cuda_blas_lt.h
+++ b/xla/stream_executor/cuda/cuda_blas_lt.h
@@ -86,18 +86,22 @@ class BlasLt : public gpu::BlasLt {
 
   class MatmulPlan : public gpu::BlasLt::MatmulPlan {
    public:
+    friend class BlasLt;
+    // We use a fixed-size array to store the alpha and beta values which can
+    // fit all supported scale types.
+    constexpr static size_t kMaxScaleBytes = 16;
+
     MatmulPlan(const BlasLt& blas_lt, MatmulDesc&& op_desc,
                MatrixLayout&& a_desc, MatrixLayout&& b_desc,
-               MatrixLayout&& c_desc, MatrixLayout&& d_desc,
-               xla::complex128 alpha, double beta, bool must_swap_operands)
+               MatrixLayout&& c_desc, MatrixLayout&& d_desc, bool zero_beta,
+               bool must_swap_operands)
         : blas_lt_(blas_lt),
           op_desc_(std::move(op_desc)),
           a_desc_(std::move(a_desc)),
           b_desc_(std::move(b_desc)),
           c_desc_(std::move(c_desc)),
           d_desc_(std::move(d_desc)),
-          alpha_(alpha),
-          beta_(beta),
+          zero_beta_(zero_beta),
           must_swap_operands_(must_swap_operands) {}
 
     ~MatmulPlan() override = default;
@@ -115,21 +119,17 @@ class BlasLt : public gpu::BlasLt {
     }
 
    private:
-    absl::Status DoMatmul(Stream* stream, const void* alpha, const void* beta,
-                          const gpu::BlasLt::MemoryArgs& args,
-                          blas::ProfileResult* profile_result) const;
-
     const BlasLt& blas_lt_;
     MatmulDesc op_desc_;
     MatrixLayout a_desc_;
     MatrixLayout b_desc_;
     MatrixLayout c_desc_;
     MatrixLayout d_desc_;
-    xla::complex128 alpha_;
-    double beta_;
+    std::array<uint8_t, kMaxScaleBytes> alpha_, beta_;
+    bool zero_beta_;
     bool must_swap_operands_;
     std::optional<MatmulAlgorithm> algorithm_;  // selected algorithm
-  };  // class MatmulPlan
+  };                                            // class MatmulPlan
 
   explicit BlasLt(StreamExecutor* executor)
       : executor_(executor), handle_(nullptr, cublasLtDestroy) {}

--- a/xla/stream_executor/gpu/gpu_blas_lt.h
+++ b/xla/stream_executor/gpu/gpu_blas_lt.h
@@ -234,35 +234,7 @@ struct BlasLt {
   };
 
   struct MatmulPlan {
-    // API that uses scratch_allocator to allocate workspace.
-    // This version is used by TF: see tensorflow/core/kernels/matmul_util.cc
-    absl::Status ExecuteOnStream(
-        Stream* stream, DeviceAddressBase a, DeviceAddressBase b,
-        DeviceAddressBase c, DeviceAddressBase d,
-        DeviceAddressBase bias,  // may be null
-        DeviceAddressBase aux,   // may be null
-        DeviceAddressBase a_scale, DeviceAddressBase b_scale,
-        DeviceAddressBase c_scale, DeviceAddressBase d_scale,
-        DeviceAddressBase d_amax, ScratchAllocator& scratch_allocator,
-        blas::ProfileResult* profile_result = nullptr) const {
-      return ExecuteOnStream(stream,
-                             MemoryArgs{a,
-                                        b,
-                                        c,
-                                        d,
-                                        bias,
-                                        aux,
-                                        a_scale,
-                                        b_scale,
-                                        c_scale,
-                                        d_scale,
-                                        {d_amax},
-                                        DeviceAddressBase{},
-                                        &scratch_allocator},
-                             profile_result);
-    }
-
-    // The most general form: to be implemented by derived clases.
+    // Execute the matmul operation on the given stream.
     virtual absl::Status ExecuteOnStream(
         Stream* stream, const MemoryArgs& args,
         blas::ProfileResult* profile_result = nullptr) const = 0;
@@ -272,14 +244,6 @@ struct BlasLt {
     // an internal heuristic.
     virtual absl::StatusOr<std::vector<MatmulAlgorithm>> GetAlgorithms(
         size_t max_algorithm_count, size_t max_workspace_size) const = 0;
-
-    // Shim for Tensorflow: to be removed once Tensorflow BlasLt interface is
-    // updated. Do not use this function directly !
-    virtual absl::StatusOr<std::vector<MatmulAlgorithm>> GetAlgorithms(
-        const Stream* /*stream*/, size_t max_algorithm_count,
-        size_t max_workspace_size) const {
-      return GetAlgorithms(max_algorithm_count, max_workspace_size);
-    }
 
     // Algorithm must to be set before calling ExecuteOnStream function(s).
     // Usually, we call ExecuteOnStream with the same algorithm ID, hence using
@@ -302,15 +266,6 @@ struct BlasLt {
       const gpu::GroupedGemmConfig& config, Epilogue epilogue) const = 0;
 
   static absl::StatusOr<BlasLt*> Get(StreamExecutor* executor);
-
-  // Shim for Tensorflow: to be removed once Tensorflow BlasLt interface
-  // is updated. Do not use this function directly !
-  static absl::StatusOr<MatmulPlanPtr> GetMatmulPlan(Stream* stream,
-                                                     const GemmConfig& cfg,
-                                                     Epilogue epilogue) {
-    ASSIGN_OR_RETURN(auto* blas_lt, Get(stream->parent()));
-    return blas_lt->GetMatmulPlan(cfg, epilogue);
-  }
 
   absl::StatusOr<MatmulPlan*> GetOrCreateMatmulPlan(const std::string& key,
                                                     PlanCreateFunc create);

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -393,147 +393,35 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
     }
   }
 
-  return std::make_unique<RegularMatmulPlan>(
+  std::tuple operand_types{a_desc.type(), b_desc.type(), c_desc.type(),
+                           d_desc.type()};
+
+  auto plan = std::make_unique<RegularMatmulPlan>(
       *this, std::move(op_desc), std::move(a_desc), std::move(b_desc),
-      std::move(c_desc), std::move(d_desc), cfg.alpha, cfg.beta,
-      must_swap_operands);
-}
+      std::move(c_desc), std::move(d_desc), must_swap_operands);
 
-absl::Status BlasLt::RegularMatmulPlan::DoMatmul(
-    Stream* stream, const void* alpha, const void* beta,
-    const gpu::BlasLt::MemoryArgs& args,
-    blas::ProfileResult* profile_result) const {
-  if (!algorithm_.has_value()) {
-    return absl::InternalError(
-        "Algorithm must be set before calling DoMatMul!");
-  }
-  DeviceAddressBase a = args.a, b = args.b;
-  DeviceAddressBase a_scale = args.a_scale, b_scale = args.b_scale;
-  if (must_swap_operands_) {
-    std::swap(a, b);
-    if (a_scale != nullptr && b_scale != nullptr) {
-      std::swap(a_scale, b_scale);
-    }
-  }
-
-  absl::Status status =
-      blas_lt_.executor_->RecordApiTrace(StreamExecutor::GemmCallTrace{
-          StreamExecutor::GemmCallTrace::GemmType::kBlasLt, 0, a.size(),
-          b.size()});
-  std::unique_ptr<EventBasedTimer> timer;
-
-  if (profile_result != nullptr) {
-    ASSIGN_OR_RETURN(timer, stream->CreateEventBasedTimer(
-                                profile_result->warmup_run_executed()));
-  }
-
-  void* workspace_addr = nullptr;
-  uint64_t workspace_size = algorithm_->workspace_size;
-  if (workspace_size > 0) {
-    if (args.scratch_allocator != nullptr) {
-      ASSIGN_OR_RETURN(DeviceAddress<uint8_t> alloc,
-                       args.scratch_allocator->AllocateBytes(workspace_size));
-      workspace_addr = gpu::GpuMemoryMutable(&alloc);
-    } else {
-      workspace_addr = args.workspace.opaque();
-      size_t new_size = args.workspace.size();
-      TF_RET_CHECK(workspace_addr != nullptr && new_size >= workspace_size);
-      workspace_size = new_size;
-    }
-  }
-
-  auto palgo = std::any_cast<hipblasLtMatmulAlgo_t>(&algorithm_->opaque_algo);
-  {
-    absl::MutexLock lock(blas_lt_.mu_);
-    TF_RET_CHECK(blas_lt_.handle_ != nullptr);
-    // We must set the bias and aux pointers while holding the mutex, to avoid a
-    // potential race condition from multiple threads sharing the same plan.
-    if (op_desc_.has_bias_epilogue() && args.bias != nullptr) {
-      RETURN_IF_ERROR(SetAttr(op_desc_.get(),
-                              HIPBLASLT_MATMUL_DESC_BIAS_POINTER,
-                              args.bias.opaque()));
-    }
-
-    if (a_scale != nullptr) {
-      RETURN_IF_ERROR(SetAttr(op_desc_.get(),
-                              HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
-                              a_scale.opaque()));
-    }
-    if (b_scale != nullptr) {
-      RETURN_IF_ERROR(SetAttr(op_desc_.get(),
-                              HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER,
-                              b_scale.opaque()));
-    }
-    if (args.c_scale != nullptr) {
-      RETURN_IF_ERROR(SetAttr(op_desc_.get(),
-                              HIPBLASLT_MATMUL_DESC_C_SCALE_POINTER,
-                              args.c_scale.opaque()));
-    }
-    if (args.d_scale != nullptr) {
-      RETURN_IF_ERROR(SetAttr(op_desc_.get(),
-                              HIPBLASLT_MATMUL_DESC_D_SCALE_POINTER,
-                              args.d_scale.opaque()));
-    }
-
-    if (args.d_amax != nullptr) {
-      return absl::InternalError("hipblaslt does not support amax");
-    }
-
-    if (args.aux != nullptr) {
-      return absl::InternalError(
-          "hipblaslt does not support auxiliary inputs / outputs");
-    }
-
-    std::unique_ptr<ActivateContext> activation =
-        blas_lt_.executor_->Activate();
-
-    if (palgo != nullptr) {
-      SE_HIPBLAS_RETURN_IF_ERROR(
-          hipblasLtMatmul(blas_lt_.handle_.get(), op_desc_.get(), alpha,
-                          a.opaque(), a_desc_.get(), b.opaque(), b_desc_.get(),
-                          beta, args.c.opaque(), c_desc_.get(), args.d.opaque(),
-                          d_desc_.get(), palgo, workspace_addr, workspace_size,
-                          absl::bit_cast<hipStream_t>(
-                              stream->platform_specific_handle().stream)));
-    } else {
-      return absl::InternalError("hipblaslt: Invalid algorithm type");
-    }
-  }
-
-  if (profile_result != nullptr) {
-    ASSIGN_OR_RETURN(absl::Duration elapsed, timer->GetElapsedDuration());
-    // set algorithm ID to be unique (otherwise it gets kDefaultAlgorithm ID)
-    profile_result->set_algorithm(hipblaslt_ext::getIndexFromAlgo(*palgo));
-    profile_result->set_is_valid(true);
-    profile_result->set_elapsed_time_in_ms(absl::ToDoubleMilliseconds(elapsed));
-  }
-  return absl::OkStatus();
-}
-
-absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
-    Stream* stream, const gpu::BlasLt::MemoryArgs& args,
-    blas::ProfileResult* profile_result) const {
-  auto wrapped_matmul = [&](auto scale) {
+  auto assign_alpha_beta = [&](auto scale) {
     using Scale = decltype(scale);
-    Scale salpha;
+    static_assert(sizeof(Scale) <= RegularMatmulPlan::kMaxScaleBytes,
+                  "Scale type must fit in kMaxScaleBytes");
+    auto* palpha = reinterpret_cast<Scale*>(&plan->alpha_[0]);
     if constexpr (std::is_same_v<Scale, xla::complex64> ||
                   std::is_same_v<Scale, xla::complex128>) {
-      salpha = static_cast<Scale>(alpha_);
+      *palpha = static_cast<Scale>(cfg.alpha);
     } else {
-      salpha = static_cast<Scale>(alpha_.real());
+      *palpha = static_cast<Scale>(cfg.alpha.real());
     }
-    Scale sbeta = static_cast<Scale>(beta_);
-    return DoMatmul(stream, &salpha, &sbeta, args, profile_result);
+    auto* pbeta = reinterpret_cast<Scale*>(&plan->beta_[0]);
+    *pbeta = static_cast<Scale>(cfg.beta);
   };
 
-  std::tuple operand_types{a_desc_.type(), b_desc_.type(), c_desc_.type(),
-                           d_desc_.type()};
-
-#define TYPED_MATMUL(Scale, ATYPE, BTYPE, CTYPE, DTYPE)          \
-  if (operand_types == std::tuple{ATYPE, BTYPE, CTYPE, DTYPE}) { \
-    return wrapped_matmul(Scale{});                              \
+#define TYPED_MATMUL(Scale, ATYPE, BTYPE, CTYPE, DTYPE)               \
+  else if (operand_types == std::tuple{ATYPE, BTYPE, CTYPE, DTYPE}) { \
+    assign_alpha_beta(Scale{});                                       \
   }
 
+  if (false) {
+  }  // This is needed to avoid compiler error for the else clause.
 // FP8 compatible types combinations (Full table in
 // https://github.com/ROCm/hipBLASLt/blob/develop/docs/api-reference.rst?plain=1)
   TYPED_MATMUL(float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_16F,
@@ -652,8 +540,120 @@ absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
   TYPED_MATMUL(complex128, HIP_C_64F, HIP_C_64F, HIP_C_64F, HIP_C_64F)
 
 #undef TYPED_MATMUL
+  return plan;
+}
 
-  return xla::Internal("Unexpected dtype");
+absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
+    Stream* stream, const gpu::BlasLt::MemoryArgs& args,
+    blas::ProfileResult* profile_result) const {
+  if (!algorithm_.has_value()) {
+    return absl::InternalError(
+        "Algorithm must be set before calling DoMatMul!");
+  }
+  DeviceAddressBase a = args.a, b = args.b;
+  DeviceAddressBase a_scale = args.a_scale, b_scale = args.b_scale;
+  if (must_swap_operands_) {
+    std::swap(a, b);
+    std::swap(a_scale, b_scale);
+  }
+
+  absl::Status status =
+      blas_lt_.executor_->RecordApiTrace(StreamExecutor::GemmCallTrace{
+          StreamExecutor::GemmCallTrace::GemmType::kBlasLt, 0, a.size(),
+          b.size()});
+
+  std::unique_ptr<EventBasedTimer> timer;
+  if (profile_result != nullptr) {
+    ASSIGN_OR_RETURN(timer, stream->CreateEventBasedTimer(
+                                profile_result->warmup_run_executed()));
+  }
+
+  void* workspace_addr = nullptr;
+  uint64_t workspace_size = algorithm_->workspace_size;
+  if (workspace_size > 0) {
+    if (args.scratch_allocator != nullptr) {
+      ASSIGN_OR_RETURN(DeviceAddress<uint8_t> alloc,
+                       args.scratch_allocator->AllocateBytes(workspace_size));
+      workspace_addr = gpu::GpuMemoryMutable(&alloc);
+    } else {
+      workspace_addr = args.workspace.opaque();
+      size_t new_size = args.workspace.size();
+      TF_RET_CHECK(workspace_addr != nullptr && new_size >= workspace_size);
+      workspace_size = new_size;
+    }
+  }
+
+  auto palgo = std::any_cast<hipblasLtMatmulAlgo_t>(&algorithm_->opaque_algo);
+  {
+    absl::MutexLock lock(blas_lt_.mu_);
+    TF_RET_CHECK(blas_lt_.handle_ != nullptr);
+    // We must set the bias and aux pointers while holding the mutex, to avoid a
+    // potential race condition from multiple threads sharing the same plan.
+    if (op_desc_.has_bias_epilogue() && args.bias != nullptr) {
+      RETURN_IF_ERROR(SetAttr(op_desc_.get(),
+                              HIPBLASLT_MATMUL_DESC_BIAS_POINTER,
+                              args.bias.opaque()));
+    }
+
+#if TF_ROCM_VERSION >= 60000
+    if (a_scale != nullptr) {
+      RETURN_IF_ERROR(SetAttr(op_desc_.get(),
+                              HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
+                              a_scale.opaque()));
+    }
+    if (b_scale != nullptr) {
+      RETURN_IF_ERROR(SetAttr(op_desc_.get(),
+                              HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER,
+                              b_scale.opaque()));
+    }
+    if (args.c_scale != nullptr) {
+      RETURN_IF_ERROR(SetAttr(op_desc_.get(),
+                              HIPBLASLT_MATMUL_DESC_C_SCALE_POINTER,
+                              args.c_scale.opaque()));
+    }
+    if (args.d_scale != nullptr) {
+      RETURN_IF_ERROR(SetAttr(op_desc_.get(),
+                              HIPBLASLT_MATMUL_DESC_D_SCALE_POINTER,
+                              args.d_scale.opaque()));
+    }
+#else
+    if (!(args.a_scale == nullptr && args.b_scale == nullptr &&
+          args.c_scale == nullptr && args.d_scale == nullptr)) {
+      return absl::InternalError("hipblaslt does not support scale");
+    }
+#endif
+    if (args.d_amax != nullptr) {
+      return absl::InternalError("hipblaslt does not support amax");
+    }
+    if (args.aux != nullptr) {
+      return absl::InternalError(
+          "hipblaslt does not support auxiliary inputs / outputs");
+    }
+
+    std::unique_ptr<ActivateContext> activation =
+        blas_lt_.executor_->Activate();
+
+    if (palgo != nullptr) {
+      SE_HIPBLAS_RETURN_IF_ERROR(hipblasLtMatmul(
+          blas_lt_.handle_.get(), op_desc_.get(), &alpha_[0], a.opaque(),
+          a_desc_.get(), b.opaque(), b_desc_.get(), &beta_[0], args.c.opaque(),
+          c_desc_.get(), args.d.opaque(), d_desc_.get(), palgo, workspace_addr,
+          workspace_size,
+          absl::bit_cast<hipStream_t>(
+              stream->platform_specific_handle().stream)));
+    } else {
+      return absl::InternalError("hipblaslt: Invalid algorithm type");
+    }
+  }
+
+  if (profile_result != nullptr) {
+    ASSIGN_OR_RETURN(absl::Duration elapsed, timer->GetElapsedDuration());
+    // set algorithm ID to be unique (otherwise it gets kDefaultAlgorithm ID)
+    profile_result->set_algorithm(hipblaslt_ext::getIndexFromAlgo(*palgo));
+    profile_result->set_is_valid(true);
+    profile_result->set_elapsed_time_in_ms(absl::ToDoubleMilliseconds(elapsed));
+  }
+  return absl::OkStatus();
 }
 
 auto BlasLt::GroupedMatmulPlan::GetAlgorithms(size_t max_algorithm_count,

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -539,7 +539,9 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
   TYPED_MATMUL(float, HIP_R_8I, HIP_R_8I, HIP_R_32F, HIP_R_32F)
   TYPED_MATMUL(complex64, HIP_C_32F, HIP_C_32F, HIP_C_32F, HIP_C_32F)
   TYPED_MATMUL(complex128, HIP_C_64F, HIP_C_64F, HIP_C_64F, HIP_C_64F)
-
+  else {
+    return xla::Internal("Unexpected operand types for hipblaslt matmul");
+  }
 #undef TYPED_MATMUL
   return plan;
 }

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -422,8 +422,9 @@ absl::StatusOr<BlasLt::MatmulPlanPtr> BlasLt::GetMatmulPlan(
 
   if (false) {
   }  // This is needed to avoid compiler error for the else clause.
-// FP8 compatible types combinations (Full table in
-// https://github.com/ROCm/hipBLASLt/blob/develop/docs/api-reference.rst?plain=1)
+
+  // FP8 compatible types combinations (Full table in
+  // https://github.com/ROCm/hipBLASLt/blob/develop/docs/api-reference.rst?plain=1)
   TYPED_MATMUL(float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_16F,
                HIP_R_16F)
   TYPED_MATMUL(float, HIP_R_8F_E4M3_FNUZ, HIP_R_8F_E4M3_FNUZ, HIP_R_32F,
@@ -595,7 +596,6 @@ absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
                               args.bias.opaque()));
     }
 
-#if TF_ROCM_VERSION >= 60000
     if (a_scale != nullptr) {
       RETURN_IF_ERROR(SetAttr(op_desc_.get(),
                               HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER,
@@ -616,12 +616,6 @@ absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
                               HIPBLASLT_MATMUL_DESC_D_SCALE_POINTER,
                               args.d_scale.opaque()));
     }
-#else
-    if (!(args.a_scale == nullptr && args.b_scale == nullptr &&
-          args.c_scale == nullptr && args.d_scale == nullptr)) {
-      return absl::InternalError("hipblaslt does not support scale");
-    }
-#endif
     if (args.d_amax != nullptr) {
       return absl::InternalError("hipblaslt does not support amax");
     }

--- a/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/xla/stream_executor/rocm/hip_blas_lt.h
@@ -98,10 +98,14 @@ class BlasLt : public gpu::BlasLt {
 
   class RegularMatmulPlan : public gpu::BlasLt::MatmulPlan {
    public:
+    friend class BlasLt;
+    // We use a fixed-size array to store the alpha and beta values which can
+    // fit all supported scale types.
+    constexpr static size_t kMaxScaleBytes = 16;
+
     RegularMatmulPlan(const BlasLt& blas_lt, MatmulDesc&& op_desc,
                       MatrixLayout&& a_desc, MatrixLayout&& b_desc,
                       MatrixLayout&& c_desc, MatrixLayout&& d_desc,
-                      xla::complex128 alpha, double beta,
                       bool must_swap_operands)
         : blas_lt_(blas_lt),
           op_desc_(std::move(op_desc)),
@@ -109,8 +113,6 @@ class BlasLt : public gpu::BlasLt {
           b_desc_(std::move(b_desc)),
           c_desc_(std::move(c_desc)),
           d_desc_(std::move(d_desc)),
-          alpha_(alpha),
-          beta_(beta),
           must_swap_operands_(must_swap_operands) {}
 
     ~RegularMatmulPlan() override = default;
@@ -127,11 +129,6 @@ class BlasLt : public gpu::BlasLt {
       return absl::OkStatus();
     }
 
-   protected:
-    absl::Status DoMatmul(Stream* stream, const void* alpha, const void* beta,
-                          const gpu::BlasLt::MemoryArgs& args,
-                          blas::ProfileResult* profile_result) const;
-
    private:
     const BlasLt& blas_lt_;
     MatmulDesc op_desc_;
@@ -139,8 +136,7 @@ class BlasLt : public gpu::BlasLt {
     MatrixLayout b_desc_;
     MatrixLayout c_desc_;
     MatrixLayout d_desc_;
-    xla::complex128 alpha_;
-    double beta_;
+    std::array<uint8_t, kMaxScaleBytes> alpha_, beta_;
     bool must_swap_operands_;
     mutable std::optional<MatmulAlgorithm> algorithm_;  // selected algorithm
   };  // class RegularMatmulPlan


### PR DESCRIPTION
- Removed Tensorflow shims from gpu_blas_lt interface since https://github.com/tensorflow/tensorflow/pull/119488 is already merged
- Moved alpha/beta scale computation from ExecuteOnStream into plan creation for both CUDA and ROCm backends. The MatmulPlan now stores pre-computed alpha/beta as fixed-size byte arrays (kMaxScaleBytes), determined at plan creation time based on operand types. Indeed, this is enough to run a long chain of TYPED_MATMUL macros only once during initialization. This also removes the DoMatmul indirection.

This is a 4th PR extracted from https://github.com/openxla/xla/pull/42108 