### PR TITLE
[ROCm] Fix determinism test to take HIPBLASLT instead of depricated ROCBLAS

### DIFF
--- a/xla/service/gpu/determinism_test.cc
+++ b/xla/service/gpu/determinism_test.cc
@@ -187,6 +187,8 @@ ENTRY e {
     if (!HasHipblasLt()) {
       GTEST_SKIP() << "No hipblas-lt support on this architecture!";
     }
+    debug_options_.add_xla_gpu_experimental_autotune_backends(
+      autotuner::Backend::HIPBLASLT);
   }
   debug_options_.set_xla_gpu_enable_triton_gemm(false);
 


### PR DESCRIPTION


📝 Summary of Changes
rocblas support is removed instead use hipblaslt algorithms for autotuning

🎯 Justification
legacy cublas/rocblas was removed in https://github.com/openxla/xla/pull/42940

🚀 Kind of Contribution
 🐛 Bug Fix, 


