### PR TITLE
[ROCm] Extend gpu collectives perf model to AllGather and ReduceScatter

### DIFF
--- a/xla/service/gpu/model/analytical_latency_estimator_test.cc
+++ b/xla/service/gpu/model/analytical_latency_estimator_test.cc
@@ -108,19 +108,20 @@ class AnalyticalLatencyHidingSchedulerTest : public HloPjRtGpuTestBase {
 
 TEST_F(AnalyticalLatencyHidingSchedulerTest, TestAnalyticalLatencyEstimator) {
   auto gpu_compute_capability = GetGpuComputeCapability();
-  if (gpu_compute_capability.IsRocm()) {
-    GTEST_SKIP() << "This test is for Pascal+ GPUs.";
-  }
-
-  auto* c = gpu_compute_capability.cuda_compute_capability();
-  if (!c->IsAtLeast(se::CudaComputeCapability::kPascal)) {
-    GTEST_SKIP() << "This test is for Pascal+ GPUs.";
-  }
-  if (c->major == 12 && c->minor == 1) {
-    // Skip this test for Spark. Because of the AllReduce, the test uses
-    // gpu_collective_performance_model, which only makes sense in a
-    // datacenter network setting.
-    GTEST_SKIP() << "This test is for datacenter GPUs.";
+  if (auto* c = gpu_compute_capability.cuda_compute_capability()) {
+    if (!c->IsAtLeast(se::CudaComputeCapability::kPascal)) {
+      GTEST_SKIP() << "This test is for Pascal+ GPUs.";
+    }
+    if (c->major == 12 && c->minor == 1) {
+      // Skip this test for Spark. Because of the AllReduce, the test uses
+      // gpu_collective_performance_model, which only makes sense in a
+      // datacenter network setting.
+      GTEST_SKIP() << "This test is for datacenter GPUs.";
+    }
+  } else if (auto* r = gpu_compute_capability.rocm_compute_capability()) {
+    if (!r->gfx9_mi100_or_later()) {
+      GTEST_SKIP() << "This test is for datacenter GPUs.";
+    }
   }
 
   const se::DeviceDescription dev_info = device_description();
@@ -182,6 +183,158 @@ ENTRY entry {
 
   EXPECT_LT(ar1_done_index, ar2_index);
   EXPECT_LT(ar2_index, conv0_index);
+}
+
+TEST_F(AnalyticalLatencyHidingSchedulerTest,
+       TestAnalyticalLatencyEstimatorAllGather) {
+  auto gpu_compute_capability = GetGpuComputeCapability();
+  if (auto* c = gpu_compute_capability.cuda_compute_capability()) {
+    if (!c->IsAtLeast(se::CudaComputeCapability::kPascal)) {
+      GTEST_SKIP() << "This test is for Pascal+ GPUs.";
+    }
+    if (c->major == 12 && c->minor == 1) {
+      GTEST_SKIP() << "This test is for datacenter GPUs.";
+    }
+  } else if (auto* r = gpu_compute_capability.rocm_compute_capability()) {
+    if (!r->gfx9_mi100_or_later()) {
+      GTEST_SKIP() << "This test is for datacenter GPUs.";
+    }
+  }
+
+  const se::DeviceDescription dev_info = device_description();
+
+  // Mirrors TestAnalyticalLatencyEstimator but for AllGather: 2 all-gathers
+  // where ag2 has the larger latency, so we expect ag1 to be run first and
+  // ag2 to be overlapped with conv0.
+  absl::string_view hlo_string = R"(
+HloModule module, is_scheduled=true, num_partitions=8
+
+ENTRY entry {
+  p0 = f32[16,64,256]{2,1,0} parameter(0)
+  p1 = f32[16,64,256]{2,1,0} parameter(1)
+  p2 = f32[128,2048,2048]{2,1,0} parameter(2)
+  p3 = f32[256,2048,2048]{2,1,0} parameter(3)
+  all-gather-start.1 = (f32[128,2048,2048]{2,1,0}, f32[1024,2048,2048]{2,1,0}) all-gather-start(p2), dimensions={0}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=8, use_global_device_ids=true, backend_config={"collective_backend_config": {"is_sync": false}}
+  all-gather-start.2 = (f32[256,2048,2048]{2,1,0}, f32[2048,2048,2048]{2,1,0}) all-gather-start(p3), dimensions={0}, replica_groups={{0,1,2,3,4,5,6,7}}, channel_id=10, use_global_device_ids=true, backend_config={"collective_backend_config": {"is_sync": false}}
+
+  all-gather-done.1 = f32[1024,2048,2048]{2,1,0} all-gather-done(all-gather-start.1)
+  all-gather-done.2 = f32[2048,2048,2048]{2,1,0} all-gather-done(all-gather-start.2)
+  conv0 = f32[16,256,256]{2,1,0} convolution(p0, p1),
+    window={size=16 stride=15 lhs_dilate=16}, dim_labels=0fb_0io->0fb
+
+  ROOT tuple.2 = (f32[16,256,256]{2,1,0}, f32[1024,2048,2048]{2,1,0}, f32[2048,2048,2048]{2,1,0}) tuple(conv0, all-gather-done.1, all-gather-done.2)
+}
+)";
+
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseHloText(hlo_string));
+  hlo_module->mutable_config().set_num_partitions(8);
+  hlo_module->mutable_config().set_use_spmd_partitioning(true);
+
+  HloSchedule& module_schedule = hlo_module->schedule();
+  EXPECT_TRUE(hlo_module->has_entry_computation());
+
+  auto mlir_context = std::make_unique<mlir::MLIRContext>();
+  auto scheduler_config = GetDefaultSchedulerConfig();
+  auto latency_estimator = std::make_unique<AnalyticalLatencyEstimator>(
+      scheduler_config, std::make_unique<ApproximateLatencyEstimator>(),
+      dev_info, HloCostAnalysis::DefaultShapeSize,
+      hlo_module->entry_computation(), mlir_context.get());
+  auto alias_info = GetAliasInfo();
+  EXPECT_TRUE(RunScheduler(hlo_module.get(), scheduler_config, alias_info.get(),
+                           std::move(latency_estimator))
+                  .ok());
+  EXPECT_TRUE(hlo_module->has_entry_computation());
+
+  std::vector<HloInstruction*> new_instruction_schedule =
+      module_schedule.sequence(hlo_module->entry_computation()).instructions();
+  int64_t ag2_index = GetInstructionIndexInSchedule(new_instruction_schedule,
+                                                    "all-gather-start.2");
+  int64_t ag1_done_index = GetInstructionIndexInSchedule(
+      new_instruction_schedule, "all-gather-done.1");
+  int64_t conv0_index =
+      GetInstructionIndexInSchedule(new_instruction_schedule, "conv0");
+
+  EXPECT_LT(ag1_done_index, ag2_index);
+  EXPECT_LT(ag2_index, conv0_index);
+}
+
+TEST_F(AnalyticalLatencyHidingSchedulerTest,
+       TestAnalyticalLatencyEstimatorReduceScatter) {
+  auto gpu_compute_capability = GetGpuComputeCapability();
+  if (auto* c = gpu_compute_capability.cuda_compute_capability()) {
+    if (!c->IsAtLeast(se::CudaComputeCapability::kPascal)) {
+      GTEST_SKIP() << "This test is for Pascal+ GPUs.";
+    }
+    if (c->major == 12 && c->minor == 1) {
+      GTEST_SKIP() << "This test is for datacenter GPUs.";
+    }
+  } else if (auto* r = gpu_compute_capability.rocm_compute_capability()) {
+    if (!r->gfx9_mi100_or_later()) {
+      GTEST_SKIP() << "This test is for datacenter GPUs.";
+    }
+  }
+
+  const se::DeviceDescription dev_info = device_description();
+
+  // Mirrors TestAnalyticalLatencyEstimator but for ReduceScatter: 2
+  // reduce-scatters where rs2 has the larger latency, so we expect rs1 to
+  // be run first and rs2 to be overlapped with conv0.
+  absl::string_view hlo_string = R"(
+HloModule module, is_scheduled=true, num_partitions=8
+
+region_20.995 {
+  Arg_1.997 = f32[] parameter(1)
+  Arg_0.996 = f32[] parameter(0)
+  ROOT add.589 = f32[] add(Arg_0.996, Arg_1.997)
+}
+
+ENTRY entry {
+  p0 = f32[16,64,256]{2,1,0} parameter(0)
+  p1 = f32[16,64,256]{2,1,0} parameter(1)
+  p2 = f32[1024,2048,2048]{2,1,0} parameter(2)
+  p3 = f32[2048,2048,2048]{2,1,0} parameter(3)
+  reduce-scatter-start.1 = ((f32[1024,2048,2048]{2,1,0}), f32[128,2048,2048]{2,1,0}) reduce-scatter-start(p2), channel_id=8, replica_groups={{0,1,2,3,4,5,6,7}}, dimensions={0}, to_apply=region_20.995, use_global_device_ids=true, backend_config={"collective_backend_config": {"is_sync": false}}
+  reduce-scatter-start.2 = ((f32[2048,2048,2048]{2,1,0}), f32[256,2048,2048]{2,1,0}) reduce-scatter-start(p3), channel_id=10, replica_groups={{0,1,2,3,4,5,6,7}}, dimensions={0}, to_apply=region_20.995, use_global_device_ids=true, backend_config={"collective_backend_config": {"is_sync": false}}
+
+  reduce-scatter-done.1 = f32[128,2048,2048]{2,1,0} reduce-scatter-done(reduce-scatter-start.1)
+  reduce-scatter-done.2 = f32[256,2048,2048]{2,1,0} reduce-scatter-done(reduce-scatter-start.2)
+  conv0 = f32[16,256,256]{2,1,0} convolution(p0, p1),
+    window={size=16 stride=15 lhs_dilate=16}, dim_labels=0fb_0io->0fb
+
+  ROOT tuple.2 = (f32[16,256,256]{2,1,0}, f32[128,2048,2048]{2,1,0}, f32[256,2048,2048]{2,1,0}) tuple(conv0, reduce-scatter-done.1, reduce-scatter-done.2)
+}
+)";
+
+  ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseHloText(hlo_string));
+  hlo_module->mutable_config().set_num_partitions(8);
+  hlo_module->mutable_config().set_use_spmd_partitioning(true);
+
+  HloSchedule& module_schedule = hlo_module->schedule();
+  EXPECT_TRUE(hlo_module->has_entry_computation());
+
+  auto mlir_context = std::make_unique<mlir::MLIRContext>();
+  auto scheduler_config = GetDefaultSchedulerConfig();
+  auto latency_estimator = std::make_unique<AnalyticalLatencyEstimator>(
+      scheduler_config, std::make_unique<ApproximateLatencyEstimator>(),
+      dev_info, HloCostAnalysis::DefaultShapeSize,
+      hlo_module->entry_computation(), mlir_context.get());
+  auto alias_info = GetAliasInfo();
+  EXPECT_TRUE(RunScheduler(hlo_module.get(), scheduler_config, alias_info.get(),
+                           std::move(latency_estimator))
+                  .ok());
+  EXPECT_TRUE(hlo_module->has_entry_computation());
+
+  std::vector<HloInstruction*> new_instruction_schedule =
+      module_schedule.sequence(hlo_module->entry_computation()).instructions();
+  int64_t rs2_index = GetInstructionIndexInSchedule(new_instruction_schedule,
+                                                    "reduce-scatter-start.2");
+  int64_t rs1_done_index = GetInstructionIndexInSchedule(
+      new_instruction_schedule, "reduce-scatter-done.1");
+  int64_t conv0_index =
+      GetInstructionIndexInSchedule(new_instruction_schedule, "conv0");
+
+  EXPECT_LT(rs1_done_index, rs2_index);
+  EXPECT_LT(rs2_index, conv0_index);
 }
 
 }  // namespace

--- a/xla/service/gpu/model/gpu_collective_performance_model.cc
+++ b/xla/service/gpu/model/gpu_collective_performance_model.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "absl/time/time.h"
 #include "xla/hlo/analysis/hlo_dataflow_analysis.h"
 #include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/service/gpu/model/gpu_hlo_cost_analysis.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
@@ -281,7 +282,7 @@ int GetNumThreads(int warp_size, int min_num_threads, int max_num_threads,
 }
 
 template <typename GpuBandwidthSettings>
-absl::Duration ComputeAllreduceTimeImpl(
+absl::Duration ComputeCollectiveTimeImpl(
     const HloInstruction& instr, const GpuHloCostAnalysis* cost_analysis,
     const se::DeviceDescription& gpu_device_info,
     const GpuBandwidthSettings& bandwidth_settings) {
@@ -356,17 +357,17 @@ RocmBandwidthSettings CreateSettings(
 }  // namespace
 
 /*static*/ absl::Duration
-GpuPerformanceWithCollectiveModel::ComputeAllreduceTime(
+GpuPerformanceWithCollectiveModel::ComputeCollectiveTimeForRing(
     const HloInstruction& instr, const GpuHloCostAnalysis* cost_analysis,
     const se::DeviceDescription& gpu_device_info) {
   // We use nccl group call to launch multiple allreduces so launch overhead
   // only occurs once.
   if (auto ptr =
           gpu_device_info.gpu_compute_capability().cuda_compute_capability()) {
-    return ComputeAllreduceTimeImpl(instr, cost_analysis, gpu_device_info,
-                                    CreateSettings(*ptr));
+    return ComputeCollectiveTimeImpl(instr, cost_analysis, gpu_device_info,
+                                     CreateSettings(*ptr));
   }
-  return ComputeAllreduceTimeImpl(
+  return ComputeCollectiveTimeImpl(
       instr, cost_analysis, gpu_device_info,
       CreateSettings(
           *gpu_device_info.gpu_compute_capability().rocm_compute_capability()));
@@ -388,7 +389,25 @@ GpuPerformanceWithCollectiveModel::ComputeCollectiveTime(
   switch (instr.opcode()) {
     case HloOpcode::kAllReduce:
     case HloOpcode::kAllReduceStart:
-      return ComputeAllreduceTime(instr, cost_analysis, gpu_device_info);
+    case HloOpcode::kAllGather:
+    case HloOpcode::kAllGatherStart:
+    case HloOpcode::kReduceScatter:
+      return ComputeCollectiveTimeForRing(instr, cost_analysis,
+                                          gpu_device_info);
+    case HloOpcode::kAsyncStart: {
+      auto* async_start = Cast<HloAsyncStartInstruction>(&instr);
+      switch (async_start->async_wrapped_opcode()) {
+        case HloOpcode::kReduceScatter:
+          return ComputeCollectiveTimeForRing(instr, cost_analysis,
+                                              gpu_device_info);
+        default:
+          break;
+      }
+      LOG(WARNING)
+          << "Runtime estimate for " << instr.name()
+          << " not implemented. Returning only the kernel launch time.";
+      return kNcclKernelLaunchOverhead;
+    }
     default: {
       LOG(WARNING)
           << "Runtime estimate for " << instr.name()

--- a/xla/service/gpu/model/gpu_collective_performance_model.h
+++ b/xla/service/gpu/model/gpu_collective_performance_model.h
@@ -36,7 +36,7 @@ class GpuPerformanceWithCollectiveModel : public GpuPerformanceModelBase {
       const se::DeviceDescription& gpu_device_info);
 
  private:
-  static absl::Duration ComputeAllreduceTime(
+  static absl::Duration ComputeCollectiveTimeForRing(
       const HloInstruction& instr, const GpuHloCostAnalysis* cost_analysis,
       const se::DeviceDescription& gpu_device_info);
 };

--- a/xla/service/gpu/model/gpu_hlo_cost_analysis.cc
+++ b/xla/service/gpu/model/gpu_hlo_cost_analysis.cc
@@ -413,21 +413,13 @@ absl::Status GpuHloCostAnalysis::HandleAllReduce(
   current_properties_.set_output_bytes_accessed(output_bytes_accessed);
   current_properties_[kCollBytesTransferred] = output_bytes_accessed;
   current_properties_[kBytesAccessedKey] = bytes_accessed;
-  current_properties_[kCollNumDevicesKey] = num_ranks;
   // Since allreduce has compute, we need to get flops for the compute
   // part which is an elementwise op.
   current_properties_[kFlopsKey] = GetFlopsForElementwiseOp(
       allreduce->to_apply()->root_instruction()->opcode(), allreduce->shape());
 
-  // TODO TJ support multi-node case, we need to know how many nodes there are.
-  int num_intra_steps = 2 * (num_ranks - 1);
-  // Compute algorithmic scaling ratio, this can be used to be multiplied with
-  // bus bandwidth to get the effective bandwidth of the algorithm. The scaling
-  // ratio differs based on what algorithm NCCL chooses to use. This is the
-  // scaling factor for ring since NCCL will only use ring for single-node, need
-  // to add support for tree algo in multi-node case.
-  float scaling_ratio = (1.0 * num_ranks) / num_intra_steps;
-  current_properties_[kCollAlgoScaleRatioKey] = scaling_ratio;
+  SetRingCollectiveProperties(num_ranks,
+                              /*num_intra_steps=*/2 * (num_ranks - 1));
 
   return absl::OkStatus();
 }
@@ -501,14 +493,33 @@ absl::Status GpuHloCostAnalysis::HandleReduce(const HloInstruction* hlo) {
   return absl::OkStatus();
 }
 
+void GpuHloCostAnalysis::SetRingCollectiveProperties(int64_t num_ranks,
+                                                     int64_t num_intra_steps) {
+  current_properties_[kCollNumDevicesKey] = num_ranks;
+  // TODO TJ support multi-node case, we need to know how many nodes there are.
+  // Compute algorithmic scaling ratio, this can be used to be multiplied with
+  // bus bandwidth to get the effective bandwidth of the algorithm. The scaling
+  // ratio differs based on what algorithm NCCL chooses to use. This is the
+  // scaling factor for ring since NCCL will only use ring for single-node, need
+  // to add support for tree algo in multi-node case.
+  current_properties_[kCollAlgoScaleRatioKey] =
+      num_intra_steps > 0 ? static_cast<float>(num_ranks) / num_intra_steps : 0;
+}
+
 absl::Status GpuHloCostAnalysis::HandleAllReduceStart(
     const HloInstruction* hlo) {
+  TF_ASSIGN_OR_RETURN(int64_t num_ranks,
+                      NumRanks(*Cast<HloAllReduceInstruction>(hlo)));
+
   int64_t bytes_transferred = ShapeSize(hlo->shape(), options_.shape_size);
 
   current_properties_[kFlopsKey] = GetFlopsForElementwiseOp(
       hlo->to_apply()->root_instruction()->opcode(), hlo->shape());
   current_properties_[kBytesAccessedKey] = bytes_transferred;
   current_properties_[kCollBytesTransferred] = bytes_transferred;
+  SetRingCollectiveProperties(num_ranks,
+                              /*num_intra_steps=*/2 * (num_ranks - 1));
+
   return absl::OkStatus();
 }
 
@@ -523,6 +534,7 @@ absl::Status GpuHloCostAnalysis::HandleAllGather(const HloInstruction* hlo) {
 
   current_properties_[kBytesAccessedKey] = write_bytes + read_bytes;
   current_properties_[kCollBytesTransferred] = bytes_transferred;
+  SetRingCollectiveProperties(num_ranks, /*num_intra_steps=*/num_ranks - 1);
 
   return absl::OkStatus();
 }
@@ -540,6 +552,7 @@ absl::Status GpuHloCostAnalysis::HandleAllGatherStart(
 
   current_properties_[kBytesAccessedKey] = write_bytes + read_bytes;
   current_properties_[kCollBytesTransferred] = bytes_transferred;
+  SetRingCollectiveProperties(num_ranks, /*num_intra_steps=*/num_ranks - 1);
 
   return absl::OkStatus();
 }
@@ -573,6 +586,7 @@ absl::Status GpuHloCostAnalysis::HandleReduceScatter(
   current_properties_[kCollBytesTransferred] = bytes_transferred;
   current_properties_[kFlopsKey] = GetFlopsForElementwiseOp(
       hlo->to_apply()->root_instruction()->opcode(), hlo->shape());
+  SetRingCollectiveProperties(num_ranks, /*num_intra_steps=*/num_ranks - 1);
 
   return absl::OkStatus();
 }

--- a/xla/service/gpu/model/gpu_hlo_cost_analysis.cc
+++ b/xla/service/gpu/model/gpu_hlo_cost_analysis.cc
@@ -508,8 +508,8 @@ void GpuHloCostAnalysis::SetRingCollectiveProperties(int64_t num_ranks,
 
 absl::Status GpuHloCostAnalysis::HandleAllReduceStart(
     const HloInstruction* hlo) {
-  TF_ASSIGN_OR_RETURN(int64_t num_ranks,
-                      NumRanks(*Cast<HloAllReduceInstruction>(hlo)));
+  ASSIGN_OR_RETURN(int64_t num_ranks,
+                   NumRanks(*Cast<HloAllReduceInstruction>(hlo)));
 
   int64_t bytes_transferred = ShapeSize(hlo->shape(), options_.shape_size);
 

--- a/xla/service/gpu/model/gpu_hlo_cost_analysis.h
+++ b/xla/service/gpu/model/gpu_hlo_cost_analysis.h
@@ -111,6 +111,11 @@ class GpuHloCostAnalysis : public HloCostAnalysis {
   int64_t GetFlopsForElementwiseOp(const HloInstruction* instr) const;
 
  protected:
+  // Populates kCollNumDevicesKey and kCollAlgoScaleRatioKey in
+  // current_properties_ for a ring-algorithm collective with `num_ranks`
+  // participants and `num_intra_steps` ring steps.
+  void SetRingCollectiveProperties(int64_t num_ranks, int64_t num_intra_steps);
+
   std::unique_ptr<HloCostAnalysis> CreateNestedCostAnalysis() override;
   int64_t FusionParameterReadBytes(const HloInstruction* hlo) const override;
   absl::Status FusionCalculateUtilizations(


### PR DESCRIPTION
📝 Summary of Changes
The analytical collective cost model previously only handled AllReduce. This PR extends it to AllGather and ReduceScatter, which share similar cost calculation.

Enabled analytical_latency_estimator_test on ROCm and extended with AG/RS tests mirroring the existing AR one.

🚀 Kind of Contribution
✨ New Feature, 🧪 Tests
