### PR TITLE
[ROCm] Fix dot_bf16.hlo test

### DIFF
--- a/xla/backends/gpu/tests/BUILD
+++ b/xla/backends/gpu/tests/BUILD
@@ -808,6 +808,7 @@ lit_test_suite_for_gpus(
             "pdl.hlo",
         ],
         "mi200": [
+            "dot_bf16.hlo",
             "element_wise_row_vectorization.hlo",
             "scatter_bf16.hlo",
             "single_instruction.hlo",

--- a/xla/backends/gpu/tests/dot_bf16.hlo
+++ b/xla/backends/gpu/tests/dot_bf16.hlo
@@ -1,6 +1,6 @@
 // RUN: %if !IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../target_config/specs/v100.txtpb --split-input-file | FileCheck %s --check-prefixes=CHECK-SM70 %}
 // RUN: %if !IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../target_config/specs/a100_pcie_80.txtpb --split-input-file --xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false | FileCheck %s --check-prefixes=CHECK-SM80 %}
-// RUN: %if IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../target_config/specs/mi200.txtpb --split-input-file --xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false | FileCheck %s --check-prefixes=CHECK-SM80 %}
+// RUN: %if IS_ROCM %{ hlo-opt %s --platform=gpu --stage=hlo --xla_gpu_target_config_filename=%S/../target_config/specs/%{GPU}.txtpb --split-input-file --xla_gpu_autotune_level=0 --xla_gpu_enable_triton_gemm=false | FileCheck %s --check-prefixes=CHECK-SM80 %}
 
 
 // CHECK-SM70: %[[convert1:.+]] = f32[1536,6144]{1,0} fusion(%{{.+}})


### PR DESCRIPTION
kDot (bf16 x bf16 -> f32) is unsupported by hipBLASLt on gfx90a (MI200) and relied on the legacy cublas fallback removed in 115a93ed. Disable the test on mi200 and switch the ROCm RUN line to %{GPU}.txtpb so gfx1250 (and future ROCm targets) use their own spec instead of mi200's.
