### PR TITLE
[ROCm] Add minimal ROCm support for runtime ABI version check

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -693,7 +693,6 @@ xla_cc_test(
     ],
     deps = [
         ":cublas_pad_for_gemms",
-        "//xla:xla_data_proto_cc",
         "//xla:xla_proto_cc",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
@@ -810,6 +809,7 @@ cc_library(
         "//xla/tests:hlo_pjrt_interpreter_reference_mixin",
         "//xla/tests/restricted:hlo_test_base_legacy",
         "//xla/tsl/lib/core:status_test_util",
+        "//xla/tsl/platform:statusor",
         "//xla/tsl/protobuf:dnn_proto_cc",
         "//xla/tsl/util:command_line_flags",
         "@com_google_absl//absl/container:flat_hash_map",
@@ -897,12 +897,6 @@ cc_library(
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:statusor",
     ]) + [
-        "//xla:status_macros",
-        "//xla/service:matmul_indexing_utils",
-        "//xla/stream_executor:engine_options",
-        "//xla/tsl/platform:errors",
-        "//xla/tsl/platform:status_macros",
-        "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/strings",
         "@cudnn_frontend_archive//:cudnn_frontend",
     ],
@@ -1098,11 +1092,6 @@ cc_library(
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:statusor",
     ]) + [
-        "//xla:xla_data_proto_cc",
-        "//xla/tsl/platform:errors",
-        "//xla/tsl/platform:status_macros",
-        "//xla/tsl/platform:statusor",
-        "//xla/tsl/protobuf:dnn_proto_cc",
         "@com_google_absl//absl/container:flat_hash_map",
     ],
 )
@@ -1218,15 +1207,12 @@ xla_test(
             "//xla/hlo/ir:hlo",
             "//xla/hlo/utils:hlo_matchers",
             "//xla/service:pattern_matcher",
-            "@tsl//tsl/platform:statusor",
         ],
         [
             # b/317293391
             "@com_google_googletest//:gtest_main",
         ],
-    ) + [
-        "//xla/tsl/platform:statusor",
-    ],
+    ),
 )
 
 cc_library(

--- a/xla/stream_executor/abi/executable_abi_version.cc
+++ b/xla/stream_executor/abi/executable_abi_version.cc
@@ -45,7 +45,7 @@ static absl::StatusOr<ExecutableAbiVersion> CreateForCuda(
 static absl::StatusOr<ExecutableAbiVersion> CreateForRocm(
     const DeviceDescription& /*device_description*/) {
   ExecutableAbiVersionProto proto;
-  proto.set_platform_name("ROCm");
+  proto.set_platform_name("ROCM");
   return ExecutableAbiVersion::FromProto(std::move(proto));
 }
 

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -288,6 +288,7 @@ cc_library(
     deps = [
         ":rocm_executor",
         ":rocm_platform_id",
+        ":rocm_runtime_abi_version",
         ":rocm_status",
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:executor_cache",
@@ -308,6 +309,27 @@ cc_library(
     ],
     alwayslink = True,  # Registers itself with the PlatformManager.
 )
+
+cc_library(
+    name = "rocm_runtime_abi_version",
+    srcs = ["rocm_runtime_abi_version.cc"],
+    hdrs = ["rocm_runtime_abi_version.h"],
+    deps = [
+        ":rocm_platform_id",
+        "//xla/stream_executor:platform_id",
+        "//xla/stream_executor/abi:executable_abi_version",
+        "//xla/stream_executor/abi:executable_abi_version_proto_cc",
+        "//xla/stream_executor/abi:runtime_abi_version",
+        "//xla/stream_executor/abi:runtime_abi_version_proto_cc",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/base:nullability",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
 
 cc_library(
     name = "rocm_platform_id",

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -295,6 +295,7 @@ cc_library(
         "//xla/stream_executor:platform",
         "//xla/stream_executor:platform_manager",
         "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor/abi:runtime_abi_version",
         "//xla/stream_executor/platform:initialize",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:status_macros",

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -330,6 +330,21 @@ cc_library(
     ],
 )
 
+xla_cc_test(
+    name = "rocm_runtime_abi_version_test",
+    srcs = ["rocm_runtime_abi_version_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_runtime_abi_version",
+        "//xla/stream_executor/abi:executable_abi_version",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
 
 cc_library(
     name = "rocm_platform_id",

--- a/xla/stream_executor/rocm/rocm_platform.cc
+++ b/xla/stream_executor/rocm/rocm_platform.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/stream_executor/platform_manager.h"
 #include "xla/stream_executor/rocm/rocm_executor.h"
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
+#include "xla/stream_executor/rocm/rocm_runtime_abi_version.h"
 #include "xla/stream_executor/rocm/rocm_status.h"
 #include "xla/tsl/platform/errors.h"
 
@@ -107,6 +108,11 @@ ROCmPlatform::GetUncachedExecutor(int ordinal) {
   auto executor = std::make_unique<RocmExecutor>(this, ordinal);
   RETURN_IF_ERROR(executor->Init());
   return std::move(executor);
+}
+
+absl::StatusOr<std::unique_ptr<RuntimeAbiVersion> absl_nonnull>
+ROCmPlatform::GetRuntimeAbiVersion() const {
+    return std::make_unique<ROCmRuntimeAbiVersion>();
 }
 
 }  // namespace gpu

--- a/xla/stream_executor/rocm/rocm_platform.cc
+++ b/xla/stream_executor/rocm/rocm_platform.cc
@@ -112,7 +112,7 @@ ROCmPlatform::GetUncachedExecutor(int ordinal) {
 
 absl::StatusOr<std::unique_ptr<RuntimeAbiVersion> absl_nonnull>
 ROCmPlatform::GetRuntimeAbiVersion() const {
-    return std::make_unique<ROCmRuntimeAbiVersion>();
+  return std::make_unique<ROCmRuntimeAbiVersion>();
 }
 
 }  // namespace gpu

--- a/xla/stream_executor/rocm/rocm_platform.h
+++ b/xla/stream_executor/rocm/rocm_platform.h
@@ -74,12 +74,6 @@ class ROCmPlatform : public Platform {
 };
 
 }  // namespace gpu
-
-namespace rocm {
-
-using ROCmPlatform = gpu::ROCmPlatform;
-
-}  // namespace cuda
 }  // namespace stream_executor
 
 #endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_PLATFORM_H_

--- a/xla/stream_executor/rocm/rocm_platform.h
+++ b/xla/stream_executor/rocm/rocm_platform.h
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include "absl/status/statusor.h"
 #include "absl/synchronization/mutex.h"
+#include "xla/stream_executor/abi/runtime_abi_version.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/executor_cache.h"
 #include "xla/stream_executor/platform.h"
@@ -49,6 +50,8 @@ class ROCmPlatform : public Platform {
 
   absl::StatusOr<StreamExecutor*> ExecutorForDevice(int ordinal) override;
   absl::StatusOr<StreamExecutor*> FindExisting(int ordinal) override;
+  absl::StatusOr<std::unique_ptr<RuntimeAbiVersion> absl_nonnull>
+  GetRuntimeAbiVersion() const override;
 
  private:
   // Returns a device constructed with ordinal without
@@ -71,6 +74,12 @@ class ROCmPlatform : public Platform {
 };
 
 }  // namespace gpu
+
+namespace rocm {
+
+using ROCmPlatform = gpu::ROCmPlatform;
+
+}  // namespace cuda
 }  // namespace stream_executor
 
 #endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_PLATFORM_H_

--- a/xla/stream_executor/rocm/rocm_runtime_abi_version.cc
+++ b/xla/stream_executor/rocm/rocm_runtime_abi_version.cc
@@ -27,18 +27,17 @@ limitations under the License.
 #include "xla/stream_executor/abi/executable_abi_version.h"
 #include "xla/stream_executor/abi/executable_abi_version.pb.h"
 #include "xla/stream_executor/abi/runtime_abi_version.pb.h"
-#include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/stream_executor/platform_id.h"
+#include "xla/stream_executor/rocm/rocm_platform_id.h"
 
 namespace stream_executor::gpu {
-
 
 absl::StatusOr<PlatformId> ROCmRuntimeAbiVersion::platform_id() const {
   return rocm::kROCmPlatformId;
 }
 
 absl::StatusOr<RuntimeAbiVersionProto> ROCmRuntimeAbiVersion::ToProto() const {
-    return RuntimeAbiVersionProto();
+  return RuntimeAbiVersionProto();
 }
 
 absl::Status ROCmRuntimeAbiVersion::IsCompatibleWith(

--- a/xla/stream_executor/rocm/rocm_runtime_abi_version.cc
+++ b/xla/stream_executor/rocm/rocm_runtime_abi_version.cc
@@ -15,15 +15,9 @@ limitations under the License.
 
 #include "xla/stream_executor/rocm/rocm_runtime_abi_version.h"
 
-#include <memory>
-#include <string>
-#include <utility>
-
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
-#include "xla/tsl/platform/status_macros.h"
 #include "xla/stream_executor/abi/executable_abi_version.h"
 #include "xla/stream_executor/abi/executable_abi_version.pb.h"
 #include "xla/stream_executor/abi/runtime_abi_version.pb.h"

--- a/xla/stream_executor/rocm/rocm_runtime_abi_version.cc
+++ b/xla/stream_executor/rocm/rocm_runtime_abi_version.cc
@@ -1,0 +1,58 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_runtime_abi_version.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/stream_executor/abi/executable_abi_version.h"
+#include "xla/stream_executor/abi/executable_abi_version.pb.h"
+#include "xla/stream_executor/abi/runtime_abi_version.pb.h"
+#include "xla/stream_executor/rocm/rocm_platform_id.h"
+#include "xla/stream_executor/platform_id.h"
+
+namespace stream_executor::gpu {
+
+
+absl::StatusOr<PlatformId> ROCmRuntimeAbiVersion::platform_id() const {
+  return rocm::kROCmPlatformId;
+}
+
+absl::StatusOr<RuntimeAbiVersionProto> ROCmRuntimeAbiVersion::ToProto() const {
+    return RuntimeAbiVersionProto();
+}
+
+absl::Status ROCmRuntimeAbiVersion::IsCompatibleWith(
+    const ExecutableAbiVersion& executable_abi_version) const {
+  const ExecutableAbiVersionProto& executable_proto =
+      executable_abi_version.proto();
+
+  if (executable_proto.platform_name() != rocm::kROCmPlatformId->ToName()) {
+    return absl::FailedPreconditionError(absl::StrCat(
+        "Platform name mismatch. Expected ", rocm::kROCmPlatformId->ToName(),
+        ", but got ", executable_proto.platform_name()));
+  }
+
+  return absl::OkStatus();
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_runtime_abi_version.h
+++ b/xla/stream_executor/rocm/rocm_runtime_abi_version.h
@@ -16,12 +16,8 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_RUNTIME_ABI_VERSION_H_
 #define XLA_STREAM_EXECUTOR_ROCM_ROCM_RUNTIME_ABI_VERSION_H_
 
-#include <memory>
-
-#include "absl/base/nullability.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
 #include "xla/stream_executor/abi/executable_abi_version.h"
 #include "xla/stream_executor/abi/runtime_abi_version.h"
 #include "xla/stream_executor/abi/runtime_abi_version.pb.h"

--- a/xla/stream_executor/rocm/rocm_runtime_abi_version.h
+++ b/xla/stream_executor/rocm/rocm_runtime_abi_version.h
@@ -1,0 +1,45 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_RUNTIME_ABI_VERSION_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_RUNTIME_ABI_VERSION_H_
+
+#include <memory>
+
+#include "absl/base/nullability.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/stream_executor/abi/executable_abi_version.h"
+#include "xla/stream_executor/abi/runtime_abi_version.h"
+#include "xla/stream_executor/abi/runtime_abi_version.pb.h"
+#include "xla/stream_executor/platform_id.h"
+
+namespace stream_executor::gpu {
+
+class ROCmRuntimeAbiVersion : public RuntimeAbiVersion {
+ public:
+
+  absl::StatusOr<RuntimeAbiVersionProto> ToProto() const override;
+  absl::StatusOr<PlatformId> platform_id() const override;
+
+  absl::Status IsCompatibleWith(
+      const ExecutableAbiVersion& executable_abi_version) const override;
+
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_RUNTIME_ABI_VERSION_H_

--- a/xla/stream_executor/rocm/rocm_runtime_abi_version.h
+++ b/xla/stream_executor/rocm/rocm_runtime_abi_version.h
@@ -31,13 +31,11 @@ namespace stream_executor::gpu {
 
 class ROCmRuntimeAbiVersion : public RuntimeAbiVersion {
  public:
-
   absl::StatusOr<RuntimeAbiVersionProto> ToProto() const override;
   absl::StatusOr<PlatformId> platform_id() const override;
 
   absl::Status IsCompatibleWith(
       const ExecutableAbiVersion& executable_abi_version) const override;
-
 };
 
 }  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_runtime_abi_version_test.cc
+++ b/xla/stream_executor/rocm/rocm_runtime_abi_version_test.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "xla/stream_executor/rocm/rocm_runtime_abi_version.h"
 
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/status/status.h"
@@ -24,7 +23,6 @@ limitations under the License.
 
 namespace stream_executor::gpu {
 namespace {
-
 
 TEST(RocmRuntimeAbiVersionTest, IsCompatibleWith) {
   ROCmRuntimeAbiVersion current_runtime_abi_version;
@@ -38,7 +36,6 @@ TEST(RocmRuntimeAbiVersionTest, IsCompatibleWith) {
   // ABI versions.
   EXPECT_OK(current_runtime_abi_version.IsCompatibleWith(
       current_executable_abi_version));
-
 }
 }  // namespace
-}  // namespace stream_executor::cuda
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_runtime_abi_version_test.cc
+++ b/xla/stream_executor/rocm/rocm_runtime_abi_version_test.cc
@@ -1,0 +1,44 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_runtime_abi_version.h"
+
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "xla/stream_executor/abi/executable_abi_version.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+
+TEST(RocmRuntimeAbiVersionTest, IsCompatibleWith) {
+  ROCmRuntimeAbiVersion current_runtime_abi_version;
+
+  ASSERT_OK_AND_ASSIGN(ExecutableAbiVersion current_executable_abi_version, [] {
+    ExecutableAbiVersionProto proto;
+    proto.set_platform_name("ROCM");
+    return ExecutableAbiVersion::FromProto(proto);
+  }());
+
+  // ABI versions.
+  EXPECT_OK(current_runtime_abi_version.IsCompatibleWith(
+      current_executable_abi_version));
+
+}
+}  // namespace
+}  // namespace stream_executor::cuda


### PR DESCRIPTION
📝 Summary of Changes
Add minimal support in ROCm for runtime ABI checks

🎯 Justification
cuda has added them in https://github.com/openxla/xla/commit/45e9f69c187839f0abc8cfbd3071163f0a8e081a and se_pjrt_gpu_client_test uses runtime abi version check in a platform agnostic way

🚀 Kind of Contribution: ✨ New Feature

