### PR TITLE
[XLA:GPU] Add explicit VMM allocator synchronization

### DIFF
--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -236,6 +236,26 @@ TEST_F(DeviceAddressVmmAllocatorTest, ExplicitDeallocate) {
   scoped_address.Release();
 }
 
+TEST_F(DeviceAddressVmmAllocatorTest, SynchronizePendingOperationsDrainsQueue) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(ordinal, 1024, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  DeviceAddressBase addr = scoped_address.cref();
+  scoped_address.Release();
+  ASSERT_THAT(allocator->Deallocate(ordinal, addr), IsOk());
+  EXPECT_NE(allocator->GetRawAllocation(ordinal, addr), nullptr);
+
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+  EXPECT_EQ(allocator->GetRawAllocation(ordinal, addr), nullptr);
+}
+
 TEST_F(DeviceAddressVmmAllocatorTest, DeallocateNull) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto allocator,

--- a/xla/stream_executor/memory_reservation.h
+++ b/xla/stream_executor/memory_reservation.h
@@ -70,6 +70,9 @@ class MemoryReservation {
     // allocation(s) and can be accessed from the device.
     DeviceAddressBase mapped_address() const;
 
+    // Returns true if this object does not own a mapping.
+    bool is_null() const { return reservation_ == nullptr; }
+
    private:
     // Unmaps the given range on the reservation and logs on failure.
     static void UnmapAndLogIfError(MemoryReservation* reservation,

--- a/xla/stream_executor/vmm_device_address_allocator.cc
+++ b/xla/stream_executor/vmm_device_address_allocator.cc
@@ -394,7 +394,7 @@ absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
 
   uint64_t target_seqno;
   {
-    absl::MutexLock lock(&state->mu);
+    absl::MutexLock lock(state->mu);
     if (state->pending_deallocations.empty()) {
       return absl::OkStatus();
     }
@@ -406,7 +406,7 @@ absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
   }
 
   {
-    absl::MutexLock lock(&state->mu);
+    absl::MutexLock lock(state->mu);
     while (!state->pending_deallocations.empty() &&
            state->pending_deallocations.front().seqno <= target_seqno) {
       DoDeallocate(*state, state->pending_deallocations.front().mem);

--- a/xla/stream_executor/vmm_device_address_allocator.cc
+++ b/xla/stream_executor/vmm_device_address_allocator.cc
@@ -392,25 +392,27 @@ absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
     return DeviceNotFoundError(device_ordinal);
   }
 
-  state->mu.lock();
-  if (state->pending_deallocations.empty()) {
-    state->mu.unlock();
-    return absl::OkStatus();
+  uint64_t target_seqno;
+  {
+    absl::MutexLock lock(&state->mu);
+    if (state->pending_deallocations.empty()) {
+      return absl::OkStatus();
+    }
+    target_seqno = state->pending_deallocations.back().seqno;
   }
-  uint64_t target_seqno = state->pending_deallocations.back().seqno;
 
-  state->mu.unlock();
   while (LoadTimeline(state->pinned_timeline) < target_seqno) {
     absl::SleepFor(absl::Microseconds(50));
   }
-  state->mu.lock();
 
-  while (!state->pending_deallocations.empty() &&
-         state->pending_deallocations.front().seqno <= target_seqno) {
-    DoDeallocate(*state, state->pending_deallocations.front().mem);
-    state->pending_deallocations.pop_front();
+  {
+    absl::MutexLock lock(&state->mu);
+    while (!state->pending_deallocations.empty() &&
+           state->pending_deallocations.front().seqno <= target_seqno) {
+      DoDeallocate(*state, state->pending_deallocations.front().mem);
+      state->pending_deallocations.pop_front();
+    }
   }
-  state->mu.unlock();
 
   return absl::OkStatus();
 }

--- a/xla/stream_executor/vmm_device_address_allocator.cc
+++ b/xla/stream_executor/vmm_device_address_allocator.cc
@@ -385,6 +385,36 @@ absl::StatusOr<Stream*> DeviceAddressVmmAllocator::GetStream(
   return state->stream;
 }
 
+absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
+    int device_ordinal) {
+  PerDeviceState* state = GetPerDeviceState(device_ordinal);
+  if (state == nullptr) {
+    return DeviceNotFoundError(device_ordinal);
+  }
+
+  state->mu.lock();
+  if (state->pending_deallocations.empty()) {
+    state->mu.unlock();
+    return absl::OkStatus();
+  }
+  uint64_t target_seqno = state->pending_deallocations.back().seqno;
+
+  state->mu.unlock();
+  while (LoadTimeline(state->pinned_timeline) < target_seqno) {
+    absl::SleepFor(absl::Microseconds(50));
+  }
+  state->mu.lock();
+
+  while (!state->pending_deallocations.empty() &&
+         state->pending_deallocations.front().seqno <= target_seqno) {
+    DoDeallocate(*state, state->pending_deallocations.front().mem);
+    state->pending_deallocations.pop_front();
+  }
+  state->mu.unlock();
+
+  return absl::OkStatus();
+}
+
 absl::StatusOr<StreamExecutor*> DeviceAddressVmmAllocator::GetStreamExecutor(
     int device_ordinal) const {
   PerDeviceState* state = GetPerDeviceState(device_ordinal);

--- a/xla/stream_executor/vmm_device_address_allocator.cc
+++ b/xla/stream_executor/vmm_device_address_allocator.cc
@@ -50,6 +50,15 @@ static absl::Status DeviceNotFoundError(int device_ordinal) {
                       device_ordinal));
 }
 
+// Interval between CPU polls of the GPU-written deallocation timeline while
+// waiting for deferred frees to become safe. The 50us value is a conservative
+// initial tradeoff: long enough to avoid busy-spinning a CPU core and short
+// enough to keep forced allocator synchronization responsive; it has not been
+// benchmark-tuned, so workload-specific tests could refine it if this wait
+// shows up in profiles.
+static constexpr absl::Duration kGpuTimelinePollInterval =
+    absl::Microseconds(50);
+
 // Returns the completed timeline value from pinned host memory using an
 // acquire load, so all GPU writes prior to this value are visible.
 // Uses __atomic_load_n rather than std::atomic<> because the pointer is
@@ -107,7 +116,7 @@ DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
     // memory. pinned_timeline is not ABSL_GUARDED_BY and last_seqno is a local.
     if (state->pinned_timeline != nullptr && last_seqno > 0) {
       while (LoadTimeline(state->pinned_timeline) < last_seqno) {
-        absl::SleepFor(absl::Microseconds(50));
+        absl::SleepFor(kGpuTimelinePollInterval);
       }
     }
 
@@ -187,10 +196,8 @@ void DeviceAddressVmmAllocator::WaitPendingDeallocationsToComplete(
   // Poll until the GPU writes a timeline value >= target_seqno.
   // Since timeline values are written in stream order, this guarantees all
   // earlier pending deallocations have also completed.
-  // Sleep 50us per iteration to release the CPU core while waiting rather
-  // than hot-spinning.
   while (LoadTimeline(state.pinned_timeline) < target_seqno) {
-    absl::SleepFor(absl::Microseconds(50));
+    absl::SleepFor(kGpuTimelinePollInterval);
   }
 
   // Reacquire the lock before modifying the maps.
@@ -402,7 +409,7 @@ absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
   }
 
   while (LoadTimeline(state->pinned_timeline) < target_seqno) {
-    absl::SleepFor(absl::Microseconds(50));
+    absl::SleepFor(kGpuTimelinePollInterval);
   }
 
   {

--- a/xla/stream_executor/vmm_device_address_allocator.h
+++ b/xla/stream_executor/vmm_device_address_allocator.h
@@ -108,6 +108,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // Returns the stream for the given device ordinal.
   absl::StatusOr<Stream*> GetStream(int device_ordinal) override;
 
+  // Waits for all pending stream-ordered deallocations on the given device to
+  // complete, then releases the corresponding allocator bookkeeping.
+  absl::Status SynchronizePendingOperations(int device_ordinal);
+
   // Returns the StreamExecutor for the given device ordinal.
   absl::StatusOr<StreamExecutor*> GetStreamExecutor(int device_ordinal) const;
 


### PR DESCRIPTION
  📝 Summary of Changes
  Adds `DeviceAddressVmmAllocator::SynchronizePendingOperations(...)` to wait for pending stream-ordered deallocations on a device and drain the corresponding allocator bookkeeping.

  Also adds `MemoryReservation::ScopedMapping::is_null()` and a CUDA VMM allocator test covering the new synchronization path.

  🎯 Justification
  This provides an explicit synchronization hook for VMM allocator users that need deterministic cleanup of deferred deallocations before inspecting or reusing allocator state.

  🚀 Kind of Contribution
  ✨ New Feature, 🧪 Tests

  📊 Benchmark (for Performance Improvements)
  N/A. This is not intended as a performance change.

  🧪 Unit Tests:
  Added `DeviceAddressVmmAllocatorTest.SynchronizePendingOperationsDrainsQueue`.

  🧪 Execution Tests:
  Built the CUDA VMM allocator test target:
  `bazel build --config=cuda //xla/stream_executor/cuda:cuda_device_address_vmm_allocator_test`

