### PR TITLE
[XLA:GPU] DeviceAddressVmmAllocate adds new Allocate() API that can map physical allocation to some pre-created VA range during allocate time

### DIFF
--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -1014,8 +1014,10 @@ xla_cc_test(
     ],
     deps = [
         ":cuda_device_address_vmm_allocator",
+        ":cuda_memory_reservation",
         ":cuda_platform",
         "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_space",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:platform_manager",
         "//xla/stream_executor:stream",

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -24,7 +24,9 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
+#include "xla/stream_executor/cuda/cuda_memory_reservation.h"
 #include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_space.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
 #include "xla/stream_executor/stream.h"
@@ -91,9 +93,6 @@ TEST_F(DeviceAddressVmmAllocatorTest, AllocateAndDeallocate) {
   EXPECT_EQ(scoped_address->size(), 1024);
   EXPECT_NE(
       allocator->GetRawAllocation(executor_->device_ordinal(), *scoped_address),
-      nullptr);
-  EXPECT_NE(
-      allocator->GetReservation(executor_->device_ordinal(), *scoped_address),
       nullptr);
 
   // The ScopedDeviceAddress will automatically deallocate when it goes out of
@@ -254,6 +253,34 @@ TEST_F(DeviceAddressVmmAllocatorTest, SynchronizePendingOperationsDrainsQueue) {
 
   ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
   EXPECT_EQ(allocator->GetRawAllocation(ordinal, addr), nullptr);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, MapAndUnMapReservationAlias) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+
+  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
+                                             executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  ASSERT_THAT(allocator->Map(ordinal, source.cref(), reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+  EXPECT_THAT(allocator->Deallocate(ordinal, source.cref()),
+              absl_testing::StatusIs(absl::StatusCode::kFailedPrecondition));
+
+  ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
 }
 
 TEST_F(DeviceAddressVmmAllocatorTest, DeallocateNull) {
@@ -493,8 +520,6 @@ TEST_F(MultiDeviceVmmAllocatorTest, AllocateOnBothDevices) {
     EXPECT_NE(
         allocator->GetRawAllocation(executors_[i]->device_ordinal(), *addr),
         nullptr);
-    EXPECT_NE(allocator->GetReservation(executors_[i]->device_ordinal(), *addr),
-              nullptr);
     TF_ASSERT_OK_AND_ASSIGN(
         StreamExecutor * se,
         allocator->GetStreamExecutor(executors_[i]->device_ordinal()));

--- a/xla/stream_executor/vmm_device_address_allocator.cc
+++ b/xla/stream_executor/vmm_device_address_allocator.cc
@@ -123,7 +123,11 @@ DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
     {
       absl::MutexLock lock(state->mu);
       for (auto& pending : state->pending_deallocations) {
-        DoDeallocate(*state, pending.mem);
+        if (pending.kind == PendingDeallocationKind::kAllocate) {
+          DoDeallocate(*state, pending.mem);
+        } else {
+          DoUnMap(*state, pending.mem);
+        }
       }
       state->pending_deallocations.clear();
     }
@@ -152,7 +156,12 @@ void DeviceAddressVmmAllocator::ProcessCompletedPendingDeallocations(
     if (state.pending_deallocations.front().seqno > completed) {
       break;
     }
-    DoDeallocate(state, state.pending_deallocations.front().mem);
+    if (state.pending_deallocations.front().kind ==
+        PendingDeallocationKind::kAllocate) {
+      DoDeallocate(state, state.pending_deallocations.front().mem);
+    } else {
+      DoUnMap(state, state.pending_deallocations.front().mem);
+    }
     state.pending_deallocations.pop_front();
   }
 }
@@ -172,7 +181,9 @@ void DeviceAddressVmmAllocator::WaitPendingDeallocationsToComplete(
   uint64_t target_size = rounded_size + rounded_size / 10;
 
   for (const auto& pending : state.pending_deallocations) {
-    accumulated_size += RoundUpToGranularity(state, pending.mem.size());
+    if (pending.kind == PendingDeallocationKind::kAllocate) {
+      accumulated_size += RoundUpToGranularity(state, pending.mem.size());
+    }
     target_seqno = pending.seqno;
     ++count_to_wait;
     if (accumulated_size >= target_size) {
@@ -204,7 +215,11 @@ void DeviceAddressVmmAllocator::WaitPendingDeallocationsToComplete(
   state.mu.lock();
 
   for (auto& item : selected) {
-    DoDeallocate(state, item.mem);
+    if (item.kind == PendingDeallocationKind::kAllocate) {
+      DoDeallocate(state, item.mem);
+    } else {
+      DoUnMap(state, item.mem);
+    }
   }
 }
 
@@ -225,6 +240,15 @@ void DeviceAddressVmmAllocator::DoDeallocate(PerDeviceState& state,
   uint64_t rounded_size = RoundUpToGranularity(state, mem.size());
   DCHECK_GE(state.pa_allocated, rounded_size);
   state.pa_allocated -= rounded_size;
+}
+
+void DeviceAddressVmmAllocator::DoUnMap(PerDeviceState& state,
+                                        DeviceAddressBase mem) {
+  VLOG(3) << absl::StreamFormat(
+      "Actually unmapping reservation address %p (size=%uB) on device ordinal "
+      "%d",
+      mem.opaque(), mem.size(), state.executor->device_ordinal());
+  state.stale_reservation_mappings.erase(mem.opaque());
 }
 
 absl::StatusOr<DeviceAddressBase> DeviceAddressVmmAllocator::AllocateWithBudget(
@@ -367,6 +391,26 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
 
   absl::MutexLock lock(state->mu);
 
+  if (!state->raw_allocations.contains(mem.opaque())) {
+    if (state->active_reservation_mappings.contains(mem.opaque()) ||
+        state->stale_reservation_mappings.contains(mem.opaque())) {
+      return absl::InvalidArgumentError(
+          "DeviceAddressVmmAllocator::Deallocate does not accept reservation "
+          "alias addresses; use UnMap instead");
+    }
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "DeviceAddressVmmAllocator::Deallocate received an unknown address %p",
+        mem.opaque()));
+  }
+
+  for (const auto& [_, mapping] : state->active_reservation_mappings) {
+    if (mapping.allocator_address.IsSameAs(mem)) {
+      return absl::FailedPreconditionError(
+          "DeviceAddressVmmAllocator::Deallocate requires active reservation "
+          "aliases to be released with UnMap first");
+    }
+  }
+
   VLOG(3) << absl::StreamFormat(
       "Queueing deferred deallocation for virtual address %p (size=%uB) "
       "on device ordinal %d",
@@ -378,8 +422,135 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   uint64_t seqno = state->next_seqno++;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
 
-  state->pending_deallocations.push_back({mem, seqno});
+  state->pending_deallocations.push_back(
+      {PendingDeallocationKind::kAllocate, mem, seqno});
 
+  return absl::OkStatus();
+}
+
+absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
+                                            DeviceAddressBase addr,
+                                            MemoryReservation* reservation,
+                                            uint64_t reservation_offset,
+                                            uint64_t size) {
+  if (size == 0) {
+    return absl::OkStatus();
+  }
+  if (addr.is_null()) {
+    return absl::InvalidArgumentError(
+        "DeviceAddressVmmAllocator::Map requires a non-null source address");
+  }
+  if (reservation == nullptr) {
+    return absl::InvalidArgumentError(
+        "DeviceAddressVmmAllocator::Map requires a non-null reservation");
+  }
+  DeviceAddressBase reservation_range = reservation->address();
+  if (reservation_offset > reservation_range.size() ||
+      size > reservation_range.size() - reservation_offset) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Reservation range [%u, %u) is outside reservation size %u",
+        reservation_offset, reservation_offset + size,
+        reservation_range.size()));
+  }
+  DeviceAddressBase reservation_address =
+      reservation_range.GetByteSlice(reservation_offset, size);
+
+  PerDeviceState* state = GetPerDeviceState(device_ordinal);
+  if (state == nullptr) {
+    return DeviceNotFoundError(device_ordinal);
+  }
+
+  absl::MutexLock lock(state->mu);
+  auto raw_it = state->raw_allocations.find(addr.opaque());
+  if (raw_it == state->raw_allocations.end()) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "DeviceAddressVmmAllocator::Map received an unknown allocator address "
+        "%p",
+        addr.opaque()));
+  }
+  if (size > raw_it->second->address().size()) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "DeviceAddressVmmAllocator::Map size %u exceeds raw allocation size "
+        "%u",
+        size, raw_it->second->address().size()));
+  }
+  if (state->active_reservation_mappings.contains(
+          reservation_address.opaque()) ||
+      state->stale_reservation_mappings.contains(
+          reservation_address.opaque())) {
+    return absl::FailedPreconditionError(
+        "Reservation address is already tracked by this allocator");
+  }
+  for (const auto& [_, mapping] : state->active_reservation_mappings) {
+    if (mapping.allocator_address.IsSameAs(addr)) {
+      return absl::FailedPreconditionError(
+          "Allocator address already has an active reservation alias");
+    }
+  }
+
+  ASSIGN_OR_RETURN(
+      MemoryReservation::ScopedMapping scoped_mapping,
+      reservation->MapTo(reservation_offset, /*allocation_offset=*/0, size,
+                         *raw_it->second));
+  state->active_reservation_mappings.emplace(
+      reservation_address.opaque(),
+      ReservationMapping{addr, reservation_address, reservation,
+                         reservation_offset, size, std::move(scoped_mapping)});
+  return absl::OkStatus();
+}
+
+absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
+                                              MemoryReservation* reservation,
+                                              uint64_t reservation_offset,
+                                              uint64_t size) {
+  if (size == 0) {
+    return absl::OkStatus();
+  }
+  if (reservation == nullptr) {
+    return absl::InvalidArgumentError(
+        "DeviceAddressVmmAllocator::UnMap requires a non-null reservation");
+  }
+  DeviceAddressBase reservation_range = reservation->address();
+  if (reservation_offset > reservation_range.size() ||
+      size > reservation_range.size() - reservation_offset) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Reservation range [%u, %u) is outside reservation size %u",
+        reservation_offset, reservation_offset + size,
+        reservation_range.size()));
+  }
+  DeviceAddressBase reservation_address =
+      reservation_range.GetByteSlice(reservation_offset, size);
+
+  PerDeviceState* state = GetPerDeviceState(device_ordinal);
+  if (state == nullptr) {
+    return DeviceNotFoundError(device_ordinal);
+  }
+
+  absl::MutexLock lock(state->mu);
+  auto it =
+      state->active_reservation_mappings.find(reservation_address.opaque());
+  if (it == state->active_reservation_mappings.end()) {
+    return absl::InvalidArgumentError(
+        "DeviceAddressVmmAllocator::UnMap received an untracked reservation "
+        "address");
+  }
+  if (it->second.reservation != reservation ||
+      it->second.reservation_offset != reservation_offset ||
+      it->second.size != size) {
+    return absl::InvalidArgumentError(
+        "DeviceAddressVmmAllocator::UnMap requires the same full reservation "
+        "range passed to Map");
+  }
+
+  uint64_t seqno = state->next_seqno++;
+  RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
+
+  ReservationMapping mapping = std::move(it->second);
+  state->active_reservation_mappings.erase(it);
+  state->stale_reservation_mappings.emplace(reservation_address.opaque(),
+                                            std::move(mapping));
+  state->pending_deallocations.push_back(
+      {PendingDeallocationKind::kMap, reservation_address, seqno});
   return absl::OkStatus();
 }
 
@@ -416,7 +587,12 @@ absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
     absl::MutexLock lock(state->mu);
     while (!state->pending_deallocations.empty() &&
            state->pending_deallocations.front().seqno <= target_seqno) {
-      DoDeallocate(*state, state->pending_deallocations.front().mem);
+      if (state->pending_deallocations.front().kind ==
+          PendingDeallocationKind::kAllocate) {
+        DoDeallocate(*state, state->pending_deallocations.front().mem);
+      } else {
+        DoUnMap(*state, state->pending_deallocations.front().mem);
+      }
       state->pending_deallocations.pop_front();
     }
   }
@@ -447,20 +623,6 @@ MemoryAllocation* DeviceAddressVmmAllocator::GetRawAllocation(
   return it->second.get();
 }
 
-MemoryReservation* DeviceAddressVmmAllocator::GetReservation(
-    int device_ordinal, DeviceAddressBase addr) const {
-  PerDeviceState* state = GetPerDeviceState(device_ordinal);
-  if (state == nullptr) {
-    return nullptr;
-  }
-  absl::MutexLock lock(state->mu);
-  auto it = state->reservations.find(addr.opaque());
-  if (it == state->reservations.end()) {
-    return nullptr;
-  }
-  return it->second.get();
-}
-
 uint64_t DeviceAddressVmmAllocator::GetAllocationGranularity(
     StreamExecutor* executor) const {
   PerDeviceState* state = GetPerDeviceState(executor->device_ordinal());
@@ -476,6 +638,9 @@ DeviceAddressVmmAllocator::TryReusePendingDeallocation(PerDeviceState& state,
   uint64_t rounded_size = RoundUpToGranularity(state, size);
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
+    if (it->kind != PendingDeallocationKind::kAllocate) {
+      continue;
+    }
     if (RoundUpToGranularity(state, it->mem.size()) != rounded_size) {
       continue;
     }

--- a/xla/stream_executor/vmm_device_address_allocator.h
+++ b/xla/stream_executor/vmm_device_address_allocator.h
@@ -58,7 +58,9 @@ namespace stream_executor {
 //
 // The allocator tracks the ScopedMapping and underlying MemoryAllocation and
 // MemoryReservation objects for each returned DeviceAddressBase. Callers can
-// retrieve these via GetRawAllocation() and GetReservation().
+// retrieve the raw physical allocation via GetRawAllocation(). Callers can
+// also create non-owning aliases into caller-owned MemoryReservation ranges
+// with Map(), then release those aliases with UnMap().
 //
 // This allocator supports asynchronous deallocation: when Deallocate() is
 // called, it records a GPU timeline write on the device's stream and defers
@@ -102,6 +104,20 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // completes.
   absl::Status Deallocate(int device_ordinal, DeviceAddressBase mem) override;
 
+  // Maps the physical allocation backing `addr` into `reservation` at
+  // `reservation_offset`. `addr` must be an active allocator address returned
+  // by Allocate(), and each allocator address may have at most one active
+  // reservation alias.
+  absl::Status Map(int device_ordinal, DeviceAddressBase addr,
+                   MemoryReservation* reservation, uint64_t reservation_offset,
+                   uint64_t size);
+
+  // Defers unmapping the reservation alias created by Map() until all
+  // previously enqueued work on this allocator's stream has completed. The
+  // caller must pass the same full reservation range used for Map().
+  absl::Status UnMap(int device_ordinal, MemoryReservation* reservation,
+                     uint64_t reservation_offset, uint64_t size);
+
   // Returns true — this allocator supports asynchronous deallocation.
   bool AllowsAsynchronousDeallocation() const override { return true; }
 
@@ -122,13 +138,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   MemoryAllocation* GetRawAllocation(int device_ordinal,
                                      DeviceAddressBase addr) const;
 
-  // Returns the MemoryReservation (virtual address range) for the given
-  // virtual address on the specified device, or nullptr if the address was not
-  // allocated by this allocator. The returned pointer is valid until the
-  // allocation is deallocated.
-  MemoryReservation* GetReservation(int device_ordinal,
-                                    DeviceAddressBase addr) const;
-
   // Returns the VMM allocation granularity for the device associated with
   // `executor`, or 0 if the device is not registered or granularity is unknown.
   uint64_t GetAllocationGranularity(StreamExecutor* executor) const;
@@ -138,11 +147,26 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       StreamExecutor* executor, uint64_t size) = 0;
 
  protected:
+  enum class PendingDeallocationKind {
+    kAllocate,
+    kMap,
+  };
+
   struct PendingDeallocation {
+    PendingDeallocationKind kind = PendingDeallocationKind::kAllocate;
     DeviceAddressBase mem;
     // GPU stream sequence number recorded at deallocation time. When the
     // pinned_timeline value reaches this seqno, the memory is safe to free.
-    uint64_t seqno;
+    uint64_t seqno = 0;
+  };
+
+  struct ReservationMapping {
+    DeviceAddressBase allocator_address;
+    DeviceAddressBase reservation_address;
+    MemoryReservation* reservation = nullptr;
+    uint64_t reservation_offset = 0;
+    uint64_t size = 0;
+    MemoryReservation::ScopedMapping scoped_mapping;
   };
 
   struct PerDeviceState {
@@ -181,6 +205,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     absl::flat_hash_map<void*, std::unique_ptr<MemoryReservation>> reservations
         ABSL_GUARDED_BY(mu);
     absl::flat_hash_map<void*, MemoryReservation::ScopedMapping> scoped_mappings
+        ABSL_GUARDED_BY(mu);
+    absl::flat_hash_map<void*, ReservationMapping> active_reservation_mappings
+        ABSL_GUARDED_BY(mu);
+    absl::flat_hash_map<void*, ReservationMapping> stale_reservation_mappings
         ABSL_GUARDED_BY(mu);
   };
 
@@ -232,6 +260,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   // Actually perform the synchronous deallocation.
   void DoDeallocate(PerDeviceState& state, DeviceAddressBase mem)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Actually perform the synchronous unmap for a stale reservation alias.
+  void DoUnMap(PerDeviceState& state, DeviceAddressBase mem)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Try to reuse a pending deallocation with matching rounded size.


### PR DESCRIPTION
  📝 Summary of Changes
  Adds `DeviceAddressVmmAllocator::Map()` and `UnMap()` APIs for creating and releasing non-owning aliases from allocator-owned physical allocations into caller-owned `MemoryReservation` ranges.

  This also tracks active/stale reservation mappings separately from allocator-owned addresses, defers unmap teardown through the existing stream-ordered pending-deallocation queue, and rejects `Deallocate()` while an allocation still has an active reservation alias.

  🎯 Justification
  This is the next VMM allocator API layer needed for command-buffer VA remapping: callers can map stable reservation addresses to allocator-backed physical memory while keeping teardown stream-ordered.

  🚀 Kind of Contribution
  ✨ New Feature, 🧪 Tests

  📊 Benchmark (for Performance Improvements)
  N/A. This is not intended as a performance change.

  🧪 Unit Tests:
  Added `DeviceAddressVmmAllocatorTest.MapAndUnMapReservationAlias`.

  🧪 Execution Tests:
  Built the CUDA VMM allocator test target:
  `bazel build --config=cuda //xla/stream_executor/cuda:cuda_device_address_vmm_allocator_test`

  For the stacked PR, set the base branch to vmm-sync-foundation.

