### PR TITLE
[XLA:GPU][oneAPI] Skip block_scaled_dot tests in collectives e2e test suite

### DIFF
--- a/xla/backends/gpu/tests/collective_ops_sharded_unsharded_e2e_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_sharded_unsharded_e2e_test.cc
@@ -373,8 +373,8 @@ ENTRY entry {
 }
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded, BlockScaledDotBatchAndBatch) {
-  if (Capability().IsRocm()) {
-    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  if (Capability().IsRocm() || Capability().IsOneAPI()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm or OneAPI";
   }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[4,16,64]{2,1,0}, f8e8m0fnu[4,16,2]{2,1,0}, f8e4m3fn[4,4,64]{2,1,0}, f8e8m0fnu[4,4,2]{2,1,0})->f32[4,16,4]{2,1,0}}, num_partitions=2
@@ -391,8 +391,8 @@ ENTRY entry {
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded,
        BlockScaledDotBatchAndNonContracting) {
-  if (Capability().IsRocm()) {
-    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  if (Capability().IsRocm() || Capability().IsOneAPI()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm or OneAPI";
   }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[4,16,64]{2,1,0}, f8e8m0fnu[4,16,2]{2,1,0}, f8e4m3fn[4,4,64]{2,1,0}, f8e8m0fnu[4,4,2]{2,1,0})->f32[4,16,4]{2,1,0}}, num_partitions=2
@@ -409,8 +409,8 @@ ENTRY entry {
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded,
        BlockScaledDotContractingAndContracting) {
-  if (Capability().IsRocm()) {
-    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  if (Capability().IsRocm() || Capability().IsOneAPI()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm or OneAPI";
   }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[16,64]{1,0}, f8e8m0fnu[16,2]{1,0}, f8e4m3fn[4,64]{1,0}, f8e8m0fnu[4,2]{1,0})->f32[16,4]{1,0}}, num_partitions=2
@@ -427,8 +427,8 @@ ENTRY entry {
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded,
        BlockScaledDotNonContractingAndContracting) {
-  if (Capability().IsRocm()) {
-    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  if (Capability().IsRocm() || Capability().IsOneAPI()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm or OneAPI";
   }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[16,128]{1,0}, f8e8m0fnu[16,4]{1,0}, f8e4m3fn[4,128]{1,0}, f8e8m0fnu[4,4]{1,0})->f32[16,4]{1,0}}, num_partitions=2
@@ -445,8 +445,8 @@ ENTRY entry {
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded,
        BlockScaledDotContractingAndReplicated) {
-  if (Capability().IsRocm()) {
-    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  if (Capability().IsRocm() || Capability().IsOneAPI()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm or OneAPI";
   }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[16,128]{1,0}, f8e8m0fnu[16,4]{1,0}, f8e4m3fn[4,128]{1,0}, f8e8m0fnu[4,4]{1,0})->f32[16,4]{1,0}}, num_partitions=2
@@ -463,8 +463,8 @@ ENTRY entry {
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded,
        BlockScaledDotReplicatedAndReplicated) {
-  if (Capability().IsRocm()) {
-    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  if (Capability().IsRocm() || Capability().IsOneAPI()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm or OneAPI";
   }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[4,128]{1,0}, f8e8m0fnu[4,4], f8e4m3fn[1,128]{1,0}, f8e8m0fnu[1,4]{1,0})->f32[4,1]{1,0}}, num_partitions=2
@@ -481,8 +481,8 @@ ENTRY entry {
 
 TEST_F(CollectiveOpsTestE2EShardedUnsharded,
        BlockScaledDotContractingNonContractingAndContractingNonContracting) {
-  if (Capability().IsRocm()) {
-    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm";
+  if (Capability().IsRocm() || Capability().IsOneAPI()) {
+    GTEST_SKIP() << "block_scaled_dot is not supported on ROCm or OneAPI";
   }
   const std::string hlo_text = R"(
 HloModule module, entry_computation_layout={(f8e4m3fn[8,128]{1,0}, f8e8m0fnu[8,4]{1,0}, f8e4m3fn[4,128]{1,0}, f8e8m0fnu[4,4]{1,0})->f32[8,4]{1,0}}, num_partitions=4


### PR DESCRIPTION
`block_scaled_dot` is not yet supported on oneAPI backend, hence this PR skips the corresponding tests in `collective_ops_sharded_unsharded_e2e_test` for oneAPI.