### PR TITLE
[xla:gpu] Handle empty traced command buffers

### DIFF
--- a/xla/stream_executor/cuda/cuda_command_buffer.cc
+++ b/xla/stream_executor/cuda/cuda_command_buffer.cc
@@ -718,16 +718,17 @@ absl::Status CudaCommandBuffer::Trace(
           << (end_nanos - start_nanos) / 1000 << " μs)";
 
   // Check that traced graph is not empty. Trying to instantiate a CUDA graph
-  // with empty child node leads to a crash.
+  // with an empty child node leads to a crash. If the traced operation did not
+  // launch any CUDA work, add an explicit empty node so the child graph is a
+  // valid no-op command.
   size_t num_root_nodes = 0;
   RETURN_IF_ERROR(cuda::ToStatus(
       cuGraphGetRootNodes(captured_graph, nullptr, &num_root_nodes)));
 
   if (num_root_nodes == 0) {
-    return absl::InternalError(
-        "Traced CUDA graph is empty. Traced function (custom call) did not "
-        "launch any CUDA operations on the captured CUDA stream. Instantiating "
-        "empty child nodes leads to CUDA crashes.");
+    VLOG(5) << "Traced CUDA graph is empty; adding an empty node";
+    ASSIGN_OR_RETURN(auto* empty, CreateEmptyCmd({}, StreamPriority::Default));
+    (void)empty;
   }
 
   return absl::OkStatus();

--- a/xla/stream_executor/gpu/gpu_command_buffer_test.cc
+++ b/xla/stream_executor/gpu/gpu_command_buffer_test.cc
@@ -176,6 +176,32 @@ TEST(GpuCommandBufferTest, TraceSingleKernel) {
   ASSERT_EQ(dst, expected);
 }
 
+TEST(GpuCommandBufferTest, TraceEmptyChildCommand) {
+  Platform* platform = GpuPlatform();
+  StreamExecutor* executor = platform->ExecutorForDevice(0).value();
+
+  if (executor->GetPlatform()->id() == cuda::kCudaPlatformId &&
+      !IsAtLeastCuda12300(executor)) {
+    GTEST_SKIP() << "Command buffer tracing is supported after CUDA 12.3";
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor->CreateStream());
+
+  ASSERT_OK_AND_ASSIGN(auto traced_cmd_buffer,
+                       TraceCommandBufferFactory::Create(
+                           executor, stream.get(),
+                           [](Stream*) { return absl::OkStatus(); }, nested));
+
+  ASSERT_OK_AND_ASSIGN(auto cmd_buffer, executor->CreateCommandBuffer(primary));
+  ASSERT_OK_AND_ASSIGN(auto* child,
+                       cmd_buffer->CreateChildCommand(*traced_cmd_buffer, {}));
+  (void)child;
+  ASSERT_OK(cmd_buffer->Finalize());
+
+  ASSERT_OK(cmd_buffer->Submit(stream.get()));
+  ASSERT_OK(stream->BlockHostUntilDone());
+}
+
 TEST(GpuCommandBufferTest, LaunchNestedCommandBuffer) {
   Platform* platform = GpuPlatform();
   StreamExecutor* executor = platform->ExecutorForDevice(0).value();

--- a/xla/stream_executor/rocm/rocm_command_buffer.cc
+++ b/xla/stream_executor/rocm/rocm_command_buffer.cc
@@ -420,10 +420,9 @@ absl::Status RocmCommandBuffer::Trace(
                "Failed to get HIP graph root node count"));
 
   if (num_root_nodes == 0) {
-    return absl::InternalError(
-        "Traced HIP graph is empty. Traced function (custom call) did not "
-        "launch any HIP operations on the captured HIP stream. Instantiating "
-        "empty child nodes leads to crashes.");
+    VLOG(5) << "Traced HIP graph is empty; adding an empty node";
+    ASSIGN_OR_RETURN(auto* empty, CreateEmptyCmd({}, StreamPriority::Default));
+    (void)empty;
   }
 
   return absl::OkStatus();


### PR DESCRIPTION
  PR Description
  📝 Summary of Changes
  Allow command buffer tracing to handle captures that produce an empty CUDA/HIP graph. Instead of treating this as an error, XLA now inserts an explicit empty no-op node so the traced child command buffer remains valid.

  🎯 Justification
  Some normal workloads can legitimately produce empty command-buffer captures, for example when a command-buffer-compatible traced operation does not enqueue GPU work on a particular invocation. This should not be treated as a runtime error.

  🚀 Kind of Contribution
  🐛 Bug Fix, 🧪 Tests

  📊 Benchmark (for Performance Improvements)
  N/A

  🧪 Unit Tests:
  Added GpuCommandBufferTest.TraceEmptyChildCommand to verify that an empty traced nested command buffer can be inserted into a primary command buffer, finalized, submitted, and completed successfully.

  🧪 Execution Tests:
  Ran:

  bazel test //xla/stream_executor/gpu:gpu_command_buffer_test \
    --test_filter=GpuCommandBufferTest.TraceEmptyChildCommand --test_output=errors

