### PR TITLE
[ROCm] Remove post commit pipeline for jax/xla rocm

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -18,9 +18,6 @@ permissions:
   contents: read
 on:
   pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
📝 Summary of Changes
Remove post submit pipelines for rocm

🎯 Justification
ROCm rbe is still too weak to handle all that load from upstream,
we remove the post submit pipelines to reduce the load

🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
