### PR TITLE
[xla:gpu] Add support for aliasing through no-op HLOs

### DIFF
--- a/xla/hlo/analysis/alias_info.cc
+++ b/xla/hlo/analysis/alias_info.cc
@@ -42,6 +42,12 @@ AliasInfo::GetFusionInstructionInPlaceInputOutputPairs(
     const HloFusionInstruction* fusion) const {
   std::vector<std::pair<HloOperandIndex, ShapeIndex>>
       in_place_input_output_pairs;
+  // Follow HLO use-def chains through tuple and no-op indirections.
+  auto follow_indirections = [&](const HloInstruction* instruction,
+                                 ShapeIndex index) {
+    std::tie(instruction, index) = FollowTupleIndirection(instruction, index);
+    return FollowNoOpIndirection(instruction, index);
+  };
 
   // Each of these leaves represents one array output of the fusion that might
   // be aliased with one of the fusion computation's array inputs (both could be
@@ -49,21 +55,21 @@ AliasInfo::GetFusionInstructionInPlaceInputOutputPairs(
   ShapeUtil::ForEachLeafShape(fusion->shape(), [&](const Shape& sub_shape,
                                                    const ShapeIndex& index) {
     // Start from the root instruction of the fusion computation and follow
-    // tuple indirection backwards to find the "output source", i.e. the
-    // instruction that is the original source of the array output in
-    // question. If there is no such indirection the "output source" will
-    // just be the fusion root instruction itself.
+    // indirections backwards to find the "output source", i.e. the instruction
+    // that is the original source of the array output in question. If there is
+    // no such indirection the "output source" will just be the fusion root
+    // instruction itself.
     const HloInstruction* output_source_instruction =
         fusion->fused_expression_root();
     ShapeIndex output_source_index = index;
     std::tie(output_source_instruction, output_source_index) =
-        FollowTupleIndirection(output_source_instruction, output_source_index);
+        follow_indirections(output_source_instruction, output_source_index);
 
     // The aliasing rules of the "output source" instruction determine the
     // aliasing rules for the entire fusion. If we can connect (following
-    // tuple indirection) the input of an "in-place" pair to one of the
-    // fusion's inputs, and the output of this "in-place" pair to the fusion
-    // output in question, then this fusion input and output must alias.
+    // indirections) the input of an "in-place" pair to one of the fusion's
+    // inputs, and the output of this "in-place" pair to the fusion output in
+    // question, then this fusion input and output must alias.
     auto in_place_pairs = GetInPlaceInputOutputPairs(output_source_instruction);
     ShapeIndex in_place_input_index;
     const HloInstruction* in_place_input_source = nullptr;
@@ -77,11 +83,11 @@ AliasInfo::GetFusionInstructionInPlaceInputOutputPairs(
         in_place_input_source =
             output_source_instruction->operand(input.operand_number);
         in_place_input_index = input.operand_index;
-        // Follow tuple indirection backwards from the instruction input to
-        // try to find a fusion parameter. If found, that parameter aliases
-        // the current output. If not, the current output aliases no input.
+        // Follow indirections backwards from the instruction input to try to
+        // find a fusion parameter. If found, that parameter aliases the current
+        // output. If not, the current output aliases no input.
         std::tie(in_place_input_source, in_place_input_index) =
-            FollowTupleIndirection(in_place_input_source, in_place_input_index);
+            follow_indirections(in_place_input_source, in_place_input_index);
         if (in_place_input_source->opcode() == HloOpcode::kFusion) {
           // Nested fusions can have aliasing that allows us to peephole
           // through to their producer.
@@ -95,17 +101,12 @@ AliasInfo::GetFusionInstructionInPlaceInputOutputPairs(
                   in_place_input_source->operand(pair.first.operand_number);
               in_place_input_index = pair.first.operand_index;
               std::tie(in_place_input_source, in_place_input_index) =
-                  FollowTupleIndirection(in_place_input_source,
-                                         in_place_input_index);
+                  follow_indirections(in_place_input_source,
+                                      in_place_input_index);
             }
           }
         }
       }
-    }
-    // Skip bitcast
-    if (in_place_input_source != nullptr &&
-        in_place_input_source->opcode() == HloOpcode::kBitcast) {
-      in_place_input_source = in_place_input_source->operand(0);
     }
     if (in_place_input_source != nullptr &&
         in_place_input_source->opcode() == HloOpcode::kParameter) {
@@ -269,6 +270,14 @@ AliasInfo::GetInPlaceInputOutputPairs(const HloInstruction* user) const {
     return {{HloOperandIndex{1, {}}, {}}};
   }
   return {};
+}
+
+std::pair<const HloInstruction*, ShapeIndex> AliasInfo::FollowNoOpIndirection(
+    const HloInstruction* instruction, ShapeIndex operand_index) const {
+  while (operand_index.empty() && IsNoOpForAliasAnalysis(instruction)) {
+    instruction = instruction->operand(0);
+  }
+  return {instruction, operand_index};
 }
 
 std::pair<const HloInstruction*, ShapeIndex> FollowTupleIndirection(

--- a/xla/hlo/analysis/alias_info.cc
+++ b/xla/hlo/analysis/alias_info.cc
@@ -33,10 +33,18 @@ limitations under the License.
 
 namespace xla {
 
-// Returns in-place input/output pairs for the given fusion instruction,
-// according to the aliasing rules for the corresponding fusion computation.
-//
-// `instruction` must be a fusion instruction.
+std::vector<std::pair<HloOperandIndex, ShapeIndex>>
+AliasInfo::GetOutputSourceInPlaceInputOutputPairs(
+    const HloInstruction* instruction) const {
+  if (const auto* fusion = DynCast<HloFusionInstruction>(instruction)) {
+    return GetFusionInstructionInPlaceInputOutputPairs(fusion);
+  }
+  return GetInPlaceInputOutputPairs(instruction);
+}
+
+// Returns in-place input/output pairs discovered from the fusion computation
+// body. This does not include output_to_operand_aliasing annotations on
+// `fusion` itself; GetInPlaceInputOutputPairs adds them for the public API.
 std::vector<std::pair<HloOperandIndex, ShapeIndex>>
 AliasInfo::GetFusionInstructionInPlaceInputOutputPairs(
     const HloFusionInstruction* fusion) const {
@@ -70,7 +78,8 @@ AliasInfo::GetFusionInstructionInPlaceInputOutputPairs(
     // indirections) the input of an "in-place" pair to one of the fusion's
     // inputs, and the output of this "in-place" pair to the fusion output in
     // question, then this fusion input and output must alias.
-    auto in_place_pairs = GetInPlaceInputOutputPairs(output_source_instruction);
+    auto in_place_pairs =
+        GetOutputSourceInPlaceInputOutputPairs(output_source_instruction);
     ShapeIndex in_place_input_index;
     const HloInstruction* in_place_input_source = nullptr;
 

--- a/xla/hlo/analysis/alias_info.h
+++ b/xla/hlo/analysis/alias_info.h
@@ -81,12 +81,27 @@ class AliasInfo {
     return std::nullopt;
   }
 
+  // Returns whether `instruction` can be ignored when tracing fusion in-place
+  // aliases because it does not change the underlying buffer. Backends may
+  // override this to add target-specific no-op wrappers.
+  virtual bool IsNoOpForAliasAnalysis(const HloInstruction* instruction) const {
+    return instruction->opcode() == HloOpcode::kBitcast;
+  }
+
  private:
   // Returns in-place input/output pairs for the given fusion instruction,
   // according to the aliasing rules for the corresponding fusion computation.
   std::vector<std::pair<HloOperandIndex, ShapeIndex>>
   GetFusionInstructionInPlaceInputOutputPairs(
       const HloFusionInstruction* fusion) const;
+
+  // Follows no-op wrappers while tracing an HLO value to its source. For
+  // example, if a fusion root is bitcast(dus), this returns dus.
+  //
+  // Only array values are followed: `operand_index` must be empty before a
+  // wrapper can be skipped.
+  std::pair<const HloInstruction*, ShapeIndex> FollowNoOpIndirection(
+      const HloInstruction* instruction, ShapeIndex operand_index) const;
 };
 
 // Removes layers of tuple indirection introduced via 'tuple' and

--- a/xla/hlo/analysis/alias_info.h
+++ b/xla/hlo/analysis/alias_info.h
@@ -89,8 +89,16 @@ class AliasInfo {
   }
 
  private:
-  // Returns in-place input/output pairs for the given fusion instruction,
-  // according to the aliasing rules for the corresponding fusion computation.
+  // Returns in-place pairs for an output source instruction while analyzing a
+  // fusion body. Nested fusion annotations are not inherited here; only aliases
+  // discovered from the nested fusion body are visible.
+  std::vector<std::pair<HloOperandIndex, ShapeIndex>>
+  GetOutputSourceInPlaceInputOutputPairs(
+      const HloInstruction* instruction) const;
+
+  // Returns in-place input/output pairs discovered from the fusion computation
+  // body. This does not include output_to_operand_aliasing annotations on
+  // `fusion` itself; GetInPlaceInputOutputPairs adds them for the public API.
   std::vector<std::pair<HloOperandIndex, ShapeIndex>>
   GetFusionInstructionInPlaceInputOutputPairs(
       const HloFusionInstruction* fusion) const;

--- a/xla/hlo/analysis/alias_info_test.cc
+++ b/xla/hlo/analysis/alias_info_test.cc
@@ -323,6 +323,68 @@ ENTRY test {
   EXPECT_EQ(in_place_pairs, expected_pairs);
 }
 
+TEST_F(GetInPlaceInputOutputPairsTest, NestedFusionBodyAliasingThroughBitcast) {
+  const char* kHlo = R"(
+HloModule test
+
+inner_fusion {
+  p0 = f32[4] parameter(0)
+  update = f32[2] parameter(1)
+  c0 = s32[] constant(0)
+  ROOT dus = f32[4] dynamic-update-slice(p0, update, c0)
+}
+
+outer_fusion {
+  p0 = f32[4] parameter(0)
+  update = f32[2] parameter(1)
+  nested = f32[4] fusion(p0, update), kind=kLoop, calls=inner_fusion
+  ROOT bitcast = f32[2,2] bitcast(nested)
+}
+
+ENTRY test {
+  p0 = f32[4] parameter(0)
+  update = f32[2] parameter(1)
+  ROOT fusion = f32[2,2] fusion(p0, update), kind=kLoop,
+      calls=outer_fusion
+}
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  HloInstruction* fusion = module->entry_computation()->root_instruction();
+
+  auto in_place_pairs = alias_info_.GetInPlaceInputOutputPairs(fusion);
+  std::vector<std::pair<HloOperandIndex, ShapeIndex>> expected_pairs;
+  expected_pairs.push_back({HloOperandIndex{0, {}}, {}});
+  EXPECT_EQ(in_place_pairs, expected_pairs);
+}
+
+TEST_F(GetInPlaceInputOutputPairsTest,
+       NestedFusionAnnotationNotInheritedThroughBitcast) {
+  const char* kHlo = R"(
+HloModule test
+
+copy_fusion {
+  p0 = f32[4] parameter(0)
+  ROOT copy = f32[4] copy(p0)
+}
+
+outer_fusion {
+  p0 = f32[4] parameter(0)
+  nested = f32[4] fusion(p0), kind=kLoop,
+      output_to_operand_aliasing={{}: (0, {})}, calls=copy_fusion
+  ROOT bitcast = f32[2,2] bitcast(nested)
+}
+
+ENTRY test {
+  p0 = f32[4] parameter(0)
+  ROOT fusion = f32[2,2] fusion(p0), kind=kLoop, calls=outer_fusion
+}
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  HloInstruction* fusion = module->entry_computation()->root_instruction();
+
+  EXPECT_THAT(alias_info_.GetInPlaceInputOutputPairs(fusion), IsEmpty());
+}
+
 // Verifies in-place behavior for nested multi-output fusions containing DUS.
 TEST_F(GetInPlaceInputOutputPairsTest, NestedMultiOutputDUSFusion) {
   const char* kHlo = R"(

--- a/xla/service/gpu/alias_info.cc
+++ b/xla/service/gpu/alias_info.cc
@@ -218,6 +218,12 @@ std::optional<bool> FusionCanShareBufferHint(
 }
 }  // namespace
 
+bool GpuAliasInfo::IsNoOpForAliasAnalysis(
+    const HloInstruction* instruction) const {
+  return AliasInfo::IsNoOpForAliasAnalysis(instruction) ||
+         instruction->opcode() == HloOpcode::kReshape;
+}
+
 std::optional<bool> GpuAliasInfo::MayAlias(const HloInstruction* operand,
                                            const ShapeIndex& operand_index,
                                            const HloInstruction* user,

--- a/xla/service/gpu/alias_info.h
+++ b/xla/service/gpu/alias_info.h
@@ -39,6 +39,8 @@ class GpuAliasInfo : public AliasInfo {
                                const ShapeIndex& user_index) const override;
 
  protected:
+  bool IsNoOpForAliasAnalysis(const HloInstruction* instruction) const override;
+
   se::DeviceDescription device_description_;
 };
 }  // namespace xla::gpu

--- a/xla/service/gpu/gpu_copy_insertion_test.cc
+++ b/xla/service/gpu/gpu_copy_insertion_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include "absl/strings/string_view.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_module.h"
@@ -53,6 +54,26 @@ int64_t CountCopies(const HloModule& module) {
   return count;
 }
 
+void ExpectFusionOperandIsCopyOf(const HloModule& module,
+                                 absl::string_view fusion_name,
+                                 absl::string_view copied_instruction_name) {
+  const HloInstruction* fusion =
+      HloHardwareIndependentTestBase::FindInstruction(&module, fusion_name);
+  ASSERT_NE(fusion, nullptr);
+  ASSERT_GT(fusion->operand_count(), 0);
+  const HloInstruction* copy = fusion->operand(0);
+  ASSERT_EQ(copy->opcode(), HloOpcode::kCopy);
+  const HloInstruction* copy_source = copy->operand(0);
+  while (copy_source->opcode() == HloOpcode::kCopy) {
+    copy_source = copy_source->operand(0);
+  }
+  const HloInstruction* copied_instruction =
+      HloHardwareIndependentTestBase::FindInstruction(&module,
+                                                      copied_instruction_name);
+  ASSERT_NE(copied_instruction, nullptr);
+  EXPECT_EQ(copy_source, copied_instruction) << module.ToString();
+}
+
 class GpuCopyInsertionTest : public HloHardwareIndependentTestBase {
  public:
   CopyInsertion CreateCopyInsertion() const {
@@ -68,7 +89,7 @@ class GpuCopyInsertionTest : public HloHardwareIndependentTestBase {
 
 // This is some kind of end-to-end test for FusionCanShareBufferHint.
 TEST_F(GpuCopyInsertionTest, DUSBitcastNoCopy) {
-  const char* const kModuleString = R"(
+  constexpr absl::string_view kModuleString = R"(
 HloModule bitcast_fusion
 
 fused_computation.549 {
@@ -126,10 +147,69 @@ ENTRY main {
   EXPECT_EQ(CountCopies(*module), 2);
 }
 
+TEST_F(GpuCopyInsertionTest, BitcastedFusedDynamicUpdateSliceCopy) {
+  constexpr absl::string_view kModuleString = R"(
+HloModule Module
+
+fused_computation {
+  param0 = f32[4,4] parameter(0)
+  update = f32[1,4] constant({{1, 2, 3, 4}})
+  constant.0 = s32[] constant(0)
+  dus = f32[4,4] dynamic-update-slice(param0, update, constant.0, constant.0)
+  ROOT bitcast = f32[16] bitcast(dus)
+}
+
+ENTRY main {
+  param = f32[4,4] parameter(0)
+  negate = f32[4,4] negate(param)
+  add = f32[4,4] add(negate, negate)
+  fusion = f32[16] fusion(negate), kind=kLoop, calls=fused_computation
+  bitcast = f32[4,4] bitcast(fusion)
+  ROOT tuple = (f32[4,4], f32[4,4]) tuple(add, bitcast)
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::HloModule> module,
+                          ParseAndReturnVerifiedModule(kModuleString));
+
+  CopyInsertion copy_insertion = CreateCopyInsertion();
+  ASSERT_IS_OK(copy_insertion.Run(module.get()).status());
+  EXPECT_EQ(CountCopies(*module), 1);
+  ExpectFusionOperandIsCopyOf(*module, "fusion", "negate");
+}
+
+TEST_F(GpuCopyInsertionTest, ReshapedFusedDynamicUpdateSliceCopy) {
+  constexpr absl::string_view kModuleString = R"(
+HloModule Module
+
+fused_computation {
+  param0 = f32[4,4] parameter(0)
+  update = f32[1,4] constant({{1, 2, 3, 4}})
+  constant.0 = s32[] constant(0)
+  dus = f32[4,4] dynamic-update-slice(param0, update, constant.0, constant.0)
+  ROOT reshape = f32[16] reshape(dus)
+}
+
+ENTRY main {
+  param = f32[4,4] parameter(0)
+  negate = f32[4,4] negate(param)
+  add = f32[4,4] add(negate, negate)
+  fusion = f32[16] fusion(negate), kind=kLoop, calls=fused_computation
+  reshape = f32[4,4] reshape(fusion)
+  ROOT tuple = (f32[4,4], f32[4,4]) tuple(add, reshape)
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::HloModule> module,
+                          ParseAndReturnVerifiedModule(kModuleString));
+
+  CopyInsertion copy_insertion = CreateCopyInsertion();
+  ASSERT_IS_OK(copy_insertion.Run(module.get()).status());
+  ExpectFusionOperandIsCopyOf(*module, "fusion", "negate");
+}
+
 // For loops unrolled with double buffering,
 // copyInsertion should not insert any copy.
 TEST_F(GpuCopyInsertionTest, UnrolledLoopShouldNotHaveCopy) {
-  const char* const kModuleString = R"(
+  constexpr absl::string_view kModuleString = R"(
 HloModule all_gather_overlapping, entry_computation_layout={(f32[1,128]{1,0}, f32[2,128]{1,0})->(f32[1,128]{1,0}, f32[1,128]{1,0}, f32[2,128]{1,0}, s32[])}
 
 body {

--- a/xla/service/gpu/gpu_copy_insertion_test.cc
+++ b/xla/service/gpu/gpu_copy_insertion_test.cc
@@ -206,6 +206,42 @@ ENTRY main {
   ExpectFusionOperandIsCopyOf(*module, "fusion", "negate");
 }
 
+TEST_F(GpuCopyInsertionTest, F8DotCopyReproducer) {
+  constexpr absl::string_view kModuleString = R"(
+HloModule Module
+
+%bitcast_fusion (bitcast_input: bf16[256,256]) -> bf16[256,256] {
+  %bitcast_input = bf16[256,256]{1,0} parameter(0)
+  ROOT %bitcast = bf16[256,256]{1,0} bitcast(%bitcast_input)
+}
+
+%copy_fusion (input: f8e4m3fn[256,256]) -> f8e4m3fn[256,256] {
+  %input = f8e4m3fn[256,256]{1,0} parameter(0)
+  ROOT %copy = f8e4m3fn[256,256]{1,0} copy(%input)
+}
+
+%bitcast_fusion.1 (bitcast_input.1: f8e4m3fn[256,256]) -> f8e4m3fn[256,256] {
+  %bitcast_input.1 = f8e4m3fn[256,256]{1,0} parameter(0)
+  %fusion.3 = f8e4m3fn[256,256]{1,0} fusion(%bitcast_input.1), kind=kLoop, output_to_operand_aliasing={{}: (0, {})}, calls=%copy_fusion
+  ROOT %bitcast.1 = f8e4m3fn[256,256]{1,0} bitcast(%fusion.3)
+}
+
+ENTRY %main (param_0: bf16[256,256], param_1: f8e4m3fn[256,256]) -> f32[256,256] {
+  %param_0 = bf16[256,256]{1,0} parameter(0)
+  %fusion.1 = bf16[256,256]{1,0} fusion(%param_0), kind=kLoop, calls=%bitcast_fusion
+  %param_1 = f8e4m3fn[256,256]{1,0} parameter(1)
+  %fusion.2 = f8e4m3fn[256,256]{1,0} fusion(%param_1), kind=kLoop, calls=%bitcast_fusion.1
+  ROOT %convolution.1 = f32[256,256]{1,0} convolution(%fusion.1, %fusion.2), dim_labels=bf_io->bf
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::HloModule> module,
+                          ParseAndReturnVerifiedModule(kModuleString));
+
+  CopyInsertion copy_insertion = CreateCopyInsertion();
+  ASSERT_IS_OK(copy_insertion.Run(module.get()).status());
+  EXPECT_EQ(CountCopies(*module), 1);
+}
+
 // For loops unrolled with double buffering,
 // copyInsertion should not insert any copy.
 TEST_F(GpuCopyInsertionTest, UnrolledLoopShouldNotHaveCopy) {


### PR DESCRIPTION
In GPU backend `bitcast` and `reshape` are no-ops (`bitcast` is no-op on all backends), and they should not get in a way of alias analysis when it tries connect ROOT with a parameter.

This should reduce the number of copies in the final HLO program and improve memory and bandwidth utilization on GPU backend.