### PR TITLE
[xla:gpu] Add RegisteredMemory API to XLA collectives

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -302,6 +302,7 @@ xla_cc_test(
         "//xla/core/collectives:communicator",
         "//xla/core/collectives:rank_id",
         "//xla/core/collectives:reduction_kind",
+        "//xla/core/collectives:registered_memory",
         "//xla/core/collectives:symmetric_memory",
         "//xla/runtime:device_id",
         "//xla/stream_executor:device_address",
@@ -338,6 +339,7 @@ cc_library(
         "//xla/core/collectives:communicator",
         "//xla/core/collectives:rank_id",
         "//xla/core/collectives:reduction_kind",
+        "//xla/core/collectives:registered_memory",
         "//xla/core/collectives:symmetric_memory",
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:kernel_args",
@@ -513,6 +515,30 @@ cc_library(
         "@com_google_absl//absl/log:vlog_is_on",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/time",
+    ],
+)
+
+cc_library(
+    name = "nccl_registered_memory",
+    srcs = ["nccl_registered_memory.cc"],
+    hdrs = ["nccl_registered_memory.h"],
+    tags = [
+        "cuda-only",
+        "gpu",
+    ],
+    visibility = [
+        "//xla/backends/gpu/runtime:__subpackages__",
+        "//xla/stream_executor/cuda:__subpackages__",
+    ],
+    deps = [
+        ":nccl_errors",
+        "//xla/core/collectives:registered_memory",
+        "//xla/stream_executor:device_address",
+        "//xla/tsl/cuda:nccl",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 
@@ -712,6 +738,7 @@ cc_library(
         ":gpu_collectives",
         ":gpu_communicator",
         ":nccl_errors",
+        ":nccl_registered_memory",
         ":nccl_symmetric_memory",
         ":nccl_types",
         ":single_threaded_executor",
@@ -722,6 +749,7 @@ cc_library(
         "//xla/core/collectives:communicator",
         "//xla/core/collectives:rank_id",
         "//xla/core/collectives:reduction_kind",
+        "//xla/core/collectives:registered_memory",
         "//xla/core/collectives:symmetric_memory",
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:stream",
@@ -745,6 +773,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
         "@local_config_cuda//cuda:cuda_headers",

--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
+#include "xla/core/collectives/registered_memory.h"
 #include "xla/core/collectives/symmetric_memory.h"
 #include "xla/future.h"
 #include "xla/runtime/device_id.h"
@@ -301,6 +302,37 @@ TEST(GpuCollectivesTest, CreateSymmetricMemory) {
   // Register allocated buffers as symmetric memory.
   auto fsymm = CreateSymmetricMemory(exec, comms, allocs);
   ASSERT_OK_AND_ASSIGN(auto symm, AwaitSymmetricMemory(std::move(fsymm)));
+}
+
+TEST(GpuCollectivesTest, CreateRegisteredMemory) {
+  ASSERT_OK_AND_ASSIGN(se::Platform * platform,
+                       se::PlatformManager::PlatformWithName("CUDA"));
+
+  if (platform->VisibleDeviceCount() < 2) {
+    GTEST_SKIP() << "Test requires at least 2 GPUs";
+  }
+
+  ASSERT_OK_AND_ASSIGN(std::vector<se::StreamExecutor*> executors,
+                       CreateExecutors(platform, 2));
+
+  ASSERT_OK_AND_ASSIGN(auto comms, CreateCommunicators(executors, {kD0, kD1}));
+
+  EXPECT_TRUE(comms[0]->platform_comm().handle);
+  EXPECT_TRUE(comms[1]->platform_comm().handle);
+
+  ASSERT_OK_AND_ASSIGN(auto allocators, CreateMemoryAllocators(executors));
+  ASSERT_OK_AND_ASSIGN(auto allocs, Allocate(allocators, 1024));
+
+  // Unlike symmetric memory, buffer registration is not a collective operation:
+  // each rank may register independently. The returned handle keeps the buffer
+  // registered until it is destroyed.
+  std::vector<std::unique_ptr<RegisteredMemory>> registered;
+  for (size_t i = 0; i < comms.size(); ++i) {
+    ASSERT_OK_AND_ASSIGN(
+        auto reg, comms[i]->CreateRegisteredMemory(allocs[i]->address()));
+    EXPECT_EQ(reg->addr(), allocs[i]->address());
+    registered.push_back(std::move(reg));
+  }
 }
 
 TEST(GpuCollectivesTest, CreateSymmetricMemoryOnDifferentComms) {

--- a/xla/backends/gpu/collectives/gpu_communicator.h
+++ b/xla/backends/gpu/collectives/gpu_communicator.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
+#include "xla/core/collectives/registered_memory.h"
 #include "xla/core/collectives/symmetric_memory.h"
 #include "xla/future.h"
 #include "xla/stream_executor/device_address.h"
@@ -135,6 +136,16 @@ class GpuCommunicator : public Communicator {
   virtual absl::StatusOr<std::unique_ptr<GpuDeviceCommunicator>>
   CreateDeviceComm(const GpuDeviceCommunicator::Requirements& requirements) {
     return Unimplemented("Device communicator is not implementing");
+  }
+
+  // Registers an existing device address range with this communicator for
+  // accelerated ("zero-copy") collectives. Unlike CreateSymmetricMemory this
+  // makes no symmetry assumption about the buffer's address across ranks and is
+  // NOT a collective operation -- each rank may register independently. Returns
+  // an RAII handle; destroying it deregisters the range from this communicator.
+  virtual absl::StatusOr<std::unique_ptr<RegisteredMemory>>
+  CreateRegisteredMemory(se::DeviceAddressBase addr) {
+    return Unimplemented("Registered memory is not implemented");
   }
 
   // Creates a symmetric memory from the existing device address range. This is

--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -40,12 +40,14 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/backends/gpu/collectives/nccl_errors.h"
+#include "xla/backends/gpu/collectives/nccl_registered_memory.h"
 #include "xla/backends/gpu/collectives/nccl_symmetric_memory.h"
 #include "xla/backends/gpu/collectives/nccl_types.h"
 #include "xla/backends/gpu/collectives/single_threaded_executor.h"
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
+#include "xla/core/collectives/registered_memory.h"
 #include "xla/core/collectives/symmetric_memory.h"
 #include "xla/future.h"
 #include "xla/primitive_util.h"
@@ -186,6 +188,19 @@ NcclCommunicator::CreateDeviceComm(
         }
 
         return NcclDeviceCommunicator::CreateFrom(*this, requirements);
+      });
+}
+
+absl::StatusOr<std::unique_ptr<RegisteredMemory>>
+NcclCommunicator::CreateRegisteredMemory(se::DeviceAddressBase addr) {
+  return ExecuteAwait<std::unique_ptr<RegisteredMemory>>(
+      [this, addr]() -> absl::StatusOr<std::unique_ptr<RegisteredMemory>> {
+        VLOG(5) << "Registering buffer for device address: " << addr.opaque();
+        if (cancel_->IsCancelled()) {
+          return FailedPrecondition("NcclCommunicator aborted");
+        }
+
+        return NcclRegisteredMemory::Create(comm_, addr);
       });
 }
 

--- a/xla/backends/gpu/collectives/nccl_communicator.h
+++ b/xla/backends/gpu/collectives/nccl_communicator.h
@@ -39,6 +39,7 @@ limitations under the License.
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
+#include "xla/core/collectives/registered_memory.h"
 #include "xla/core/collectives/symmetric_memory.h"
 #include "xla/future.h"
 #include "xla/stream_executor/device_address.h"
@@ -104,6 +105,9 @@ class NcclCommunicator : public GpuCommunicator {
 
   absl::StatusOr<std::unique_ptr<GpuDeviceCommunicator>> CreateDeviceComm(
       const GpuDeviceCommunicator::Requirements& requirements) final;
+
+  absl::StatusOr<std::unique_ptr<RegisteredMemory>> CreateRegisteredMemory(
+      se::DeviceAddressBase addr) final;
 
   absl::StatusOr<std::unique_ptr<SymmetricMemory>> CreateSymmetricMemory(
       se::DeviceAddressBase addr) final;

--- a/xla/backends/gpu/collectives/nccl_registered_memory.cc
+++ b/xla/backends/gpu/collectives/nccl_registered_memory.cc
@@ -1,0 +1,66 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/nccl_registered_memory.h"
+
+#include <memory>
+#include <string>
+
+#include "absl/log/log.h"
+#include "absl/memory/memory.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "xla/backends/gpu/collectives/nccl_errors.h"
+#include "xla/stream_executor/device_address.h"
+
+// Include NCCL after XLA headers.
+#include "third_party/nccl/nccl.h"
+
+namespace xla::gpu {
+
+NcclRegisteredMemory::NcclRegisteredMemory(
+    ncclComm_t comm, void* handle, stream_executor::DeviceAddressBase addr)
+    : comm_(comm), handle_(handle), addr_(addr) {}
+
+absl::StatusOr<std::unique_ptr<NcclRegisteredMemory>>
+NcclRegisteredMemory::Create(ncclComm_t comm,
+                             stream_executor::DeviceAddressBase addr) {
+  VLOG(3) << absl::StrFormat(
+      "Create NCCL registered memory on comm=%p from: ptr=%p; size=%ld", comm,
+      addr.opaque(), addr.size());
+
+  void* handle = nullptr;
+  XLA_NCCL_RETURN_IF_ERROR(
+      ncclCommRegister(comm, addr.opaque(), addr.size(), &handle));
+
+  return absl::WrapUnique(new NcclRegisteredMemory(comm, handle, addr));
+}
+
+NcclRegisteredMemory::~NcclRegisteredMemory() {
+  VLOG(3) << absl::StrFormat("Destroy %v", *this);
+  XLA_NCCL_LOG_IF_ERROR(ncclCommDeregister(comm_, handle_));
+}
+
+stream_executor::DeviceAddressBase NcclRegisteredMemory::addr() const {
+  return addr_;
+}
+
+std::string NcclRegisteredMemory::ToString() const {
+  return absl::StrFormat(
+      "NcclRegisteredMemory(comm=%p, handle=%p, ptr=%p, size=%ld)", comm_,
+      handle_, addr_.opaque(), addr_.size());
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/nccl_registered_memory.h
+++ b/xla/backends/gpu/collectives/nccl_registered_memory.h
@@ -1,0 +1,60 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_NCCL_REGISTERED_MEMORY_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_NCCL_REGISTERED_MEMORY_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "third_party/nccl/nccl.h"
+#include "xla/core/collectives/registered_memory.h"
+#include "xla/stream_executor/device_address.h"
+
+namespace xla::gpu {
+
+// A NCCL local buffer registration handle (ncclCommRegister). Registering a
+// buffer lets NCCL set up IPC / NVLS / network handles for the range ahead of
+// time so that subsequent collectives over the range can run zero-copy.
+//
+// Unlike NcclSymmetricMemory this does NOT call ncclCommWindowRegister and
+// makes no symmetry assumption about the buffer across ranks: it is safe for
+// arbitrary device address ranges (e.g. slices into a larger allocation) that
+// are not symmetric across the clique. The handle is deregistered
+// (ncclCommDeregister) on destruction.
+class NcclRegisteredMemory final : public RegisteredMemory {
+ public:
+  ~NcclRegisteredMemory() final;
+
+  static absl::StatusOr<std::unique_ptr<NcclRegisteredMemory>> Create(
+      ncclComm_t comm, stream_executor::DeviceAddressBase addr);
+
+  stream_executor::DeviceAddressBase addr() const final;
+
+  std::string ToString() const final;
+
+ private:
+  NcclRegisteredMemory(ncclComm_t comm, void* handle,
+                       stream_executor::DeviceAddressBase addr);
+
+  ncclComm_t comm_;
+  void* handle_;
+  stream_executor::DeviceAddressBase addr_;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_NCCL_REGISTERED_MEMORY_H_

--- a/xla/core/collectives/BUILD
+++ b/xla/core/collectives/BUILD
@@ -137,6 +137,15 @@ tf_proto_library(
 )
 
 cc_library(
+    name = "registered_memory",
+    hdrs = ["registered_memory.h"],
+    deps = [
+        "//xla/stream_executor:device_address",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)
+
+cc_library(
     name = "symmetric_memory",
     hdrs = ["symmetric_memory.h"],
     deps = [

--- a/xla/core/collectives/registered_memory.h
+++ b/xla/core/collectives/registered_memory.h
@@ -1,0 +1,59 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_CORE_COLLECTIVES_REGISTERED_MEMORY_H_
+#define XLA_CORE_COLLECTIVES_REGISTERED_MEMORY_H_
+
+#include <string>
+
+#include "absl/strings/str_format.h"
+#include "xla/stream_executor/device_address.h"
+
+namespace xla {
+
+// An RAII handle for a device address range that has been registered with a
+// communicator for accelerated ("zero-copy") collective operations.
+//
+// Unlike SymmetricMemory, registration makes NO symmetry assumption about the
+// buffer's address across ranks: the same logical buffer may live at a
+// different virtual address, and at a different offset within its allocation,
+// on every rank. Registration is a purely local optimization hint to the
+// backend; it does not change collective semantics or results, only speed. As
+// such, registration is *not* a collective operation -- each rank may register
+// (and deregister) independently.
+//
+// Because no symmetry is assumed, a RegisteredMemory exposes nothing usable
+// from a device kernel (no peer pointers, no multimem address, no packed kernel
+// argument). It is purely a host-side lifetime handle: the range stays
+// registered for as long as this object is alive, and is deregistered from the
+// owning communicator when the object is destroyed.
+class RegisteredMemory {
+ public:
+  virtual ~RegisteredMemory() = default;
+
+  // The device address range this handle keeps registered.
+  virtual stream_executor::DeviceAddressBase addr() const = 0;
+
+  virtual std::string ToString() const = 0;
+
+  template <typename Sink>
+  friend void AbslStringify(Sink& sink, const RegisteredMemory& mem) {
+    absl::Format(&sink, "%s", mem.ToString());
+  }
+};
+
+}  // namespace xla
+
+#endif  // XLA_CORE_COLLECTIVES_REGISTERED_MEMORY_H_


### PR DESCRIPTION
This is a revival of registered memory deleted in https://github.com/openxla/xla/commit/51ba59ee3cf4e42c5bb503aa236494988ab44d6e, the old API was useless, but the registered memory vs symmetric memory distinction is critical and we need both at run time. This PR restores registered memory in XLA, but in a new modernized form consistent with `SymmetricMemory`.

`RegisteredMemory` is purely a host-side optimization hint and lifetime handle: it lets NCCL set up IPC/NVLS/network handles for the range ahead of time so subsequent collectives run zero-copy, without changing collective semantics or results. Because no symmetry is assumed, it deliberately exposes no usable APIs.