### PR TITLE
[NVIDIA GPU] Add manual mode for double buffer unrolling pass

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1328,6 +1328,7 @@ cc_library(
     srcs = ["double_buffer_loop_unrolling.cc"],
     hdrs = ["double_buffer_loop_unrolling.h"],
     deps = [
+        "//xla:side_effect_util",
         "//xla:util",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",

--- a/xla/backends/gpu/transforms/double_buffer_loop_unrolling.cc
+++ b/xla/backends/gpu/transforms/double_buffer_loop_unrolling.cc
@@ -581,26 +581,31 @@ absl::StatusOr<bool> DoubleBufferLoopUnrolling::RunImpl(
     auto& attrs = while_instr->frontend_attributes().map();
     if (auto it = attrs.find(kXlaLoopUnrollAttr); it != attrs.end()) {
       manual_unroll_attr_val = it->second;
-      CHECK(absl::EqualsIgnoreCase(manual_unroll_attr_val,
-                                   manual_unroll_double_buffer) ||
-            absl::EqualsIgnoreCase(manual_unroll_attr_val, manual_unroll_full))
-          << "Invalid value for " << kXlaLoopUnrollAttr
-          << " attribute: " << manual_unroll_attr_val
-          << ". Expected values are: " << manual_unroll_double_buffer << ", "
-          << manual_unroll_full;
+      if (!(absl::EqualsIgnoreCase(manual_unroll_attr_val,
+                                   kManualUnrollDoubleBuffer) ||
+            absl::EqualsIgnoreCase(manual_unroll_attr_val,
+                                   kManualUnrollFull))) {
+        LOG(FATAL) << "Invalid value for " << kXlaLoopUnrollAttr
+                   << " attribute: " << manual_unroll_attr_val
+                   << ". Expected values are: " << kManualUnrollDoubleBuffer
+                   << ", " << kManualUnrollFull;
+      }
     }
-    if (unroll_strategy_ == UnrollStrategy::kFullUnroll ||
-        (unroll_strategy_ == UnrollStrategy::kManual &&
-         absl::EqualsIgnoreCase(manual_unroll_attr_val, manual_unroll_full))) {
+    if (unroll_strategy_ == UnrollStrategy::kFullUnroll) {
       ASSIGN_OR_RETURN(changed, FullyUnroll(while_instr, module));
-    } else if (unroll_strategy_ == UnrollStrategy::kDoubleBuffer ||
-               (unroll_strategy_ == UnrollStrategy::kManual &&
-                absl::EqualsIgnoreCase(manual_unroll_attr_val,
-                                       manual_unroll_double_buffer))) {
+    } else if (unroll_strategy_ == UnrollStrategy::kDoubleBuffer) {
       ASSIGN_OR_RETURN(changed, DoubleBufferingUnroll(while_instr, module));
     } else if (unroll_strategy_ == UnrollStrategy::kAuto) {
       ASSIGN_OR_RETURN(changed, AutoUnroll(while_instr, module));
-    } else if (unroll_strategy_ != UnrollStrategy::kManual) {
+    } else if (unroll_strategy_ == UnrollStrategy::kManual) {
+      if (absl::EqualsIgnoreCase(manual_unroll_attr_val, kManualUnrollFull)) {
+        ASSIGN_OR_RETURN(changed, FullyUnroll(while_instr, module));
+      }
+      if (absl::EqualsIgnoreCase(manual_unroll_attr_val,
+                                 kManualUnrollDoubleBuffer)) {
+        ASSIGN_OR_RETURN(changed, DoubleBufferingUnroll(while_instr, module));
+      }
+    } else {
       LOG(FATAL) << absl::StrCat("Unhandled unrolling strategy: ",
                                  unroll_strategy_);
     }

--- a/xla/backends/gpu/transforms/double_buffer_loop_unrolling.cc
+++ b/xla/backends/gpu/transforms/double_buffer_loop_unrolling.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "xla/tsl/platform/status_macros.h"
@@ -41,6 +42,7 @@ limitations under the License.
 #include "xla/hlo/utils/hlo_query.h"
 #include "xla/service/collective_ops_utils.h"
 #include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/side_effect_util.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
 
@@ -575,14 +577,30 @@ absl::StatusOr<bool> DoubleBufferLoopUnrolling::RunImpl(
               << " has an iteration count of one, skipping unrolling.";
       continue;
     }
-
-    if (unroll_strategy_ == UnrollStrategy::kFullUnroll) {
+    absl::string_view manual_unroll_attr_val = "";
+    auto& attrs = while_instr->frontend_attributes().map();
+    if (auto it = attrs.find(kXlaLoopUnrollAttr); it != attrs.end()) {
+      manual_unroll_attr_val = it->second;
+      CHECK(absl::EqualsIgnoreCase(manual_unroll_attr_val,
+                                   manual_unroll_double_buffer) ||
+            absl::EqualsIgnoreCase(manual_unroll_attr_val, manual_unroll_full))
+          << "Invalid value for " << kXlaLoopUnrollAttr
+          << " attribute: " << manual_unroll_attr_val
+          << ". Expected values are: " << manual_unroll_double_buffer << ", "
+          << manual_unroll_full;
+    }
+    if (unroll_strategy_ == UnrollStrategy::kFullUnroll ||
+        (unroll_strategy_ == UnrollStrategy::kManual &&
+         absl::EqualsIgnoreCase(manual_unroll_attr_val, manual_unroll_full))) {
       ASSIGN_OR_RETURN(changed, FullyUnroll(while_instr, module));
-    } else if (unroll_strategy_ == UnrollStrategy::kDoubleBuffer) {
+    } else if (unroll_strategy_ == UnrollStrategy::kDoubleBuffer ||
+               (unroll_strategy_ == UnrollStrategy::kManual &&
+                absl::EqualsIgnoreCase(manual_unroll_attr_val,
+                                       manual_unroll_double_buffer))) {
       ASSIGN_OR_RETURN(changed, DoubleBufferingUnroll(while_instr, module));
     } else if (unroll_strategy_ == UnrollStrategy::kAuto) {
       ASSIGN_OR_RETURN(changed, AutoUnroll(while_instr, module));
-    } else {
+    } else if (unroll_strategy_ != UnrollStrategy::kManual) {
       LOG(FATAL) << absl::StrCat("Unhandled unrolling strategy: ",
                                  unroll_strategy_);
     }

--- a/xla/backends/gpu/transforms/double_buffer_loop_unrolling.h
+++ b/xla/backends/gpu/transforms/double_buffer_loop_unrolling.h
@@ -64,8 +64,8 @@ class DoubleBufferLoopUnrolling : public HloModulePass {
     kAuto,
     kManual,
   };
-  static constexpr absl::string_view manual_unroll_full = "full";
-  static constexpr absl::string_view manual_unroll_double_buffer =
+  static constexpr absl::string_view kManualUnrollFull = "full";
+  static constexpr absl::string_view kManualUnrollDoubleBuffer =
       "double-buffer";
 
   explicit DoubleBufferLoopUnrolling(

--- a/xla/backends/gpu/transforms/double_buffer_loop_unrolling.h
+++ b/xla/backends/gpu/transforms/double_buffer_loop_unrolling.h
@@ -58,7 +58,15 @@ namespace gpu {
 // stride is multiplied by the unroll factor.
 class DoubleBufferLoopUnrolling : public HloModulePass {
  public:
-  enum class UnrollStrategy { kDoubleBuffer, kFullUnroll, kAuto };
+  enum class UnrollStrategy {
+    kDoubleBuffer,
+    kFullUnroll,
+    kAuto,
+    kManual,
+  };
+  static constexpr absl::string_view manual_unroll_full = "full";
+  static constexpr absl::string_view manual_unroll_double_buffer =
+      "double-buffer";
 
   explicit DoubleBufferLoopUnrolling(
       UnrollStrategy unroll_strategy = UnrollStrategy::kDoubleBuffer)

--- a/xla/backends/gpu/transforms/double_buffer_loop_unrolling_test.cc
+++ b/xla/backends/gpu/transforms/double_buffer_loop_unrolling_test.cc
@@ -2014,6 +2014,126 @@ ENTRY main {
               )pb"));
 }
 
+TEST_F(GpuLoopDoubleBufferTransformerTest, ManualFullyUnroll) {
+  const char* const kModuleString = R"(
+HloModule Manual_unroll
+condition_nested {
+  input_tuple = (s32[]) parameter(0)
+  cond = s32[] get-tuple-element(input_tuple), index=0
+  trip_count = s32[] constant(10)
+  ROOT done = pred[] compare(cond, trip_count), direction=LT
+}
+body_nested {
+ input_tuple = (s32[]) parameter(0)
+ cond = s32[] get-tuple-element(input_tuple), index=0
+ one = s32[] constant(1)
+ cond_plus_1 = s32[] add(cond, one)
+ ROOT output = (s32[]) tuple(cond_plus_1)
+}
+condition {
+  input_tuple = (s32[]) parameter(0)
+  cond = s32[] get-tuple-element(input_tuple), index=0
+  trip_count = s32[] constant(10)
+  ROOT done = pred[] compare(cond, trip_count), direction=LT
+}
+body {
+  input_tuple = (s32[]) parameter(0)
+  ROOT output = (s32[]) while(input_tuple), condition=condition_nested, body=body_nested, backend_config={"known_trip_count":{"n":"11"}}, frontend_attributes={_xla_loop_unroll="full"}
+}
+ENTRY main {
+ param_0 = (s32[]) parameter(0)
+ ROOT while = (s32[]) while(param_0), condition=condition, body=body, backend_config={"known_trip_count":{"n":"11"}}
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::HloModule> module,
+                          ParseAndReturnVerifiedModule(kModuleString));
+  DoubleBufferLoopUnrolling double_buffer(
+      DoubleBufferLoopUnrolling::UnrollStrategy::kManual);
+  EXPECT_THAT(double_buffer.Run(module.get()),
+              absl_testing::IsOkAndHolds(true));
+  auto outter_while = module->entry_computation()->root_instruction();
+  // The outter while loop should not be touched at all.
+  EXPECT_EQ(outter_while->opcode(), HloOpcode::kWhile);
+  EXPECT_EQ(outter_while->backend_config<WhileLoopBackendConfig>()
+                ->known_trip_count()
+                .n(),
+            11);
+  auto outter_while_body = outter_while->while_body();
+  int64_t num_inner_whiles = 0;
+  hlo_query::ForEachInstructionWithOpcode(
+      *outter_while_body, HloOpcode::kWhile,
+      [&num_inner_whiles](HloInstruction* instr) {
+        EXPECT_EQ(instr->backend_config<WhileLoopBackendConfig>()
+                      ->known_trip_count()
+                      .n(),
+                  1);
+        ++num_inner_whiles;
+      });
+  // Outter loop should not be unrolled, the inner while count should be still
+  // be 1.
+  EXPECT_EQ(num_inner_whiles, 1);
+}
+
+TEST_F(GpuLoopDoubleBufferTransformerTest, ManualDoubleBufferUnroll) {
+  const char* const kModuleString = R"(
+HloModule Manual_unroll
+condition_nested {
+  input_tuple = (s32[]) parameter(0)
+  cond = s32[] get-tuple-element(input_tuple), index=0
+  trip_count = s32[] constant(10)
+  ROOT done = pred[] compare(cond, trip_count), direction=LT
+}
+body_nested {
+ input_tuple = (s32[]) parameter(0)
+ cond = s32[] get-tuple-element(input_tuple), index=0
+ one = s32[] constant(1)
+ cond_plus_1 = s32[] add(cond, one)
+ ROOT output = (s32[]) tuple(cond_plus_1)
+}
+condition {
+  input_tuple = (s32[]) parameter(0)
+  cond = s32[] get-tuple-element(input_tuple), index=0
+  trip_count = s32[] constant(10)
+  ROOT done = pred[] compare(cond, trip_count), direction=LT
+}
+body {
+  input_tuple = (s32[]) parameter(0)
+  ROOT output = (s32[]) while(input_tuple), condition=condition_nested, body=body_nested, backend_config={"known_trip_count":{"n":"11"}}, frontend_attributes={_xla_loop_unroll="double-buffer"}
+}
+ENTRY main {
+ param_0 = (s32[]) parameter(0)
+ ROOT while = (s32[]) while(param_0), condition=condition, body=body, backend_config={"known_trip_count":{"n":"11"}}
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::HloModule> module,
+                          ParseAndReturnVerifiedModule(kModuleString));
+  DoubleBufferLoopUnrolling double_buffer(
+      DoubleBufferLoopUnrolling::UnrollStrategy::kManual);
+  EXPECT_THAT(double_buffer.Run(module.get()),
+              absl_testing::IsOkAndHolds(true));
+  auto outter_while = module->entry_computation()->root_instruction();
+  // The outter while loop should not be touched at all.
+  EXPECT_EQ(outter_while->opcode(), HloOpcode::kWhile);
+  EXPECT_EQ(outter_while->backend_config<WhileLoopBackendConfig>()
+                ->known_trip_count()
+                .n(),
+            11);
+  auto outter_while_body = outter_while->while_body();
+  int64_t num_inner_whiles = 0;
+  hlo_query::ForEachInstructionWithOpcode(
+      *outter_while_body, HloOpcode::kWhile,
+      [&num_inner_whiles](HloInstruction* instr) {
+        EXPECT_EQ(instr->backend_config<WhileLoopBackendConfig>()
+                      ->known_trip_count()
+                      .n(),
+                  5);
+        ++num_inner_whiles;
+      });
+  // Outter loop should not be unrolled, the inner while count should be still
+  // be 1.
+  EXPECT_EQ(num_inner_whiles, 1);
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/xla/backends/gpu/transforms/double_buffer_loop_unrolling_test.cc
+++ b/xla/backends/gpu/transforms/double_buffer_loop_unrolling_test.cc
@@ -2038,7 +2038,7 @@ condition {
 }
 body {
   input_tuple = (s32[]) parameter(0)
-  ROOT output = (s32[]) while(input_tuple), condition=condition_nested, body=body_nested, backend_config={"known_trip_count":{"n":"11"}}, frontend_attributes={_xla_loop_unroll="full"}
+  ROOT output = (s32[]) while(input_tuple), condition=condition_nested, body=body_nested, backend_config={"known_trip_count":{"n":"11"}}, frontend_attributes={_xla_loop_unroll_strategy="full"}
 }
 ENTRY main {
  param_0 = (s32[]) parameter(0)
@@ -2051,14 +2051,15 @@ ENTRY main {
       DoubleBufferLoopUnrolling::UnrollStrategy::kManual);
   EXPECT_THAT(double_buffer.Run(module.get()),
               absl_testing::IsOkAndHolds(true));
-  auto outter_while = module->entry_computation()->root_instruction();
+  HloInstruction* outter_while =
+      module->entry_computation()->root_instruction();
   // The outter while loop should not be touched at all.
   EXPECT_EQ(outter_while->opcode(), HloOpcode::kWhile);
   EXPECT_EQ(outter_while->backend_config<WhileLoopBackendConfig>()
                 ->known_trip_count()
                 .n(),
             11);
-  auto outter_while_body = outter_while->while_body();
+  HloComputation* outter_while_body = outter_while->while_body();
   int64_t num_inner_whiles = 0;
   hlo_query::ForEachInstructionWithOpcode(
       *outter_while_body, HloOpcode::kWhile,
@@ -2098,7 +2099,7 @@ condition {
 }
 body {
   input_tuple = (s32[]) parameter(0)
-  ROOT output = (s32[]) while(input_tuple), condition=condition_nested, body=body_nested, backend_config={"known_trip_count":{"n":"11"}}, frontend_attributes={_xla_loop_unroll="double-buffer"}
+  ROOT output = (s32[]) while(input_tuple), condition=condition_nested, body=body_nested, backend_config={"known_trip_count":{"n":"11"}}, frontend_attributes={_xla_loop_unroll_strategy="double-buffer"}
 }
 ENTRY main {
  param_0 = (s32[]) parameter(0)
@@ -2111,14 +2112,15 @@ ENTRY main {
       DoubleBufferLoopUnrolling::UnrollStrategy::kManual);
   EXPECT_THAT(double_buffer.Run(module.get()),
               absl_testing::IsOkAndHolds(true));
-  auto outter_while = module->entry_computation()->root_instruction();
+  HloInstruction* outter_while =
+      module->entry_computation()->root_instruction();
   // The outter while loop should not be touched at all.
   EXPECT_EQ(outter_while->opcode(), HloOpcode::kWhile);
   EXPECT_EQ(outter_while->backend_config<WhileLoopBackendConfig>()
                 ->known_trip_count()
                 .n(),
             11);
-  auto outter_while_body = outter_while->while_body();
+  HloComputation* outter_while_body = outter_while->while_body();
   int64_t num_inner_whiles = 0;
   hlo_query::ForEachInstructionWithOpcode(
       *outter_while_body, HloOpcode::kWhile,

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -1776,7 +1776,9 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "`WHILE_LOOP_UNROLLING_DOUBLE_BUFFER` unrolls the loop by factor of 2, "
       "`WHILE_LOOP_UNROLLING_FULL_UNROLL` will unroll the entire loop "
       "`WHILE_LOOP_UNROLLING_AUTO_UNROLL` unrolls by a factor of 2, if there is"
-      " any collective present within a while loop."));
+      " any collective present within a while loop."
+      "`WHILE_LOOP_UNROLLING_MANUAL_UNROLL` will unroll loops annotated with"
+      " the `_xla_loop_unroll` attribute."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_all_reduce_combine_threshold_bytes",
       int64_setter_for(

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -105,7 +105,8 @@ absl::StatusOr<std::vector<RepeatedFlagModifier>> ParseRepeatedEnumModifiers(
 namespace {
 
 template <typename T>
-static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list, T value) {
+static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list,
+                                   T value) {
   for (auto it = list->begin(); it != list->end(); ++it) {
     if (*it == value) {
       return it;
@@ -1778,7 +1779,7 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "`WHILE_LOOP_UNROLLING_AUTO_UNROLL` unrolls by a factor of 2, if there is"
       " any collective present within a while loop."
       "`WHILE_LOOP_UNROLLING_MANUAL_UNROLL` will unroll loops annotated with"
-      " the `_xla_loop_unroll` attribute."));
+      " the `_xla_loop_unroll_strategy` attribute."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_all_reduce_combine_threshold_bytes",
       int64_setter_for(
@@ -3372,8 +3373,7 @@ FlagStatus GetFlagStatus(absl::string_view flag_name) {
           "xla_gpu_all_reduce_combine_threshold_bytes",
           "xla_gpu_autotune_level",
           "xla_gpu_collective_permute_decomposer_threshold",
-          "xla_gpu_cublas_fallback",
-          "xla_gpu_dot_merger_threshold_mb",
+          "xla_gpu_cublas_fallback", "xla_gpu_dot_merger_threshold_mb",
           "xla_gpu_enable_dynamic_slice_fusion",
           "xla_gpu_enable_latency_hiding_scheduler",
           "xla_gpu_enable_pipelined_all_gather",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1296,6 +1296,12 @@ void AddDoubleBufferingPasses(const HloModule& module,
       !opts.xla_gpu_enable_while_loop_double_buffering()) {
     unroll_strategy = DoubleBufferLoopUnrolling::UnrollStrategy::kAuto;
   }
+  if (opts.xla_gpu_enable_while_loop_unrolling() ==
+          DebugOptions::WHILE_LOOP_UNROLLING_MANUAL_UNROLL &&
+      IsPassEnabledAtOptimizationEffort<DoubleBufferLoopUnrolling>(module) &&
+      !opts.xla_gpu_enable_while_loop_double_buffering()) {
+    unroll_strategy = DoubleBufferLoopUnrolling::UnrollStrategy::kManual;
+  }
   if (unroll_strategy.has_value()) {
     pipeline.AddPass<WhileLoopSimplifier>();
     pipeline.AddPass<DoubleBufferLoopUnrolling>(*unroll_strategy);

--- a/xla/side_effect_util.cc
+++ b/xla/side_effect_util.cc
@@ -105,4 +105,6 @@ const char kXlaTableNameAttr[] = "_xla_table_name";
 
 const char kCombinerKeyAttr[] = "combiner_key";
 
+const char kXlaLoopUnrollAttr[] = "_xla_loop_unroll";
+
 }  // namespace xla

--- a/xla/side_effect_util.cc
+++ b/xla/side_effect_util.cc
@@ -105,6 +105,6 @@ const char kXlaTableNameAttr[] = "_xla_table_name";
 
 const char kCombinerKeyAttr[] = "combiner_key";
 
-const char kXlaLoopUnrollAttr[] = "_xla_loop_unroll";
+const char kXlaLoopUnrollAttr[] = "_xla_loop_unroll_strategy";
 
 }  // namespace xla

--- a/xla/side_effect_util.h
+++ b/xla/side_effect_util.h
@@ -128,6 +128,9 @@ extern const char kXlaTableNameAttr[];
 // Collectives with different combiner_key values will not be combined together.
 extern const char kCombinerKeyAttr[];
 
+// Frontend attribute key used to control loop unrolling.
+extern const char kXlaLoopUnrollAttr[];
+
 }  // namespace xla
 
 #endif  // XLA_SIDE_EFFECT_UTIL_H_

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -140,7 +140,8 @@ message DebugOptions {
     // Enables loop unrolling when we have at least one collective within a
     // while loop.
     WHILE_LOOP_UNROLLING_AUTO_UNROLL = 3;
-    // Enables loop unrolling only on loops annotated with _xla_loop_unroll.
+    // Enables loop unrolling only on loops annotated with
+    // `_xla_loop_unroll_strategy`.
     WHILE_LOOP_UNROLLING_MANUAL_UNROLL = 4;
   }
 

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -140,6 +140,8 @@ message DebugOptions {
     // Enables loop unrolling when we have at least one collective within a
     // while loop.
     WHILE_LOOP_UNROLLING_AUTO_UNROLL = 3;
+    // Enables loop unrolling only on loops annotated with _xla_loop_unroll.
+    WHILE_LOOP_UNROLLING_MANUAL_UNROLL = 4;
   }
 
   //--------------------------------------------------------------------------//


### PR DESCRIPTION
📝 Summary of Changes
Support manual mode in the double buffer unrolling pass.
This is to give users the flexibility to annotate which while loop that needs to be unrolled.
It's non-trivial to infer user intention in terms of loop unrolling, so I'm providing an option for users to tell xla the intention.