### PR TITLE
[xla:gpu] Add safety checks for DUS buffer aliasing

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -631,6 +631,7 @@ xla_test(
         "//xla/tsl/platform:test",
         "//xla/tsl/util/proto:proto_matchers",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",  # fixdeps: keep

--- a/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.cc
@@ -136,6 +136,48 @@ absl::Status DynamicSliceFusionV2Thunk::Initialize(
   return executor_.Initialize(params);
 }
 
+absl::Status DynamicSliceFusionV2Thunk::VerifyBufferAssignment(
+    absl::Span<const DynamicSliceFusion::Result> results,
+    absl::Span<const BufferAllocation::Slice> parameter_buffers,
+    absl::Span<const BufferAllocation::Slice> result_buffers) {
+  for (const DynamicSliceFusion::Result& result : results) {
+    if (!result.parameter_number.has_value()) {
+      continue;
+    }
+
+    const int64_t parameter_number = *result.parameter_number;
+    const int64_t parameter_buffer_count = parameter_buffers.size();
+
+    if (parameter_number < 0 || parameter_number >= parameter_buffer_count) {
+      return Internal(
+          "DUS result %d targets missing fusion parameter %d; parameter buffer "
+          "count is %d",
+          result.result_number, parameter_number, parameter_buffer_count);
+    }
+
+    const int64_t result_buffer_count = result_buffers.size();
+    if (result.result_number < 0 ||
+        result.result_number >= result_buffer_count) {
+      return Internal(
+          "DUS result %d has no result buffer; result buffer count is %d",
+          result.result_number, result_buffer_count);
+    }
+
+    const BufferAllocation::Slice& parameter_buffer =
+        parameter_buffers[parameter_number];
+    const BufferAllocation::Slice& result_buffer =
+        result_buffers[result.result_number];
+    if (parameter_buffer != result_buffer) {
+      return Internal(
+          "DUS result %d must alias fusion parameter %d, but result buffer is "
+          "%v and parameter buffer is %v",
+          result.result_number, parameter_number, result_buffer,
+          parameter_buffer);
+    }
+  }
+  return absl::OkStatus();
+}
+
 static absl::Status VerifySliceOffset(
     se::Stream& stream, const BufferAllocations& orig, absl::string_view kind,
     size_t idx, const std::optional<DynamicSliceConfig>& config,

--- a/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.h
+++ b/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.h
@@ -96,6 +96,14 @@ class DynamicSliceFusionV2Thunk : public Thunk {
   std::string ToString(int indent) const override;
 
   absl::StatusOr<ThunkProto> ToProto() const override;
+
+  // Verifies that every result written through a DynamicUpdateSlice aliases the
+  // fusion parameter used as the DUS target buffer.
+  static absl::Status VerifyBufferAssignment(
+      absl::Span<const DynamicSliceFusion::Result> results,
+      absl::Span<const BufferAllocation::Slice> parameter_buffers,
+      absl::Span<const BufferAllocation::Slice> result_buffers);
+
   static absl::StatusOr<std::unique_ptr<DynamicSliceFusionV2Thunk>> FromProto(
       ThunkInfo thunk_info, const DynamicSliceFusionThunkProto& proto,
       absl::Span<const BufferAllocation> buffer_allocations,

--- a/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk_test.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk_test.cc
@@ -23,7 +23,9 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
@@ -53,11 +55,13 @@ limitations under the License.
 namespace xla::gpu {
 namespace {
 
+using ::absl_testing::StatusIs;
+using ::testing::HasSubstr;
+using ::tsl::proto_testing::EqualsProto;
+
 using Parameter = DynamicSliceFusion::Parameter;
 using Result = DynamicSliceFusion::Result;
 using Offset = DynamicSliceFusion::Offset;
-using Expr = Offset::Expr;
-using ::tsl::proto_testing::EqualsProto;
 
 static absl::StatusOr<se::StreamExecutor*> CreateExecutor() {
   ASSIGN_OR_RETURN(std::string platform_name,
@@ -121,6 +125,31 @@ Thunk::ExecuteParams MakeExecuteParams(
       run_options, buffer_allocations, stream,
       /*command_buffer_trace_stream=*/nullptr, /*collective_params=*/nullptr,
       /*collective_cliques=*/nullptr, /*collective_memory=*/nullptr);
+}
+
+TEST(DynamicSliceFusionV2ThunkTest, VerifyBufferAssignment) {
+  BufferAllocation parameter_buffer(0, 1024, 0);
+  BufferAllocation unaliased_result_buffer(1, 1024, 0);
+  Shape result_shape = ShapeUtil::MakeShape(F32, {256});
+  Shape update_shape = ShapeUtil::MakeShape(F32, {64});
+
+  std::vector<Result> results = {
+      {0, 0, result_shape, update_shape, MakeConfig(0, 0, 256)}};
+
+  std::vector<BufferAllocation::Slice> parameter_buffers = {
+      BufferAllocation::Slice(&parameter_buffer, 0, 1024)};
+  std::vector<BufferAllocation::Slice> aliased_result_buffers = {
+      BufferAllocation::Slice(&parameter_buffer, 0, 1024)};
+  std::vector<BufferAllocation::Slice> unaliased_result_buffers = {
+      BufferAllocation::Slice(&unaliased_result_buffer, 0, 1024)};
+
+  EXPECT_OK(DynamicSliceFusionV2Thunk::VerifyBufferAssignment(
+      results, parameter_buffers, aliased_result_buffers));
+
+  absl::Status status = DynamicSliceFusionV2Thunk::VerifyBufferAssignment(
+      results, parameter_buffers, unaliased_result_buffers);
+  EXPECT_THAT(status,
+              StatusIs(absl::StatusCode::kInternal, HasSubstr("must alias")));
 }
 
 //===----------------------------------------------------------------------===//

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -1411,6 +1411,9 @@ AsyncThunkSequence ThunkEmitter::EmitDynamicSliceFusionV2(
         return absl::OkStatus();
       }));
 
+  RETURN_IF_ERROR(DynamicSliceFusionV2Thunk::VerifyBufferAssignment(
+      results, parameter_buffers, result_buffers));
+
   // embedded_allocations: synthetic allocations for the embedded thunk
   // executor. First N entries are for hero operands (one per Parameter),
   // then M entries for hero results (one per Result).


### PR DESCRIPTION
DUS thunk assumes that all `dynamic-update-slice` operations performed inplace, and it is safe to assume so, because alias analysis forces all fusions with DUS root to alias with parameters. However if for any reason this is not true (bugs?), executing DUS thunk will lead to UB. Add explicit check to catch such bugs early.