### PR TITLE
  [XLA:GPU] DeviceAddressVmmAllocator supports reservation-backed VMM allocations

### DIFF
--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -1017,9 +1017,11 @@ xla_cc_test(
     ],
     deps = [
         ":cuda_device_address_vmm_allocator",
+        ":cuda_memory_reservation",
         ":cuda_platform",
         "//xla/service:computation_placer_hdr",
         "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_space",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:platform_manager",
         "//xla/stream_executor:stream",

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -284,6 +284,62 @@ TEST_F(DeviceAddressVmmAllocatorTest, MapAndUnMapReservationAlias) {
   ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
 }
 
+TEST_F(DeviceAddressVmmAllocatorTest,
+       AllocateIntoReservationReturnsReservationAddress) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+
+  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
+                                             executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto address,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective),
+                          reservation.get(), /*reservation_offset=*/0,
+                          granularity,
+                          /*return_reservation_address=*/true));
+
+  EXPECT_EQ(address->opaque(), reservation->address().opaque());
+  EXPECT_NE(allocator->GetRawAllocation(ordinal, address.cref()), nullptr);
+
+  ASSERT_THAT(allocator->Deallocate(ordinal, address.Release()), IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       AllocateIntoReservationReturnsAllocatorAddress) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+
+  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
+                                             executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto address,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective),
+                          reservation.get(), /*reservation_offset=*/0,
+                          granularity,
+                          /*return_reservation_address=*/false));
+
+  EXPECT_NE(address->opaque(), reservation->address().opaque());
+  EXPECT_THAT(allocator->Deallocate(ordinal, address.cref()),
+              absl_testing::StatusIs(absl::StatusCode::kFailedPrecondition));
+  ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
 TEST_F(DeviceAddressVmmAllocatorTest, DeallocateNull) {
   TF_ASSERT_OK_AND_ASSIGN(
       auto allocator,

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -25,7 +25,9 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "xla/service/computation_placer.h"
+#include "xla/stream_executor/cuda/cuda_memory_reservation.h"
 #include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_space.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
 #include "xla/stream_executor/stream.h"
@@ -92,9 +94,6 @@ TEST_F(DeviceAddressVmmAllocatorTest, AllocateAndDeallocate) {
   EXPECT_EQ(scoped_address->size(), 1024);
   EXPECT_NE(
       allocator->GetRawAllocation(executor_->device_ordinal(), *scoped_address),
-      nullptr);
-  EXPECT_NE(
-      allocator->GetReservation(executor_->device_ordinal(), *scoped_address),
       nullptr);
 
   // The ScopedDeviceAddress will automatically deallocate when it goes out of
@@ -255,6 +254,34 @@ TEST_F(DeviceAddressVmmAllocatorTest, SynchronizePendingOperationsDrainsQueue) {
 
   ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
   EXPECT_EQ(allocator->GetRawAllocation(ordinal, addr), nullptr);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, MapAndUnMapReservationAlias) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+
+  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
+                                             executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  ASSERT_THAT(allocator->Map(ordinal, source.cref(), reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+  EXPECT_THAT(allocator->Deallocate(ordinal, source.cref()),
+              absl_testing::StatusIs(absl::StatusCode::kFailedPrecondition));
+
+  ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
 }
 
 TEST_F(DeviceAddressVmmAllocatorTest, DeallocateNull) {
@@ -494,8 +521,6 @@ TEST_F(MultiDeviceVmmAllocatorTest, AllocateOnBothDevices) {
     EXPECT_NE(
         allocator->GetRawAllocation(executors_[i]->device_ordinal(), *addr),
         nullptr);
-    EXPECT_NE(allocator->GetReservation(executors_[i]->device_ordinal(), *addr),
-              nullptr);
     TF_ASSERT_OK_AND_ASSIGN(
         StreamExecutor * se,
         allocator->GetStreamExecutor(executors_[i]->device_ordinal()));

--- a/xla/stream_executor/vmm_device_address_allocator.cc
+++ b/xla/stream_executor/vmm_device_address_allocator.cc
@@ -311,6 +311,112 @@ absl::StatusOr<DeviceAddressBase> DeviceAddressVmmAllocator::AllocateWithBudget(
   return DeviceAddressBase(va_ptr, size);
 }
 
+absl::StatusOr<ScopedDeviceAddress<uint8_t>>
+DeviceAddressVmmAllocator::Allocate(
+    int device_ordinal, uint64_t allocation_size, bool /*retry_on_failure*/,
+    int64_t /*memory_space*/, MemoryReservation* reservation,
+    uint64_t reservation_offset, uint64_t mapping_size,
+    bool return_reservation_address) {
+  if (allocation_size != mapping_size) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "VMM mapped allocation size (%u) must equal mapping size (%u)",
+        allocation_size, mapping_size));
+  }
+  if (allocation_size == 0) {
+    return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
+                                        this);
+  }
+  if (reservation == nullptr) {
+    return absl::InvalidArgumentError(
+        "VMM mapped allocation requires a non-null reservation");
+  }
+  DeviceAddressBase reservation_range = reservation->address();
+  if (reservation_offset > reservation_range.size() ||
+      mapping_size > reservation_range.size() - reservation_offset) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Reservation range [%u, %u) is outside reservation size %u",
+        reservation_offset, reservation_offset + mapping_size,
+        reservation_range.size()));
+  }
+  DeviceAddressBase reservation_address =
+      reservation_range.GetByteSlice(reservation_offset, mapping_size);
+
+  PerDeviceState* state = GetPerDeviceState(device_ordinal);
+  if (state == nullptr) {
+    return DeviceNotFoundError(device_ordinal);
+  }
+
+  const bool multi_device = CurrentMultiDevice();
+
+  absl::MutexLock lock(state->mu);
+  if (state->active_reservation_mappings.contains(
+          reservation_address.opaque()) ||
+      state->stale_reservation_mappings.contains(
+          reservation_address.opaque()) ||
+      state->raw_allocations.contains(reservation_address.opaque())) {
+    return absl::FailedPreconditionError(
+        "Reservation address is already tracked by this allocator");
+  }
+
+  uint64_t rounded_size = RoundUpToGranularity(*state, allocation_size);
+  if (state->pa_allocated + rounded_size > state->pa_budget) {
+    return absl::ResourceExhaustedError(absl::StrFormat(
+        "Not enough PA budget for allocation: pa_allocated=%uB, "
+        "rounded_size=%uB, pa_budget=%uB",
+        state->pa_allocated, rounded_size, state->pa_budget));
+  }
+
+  ASSIGN_OR_RETURN(auto raw_alloc,
+                   CreateAllocation(state->executor, allocation_size));
+  const uint64_t padded_size = raw_alloc->address().size();
+  if (mapping_size > padded_size) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Mapping size %u exceeds raw allocation size %u",
+                        mapping_size, padded_size));
+  }
+
+  ASSIGN_OR_RETURN(
+      MemoryReservation::ScopedMapping reservation_mapping,
+      reservation->MapTo(reservation_offset, /*allocation_offset=*/0,
+                         mapping_size, *raw_alloc));
+
+  std::unique_ptr<MemoryReservation> allocator_reservation;
+  MemoryReservation::ScopedMapping allocator_mapping;
+  DeviceAddressBase allocator_address = reservation_address;
+
+  if (!return_reservation_address) {
+    ASSIGN_OR_RETURN(allocator_reservation,
+                     CreateReservation(state->executor, allocation_size));
+    ASSIGN_OR_RETURN(allocator_mapping,
+                     allocator_reservation->MapTo(
+                         /*reservation_offset=*/0, /*allocation_offset=*/0,
+                         padded_size, *raw_alloc));
+    allocator_address = DeviceAddressBase(
+        allocator_reservation->address().opaque(), allocation_size);
+  }
+
+  void* allocator_ptr = allocator_address.opaque();
+  state->raw_allocations.emplace(allocator_ptr, std::move(raw_alloc));
+  state->scoped_mappings.emplace(allocator_ptr, std::move(allocator_mapping));
+  if (allocator_reservation != nullptr) {
+    state->reservations.emplace(allocator_ptr,
+                                std::move(allocator_reservation));
+    state->active_reservation_mappings.emplace(
+        reservation_address.opaque(),
+        ReservationMapping{allocator_address, reservation_address, reservation,
+                           reservation_offset, mapping_size,
+                           std::move(reservation_mapping)});
+  } else {
+    state->scoped_mappings[allocator_ptr] = std::move(reservation_mapping);
+  }
+
+  state->pa_allocated += rounded_size;
+  if (multi_device) {
+    state->multi_device_allocations.insert({allocator_ptr, true});
+  }
+  return ScopedDeviceAddress<uint8_t>(allocator_address, device_ordinal, this);
+}
+
 // Allocation flow with retry:
 //
 // Allocate(device_ordinal, size)
@@ -688,6 +794,9 @@ DeviceAddressVmmAllocator::TryReusePendingDeallocation(PerDeviceState& state,
       continue;
     }
     if (it->multi_device != multi_device) {
+      continue;
+    }
+    if (!state.reservations.contains(it->mem.opaque())) {
       continue;
     }
     if (RoundUpToGranularity(state, it->mem.size()) != rounded_size) {

--- a/xla/stream_executor/vmm_device_address_allocator.cc
+++ b/xla/stream_executor/vmm_device_address_allocator.cc
@@ -146,7 +146,11 @@ DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
     {
       absl::MutexLock lock(state->mu);
       for (auto& pending : state->pending_deallocations) {
-        DoDeallocate(*state, pending.mem);
+        if (pending.kind == PendingDeallocationKind::kAllocate) {
+          DoDeallocate(*state, pending.mem);
+        } else {
+          DoUnMap(*state, pending.mem);
+        }
       }
       state->pending_deallocations.clear();
     }
@@ -175,7 +179,12 @@ void DeviceAddressVmmAllocator::ProcessCompletedPendingDeallocations(
     if (state.pending_deallocations.front().seqno > completed) {
       break;
     }
-    DoDeallocate(state, state.pending_deallocations.front().mem);
+    if (state.pending_deallocations.front().kind ==
+        PendingDeallocationKind::kAllocate) {
+      DoDeallocate(state, state.pending_deallocations.front().mem);
+    } else {
+      DoUnMap(state, state.pending_deallocations.front().mem);
+    }
     state.pending_deallocations.pop_front();
   }
 }
@@ -195,7 +204,9 @@ void DeviceAddressVmmAllocator::WaitPendingDeallocationsToComplete(
   uint64_t target_size = rounded_size + rounded_size / 10;
 
   for (const auto& pending : state.pending_deallocations) {
-    accumulated_size += RoundUpToGranularity(state, pending.mem.size());
+    if (pending.kind == PendingDeallocationKind::kAllocate) {
+      accumulated_size += RoundUpToGranularity(state, pending.mem.size());
+    }
     target_seqno = pending.seqno;
     ++count_to_wait;
     if (accumulated_size >= target_size) {
@@ -227,7 +238,11 @@ void DeviceAddressVmmAllocator::WaitPendingDeallocationsToComplete(
   state.mu.lock();
 
   for (auto& item : selected) {
-    DoDeallocate(state, item.mem);
+    if (item.kind == PendingDeallocationKind::kAllocate) {
+      DoDeallocate(state, item.mem);
+    } else {
+      DoUnMap(state, item.mem);
+    }
   }
 }
 
@@ -249,6 +264,15 @@ void DeviceAddressVmmAllocator::DoDeallocate(PerDeviceState& state,
   uint64_t rounded_size = RoundUpToGranularity(state, mem.size());
   DCHECK_GE(state.pa_allocated, rounded_size);
   state.pa_allocated -= rounded_size;
+}
+
+void DeviceAddressVmmAllocator::DoUnMap(PerDeviceState& state,
+                                        DeviceAddressBase mem) {
+  VLOG(3) << absl::StreamFormat(
+      "Actually unmapping reservation address %p (size=%uB) on device ordinal "
+      "%d",
+      mem.opaque(), mem.size(), state.executor->device_ordinal());
+  state.stale_reservation_mappings.erase(mem.opaque());
 }
 
 absl::StatusOr<DeviceAddressBase> DeviceAddressVmmAllocator::AllocateWithBudget(
@@ -396,6 +420,26 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
 
   absl::MutexLock lock(state->mu);
 
+  if (!state->raw_allocations.contains(mem.opaque())) {
+    if (state->active_reservation_mappings.contains(mem.opaque()) ||
+        state->stale_reservation_mappings.contains(mem.opaque())) {
+      return absl::InvalidArgumentError(
+          "DeviceAddressVmmAllocator::Deallocate does not accept reservation "
+          "alias addresses; use UnMap instead");
+    }
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "DeviceAddressVmmAllocator::Deallocate received an unknown address %p",
+        mem.opaque()));
+  }
+
+  for (const auto& [_, mapping] : state->active_reservation_mappings) {
+    if (mapping.allocator_address.IsSameAs(mem)) {
+      return absl::FailedPreconditionError(
+          "DeviceAddressVmmAllocator::Deallocate requires active reservation "
+          "aliases to be released with UnMap first");
+    }
+  }
+
   VLOG(3) << absl::StreamFormat(
       "Queueing deferred deallocation for virtual address %p (size=%uB) "
       "on device ordinal %d",
@@ -409,8 +453,135 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   uint64_t seqno = state->next_seqno++;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
 
-  state->pending_deallocations.push_back({mem, seqno, multi_device});
+  state->pending_deallocations.push_back(
+      {PendingDeallocationKind::kAllocate, mem, seqno, multi_device});
 
+  return absl::OkStatus();
+}
+
+absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
+                                            DeviceAddressBase addr,
+                                            MemoryReservation* reservation,
+                                            uint64_t reservation_offset,
+                                            uint64_t size) {
+  if (size == 0) {
+    return absl::OkStatus();
+  }
+  if (addr.is_null()) {
+    return absl::InvalidArgumentError(
+        "DeviceAddressVmmAllocator::Map requires a non-null source address");
+  }
+  if (reservation == nullptr) {
+    return absl::InvalidArgumentError(
+        "DeviceAddressVmmAllocator::Map requires a non-null reservation");
+  }
+  DeviceAddressBase reservation_range = reservation->address();
+  if (reservation_offset > reservation_range.size() ||
+      size > reservation_range.size() - reservation_offset) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Reservation range [%u, %u) is outside reservation size %u",
+        reservation_offset, reservation_offset + size,
+        reservation_range.size()));
+  }
+  DeviceAddressBase reservation_address =
+      reservation_range.GetByteSlice(reservation_offset, size);
+
+  PerDeviceState* state = GetPerDeviceState(device_ordinal);
+  if (state == nullptr) {
+    return DeviceNotFoundError(device_ordinal);
+  }
+
+  absl::MutexLock lock(state->mu);
+  auto raw_it = state->raw_allocations.find(addr.opaque());
+  if (raw_it == state->raw_allocations.end()) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "DeviceAddressVmmAllocator::Map received an unknown allocator address "
+        "%p",
+        addr.opaque()));
+  }
+  if (size > raw_it->second->address().size()) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "DeviceAddressVmmAllocator::Map size %u exceeds raw allocation size "
+        "%u",
+        size, raw_it->second->address().size()));
+  }
+  if (state->active_reservation_mappings.contains(
+          reservation_address.opaque()) ||
+      state->stale_reservation_mappings.contains(
+          reservation_address.opaque())) {
+    return absl::FailedPreconditionError(
+        "Reservation address is already tracked by this allocator");
+  }
+  for (const auto& [_, mapping] : state->active_reservation_mappings) {
+    if (mapping.allocator_address.IsSameAs(addr)) {
+      return absl::FailedPreconditionError(
+          "Allocator address already has an active reservation alias");
+    }
+  }
+
+  ASSIGN_OR_RETURN(
+      MemoryReservation::ScopedMapping scoped_mapping,
+      reservation->MapTo(reservation_offset, /*allocation_offset=*/0, size,
+                         *raw_it->second));
+  state->active_reservation_mappings.emplace(
+      reservation_address.opaque(),
+      ReservationMapping{addr, reservation_address, reservation,
+                         reservation_offset, size, std::move(scoped_mapping)});
+  return absl::OkStatus();
+}
+
+absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
+                                              MemoryReservation* reservation,
+                                              uint64_t reservation_offset,
+                                              uint64_t size) {
+  if (size == 0) {
+    return absl::OkStatus();
+  }
+  if (reservation == nullptr) {
+    return absl::InvalidArgumentError(
+        "DeviceAddressVmmAllocator::UnMap requires a non-null reservation");
+  }
+  DeviceAddressBase reservation_range = reservation->address();
+  if (reservation_offset > reservation_range.size() ||
+      size > reservation_range.size() - reservation_offset) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Reservation range [%u, %u) is outside reservation size %u",
+        reservation_offset, reservation_offset + size,
+        reservation_range.size()));
+  }
+  DeviceAddressBase reservation_address =
+      reservation_range.GetByteSlice(reservation_offset, size);
+
+  PerDeviceState* state = GetPerDeviceState(device_ordinal);
+  if (state == nullptr) {
+    return DeviceNotFoundError(device_ordinal);
+  }
+
+  absl::MutexLock lock(state->mu);
+  auto it =
+      state->active_reservation_mappings.find(reservation_address.opaque());
+  if (it == state->active_reservation_mappings.end()) {
+    return absl::InvalidArgumentError(
+        "DeviceAddressVmmAllocator::UnMap received an untracked reservation "
+        "address");
+  }
+  if (it->second.reservation != reservation ||
+      it->second.reservation_offset != reservation_offset ||
+      it->second.size != size) {
+    return absl::InvalidArgumentError(
+        "DeviceAddressVmmAllocator::UnMap requires the same full reservation "
+        "range passed to Map");
+  }
+
+  uint64_t seqno = state->next_seqno++;
+  RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
+
+  ReservationMapping mapping = std::move(it->second);
+  state->active_reservation_mappings.erase(it);
+  state->stale_reservation_mappings.emplace(reservation_address.opaque(),
+                                            std::move(mapping));
+  state->pending_deallocations.push_back(
+      {PendingDeallocationKind::kMap, reservation_address, seqno});
   return absl::OkStatus();
 }
 
@@ -447,7 +618,12 @@ absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
     absl::MutexLock lock(state->mu);
     while (!state->pending_deallocations.empty() &&
            state->pending_deallocations.front().seqno <= target_seqno) {
-      DoDeallocate(*state, state->pending_deallocations.front().mem);
+      if (state->pending_deallocations.front().kind ==
+          PendingDeallocationKind::kAllocate) {
+        DoDeallocate(*state, state->pending_deallocations.front().mem);
+      } else {
+        DoUnMap(*state, state->pending_deallocations.front().mem);
+      }
       state->pending_deallocations.pop_front();
     }
   }
@@ -508,8 +684,15 @@ DeviceAddressVmmAllocator::TryReusePendingDeallocation(PerDeviceState& state,
   uint64_t rounded_size = RoundUpToGranularity(state, size);
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
-    if (it->multi_device != multi_device) continue;
-    if (RoundUpToGranularity(state, it->mem.size()) != rounded_size) continue;
+    if (it->kind != PendingDeallocationKind::kAllocate) {
+      continue;
+    }
+    if (it->multi_device != multi_device) {
+      continue;
+    }
+    if (RoundUpToGranularity(state, it->mem.size()) != rounded_size) {
+      continue;
+    }
 
     DeviceAddressBase reused_mem(it->mem.opaque(), size);
     VLOG(3) << absl::StreamFormat(

--- a/xla/stream_executor/vmm_device_address_allocator.h
+++ b/xla/stream_executor/vmm_device_address_allocator.h
@@ -62,7 +62,9 @@ namespace stream_executor {
 //
 // The allocator tracks the ScopedMapping and underlying MemoryAllocation and
 // MemoryReservation objects for each returned DeviceAddressBase. Callers can
-// retrieve these via GetRawAllocation() and GetReservation().
+// retrieve these via GetRawAllocation() and GetReservation(). Callers can also
+// create non-owning aliases into caller-owned MemoryReservation ranges with
+// Map(), then release those aliases with UnMap().
 //
 // This allocator supports asynchronous deallocation: when Deallocate() is
 // called, it records a GPU timeline write on the device's stream and defers
@@ -120,6 +122,20 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // completes.
   absl::Status Deallocate(int device_ordinal, DeviceAddressBase mem) override;
 
+  // Maps the physical allocation backing `addr` into `reservation` at
+  // `reservation_offset`. `addr` must be an active allocator address returned
+  // by Allocate(), and each allocator address may have at most one active
+  // reservation alias.
+  absl::Status Map(int device_ordinal, DeviceAddressBase addr,
+                   MemoryReservation* reservation, uint64_t reservation_offset,
+                   uint64_t size);
+
+  // Defers unmapping the reservation alias created by Map() until all
+  // previously enqueued work on this allocator's stream has completed. The
+  // caller must pass the same full reservation range used for Map().
+  absl::Status UnMap(int device_ordinal, MemoryReservation* reservation,
+                     uint64_t reservation_offset, uint64_t size);
+
   // Returns true — this allocator supports asynchronous deallocation.
   bool AllowsAsynchronousDeallocation() const override { return true; }
 
@@ -156,12 +172,27 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       StreamExecutor* executor, uint64_t size) = 0;
 
  protected:
+  enum class PendingDeallocationKind {
+    kAllocate,
+    kMap,
+  };
+
   struct PendingDeallocation {
+    PendingDeallocationKind kind = PendingDeallocationKind::kAllocate;
     DeviceAddressBase mem;
     // GPU stream sequence number recorded at deallocation time. When the
     // pinned_timeline value reaches this seqno, the memory is safe to free.
-    uint64_t seqno;
+    uint64_t seqno = 0;
     bool multi_device = false;
+  };
+
+  struct ReservationMapping {
+    DeviceAddressBase allocator_address;
+    DeviceAddressBase reservation_address;
+    MemoryReservation* reservation = nullptr;
+    uint64_t reservation_offset = 0;
+    uint64_t size = 0;
+    MemoryReservation::ScopedMapping scoped_mapping;
   };
 
   struct PerDeviceState {
@@ -202,6 +233,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     absl::flat_hash_map<void*, MemoryReservation::ScopedMapping> scoped_mappings
         ABSL_GUARDED_BY(mu);
     absl::flat_hash_map<void*, bool> multi_device_allocations
+        ABSL_GUARDED_BY(mu);
+    absl::flat_hash_map<void*, ReservationMapping> active_reservation_mappings
+        ABSL_GUARDED_BY(mu);
+    absl::flat_hash_map<void*, ReservationMapping> stale_reservation_mappings
         ABSL_GUARDED_BY(mu);
   };
 
@@ -253,6 +288,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   // Actually perform the synchronous deallocation.
   void DoDeallocate(PerDeviceState& state, DeviceAddressBase mem)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Actually perform the synchronous unmap for a stale reservation alias.
+  void DoUnMap(PerDeviceState& state, DeviceAddressBase mem)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Try to reuse a pending deallocation with matching rounded size.

--- a/xla/stream_executor/vmm_device_address_allocator.h
+++ b/xla/stream_executor/vmm_device_address_allocator.h
@@ -99,6 +99,22 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       int device_ordinal, uint64_t size, bool retry_on_failure,
       int64_t memory_space) override;
 
+  // Allocates raw physical memory and maps it into a caller-owned
+  // MemoryReservation range. `allocation_size` and `mapping_size` must be
+  // equal.
+  //
+  // If `return_reservation_address` is true, the returned allocator address is
+  // the reservation slice and must be released with Deallocate(); `reservation`
+  // must outlive the returned address and any pending deallocation. If false,
+  // the returned allocator address is a separate allocator-owned VA and the
+  // reservation slice is a non-owning alias that must be released with UnMap()
+  // before the returned allocator address is deallocated.
+  absl::StatusOr<ScopedDeviceAddress<uint8_t>> Allocate(
+      int device_ordinal, uint64_t allocation_size, bool retry_on_failure,
+      int64_t memory_space, MemoryReservation* reservation,
+      uint64_t reservation_offset, uint64_t mapping_size,
+      bool return_reservation_address);
+
   // Pull in two-arg overload that sets retry_on_failure to true.
   using DeviceAddressAllocator::Allocate;
 


### PR DESCRIPTION
  📝 Summary of Changes
 Add a  new Allocate() API to DeviceAddressVmmAllocator, that can map newly allocated physical memory into a caller-owned MemoryReservation when doing the allocation:

```  
absl::StatusOr<ScopedDeviceAddress<uint8_t>> Allocate(
      int device_ordinal, uint64_t allocation_size, bool retry_on_failure,
      int64_t memory_space, MemoryReservation* reservation,
      uint64_t reservation_offset, uint64_t mapping_size,
      bool return_reservation_address);
```
  Key parameters:
```
  - reservation: caller-owned virtual address reservation to map into.
  - reservation_offset: byte offset into reservation where the mapping starts.
  - mapping_size: number of bytes mapped into the reservation. Currently must equal allocation_size.
  - return_reservation_address: when true, returns the reservation slice as the allocator address and it must be released with Deallocate(). When false, returns a separate allocator-owned VA and treats the reservation slice as an alias that must be released with UnMap() before deallocating the returned address.
```
  This includes:

  - Tracking active and stale reservation mappings.
  - Deferring reservation unmap operations through the stream-ordered pending operation queue.
  - CUDA tests for map/unmap aliases, reservation-backed allocation modes, and pending-operation synchronization.

  🎯 Justification
  This enables VMM allocations to be backed by externally managed virtual address reservations, which is needed for workflows that need explicit control over VA layout while preserving stream-ordered lifetime handling.

  🚀 Kind of Contribution
  ✨ New Feature, 🧪 Tests

  📊 Benchmark (for Performance Improvements)
  N/A. This is not a performance improvement PR.

  🧪 Unit Tests:
  Added coverage in //xla/stream_executor/cuda:cuda_device_address_vmm_allocator_test.

  🧪 Execution Tests:
  Ran:

  bazel test --test_output=errors //xla/stream_executor/cuda:cuda_device_address_vmm_allocator_test

