### PR TITLE
Fix stuck miopen test do to not allowing asynchronous deallocation

### DIFF
--- a/xla/backends/gpu/autotuner/miopen.cc
+++ b/xla/backends/gpu/autotuner/miopen.cc
@@ -330,11 +330,6 @@ GetConvolutionCustomCallConfigs(const HloCustomCallInstruction* instr,
       /* use_fallback = */ false, &scratch_allocator, engine_options,
       &conv_runners));
 
-  // Synchronize the stream to ensure all GPU work completes before the
-  // scratch allocator is destroyed. This prevents use-after-free when
-  // the scratch buffers are deallocated.
-  RETURN_IF_ERROR(stream->BlockHostUntilDone());
-
   std::vector<std::unique_ptr<BackendConfig>> configs;
   configs.reserve(conv_runners.size());
   for (const auto& runner : conv_runners) {

--- a/xla/backends/gpu/autotuner/miopen.cc
+++ b/xla/backends/gpu/autotuner/miopen.cc
@@ -330,6 +330,11 @@ GetConvolutionCustomCallConfigs(const HloCustomCallInstruction* instr,
       /* use_fallback = */ false, &scratch_allocator, engine_options,
       &conv_runners));
 
+  // Synchronize the stream to ensure all GPU work completes before the
+  // scratch allocator is destroyed. This prevents use-after-free when
+  // the scratch buffers are deallocated.
+  RETURN_IF_ERROR(stream->BlockHostUntilDone());
+
   std::vector<std::unique_ptr<BackendConfig>> configs;
   configs.reserve(conv_runners.size());
   for (const auto& runner : conv_runners) {

--- a/xla/backends/gpu/autotuner/miopen_test.cc
+++ b/xla/backends/gpu/autotuner/miopen_test.cc
@@ -87,7 +87,8 @@ class MIOpenBackendTest : public HloHardwareIndependentTestBase {
                              ->ExecutorForDevice(0)
                              .value()),
         target_config_(stream_executor_),
-        allocator_(stream_executor_, /*allows_asynchronous_deallocation=*/true),
+        allocator_(stream_executor_,
+                   /*allows_asynchronous_deallocation=*/true),
         backend_(
             stream_executor_,
             [](auto& opts) {

--- a/xla/backends/gpu/autotuner/miopen_test.cc
+++ b/xla/backends/gpu/autotuner/miopen_test.cc
@@ -87,7 +87,7 @@ class MIOpenBackendTest : public HloHardwareIndependentTestBase {
                              ->ExecutorForDevice(0)
                              .value()),
         target_config_(stream_executor_),
-        allocator_(stream_executor_),
+        allocator_(stream_executor_, /*allows_asynchronous_deallocation=*/true),
         backend_(
             stream_executor_,
             [](auto& opts) {

--- a/xla/stream_executor/stream_executor_address_allocator.cc
+++ b/xla/stream_executor/stream_executor_address_allocator.cc
@@ -37,16 +37,19 @@ limitations under the License.
 namespace stream_executor {
 
 StreamExecutorAddressAllocator::StreamExecutorAddressAllocator(
-    StreamExecutor* executor)
-    : DeviceAddressAllocator(executor->GetPlatform()) {
+    StreamExecutor* executor, bool allows_asynchronous_deallocation)
+    : DeviceAddressAllocator(executor->GetPlatform()),
+      allows_asynchronous_deallocation_{allows_asynchronous_deallocation} {
   stream_executors_ = {executor};
 }
 
 StreamExecutorAddressAllocator::StreamExecutorAddressAllocator(
     const Platform* platform,
-    absl::Span<StreamExecutor* const> stream_executors)
+    absl::Span<StreamExecutor* const> stream_executors,
+    bool allows_asynchronous_deallocation)
     : DeviceAddressAllocator(platform),
-      stream_executors_(stream_executors.begin(), stream_executors.end()) {}
+      stream_executors_(stream_executors.begin(), stream_executors.end()),
+      allows_asynchronous_deallocation_{allows_asynchronous_deallocation} {}
 
 absl::StatusOr<ScopedDeviceAddress<uint8_t>>
 StreamExecutorAddressAllocator::Allocate(int device_ordinal, uint64_t size,
@@ -96,7 +99,7 @@ StreamExecutorAddressAllocator::GetStreamExecutor(int device_ordinal) const {
 }
 
 bool StreamExecutorAddressAllocator::AllowsAsynchronousDeallocation() const {
-  return false;
+  return allows_asynchronous_deallocation_;
 }
 
 absl::StatusOr<Stream*> StreamExecutorAddressAllocator::GetStream(

--- a/xla/stream_executor/stream_executor_address_allocator.h
+++ b/xla/stream_executor/stream_executor_address_allocator.h
@@ -39,14 +39,16 @@ class StreamExecutorAddressAllocator : public DeviceAddressAllocator {
  public:
   // Create an allocator supporting a single device, corresponding to the
   // passed executor.
-  explicit StreamExecutorAddressAllocator(StreamExecutor* executor);
+  explicit StreamExecutorAddressAllocator(
+      StreamExecutor* executor, bool allows_asynchronous_deallocation = false);
 
   // Create an allocator supporting multiple stream executors.
   //
   // Precondition: all stream_executors have different device ordinals.
   StreamExecutorAddressAllocator(
       const Platform* platform,
-      absl::Span<StreamExecutor* const> stream_executors);
+      absl::Span<StreamExecutor* const> stream_executors,
+      bool allows_asynchronous_deallocation = false);
 
   absl::StatusOr<ScopedDeviceAddress<uint8_t>> Allocate(
       int device_ordinal, uint64_t size, bool retry_on_failure,
@@ -75,6 +77,9 @@ class StreamExecutorAddressAllocator : public DeviceAddressAllocator {
 
   // Cache of streams for GetStream.
   std::map<int, std::unique_ptr<Stream>> streams_ ABSL_GUARDED_BY(mutex_);
+
+  // Whether this allocator supports asynchronous deallocation.
+  bool allows_asynchronous_deallocation_;
 };
 
 }  // namespace stream_executor


### PR DESCRIPTION
📝 Summary of Changes
Fix memory deallocation deadlock when using StreamExecutorAddressAllocator,
allow asynchronous deallocation for miopen test

🎯 Justification
miopen_test is failing or rocm config because of the deadlock while using StreamExecutorAddressAllocator

 ```
 Thread: Main (383)                          Thread: Callback (388)
 ==================                          =======================

 GetConvolutionCustomCallConfigs()
   │
   ├─ GetConvolveRunners()
   │    └─ GPU work enqueued
   │
   ├─ Function returns (no sync!)
   │
   ├─ ~OwningScratchAllocator() destructor
   │    │
   │    ├─ GetStream(0) → creates stream2
   │    │
   │    ├─ stream2->DoHostCallback(lambda)
   │    │    └─ schedules: buffers.clear()
   │    │                                           │
   │    └─ destructor returns                      ├─ lambda starts
   │                                                │
   ├─ Test completes                               │
   │                                                ├─ buffers.clear()
   ├─ ~MIOpenBackendTest()                        │    │
   │    ├─ ~backend_                               │    ├─ ~ScopedDeviceAddress[0]
   │    │                                           │    │    └─ allocator_->Deallocate()
   │    │                                           │    │         │
   │    └─ ~allocator_                            │    │         │
   │         │                                      │    │         │
   │         └─ ~StreamExecutorAddressAllocator()│    │         │
   │              │                                 │    │         │
   │              └─ destroy streams_              │    │         │
   │                   └─ ~Stream()               │    │         │
   │                        │                       │    │         ▼
   │                        └─ Wait for callbacks  │    │      Trying Deallocate
   │                             to complete        │    │      but allocator is
   │                        ◄────────────────────┐ │    │      being destroyed!
   │                             DEADLOCK! ✗      │ │    │
   │                        Main waits for        │ │    │      **HANGS HERE**
   │                        callback, but         │ │    │
   │                        callback stuck in     │ │    │
   │                        Deallocate            │ │    │
   └────────────────────────────────────────────┘ └────┘
 ```

Current implementation:

```
 Thread: Main                              GPU
 ===========                              ====

 GetConvolutionCustomCallConfigs()
   │
   ├─ CreateStream() → stream1
   │
   ├─ OwningScratchAllocator created
   │    └─ allocates 3 buffers
   │
   ├─ GetConvolveRunners(stream1, &scratch_allocator)
   │    │
   │    └─ GPU work enqueued ─────────────►  Working...
   │                                            │
   ├─ stream->BlockHostUntilDone() ◄───────────┤
   │    │                                       ▼
   │    └─ WAITS for GPU to complete        Finished! ✓
   │
   ├─ Function returns
   │    (GPU work is done!)
   │
   ├─ ~OwningScratchAllocator()
   │    │
   │    ├─ if (AllowsAsynchronousDeallocation())
   │    │    return;  // ✓ SKIPS callback path
   │    │
   │    └─ buffers deallocated synchronously
   │         (safe because GPU is done!)
   │
   └─ Test completes successfully ✓
 ```

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
