### PR TITLE
  [XLA:GPU] Refactor to avoid code duplication for GpuExecutable and PjRt RunAsync

### DIFF
--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -193,7 +193,6 @@ cc_library(
         # keep sorted
         "//xla:debug_options_flags",
         "//xla/service/gpu:gpu_compiler",
-        "//xla/service/gpu:gpu_constants",
         "//xla/service/gpu:gpu_executable",
         "//xla/service/gpu:stream_executor_util",
     ]) + if_cuda([
@@ -209,7 +208,6 @@ cc_library(
         # keep sorted
         "//xla:debug_options_flags",
         "//xla/service/gpu:gpu_compiler",
-        "//xla/service/gpu:gpu_constants",
         "//xla/service/gpu:gpu_executable",
         "//xla/service/gpu:stream_executor_util",
         "@local_config_sycl//sycl:sycl_headers",

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -2036,29 +2036,10 @@ StreamExecutorGpuClient::RunAsync(
       } else if (!output_info.passthrough &&
                  !ShapeUtil::GetSubshape(gpu_exec->result_shape(), index)
                       .IsTuple()) {
-        // The guard is above is not to insert copy-protection when aliasing
-        // pass-through params, as we do not need to write into the output
-        // buffer.
-        XLA_VLOG_DEVICE(3, device_ordinal)
-            << "Using copy-protection: aliasing is specified, but the "
-               "buffer is not donated; allocating a fresh buffer";
-        int64_t allocation_size = ShapeUtil::ByteSizeOf(
-            ShapeUtil::GetSubshape(gpu_exec->result_shape(), index));
-        absl::StatusOr<se::ScopedDeviceAddress<uint8_t>> allocated_buffer =
-            memory_allocator->Allocate(device_ordinal, allocation_size,
-                                       /*retry_on_failure=*/true,
-                                       /*memory_space=*/allocation->color());
-        if (!allocated_buffer.ok()) {
-          return gpu_exec->VerboseAllocationError(allocated_buffer.status());
-        }
-        result_buffer = allocated_buffer->Release();
-        se::DeviceAddressBase& aliased_buffer =
-            buffer_allocations.GetMutableDeviceAddress(
-                output_info.allocation_index);
-        CHECK_EQ(aliased_buffer.size(), result_buffer.size());
-        RETURN_IF_ERROR(run_options->stream()->MemcpyD2D(
-            &result_buffer, aliased_buffer, aliased_buffer.size()));
-        aliased_buffer = result_buffer;
+        ASSIGN_OR_RETURN(result_buffer,
+                         gpu_exec->AllocateCopyProtectedOutputBuffer(
+                             run_options, buffer_allocations, index,
+                             *allocation, device_ordinal, memory_allocator));
       }
     }
 

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -134,6 +134,7 @@ limitations under the License.
 #include "xla/pjrt/gpu/gpu_metrics.h"
 #include "xla/pjrt/proto/compile_options.pb.h"
 #include "xla/pjrt/stream_executor_executable.pb.h"
+#include "xla/service/gpu/buffer_allocations.h"
 #include "xla/service/gpu/gpu_executable.h"
 #include "xla/service/gpu/stream_executor_util.h"
 #include "xla/xla.pb.h"
@@ -1971,22 +1972,25 @@ StreamExecutorGpuClient::RunAsync(
   // collective-memory granularity rounding and alignment checks are handled by
   // GpuExecutable::GenerateBufferAllocations.
   auto get_parameter_buffer = [&](const BufferAllocation& allocation)
-      -> absl::StatusOr<se::DeviceAddressBase> {
+      -> absl::StatusOr<gpu::GpuExecutable::ParameterBuffer> {
     int64_t param_no;
     if (parameter_is_tupled_arguments) {
       // TODO(parkers): Change compiler to not even pretend to read
       // the tuple index tables (also GPU shouldn't tuple ever).
       if (allocation.param_shape_index().empty()) {
-        return se::DeviceAddressBase{};
+        return gpu::GpuExecutable::ParameterBuffer{
+            se::DeviceAddressBase{}, allocation.parameter_number()};
       }
       param_no = allocation.param_shape_index()[0];
     } else {
       param_no = allocation.parameter_number();
     }
-    return tensorflow::down_cast<const xla::PjRtStreamExecutorRawBuffer*>(
-               flat_arguments[param_no].get())
-        ->device_buffer()
-        ->mem();
+    return gpu::GpuExecutable::ParameterBuffer{
+        tensorflow::down_cast<const xla::PjRtStreamExecutorRawBuffer*>(
+            flat_arguments[param_no].get())
+            ->device_buffer()
+            ->mem(),
+        param_no};
   };
 
   ASSIGN_OR_RETURN(xla::gpu::BufferAllocations buffer_allocations,

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -134,7 +134,6 @@ limitations under the License.
 #include "xla/pjrt/gpu/gpu_metrics.h"
 #include "xla/pjrt/proto/compile_options.pb.h"
 #include "xla/pjrt/stream_executor_executable.pb.h"
-#include "xla/service/gpu/gpu_constants.h"
 #include "xla/service/gpu/gpu_executable.h"
 #include "xla/service/gpu/stream_executor_util.h"
 #include "xla/xla.pb.h"
@@ -1902,30 +1901,6 @@ std::vector<std::unique_ptr<PjRtStreamExecutorDevice>> BuildLocalDevices(
   return devices;
 }
 
-#if defined(GOOGLE_CUDA) || defined(TENSORFLOW_USE_ROCM) || \
-    defined(TENSORFLOW_USE_SYCL)
-static absl::Status CheckAlignment(const BufferAllocation& allocation,
-                                   se::DeviceAddressBase buffer, int arg_idx) {
-  const int64_t expected_alignment = [&] {
-    if (allocation.is_entry_computation_parameter()) {
-      return gpu::kEntryParameterAlignBytes;
-    } else if (allocation.is_constant()) {
-      return gpu::kConstantBufferAlignBytes;
-    } else {
-      return gpu::kXlaAllocatedBufferAlignBytes;
-    }
-  }();
-  if (!buffer.is_null() &&
-      reinterpret_cast<uintptr_t>(buffer.opaque()) % expected_alignment != 0) {
-    return Internal(
-        "Address of buffer %d must be a multiple of %x, but "
-        "was %p",
-        arg_idx, expected_alignment, buffer.opaque());
-  }
-  return absl::OkStatus();
-}
-#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM || TENSORFLOW_USE_SYCL
-
 absl::StatusOr<PjRtStreamExecutorExecutionOutput>
 StreamExecutorGpuClient::RunAsync(
     LocalExecutable& exec, PjRtDevice* device,
@@ -1991,82 +1966,33 @@ StreamExecutorGpuClient::RunAsync(
   absl::Span<const BufferAllocation* const> allocations =
       gpu_exec->GetAllocations();
 
-  // Build a map of per-color allocation granularity. Collective memory requires
-  // larger alignment than the BFC allocator guarantees (256 bytes).
-  absl::flat_hash_map<LogicalBuffer::Color, int64_t> allocate_granularity;
-  if (auto* collectives =
-          gpu::GpuCollectives::Default(executor->GetPlatform()->Name())) {
-    const int64_t collective_memory_alignment =
-        collectives->SymmetricMemoryAlignment();
-    XLA_VLOG_DEVICE(5, device_ordinal)
-        << "Using collective memory alignment: " << collective_memory_alignment;
-    allocate_granularity[static_cast<LogicalBuffer::Color>(
-        gpu::MemorySpaceColor::kCollective)] = collective_memory_alignment;
-  }
-
-  std::vector<se::DeviceAddressBase> buffers(allocations.size());
-  {
-    tsl::profiler::TraceMe hlo_module_activity(
-        [&] { return std::string("Build buffer allocations"); },
-        tsl::profiler::TraceMeLevel::kInfo);
-    const int64_t num_buffers = allocations.size();
-    for (int64_t i = 0; i < num_buffers; ++i) {
-      const BufferAllocation& allocation = *allocations[i];
-      se::DeviceAddressBase& buffer = buffers[i];
-      if (allocation.is_thread_local()) {
-        // buffer = se::DeviceAddressBase{};
-      } else if (allocation.is_entry_computation_parameter()) {
-        int64_t param_no;
-        if (parameter_is_tupled_arguments) {
-          // TODO(parkers): Change compiler to not even pretend to read
-          // the tuple index tables (also GPU shouldn't tuple ever).
-          if (allocation.param_shape_index().empty()) {
-            continue;
-          }
-          param_no = allocation.param_shape_index()[0];
-        } else {
-          param_no = allocation.parameter_number();
-        }
-        buffer = tensorflow::down_cast<const xla::PjRtStreamExecutorRawBuffer*>(
-                     flat_arguments[param_no].get())
-                     ->device_buffer()
-                     ->mem();
-        if (buffer.is_null() && buffer.size() > 0) {
-          return FailedPrecondition(
-              "Cannot run XLA computation because pointer to (sub-)buffer at "
-              "index %s of parameter %d was null.  All pointers to "
-              "(sub-)buffers must not be null, unless the (sub-)buffer has "
-              "zero elements.",
-              allocation.param_shape_index().ToString(), param_no);
-        }
-      } else if (allocation.is_constant()) {
-        auto it = globals->find(i);
-        if (it != globals->end()) {
-          buffer = it->second;
-        }
-      } else {
-        // Allocate each allocation that might escape, or is the temp buffer.
-        CHECK(allocation.maybe_live_out() ||
-              allocation.IsPreallocatedTempBuffer());
-        int64_t buffer_size = allocation.size();
-        if (auto it = allocate_granularity.find(allocation.color());
-            it != allocate_granularity.end()) {
-          buffer_size = RoundUpTo(buffer_size, it->second);
-        }
-        if (buffer_size > 0) {
-          ASSIGN_OR_RETURN(
-              se::ScopedDeviceAddress<uint8_t> owning_buffer,
-              memory_allocator->Allocate(device_ordinal, buffer_size,
-                                         /*retry_on_failure=*/true,
-                                         /*memory_space=*/allocation.color()));
-          buffer = owning_buffer.Release();
-        }
+  // Resolve entry-parameter buffers from the PjRt raw arguments. All other
+  // allocations (thread-local, constant, temp/maybe-live-out) and the
+  // collective-memory granularity rounding and alignment checks are handled by
+  // GpuExecutable::GenerateBufferAllocations.
+  auto get_parameter_buffer = [&](const BufferAllocation& allocation)
+      -> absl::StatusOr<se::DeviceAddressBase> {
+    int64_t param_no;
+    if (parameter_is_tupled_arguments) {
+      // TODO(parkers): Change compiler to not even pretend to read
+      // the tuple index tables (also GPU shouldn't tuple ever).
+      if (allocation.param_shape_index().empty()) {
+        return se::DeviceAddressBase{};
       }
-      RETURN_IF_ERROR(CheckAlignment(allocation, buffer, i));
+      param_no = allocation.param_shape_index()[0];
+    } else {
+      param_no = allocation.parameter_number();
     }
-  }
-  xla::gpu::BufferAllocations buffer_allocations(buffers, device_ordinal,
-                                                 memory_allocator);
+    return tensorflow::down_cast<const xla::PjRtStreamExecutorRawBuffer*>(
+               flat_arguments[param_no].get())
+        ->device_buffer()
+        ->mem();
+  };
+
+  ASSIGN_OR_RETURN(xla::gpu::BufferAllocations buffer_allocations,
+                   gpu_exec->GenerateBufferAllocations(
+                       run_options, get_parameter_buffer, globals,
+                       memory_allocator, device_ordinal));
   XLA_VLOG_DEVICE(3, device_ordinal)
       << "Buffer allocations: " << buffer_allocations.ToString();
 

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -802,6 +802,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -1091,18 +1091,19 @@ absl::StatusOr<se::DeviceAddressBase> GpuExecutable::BufferForAllocation(
     return se::DeviceAddressBase{};
   }
   if (allocation.is_entry_computation_parameter()) {
-    ASSIGN_OR_RETURN(se::DeviceAddressBase registered_buffer,
+    ASSIGN_OR_RETURN(ParameterBuffer registered_buffer,
                      get_parameter_buffer(allocation));
-    if (registered_buffer.is_null() && registered_buffer.size() > 0) {
+    if (registered_buffer.buffer.is_null() &&
+        registered_buffer.buffer.size() > 0) {
       return FailedPrecondition(
           "Cannot run XLA computation because pointer to (sub-)buffer at "
           "index %s of parameter %d was null.  All pointers to "
           "(sub-)buffers must not be null, unless the (sub-)buffer has "
           "zero elements.",
           allocation.param_shape_index().ToString(),
-          allocation.parameter_number());
+          registered_buffer.parameter_number);
     }
-    return registered_buffer;
+    return registered_buffer.buffer;
   }
   if (allocation.is_constant()) {
     auto it = globals->find(arg_idx);
@@ -1313,16 +1314,20 @@ absl::StatusOr<ExecutionOutput> GpuExecutable::ExecuteAsyncOnStreamImpl(
                          executor->device_ordinal());
 
   auto get_parameter_buffer = [&](const BufferAllocation& allocation)
-      -> absl::StatusOr<se::DeviceAddressBase> {
+      -> absl::StatusOr<ParameterBuffer> {
     int64_t param_no = allocation.parameter_number();
     if (auto unowned_shapedbuffers =
             std::get_if<absl::Span<const ShapedBuffer* const>>(&arguments)) {
-      return (*unowned_shapedbuffers)[param_no]->buffers().element(
-          allocation.param_shape_index());
+      return ParameterBuffer{
+          (*unowned_shapedbuffers)[param_no]->buffers().element(
+              allocation.param_shape_index()),
+          param_no};
     }
-    return std::get<absl::Span<ExecutionInput>>(arguments)[param_no]
-        .Buffer(allocation.param_shape_index())
-        .AsDeviceAddress();
+    return ParameterBuffer{
+        std::get<absl::Span<ExecutionInput>>(arguments)[param_no]
+            .Buffer(allocation.param_shape_index())
+            .AsDeviceAddress(),
+        param_no};
   };
   ASSIGN_OR_RETURN(
       BufferAllocations buffer_allocations,

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -184,7 +184,7 @@ class GpuExecutableThunkPassBufferAllocator : public ThunkPassBufferAllocator {
       BufferAllocation::Index start_idx)
       : next_idx_(start_idx) {}
 
-  absl::StatusOr<BufferAllocation* absl_nonnull> NewEmptyAllocation(
+  absl::StatusOr<BufferAllocation * absl_nonnull> NewEmptyAllocation(
       int64_t size) override {
     allocations_.push_back(BufferAllocation(next_idx_++, size, /*color=*/0));
     return &allocations_.back();
@@ -918,8 +918,7 @@ absl::Status RendezvousAfterInitialization(
       run_options.device_ordinal(), run_options.run_options().run_id().ToInt());
 
   return Rendezvous(
-      rendezvous_name, rendezvous_key,
-      num_local_participants,
+      rendezvous_name, rendezvous_key, num_local_participants,
       absl::Seconds(
           debug_options
               ? debug_options->xla_gpu_executable_warn_stuck_timeout_seconds()
@@ -1081,7 +1080,7 @@ GpuExecutable::ResolveConstantGlobals(se::Stream* stream) {
 }
 
 absl::StatusOr<se::DeviceAddressBase> GpuExecutable::BufferForAllocation(
-    VariantArguments arguments,
+    ParameterBufferResolver get_parameter_buffer,
     const GpuExecutable::BufferAllocToDeviceMemoryMap* globals,
     const BufferAllocation& allocation,
     se::DeviceAddressAllocator* const memory_allocator, int device_ordinal,
@@ -1092,24 +1091,16 @@ absl::StatusOr<se::DeviceAddressBase> GpuExecutable::BufferForAllocation(
     return se::DeviceAddressBase{};
   }
   if (allocation.is_entry_computation_parameter()) {
-    int64_t param_no = allocation.parameter_number();
-    se::DeviceAddressBase registered_buffer = [&] {
-      if (auto unowned_shapedbuffers =
-              std::get_if<absl::Span<const ShapedBuffer* const>>(&arguments)) {
-        return (*unowned_shapedbuffers)[param_no]->buffers().element(
-            allocation.param_shape_index());
-      }
-      return std::get<absl::Span<ExecutionInput>>(arguments)[param_no]
-          .Buffer(allocation.param_shape_index())
-          .AsDeviceAddress();
-    }();
+    ASSIGN_OR_RETURN(se::DeviceAddressBase registered_buffer,
+                     get_parameter_buffer(allocation));
     if (registered_buffer.is_null() && registered_buffer.size() > 0) {
       return FailedPrecondition(
           "Cannot run XLA computation because pointer to (sub-)buffer at "
           "index %s of parameter %d was null.  All pointers to "
           "(sub-)buffers must not be null, unless the (sub-)buffer has "
           "zero elements.",
-          allocation.param_shape_index().ToString(), param_no);
+          allocation.param_shape_index().ToString(),
+          allocation.parameter_number());
     }
     return registered_buffer;
   }
@@ -1141,8 +1132,8 @@ absl::StatusOr<se::DeviceAddressBase> GpuExecutable::BufferForAllocation(
   return buffer_address;
 }
 
-static absl::Status CheckAlignment(const BufferAllocation& allocation,
-                                   se::DeviceAddressBase buffer, int arg_idx) {
+absl::Status CheckAlignment(const BufferAllocation& allocation,
+                            se::DeviceAddressBase buffer, int arg_idx) {
   const int64_t expected_alignment = [&] {
     if (allocation.is_entry_computation_parameter()) {
       return kEntryParameterAlignBytes;
@@ -1192,7 +1183,8 @@ static GpuCollectives* ResolveGpuCollectives(
 }
 
 absl::StatusOr<BufferAllocations> GpuExecutable::GenerateBufferAllocations(
-    const ServiceExecutableRunOptions* run_options, VariantArguments arguments,
+    const ServiceExecutableRunOptions* run_options,
+    ParameterBufferResolver get_parameter_buffer,
     const GpuExecutable::BufferAllocToDeviceMemoryMap* globals,
     se::DeviceAddressAllocator* const memory_allocator, int device_ordinal) {
   tsl::profiler::TraceMe hlo_module_activity(
@@ -1224,8 +1216,9 @@ absl::StatusOr<BufferAllocations> GpuExecutable::GenerateBufferAllocations(
     const BufferAllocation& allocation = *allocations[i];
     ASSIGN_OR_RETURN(
         buffers.emplace_back(),
-        BufferForAllocation(arguments, globals, allocation, memory_allocator,
-                            device_ordinal, i, allocate_granularity));
+        BufferForAllocation(get_parameter_buffer, globals, allocation,
+                            memory_allocator, device_ordinal, i,
+                            allocate_granularity));
     RETURN_IF_ERROR(CheckAlignment(allocation, buffers.back(), i));
   }
   return {{buffers, device_ordinal, memory_allocator}};
@@ -1289,9 +1282,22 @@ absl::StatusOr<ExecutionOutput> GpuExecutable::ExecuteAsyncOnStreamImpl(
                          memory_allocator, device_ordinal,
                          executor->device_ordinal());
 
-  ASSIGN_OR_RETURN(BufferAllocations buffer_allocations,
-                   GenerateBufferAllocations(run_options, arguments, globals,
-                                             memory_allocator, device_ordinal));
+  auto get_parameter_buffer = [&](const BufferAllocation& allocation)
+      -> absl::StatusOr<se::DeviceAddressBase> {
+    int64_t param_no = allocation.parameter_number();
+    if (auto unowned_shapedbuffers =
+            std::get_if<absl::Span<const ShapedBuffer* const>>(&arguments)) {
+      return (*unowned_shapedbuffers)[param_no]->buffers().element(
+          allocation.param_shape_index());
+    }
+    return std::get<absl::Span<ExecutionInput>>(arguments)[param_no]
+        .Buffer(allocation.param_shape_index())
+        .AsDeviceAddress();
+  };
+  ASSIGN_OR_RETURN(
+      BufferAllocations buffer_allocations,
+      GenerateBufferAllocations(run_options, get_parameter_buffer, globals,
+                                memory_allocator, device_ordinal));
   XLA_VLOG_DEVICE(3, device_ordinal) << buffer_allocations.ToString();
   absl::Span<const BufferAllocation* const> allocations = GetAllocations();
 

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -1224,6 +1224,36 @@ absl::StatusOr<BufferAllocations> GpuExecutable::GenerateBufferAllocations(
   return {{buffers, device_ordinal, memory_allocator}};
 }
 
+absl::StatusOr<se::DeviceAddressBase>
+GpuExecutable::AllocateCopyProtectedOutputBuffer(
+    const ServiceExecutableRunOptions* run_options,
+    BufferAllocations& buffer_allocations, const ShapeIndex& index,
+    const BufferAllocation& allocation, int device_ordinal,
+    se::DeviceAddressAllocator* const memory_allocator) {
+  // The caller guards this against aliasing pass-through params, as we do not
+  // need to write into the output buffer in that case.
+  XLA_VLOG_DEVICE(3, device_ordinal)
+      << "Using copy-protection: aliasing is specified, but the "
+         "buffer is not donated; allocating a fresh buffer";
+  int64_t allocation_size =
+      ShapeUtil::ByteSizeOf(ShapeUtil::GetSubshape(result_shape(), index));
+  absl::StatusOr<se::ScopedDeviceAddress<uint8_t>> allocated_buffer =
+      memory_allocator->Allocate(device_ordinal, allocation_size,
+                                 /*retry_on_failure=*/true,
+                                 /*memory_space=*/allocation.color());
+  if (!allocated_buffer.ok()) {
+    return VerboseAllocationError(allocated_buffer.status());
+  }
+  se::DeviceAddressBase result_buffer = allocated_buffer->Release();
+  se::DeviceAddressBase& aliased_buffer =
+      buffer_allocations.GetMutableDeviceAddress(allocation.index());
+  CHECK_EQ(aliased_buffer.size(), result_buffer.size());
+  RETURN_IF_ERROR(run_options->stream()->MemcpyD2D(
+      &result_buffer, aliased_buffer, aliased_buffer.size()));
+  aliased_buffer = result_buffer;
+  return result_buffer;
+}
+
 absl::StatusOr<ExecutionOutput> GpuExecutable::ExecuteAsyncOnStream(
     const ServiceExecutableRunOptions* run_options,
     std::vector<ExecutionInput> arguments) {
@@ -1373,29 +1403,10 @@ absl::StatusOr<ExecutionOutput> GpuExecutable::ExecuteAsyncOnStreamImpl(
       } else if (!output_info.passthrough &&
                  !ShapeUtil::GetSubshape(program_shape_.result(), index)
                       .IsTuple()) {
-        // The guard is above is not to insert copy-protection when aliasing
-        // pass-through params, as we do not need to write into the output
-        // buffer.
-        XLA_VLOG_DEVICE(3, device_ordinal)
-            << "Using copy-protection: aliasing is specified, but the "
-               "buffer is not donated; allocating a fresh buffer";
-        int64_t allocation_size = ShapeUtil::ByteSizeOf(
-            ShapeUtil::GetSubshape(program_shape_.result(), index));
-        absl::StatusOr<se::ScopedDeviceAddress<uint8_t>> allocated_buffer =
-            memory_allocator->Allocate(device_ordinal, allocation_size,
-                                       /*retry_on_failure=*/true,
-                                       /*memory_space=*/allocation->color());
-        if (!allocated_buffer.ok()) {
-          return VerboseAllocationError(allocated_buffer.status());
-        }
-        result_buffer = allocated_buffer->Release();
-        se::DeviceAddressBase& aliased_buffer =
-            buffer_allocations.GetMutableDeviceAddress(
-                output_info.allocation_index);
-        CHECK_EQ(aliased_buffer.size(), result_buffer.size());
-        RETURN_IF_ERROR(run_options->stream()->MemcpyD2D(
-            &result_buffer, aliased_buffer, aliased_buffer.size()));
-        aliased_buffer = result_buffer;
+        ASSIGN_OR_RETURN(result_buffer,
+                         AllocateCopyProtectedOutputBuffer(
+                             run_options, buffer_allocations, index,
+                             *allocation, device_ordinal, memory_allocator));
       }
     }
 

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -31,6 +31,7 @@ limitations under the License.
 #include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/node_hash_map.h"
+#include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
@@ -206,7 +207,14 @@ class GpuExecutable : public Executable {
       const ServiceExecutableRunOptions* run_options,
       VariantArguments arguments);
 
-  absl::Span<const BufferAllocation* absl_nonnull const> GetAllocations()
+  // Resolves the device address backing an entry-computation-parameter
+  // allocation. Returning a null DeviceAddressBase means "leave the buffer
+  // unset" (e.g. a skipped tuple index-table allocation).
+  using ParameterBufferResolver =
+      absl::FunctionRef<absl::StatusOr<se::DeviceAddressBase>(
+          const BufferAllocation& allocation)>;
+
+  absl::Span<const BufferAllocation * absl_nonnull const> GetAllocations()
       const override {
     return allocation_ptrs_;
   }
@@ -247,6 +255,16 @@ class GpuExecutable : public Executable {
   // instead.
   absl::StatusOr<const BufferAllocToDeviceMemoryMap*> ResolveConstantGlobals(
       se::Stream* stream);
+
+  // Builds the BufferAllocations for an execution. Entry-computation-parameter
+  // buffers are obtained from `get_parameter_buffer`; all other allocations
+  // (thread-local, constant, temp/maybe-live-out) are resolved internally,
+  // including collective-memory granularity rounding and alignment checking.
+  absl::StatusOr<BufferAllocations> GenerateBufferAllocations(
+      const ServiceExecutableRunOptions* run_options,
+      ParameterBufferResolver get_parameter_buffer,
+      const BufferAllocToDeviceMemoryMap* globals,
+      se::DeviceAddressAllocator* memory_allocator, int device_ordinal);
 
   absl::Status VerboseAllocationError(absl::Status s);
 
@@ -327,14 +345,8 @@ class GpuExecutable : public Executable {
   absl::Status CheckCompatibilityWithServiceExecutableRunOptions(
       const ServiceExecutableRunOptions* run_options);
 
-  absl::StatusOr<BufferAllocations> GenerateBufferAllocations(
-      const ServiceExecutableRunOptions* run_options,
-      VariantArguments arguments,
-      const GpuExecutable::BufferAllocToDeviceMemoryMap* globals,
-      se::DeviceAddressAllocator* memory_allocator, int device_ordinal);
-
   absl::StatusOr<se::DeviceAddressBase> BufferForAllocation(
-      VariantArguments arguments,
+      ParameterBufferResolver get_parameter_buffer,
       const GpuExecutable::BufferAllocToDeviceMemoryMap* globals,
       const BufferAllocation& allocation,
       se::DeviceAddressAllocator* memory_allocator, int device_ordinal,
@@ -495,6 +507,12 @@ class GpuExecutable : public Executable {
 
 absl::StatusOr<absl::flat_hash_map<ShapeIndex, GpuExecutable::OutputInfo>>
 GetOutputInfo(const HloModule& hlo_module, const BufferAssignment& assignment);
+
+// Verifies that `buffer` satisfies the alignment required for `allocation`'s
+// kind (entry parameter, constant, or XLA-allocated). `arg_idx` is used only
+// for error messages.
+absl::Status CheckAlignment(const BufferAllocation& allocation,
+                            se::DeviceAddressBase buffer, int arg_idx);
 
 }  // namespace gpu
 }  // namespace xla

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -266,6 +266,17 @@ class GpuExecutable : public Executable {
       const BufferAllocToDeviceMemoryMap* globals,
       se::DeviceAddressAllocator* memory_allocator, int device_ordinal);
 
+  // Copy-protection for an aliased output that was not donated at runtime:
+  // allocates a fresh result buffer for the output at `index`, copies the
+  // contents of the aliased buffer (allocation `allocation`) into it, and
+  // redirects the aliased entry in `buffer_allocations` to the fresh buffer.
+  // Returns the newly allocated result buffer.
+  absl::StatusOr<se::DeviceAddressBase> AllocateCopyProtectedOutputBuffer(
+      const ServiceExecutableRunOptions* run_options,
+      BufferAllocations& buffer_allocations, const ShapeIndex& index,
+      const BufferAllocation& allocation, int device_ordinal,
+      se::DeviceAddressAllocator* memory_allocator);
+
   absl::Status VerboseAllocationError(absl::Status s);
 
   static absl::StatusOr<std::unique_ptr<GpuExecutable>> FromProto(

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -207,11 +207,17 @@ class GpuExecutable : public Executable {
       const ServiceExecutableRunOptions* run_options,
       VariantArguments arguments);
 
+  struct ParameterBuffer {
+    se::DeviceAddressBase buffer;
+    int64_t parameter_number;
+  };
+
   // Resolves the device address backing an entry-computation-parameter
   // allocation. Returning a null DeviceAddressBase means "leave the buffer
-  // unset" (e.g. a skipped tuple index-table allocation).
+  // unset" (e.g. a skipped tuple index-table allocation). The parameter number
+  // is used only for diagnostics.
   using ParameterBufferResolver =
-      absl::FunctionRef<absl::StatusOr<se::DeviceAddressBase>(
+      absl::FunctionRef<absl::StatusOr<ParameterBuffer>(
           const BufferAllocation& allocation)>;
 
   absl::Span<const BufferAllocation * absl_nonnull const> GetAllocations()


### PR DESCRIPTION
  📝 Summary of Changes
  This refactors duplicated GPU execution setup logic shared by
  `GpuExecutable::ExecuteAsyncOnStreamImpl` and `StreamExecutorGpuClient::RunAsync`.

  - Parameterize `GpuExecutable::GenerateBufferAllocations` with a
    `ParameterBufferResolver`, so each caller only supplies how entry-parameter
    buffers are resolved.
  - Move collective-memory granularity handling, allocation looping, and alignment
    checks into the shared `GpuExecutable` path.
  - Extract aliased-output copy protection into
    `GpuExecutable::AllocateCopyProtectedOutputBuffer`.
  - Remove the now-unused `gpu_constants` include and BUILD dependency from the
    PjRt GPU client.

  🎯 Justification
  The PjRt reactor raw-buffer path duplicated substantial logic from
  `GpuExecutable`, including allocation resolution, collective-memory alignment
  rounding, and copy-protection handling for non-donated aliased outputs.

  Sharing this logic reduces maintenance risk and keeps the PjRt path aligned with
  the regular GPU executable path while preserving caller-specific argument and
  output handling.

  🚀 Kind of Contribution
  ♻️  Cleanup

  📊 Benchmark (for Performance Improvements)
  N/A. This is a cleanup/refactor with no intended performance change.

  🧪 Unit Tests:
  No new unit tests were added. The change is intended to preserve existing
  behavior by moving duplicated logic into shared helpers.

  🧪 Execution Tests:
  No new execution tests were added. Existing GPU executable and PjRt execution
  coverage should exercise the affected paths.
