### PR TITLE
[ROCm] Clean-up rbe pool, control in rocm internal shim

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -131,5 +131,4 @@ jobs:
             --config=rocm_rbe \
             --config=ci_single_gpu \
             --local_test_jobs=1 \
-            --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${DOCKER_IMAGE}"


### PR DESCRIPTION
📝 Summary of Changes
Remove unnecessary rbe pool selection argument as it is selected lateron in shim

🎯 Justification
This argument get overwritten later on and therefore is not required

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
