### PR TITLE
[XLA:GPU] Add s64 support for cuDNN ragged dot group size

### DIFF
--- a/xla/backends/gpu/transforms/cudnn_fusion_compiler.cc
+++ b/xla/backends/gpu/transforms/cudnn_fusion_compiler.cc
@@ -157,6 +157,8 @@ inline std::optional<fe::DataType_t> ToCudnnDataType(const PrimitiveType type) {
       return t::BFLOAT16;
     case PrimitiveType::S32:
       return t::INT32;
+    case PrimitiveType::S64:
+      return t::INT64;
     case PrimitiveType::S4:
       return t::INT4;
     case PrimitiveType::S8:
@@ -181,6 +183,8 @@ inline std::optional<fe::DataType_t> GetComputeDataType(
   fe::DataType_t compute_dtype = fe::DataType_t::FLOAT;
   if (type == F64) {
     compute_dtype = fe::DataType_t::DOUBLE;
+  } else if (type == S64) {
+    compute_dtype = fe::DataType_t::INT64;
   } else if (primitive_util::IsIntegralType(type)) {
 #if CUDNN_VERSION >= 90100
     compute_dtype = fe::DataType_t::INT32;

--- a/xla/backends/gpu/transforms/ragged_dot_fusion_rewriter_test.cc
+++ b/xla/backends/gpu/transforms/ragged_dot_fusion_rewriter_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <initializer_list>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include <gmock/gmock.h>
@@ -58,6 +59,7 @@ using ::testing::HasSubstr;
 using ::testing::Not;
 
 static const std::initializer_list<absl::string_view> kbf16f16{"bf16", "f16"};
+static const std::initializer_list<absl::string_view> ks32s64{"s32", "s64"};
 
 // This class performs isolated unit testing of the RaggedDotFusionRewriter
 // pass. It verifies that specific HLO patterns are correctly recognized and
@@ -125,7 +127,8 @@ TEST_F(RaggedDotFusionRewriterUnitTest, TestSupportedRaggedDot) {
 // optimization pipeline and produces numerically correct results on hardware.
 class RaggedDotFusionRewriterIntegrationTest
     : public HloPjRtInterpreterReferenceMixin<HloPjRtGpuTestBase>,
-      public ::testing::WithParamInterface<absl::string_view> {
+      public ::testing::WithParamInterface<
+          std::tuple<absl::string_view, absl::string_view>> {
  public:
   bool IsCuda() const {
     return device_description().gpu_compute_capability().IsCuda();
@@ -176,6 +179,7 @@ TEST_P(RaggedDotFusionRewriterIntegrationTest, TestRaggedDotOnly) {
     GTEST_SKIP() << "CuDNN ragged dot requires cuDNN 9.21+.";
   }
 
+  const auto& [data_type, group_type] = GetParam();
   const std::string hlo_with_new_type =
       absl::StrReplaceAll(R"(
     HloModule Test
@@ -183,11 +187,11 @@ TEST_P(RaggedDotFusionRewriterIntegrationTest, TestRaggedDotOnly) {
     ENTRY Test {
       input = TYPE[128,512]{1,0} parameter(0)
       weight = TYPE[16,512,256]{2,1,0} parameter(1)
-      group_sizes = s32[16]{0} parameter(2)
+      group_sizes = GROUP_TYPE[16]{0} constant({7,9,6,10,8,8,8,8,8,8,8,8,8,8,8,8})
       ROOT rd = TYPE[128,256]{1,0} ragged-dot(input, weight, group_sizes),
              lhs_contracting_dims={1}, rhs_contracting_dims={1}, lhs_ragged_dims={0}, rhs_group_dims={0}
     })",
-                          {{"TYPE", GetParam()}});
+                          {{"TYPE", data_type}, {"GROUP_TYPE", group_type}});
   std::string optimized_hlo_string = GetOptimizedHlo(hlo_with_new_type);
   EXPECT_THAT(optimized_hlo_string, HasSubstr(kCuDnnFusionKind));
 
@@ -200,8 +204,10 @@ TEST_P(RaggedDotFusionRewriterIntegrationTest, TestRaggedDotOnly) {
       << optimized_hlo_string;
 }
 
-INSTANTIATE_TEST_SUITE_P(AllTypes, RaggedDotFusionRewriterIntegrationTest,
-                         ::testing::ValuesIn(kbf16f16));
+INSTANTIATE_TEST_SUITE_P(
+    AllTypes, RaggedDotFusionRewriterIntegrationTest,
+    ::testing::Combine(::testing::ValuesIn(kbf16f16),
+                       ::testing::ValuesIn(ks32s64)));
 }  // namespace
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
📝 Summary of Changes
* Add S64 support for cuDNN ragged dot group_size argument. cuDNN supports both S32 and S64. 
* Add tests as well for S64. Changed the unit test to use constant group size to avoid invalid address error due to random initial value of group size.