### PR TITLE
[xla:gpu] Print the version of NCCL linked at run time

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -600,6 +600,7 @@ cc_library(
         "//xla/tsl/platform:logging",
         "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/algorithm/container.h"
+#include "absl/base/casts.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_map.h"
@@ -204,6 +205,21 @@ class NcclIdStore {
 // NcclCollectives
 //===----------------------------------------------------------------------===//
 
+// The version of NCCL that XLA was compiled with and the version of NCCL loaded
+// at run time might be different (JAX and XLA compiled against the NCCL stub,
+// and NCCL loaded from a shared object at run time), for debugging purpose we
+// log both versions to detect version skew as potential source of bugs.
+static absl::StatusOr<int> GetLinkedNcclVersion() {
+  int nccl_version;
+  XLA_NCCL_RETURN_IF_ERROR(ncclGetVersion(&nccl_version));
+  return nccl_version;
+}
+
+static std::string FormatNcclVersion(int nccl_version) {
+  return absl::StrFormat("%d.%d.%d", nccl_version / 10000,
+                         (nccl_version / 100) % 100, nccl_version % 100);
+}
+
 static absl::StatusOr<std::unique_ptr<Communicator>> Cast(
     absl::StatusOr<std::unique_ptr<NcclCommunicator>> comm_or) {
   ASSIGN_OR_RETURN(auto comm, std::move(comm_or));
@@ -257,8 +273,8 @@ static absl::StatusOr<ncclConfig_t> AsNcclConfig(
   ncclConfig_t comm_config = NCCL_CONFIG_INITIALIZER;
   comm_config.blocking = config.blocking_communicators ? 1 : 0;
   comm_config.splitShare = config.split_share;
-  int nccl_version;
-  XLA_NCCL_RETURN_IF_ERROR(ncclGetVersion(&nccl_version));
+
+  ASSIGN_OR_RETURN(int nccl_version, GetLinkedNcclVersion());
 
   if (xla::GetDebugOptionsFromFlags()
           .xla_gpu_experimental_enable_nccl_symmetric_buffers() &&
@@ -317,13 +333,16 @@ NcclCollectives::CreateCommunicatorsWithCancel(
   if (!clique_ids.has_value() || clique_ids->data().empty()) {
     return InvalidArgument("CliqueId is required to create NCCL communicators");
   }
+
+  ASSIGN_OR_RETURN(int nccl_version, GetLinkedNcclVersion());
   VLOG(1) << absl::StreamFormat(
-      "[%s] [ranks=%s] Initialize NCCL (version %d.%d.%d) "
+      "[%s] [ranks=%s] Initialize NCCL (compiled with %s, linked with %s) "
       "communicators for %d local devices (out of %d global devices); "
       "size(id)=%zu; fingerprint(id)=%v",
-      DeviceOrdinalsToString(ranks), DeviceRanksToString(ranks), NCCL_MAJOR,
-      NCCL_MINOR, NCCL_PATCH, ranks.size(), clique_key.num_devices(),
-      clique_ids->size(), clique_ids->fingerprint());
+      DeviceOrdinalsToString(ranks), DeviceRanksToString(ranks),
+      FormatNcclVersion(NCCL_VERSION_CODE), FormatNcclVersion(nccl_version),
+      ranks.size(), clique_key.num_devices(), clique_ids->size(),
+      clique_ids->fingerprint());
 
   const auto& gpu_config =
       absl::down_cast<const GpuCollectives::Config&>(config);


### PR DESCRIPTION
Version of NCCL that XLA/JAX were compiled with and NCCL loaded at run time could be different, and it is ok because NCCL guarantees backward compatibility. For debugging print both version in XLA.