### PR TITLE
[XLA:GPU][oneAPI] Skip tests that involve FP8 on Intel's GPUs

### DIFF
--- a/xla/backends/gpu/tests/collective_ops_e2e_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_e2e_test.cc
@@ -85,6 +85,8 @@ class CollectiveOpsTestE2E : public CollectiveOpsE2ETestBase {
     if (Capability().IsCuda()) {
       return Capability().cuda_compute_capability()->IsAtLeast(8, 9);
     }
+    // TODO(Intel-tf): Update this when FP8 is supported.
+    if (Capability().IsOneAPI()) return false;
     return Capability().rocm_compute_capability()->has_fp8_support() &&
            GetDebugOptionsForTest().xla_gpu_enable_cublaslt();
   }


### PR DESCRIPTION
📝 Summary of Changes
Skip tests that involve FP8 on Intel's GPUs

🎯 Justification
[`HasFp8Support`](https://github.com/openxla/xla/blob/main/xla/backends/gpu/tests/collective_ops_e2e_test.cc#L84) does not support FP8 capability check on Intel's GPUs. This can cause the test to crash without error message when running on Intel's GPUs. This PR fixes that issue.

🚀 Kind of Contribution
✨ New Feature