### PR TITLE
[ROCm] Add remote cache compression for rocm rbe

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -131,5 +131,4 @@ jobs:
             --config=rocm_rbe \
             --config=ci_single_gpu \
             --local_test_jobs=1 \
-            --repo_env=TF_ROCM_RBE_SINGLE_GPU_POOL=linux_x64_gpu_gfx90a \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${DOCKER_IMAGE}"

--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -14,6 +14,7 @@ build:rocm_rbe --tls_client_certificate="/data/ci-cert.crt"
 build:rocm_rbe --tls_client_key="/data/ci-cert.key"
 build:rocm_rbe --spawn_strategy=remote,local
 build:rocm_rbe --grpc_keepalive_time=30s
+build:rocm_rbe --remote_cache_compression
 
 test:rocm_rbe --jobs=200
 test:rocm_rbe --remote_executor=grpcs://wardite.cluster.engflow.com


### PR DESCRIPTION
📝 Summary of Changes
Use --remote_cache_compression for rocm_rbe config

🎯 Justification
This change is required to reduce the load on amd internal network

🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement,

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
