### PR TITLE
[ROCm] Split rocm gpu and cpu tests to run separately locally vs on rbe

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -131,4 +131,16 @@ jobs:
             --config=rocm_rbe \
             --config=ci_single_gpu \
             --local_test_jobs=1 \
+            --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${DOCKER_IMAGE}" \
+            --local_test_jobs=1 \
+            --internal_spawn_scheduler \
+            --strategy=TestRunner=dynamic
+      - name: Test XLA [lit]
+        timeout-minutes: 120
+        run: |
+          build_tools/rocm/execute_ci_build_upstream.sh \
+            --config=rocm_ci \
+            --config=rocm_rbe \
+            --config=ci_lit \
+            --local_test_jobs=200 \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${DOCKER_IMAGE}"

--- a/build_tools/lint/tags.py
+++ b/build_tools/lint/tags.py
@@ -74,6 +74,7 @@ _TAGS_TO_DOCUMENTATION_MAP = {
     "requires-gpu-sm120-only": "Requires exactly sm120.",
     "full": "Test requires a full GPU, not a partitioned one. No effect in"
             " OSS.",
+    "lit": "Lit test from lit test suite",
     "gpu": "Catch-all tag for targets that should be built/tested on GPU CI",
     "cpu": "Catch-all tag for targets that should be built/tested on CPU CI.",
     "cuda-only": "Targets that require the CUDA backend to be enabled.",

--- a/build_tools/rocm/rocm_tag_filters.sh
+++ b/build_tools/rocm/rocm_tag_filters.sh
@@ -17,6 +17,7 @@
 
 TAG_FILTERS=(
     -no_gpu
+    -lit
     -requires-gpu-intel
     -requires-gpu-nvidia
     -cuda-only

--- a/build_tools/rocm/rocm_tag_filters.sh
+++ b/build_tools/rocm/rocm_tag_filters.sh
@@ -17,7 +17,6 @@
 
 TAG_FILTERS=(
     -no_gpu
-    -lit
     -requires-gpu-intel
     -requires-gpu-nvidia
     -cuda-only

--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -58,6 +58,9 @@ build:ci_multi_gpu --flaky_test_attempts=3
 build:ci_multi_gpu --experimental_guard_against_concurrent_changes
 build:ci_multi_gpu --test_env=HIP_VISIBLE_DEVICES=0,1,2,3
 
+build:ci_lit --run_under=//build_tools/rocm:sanitizer_wrapper
+build:ci_lit --strategy=TestRunner=local
+
 test:xla_sgpu -- \
 //xla/... \
 -//xla/tests:iota_test_amdgpu_any \

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -25,10 +25,13 @@ mkdir -p /tf/pkg
 
 for arg in "$@"; do
     if [[ "$arg" == "--config=ci_multi_gpu" ]]; then
-        TAG_FILTERS="${TAG_FILTERS},multi_gpu"
+        TAG_FILTERS="${TAG_FILTERS},multi_gpu,-lit"
     fi
     if [[ "$arg" == "--config=ci_single_gpu" ]]; then
-        TAG_FILTERS="${TAG_FILTERS},gpu,-multi_gpu"
+        TAG_FILTERS="${TAG_FILTERS},gpu,-lit,-multi_gpu"
+    fi
+    if [[ "$arg" == "--config=ci_lit" ]]; then
+        TAG_FILTERS="${TAG_FILTERS},lit"
     fi
 done
 

--- a/xla/lit.bzl
+++ b/xla/lit.bzl
@@ -139,7 +139,7 @@ def lit_test_suite(
             visibility = visibility,
             env = env,
             timeout = timeout,
-            tags = tags + default_tags + tags_override.get(test_file, []),
+            tags = tags + ["lit"] + default_tags + tags_override.get(test_file, []),
             hermetic_cuda_data_dir = hermetic_cuda_data_dir,
             exec_properties = exec_properties,
             gpu_suffix = gpu_suffix,


### PR DESCRIPTION
📝 Summary of Changes
Ignore lit test when running tests using rocm rbe

🎯 Justification
Lit tests do not require a physical gpu to get executed, they do pollute
rocm rbe infrastructure uploading huge chunks of data. We do filter
these tests to decrease load on rocm infra

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevant
