### PR TITLE
[XLA:GPU] Command buffer executor support commands that require updates even buffer allocations do not change (i.e DynamicSliceThunk)

### DIFF
--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -208,6 +208,10 @@ class Command : public Thunk {
   // ensure that all ranks execute NCCL command update.
   virtual bool requires_initialization() const { return false; }
 
+  // Returns true if command buffer command parameters can change even when
+  // buffer allocation base addresses are unchanged.
+  virtual bool requires_update() const { return false; }
+
   // Returns true if this command is implemented via CUDA stream activity
   // tracing (i.e. a subclass of TracedCommand).
   virtual bool IsTracedCommand() const { return false; }

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -319,10 +319,13 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
   bool is_first_record =
       command_buffer_update_mode_ == DebugOptions::NEVER_UPDATE &&
       cmd_buffer->command_buffer->state() == se::CommandBuffer::State::kCreate;
+  bool has_commands_requiring_update =
+      command_buffer_update_mode_ != DebugOptions::NEVER_UPDATE &&
+      commands_.requires_update();
   bool needs_update =
       (command_buffer_update_mode_ == DebugOptions::ALWAYS_UPDATE ||
        command_buffer_update_mode_ == DebugOptions::CAPTURE_CMD_NEVER_UPDATE) &&
-      !updated_allocs.empty();
+      (has_commands_requiring_update || !updated_allocs.empty());
 
   if (is_first_record || needs_update) {
     XLA_VLOG_DEVICE(3, executor->device_ordinal())

--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -566,6 +566,10 @@ absl::Status CommandExecutor::RecordUpdate(
 
     Command* command = commands_[id];
 
+    if (command->requires_update()) {
+      return false;
+    }
+
     // For CAPTURE_CMD_NEVER_UPDATE mode, always skip updates for commands
     // implemented via tracing. This includes CollectiveThunk command/thunk
     // hybrids: their buffer allocations are VA-remapped to fixed offsets within

--- a/xla/backends/gpu/runtime/command_executor.h
+++ b/xla/backends/gpu/runtime/command_executor.h
@@ -162,6 +162,14 @@ class CommandExecutor {
     return requires_initialization;
   }
 
+  bool requires_update() const {
+    bool requires_update = false;
+    commands_.Walk([&](const Command* command) {
+      requires_update |= command->requires_update();
+    });
+    return requires_update;
+  }
+
   bool support_loop_unroll() const {
     bool support_loop_unroll = true;
     commands_.Walk([&](const Command* command) {


### PR DESCRIPTION
  📝 Summary of Changes
  Add a new `Command::requires_update()` API for commands whose recorded command-buffer parameters can change even when buffer allocation base addresses are unchanged.

  This PR also teaches `CommandExecutor` and `CommandBufferThunk` to honor that API:
  - `CommandExecutor::requires_update()` aggregates the requirement across nested commands.
  - `CommandExecutor::RecordUpdate()` does not skip commands that report `requires_update()`.
  - `CommandBufferThunk` forces command-buffer update when any command requires it, unless the command buffer mode is `NEVER_UPDATE`.

  🎯 Justification
  Command buffer updates were previously driven by changed buffer allocation base addresses. That is not sufficient for commands whose recorded parameters depend on execution context or host-computed values.

  A downstream example is DynamicSliceThunk command-buffer recording: slice offsets can be computed from the while-loop induction variable. Between loop iterations, the input/output buffer base addresses can stay unchanged, but the recorded child command buffer still needs to be updated because the slice start address changes.

  The new API lets commands explicitly declare this requirement instead of overloading allocation-change tracking for non-allocation state.

  🚀 Kind of Contribution
  🐛 Bug Fix

  📊 Benchmark (for Performance Improvements)
  N/A. This is not a performance improvement.

  🧪 Unit Tests:
  No new unit tests in this infrastructure-only PR. The feature-specific regression test is added in the stacked DynamicSliceThunk runtime PR.

  Verified build:
  `bazel build //xla/backends/gpu/runtime:command_buffer_thunk //xla/backends/gpu/runtime:command_executor`

  🧪 Execution Tests:
  No execution tests added in this PR. Execution coverage is added in the stacked DynamicSliceThunk runtime PR that uses this API.
