### PR TITLE
[ROCm] Add missing remotecache setting for rocm_rbe

### DIFF
--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -1,8 +1,9 @@
 # Test-related settings.
 
 build:rocm_dev --remote_upload_local_results=false
-build:rocm_dev --remote_cache="https://wardite.cluster.engflow.com"
+build:rocm_dev --remote_cache="grpcs://wardite.cluster.engflow.com"
 
+build:rocm_rbe --remote_cache="grpcs://wardite.cluster.engflow.com"
 build:rocm_rbe --repo_env=REMOTE_GPU_TESTING=1
 build:rocm_rbe --bes_backend="grpcs://wardite.cluster.engflow.com"
 build:rocm_rbe --bes_results_url="https://wardite.cluster.engflow.com/invocation/"


### PR DESCRIPTION
📝 Summary of Changes
Add missing remote cache setting for rocm-rbe config

🎯 Justification
We did miss remote-cache setting for rocm_rbe config

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
