### PR TITLE
[ROCm] Limit deps files based on requested during the build archs list

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -1,7 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@config_rocm_hipcc//rocm:build_defs.bzl", "hipcc_config")
-load("@local_config_rocm//rocm:build_defs.bzl", "rocm_lib_import", "rocm_version_number")
+load("@local_config_rocm//rocm:build_defs.bzl", "rocm_gpu_architectures", "rocm_lib_import", "rocm_version_number")
 
 licenses(["restricted"])  # MPL2, portions GPL v3, LGPL v3, BSD-like
 

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -220,7 +220,9 @@ rocm_lib_import(
     name = "rocblas",
     data = glob([
         "%{rocm_root}/lib/librocblas.so*",
-        "%{rocm_root}/lib/rocblas/**",
+    ]) + glob([
+        "%{rocm_root}/lib/rocblas/library/*" + arch + "*"
+        for arch in rocm_gpu_architectures()
     ]),
     interface_library = "%{rocm_root}/lib/librocblas.so",
     deps = [
@@ -410,9 +412,11 @@ rocm_lib_import(
 rocm_lib_import(
     name = "hipblaslt",
     data = glob([
-        "%{rocm_root}/lib/hipblaslt/**",
         "%{rocm_root}/lib/libhipblaslt.so*",
         "%{rocm_root}/lib/librocroller.so*",
+    ]) + glob([
+        "%{rocm_root}/lib/hipblaslt/library/*" + arch + "*"
+        for arch in rocm_gpu_architectures()
     ]),
     interface_library = "%{rocm_root}/lib/libhipblaslt.so",
     deps = [


### PR DESCRIPTION
📝 Summary of Changes
Limit the set of deps for rocblas, rocblaslt to the relevant arch files

🎯 Justification
We do upload way too many files as a dependency to our targets.
We do upload not relevant to our test deps such as arch based hsaco files
which will never be used. We filter out these files now

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
