### PR TITLE
[xla:gpu] Bring back DynamicSliceAnnotator to GPU pipeline

### DIFF
--- a/xla/backends/gpu/tests/BUILD
+++ b/xla/backends/gpu/tests/BUILD
@@ -413,7 +413,6 @@ xla_test(
         "//xla:xla_proto_cc",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:verified_hlo_module",
-        "//xla/service:hlo_module_config",
         "//xla/tests:hlo_pjrt_interpreter_reference_mixin",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_googletest//:gtest_main",

--- a/xla/backends/gpu/tests/gpu_copy_test.cc
+++ b/xla/backends/gpu/tests/gpu_copy_test.cc
@@ -26,7 +26,6 @@ limitations under the License.
 #include "xla/hlo/testlib/verified_hlo_module.h"
 #include "xla/literal.h"
 #include "xla/literal_util.h"
-#include "xla/service/hlo_module_config.h"
 #include "xla/tests/hlo_pjrt_interpreter_reference_mixin.h"
 #include "xla/xla.pb.h"
 #include "tsl/platform/statusor.h"
@@ -423,12 +422,9 @@ TEST_F(GpuCopyTest, UseDynamicMemcpyIntegrationTest) {
   // This is an integration test to verify that the pipeline for replacing
   // dynamic-slices that depend on while loop iteration variables with memcpy
   // works as a whole.
-  HloModuleConfig config = GetModuleConfigForTest();
-  config.mutable_debug_options().set_xla_gpu_enable_dynamic_slice_fusion(true);
-
   TF_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<VerifiedHloModule> hlo_module,
-      ParseAndReturnVerifiedModule(kSliceMemcpyModuleUnfused, config));
+      ParseAndReturnVerifiedModule(kSliceMemcpyModuleUnfused));
 
   // Check that there are exactly two fusions:
   // 1. A `compare` fusion for the loop condition.

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1488,9 +1488,13 @@ absl::Status RunDynamicSliceFusionPasses(HloModule* hlo_module,
                                          CompilationStats* compilation_stats) {
   const DebugOptions& opts = hlo_module->config().debug_options();
 
+  // Always annotate dynamic slice operation with statically know offsets. We
+  // rely on these annotations when running fusion dispatch pipeline to optimize
+  // DS/DUS fusions that can be replaced by a more efficient copy operation.
+  HloPassPipeline pipeline("dynamic-slice", compilation_stats);
+  pipeline.AddPass<DynamicSliceAnnotator>();
+
   if (opts.xla_gpu_enable_dynamic_slice_fusion()) {
-    HloPassPipeline pipeline("dynamic-slice", compilation_stats);
-    pipeline.AddPass<DynamicSliceAnnotator>();
     pipeline.AddPass<GpuReduceScatterCombiner>(
         kDefaultReduceScatterCombineThreshold,
         opts.xla_gpu_reduce_scatter_combine_threshold_bytes(),
@@ -1508,10 +1512,11 @@ absl::Status RunDynamicSliceFusionPasses(HloModule* hlo_module,
           });
       return hero_op.has_value();
     });
-    RETURN_IF_ERROR(
-        pipeline.Run(hlo_module, {HloInstruction::kMainExecutionThread})
-            .status());
   }
+
+  RETURN_IF_ERROR(
+      pipeline.Run(hlo_module, {HloInstruction::kMainExecutionThread})
+          .status());
 
   return absl::OkStatus();
 }


### PR DESCRIPTION
Revert: https://github.com/openxla/xla/commit/0526796ee3124988a8883fda642f606f66baaf00

With all the fixes + improved diagnostics DUS thunk either works correctly or will print an error that points to the root cause problem.