### PR TITLE
[ROCm] Enable HLO XLA transform pass registration on GPU

### DIFF
--- a/xla/pjrt/c/BUILD
+++ b/xla/pjrt/c/BUILD
@@ -655,6 +655,8 @@ cc_library(
         ":pjrt_c_api_triton_extension_hdrs",
         ":pjrt_c_api_triton_internal",
         ":pjrt_c_api_wrapper_impl",
+        ":pjrt_c_api_xla_transform_extension_hdrs",
+        ":pjrt_c_api_xla_transform_internal",
         "//xla/backends/cpu:target_machine_options",
         "//xla/backends/profiler:profiler_backends",  # To register the Host Tracers for GPU Plugin.
         "//xla/backends/profiler/gpu:device_tracer",  # To register the GPU Tracers with the GPU Plugin.

--- a/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
@@ -52,6 +52,8 @@ limitations under the License.
 #include "xla/pjrt/c/pjrt_c_api_triton_extension.h"
 #include "xla/pjrt/c/pjrt_c_api_triton_internal.h"
 #include "xla/pjrt/c/pjrt_c_api_wrapper_impl.h"
+#include "xla/pjrt/c/pjrt_c_api_xla_transform_extension.h"
+#include "xla/pjrt/c/pjrt_c_api_xla_transform_internal.h"
 #include "xla/pjrt/extensions/abi_version/gpu_abi_version_extension.h"
 #include "xla/pjrt/extensions/cross_host_transfers/pjrt_c_api_cross_host_transfers_extension.h"
 #include "xla/pjrt/gpu/gpu_helpers.h"
@@ -588,8 +590,11 @@ const PJRT_Api* GetGpuPjrtApi() {
   static PJRT_Shardings_Extension shardings_extension =
       pjrt::CreateShardingsExtension(&cross_host_transfers_extension.base);
 
+  static PJRT_Xla_Transform_Extension xla_transform_extension =
+      pjrt::CreateXlaTransformExtension(&shardings_extension.base);
+
   static PJRT_AbiVersion_Extension abi_version_extension =
-      pjrt::CreateGpuAbiVersionExtension(&shardings_extension.base);
+      pjrt::CreateGpuAbiVersionExtension(&xla_transform_extension.base);
 
   static const PJRT_Api pjrt_api = pjrt::CreatePjrtApi(
       pjrt::gpu_plugin::PJRT_Client_Create,

--- a/xla/pjrt/c/pjrt_c_api_xla_transform_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_xla_transform_internal.cc
@@ -44,8 +44,11 @@ namespace {
 
 class CApiXlaTransformAdapter : public HloXlaTransform {
  public:
+  // callbacks must outlive this object. The pointer is stored directly so that
+  // implementations using offsetof-based recovery (e.g. CApiTransformHloModule
+  // Callback in jaxlib/xla.cc) receive the original address they registered.
   explicit CApiXlaTransformAdapter(std::string name,
-                                   PJRT_XlaTransform_Callbacks callbacks)
+                                   PJRT_XlaTransform_Callbacks* callbacks)
       : HloXlaTransform(std::move(name)), callbacks_(callbacks) {}
 
   absl::StatusOr<bool> Transform(xla::HloModule* module) override {
@@ -63,10 +66,10 @@ class CApiXlaTransformAdapter : public HloXlaTransform {
     args.hlo_module.data = serialized_proto.data();
     args.hlo_module.size = serialized_proto.size();
 
-    if (callbacks_.transform_hlo_module == nullptr) {
+    if (callbacks_->transform_hlo_module == nullptr) {
       return absl::InternalError("transform_hlo_module callback is null");
     }
-    callbacks_.transform_hlo_module(&callbacks_, &args);
+    callbacks_->transform_hlo_module(callbacks_, &args);
 
     absl::Status status = absl::OkStatus();
     bool changed = false;
@@ -97,7 +100,7 @@ class CApiXlaTransformAdapter : public HloXlaTransform {
   }
 
  private:
-  PJRT_XlaTransform_Callbacks callbacks_;
+  PJRT_XlaTransform_Callbacks* callbacks_;
 };
 
 }  // namespace
@@ -130,7 +133,7 @@ PJRT_Error* RegisterXlaTransform(PJRT_Register_Xla_Transform_Args* args) {
   }
 
   auto transform =
-      std::make_shared<xla::CApiXlaTransformAdapter>(name, *args->callbacks);
+      std::make_shared<xla::CApiXlaTransformAdapter>(name, args->callbacks);
   xla::HloXlaTransform::PipelineStage stage;
   switch (args->stage) {
     case PJRT_XlaTransform_PipelineStage_kPreScheduler:

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1840,6 +1840,7 @@ cc_library(
         "//xla/pjrt/distributed:key_value_store_interface",
         "//xla/pjrt/proto:compile_options_proto_cc",
         "//xla/runtime:object_pool",
+        "//xla/service:xla_transform",
         "//xla/service:all_reduce_promotion",
         "//xla/service:all_reduce_reassociate",
         "//xla/service:all_reduce_simplifier",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -322,6 +322,7 @@ limitations under the License.
 #include "xla/service/while_loop_all_reduce_code_motion.h"
 #include "xla/service/while_loop_constant_sinking.h"
 #include "xla/service/while_loop_simplifier.h"
+#include "xla/service/xla_transform.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
 #include "xla/status_macros.h"
@@ -915,6 +916,8 @@ absl::Status RunOptimizationPasses(
 
   pipeline.AddPass<HloComputationDeduplicator>(
       /*mark_fusion_duplications=*/false);
+  pipeline.AddPass<ApplyXlaTransforms>(
+      HloXlaTransform::PipelineStage::kPreScheduler);
   return pipeline.Run(hlo_module, {HloInstruction::kMainExecutionThread})
       .status();
 }
@@ -3217,6 +3220,12 @@ absl::Status GpuCompiler::RunPostSchedulingPipelines(
     mlir::MLIRContext* mlir_context) {
   tsl::profiler::TraceMe traceme("RunPostSchedulingPipelines");
   RETURN_IF_ERROR(RunPostSchedulingCopyInsertion(module, alias_info));
+  {
+    HloPassPipeline post_scheduler_pipeline("post-scheduler-xla-transforms");
+    post_scheduler_pipeline.AddPass<ApplyXlaTransforms>(
+        HloXlaTransform::PipelineStage::kPostScheduler);
+    RETURN_IF_ERROR(post_scheduler_pipeline.Run(module).status());
+  }
   HloPassPipeline main_pipeline("post-scheduling-passes");
 
   // Pipeline for async -> sync conversion on for non-overlapped async ops.


### PR DESCRIPTION
## Summary

- **`gpu_compiler.cc`**: Add `ApplyXlaTransforms` calls at the end of `RunOptimizationPasses` (PRE_SCHEDULER) and at the start of `RunPostSchedulingPipelines` (POST_SCHEDULER). The GPU compiler never called this pass, so registered transforms were silently ignored.
- **`pjrt_c_api_gpu_internal.cc`**: Add `PJRT_Xla_Transform_Extension` to the GPU plugin's extension chain (between `shardings_extension` and `abi_version_extension`). Without it, `FindExtension` returned null and registration via the PJRT C API was silently skipped.
- **`pjrt_c_api_xla_transform_internal.cc`**: Fix a bug in `CApiXlaTransformAdapter`: it previously stored `PJRT_XlaTransform_Callbacks` by value and passed the address of that copy to `transform_hlo_module`. The JAX-side callback (`CApiTransformHloModuleCallback`) uses `offsetof` arithmetic to recover its `CApiCallbackState` from that pointer, so it must receive the original registered address. Fix by storing a pointer instead.
