### PR TITLE
[xla:gpu] Automatically register all allocations with GPU communicators

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -207,6 +207,34 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "allocator_memory_registration",
+    srcs = ["allocator_memory_registration.cc"],
+    hdrs = ["allocator_memory_registration.h"],
+    deps = [
+        ":gpu_clique",
+        ":gpu_cliques",
+        ":gpu_communicator",
+        "//xla:util",
+        "//xla/core/collectives:communicator",
+        "//xla/core/collectives:rank_id",
+        "//xla/core/collectives:registered_memory",
+        "//xla/runtime:device_id",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/framework:allocator",
+        "//xla/tsl/platform:status_macros",
+        "//xla/tsl/util:tied_ref",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/synchronization",
+        "@tsl//tsl/platform:numbers",
+        "@tsl//tsl/profiler/lib:traceme",
+    ],
+)
+
 xla_cc_test(
     name = "gpu_cliques_test",
     srcs = ["gpu_cliques_test.cc"],
@@ -292,7 +320,9 @@ xla_cc_test(
         "requires-gpu-nvidia:2",
     ],
     deps = [
+        ":allocator_memory_registration",
         ":cancellation_token",
+        ":gpu_clique",
         ":gpu_clique_key",
         ":gpu_collectives",
         ":gpu_communicator",
@@ -322,6 +352,7 @@ xla_cc_test(
         "//xla/tsl/platform:status_macros",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:status_matchers",

--- a/xla/backends/gpu/collectives/allocator_memory_registration.cc
+++ b/xla/backends/gpu/collectives/allocator_memory_registration.cc
@@ -1,0 +1,142 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/allocator_memory_registration.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/backends/gpu/collectives/gpu_clique.h"
+#include "xla/backends/gpu/collectives/gpu_cliques.h"
+#include "xla/backends/gpu/collectives/gpu_communicator.h"
+#include "xla/core/collectives/communicator.h"
+#include "xla/core/collectives/rank_id.h"
+#include "xla/core/collectives/registered_memory.h"
+#include "xla/runtime/device_id.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/framework/allocator.h"
+#include "xla/tsl/util/tied_ref.h"
+#include "xla/util.h"
+#include "tsl/platform/numbers.h"
+#include "tsl/profiler/lib/traceme.h"
+
+namespace xla::gpu {
+
+tsl::SubAllocator::Visitor AllocatorMemoryRegistration::alloc_visitor() {
+  return [self = shared_from_this()](void* ptr, int32_t device_ordinal,
+                                     size_t bytes) {
+    self->RecordAlloc(ptr, device_ordinal, bytes);
+  };
+}
+
+tsl::SubAllocator::Visitor AllocatorMemoryRegistration::free_visitor() {
+  return [self = shared_from_this()](void* ptr, int32_t device_ordinal,
+                                     size_t bytes) {
+    self->RecordFree(ptr, device_ordinal, bytes);
+  };
+}
+
+GpuCliqueCreatedCallback AllocatorMemoryRegistration::CliqueCreatedCallback() {
+  return [self = shared_from_this()](GpuClique& clique) {
+    if (absl::Status status = self->RegisterWithClique(clique); !status.ok()) {
+      LOG_FIRST_N(WARNING, 10) << "Failed to register GPU memory with clique "
+                               << clique.key() << ": " << status;
+    }
+  };
+}
+
+void AllocatorMemoryRegistration::RecordAlloc(void* ptr, int32_t device_ordinal,
+                                              size_t bytes) {
+  XLA_VLOG_DEVICE(5, device_ordinal)
+      << "Record GPU allocation " << ptr << " of "
+      << tsl::strings::HumanReadableNumBytes(bytes);
+  if (ptr == nullptr || bytes == 0) {
+    return;
+  }
+
+  absl::MutexLock lock(mu_);
+  allocations_[LocalDeviceId(device_ordinal)].push_back(
+      Allocation{se::DeviceAddressBase(ptr, bytes), {}});
+}
+
+void AllocatorMemoryRegistration::RecordFree(void* ptr, int32_t device_ordinal,
+                                             size_t bytes) {
+  XLA_VLOG_DEVICE(5, device_ordinal)
+      << "Record GPU free " << ptr << " of "
+      << tsl::strings::HumanReadableNumBytes(bytes);
+  if (ptr == nullptr) {
+    return;
+  }
+
+  absl::MutexLock lock(mu_);
+  // Match on the base pointer only: the size reported to the free visitor is
+  // not always consistent with what was recorded on allocation. Erasing the
+  // allocation releases its TiedRefs, deregistering the range from every clique
+  // it was registered with.
+  auto& allocs = allocations_[LocalDeviceId(device_ordinal)];
+  allocs.erase(std::remove_if(allocs.begin(), allocs.end(),
+                              [&](const Allocation& a) {
+                                return a.range.opaque() == ptr;
+                              }),
+               allocs.end());
+}
+
+absl::Status AllocatorMemoryRegistration::RegisterWithClique(
+    GpuClique& clique) {
+  tsl::profiler::TraceMe trace(
+      "AllocatorMemoryRegistration::RegisterWithClique");
+
+  auto register_on_comm = [&](RankId, Communicator* comm) -> absl::Status {
+    auto* gpu_comm = dynamic_cast<GpuCommunicator*>(comm);
+    if (gpu_comm == nullptr) {
+      return absl::OkStatus();
+    }
+
+    se::StreamExecutor* executor = gpu_comm->stream_executor();
+    if (executor == nullptr) {
+      return absl::OkStatus();
+    }
+
+    absl::MutexLock lock(mu_);
+    auto& allocs = allocations_[LocalDeviceId(executor->device_ordinal())];
+
+    XLA_VLOG_DEVICE(3, executor->device_ordinal())
+        << "Registering " << allocs.size()
+        << " recorded allocations with GPU clique " << clique.key();
+
+    for (Allocation& allocation : allocs) {
+      ASSIGN_OR_RETURN(std::unique_ptr<RegisteredMemory> registered,
+                       gpu_comm->CreateRegisteredMemory(allocation.range));
+      ASSIGN_OR_RETURN(tsl::TiedRef<RegisteredMemory> tied,
+                       clique.Tie(std::move(registered)));
+      allocation.registrations.push_back(std::move(tied));
+    }
+
+    return absl::OkStatus();
+  };
+
+  return clique.ForEachCommWithStatus(register_on_comm);
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/allocator_memory_registration.h
+++ b/xla/backends/gpu/collectives/allocator_memory_registration.h
@@ -1,0 +1,90 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_ALLOCATOR_MEMORY_REGISTRATION_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_ALLOCATOR_MEMORY_REGISTRATION_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/backends/gpu/collectives/gpu_clique.h"
+#include "xla/backends/gpu/collectives/gpu_cliques.h"
+#include "xla/core/collectives/registered_memory.h"
+#include "xla/runtime/device_id.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/tsl/framework/allocator.h"
+#include "xla/tsl/util/tied_ref.h"
+
+namespace xla::gpu {
+
+// Tracks allocator-owned GPU memory ranges and registers them with
+// newly-created GPU cliques.
+//
+// This is intended for the BFC preallocation path where suballocator visitors
+// report long-lived arena chunks before the first collective clique is created.
+// It deliberately tracks allocator ranges, not individual PjRt buffers, and it
+// does not discover cliques or allocations that existed before the callbacks
+// were installed.
+//
+// When a clique is created, each recorded range is registered only with the GPU
+// communicator that runs on the same local device ordinal. The resulting
+// registrations are tied to the clique and retained with the allocation record;
+// freeing the allocation releases those registrations.
+class AllocatorMemoryRegistration
+    : public std::enable_shared_from_this<AllocatorMemoryRegistration> {
+ public:
+  AllocatorMemoryRegistration() = default;
+
+  // Returns visitors compatible with tsl::SubAllocator. The visitor API passes
+  // an int32_t device index; this class interprets it as a local device
+  // ordinal.
+  tsl::SubAllocator::Visitor alloc_visitor();
+  tsl::SubAllocator::Visitor free_visitor();
+
+  // Returns a clique-created callback that registers all currently recorded
+  // allocator ranges with the newly-created GPU clique.
+  GpuCliqueCreatedCallback CliqueCreatedCallback();
+
+  // Registers each recorded allocator range with the `clique` communicator that
+  // runs on the same local device ordinal as the range. Ranges on devices not
+  // participating in `clique` are skipped.
+  absl::Status RegisterWithClique(GpuClique& clique);
+
+ private:
+  void RecordAlloc(void* ptr, int32_t device_ordinal, size_t bytes);
+  void RecordFree(void* ptr, int32_t device_ordinal, size_t bytes);
+
+  struct Allocation {
+    se::DeviceAddressBase range;
+    std::vector<tsl::TiedRef<RegisteredMemory>> registrations;
+  };
+
+  absl::Mutex mu_;
+  // Recorded allocator ranges keyed by the local device they live on. Ranges
+  // are rare in the preallocated BFC path, so a linear scan of the per-device
+  // vector is fine.
+  absl::flat_hash_map<LocalDeviceId, std::vector<Allocation>> allocations_
+      ABSL_GUARDED_BY(mu_);
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_ALLOCATOR_MEMORY_REGISTRATION_H_

--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -18,19 +18,23 @@ limitations under the License.
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/algorithm/container.h"
+#include "absl/container/btree_map.h"
 #include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "xla/backends/gpu/collectives/allocator_memory_registration.h"
 #include "xla/backends/gpu/collectives/cancellation_token.h"
+#include "xla/backends/gpu/collectives/gpu_clique.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/core/collectives/clique_id.h"
@@ -670,6 +674,46 @@ TEST(GpuCollectivesTest, PutAndWaitSignal) {
 
   EXPECT_THAT(h_recv0, testing::ElementsAre(5.0f, 6.0f, 7.0f, 8.0f));
   EXPECT_THAT(h_recv1, testing::ElementsAre(1.0f, 2.0f, 3.0f, 4.0f));
+}
+
+// Verifies that AllocatorMemoryRegistration registers recorded allocator ranges
+// with the clique communicator that runs on the same device.
+TEST(GpuCollectivesTest, AllocatorMemoryRegistrationRegistersWithClique) {
+  ASSERT_OK_AND_ASSIGN(se::Platform * platform,
+                       se::PlatformManager::PlatformWithName("CUDA"));
+
+  if (platform->VisibleDeviceCount() < 2) {
+    GTEST_SKIP() << "Test requires at least 2 GPUs";
+  }
+
+  ASSERT_OK_AND_ASSIGN(std::vector<se::StreamExecutor*> executors,
+                       CreateExecutors(platform, 2));
+
+  ASSERT_OK_AND_ASSIGN(auto comms, CreateCommunicators(executors, {kD0, kD1}));
+
+  ASSERT_OK_AND_ASSIGN(auto allocators, CreateMemoryAllocators(executors));
+  ASSERT_OK_AND_ASSIGN(auto allocs, Allocate(allocators, 1024));
+
+  // Record one allocator range per device through the suballocator visitor, the
+  // same way the BFC preallocation path would.
+  auto registration = std::make_shared<AllocatorMemoryRegistration>();
+  auto alloc_visitor = registration->alloc_visitor();
+  for (size_t i = 0; i < executors.size(); ++i) {
+    alloc_visitor(allocs[i]->address().opaque(), executors[i]->device_ordinal(),
+                  allocs[i]->address().size());
+  }
+
+  // Build a clique from the real communicators and register memory with it.
+  absl::btree_map<RankId, std::unique_ptr<Communicator>> communicators;
+  for (size_t i = 0; i < comms.size(); ++i) {
+    communicators.emplace(RankId(i), std::move(comms[i]));
+  }
+  GpuClique clique(GpuCliqueKey({kD0, kD1}, /*num_local_participants=*/2),
+                   std::nullopt, std::move(communicators),
+                   /*peer_access_enabled=*/true,
+                   std::make_shared<CancellationToken>());
+
+  ASSERT_OK(registration->RegisterWithClique(clique));
 }
 
 }  // namespace

--- a/xla/backends/gpu/collectives/gpu_communicator.h
+++ b/xla/backends/gpu/collectives/gpu_communicator.h
@@ -39,6 +39,10 @@ limitations under the License.
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
 
+namespace stream_executor {
+class StreamExecutor;
+}  // namespace stream_executor
+
 namespace xla::gpu {
 
 class GpuSignalDesc : public Communicator::SignalDesc {
@@ -132,6 +136,12 @@ class GpuCommunicator : public Communicator {
 
   // Returns true iff communicator supports device-initiated communication.
   virtual bool SupportsDeviceComm() const { return false; }
+
+  // Returns the StreamExecutor (and thus the device) this communicator runs on,
+  // or nullptr if not backed by a StreamExecutor.
+  virtual stream_executor::StreamExecutor* stream_executor() const {
+    return nullptr;
+  }
 
   // Creates a new device communicator linked to *this GPU communicator object.
   virtual absl::StatusOr<std::unique_ptr<GpuDeviceCommunicator>>

--- a/xla/backends/gpu/collectives/loopback_communicator.cc
+++ b/xla/backends/gpu/collectives/loopback_communicator.cc
@@ -56,12 +56,12 @@ static absl::Status Memcpy(const Communicator::Executor& executor,
   return stream->MemcpyD2D(&dst, src, size);
 }
 
-LoopbackCommunicator::LoopbackCommunicator(se::StreamExecutor* executor,
+LoopbackCommunicator::LoopbackCommunicator(se::StreamExecutor* stream_executor,
                                            size_t num_ranks, size_t rank)
-    : executor_(executor), num_ranks_(num_ranks), rank_(rank) {
+    : stream_executor_(stream_executor), num_ranks_(num_ranks), rank_(rank) {
   VLOG(1) << absl::StreamFormat(
       "LoopbackCommunicator created: rank=%d/%d, executor=%p", rank_,
-      num_ranks_, executor_);
+      num_ranks_, stream_executor_);
 }
 
 absl::StatusOr<size_t> LoopbackCommunicator::NumRanks() const {

--- a/xla/backends/gpu/collectives/loopback_communicator.h
+++ b/xla/backends/gpu/collectives/loopback_communicator.h
@@ -46,11 +46,14 @@ namespace xla::gpu {
 // See LoopbackCollectives for the semantics of collective operations.
 class LoopbackCommunicator : public GpuCommunicator {
  public:
-  LoopbackCommunicator(se::StreamExecutor* executor, size_t num_ranks,
+  LoopbackCommunicator(se::StreamExecutor* stream_executor, size_t num_ranks,
                        size_t rank);
 
   absl::StatusOr<size_t> NumRanks() const final;
   absl::StatusOr<size_t> CurrentRank() final;
+
+  se::StreamExecutor* stream_executor() const final { return stream_executor_; }
+
   std::string ToString() const final;
 
   Future<> AllReduce(se::DeviceAddressBase send_buffer,
@@ -132,7 +135,7 @@ class LoopbackCommunicator : public GpuCommunicator {
                           const Executor& executor) final;
 
  private:
-  se::StreamExecutor* executor_;
+  se::StreamExecutor* stream_executor_;
   size_t num_ranks_;
   size_t rank_;
 };

--- a/xla/backends/gpu/collectives/nccl_communicator.h
+++ b/xla/backends/gpu/collectives/nccl_communicator.h
@@ -161,7 +161,7 @@ class NcclCommunicator : public GpuCommunicator {
 
   ncclComm_t comm() const { return comm_; }
 
-  se::StreamExecutor* stream_executor() const { return stream_executor_; }
+  se::StreamExecutor* stream_executor() const final { return stream_executor_; }
 
   bool IsBlocking() const { return executor_ == nullptr; }
 

--- a/xla/core/collectives/BUILD
+++ b/xla/core/collectives/BUILD
@@ -23,6 +23,7 @@ cc_library(
         ":communicator",
         ":rank_id",
         "//xla:util",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/functional:function_ref",
         "@com_google_absl//absl/status",

--- a/xla/core/collectives/clique.cc
+++ b/xla/core/collectives/clique.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "absl/container/btree_map.h"
 #include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/util.h"
@@ -44,6 +45,14 @@ void Clique::ForEachComm(
   for (auto& [rank, comm] : communicators_) {
     fn(rank, comm.get());
   }
+}
+
+absl::Status Clique::ForEachCommWithStatus(
+    absl::FunctionRef<absl::Status(RankId, Communicator*)> fn) const {
+  for (auto& [rank, comm] : communicators_) {
+    RETURN_IF_ERROR(fn(rank, comm.get()));
+  }
+  return absl::OkStatus();
 }
 
 absl::Status Clique::AddComm(RankId rank,

--- a/xla/core/collectives/clique.h
+++ b/xla/core/collectives/clique.h
@@ -55,6 +55,11 @@ class Clique {
   // Calls `fn` for each communicator in the clique.
   void ForEachComm(absl::FunctionRef<void(RankId, Communicator*)> fn) const;
 
+  // Calls `fn` for each communicator in the clique, stopping early and
+  // returning the first non-OK status `fn` produces.
+  absl::Status ForEachCommWithStatus(
+      absl::FunctionRef<absl::Status(RankId, Communicator*)> fn) const;
+
   // Checks that all communicators in the clique are in a healthy state.
   virtual absl::Status HealthCheck() const = 0;
 

--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -73,6 +73,7 @@ cc_library(
         "//xla:xla_data_proto_cc",
         "//xla:xla_proto_cc",
         "//xla/backends/cpu:target_machine_options",
+        "//xla/backends/gpu/collectives:allocator_memory_registration",
         "//xla/backends/gpu/collectives:gpu_clique",
         "//xla/backends/gpu/collectives:gpu_clique_key",
         "//xla/backends/gpu/collectives:gpu_cliques",

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -47,6 +47,7 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/cpu/target_machine_options.h"
+#include "xla/backends/gpu/collectives/allocator_memory_registration.h"
 #include "xla/backends/gpu/collectives/gpu_clique.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/collectives/gpu_cliques.h"
@@ -238,7 +239,8 @@ StreamExecutorGpuClient::StreamExecutorGpuClient(
     std::shared_ptr<KeyValueStoreInterface> kv_store,
     bool abort_collectives_on_failure,
     std::shared_ptr<const GpuTopology> gpu_topology,
-    std::optional<int> num_nodes)
+    std::optional<int> num_nodes,
+    std::shared_ptr<gpu::AllocatorMemoryRegistration> memory_registration)
     : xla::PjRtStreamExecutorClient(
           platform_name, client, std::move(devices), process_index,
           /*memory_spaces=*/{},  // Initialized below.
@@ -246,6 +248,7 @@ StreamExecutorGpuClient::StreamExecutorGpuClient(
           should_stage_host_to_device_transfers, std::move(gpu_run_options)),
       num_nodes_(num_nodes),
       abort_collectives_on_failure_(abort_collectives_on_failure),
+      memory_registration_(std::move(memory_registration)),
       kv_store_(std::move(kv_store)) {
   VLOG(1) << absl::StreamFormat(
       "Constructed StreamExecutor GPU client: #devices=%d #num_nodes=%d",
@@ -1293,6 +1296,30 @@ BuildLocalDeviceStates(LocalClient* xla_client, bool schedule_async,
   return std::move(addressable_devices);
 }
 
+// Creates allocator memory registration and adds the required suballocator
+// visitors to `allocator_config`. Allocators that do not use suballocator
+// visitors simply ignore them.
+std::shared_ptr<gpu::AllocatorMemoryRegistration>
+CreateAllocatorMemoryRegistration(GpuAllocatorConfig* allocator_config) {
+  // Automatic memory registration is only safe for preallocated BFC arenas.
+  // If BFC grows later, ranks may not see a consistent set of registered
+  // backing allocations, which can lead to undefined behavior or deadlocks.
+  if (!allocator_config->preallocate) {
+    return nullptr;
+  }
+
+  auto memory_registration =
+      std::make_shared<gpu::AllocatorMemoryRegistration>();
+  gpu::RegisterOnGpuCliqueCreatedCallback(
+      memory_registration->CliqueCreatedCallback());
+  allocator_config->sub_allocator_alloc_visitors.push_back(
+      memory_registration->alloc_visitor());
+  allocator_config->sub_allocator_free_visitors.push_back(
+      memory_registration->free_visitor());
+
+  return memory_registration;
+}
+
 // Constructs a GPU device memory allocator to use, according to the allocator
 // configuration the client requested.
 absl::StatusOr<std::unique_ptr<se::DeviceAddressAllocator>>
@@ -1804,10 +1831,16 @@ absl::StatusOr<std::unique_ptr<PjRtClient>> GetStreamExecutorGpuClient(
                    BuildLocalDeviceStates(xla_client, use_async_dispatch,
                                           options.max_inflight_computations));
   EnablePeerAccess(xla_client->backend().stream_executors());
+
+  GpuAllocatorConfig allocator_config = options.allocator_config;
+  auto memory_registration =
+      CreateAllocatorMemoryRegistration(&allocator_config);
+
   ASSIGN_OR_RETURN(auto allocator,
-                   GetStreamExecutorGpuDeviceAllocator(xla_client->platform(),
-                                                       options.allocator_config,
-                                                       local_device_states));
+                   GetStreamExecutorGpuDeviceAllocator(
+                       xla_client->platform(), std::move(allocator_config),
+                       local_device_states));
+
   std::unique_ptr<HostMemoryAllocator> host_memory_allocator;
   if (options.host_memory_allocator_factory != nullptr) {
     se::StreamExecutor* const stream_executor =
@@ -1877,7 +1910,8 @@ absl::StatusOr<std::unique_ptr<PjRtClient>> GetStreamExecutorGpuClient(
       options.node_id, std::move(allocator), std::move(host_memory_allocator),
       options.should_stage_host_to_device_transfers, std::move(gpu_run_options),
       std::move(kv_store), options.abort_collectives_on_failure,
-      std::move(gpu_topology), options.num_nodes);
+      std::move(gpu_topology), options.num_nodes,
+      std::move(memory_registration));
 }
 
 std::vector<std::unique_ptr<PjRtStreamExecutorDevice>> BuildLocalDevices(

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.h
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
+#include "xla/backends/gpu/collectives/allocator_memory_registration.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/collectives/gpu_cliques.h"
 #include "xla/client/local_client.h"
@@ -121,7 +122,9 @@ class StreamExecutorGpuClient : public xla::PjRtStreamExecutorClient {
       std::shared_ptr<KeyValueStoreInterface> kv_store,
       bool abort_collectives_on_failure,
       std::shared_ptr<const GpuTopology> gpu_topology,
-      std::optional<int> num_processes);
+      std::optional<int> num_processes,
+      std::shared_ptr<gpu::AllocatorMemoryRegistration> memory_registration =
+          nullptr);
 
   std::optional<std::shared_ptr<KeyValueStoreInterface>> key_value_store()
       const override {
@@ -208,6 +211,7 @@ class StreamExecutorGpuClient : public xla::PjRtStreamExecutorClient {
   std::optional<int> num_nodes_;
   const bool abort_collectives_on_failure_ = false;
   std::optional<xla::StreamExecutorGpuTopologyDescription> topology_;
+  std::shared_ptr<gpu::AllocatorMemoryRegistration> memory_registration_;
   std::shared_ptr<KeyValueStoreInterface> kv_store_;
 
   // Helpers for cross host transfers.

--- a/xla/tsl/util/tied_ref.h
+++ b/xla/tsl/util/tied_ref.h
@@ -241,7 +241,7 @@ bool TiedRef<T>::Expired() const {
 
 template <typename T>
 TiedRef<T> Tied<T>::Tie(std::unique_ptr<T> value) {
-  absl::MutexLock lock(&mu_);
+  absl::MutexLock lock(mu_);
 
   // Lazy garbage collection: erase entries whose inner shared_ptr was reset
   // by a TiedRef destructor.
@@ -260,7 +260,7 @@ TiedRef<T> Tied<T>::Tie(std::unique_ptr<T> value) {
 
 template <typename T>
 TiedRef<T> TiedAny::Tie(std::unique_ptr<T> value) {
-  absl::MutexLock lock(&mu_);
+  absl::MutexLock lock(mu_);
   auto& base = entries_[&TypeId<T>::kId];
   if (!base) {
     base = std::make_unique<TiedTyped<T>>();


### PR DESCRIPTION
- Add `AllocatorMemoryRegistration` to track allocator-owned GPU ranges reported by BFC suballocator visitors.
- Register recorded ranges with newly-created GPU cliques, using only the communicator on the same local device ordinal.
- Tie NCCL registered-memory lifetimes to the clique and release registrations when allocator ranges are freed.
- Enable this path in SE GPU PJRT only for BFC with preallocation.

We deliberately do pre-registration only when XLA uses BFC with preallocation as in this case we can guarantee that all memory is allocated before the first communicator is created. Supporting dynamic memory allocation is out of scope op this PR, but can be added later if needed.