### PR TITLE
[XLA:GPU] Remove requires-gpu tags from hlo-opt lit tests.

### DIFF
--- a/xla/tools/hlo_opt/BUILD
+++ b/xla/tools/hlo_opt/BUILD
@@ -14,10 +14,6 @@ load(
     "if_gpu_is_configured",
 )
 load("//xla/tsl:tsl.default.bzl", "filegroup")
-load(
-    "//xla/tsl/platform:build_config_root.bzl",
-    "tf_gpu_tests_tags",
-)
 
 # hlo-opt tool.
 load(
@@ -259,7 +255,7 @@ lit_test_suite(
     ]),
     cfg = "//xla:lit.cfg.py",
     data = [":test_utilities"],
-    default_tags = tf_gpu_tests_tags(),
+    default_tags = ["gpu"], # Needs to run in a build with a gpu configured.
     hermetic_cuda_data_dir = "%S/../../../../../" + get_canonical_repo_name("cuda_nvcc"),
     tags_override = {
         "tests/gpu_hlo_ptx.hlo": ["cuda-only"],


### PR DESCRIPTION
tf_gpu_tests_tags() adds a "requires-gpu-cuda"/"requires-gpu-rocm" tag that forces these tests onto a machine with a physical GPU. The hlo-opt lit tests don't execute on the GPU, so we drop the requires-gpu-* tag and keep only the "gpu" tag, which still requires a GPU-configured build.