### PR TITLE
[XLA:GPU][oneAPI] Parameterize hermetic oneAPI version reporting

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -310,10 +310,13 @@ common:sycl --repo_env=SYCL_BUILD_HERMETIC=0
 # Enable Clang for host and icpx for SYCL
 common:icpx_clang --repo_env TF_ICPX_CLANG=1
 common:icpx_clang --copt=-fclang-abi-compat=17
+common:icpx_clang --copt=-Wno-unknown-warning-option
 
 # Hermetic SYCL Configuration
 common:sycl_hermetic --config=sycl
+common:sycl_hermetic --config=icpx_clang
 common:sycl_hermetic --repo_env=SYCL_BUILD_HERMETIC=1
+common:sycl_hermetic --repo_env=ONEAPI_VERSION=2025.1
 
 # Options to disable default on features
 common:nonccl --define=no_nccl_support=true

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -298,10 +298,8 @@ absl::string_view StreamExecutorGpuClient::platform_version() const {
   return "rocm " STRINGIFY(TF_ROCM_VERSION);
 #elif GOOGLE_CUDA && defined(CUDART_VERSION)  // cuda
   return "cuda " STRINGIFY(CUDART_VERSION);
-// TODO(intel-tf): Oneapi multiple platform version support
-// will be added in future, for now, oneapi 2025.1 is supported
 #elif TENSORFLOW_USE_SYCL                     // oneapi
-  return "oneapi 2025.1";
+  return "oneapi " STRINGIFY(ONEAPI_VERSION);
 #else
   return "<unknown>";
 #endif  // TENSORFLOW_USE_ROCM && defined(TF_ROCM_VERSION)


### PR DESCRIPTION
📝 Summary of Changes

Follow-up to #44418.

This PR no longer updates `rules_ml_toolchain`; that update is handled by
#44418 and this PR should be merged after it.

This change:
- keeps the hermetic SYCL default at oneAPI 2025.1
- wires `--config=sycl_hermetic` through `--config=icpx_clang`
- adds the icpx/clang `-Wno-unknown-warning-option` flag
- reports the SYCL PJRT platform version from `ONEAPI_VERSION` instead of a hard-coded oneAPI string


🎯 Justification

To update ZML to fully support the latest intel GPU and the lattest oneAPI toolkit, we need to update the XLA project with oneAPI 2026 with oneAPI 2026.

Future oneAPI development in XLA needs access to the latest Intel toolkit and library layout :
- Enables the hermetic SYCL configuration to select oneAPI 2026.0 on Ubuntu 24.04 and updates the reported PJRT platform version accordingly.
- This PR intentionally does not include runtime changes, SYCL BLAS work, TopK changes, PJRT synchronization changes, oneCCL changes, or packaging changes.

@mraunak pointed out that oneAPI 2025.1 needs to remain the default for now
because changing the default would break Intel JAX tests.

This keeps the default stable while separating the `rules_ml_toolchain` update
from the XLA SYCL configuration follow-up.

cc @bhavani-subramanian @akhilgoe @nhatleSummer22 @ashiqimranintel @mraunak

🚀 Kind of Contribution

📊 Benchmark (for Performance Improvements)

🧪 Unit Tests:

🧪 Execution Tests:

```sh
bazel build \
  --config=sycl_hermetic \
  --repo_env=ONEAPI_VERSION=2026.0 \
  --repo_env=OS=ubuntu_24.10 \
  --copt=-Wno-unknown-warning-option \
  //xla/pjrt/c:pjrt_c_api_gpu_plugin.so
```
