### PR TITLE
[XLA:GPU] Adapt SolLatencyEstimator for Triton and Custom kernel intra-node AllReduce backend (3/3)

### DIFF
--- a/xla/service/gpu/model/sol_latency_estimator.cc
+++ b/xla/service/gpu/model/sol_latency_estimator.cc
@@ -59,6 +59,12 @@ namespace {
 
 using ::mlir::MLIRContext;
 
+bool IsTritonCollectiveKernel(
+    CollectiveBackendConfig::CollectiveKernelStrategy ks) {
+  return ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT ||
+         ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_TWO_SHOT;
+}
+
 bool IsSupportedCollectiveOp(const HloInstruction& instr) {
   return HloPredicateIsOp<HloOpcode::kAllReduceStart, HloOpcode::kAllReduce,
                           HloOpcode::kReduceScatter, HloOpcode::kAllGatherStart,
@@ -253,15 +259,13 @@ absl::StatusOr<absl::Duration> DispatchEstimation(
     }
     case GPUCommunicationType::SINGLE_PARTITION: {
       // If an intra-node collective kernel will be used (Triton codegen kernel
-      // or the built-in custom C++ kernel — both use the same NVLink-based
-      // cost formula), apply the NVLink model instead of the NCCL-calibrated
-      // CollectiveInterpolator.
-      auto backend_cfg = instr.backend_config<GpuBackendConfig>();
+      // — uses the NVLink-based cost formula), apply the NVLink model instead
+      // of the NCCL-calibrated CollectiveInterpolator.
+      absl::StatusOr<GpuBackendConfig> backend_cfg =
+          instr.backend_config<GpuBackendConfig>();
       if (backend_cfg.ok()) {
-        const auto ks =
-            backend_cfg->collective_backend_config().kernel_strategy();
-        if (ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT ||
-            ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_TWO_SHOT) {
+        if (IsTritonCollectiveKernel(
+                backend_cfg->collective_backend_config().kernel_strategy())) {
           SolGPUCostModel sol_model(sol_flags);
           const int num_gpus = num_groups_and_devices->second;
           const int active_links =
@@ -474,18 +478,17 @@ LatencyEstimator::TimeCost SolLatencyEstimator::GetLatencyBetween(
     return kLowLatency;
   }
 
-  // For sync intra-node AllReduce (Triton codegen or built-in custom C++
-  // kernel — both annotated as TRITON_ONE_SHOT / TRITON_TWO_SHOT) the kernel
-  // runs on the compute stream and fully blocks further compute — no overlap
-  // is possible between start and done.  NodeCost() already reports the full
-  // blocking latency on the critical path, so return kLowLatency here to
-  // avoid double-counting.
-  if (IsGPUSyncCollective(from.GetInstr())) {
-    auto cfg = from.GetInstr().backend_config<GpuBackendConfig>();
-    if (cfg.ok()) {
-      const auto ks = cfg->collective_backend_config().kernel_strategy();
-      if (ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT ||
-          ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_TWO_SHOT) {
+  // For sync intra-node AllReduce (Triton codegen kernel annotated as
+  // TRITON_ONE_SHOT / TRITON_TWO_SHOT) the kernel runs on the compute stream
+  // and fully blocks further compute — no overlap is possible between start
+  // and done.  NodeCost() already reports the full blocking latency on the
+  // critical path, so return kLowLatency here to avoid double-counting.
+  {
+    absl::StatusOr<GpuBackendConfig> cfg =
+        from.GetInstr().backend_config<GpuBackendConfig>();
+    if (cfg.ok() && cfg->collective_backend_config().is_sync()) {
+      if (IsTritonCollectiveKernel(
+              cfg->collective_backend_config().kernel_strategy())) {
         VLOG(10) << "GetLatencyBetween: Returning kLowLatency for sync "
                     "intra-node AllReduce (cost already in NodeCost): "
                  << from.GetInstr().name();
@@ -526,18 +529,16 @@ LatencyEstimator::TimeCost SolLatencyEstimator::NodeCost(
   if (const std::optional<TimeCost> latency = GetLatencyFromMetadata(*instr)) {
     return *latency;
   }
-  // Sync intra-node AllReduce kernels (Triton codegen or built-in custom C++,
-  // both annotated as TRITON_ONE_SHOT / TRITON_TWO_SHOT) run on the compute
-  // stream and block compute entirely.  Their full latency is on the critical
-  // path, so we must report it here as NodeCost rather than as a hidden
-  // GetLatencyBetween.
-  if (hlo_query::IsAsyncCollectiveStartOp(instr, /*include_send_recv=*/true) &&
-      IsGPUSyncCollective(*instr)) {
-    auto cfg = instr->backend_config<GpuBackendConfig>();
-    if (cfg.ok()) {
-      const auto ks = cfg->collective_backend_config().kernel_strategy();
-      if (ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT ||
-          ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_TWO_SHOT) {
+  // Sync intra-node AllReduce kernels (Triton codegen, annotated as
+  // TRITON_ONE_SHOT / TRITON_TWO_SHOT) run on the compute stream and block
+  // compute entirely.  Their full latency is on the critical path, so we must
+  // report it here as NodeCost rather than as a hidden GetLatencyBetween.
+  if (hlo_query::IsAsyncCollectiveStartOp(instr, /*include_send_recv=*/true)) {
+    absl::StatusOr<GpuBackendConfig> cfg =
+        instr->backend_config<GpuBackendConfig>();
+    if (cfg.ok() && cfg->collective_backend_config().is_sync()) {
+      if (IsTritonCollectiveKernel(
+              cfg->collective_backend_config().kernel_strategy())) {
         absl::StatusOr<absl::Duration> t = ComputeCollectiveTime(
             *instr, gpu_info_, shape_size_function_, sol_flags_,
             *cost_analysis_, collective_interpolator_.get());

--- a/xla/service/gpu/model/sol_latency_estimator.cc
+++ b/xla/service/gpu/model/sol_latency_estimator.cc
@@ -231,6 +231,11 @@ absl::StatusOr<absl::Duration> DispatchEstimation(
   GPUCommunicationType comm = *communication_type;
   ASSIGN_OR_RETURN(auto num_groups_and_devices,
                    GetReplicaGroupCountAndSize(&instr));
+  if (!num_groups_and_devices.has_value()) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Could not determine replica group count and size for collective: ",
+        instr.name()));
+  }
   int64_t partition_size = GetPartitionSize(instr, sol_flags);
 
   switch (comm) {
@@ -247,6 +252,33 @@ absl::StatusOr<absl::Duration> DispatchEstimation(
           gpu_device_info, sol_flags, analysis);
     }
     case GPUCommunicationType::SINGLE_PARTITION: {
+      // If an intra-node collective kernel will be used (Triton codegen kernel
+      // or the built-in custom C++ kernel — both use the same NVLink-based
+      // cost formula), apply the NVLink model instead of the NCCL-calibrated
+      // CollectiveInterpolator.
+      auto backend_cfg = instr.backend_config<GpuBackendConfig>();
+      if (backend_cfg.ok()) {
+        const auto ks =
+            backend_cfg->collective_backend_config().kernel_strategy();
+        if (ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT ||
+            ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_TWO_SHOT) {
+          SolGPUCostModel sol_model(sol_flags);
+          const int num_gpus = num_groups_and_devices->second;
+          const int active_links =
+              gpu_device_info.device_interconnect_info().active_links;
+          const int64_t size_bytes =
+              static_cast<int64_t>(analysis.BytesTransferred(instr));
+          // Add HBM time (reading/writing local buffers) on top of NVLink time.
+          absl::Duration hbm_time =
+              absl::Seconds(1.0f * analysis.bytes_accessed(instr) /
+                            gpu_device_info.memory_bandwidth());
+          ASSIGN_OR_RETURN(absl::Duration nvlink_time,
+                           sol_model.IntraNodeAllReduceLatency(
+                               size_bytes, num_gpus, active_links));
+          return hbm_time + nvlink_time;
+        }
+      }
+      // NCCL intra-node collective: use empirical CollectiveInterpolator.
       if (collective_interpolator == nullptr) {
         return absl::InvalidArgumentError(
             "Collective interpolator is required for single partition "
@@ -442,6 +474,26 @@ LatencyEstimator::TimeCost SolLatencyEstimator::GetLatencyBetween(
     return kLowLatency;
   }
 
+  // For sync intra-node AllReduce (Triton codegen or built-in custom C++
+  // kernel — both annotated as TRITON_ONE_SHOT / TRITON_TWO_SHOT) the kernel
+  // runs on the compute stream and fully blocks further compute — no overlap
+  // is possible between start and done.  NodeCost() already reports the full
+  // blocking latency on the critical path, so return kLowLatency here to
+  // avoid double-counting.
+  if (IsGPUSyncCollective(from.GetInstr())) {
+    auto cfg = from.GetInstr().backend_config<GpuBackendConfig>();
+    if (cfg.ok()) {
+      const auto ks = cfg->collective_backend_config().kernel_strategy();
+      if (ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT ||
+          ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_TWO_SHOT) {
+        VLOG(10) << "GetLatencyBetween: Returning kLowLatency for sync "
+                    "intra-node AllReduce (cost already in NodeCost): "
+                 << from.GetInstr().name();
+        return kLowLatency;
+      }
+    }
+  }
+
   if (!IsAsyncPair(from, target) && !IsSupportedCollectiveOp(from.GetInstr())) {
     TimeCost latency = latency_estimator_->GetLatencyBetween(from, target);
     VLOG(10)
@@ -474,6 +526,31 @@ LatencyEstimator::TimeCost SolLatencyEstimator::NodeCost(
   if (const std::optional<TimeCost> latency = GetLatencyFromMetadata(*instr)) {
     return *latency;
   }
+  // Sync intra-node AllReduce kernels (Triton codegen or built-in custom C++,
+  // both annotated as TRITON_ONE_SHOT / TRITON_TWO_SHOT) run on the compute
+  // stream and block compute entirely.  Their full latency is on the critical
+  // path, so we must report it here as NodeCost rather than as a hidden
+  // GetLatencyBetween.
+  if (hlo_query::IsAsyncCollectiveStartOp(instr, /*include_send_recv=*/true) &&
+      IsGPUSyncCollective(*instr)) {
+    auto cfg = instr->backend_config<GpuBackendConfig>();
+    if (cfg.ok()) {
+      const auto ks = cfg->collective_backend_config().kernel_strategy();
+      if (ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT ||
+          ks == CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_TWO_SHOT) {
+        absl::StatusOr<absl::Duration> t = ComputeCollectiveTime(
+            *instr, gpu_info_, shape_size_function_, sol_flags_,
+            *cost_analysis_, collective_interpolator_.get());
+        if (t.ok()) {
+          VLOG(10) << "NodeCost: Sync intra-node AllReduce cost for "
+                   << instr->name() << ": " << absl::ToDoubleMicroseconds(*t)
+                   << " us";
+          return absl::ToDoubleMicroseconds(*t);
+        }
+      }
+    }
+  }
+
   if (hlo_query::IsAsyncCollectiveStartOp(instr, /*include_send_recv=*/true) ||
       hlo_query::IsAsyncCollectiveDoneOp(instr, /*include_send_recv=*/true)) {
     VLOG(10) << "NodeCost: Returning kLowCost for async start/done op "

--- a/xla/service/gpu/model/sol_latency_estimator_test.cc
+++ b/xla/service/gpu/model/sol_latency_estimator_test.cc
@@ -959,10 +959,6 @@ ENTRY e {
     auto estimator = *SolLatencyEstimator::Create(
         scheduler_config_, std::make_unique<DummyLatencyEstimator>(),
         gpu_device_info_, HloCostAnalysis::DefaultShapeSize, computation);
-    // Patch sol_flags_ into the estimator via Create's sol_config derivation:
-    // sol_config is read from GetConfig(module, device_info) in Create, so we
-    // can't inject it directly here.  Instead we call ComputeCollectiveTime
-    // directly for the sync test, which uses our patched sol_flags_.
     return absl::Microseconds(
         static_cast<int64_t>(estimator->NodeCost(&instr)));
   }

--- a/xla/service/gpu/model/sol_latency_estimator_test.cc
+++ b/xla/service/gpu/model/sol_latency_estimator_test.cc
@@ -27,7 +27,6 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/time/time.h"
 #include "xla/tsl/platform/status_macros.h"
-#include "mlir/IR/MLIRContext.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/hlo/ir/replica_group.h"
@@ -878,6 +877,228 @@ TEST_F(IsSolLatencyEstimatorEnabledTest, DisabledForHopperWithHostOffloaded) {
 
   EXPECT_FALSE(
       SolLatencyEstimator::IsSupportedForModule(*module, gpu_device_info_));
+}
+
+// ---- Triton collective scheduler integration tests -----------------------
+//
+// These tests verify that SolLatencyEstimator correctly uses the NVLink-based
+// cost formula when an AllReduceStart is annotated with a Triton kernel
+// strategy, and that the sync case is correctly handled by NodeCost.
+
+class TritonAllReduceSchedulerTest : public HloHardwareIndependentTestBase {
+ protected:
+  // 32768 F32 elements = 128 KB → one-shot strategy (< 256 KB threshold).
+  // All 8 replicas in a single group → SINGLE_PARTITION communication type.
+  static constexpr absl::string_view kOneShotAllReduceHlo = R"(
+HloModule m, num_partitions=8
+
+add {
+  p0 = f32[] parameter(0)
+  p1 = f32[] parameter(1)
+  ROOT r = f32[] add(p0, p1)
+}
+
+ENTRY e {
+  p = f32[32768] parameter(0)
+  ar-start = f32[32768] all-reduce-start(p),
+      replica_groups={{0,1,2,3,4,5,6,7}},
+      to_apply=add
+  ROOT ar-done = f32[32768] all-reduce-done(ar-start)
+})";
+
+  TritonAllReduceSchedulerTest() {
+    // Use an RTXA6000 with Hopper capability.
+    gpu_device_info_ =
+        TestGpuDeviceInfo::RTXA6000DeviceInfo(se::CudaComputeCapability(9, 0));
+    // Equip it with 18 active NVLink links (H100-like topology).
+    se::DeviceInterconnectInfo interconnect;
+    interconnect.active_links = 18;
+    gpu_device_info_.set_device_interconnect_info(interconnect);
+
+    // NVLink-aware sol_flags: 20 GB/s per lane, 1.5 µs barrier.
+    sol_flags_ = {
+        /*nccl_op_launch_time=*/absl::Microseconds(100),
+        /*nic_speed_gbps=*/100,
+        /*chunk_prep_time=*/absl::Microseconds(100),
+        /*rtt=*/absl::Microseconds(100),
+        /*gpus_per_node=*/8,
+        /*chunk_size_bytes=*/4 * 1024 * 1024,
+        /*partition_size=*/0,
+        /*nvlink_bw_per_lane_gbps=*/20.0,
+        /*nvlink_barrier_latency=*/absl::Microseconds(1.5),
+    };
+  }
+
+  // Annotates `instr` with the given Triton kernel strategy.
+  static void SetKernelStrategy(
+      HloInstruction* instr,
+      CollectiveBackendConfig::CollectiveKernelStrategy strategy) {
+    GpuBackendConfig cfg = instr->backend_config<GpuBackendConfig>().value();
+    cfg.mutable_collective_backend_config()->set_kernel_strategy(strategy);
+    CHECK_OK(instr->set_backend_config(cfg));
+  }
+
+  // Marks `instr` as synchronous (runs on compute stream, no async overlap).
+  static void SetSync(HloInstruction* instr) {
+    GpuBackendConfig cfg = instr->backend_config<GpuBackendConfig>().value();
+    cfg.mutable_collective_backend_config()->set_is_sync(true);
+    CHECK_OK(instr->set_backend_config(cfg));
+  }
+
+  // Calls ComputeCollectiveTime with the fixture's device and flags.
+  absl::StatusOr<absl::Duration> ComputeCollectiveTime(
+      const HloInstruction& instr) {
+    return SolLatencyEstimator::ComputeCollectiveTime(
+        instr, gpu_device_info_, HloCostAnalysis::DefaultShapeSize, sol_flags_,
+        /*collective_interpolator=*/nullptr);
+  }
+
+  // Creates a SolLatencyEstimator and calls NodeCost.
+  absl::Duration NodeCost(const HloInstruction& instr,
+                          const HloComputation* computation) {
+    auto estimator = *SolLatencyEstimator::Create(
+        scheduler_config_, std::make_unique<DummyLatencyEstimator>(),
+        gpu_device_info_, HloCostAnalysis::DefaultShapeSize, computation);
+    // Patch sol_flags_ into the estimator via Create's sol_config derivation:
+    // sol_config is read from GetConfig(module, device_info) in Create, so we
+    // can't inject it directly here.  Instead we call ComputeCollectiveTime
+    // directly for the sync test, which uses our patched sol_flags_.
+    return absl::Microseconds(
+        static_cast<int64_t>(estimator->NodeCost(&instr)));
+  }
+
+  se::DeviceDescription gpu_device_info_;
+  SolGPUCostModel::Config sol_flags_;
+  SchedulerConfig scheduler_config_;
+};
+
+// Test 1: async Triton ONE_SHOT AllReduce.
+// With the KERNEL_STRATEGY_TRITON_ONE_SHOT annotation and 18 NVLink
+// links at 20 GB/s, ComputeCollectiveTime must return the NVLink formula
+// result:
+//   transfer = 7 × 128 KB / (18 × 20 GB/s) ≈ 2.5 µs
+//   total ≈ launch(1µs) + 2.5µs + barrier(1.5µs) ≈ 5 µs
+// This must be different from the NCCL ring estimate (which uses nic_speed_gbps
+// and has a much larger RTT term).
+TEST_F(TritonAllReduceSchedulerTest, AsyncTritonOneShotUsesNvlinkFormula) {
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       ParseAndReturnVerifiedModule(kOneShotAllReduceHlo));
+
+  HloInstruction* ar_start = hlo_query::FindInstruction(
+      module->entry_computation(), HloOpcode::kAllReduceStart);
+  ASSERT_NE(ar_start, nullptr);
+
+  // Annotate with Triton one-shot strategy (async: is_sync is false by default)
+  SetKernelStrategy(ar_start,
+                    CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT);
+
+  // A real interpolator is passed so the NCCL fallback path doesn't crash.
+  // If the Triton dispatch fires correctly, the interpolator is not called.
+  auto interpolator = *CollectiveInterpolator::Create(
+      sol_flags_.gpus_per_node, gpu_device_info_, /*analysis=*/nullptr);
+
+  ASSERT_OK_AND_ASSIGN(
+      absl::Duration triton_time,
+      SolLatencyEstimator::ComputeCollectiveTime(
+          *ar_start, gpu_device_info_, HloCostAnalysis::DefaultShapeSize,
+          sol_flags_, interpolator.get()));
+  triton_time = absl::Trunc(triton_time, absl::Microseconds(1));
+
+  // The NVLink formula gives ~5 µs.
+  EXPECT_EQ(triton_time, absl::Microseconds(5));
+
+  // Verify this is different from the NCCL ring estimate: remove annotation.
+  SetKernelStrategy(ar_start, CollectiveBackendConfig::KERNEL_STRATEGY_DEFAULT);
+  ASSERT_OK_AND_ASSIGN(
+      absl::Duration nccl_time,
+      SolLatencyEstimator::ComputeCollectiveTime(
+          *ar_start, gpu_device_info_, HloCostAnalysis::DefaultShapeSize,
+          sol_flags_, interpolator.get()));
+  // NCCL ring with nic=100 GB/s and rtt=100 µs gives a much larger value.
+  EXPECT_NE(absl::Trunc(nccl_time, absl::Microseconds(1)), triton_time);
+}
+
+// Test 2: sync Triton ONE_SHOT AllReduce - NodeCost must NOT return kLowCost.
+// When is_sync=true and kernel_strategy=TRITON_ONE_SHOT, NodeCost() must
+// delegate to ComputeCollectiveTime so the latency is on the critical path.
+// We verify this by calling ComputeCollectiveTime directly (which uses our
+// NVLink flags) and checking it returns > kLowCost (1.0 µs).
+TEST_F(TritonAllReduceSchedulerTest,
+       SyncTritonOneShotComputeCollectiveTimeExceedsLowCost) {
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       ParseAndReturnVerifiedModule(kOneShotAllReduceHlo));
+
+  HloInstruction* ar_start = hlo_query::FindInstruction(
+      module->entry_computation(), HloOpcode::kAllReduceStart);
+  ASSERT_NE(ar_start, nullptr);
+
+  // Mark as synchronous Triton one-shot.
+  SetSync(ar_start);
+  SetKernelStrategy(ar_start,
+                    CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT);
+
+  ASSERT_OK_AND_ASSIGN(absl::Duration cost, ComputeCollectiveTime(*ar_start));
+
+  // The NVLink formula must return significantly more than kLowCost = 1.0 µs.
+  // We expect ~5 µs.  Any value > 2 µs confirms we are not returning kLowCost.
+  EXPECT_GT(cost, absl::Microseconds(2));
+  EXPECT_EQ(absl::Trunc(cost, absl::Microseconds(1)), absl::Microseconds(5));
+}
+
+// Test 3: sync Triton ONE_SHOT AllReduce exercises the actual NodeCost
+// branching logic end-to-end via SolLatencyEstimator::Create.
+// SolLatencyEstimator::Create derives sol_flags from GetConfig(module,
+// device_info), which calls GetIciBandwidthPerLaneGbps on the device.
+// For RTXA6000 with SM9.0 (Hopper) and 18 active NVLink links:
+//   nvlink_bw_per_lane_gbps = kSm90NvlinkBandwidth = 20.0 GB/s
+//   nvlink_barrier_latency  = 1.5 µs  (kUnknownKey table entry)
+// → NodeCost returns ~5 µs via ComputeCollectiveTime, confirming that the
+//   IsGPUSyncCollective + TRITON_ONE_SHOT branch in NodeCost fires correctly
+//   with production-derived (not test-injected) sol_flags.
+TEST_F(TritonAllReduceSchedulerTest,
+       SyncTritonOneShotNodeCostExceedsLowCostEndToEnd) {
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       ParseAndReturnVerifiedModule(kOneShotAllReduceHlo));
+
+  HloInstruction* ar_start = hlo_query::FindInstruction(
+      module->entry_computation(), HloOpcode::kAllReduceStart);
+  ASSERT_NE(ar_start, nullptr);
+
+  SetSync(ar_start);
+  SetKernelStrategy(ar_start,
+                    CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT);
+
+  // NodeCost() internally calls SolLatencyEstimator::Create which reads
+  // sol_flags from GetConfig(module, device_info).  For SM9.0 + 18 links
+  // the derived config gives nvlink_bw=20.0 GB/s and barrier=1.5 µs, so
+  // the Triton one-shot formula produces ~5 µs — well above kLowCost=1 µs.
+  absl::Duration node_cost = NodeCost(*ar_start, module->entry_computation());
+
+  // The Triton one-shot formula: launch(1µs) + 7×128KB/(18×20GB/s) + 1.5µs
+  // ≈ 5 µs.  Verify the NodeCost branch fires (> kLowCost) and matches.
+  EXPECT_GT(node_cost, absl::Microseconds(1))
+      << "NodeCost for sync Triton AllReduce should exceed kLowCost=1µs; "
+         "verify that the TRITON_ONE_SHOT branch in NodeCost fired";
+  EXPECT_EQ(node_cost, absl::Microseconds(5));
+}
+
+// Test 4: without the annotation (NCCL path), async AllReduceStart NodeCost
+// returns SolLatencyEstimator::kLowCost = 1.0 (latency is hidden, not on
+// critical path).
+TEST_F(TritonAllReduceSchedulerTest, AsyncNcclAllReduceNodeCostIsLow) {
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       ParseAndReturnVerifiedModule(kOneShotAllReduceHlo));
+
+  HloInstruction* ar_start = hlo_query::FindInstruction(
+      module->entry_computation(), HloOpcode::kAllReduceStart);
+  ASSERT_NE(ar_start, nullptr);
+  // No annotation: is_sync=false (default), kernel_strategy=DEFAULT (default).
+
+  absl::Duration node_cost = NodeCost(*ar_start, module->entry_computation());
+
+  // kLowCost = 1.0 µs: async collective start is treated as negligible node
+  // cost because its latency is hidden by GetLatencyBetween.
+  EXPECT_EQ(node_cost, absl::Microseconds(1));
 }
 
 }  // namespace


### PR DESCRIPTION
📝 Summary of Changes

This PR is the third in a series of three.
PR 1/3: https://github.com/openxla/xla/pull/43742
PR 2/3: https://github.com/openxla/xla/pull/43743
PR 3/3: https://github.com/openxla/xla/pull/43745     <= This PR

Wire the kernel_strategy annotation (PR 1) and NVLink cost formula (PR 2) into the scheduler to fix two categories of incorrect scheduling decisions when xla_gpu_unsupported_use_all_reduce_one_shot_kernel is enabled:

1. Async AllReduce: GetLatencyBetween() budget. When kernel_strategy is TRITON_ONE/TWO_SHOT, route SINGLE_PARTITION AllReduces to TritonAllReduceLatency() (NVLink P2P formula) instead of CollectiveInterpolator (NCCL empirical bandwidth tables). This gives the Latency Hiding Scheduler a correct overlap budget.

2. Sync AllReduce: NodeCost() on the critical path. When is_sync=true and kernel_strategy is TRITON_ONE/TWO_SHOT, return ComputeCollectiveTime() instead of kLowCost=1us, so the blocking compute-stream AllReduce lands correctly on the critical path.

- sol_latency_estimator.cc: read kernel_strategy from CollectiveBackendConfig, dispatch accordingly in DispatchEstimation and NodeCost.
- sol_latency_estimator_test.cc: verify async Triton ONE_SHOT uses NVLink formula and differs from NCCL; sync Triton ONE_SHOT NodeCost exceeds kLowCost; async NCCL NodeCost remains 1us unchanged.

This series of PRs introduces a three-layer fix:

1. CollectiveKernelStrategy proto annotation (backend_configs.proto)
Add CollectiveKernelStrategy enum to CollectiveBackendConfig with KERNEL_STRATEGY_DEFAULT (NCCL), KERNEL_STRATEGY_TRITON_CUSTOM_ONE_SHOT, KERNEL_STRATEGY_TRITON_CUSTOM_TWO_SHOT. Both the Triton codegen kernel and the built-in custom C++ kernel receive the same annotation values, because they implement identical NVLink data-movement patterns: one-shot performs (N-1) direct full-buffer reads from peers; two-shot performs reduce-scatter + all-gather, each phase reading (N-1)/N of the buffer from peers. A single annotation therefore correctly covers both backends.

2. New HLO pass: CollectiveKernelStrategyAnnotator
Runs after CollectiveBackendAssigner, before scheduling. Calls BuildAllReduceInfo() (the same eligibility check used by thunk_emitter) to determine whether the one-shot or two-shot custom kernel will be used at runtime — for both the Triton codegen and the built-in C++ backend — and annotates the HLO instruction's backend_config. Only registered when xla_gpu_unsupported_use_all_reduce_one_shot_kernel is enabled, keeping the NCCL path completely unchanged otherwise.

3. SolGPUCostModel / SolLatencyEstimator updates
SolGPUCostModel::Config: add nvlink_bw_per_lane_gbps (populated from CudaBandwidthSettings / RocmBandwidthSettings via GpuPerformanceWithCollectiveModel::GetIciBandwidthPerLaneGbps) and nvlink_barrier_latency.
SolGPUCostModel::IntraNodeAllReduceLatency: NVLink-based formula for one-shot (≤ 256 KB) and two-shot (≤ 4 MB) strategies, applicable to both the Triton codegen kernel and the built-in custom C++ kernel. Strategy is derived internally from size_bytes via GetAllReduceStrategy(), matching the runtime threshold exactly.
SolLatencyEstimator::DispatchEstimation SINGLE_PARTITION path: when kernel_strategy is KERNEL_STRATEGY_TRITON_CUSTOM_ONE_SHOT or KERNEL_STRATEGY_TRITON_CUSTOM_TWO_SHOT, use IntraNodeAllReduceLatency (NVLink formula + HBM time) instead of CollectiveInterpolator (NCCL empirical table). A single code path covers both backend variants because they perform identical NVLink traffic: (N-1)×size_bytes for one-shot, 2×(N-1)/N×size_bytes for two-shot.
SolLatencyEstimator::NodeCost: when a sync custom kernel AllReduce (Triton codegen or built-in C++) runs on the compute stream and fully blocks compute, return ComputeCollectiveTime rather than kLowCost=1.0 µs, so the latency lands on the critical path.

🎯 Justification
Intra-node custom collective kernels — both the Triton codegen variant and the built-in custom C++ variant (selected by xla_gpu_unsupported_use_all_reduce_one_shot_kernel) — use GPU-side P2P NVLink symmetric memory access rather than the NCCL/RCCL ring algorithm, so the existing NIC-bandwidth-based cost model is wrong for those collectives.

Without this change, enabling either custom AllReduce kernel causes two independent categories of incorrect scheduling decisions:

1. Async custom kernel AllReduce: wrong GetLatencyBetween budget
SolLatencyEstimator::GetLatencyBetween(AllReduceStart, AllReduceDone) returns the value of ComputeCollectiveTime(), which routes intra-node (SINGLE_PARTITION) collectives to CollectiveInterpolator. CollectiveInterpolator uses NCCL-calibrated empirical bandwidth tables. The Latency Hiding Scheduler uses this budget to decide how much compute to interleave between AllReduceStart and AllReduceDone. An over-estimated budget causes the scheduler to try to fill a large overlapping window that does not exist at runtime, potentially reordering compute operations in ways that hurt rather than help. An under-estimated budget would prevent profitable overlap from being exploited.

2. Sync custom kernel AllReduce: NodeCost returns kLowCost instead of the true blocking latency
The sync custom kernel AllReduce is dispatched on the compute stream and fully blocks all further compute until it finishes. NodeCost() currently returns kLowCost=1 µs for any IsAsyncCollectiveStartOp() instruction regardless of is_sync. This causes the scheduler to treat a ~5 µs blocking op as if it were free on the critical path. For a Transformer training step with many small AllReduces (e.g. bias/norm gradient synchronisations), this error compounds: the scheduler builds incorrect priority orders and may produce a schedule that is far from optimal.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

🧪 Execution Tests:
- sol_latency_estimator_test.cc: scheduler integration — async custom kernel ONE_SHOT uses the NVLink formula and differs from NCCL; sync custom kernel ONE_SHOT ComputeCollectiveTime exceeds kLowCost; async NCCL NodeCost remains kLowCost=1 µs.