### PR TITLE
[ROCm] Add VMM device-address allocator and enable it in PJRT GPU client

### DIFF
--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -143,6 +143,7 @@ cc_library(
         "//xla/stream_executor:platform",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor:vmm_device_address_allocator_factory",
         "//xla/stream_executor/integrations:device_mem_allocator",
         "//xla/stream_executor/integrations:tf_allocator_adapter",
         "//xla/tsl/concurrency:async_value",

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -143,8 +143,6 @@ limitations under the License.
 #if GOOGLE_CUDA
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
-#include "xla/stream_executor/cuda/cuda_compute_capability.h"
-#include "xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h"
 #include "xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h"
 #elif TENSORFLOW_USE_ROCM
 #include "rocm/rocm_config.h"
@@ -152,6 +150,7 @@ limitations under the License.
 
 #include "xla/service/gpu/gpu_executable_run_options.h"
 #include "xla/stream_executor/integrations/tf_allocator_adapter.h"
+#include "xla/stream_executor/vmm_device_address_allocator.h"
 #include "xla/util.h"
 
 namespace xla {
@@ -1361,20 +1360,15 @@ GetStreamExecutorGpuDeviceAllocator(
       return nullptr;
 
     case GpuAllocatorConfig::Kind::kVmm: {
-#if GOOGLE_CUDA
       std::vector<std::pair<se::StreamExecutor*, se::Stream*>> executor_streams;
       executor_streams.reserve(addressable_devices.size());
       for (const auto& [ordinal, device] : addressable_devices) {
         executor_streams.push_back(
             {device->executor(), device->compute_stream()});
       }
-      return se::gpu::CudaDeviceAddressVmmAllocator::Create(
+      return se::DeviceAddressVmmAllocator::Create(
           platform, allocator_config.memory_fraction,
           allocator_config.gpu_system_memory_size, executor_streams);
-#else
-      return absl::UnimplementedError(
-          "VMM allocator is only supported with CUDA.");
-#endif  // GOOGLE_CUDA
     }
   }
 

--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -1,4 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load("//xla:xla.default.bzl", "xla_cc_test")
 load("//xla/stream_executor:build_defs.bzl", "stream_executor_build_defs_bzl_deps", "stream_executor_friends", "stream_executor_internal")
 load("//xla/tsl:tsl.bzl", "if_google", "if_oss", "internal_visibility")
@@ -379,6 +381,26 @@ cc_library(
 )
 
 cc_library(
+    name = "vmm_device_address_allocator_factory",
+    srcs = ["vmm_device_address_allocator_factory.cc"],
+    local_defines = if_cuda(["GOOGLE_CUDA=1"]) + if_rocm(["TENSORFLOW_USE_ROCM=1"]),
+    deps = [
+        ":platform",
+        ":stream",
+        ":stream_executor_h",
+        ":vmm_device_address_allocator",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
+    ] + if_cuda([
+        "//xla/stream_executor/cuda:cuda_device_address_vmm_allocator",
+    ]) + if_rocm([
+        "//xla/stream_executor/rocm:rocm_device_address_vmm_allocator",
+    ]),
+)
+
+cc_library(
     name = "launch_dim",
     srcs = ["launch_dim.cc"],
     hdrs = ["launch_dim.h"],
@@ -442,6 +464,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -1383,3 +1383,212 @@ rocm_library(
     ],
     alwayslink = 1,
 )
+
+cc_library(
+    name = "rocm_raw_memory_allocation",
+    srcs = ["rocm_raw_memory_allocation.cc"],
+    hdrs = ["rocm_raw_memory_allocation.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        ":rocm_status",
+        "//xla:util",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_raw_memory_allocation_test",
+    srcs = ["rocm_raw_memory_allocation_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_platform",
+        ":rocm_platform_id",
+        ":rocm_raw_memory_allocation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test",
+    ],
+)
+
+cc_library(
+    name = "rocm_memory_reservation",
+    srcs = ["rocm_memory_reservation.cc"],
+    hdrs = ["rocm_memory_reservation.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        ":rocm_raw_memory_allocation",
+        ":rocm_status",
+        "//xla:util",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_reservation",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_memory_reservation_test",
+    srcs = ["rocm_memory_reservation_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":amdhipblaslt_plugin",
+        ":rocm_memory_reservation",
+        ":rocm_platform",
+        ":rocm_platform_id",
+        ":rocm_raw_memory_allocation",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_reservation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test",
+    ],
+)
+
+cc_library(
+    name = "rocm_vmm_allocator",
+    srcs = ["rocm_vmm_allocator.cc"],
+    hdrs = ["rocm_vmm_allocator.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        ":rocm_status",
+        "@com_google_absl//absl/cleanup",
+        "//xla:util",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_allocator",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+cc_library(
+    name = "rocm_device_address_vmm_allocator",
+    srcs = ["rocm_device_address_vmm_allocator.cc"],
+    hdrs = ["rocm_device_address_vmm_allocator.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        ":rocm_memory_reservation",
+        ":rocm_raw_memory_allocation",
+        ":rocm_status",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_reservation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor:vmm_device_address_allocator",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:span",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_vmm_allocator_test",
+    srcs = ["rocm_vmm_allocator_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_platform",
+        ":rocm_vmm_allocator",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_device_address_vmm_allocator_test",
+    srcs = ["rocm_device_address_vmm_allocator_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":amdhipblaslt_plugin",
+        ":rocm_device_address_vmm_allocator",
+        ":rocm_platform",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor:vmm_device_address_allocator",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.cc
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.cc
@@ -1,0 +1,166 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "absl/types/span.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/platform.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/rocm/rocm_memory_reservation.h"
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/vmm_device_address_allocator.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+
+RocmDeviceAddressVmmAllocator::RocmDeviceAddressVmmAllocator(
+    const Platform* platform)
+    : DeviceAddressVmmAllocator(platform) {}
+
+absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
+RocmDeviceAddressVmmAllocator::Create(const Platform* platform,
+                                      absl::Span<const DeviceConfig> devices) {
+  auto allocator =
+      absl::WrapUnique(new RocmDeviceAddressVmmAllocator(platform));
+  TF_RETURN_IF_ERROR(PopulateDevices(allocator.get(), devices));
+  return allocator;
+}
+
+absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
+RocmDeviceAddressVmmAllocator::Create(StreamExecutor* executor, Stream* stream,
+                                      uint64_t pa_budget) {
+  return Create(executor->GetPlatform(),
+                {{DeviceConfig{executor, stream, pa_budget}}});
+}
+
+absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
+RocmDeviceAddressVmmAllocator::Create(
+    const Platform* platform, double memory_fraction,
+    std::optional<int64_t> gpu_system_memory_size,
+    absl::Span<const std::pair<StreamExecutor*, Stream*>> devices) {
+  LOG(INFO) << "Using VMM (Virtual Memory Management) allocator for ROCm.";
+  std::vector<DeviceConfig> device_configs;
+  device_configs.reserve(devices.size());
+  for (const auto& [executor, stream] : devices) {
+    int64_t free_memory;
+    int64_t total_memory;
+    if (!executor->DeviceMemoryUsage(&free_memory, &total_memory)) {
+      return absl::UnavailableError(
+          absl::StrFormat("Failed to query available memory from device %i",
+                          executor->device_ordinal()));
+    }
+    DCHECK(memory_fraction >= 0.0 && memory_fraction <= 1.0)
+        << "memory_fraction must be in [0, 1], got " << memory_fraction;
+    uint64_t pa_budget = total_memory * memory_fraction;
+    if (gpu_system_memory_size.has_value()) {
+      pa_budget = gpu_system_memory_size.value();
+    }
+    LOG(INFO) << "VMM allocator pa_budget for device "
+              << executor->device_ordinal() << ": " << pa_budget << " bytes.";
+    device_configs.push_back({executor, stream, pa_budget});
+  }
+  return Create(platform, device_configs);
+}
+
+absl::Status RocmDeviceAddressVmmAllocator::InitializeDeviceState(
+    PerDeviceState& state) {
+  int ordinal = state.executor->device_ordinal();
+
+  // Query allocation granularity for this device.
+  size_t granularity = 0;
+  {
+    std::unique_ptr<ActivateContext> activation = state.executor->Activate();
+    hipDevice_t hip_device;
+    TF_RETURN_IF_ERROR(
+        ToStatus(hipDeviceGet(&hip_device, ordinal), "hipDeviceGet"));
+    hipMemAllocationProp alloc_props = {};
+    alloc_props.type = hipMemAllocationTypePinned;
+    alloc_props.location.type = hipMemLocationTypeDevice;
+    alloc_props.location.id = hip_device;
+    alloc_props.requestedHandleTypes = hipMemHandleTypeNone;
+    TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+        &granularity, &alloc_props, hipMemAllocationGranularityRecommended)));
+  }
+  state.allocation_granularity = static_cast<uint64_t>(granularity);
+
+  // Allocate coherent host memory for the per-device timeline counter.
+  // hipStreamWriteValue64 writes to this location; the CPU polls it to
+  // determine when deferred deallocations are safe to execute.
+  void* host_ptr = nullptr;
+  TF_RETURN_IF_ERROR(ToStatus(
+hipHostMalloc(&host_ptr, sizeof(uint64_t), hipHostMallocCoherent),
+      "hipHostMalloc for timeline counter"));
+  *static_cast<volatile uint64_t*>(host_ptr) = 0;
+
+  // Set timeline fields and destroy_fn immediately so that any early return
+  // still cleans up via ~DeviceAddressVmmAllocator.
+  state.pinned_timeline = static_cast<volatile uint64_t*>(host_ptr);
+  // HIP's hipStreamWriteValue64 accepts void*, so the host pointer is
+  // directly usable as the target (unlike CUDA which needs a separate
+  // device pointer via cuMemHostGetDevicePointer).
+  state.timeline_dev_ptr = reinterpret_cast<uint64_t>(host_ptr);
+  state.destroy_fn = [host_ptr, ordinal]() {
+    auto status =
+        ToStatus(hipHostFree(host_ptr), "hipHostFree for timeline");
+    if (!status.ok()) {
+      LOG(WARNING) << "Failed to free timeline memory for device " << ordinal
+                   << ": " << status;
+    }
+  };
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<MemoryAllocation>>
+RocmDeviceAddressVmmAllocator::CreateAllocation(StreamExecutor* executor,
+                                                uint64_t size) {
+  return RocmRawMemoryAllocation::Create(executor, size);
+}
+
+absl::StatusOr<std::unique_ptr<MemoryReservation>>
+RocmDeviceAddressVmmAllocator::CreateReservation(StreamExecutor* executor,
+                                                 uint64_t size) {
+  return RocmMemoryReservation::Create(executor, size);
+}
+
+absl::Status RocmDeviceAddressVmmAllocator::EnqueueDeferredDeallocation(
+    PerDeviceState& state, uint64_t seqno) {
+  hipStream_t hip_stream =
+      static_cast<hipStream_t>(state.stream->platform_specific_handle().stream);
+  return ToStatus(
+hipStreamWriteValue64(
+          hip_stream, reinterpret_cast<void*>(state.timeline_dev_ptr), seqno,
+          0),
+      "hipStreamWriteValue64");
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h
@@ -1,0 +1,102 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_DEVICE_ADDRESS_VMM_ALLOCATOR_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_DEVICE_ADDRESS_VMM_ALLOCATOR_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/vmm_device_address_allocator.h"
+
+namespace stream_executor::gpu {
+
+// ROCm/HIP implementation of DeviceAddressVmmAllocator.
+//
+// Uses hipMemCreate/hipMemAddressReserve for physical and virtual memory
+// management, and hipStreamWriteValue64 for GPU timeline-based deferred
+// deallocation. Requires ROCm >= 6.0 for HIP VMM API support.
+//
+// The timeline counter is allocated as signal memory via
+// hipExtMallocWithFlags(hipMallocSignalMemory), which is required by
+// hipStreamWriteValue64 on AMD hardware.
+//
+// Use the Create() factories to obtain an instance.
+class RocmDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
+ public:
+  // Creates an allocator supporting multiple devices.
+  //
+  // Precondition: all entries in `devices` have distinct device ordinals.
+  static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(
+      const Platform* platform, absl::Span<const DeviceConfig> devices);
+
+  // Creates an allocator supporting multiple devices, computing the pa_budget
+  // for each device by querying DeviceMemoryUsage and applying memory_fraction.
+  // If gpu_system_memory_size is set, it overrides the memory_fraction budget.
+  //
+  // Precondition: all entries in `devices` have distinct device ordinals.
+  static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(
+      const Platform* platform, double memory_fraction,
+      std::optional<int64_t> gpu_system_memory_size,
+      absl::Span<const std::pair<StreamExecutor*, Stream*>> devices);
+
+  // Creates an allocator for a single device.
+  //
+  // Parameters:
+  //   executor:  StreamExecutor for this device. Must outlive the allocator.
+  //   stream:    Stream used for deferred deallocation. Must outlive the
+  //              allocator.
+  //   pa_budget: Maximum bytes of physical memory that may be simultaneously
+  //              allocated on this device. Defaults to unlimited.
+  static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(
+      StreamExecutor* executor, Stream* stream,
+      uint64_t pa_budget = UINT64_MAX);
+
+ protected:
+  // Allocates signal memory via hipExtMallocWithFlags(hipMallocSignalMemory)
+  // for the per-device timeline counter, and queries the allocation
+  // granularity via hipMemGetAllocationGranularity.
+  absl::Status InitializeDeviceState(PerDeviceState& state) override;
+
+  // Creates a physical memory allocation via RocmRawMemoryAllocation::Create.
+  absl::StatusOr<std::unique_ptr<MemoryAllocation>> CreateAllocation(
+      StreamExecutor* executor, uint64_t size) override;
+
+  // Creates a virtual address reservation via RocmMemoryReservation::Create.
+  absl::StatusOr<std::unique_ptr<MemoryReservation>> CreateReservation(
+      StreamExecutor* executor, uint64_t size) override;
+
+  // Enqueues a hipStreamWriteValue64 on the device's stream to write `seqno`
+  // to the signal memory timeline when the GPU reaches this point.
+  absl::Status EnqueueDeferredDeallocation(PerDeviceState& state,
+                                           uint64_t seqno) override;
+
+ private:
+  explicit RocmDeviceAddressVmmAllocator(const Platform* platform);
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_DEVICE_ADDRESS_VMM_ALLOCATOR_H_

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator_test.cc
@@ -1,0 +1,434 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/vmm_device_address_allocator.h"
+#include "xla/tsl/platform/statusor.h"
+
+namespace stream_executor {
+namespace {
+
+using ::absl_testing::IsOk;
+using ::absl_testing::IsOkAndHolds;
+using ::testing::Ne;
+
+class DeviceAddressVmmAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    platform_ = platform_or.value();
+
+    auto executor_or = platform_->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+
+    auto stream_or = executor_->CreateStream();
+    if (!stream_or.ok()) {
+      GTEST_SKIP() << "Failed to create stream";
+    }
+    stream_ = std::move(stream_or.value());
+
+    auto probe =
+        gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get());
+    if (!probe.ok()) {
+      GTEST_SKIP() << "RocmDeviceAddressVmmAllocator not supported: "
+                   << probe.status();
+    }
+  }
+
+  Platform* platform_ = nullptr;
+  StreamExecutor* executor_ = nullptr;
+  std::unique_ptr<Stream> stream_;
+};
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllocateAndDeallocate) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(executor_->device_ordinal(), 1024,
+                          /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  EXPECT_FALSE(scoped_address.is_null());
+  EXPECT_EQ(scoped_address->size(), 1024);
+  EXPECT_NE(
+      allocator->GetRawAllocation(executor_->device_ordinal(), *scoped_address),
+      nullptr);
+  EXPECT_NE(
+      allocator->GetReservation(executor_->device_ordinal(), *scoped_address),
+      nullptr);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllocateZeroSize) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(executor_->device_ordinal(), 0,
+                          /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  EXPECT_TRUE(scoped_address.is_null());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllocateMultiple) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr1, allocator->Allocate(executor_->device_ordinal(), 1024,
+                                      /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr2, allocator->Allocate(executor_->device_ordinal(), 2048,
+                                      /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+
+  EXPECT_FALSE(addr1.is_null());
+  EXPECT_FALSE(addr2.is_null());
+  EXPECT_NE(addr1->opaque(), addr2->opaque());
+  EXPECT_EQ(addr1.cref().size(), 1024);
+  EXPECT_EQ(addr2.cref().size(), 2048);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, MemoryReadWrite) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(executor_->device_ordinal(), 1024,
+                          /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  ASSERT_NE(scoped_address->opaque(), nullptr);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor_->CreateStream());
+
+  constexpr uint64_t kTestValue = 0xDEADBEEFCAFEBABE;
+  DeviceAddressBase addr = scoped_address.cref();
+  EXPECT_THAT(stream->Memcpy(&addr, &kTestValue, sizeof(kTestValue)),
+              absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+
+  uint64_t read_value = 0;
+  EXPECT_THAT(stream->Memcpy(&read_value, addr, sizeof(read_value)),
+              absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+
+  EXPECT_EQ(read_value, kTestValue);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, GetStream) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(Stream * stream,
+                          allocator->GetStream(executor_->device_ordinal()));
+  EXPECT_EQ(stream, stream_.get());
+
+  TF_ASSERT_OK_AND_ASSIGN(Stream * stream2,
+                          allocator->GetStream(executor_->device_ordinal()));
+  EXPECT_EQ(stream, stream2);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, GetStreamExecutor) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      StreamExecutor * se,
+      allocator->GetStreamExecutor(executor_->device_ordinal()));
+  EXPECT_EQ(se, executor_);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllowsAsynchronousDeallocation) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  EXPECT_TRUE(allocator->AllowsAsynchronousDeallocation());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, ExplicitDeallocate) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(executor_->device_ordinal(), 1024,
+                          /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  ASSERT_NE(scoped_address->opaque(), nullptr);
+  DeviceAddressBase addr = scoped_address.cref();
+
+  EXPECT_THAT(allocator->Deallocate(executor_->device_ordinal(), addr),
+              absl_testing::IsOk());
+
+  scoped_address.Release();
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, DeallocateNull) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  DeviceAddressBase null_addr;
+  EXPECT_THAT(allocator->Deallocate(executor_->device_ordinal(), null_addr),
+              absl_testing::IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       PendingDeallocationReusesSameVirtualAddress) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  constexpr uint64_t kSize = 1024;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr1, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+  void* const va = addr1->opaque();
+
+  DeviceAddressBase raw = addr1.cref();
+  addr1.Release();
+  ASSERT_THAT(allocator->Deallocate(ordinal, raw), IsOk());
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr2, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+  EXPECT_EQ(addr2->opaque(), va);
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       DeferredDeallocationSafeWhileGpuWritesData) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr,
+      allocator->Allocate(ordinal, sizeof(uint64_t), /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  constexpr uint64_t kPattern = 0xCAFEBABEDEADBEEFULL;
+  DeviceAddressBase dev_addr = addr.cref();
+  ASSERT_THAT(stream_->Memcpy(&dev_addr, &kPattern, sizeof(kPattern)), IsOk());
+
+  ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       MultipleSeqnosAllCompleteAfterStreamSync) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  constexpr int kCount = 8;
+  constexpr uint64_t kSize = 1024;
+
+  for (int i = 0; i < kCount; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto addr,
+        allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                            static_cast<int64_t>(MemorySpace::kCollective)));
+    ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
+  }
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+
+  for (int i = 0; i < kCount; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto addr,
+        allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                            static_cast<int64_t>(MemorySpace::kCollective)));
+    EXPECT_FALSE(addr.is_null());
+  }
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       DestructorWithPendingDeallocationsDoesNotCrash) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+
+  for (int i = 0; i < 4; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto addr,
+        allocator->Allocate(ordinal, 1024, /*retry_on_failure=*/true,
+                            static_cast<int64_t>(MemorySpace::kCollective)));
+    ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
+  }
+
+  allocator.reset();
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, UnknownDeviceOrdinalReturnsError) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int unknown_ordinal = 9999;
+  EXPECT_FALSE(allocator
+                   ->Allocate(unknown_ordinal, 1024, /*retry_on_failure=*/true,
+                              static_cast<int64_t>(MemorySpace::kCollective))
+                   .ok());
+  EXPECT_THAT(allocator->Deallocate(unknown_ordinal, DeviceAddressBase{}),
+              absl_testing::IsOk());
+  DeviceAddressBase fake_addr(reinterpret_cast<void*>(0x1000), 64);
+  EXPECT_FALSE(allocator->Deallocate(unknown_ordinal, fake_addr).ok());
+  EXPECT_FALSE(allocator->GetStream(unknown_ordinal).ok());
+  EXPECT_FALSE(allocator->GetStreamExecutor(unknown_ordinal).ok());
+}
+
+class MultiDeviceVmmAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    platform_ = platform_or.value();
+
+    if (platform_->VisibleDeviceCount() < 2) {
+      GTEST_SKIP() << "Fewer than two ROCm devices available";
+    }
+
+    for (int i = 0; i < 2; ++i) {
+      auto executor_or = platform_->ExecutorForDevice(i);
+      if (!executor_or.ok()) {
+        GTEST_SKIP() << "ROCM executor not available for device " << i;
+      }
+      executors_.push_back(executor_or.value());
+
+      auto stream_or = executors_.back()->CreateStream();
+      if (!stream_or.ok()) {
+        GTEST_SKIP() << "Failed to create stream for device " << i;
+      }
+      streams_.push_back(std::move(stream_or.value()));
+    }
+
+    auto probe = gpu::RocmDeviceAddressVmmAllocator::Create(executors_[0],
+                                                            streams_[0].get());
+    if (!probe.ok()) {
+      GTEST_SKIP() << "RocmDeviceAddressVmmAllocator not supported: "
+                   << probe.status();
+    }
+  }
+
+  Platform* platform_ = nullptr;
+  std::vector<StreamExecutor*> executors_;
+  std::vector<std::unique_ptr<Stream>> streams_;
+};
+
+TEST_F(MultiDeviceVmmAllocatorTest, AllocateOnBothDevices) {
+  std::vector<DeviceAddressVmmAllocator::DeviceConfig> configs;
+  for (int i = 0; i < 2; ++i) {
+    configs.push_back({executors_[i], streams_[i].get()});
+  }
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(platform_, configs));
+
+  for (int i = 0; i < 2; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto addr,
+        allocator->Allocate(executors_[i]->device_ordinal(), 1024,
+                            /*retry_on_failure=*/true,
+                            static_cast<int64_t>(MemorySpace::kCollective)));
+    EXPECT_FALSE(addr.is_null());
+    EXPECT_EQ(addr->size(), 1024);
+    EXPECT_NE(
+        allocator->GetRawAllocation(executors_[i]->device_ordinal(), *addr),
+        nullptr);
+    EXPECT_NE(allocator->GetReservation(executors_[i]->device_ordinal(), *addr),
+              nullptr);
+    TF_ASSERT_OK_AND_ASSIGN(
+        StreamExecutor * se,
+        allocator->GetStreamExecutor(executors_[i]->device_ordinal()));
+    EXPECT_EQ(se, executors_[i]);
+    TF_ASSERT_OK_AND_ASSIGN(
+        Stream * stream, allocator->GetStream(executors_[i]->device_ordinal()));
+    EXPECT_EQ(stream, streams_[i].get());
+  }
+}
+
+TEST_F(MultiDeviceVmmAllocatorTest, AllocationOnOneDeviceDoesNotAffectOther) {
+  std::vector<DeviceAddressVmmAllocator::DeviceConfig> configs;
+  for (int i = 0; i < 2; ++i) {
+    configs.push_back({executors_[i], streams_[i].get()});
+  }
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(platform_, configs));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr0, allocator->Allocate(executors_[0]->device_ordinal(), 4096,
+                                      /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+  EXPECT_FALSE(addr0.is_null());
+
+  EXPECT_EQ(
+      allocator->GetRawAllocation(executors_[1]->device_ordinal(), *addr0),
+      nullptr);
+}
+
+}  // namespace
+}  // namespace stream_executor

--- a/xla/stream_executor/rocm/rocm_event.cc
+++ b/xla/stream_executor/rocm/rocm_event.cc
@@ -108,6 +108,12 @@ absl::Status RocmEvent::WaitForEventOnExternalStream(std::intptr_t stream) {
                            handle_);
 }
 
+absl::Status RocmEvent::Synchronize() {
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  return ToStatus(hipEventSynchronize(handle_),
+                  "could not synchronize on ROCm event");
+}
+
 absl::StatusOr<RocmEvent> RocmEvent::Create(StreamExecutor *executor,
                                             bool allow_timing) {
   ASSIGN_OR_RETURN(

--- a/xla/stream_executor/rocm/rocm_event.h
+++ b/xla/stream_executor/rocm/rocm_event.h
@@ -31,6 +31,7 @@ class RocmEvent : public Event {
  public:
   Event::Status PollForStatus() override;
   absl::Status WaitForEventOnExternalStream(std::intptr_t stream) override;
+  absl::Status Synchronize() override;
 
   // Creates a new RocmEvent. If allow_timing is false, the event will not
   // support timing, which is cheaper to create.

--- a/xla/stream_executor/rocm/rocm_memory_reservation.cc
+++ b/xla/stream_executor/rocm/rocm_memory_reservation.cc
@@ -1,0 +1,156 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_memory_reservation.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+
+absl::StatusOr<std::unique_ptr<RocmMemoryReservation>>
+RocmMemoryReservation::Create(StreamExecutor* executor, uint64_t size) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  hipDevice_t device;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
+
+  hipMemAllocationProp props = {};
+  props.type = hipMemAllocationTypePinned;
+  props.location.type = hipMemLocationTypeDevice;
+  props.location.id = device;
+  props.requestedHandleTypes = hipMemHandleTypeNone;
+
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+      &granularity, &props, hipMemAllocationGranularityRecommended)));
+
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
+
+  void* ptr = nullptr;
+  TF_RETURN_IF_ERROR(ToStatus(
+hipMemAddressReserve(&ptr, padded_size, granularity, nullptr,
+                                    0ULL)));
+
+  return std::unique_ptr<RocmMemoryReservation>(
+      new RocmMemoryReservation(executor, static_cast<char*>(ptr), padded_size));
+}
+
+RocmMemoryReservation::RocmMemoryReservation(StreamExecutor* executor,
+                                             char* ptr, uint64_t size)
+    : executor_(executor), ptr_(ptr), size_(size) {}
+
+DeviceAddressBase RocmMemoryReservation::address() const {
+  return DeviceAddressBase(ptr_, size_);
+}
+
+absl::Status RocmMemoryReservation::Map(size_t reservation_offset,
+                                        size_t allocation_offset, size_t size,
+                                        MemoryAllocation& allocation) {
+  auto* rocm_alloc = dynamic_cast<RocmRawMemoryAllocation*>(&allocation);
+  if (rocm_alloc == nullptr) {
+    return absl::InvalidArgumentError(
+        "RocmMemoryReservation::Map requires a RocmRawMemoryAllocation");
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  absl::Status status = ToStatus(hipMemMap(ptr_ + reservation_offset, size,
+                                           allocation_offset,
+                                           rocm_alloc->GetHandle(), 0ULL));
+  if (status.ok()) {
+    mapped_bytes_ += size;
+  }
+  return status;
+}
+
+absl::Status RocmMemoryReservation::SetAccess(uint64_t reservation_offset,
+                                              size_t size) {
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+
+  int device_count = 0;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipGetDeviceCount(&device_count), "hipGetDeviceCount"));
+
+  for (int peer = 0; peer < device_count; ++peer) {
+    if (peer != executor_->device_ordinal()) {
+      auto peer_executor_or =
+          const_cast<Platform*>(executor_->GetPlatform())
+              ->ExecutorForDevice(peer);
+      if (!peer_executor_or.ok() ||
+          !executor_->CanEnablePeerAccessTo(peer_executor_or.value())) {
+        continue;
+      }
+    }
+    hipMemAccessDesc desc = {};
+    desc.location.type = hipMemLocationTypeDevice;
+    desc.location.id = peer;
+    desc.flags = hipMemAccessFlagsProtReadWrite;
+    TF_RETURN_IF_ERROR(ToStatus(
+hipMemSetAccess(ptr_ + reservation_offset, size, &desc, 1),
+        "hipMemSetAccess for peer device"));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status RocmMemoryReservation::UnMap(size_t offset, size_t size) {
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  absl::Status status = ToStatus(hipMemUnmap(ptr_ + offset, size));
+  if (status.ok()) {
+    mapped_bytes_ = mapped_bytes_ >= size ? mapped_bytes_ - size : 0;
+  }
+  return status;
+}
+
+RocmMemoryReservation::~RocmMemoryReservation() {
+  if (ptr_ == nullptr) {
+    return;
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  // Only unmap if a mapping is still active. The ScopedMapping returned by
+  // MapTo/Remap normally unmaps the range before this reservation is destroyed;
+  // calling hipMemUnmap again on an already-unmapped range fails with
+  // HIP_ERROR_InvalidValue. Tracking mapped_bytes_ avoids that redundant (and
+  // very noisy) double-unmap at teardown.
+  if (mapped_bytes_ > 0) {
+    auto unmap_status =
+        ToStatus(hipMemUnmap(ptr_, size_), "Error unmapping ROCm memory");
+    if (!unmap_status.ok()) {
+      LOG(ERROR) << unmap_status.message();
+    }
+  }
+  auto free_status = ToStatus(hipMemAddressFree(ptr_, size_),
+                              "Error freeing ROCm address range");
+  if (!free_status.ok()) {
+    LOG(ERROR) << free_status.message();
+  }
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_memory_reservation.h
+++ b/xla/stream_executor/rocm/rocm_memory_reservation.h
@@ -1,0 +1,76 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_MEMORY_RESERVATION_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_MEMORY_RESERVATION_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// RAII wrapper for a ROCm virtual address range reserved via
+// hipMemAddressReserve. Physical memory can be mapped into sub-ranges of the
+// reservation via MapTo, which also enables device access before returning.
+class RocmMemoryReservation : public MemoryReservation {
+ public:
+  // Reserves a virtual address range of at least `size` bytes using
+  // hipMemAddressReserve. StreamExecutor is used only for context activation.
+  static absl::StatusOr<std::unique_ptr<RocmMemoryReservation>> Create(
+      StreamExecutor* executor, uint64_t size);
+
+  // Returns the base address and padded size of the reserved virtual range.
+  DeviceAddressBase address() const override;
+
+  ~RocmMemoryReservation() override;
+
+  // Move is disabled to prevent double-free of the virtual address range:
+  // the destructor calls hipMemAddressFree on ptr_. Matches CudaMemoryReservation.
+  RocmMemoryReservation(RocmMemoryReservation&&) = delete;
+  RocmMemoryReservation& operator=(RocmMemoryReservation&&) = delete;
+
+ private:
+  explicit RocmMemoryReservation(StreamExecutor* executor, char* ptr,
+                                 uint64_t size);
+
+  absl::Status Map(size_t reservation_offset, size_t allocation_offset,
+                   size_t size, MemoryAllocation& allocation) override;
+
+  absl::Status SetAccess(uint64_t reservation_offset, size_t size) override;
+
+  absl::Status UnMap(size_t reservation_offset, size_t size) override;
+
+  StreamExecutor* executor_;
+  char* ptr_;  // nullptr means moved-from / released
+  uint64_t size_;
+  // Bytes currently mapped into the reservation. Kept in sync by Map()/UnMap()
+  // so the destructor can skip a redundant hipMemUnmap when the ScopedMapping
+  // that owns the mapping has already unmapped the range (which would otherwise
+  // fail with HIP_ERROR_InvalidValue).
+  uint64_t mapped_bytes_ = 0;
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_MEMORY_RESERVATION_H_

--- a/xla/stream_executor/rocm/rocm_memory_reservation_test.cc
+++ b/xla/stream_executor/rocm/rocm_memory_reservation_test.cc
@@ -1,0 +1,149 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_memory_reservation.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/test.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+using absl_testing::IsOk;
+using absl_testing::StatusIs;
+
+static constexpr uint64_t kTestSize = 1024 * 1024;
+
+class FakeAllocation : public MemoryAllocation {
+ public:
+  DeviceAddressBase address() const override { return DeviceAddressBase(); }
+};
+
+class RocmMemoryReservationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    auto executor_or = platform_or.value()->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+  }
+
+  StreamExecutor* executor_ = nullptr;
+};
+
+TEST_F(RocmMemoryReservationTest, CreateReservation) {
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  EXPECT_NE(res->address().opaque(), nullptr);
+  EXPECT_GE(res->address().size(), kTestSize);
+}
+
+TEST_F(RocmMemoryReservationTest, MapToWrongType) {
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  FakeAllocation fake;
+  EXPECT_THAT(res->MapTo(0, 0, kTestSize, fake),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST_F(RocmMemoryReservationTest, MapToSingleAllocation) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  const size_t alloc_size = alloc->address().size();
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
+
+  EXPECT_EQ(mapping.mapped_address().opaque(), res->address().opaque());
+  EXPECT_EQ(mapping.mapped_address().size(), alloc_size);
+}
+
+TEST_F(RocmMemoryReservationTest, ScopedMappingUnmapsOnDestruction) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  const size_t alloc_size = alloc->address().size();
+  {
+    TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping2, res->MapTo(0, 0, alloc_size, *alloc));
+  EXPECT_NE(mapping2.mapped_address().opaque(), nullptr);
+}
+
+TEST_F(RocmMemoryReservationTest, MapToMultipleAllocations) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc1, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc2, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+
+  const size_t size1 = alloc1->address().size();
+  const size_t size2 = alloc2->address().size();
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto res, RocmMemoryReservation::Create(executor_, size1 + size2));
+  ASSERT_GE(res->address().size(), size1 + size2);
+
+  MemoryReservation::MappingDescriptor descs[] = {
+      {/*reservation_offset=*/0, /*allocation_offset=*/0, size1, alloc1.get()},
+      {/*reservation_offset=*/size1, /*allocation_offset=*/0, size2,
+       alloc2.get()},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(absl::MakeSpan(descs)));
+
+  EXPECT_EQ(mapping.mapped_address().opaque(), res->address().opaque());
+  EXPECT_EQ(mapping.mapped_address().size(), size1 + size2);
+}
+
+TEST_F(RocmMemoryReservationTest, TwoReservationsDifferentAddresses) {
+  TF_ASSERT_OK_AND_ASSIGN(auto res1,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res2,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  EXPECT_NE(res1->address().opaque(), res2->address().opaque());
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation.cc
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation.cc
@@ -1,0 +1,87 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/log/log.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/device_address.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+
+absl::StatusOr<std::unique_ptr<RocmRawMemoryAllocation>>
+RocmRawMemoryAllocation::Create(StreamExecutor* executor, uint64_t size) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  hipDevice_t device;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
+
+  hipMemAllocationProp props = {};
+  props.type = hipMemAllocationTypePinned;
+  props.location.type = hipMemLocationTypeDevice;
+  props.location.id = device;
+  props.requestedHandleTypes = hipMemHandleTypeNone;
+
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+      &granularity, &props, hipMemAllocationGranularityRecommended)));
+
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
+
+  hipMemGenericAllocationHandle_t handle;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipMemCreate(&handle, padded_size, &props, 0ULL)));
+
+  return std::unique_ptr<RocmRawMemoryAllocation>(
+      new RocmRawMemoryAllocation(executor, handle, padded_size));
+}
+
+RocmRawMemoryAllocation::RocmRawMemoryAllocation(
+    StreamExecutor* executor, hipMemGenericAllocationHandle_t handle,
+    uint64_t size)
+    : executor_(executor), handle_(handle), size_(size) {}
+
+DeviceAddressBase RocmRawMemoryAllocation::address() const {
+  // handle_ is an opaque allocation handle, not a device pointer. We expose it
+  // as a DeviceAddressBase so the base class can use opaque() for identity
+  // tracking; callers never dereference this address.
+  return DeviceAddressBase(static_cast<void*>(handle_), size_);
+}
+
+RocmRawMemoryAllocation::~RocmRawMemoryAllocation() {
+  if (handle_ == nullptr) {
+    return;
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  auto status =
+      ToStatus(hipMemRelease(handle_), "Error releasing ROCm memory");
+  if (!status.ok()) {
+    LOG(ERROR) << status.message();
+  }
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation.h
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation.h
@@ -1,0 +1,65 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_RAW_MEMORY_ALLOCATION_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_RAW_MEMORY_ALLOCATION_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// RAII wrapper for a physical memory allocation created via hipMemCreate.
+// The handle is not mapped to any virtual address; this class only manages
+// the lifetime of the hipMemGenericAllocationHandle_t.
+class RocmRawMemoryAllocation : public MemoryAllocation {
+ public:
+  // Creates a physical memory allocation of at least `size` bytes using
+  // hipMemCreate. StreamExecutor is used only for context activation.
+  static absl::StatusOr<std::unique_ptr<RocmRawMemoryAllocation>> Create(
+      StreamExecutor* executor, uint64_t size);
+
+  // Returns a DeviceAddressBase whose opaque() holds the raw
+  // hipMemGenericAllocationHandle_t cast to void*, and size() is the
+  // padded allocation size.
+  DeviceAddressBase address() const override;
+
+  hipMemGenericAllocationHandle_t GetHandle() const { return handle_; }
+
+  ~RocmRawMemoryAllocation() override;
+  RocmRawMemoryAllocation(const RocmRawMemoryAllocation&) = delete;
+  RocmRawMemoryAllocation& operator=(const RocmRawMemoryAllocation&) = delete;
+  RocmRawMemoryAllocation(RocmRawMemoryAllocation&&) = delete;
+  RocmRawMemoryAllocation& operator=(RocmRawMemoryAllocation&&) = delete;
+
+ private:
+  explicit RocmRawMemoryAllocation(StreamExecutor* executor,
+                                   hipMemGenericAllocationHandle_t handle,
+                                   uint64_t size);
+
+  StreamExecutor* executor_;
+  hipMemGenericAllocationHandle_t handle_;
+  uint64_t size_;
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_RAW_MEMORY_ALLOCATION_H_

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation_test.cc
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation_test.cc
@@ -1,0 +1,80 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+
+#include <cstdint>
+#include <memory>
+
+#include <gtest/gtest.h>
+#include "absl/status/status_matchers.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/test.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+using absl_testing::IsOk;
+
+static constexpr uint64_t kTestSize = 1024 * 1024;
+
+class RocmRawMemoryAllocationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    auto executor_or = platform_or.value()->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+  }
+
+  StreamExecutor* executor_ = nullptr;
+};
+
+TEST_F(RocmRawMemoryAllocationTest, CreateAllocation) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+
+  EXPECT_NE(alloc->GetHandle(), nullptr);
+  EXPECT_GE(alloc->address().size(), kTestSize);
+}
+
+TEST_F(RocmRawMemoryAllocationTest, AddressReflectsHandle) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+
+  EXPECT_EQ(alloc->address().opaque(),
+            static_cast<void*>(alloc->GetHandle()));
+  EXPECT_GE(alloc->address().size(), kTestSize);
+}
+
+TEST_F(RocmRawMemoryAllocationTest, SizeIsAtLeastRequested) {
+  TF_ASSERT_OK_AND_ASSIGN(auto alloc,
+                          RocmRawMemoryAllocation::Create(executor_, 1));
+
+  EXPECT_NE(alloc->GetHandle(), nullptr);
+  EXPECT_GE(alloc->address().size(), 1u);
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_vmm_allocator.cc
+++ b/xla/stream_executor/rocm/rocm_vmm_allocator.cc
@@ -1,0 +1,206 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_vmm_allocator.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include "absl/cleanup/cleanup.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+
+static hipMemAccessDesc GetVmmAccessDescriptor(int device) {
+  hipMemAccessDesc descriptor = {};
+  descriptor.location.type = hipMemLocationTypeDevice;
+  descriptor.location.id = device;
+  descriptor.flags = hipMemAccessFlagsProtReadWrite;
+  return descriptor;
+}
+
+// Allocates device memory using HIP VMM APIs. Returns the mapped pointer,
+// the padded size, and the allocation handle.
+static absl::StatusOr<
+    std::tuple<void*, uint64_t, hipMemGenericAllocationHandle_t>>
+VmmAllocate(StreamExecutor* executor, uint64_t size) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  hipDevice_t device;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
+
+  hipMemAllocationProp properties = {};
+  properties.type = hipMemAllocationTypePinned;
+  properties.location.type = hipMemLocationTypeDevice;
+  properties.location.id = device;
+  properties.requestedHandleTypes = hipMemHandleTypeNone;
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+      &granularity, &properties, hipMemAllocationGranularityRecommended)));
+
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
+  hipMemGenericAllocationHandle_t handle;
+
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipMemCreate(&handle, padded_size, &properties, 0ULL)));
+
+  hipDeviceptr_t ptr = nullptr;
+  absl::Status status = ToStatus(
+hipMemAddressReserve(&ptr, padded_size, granularity, nullptr,
+                                    0ULL));
+  if (!status.ok()) {
+    ToStatus(hipMemRelease(handle)).IgnoreError();
+    return status;
+  }
+
+  status = ToStatus(hipMemMap(ptr, padded_size, 0, handle, 0ULL));
+  if (!status.ok()) {
+    ToStatus(hipMemAddressFree(ptr, padded_size)).IgnoreError();
+    ToStatus(hipMemRelease(handle)).IgnoreError();
+    return status;
+  }
+
+  // Cleanup on error: unmap + free VA + release physical memory.
+  absl::Cleanup cleanup = [&]() {
+    ToStatus(hipMemUnmap(ptr, padded_size)).IgnoreError();
+    ToStatus(hipMemAddressFree(ptr, padded_size)).IgnoreError();
+    ToStatus(hipMemRelease(handle)).IgnoreError();
+  };
+
+  VLOG(3) << "VMM allocated " << ptr
+          << " requested size: " << size
+          << " padded size: " << padded_size
+          << " granularity: " << granularity
+          << " device: " << executor->device_ordinal();
+
+  // Set access for this device and all P2P-capable peers, matching the CUDA
+  // pattern that gates on CanEnablePeerAccessTo().
+  int device_count = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipGetDeviceCount(&device_count)));
+  for (int peer = 0; peer < device_count; peer++) {
+    if (peer != executor->device_ordinal()) {
+      auto peer_executor_or =
+          const_cast<Platform*>(executor->GetPlatform())
+              ->ExecutorForDevice(peer);
+      if (!peer_executor_or.ok() ||
+          !executor->CanEnablePeerAccessTo(peer_executor_or.value())) {
+        continue;
+      }
+    }
+    hipMemAccessDesc access_desc = GetVmmAccessDescriptor(peer);
+    TF_RETURN_IF_ERROR(
+        ToStatus(hipMemSetAccess(ptr, padded_size, &access_desc, 1)));
+  }
+
+  std::move(cleanup).Cancel();
+  return std::make_tuple(ptr, padded_size, handle);
+}
+
+static void VmmDeallocate(StreamExecutor* executor, void* ptr,
+                          uint64_t padded_size,
+                          hipMemGenericAllocationHandle_t handle) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  VLOG(3) << "VMM deallocating " << ptr
+          << " padded size: " << padded_size
+          << " device: " << executor->device_ordinal();
+
+  absl::Status status = ToStatus(hipMemUnmap(ptr, padded_size));
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to unmap VMM memory at " << ptr << ": " << status;
+  }
+  status = ToStatus(hipMemRelease(handle));
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to release VMM handle for " << ptr << ": " << status;
+  }
+  status = ToStatus(hipMemAddressFree(ptr, padded_size));
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to free VMM address at " << ptr << ": " << status;
+  }
+}
+
+namespace {
+
+class RocmVmmMemoryAllocation final : public MemoryAllocation {
+ public:
+  RocmVmmMemoryAllocation(StreamExecutor* executor, void* ptr,
+                          uint64_t requested_size, uint64_t padded_size,
+                          hipMemGenericAllocationHandle_t handle)
+      : executor_(executor),
+        ptr_(ptr),
+        requested_size_(requested_size),
+        padded_size_(padded_size),
+        handle_(handle) {}
+
+  ~RocmVmmMemoryAllocation() final {
+    if (ptr_ != nullptr) {
+      VmmDeallocate(executor_, ptr_, padded_size_, handle_);
+    }
+  }
+
+  DeviceAddressBase address() const final {
+    return DeviceAddressBase(ptr_, requested_size_);
+  }
+
+  std::string ToString() const final {
+    return absl::StrFormat(
+        "RocmVmmMemoryAllocation[device=%d, ptr=%p, size=%d, padded_size=%d]",
+        executor_->device_ordinal(), ptr_, requested_size_, padded_size_);
+  }
+
+ private:
+  StreamExecutor* executor_;
+  void* ptr_;
+  uint64_t requested_size_;
+  uint64_t padded_size_;
+  hipMemGenericAllocationHandle_t handle_;
+};
+
+}  // namespace
+
+RocmVmmAllocator::RocmVmmAllocator(StreamExecutor* executor)
+    : executor_(executor) {}
+
+absl::StatusOr<std::unique_ptr<MemoryAllocation>> RocmVmmAllocator::Allocate(
+    uint64_t size) {
+  if (size == 0) {
+    return std::make_unique<RocmVmmMemoryAllocation>(executor_, nullptr, 0, 0,
+                                                     nullptr);
+  }
+
+  TF_ASSIGN_OR_RETURN(auto result, VmmAllocate(executor_, size));
+  auto [ptr, padded_size, handle] = result;
+
+  return std::make_unique<RocmVmmMemoryAllocation>(executor_, ptr, size,
+                                                   padded_size, handle);
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_vmm_allocator.h
+++ b/xla/stream_executor/rocm/rocm_vmm_allocator.h
@@ -1,0 +1,45 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_VMM_ALLOCATOR_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_VMM_ALLOCATOR_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_allocator.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// Device memory allocator using ROCm/HIP Virtual Memory Management (VMM) APIs.
+// Returned memory allocations are always mapped to a valid device address range
+// and accessible from the device and its peers.
+class RocmVmmAllocator : public MemoryAllocator {
+ public:
+  explicit RocmVmmAllocator(StreamExecutor* executor);
+
+  absl::StatusOr<std::unique_ptr<MemoryAllocation>> Allocate(
+      uint64_t size) final;
+
+ private:
+  StreamExecutor* executor_;
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_VMM_ALLOCATOR_H_

--- a/xla/stream_executor/rocm/rocm_vmm_allocator_test.cc
+++ b/xla/stream_executor/rocm/rocm_vmm_allocator_test.cc
@@ -1,0 +1,97 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_vmm_allocator.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+class RocmVmmAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    auto executor_or = platform_or.value()->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+  }
+
+  StreamExecutor* executor_ = nullptr;
+};
+
+TEST_F(RocmVmmAllocatorTest, AllocateAndFree) {
+  RocmVmmAllocator allocator(executor_);
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
+                       allocator.Allocate(1024));
+  ASSERT_NE(allocation, nullptr);
+  EXPECT_NE(allocation->address().opaque(), nullptr);
+  EXPECT_EQ(allocation->address().size(), 1024);
+}
+
+TEST_F(RocmVmmAllocatorTest, AllocateZeroBytes) {
+  RocmVmmAllocator allocator(executor_);
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
+                       allocator.Allocate(0));
+  ASSERT_NE(allocation, nullptr);
+  EXPECT_EQ(allocation->address().opaque(), nullptr);
+}
+
+TEST_F(RocmVmmAllocatorTest, MemcpyRoundTrip) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<Stream> stream,
+                       executor_->CreateStream());
+
+  RocmVmmAllocator allocator(executor_);
+
+  constexpr int kSize = 1024;
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
+                       allocator.Allocate(kSize));
+
+  std::vector<uint8_t> host_src(kSize);
+  for (int i = 0; i < kSize; i++) {
+    host_src[i] = static_cast<uint8_t>(i);
+  }
+
+  DeviceAddress<uint8_t> addr(allocation->address());
+  ASSERT_OK(stream->MemcpyH2D(absl::MakeConstSpan(host_src), &addr));
+
+  std::vector<uint8_t> host_dst(kSize, 0);
+  ASSERT_OK(stream->MemcpyD2H(addr, absl::MakeSpan(host_dst)));
+  ASSERT_OK(stream->BlockHostUntilDone());
+
+  EXPECT_EQ(host_src, host_dst);
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/vmm_device_address_allocator.cc
+++ b/xla/stream_executor/vmm_device_address_allocator.cc
@@ -623,6 +623,20 @@ MemoryAllocation* DeviceAddressVmmAllocator::GetRawAllocation(
   return it->second.get();
 }
 
+MemoryReservation* DeviceAddressVmmAllocator::GetReservation(
+    int device_ordinal, DeviceAddressBase addr) const {
+  PerDeviceState* state = GetPerDeviceState(device_ordinal);
+  if (state == nullptr) {
+    return nullptr;
+  }
+  absl::MutexLock lock(state->mu);
+  auto it = state->reservations.find(addr.opaque());
+  if (it == state->reservations.end()) {
+    return nullptr;
+  }
+  return it->second.get();
+}
+
 uint64_t DeviceAddressVmmAllocator::GetAllocationGranularity(
     StreamExecutor* executor) const {
   PerDeviceState* state = GetPerDeviceState(executor->device_ordinal());

--- a/xla/stream_executor/vmm_device_address_allocator.h
+++ b/xla/stream_executor/vmm_device_address_allocator.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <functional>
 #include <memory>
 #include <optional>
+#include <utility>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
@@ -89,6 +90,19 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     uint64_t pa_budget = UINT64_MAX;
   };
 
+  // Creates a platform-appropriate VMM allocator for the given devices,
+  // dispatching to the CUDA or ROCm implementation based on the build platform.
+  // The pa_budget for each device is computed from `memory_fraction` (or
+  // overridden by `gpu_system_memory_size` when set). Returns an error on
+  // platforms without a VMM implementation.
+  //
+  // Defined in vmm_device_address_allocator_factory.cc so this base library
+  // does not depend on the platform-specific subclasses.
+  static absl::StatusOr<std::unique_ptr<DeviceAddressVmmAllocator>> Create(
+      const Platform* platform, double memory_fraction,
+      std::optional<int64_t> gpu_system_memory_size,
+      absl::Span<const std::pair<StreamExecutor*, Stream*>> devices);
+
   ~DeviceAddressVmmAllocator() override;
 
   absl::StatusOr<ScopedDeviceAddress<uint8_t>> Allocate(
@@ -137,6 +151,13 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // allocation is deallocated.
   MemoryAllocation* GetRawAllocation(int device_ordinal,
                                      DeviceAddressBase addr) const;
+
+  // Returns the MemoryReservation (virtual address range) for the given
+  // virtual address on the specified device, or nullptr if the address was not
+  // allocated by this allocator. The returned pointer is valid until the
+  // allocation is deallocated.
+  MemoryReservation* GetReservation(int device_ordinal,
+                                    DeviceAddressBase addr) const;
 
   // Returns the VMM allocation granularity for the device associated with
   // `executor`, or 0 if the device is not registered or granularity is unknown.

--- a/xla/stream_executor/vmm_device_address_allocator_factory.cc
+++ b/xla/stream_executor/vmm_device_address_allocator_factory.cc
@@ -1,0 +1,61 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/vmm_device_address_allocator.h"
+#include "xla/tsl/platform/statusor.h"
+
+#if GOOGLE_CUDA
+#include "xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h"
+#elif TENSORFLOW_USE_ROCM
+#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
+#endif  // GOOGLE_CUDA
+
+namespace stream_executor {
+
+absl::StatusOr<std::unique_ptr<DeviceAddressVmmAllocator>>
+DeviceAddressVmmAllocator::Create(
+    const Platform* platform, double memory_fraction,
+    std::optional<int64_t> gpu_system_memory_size,
+    absl::Span<const std::pair<StreamExecutor*, Stream*>> devices) {
+#if GOOGLE_CUDA
+  TF_ASSIGN_OR_RETURN(
+      std::unique_ptr<gpu::CudaDeviceAddressVmmAllocator> allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(
+          platform, memory_fraction, gpu_system_memory_size, devices));
+  return std::unique_ptr<DeviceAddressVmmAllocator>(std::move(allocator));
+#elif TENSORFLOW_USE_ROCM
+  TF_ASSIGN_OR_RETURN(
+      std::unique_ptr<gpu::RocmDeviceAddressVmmAllocator> allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(
+          platform, memory_fraction, gpu_system_memory_size, devices));
+  return std::unique_ptr<DeviceAddressVmmAllocator>(std::move(allocator));
+#else
+  return absl::UnimplementedError(
+      "VMM allocator is only supported with CUDA or ROCm.");
+#endif  // GOOGLE_CUDA
+}
+
+}  // namespace stream_executor


### PR DESCRIPTION
## Summary

This is **part 1 of 2** splitting #40236 (ROCm VMM allocator) into smaller, focused PRs.

Adds a ROCm Virtual Memory Manager (VMM) allocator and enables it in the PJRT GPU
client, so `GpuAllocatorConfig::Kind::kVmm` works on ROCm
(`XLA_PYTHON_CLIENT_ALLOCATOR=vmm`). Previously this path returned
*"VMM allocator is only supported with CUDA"*.

Built on the HIP VMM primitives (`hipMemCreate` / `hipMemAddressReserve` /
`hipMemMap` / `hipMemSetAccess` / `hipMemUnmap`):

- **`rocm_raw_memory_allocation`** — wraps `hipMemCreate` physical handles.
- **`rocm_memory_reservation`** — virtual address reservation + map / unmap / set-access.
- **`rocm_vmm_allocator`** — simple all-in-one VMM allocator.
- **`rocm_device_address_vmm_allocator`** — per-device allocator with deferred
  deallocation and a reservation accessor (`GetReservation`).
- **`vmm_device_address_allocator_factory`** — platform dispatch (CUDA / ROCm) behind
  `DeviceAddressVmmAllocator::Create`.
- **`se_gpu_pjrt_client`** — ROCm branch for the `kVmm` allocator kind.
- **`rocm_event`** — expose `Synchronize`.

Includes unit tests for each layer plus a PJRT VMM allocator test.

The `NEVER_UPDATE` command-buffer replay optimization (the part that makes collectives
cheap to replay) is **part 2**, stacked on top of this PR.

## Test plan
- [x] Builds standalone (jax-rocm plugin + pjrt) against this tree.
- [ ] `bazel test` the ROCm VMM unit tests on MI300X.
- [ ] Confirm `XLA_PYTHON_CLIENT_ALLOCATOR=vmm` engages the ROCm VMM allocator.
