### PR TITLE
[ROCm] Cheap NEVER_UPDATE command-buffer replay via per-slice VMM remap

### DIFF
--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -143,6 +143,7 @@ cc_library(
         "//xla/stream_executor:platform",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor:vmm_device_address_allocator_factory",
         "//xla/stream_executor/integrations:device_mem_allocator",
         "//xla/stream_executor/integrations:tf_allocator_adapter",
         "//xla/tsl/concurrency:async_value",

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -143,8 +143,6 @@ limitations under the License.
 #if GOOGLE_CUDA
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
-#include "xla/stream_executor/cuda/cuda_compute_capability.h"
-#include "xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h"
 #include "xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h"
 #elif TENSORFLOW_USE_ROCM
 #include "rocm/rocm_config.h"
@@ -152,6 +150,7 @@ limitations under the License.
 
 #include "xla/service/gpu/gpu_executable_run_options.h"
 #include "xla/stream_executor/integrations/tf_allocator_adapter.h"
+#include "xla/stream_executor/vmm_device_address_allocator.h"
 #include "xla/util.h"
 
 namespace xla {
@@ -1361,20 +1360,15 @@ GetStreamExecutorGpuDeviceAllocator(
       return nullptr;
 
     case GpuAllocatorConfig::Kind::kVmm: {
-#if GOOGLE_CUDA
       std::vector<std::pair<se::StreamExecutor*, se::Stream*>> executor_streams;
       executor_streams.reserve(addressable_devices.size());
       for (const auto& [ordinal, device] : addressable_devices) {
         executor_streams.push_back(
             {device->executor(), device->compute_stream()});
       }
-      return se::gpu::CudaDeviceAddressVmmAllocator::Create(
+      return se::DeviceAddressVmmAllocator::Create(
           platform, allocator_config.memory_fraction,
           allocator_config.gpu_system_memory_size, executor_streams);
-#else
-      return absl::UnimplementedError(
-          "VMM allocator is only supported with CUDA.");
-#endif  // GOOGLE_CUDA
     }
   }
 

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -40,6 +40,7 @@ limitations under the License.
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
@@ -1508,8 +1509,17 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
     // allocation up to the allocation granularity.
     uint64_t total_va_size = 0;
     for (BufferAllocation::Index i : command_buffer_allocation_indexes_) {
-      const uint64_t size = buffer_allocations.GetDeviceAddress(i).size();
-      total_va_size += round_up_to_granularity(size);
+      se::DeviceAddressBase buf = buffer_allocations.GetDeviceAddress(i);
+      // Skip buffers not handed out by the VMM allocator (e.g. constants for
+      // deserialized executables, where the index-collection pass cannot
+      // filter them out). They have stable fixed addresses and need no VA
+      // remapping, so they must not consume a slot in the contiguous
+      // reservation.
+      if (vmm_allocator->GetRawAllocation(executor->device_ordinal(), buf) ==
+          nullptr) {
+        continue;
+      }
+      total_va_size += round_up_to_granularity(buf.size());
     }
 
     // Reserve a single large VA range for all command buffer allocations.
@@ -1522,20 +1532,11 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
         "VA: %p total_size: %d granularity: %d",
         module_name_, va_ranges->va_reservation->address().opaque(),
         total_va_size, granularity);
-  } else {
-    ScopedAnnotation annotation_va_unmap([&] {
-      return absl::StrFormat("command_buffer_va_range_unmap:#module=%s#",
-                             module_name_);
-    });
-
-    // VA range is already initialized; wait for the unmap event to be marked
-    // and then do the VA unmapping.
-    RETURN_IF_ERROR(va_ranges->unmap_event->Synchronize());
-
-    // Unmap physical addresses from the single reserved VA range.
-    // Clearing ScopedMappings calls UnMap via their destructors.
-    va_ranges->scoped_mapping.reset();
   }
+  // NOTE: the actual unmap of a previously established mapping is deferred to
+  // the decision point below, so it can be skipped entirely when the physical
+  // buffers are unchanged across executions (handled by ScopedMapping::Remap,
+  // which synchronizes the unmap event and unmaps only the changed slices).
 
   // Build a map from allocation index to its offset within va_reservation.
   // Iterate through command_buffer_allocation_indexes_ in order (btree_set
@@ -1543,9 +1544,16 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
   absl::flat_hash_map<BufferAllocation::Index, uint64_t> allocation_va_offsets;
   uint64_t current_offset = 0;
   for (BufferAllocation::Index idx : command_buffer_allocation_indexes_) {
-    const uint64_t size = buffer_allocations.GetDeviceAddress(idx).size();
+    se::DeviceAddressBase buf = buffer_allocations.GetDeviceAddress(idx);
+    // Only VMM-managed buffers are remapped into the contiguous reservation;
+    // skip non-VMM buffers (constants) so offsets stay contiguous and match
+    // the mapping descriptors built below.
+    if (vmm_allocator->GetRawAllocation(executor->device_ordinal(), buf) ==
+        nullptr) {
+      continue;
+    }
     allocation_va_offsets[idx] = current_offset;
-    current_offset += round_up_to_granularity(size);
+    current_offset += round_up_to_granularity(buf.size());
   }
 
   if (!allocation_va_offsets.empty() && va_ranges->va_reservation == nullptr) {
@@ -1562,72 +1570,152 @@ absl::Status GpuExecutable::ExecuteThunksWithVaRemapping(
                              module_name_);
     });
 
-    // Collect mapping descriptors for the batch MapTo call. Descriptors are
-    // accumulated in reservation_offset order (guaranteed because
-    // allocation_va_offsets was built from a sorted btree_set and the loop
-    // below iterates allocation indices in ascending order).
+    // Build mapping descriptors in reservation_offset order, parallel to the
+    // VMM-managed subset of command_buffer_allocation_indexes_ (btree_set
+    // iteration order). The i-th descriptor describes the same allocation as
+    // the i-th entry of last_mapping_state from the previous step (if it
+    // exists). Non-VMM-managed indices (e.g. constants in deserialized
+    // executables) are skipped here and pass through with their original
+    // address in the mapped_buffers loop below.
     std::vector<se::MemoryReservation::MappingDescriptor> mapping_descriptors;
+    mapping_descriptors.reserve(allocation_va_offsets.size());
+    std::vector<se::MemoryReservation::RemappingDescriptor> remap_descriptors;
+    remap_descriptors.reserve(allocation_va_offsets.size());
+    std::vector<VaRanges::AllocationMappingState> new_mapping_state;
+    new_mapping_state.reserve(allocation_va_offsets.size());
 
+    if (!va_ranges->scoped_mapping.has_value()) {
+      va_ranges->last_mapping_state.clear();
+    }
+    const bool have_prev_state = !va_ranges->last_mapping_state.empty();
+
+    int skip_count = 0;
+    int run_count = 0;
+    bool prev_was_changed = false;
+    size_t prev_idx = 0;
+
+    for (BufferAllocation::Index i : command_buffer_allocation_indexes_) {
+      se::DeviceAddressBase original_buffer =
+          buffer_allocations.GetDeviceAddress(i);
+      if (original_buffer.is_null()) {
+        return Internal("Command buffer allocation %d has null address", i);
+      }
+
+      std::optional<se::DeviceAddressVmmAllocator::AllocationInfo>
+          allocation_info = vmm_allocator->GetAllocationInfo(
+              executor->device_ordinal(), original_buffer);
+      if (!allocation_info.has_value()) {
+        // Not VMM-managed (e.g. a constant in a deserialized executable). It
+        // lives at a stable fixed address for the whole executable lifetime,
+        // so it needs no VA remapping and passes through with its original
+        // address in the mapped_buffers loop below.
+        continue;
+      }
+      se::MemoryAllocation* raw_alloc = allocation_info->allocation;
+      const uint64_t mapping_size = allocation_info->mapped_size;
+
+      // allocation_va_offsets was built from the same VMM-managed subset, so
+      // the key is guaranteed to exist.
+      const uint64_t va_offset = allocation_va_offsets[i];
+
+      // Determine whether this slice's physical allocation changed since the
+      // prior step. Compare by the VMM allocator's stable allocation_id rather
+      // than raw pointer to avoid ABA problems. A size mismatch also counts as
+      // a change.
+      uint64_t old_allocation_id = 0;
+      bool changed = true;
+      if (have_prev_state && prev_idx < va_ranges->last_mapping_state.size()) {
+        const auto& prev = va_ranges->last_mapping_state[prev_idx];
+        old_allocation_id = prev.allocation_id;
+        changed = prev.alloc_index != i ||
+                  prev.reservation_offset != va_offset ||
+                  prev.allocation_id != allocation_info->allocation_id ||
+                  prev.mapping_size != mapping_size;
+      }
+      ++prev_idx;
+
+      if (changed) {
+        if (!prev_was_changed) {
+          ++run_count;
+        }
+      } else {
+        ++skip_count;
+      }
+      prev_was_changed = changed;
+
+      XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
+          "VA remapping %s: allocation[%d] size=%d id %d -> %d",
+          changed ? "remap" : "skip", i, mapping_size, old_allocation_id,
+          allocation_info->allocation_id);
+
+      mapping_descriptors.push_back(
+          {va_offset, /*allocation_offset=*/0, mapping_size, raw_alloc});
+      remap_descriptors.push_back({va_offset, /*allocation_offset=*/0,
+                                   mapping_size, raw_alloc, changed});
+      new_mapping_state.push_back(
+          {i, va_offset, mapping_size, allocation_info->allocation_id});
+    }
+
+    // Build mapped_buffers in buffer_allocations index order. For VMM-managed
+    // command-buffer allocations, substitute the VA address; for everything
+    // else, pass the original buffer through unchanged.
+    void* va_base = (va_ranges->va_reservation != nullptr)
+                        ? va_ranges->va_reservation->address().opaque()
+                        : nullptr;
     const BufferAllocation::Index num_allocations =
         static_cast<BufferAllocation::Index>(buffer_allocations.size());
     for (BufferAllocation::Index i = 0; i < num_allocations; ++i) {
       se::DeviceAddressBase original_buffer =
           buffer_allocations.GetDeviceAddress(i);
-
-      // Only do VA mapping for allocations accessed by CommandBufferThunk.
       auto offset_it = allocation_va_offsets.find(i);
       if (offset_it == allocation_va_offsets.end()) {
-        // Not a command buffer allocation (or zero-size), use the original
-        // buffer.
         mapped_buffers.push_back(original_buffer);
         continue;
       }
-
-      // This allocation is used by command buffer - validate it's not null.
-      if (original_buffer.is_null()) {
-        return Internal("Command buffer allocation %d has null address", i);
-      }
-
-      // Get the physical memory allocation from the VMM allocator.
-      se::MemoryAllocation* raw_alloc = vmm_allocator->GetRawAllocation(
-          executor->device_ordinal(), original_buffer);
-      if (raw_alloc == nullptr) {
-        return Internal(
-            "No raw allocation found for command buffer allocation %d", i);
-      }
-      const uint64_t mapping_size = raw_alloc->address().size();
-
-      // Calculate the sub-range VA address for this allocation.
-      uint64_t va_offset = offset_it->second;
       void* sub_range_ptr = reinterpret_cast<void*>(
-          reinterpret_cast<uintptr_t>(
-              va_ranges->va_reservation->address().opaque()) +
-          va_offset);
-      se::DeviceAddressBase sub_range_va(sub_range_ptr, original_buffer.size());
-
-      XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
-          "Mapping allocation %d physical: %p -> VA: %p "
-          "(offset: %d) size: %d",
-          i, original_buffer.opaque(), sub_range_va.opaque(), va_offset,
-          original_buffer.size());
-
-      mapping_descriptors.push_back(
-          {va_offset, /*allocation_offset=*/0, mapping_size, raw_alloc});
-
-      // Use VA address for execution.
+          reinterpret_cast<uintptr_t>(va_base) + offset_it->second);
       mapped_buffers.push_back(
-          se::DeviceAddressBase(sub_range_va.opaque(), original_buffer.size()));
+          se::DeviceAddressBase(sub_range_ptr, original_buffer.size()));
     }
 
-    // Batch-map all command buffer allocations into the reserved VA range in
-    // a single call. This maps the contiguous range formed by the descriptors
-    // and enables device access before returning.
+    // Apply the mapping. The first successful execution uses MapTo; subsequent
+    // executions transfer the existing ScopedMapping through Remap so only
+    // changed slices incur driver round-trips (hipMemUnmap/hipMemMap/
+    // hipMemSetAccess). Synchronize the unmap event before Remap so the GPU is
+    // done using the prior mapping before we touch it.
     if (!mapping_descriptors.empty()) {
-      ASSIGN_OR_RETURN(se::MemoryReservation::ScopedMapping scoped_mapping,
-                       va_ranges->va_reservation->MapTo(
-                           absl::MakeSpan(mapping_descriptors)));
-      va_ranges->scoped_mapping = std::move(scoped_mapping);
+      if (!va_ranges->scoped_mapping.has_value()) {
+        ASSIGN_OR_RETURN(se::MemoryReservation::ScopedMapping scoped_mapping,
+                         va_ranges->va_reservation->MapTo(
+                             absl::MakeSpan(mapping_descriptors)));
+        va_ranges->scoped_mapping = std::move(scoped_mapping);
+      } else {
+        const absl::Time t_sync0 = absl::Now();
+        RETURN_IF_ERROR(va_ranges->unmap_event->Synchronize());
+        const absl::Time t_sync1 = absl::Now();
+        std::optional<se::MemoryReservation::ScopedMapping> existing_mapping =
+            std::move(va_ranges->scoped_mapping);
+        va_ranges->scoped_mapping.reset();
+        absl::StatusOr<se::MemoryReservation::ScopedMapping> remap_result =
+            std::move(*existing_mapping)
+                .Remap(absl::MakeSpan(remap_descriptors));
+        if (!remap_result.ok()) {
+          va_ranges->last_mapping_state.clear();
+          return remap_result.status();
+        }
+        va_ranges->scoped_mapping = std::move(*remap_result);
+        const absl::Time t_remap1 = absl::Now();
+        XLA_VLOG_DEVICE(2, executor->device_ordinal()) << absl::StreamFormat(
+            "VA remapping timing: sync_us=%d remap_us=%d",
+            absl::ToInt64Microseconds(t_sync1 - t_sync0),
+            absl::ToInt64Microseconds(t_remap1 - t_sync1));
+      }
+      va_ranges->last_mapping_state = std::move(new_mapping_state);
     }
+
+    XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
+        "VA remapping: %d/%d allocations skipped, %d remap runs coalesced",
+        skip_count, static_cast<int>(allocation_va_offsets.size()), run_count);
   }
 
   if (VLOG_IS_ON(3)) {

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -327,6 +327,19 @@ class GpuExecutable : public Executable {
     // RAII wrapper that keeps the VA->physical mapping active.
     // Reset (auto-unmapping) before each re-use of the VA range.
     std::optional<se::MemoryReservation::ScopedMapping> scoped_mapping;
+
+    // Snapshot of the slices mapped on the previous step, in the same order as
+    // the mapping descriptors are built (reservation_offset order, matching
+    // command_buffer_allocation_indexes_ iteration). On the next step,
+    // allocation_id and mapping_size are compared per slice to decide which
+    // slices actually changed and need remapping; unchanged slices are skipped.
+    struct AllocationMappingState {
+      BufferAllocation::Index alloc_index;
+      size_t reservation_offset;
+      size_t mapping_size;
+      uint64_t allocation_id;
+    };
+    std::vector<AllocationMappingState> last_mapping_state;
   };
 
   // Additional streams borrowed at run time for the execution.

--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -1,4 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load("//xla:xla.default.bzl", "xla_cc_test")
 load("//xla/stream_executor:build_defs.bzl", "stream_executor_build_defs_bzl_deps", "stream_executor_friends", "stream_executor_internal")
 load("//xla/tsl:tsl.bzl", "if_google", "if_oss", "internal_visibility")
@@ -379,6 +381,26 @@ cc_library(
 )
 
 cc_library(
+    name = "vmm_device_address_allocator_factory",
+    srcs = ["vmm_device_address_allocator_factory.cc"],
+    local_defines = if_cuda(["GOOGLE_CUDA=1"]) + if_rocm(["TENSORFLOW_USE_ROCM=1"]),
+    deps = [
+        ":platform",
+        ":stream",
+        ":stream_executor_h",
+        ":vmm_device_address_allocator",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
+    ] + if_cuda([
+        "//xla/stream_executor/cuda:cuda_device_address_vmm_allocator",
+    ]) + if_rocm([
+        "//xla/stream_executor/rocm:rocm_device_address_vmm_allocator",
+    ]),
+)
+
+cc_library(
     name = "launch_dim",
     srcs = ["launch_dim.cc"],
     hdrs = ["launch_dim.h"],
@@ -442,6 +464,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/xla/stream_executor/memory_reservation.cc
+++ b/xla/stream_executor/memory_reservation.cc
@@ -17,12 +17,15 @@ limitations under the License.
 
 #include <cstddef>
 #include <utility>
+#include <vector>
 
 #include "absl/cleanup/cleanup.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/stream_executor/device_address.h"
@@ -142,6 +145,139 @@ absl::StatusOr<MemoryReservation::ScopedMapping> MemoryReservation::MapTo(
 
   std::move(cleanup).Cancel();
   return ScopedMapping(this, start_offset, total_size);
+}
+
+// ScopedMapping::Remap
+
+absl::StatusOr<MemoryReservation::ScopedMapping>
+MemoryReservation::ScopedMapping::Remap(
+    absl::Span<const MemoryReservation::RemappingDescriptor> mappings) && {
+  if (reservation_ == nullptr) {
+    return absl::FailedPreconditionError("Remap: mapping is empty");
+  }
+  if (mappings.empty()) {
+    return absl::InvalidArgumentError("Remap: mappings must not be empty");
+  }
+
+  MemoryReservation* reservation = reservation_;
+  const size_t existing_reservation_offset = reservation_offset_;
+  const size_t existing_size = size_;
+
+  const size_t start_offset = mappings[0].reservation_offset;
+  size_t expected_offset = start_offset;
+  for (const MemoryReservation::RemappingDescriptor& desc : mappings) {
+    if (desc.reservation_offset != expected_offset) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Remap: mappings are not contiguous. Expected "
+                          "reservation_offset=%zu but got %zu",
+                          expected_offset, desc.reservation_offset));
+    }
+    if (desc.allocation == nullptr) {
+      return absl::InvalidArgumentError("Remap: allocation must not be null");
+    }
+    expected_offset += desc.size;
+  }
+  const size_t total_size = expected_offset - start_offset;
+  if (start_offset != existing_reservation_offset ||
+      total_size != existing_size) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Remap: mappings must cover the existing mapping range [%zu, %zu), got "
+        "[%zu, %zu)",
+        existing_reservation_offset,
+        existing_reservation_offset + existing_size, start_offset,
+        start_offset + total_size));
+  }
+
+  // Track per-slice mapped state for cleanup on failure. Every slice starts
+  // mapped because this ScopedMapping owns the full range. Changed slices are
+  // temporarily unmapped before being mapped to their new allocation.
+  std::vector<bool> slice_mapped(mappings.size(), true);
+
+  // Detach the prior ScopedMapping without invoking its destructor; the
+  // per-slice unmaps below replace the full-range unmap it would do.
+  reservation_ = nullptr;
+
+  // On failure, unmap every slice that is still mapped so the reservation
+  // is left in a clean (fully unmapped) state rather than partially mapped
+  // with no RAII owner.
+  auto cleanup = absl::MakeCleanup([&] {
+    for (size_t k = 0; k < mappings.size(); ++k) {
+      if (slice_mapped[k]) {
+        absl::Status s = reservation->UnMap(mappings[k].reservation_offset,
+                                            mappings[k].size);
+        if (!s.ok()) {
+          LOG(ERROR) << "Remap: cleanup failed to unmap slice at offset "
+                     << mappings[k].reservation_offset << ": " << s.message();
+        }
+      }
+    }
+  });
+
+  // Phase 1: unmap the slices whose backing physical handle changed, coalescing
+  // contiguous runs into a single UnMap. A single hipMemUnmap can release a
+  // range spanning several separately-mapped slices (the ScopedMapping
+  // destructor relies on exactly this to unmap the whole reservation in one
+  // call), so unmapping per contiguous run instead of per slice cuts the number
+  // of driver round-trips on the hot path. Unchanged slices keep their mapping,
+  // which is the whole point: it avoids the page-table churn of remapping every
+  // slice on every step.
+  const absl::Time t_unmap0 = absl::Now();
+  int changed_count = 0;
+  for (size_t k = 0; k < mappings.size();) {
+    if (!mappings[k].remap_required) {
+      ++k;
+      continue;
+    }
+    const size_t run_start = mappings[k].reservation_offset;
+    size_t run_end = run_start;
+    size_t j = k;
+    while (j < mappings.size() && mappings[j].remap_required) {
+      run_end = mappings[j].reservation_offset + mappings[j].size;
+      ++changed_count;
+      ++j;
+    }
+    TF_RETURN_IF_ERROR(reservation->UnMap(run_start, run_end - run_start));
+    for (size_t m = k; m < j; ++m) {
+      slice_mapped[m] = false;
+    }
+    k = j;
+  }
+  const bool any_remapped = changed_count > 0;
+
+  // Phase 2: map each changed slice to its new physical handle. Map must be per
+  // slice because each slice has its own backing allocation and offset.
+  const absl::Time t_map0 = absl::Now();
+  for (size_t k = 0; k < mappings.size(); ++k) {
+    if (!mappings[k].remap_required) {
+      continue;
+    }
+    const auto& dk = mappings[k];
+    TF_RETURN_IF_ERROR(reservation->Map(dk.reservation_offset,
+                                        dk.allocation_offset, dk.size,
+                                        *dk.allocation));
+    slice_mapped[k] = true;
+  }
+
+  // Grant device access once over the FULL reservation range. On ROCm,
+  // hipMemSetAccess for peer devices rejects any partial range (sub-range or
+  // even a prefix that starts at the reservation base) with
+  // HIP_ERROR_InvalidValue -- empirically only the full [start_offset,
+  // total_size) range is accepted, matching MapTo's known-good behavior. Skip it
+  // entirely when no slice changed so the steady state stays free of driver
+  // calls.
+  const absl::Time t_map1 = absl::Now();
+  if (any_remapped) {
+    TF_RETURN_IF_ERROR(reservation->SetAccess(start_offset, total_size));
+  }
+  const absl::Time t_sa1 = absl::Now();
+  VLOG(2) << "Remap timing: slices=" << mappings.size()
+          << " changed=" << changed_count << " range=" << total_size
+          << " unmap_us=" << absl::ToInt64Microseconds(t_map0 - t_unmap0)
+          << " map_us=" << absl::ToInt64Microseconds(t_map1 - t_map0)
+          << " setaccess_us=" << absl::ToInt64Microseconds(t_sa1 - t_map1);
+
+  std::move(cleanup).Cancel();
+  return ScopedMapping(reservation, start_offset, total_size);
 }
 
 }  // namespace stream_executor

--- a/xla/stream_executor/memory_reservation.h
+++ b/xla/stream_executor/memory_reservation.h
@@ -55,6 +55,17 @@ class MemoryReservation {
     MemoryAllocation* allocation;
   };
 
+  // Describes a desired post-Remap mapping for a slice of the reservation.
+  struct RemappingDescriptor {
+    size_t reservation_offset;
+    size_t allocation_offset;
+    size_t size;
+    MemoryAllocation* allocation;  // current physical handle, never null
+    // Whether this slice needs UnMap/Map/SetAccess calls. When false, the
+    // existing mapping is preserved.
+    bool remap_required;
+  };
+
   // An RAII wrapper that gives access to a contiguous slice of a memory
   // reservation backed by one or more physical memory allocations.
   // Unmaps the mapped range from the reservation on destruction.
@@ -69,6 +80,16 @@ class MemoryReservation {
     // Returns the device address range that is mapped to the physical memory
     // allocation(s) and can be accessed from the device.
     DeviceAddressBase mapped_address() const;
+
+    // Re-maps this mapping's reservation range as described by `mappings`.
+    // The descriptors must cover the same full range. For each mapping where
+    // remap_required is false, the current mapping is preserved. For the rest,
+    // the slice is unmapped and mapped to `allocation`; SetAccess is invoked
+    // once per maximal run of consecutive remapped mappings. On failure after
+    // remapping starts, Remap unmaps all slices described by `mappings`,
+    // leaving the reservation with no active mapping for the range.
+    absl::StatusOr<ScopedMapping> Remap(
+        absl::Span<const RemappingDescriptor> mappings) &&;
 
     // Returns true if this object does not own a mapping.
     bool is_null() const { return reservation_ == nullptr; }

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -1383,3 +1383,212 @@ rocm_library(
     ],
     alwayslink = 1,
 )
+
+cc_library(
+    name = "rocm_raw_memory_allocation",
+    srcs = ["rocm_raw_memory_allocation.cc"],
+    hdrs = ["rocm_raw_memory_allocation.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        ":rocm_status",
+        "//xla:util",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_raw_memory_allocation_test",
+    srcs = ["rocm_raw_memory_allocation_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_platform",
+        ":rocm_platform_id",
+        ":rocm_raw_memory_allocation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test",
+    ],
+)
+
+cc_library(
+    name = "rocm_memory_reservation",
+    srcs = ["rocm_memory_reservation.cc"],
+    hdrs = ["rocm_memory_reservation.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        ":rocm_raw_memory_allocation",
+        ":rocm_status",
+        "//xla:util",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_reservation",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_memory_reservation_test",
+    srcs = ["rocm_memory_reservation_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":amdhipblaslt_plugin",
+        ":rocm_memory_reservation",
+        ":rocm_platform",
+        ":rocm_platform_id",
+        ":rocm_raw_memory_allocation",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_reservation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test",
+    ],
+)
+
+cc_library(
+    name = "rocm_vmm_allocator",
+    srcs = ["rocm_vmm_allocator.cc"],
+    hdrs = ["rocm_vmm_allocator.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        ":rocm_status",
+        "@com_google_absl//absl/cleanup",
+        "//xla:util",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_allocator",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+cc_library(
+    name = "rocm_device_address_vmm_allocator",
+    srcs = ["rocm_device_address_vmm_allocator.cc"],
+    hdrs = ["rocm_device_address_vmm_allocator.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        ":rocm_memory_reservation",
+        ":rocm_raw_memory_allocation",
+        ":rocm_status",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_reservation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor:vmm_device_address_allocator",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:span",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_vmm_allocator_test",
+    srcs = ["rocm_vmm_allocator_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_platform",
+        ":rocm_vmm_allocator",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_device_address_vmm_allocator_test",
+    srcs = ["rocm_device_address_vmm_allocator_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":amdhipblaslt_plugin",
+        ":rocm_device_address_vmm_allocator",
+        ":rocm_platform",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor:vmm_device_address_allocator",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.cc
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.cc
@@ -1,0 +1,166 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "absl/types/span.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/platform.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/rocm/rocm_memory_reservation.h"
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/vmm_device_address_allocator.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+
+RocmDeviceAddressVmmAllocator::RocmDeviceAddressVmmAllocator(
+    const Platform* platform)
+    : DeviceAddressVmmAllocator(platform) {}
+
+absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
+RocmDeviceAddressVmmAllocator::Create(const Platform* platform,
+                                      absl::Span<const DeviceConfig> devices) {
+  auto allocator =
+      absl::WrapUnique(new RocmDeviceAddressVmmAllocator(platform));
+  TF_RETURN_IF_ERROR(PopulateDevices(allocator.get(), devices));
+  return allocator;
+}
+
+absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
+RocmDeviceAddressVmmAllocator::Create(StreamExecutor* executor, Stream* stream,
+                                      uint64_t pa_budget) {
+  return Create(executor->GetPlatform(),
+                {{DeviceConfig{executor, stream, pa_budget}}});
+}
+
+absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
+RocmDeviceAddressVmmAllocator::Create(
+    const Platform* platform, double memory_fraction,
+    std::optional<int64_t> gpu_system_memory_size,
+    absl::Span<const std::pair<StreamExecutor*, Stream*>> devices) {
+  LOG(INFO) << "Using VMM (Virtual Memory Management) allocator for ROCm.";
+  std::vector<DeviceConfig> device_configs;
+  device_configs.reserve(devices.size());
+  for (const auto& [executor, stream] : devices) {
+    int64_t free_memory;
+    int64_t total_memory;
+    if (!executor->DeviceMemoryUsage(&free_memory, &total_memory)) {
+      return absl::UnavailableError(
+          absl::StrFormat("Failed to query available memory from device %i",
+                          executor->device_ordinal()));
+    }
+    DCHECK(memory_fraction >= 0.0 && memory_fraction <= 1.0)
+        << "memory_fraction must be in [0, 1], got " << memory_fraction;
+    uint64_t pa_budget = total_memory * memory_fraction;
+    if (gpu_system_memory_size.has_value()) {
+      pa_budget = gpu_system_memory_size.value();
+    }
+    LOG(INFO) << "VMM allocator pa_budget for device "
+              << executor->device_ordinal() << ": " << pa_budget << " bytes.";
+    device_configs.push_back({executor, stream, pa_budget});
+  }
+  return Create(platform, device_configs);
+}
+
+absl::Status RocmDeviceAddressVmmAllocator::InitializeDeviceState(
+    PerDeviceState& state) {
+  int ordinal = state.executor->device_ordinal();
+
+  // Query allocation granularity for this device.
+  size_t granularity = 0;
+  {
+    std::unique_ptr<ActivateContext> activation = state.executor->Activate();
+    hipDevice_t hip_device;
+    TF_RETURN_IF_ERROR(
+        ToStatus(hipDeviceGet(&hip_device, ordinal), "hipDeviceGet"));
+    hipMemAllocationProp alloc_props = {};
+    alloc_props.type = hipMemAllocationTypePinned;
+    alloc_props.location.type = hipMemLocationTypeDevice;
+    alloc_props.location.id = hip_device;
+    alloc_props.requestedHandleTypes = hipMemHandleTypeNone;
+    TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+        &granularity, &alloc_props, hipMemAllocationGranularityRecommended)));
+  }
+  state.allocation_granularity = static_cast<uint64_t>(granularity);
+
+  // Allocate coherent host memory for the per-device timeline counter.
+  // hipStreamWriteValue64 writes to this location; the CPU polls it to
+  // determine when deferred deallocations are safe to execute.
+  void* host_ptr = nullptr;
+  TF_RETURN_IF_ERROR(ToStatus(
+hipHostMalloc(&host_ptr, sizeof(uint64_t), hipHostMallocCoherent),
+      "hipHostMalloc for timeline counter"));
+  *static_cast<volatile uint64_t*>(host_ptr) = 0;
+
+  // Set timeline fields and destroy_fn immediately so that any early return
+  // still cleans up via ~DeviceAddressVmmAllocator.
+  state.pinned_timeline = static_cast<volatile uint64_t*>(host_ptr);
+  // HIP's hipStreamWriteValue64 accepts void*, so the host pointer is
+  // directly usable as the target (unlike CUDA which needs a separate
+  // device pointer via cuMemHostGetDevicePointer).
+  state.timeline_dev_ptr = reinterpret_cast<uint64_t>(host_ptr);
+  state.destroy_fn = [host_ptr, ordinal]() {
+    auto status =
+        ToStatus(hipHostFree(host_ptr), "hipHostFree for timeline");
+    if (!status.ok()) {
+      LOG(WARNING) << "Failed to free timeline memory for device " << ordinal
+                   << ": " << status;
+    }
+  };
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<MemoryAllocation>>
+RocmDeviceAddressVmmAllocator::CreateAllocation(StreamExecutor* executor,
+                                                uint64_t size) {
+  return RocmRawMemoryAllocation::Create(executor, size);
+}
+
+absl::StatusOr<std::unique_ptr<MemoryReservation>>
+RocmDeviceAddressVmmAllocator::CreateReservation(StreamExecutor* executor,
+                                                 uint64_t size) {
+  return RocmMemoryReservation::Create(executor, size);
+}
+
+absl::Status RocmDeviceAddressVmmAllocator::EnqueueDeferredDeallocation(
+    PerDeviceState& state, uint64_t seqno) {
+  hipStream_t hip_stream =
+      static_cast<hipStream_t>(state.stream->platform_specific_handle().stream);
+  return ToStatus(
+hipStreamWriteValue64(
+          hip_stream, reinterpret_cast<void*>(state.timeline_dev_ptr), seqno,
+          0),
+      "hipStreamWriteValue64");
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h
@@ -1,0 +1,102 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_DEVICE_ADDRESS_VMM_ALLOCATOR_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_DEVICE_ADDRESS_VMM_ALLOCATOR_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/vmm_device_address_allocator.h"
+
+namespace stream_executor::gpu {
+
+// ROCm/HIP implementation of DeviceAddressVmmAllocator.
+//
+// Uses hipMemCreate/hipMemAddressReserve for physical and virtual memory
+// management, and hipStreamWriteValue64 for GPU timeline-based deferred
+// deallocation. Requires ROCm >= 6.0 for HIP VMM API support.
+//
+// The timeline counter is allocated as signal memory via
+// hipExtMallocWithFlags(hipMallocSignalMemory), which is required by
+// hipStreamWriteValue64 on AMD hardware.
+//
+// Use the Create() factories to obtain an instance.
+class RocmDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
+ public:
+  // Creates an allocator supporting multiple devices.
+  //
+  // Precondition: all entries in `devices` have distinct device ordinals.
+  static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(
+      const Platform* platform, absl::Span<const DeviceConfig> devices);
+
+  // Creates an allocator supporting multiple devices, computing the pa_budget
+  // for each device by querying DeviceMemoryUsage and applying memory_fraction.
+  // If gpu_system_memory_size is set, it overrides the memory_fraction budget.
+  //
+  // Precondition: all entries in `devices` have distinct device ordinals.
+  static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(
+      const Platform* platform, double memory_fraction,
+      std::optional<int64_t> gpu_system_memory_size,
+      absl::Span<const std::pair<StreamExecutor*, Stream*>> devices);
+
+  // Creates an allocator for a single device.
+  //
+  // Parameters:
+  //   executor:  StreamExecutor for this device. Must outlive the allocator.
+  //   stream:    Stream used for deferred deallocation. Must outlive the
+  //              allocator.
+  //   pa_budget: Maximum bytes of physical memory that may be simultaneously
+  //              allocated on this device. Defaults to unlimited.
+  static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(
+      StreamExecutor* executor, Stream* stream,
+      uint64_t pa_budget = UINT64_MAX);
+
+ protected:
+  // Allocates signal memory via hipExtMallocWithFlags(hipMallocSignalMemory)
+  // for the per-device timeline counter, and queries the allocation
+  // granularity via hipMemGetAllocationGranularity.
+  absl::Status InitializeDeviceState(PerDeviceState& state) override;
+
+  // Creates a physical memory allocation via RocmRawMemoryAllocation::Create.
+  absl::StatusOr<std::unique_ptr<MemoryAllocation>> CreateAllocation(
+      StreamExecutor* executor, uint64_t size) override;
+
+  // Creates a virtual address reservation via RocmMemoryReservation::Create.
+  absl::StatusOr<std::unique_ptr<MemoryReservation>> CreateReservation(
+      StreamExecutor* executor, uint64_t size) override;
+
+  // Enqueues a hipStreamWriteValue64 on the device's stream to write `seqno`
+  // to the signal memory timeline when the GPU reaches this point.
+  absl::Status EnqueueDeferredDeallocation(PerDeviceState& state,
+                                           uint64_t seqno) override;
+
+ private:
+  explicit RocmDeviceAddressVmmAllocator(const Platform* platform);
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_DEVICE_ADDRESS_VMM_ALLOCATOR_H_

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator_test.cc
@@ -338,6 +338,130 @@ TEST_F(DeviceAddressVmmAllocatorTest, UnknownDeviceOrdinalReturnsError) {
   EXPECT_FALSE(allocator->GetStreamExecutor(unknown_ordinal).ok());
 }
 
+TEST_F(DeviceAddressVmmAllocatorTest, GetAllocationInfoReportsStableId) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  constexpr uint64_t kSize = 1024;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                     static_cast<int64_t>(MemorySpace::kCollective)));
+
+  std::optional<DeviceAddressVmmAllocator::AllocationInfo> info =
+      allocator->GetAllocationInfo(ordinal, *addr);
+  ASSERT_TRUE(info.has_value());
+  // The reported allocation must be the same physical handle GetRawAllocation
+  // returns, the ID must be non-zero, and at least the requested size mapped.
+  EXPECT_EQ(info->allocation, allocator->GetRawAllocation(ordinal, *addr));
+  EXPECT_NE(info->allocation, nullptr);
+  EXPECT_NE(info->allocation_id, 0u);
+  EXPECT_GE(info->mapped_size, kSize);
+
+  // An address never handed out by this allocator has no info.
+  DeviceAddressBase bogus(reinterpret_cast<void*>(0x1234), kSize);
+  EXPECT_FALSE(allocator->GetAllocationInfo(ordinal, bogus).has_value());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, DistinctAllocationsHaveDistinctIds) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  constexpr uint64_t kSize = 1024;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto a, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                  static_cast<int64_t>(MemorySpace::kCollective)));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto b, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                  static_cast<int64_t>(MemorySpace::kCollective)));
+
+  auto info_a = allocator->GetAllocationInfo(ordinal, *a);
+  auto info_b = allocator->GetAllocationInfo(ordinal, *b);
+  ASSERT_TRUE(info_a.has_value());
+  ASSERT_TRUE(info_b.has_value());
+  EXPECT_NE(info_a->allocation_id, info_b->allocation_id);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, ReusingPendingDeallocationPreservesId) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  constexpr uint64_t kSize = 1024;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr1, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+  auto info1 = allocator->GetAllocationInfo(ordinal, *addr1);
+  ASSERT_TRUE(info1.has_value());
+  const uint64_t id1 = info1->allocation_id;
+  void* const va = addr1->opaque();
+
+  // Defer-deallocate, then re-allocate the same size. Because the freed slice
+  // is still pending (the GPU has not reclaimed it), it is reused in place and
+  // the tracking entry — including its stable ID — is preserved.
+  DeviceAddressBase raw = addr1.cref();
+  addr1.Release();
+  ASSERT_THAT(allocator->Deallocate(ordinal, raw), IsOk());
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr2, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+  EXPECT_EQ(addr2->opaque(), va);
+
+  auto info2 = allocator->GetAllocationInfo(ordinal, *addr2);
+  ASSERT_TRUE(info2.has_value());
+  EXPECT_EQ(info2->allocation_id, id1);
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, ReuseSelectsSmallestAddressDeterministically) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  constexpr uint64_t kSize = 1024;
+
+  // Allocate two same-size buffers and remember the lower of their two virtual
+  // addresses.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto a, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                  static_cast<int64_t>(MemorySpace::kCollective)));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto b, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                  static_cast<int64_t>(MemorySpace::kCollective)));
+  const uintptr_t va_a = reinterpret_cast<uintptr_t>(a->opaque());
+  const uintptr_t va_b = reinterpret_cast<uintptr_t>(b->opaque());
+  ASSERT_NE(va_a, va_b);
+  void* const lowest = reinterpret_cast<void*>(std::min(va_a, va_b));
+
+  // Free both (order: higher address first to prove selection is by address,
+  // not deque/insertion order).
+  DeviceAddressBase raw_lo = (va_a < va_b) ? a.cref() : b.cref();
+  DeviceAddressBase raw_hi = (va_a < va_b) ? b.cref() : a.cref();
+  a.Release();
+  b.Release();
+  ASSERT_THAT(allocator->Deallocate(ordinal, raw_hi), IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, raw_lo), IsOk());
+
+  // The next same-size allocation must deterministically reuse the smallest
+  // pending address.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto c, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                  static_cast<int64_t>(MemorySpace::kCollective)));
+  EXPECT_EQ(c->opaque(), lowest);
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+}
+
 class MultiDeviceVmmAllocatorTest : public ::testing::Test {
  protected:
   void SetUp() override {

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator_test.cc
@@ -1,0 +1,434 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/vmm_device_address_allocator.h"
+#include "xla/tsl/platform/statusor.h"
+
+namespace stream_executor {
+namespace {
+
+using ::absl_testing::IsOk;
+using ::absl_testing::IsOkAndHolds;
+using ::testing::Ne;
+
+class DeviceAddressVmmAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    platform_ = platform_or.value();
+
+    auto executor_or = platform_->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+
+    auto stream_or = executor_->CreateStream();
+    if (!stream_or.ok()) {
+      GTEST_SKIP() << "Failed to create stream";
+    }
+    stream_ = std::move(stream_or.value());
+
+    auto probe =
+        gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get());
+    if (!probe.ok()) {
+      GTEST_SKIP() << "RocmDeviceAddressVmmAllocator not supported: "
+                   << probe.status();
+    }
+  }
+
+  Platform* platform_ = nullptr;
+  StreamExecutor* executor_ = nullptr;
+  std::unique_ptr<Stream> stream_;
+};
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllocateAndDeallocate) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(executor_->device_ordinal(), 1024,
+                          /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  EXPECT_FALSE(scoped_address.is_null());
+  EXPECT_EQ(scoped_address->size(), 1024);
+  EXPECT_NE(
+      allocator->GetRawAllocation(executor_->device_ordinal(), *scoped_address),
+      nullptr);
+  EXPECT_NE(
+      allocator->GetReservation(executor_->device_ordinal(), *scoped_address),
+      nullptr);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllocateZeroSize) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(executor_->device_ordinal(), 0,
+                          /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  EXPECT_TRUE(scoped_address.is_null());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllocateMultiple) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr1, allocator->Allocate(executor_->device_ordinal(), 1024,
+                                      /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr2, allocator->Allocate(executor_->device_ordinal(), 2048,
+                                      /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+
+  EXPECT_FALSE(addr1.is_null());
+  EXPECT_FALSE(addr2.is_null());
+  EXPECT_NE(addr1->opaque(), addr2->opaque());
+  EXPECT_EQ(addr1.cref().size(), 1024);
+  EXPECT_EQ(addr2.cref().size(), 2048);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, MemoryReadWrite) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(executor_->device_ordinal(), 1024,
+                          /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  ASSERT_NE(scoped_address->opaque(), nullptr);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor_->CreateStream());
+
+  constexpr uint64_t kTestValue = 0xDEADBEEFCAFEBABE;
+  DeviceAddressBase addr = scoped_address.cref();
+  EXPECT_THAT(stream->Memcpy(&addr, &kTestValue, sizeof(kTestValue)),
+              absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+
+  uint64_t read_value = 0;
+  EXPECT_THAT(stream->Memcpy(&read_value, addr, sizeof(read_value)),
+              absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+
+  EXPECT_EQ(read_value, kTestValue);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, GetStream) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(Stream * stream,
+                          allocator->GetStream(executor_->device_ordinal()));
+  EXPECT_EQ(stream, stream_.get());
+
+  TF_ASSERT_OK_AND_ASSIGN(Stream * stream2,
+                          allocator->GetStream(executor_->device_ordinal()));
+  EXPECT_EQ(stream, stream2);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, GetStreamExecutor) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      StreamExecutor * se,
+      allocator->GetStreamExecutor(executor_->device_ordinal()));
+  EXPECT_EQ(se, executor_);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllowsAsynchronousDeallocation) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  EXPECT_TRUE(allocator->AllowsAsynchronousDeallocation());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, ExplicitDeallocate) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(executor_->device_ordinal(), 1024,
+                          /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  ASSERT_NE(scoped_address->opaque(), nullptr);
+  DeviceAddressBase addr = scoped_address.cref();
+
+  EXPECT_THAT(allocator->Deallocate(executor_->device_ordinal(), addr),
+              absl_testing::IsOk());
+
+  scoped_address.Release();
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, DeallocateNull) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  DeviceAddressBase null_addr;
+  EXPECT_THAT(allocator->Deallocate(executor_->device_ordinal(), null_addr),
+              absl_testing::IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       PendingDeallocationReusesSameVirtualAddress) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  constexpr uint64_t kSize = 1024;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr1, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+  void* const va = addr1->opaque();
+
+  DeviceAddressBase raw = addr1.cref();
+  addr1.Release();
+  ASSERT_THAT(allocator->Deallocate(ordinal, raw), IsOk());
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr2, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+  EXPECT_EQ(addr2->opaque(), va);
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       DeferredDeallocationSafeWhileGpuWritesData) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr,
+      allocator->Allocate(ordinal, sizeof(uint64_t), /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  constexpr uint64_t kPattern = 0xCAFEBABEDEADBEEFULL;
+  DeviceAddressBase dev_addr = addr.cref();
+  ASSERT_THAT(stream_->Memcpy(&dev_addr, &kPattern, sizeof(kPattern)), IsOk());
+
+  ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       MultipleSeqnosAllCompleteAfterStreamSync) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  constexpr int kCount = 8;
+  constexpr uint64_t kSize = 1024;
+
+  for (int i = 0; i < kCount; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto addr,
+        allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                            static_cast<int64_t>(MemorySpace::kCollective)));
+    ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
+  }
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+
+  for (int i = 0; i < kCount; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto addr,
+        allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                            static_cast<int64_t>(MemorySpace::kCollective)));
+    EXPECT_FALSE(addr.is_null());
+  }
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       DestructorWithPendingDeallocationsDoesNotCrash) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+
+  for (int i = 0; i < 4; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto addr,
+        allocator->Allocate(ordinal, 1024, /*retry_on_failure=*/true,
+                            static_cast<int64_t>(MemorySpace::kCollective)));
+    ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
+  }
+
+  allocator.reset();
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, UnknownDeviceOrdinalReturnsError) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int unknown_ordinal = 9999;
+  EXPECT_FALSE(allocator
+                   ->Allocate(unknown_ordinal, 1024, /*retry_on_failure=*/true,
+                              static_cast<int64_t>(MemorySpace::kCollective))
+                   .ok());
+  EXPECT_THAT(allocator->Deallocate(unknown_ordinal, DeviceAddressBase{}),
+              absl_testing::IsOk());
+  DeviceAddressBase fake_addr(reinterpret_cast<void*>(0x1000), 64);
+  EXPECT_FALSE(allocator->Deallocate(unknown_ordinal, fake_addr).ok());
+  EXPECT_FALSE(allocator->GetStream(unknown_ordinal).ok());
+  EXPECT_FALSE(allocator->GetStreamExecutor(unknown_ordinal).ok());
+}
+
+class MultiDeviceVmmAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    platform_ = platform_or.value();
+
+    if (platform_->VisibleDeviceCount() < 2) {
+      GTEST_SKIP() << "Fewer than two ROCm devices available";
+    }
+
+    for (int i = 0; i < 2; ++i) {
+      auto executor_or = platform_->ExecutorForDevice(i);
+      if (!executor_or.ok()) {
+        GTEST_SKIP() << "ROCM executor not available for device " << i;
+      }
+      executors_.push_back(executor_or.value());
+
+      auto stream_or = executors_.back()->CreateStream();
+      if (!stream_or.ok()) {
+        GTEST_SKIP() << "Failed to create stream for device " << i;
+      }
+      streams_.push_back(std::move(stream_or.value()));
+    }
+
+    auto probe = gpu::RocmDeviceAddressVmmAllocator::Create(executors_[0],
+                                                            streams_[0].get());
+    if (!probe.ok()) {
+      GTEST_SKIP() << "RocmDeviceAddressVmmAllocator not supported: "
+                   << probe.status();
+    }
+  }
+
+  Platform* platform_ = nullptr;
+  std::vector<StreamExecutor*> executors_;
+  std::vector<std::unique_ptr<Stream>> streams_;
+};
+
+TEST_F(MultiDeviceVmmAllocatorTest, AllocateOnBothDevices) {
+  std::vector<DeviceAddressVmmAllocator::DeviceConfig> configs;
+  for (int i = 0; i < 2; ++i) {
+    configs.push_back({executors_[i], streams_[i].get()});
+  }
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(platform_, configs));
+
+  for (int i = 0; i < 2; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto addr,
+        allocator->Allocate(executors_[i]->device_ordinal(), 1024,
+                            /*retry_on_failure=*/true,
+                            static_cast<int64_t>(MemorySpace::kCollective)));
+    EXPECT_FALSE(addr.is_null());
+    EXPECT_EQ(addr->size(), 1024);
+    EXPECT_NE(
+        allocator->GetRawAllocation(executors_[i]->device_ordinal(), *addr),
+        nullptr);
+    EXPECT_NE(allocator->GetReservation(executors_[i]->device_ordinal(), *addr),
+              nullptr);
+    TF_ASSERT_OK_AND_ASSIGN(
+        StreamExecutor * se,
+        allocator->GetStreamExecutor(executors_[i]->device_ordinal()));
+    EXPECT_EQ(se, executors_[i]);
+    TF_ASSERT_OK_AND_ASSIGN(
+        Stream * stream, allocator->GetStream(executors_[i]->device_ordinal()));
+    EXPECT_EQ(stream, streams_[i].get());
+  }
+}
+
+TEST_F(MultiDeviceVmmAllocatorTest, AllocationOnOneDeviceDoesNotAffectOther) {
+  std::vector<DeviceAddressVmmAllocator::DeviceConfig> configs;
+  for (int i = 0; i < 2; ++i) {
+    configs.push_back({executors_[i], streams_[i].get()});
+  }
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(platform_, configs));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr0, allocator->Allocate(executors_[0]->device_ordinal(), 4096,
+                                      /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+  EXPECT_FALSE(addr0.is_null());
+
+  EXPECT_EQ(
+      allocator->GetRawAllocation(executors_[1]->device_ordinal(), *addr0),
+      nullptr);
+}
+
+}  // namespace
+}  // namespace stream_executor

--- a/xla/stream_executor/rocm/rocm_event.cc
+++ b/xla/stream_executor/rocm/rocm_event.cc
@@ -108,6 +108,12 @@ absl::Status RocmEvent::WaitForEventOnExternalStream(std::intptr_t stream) {
                            handle_);
 }
 
+absl::Status RocmEvent::Synchronize() {
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  return ToStatus(hipEventSynchronize(handle_),
+                  "could not synchronize on ROCm event");
+}
+
 absl::StatusOr<RocmEvent> RocmEvent::Create(StreamExecutor *executor,
                                             bool allow_timing) {
   ASSIGN_OR_RETURN(

--- a/xla/stream_executor/rocm/rocm_event.h
+++ b/xla/stream_executor/rocm/rocm_event.h
@@ -31,6 +31,7 @@ class RocmEvent : public Event {
  public:
   Event::Status PollForStatus() override;
   absl::Status WaitForEventOnExternalStream(std::intptr_t stream) override;
+  absl::Status Synchronize() override;
 
   // Creates a new RocmEvent. If allow_timing is false, the event will not
   // support timing, which is cheaper to create.

--- a/xla/stream_executor/rocm/rocm_memory_reservation.cc
+++ b/xla/stream_executor/rocm/rocm_memory_reservation.cc
@@ -1,0 +1,156 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_memory_reservation.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+
+absl::StatusOr<std::unique_ptr<RocmMemoryReservation>>
+RocmMemoryReservation::Create(StreamExecutor* executor, uint64_t size) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  hipDevice_t device;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
+
+  hipMemAllocationProp props = {};
+  props.type = hipMemAllocationTypePinned;
+  props.location.type = hipMemLocationTypeDevice;
+  props.location.id = device;
+  props.requestedHandleTypes = hipMemHandleTypeNone;
+
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+      &granularity, &props, hipMemAllocationGranularityRecommended)));
+
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
+
+  void* ptr = nullptr;
+  TF_RETURN_IF_ERROR(ToStatus(
+hipMemAddressReserve(&ptr, padded_size, granularity, nullptr,
+                                    0ULL)));
+
+  return std::unique_ptr<RocmMemoryReservation>(
+      new RocmMemoryReservation(executor, static_cast<char*>(ptr), padded_size));
+}
+
+RocmMemoryReservation::RocmMemoryReservation(StreamExecutor* executor,
+                                             char* ptr, uint64_t size)
+    : executor_(executor), ptr_(ptr), size_(size) {}
+
+DeviceAddressBase RocmMemoryReservation::address() const {
+  return DeviceAddressBase(ptr_, size_);
+}
+
+absl::Status RocmMemoryReservation::Map(size_t reservation_offset,
+                                        size_t allocation_offset, size_t size,
+                                        MemoryAllocation& allocation) {
+  auto* rocm_alloc = dynamic_cast<RocmRawMemoryAllocation*>(&allocation);
+  if (rocm_alloc == nullptr) {
+    return absl::InvalidArgumentError(
+        "RocmMemoryReservation::Map requires a RocmRawMemoryAllocation");
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  absl::Status status = ToStatus(hipMemMap(ptr_ + reservation_offset, size,
+                                           allocation_offset,
+                                           rocm_alloc->GetHandle(), 0ULL));
+  if (status.ok()) {
+    mapped_bytes_ += size;
+  }
+  return status;
+}
+
+absl::Status RocmMemoryReservation::SetAccess(uint64_t reservation_offset,
+                                              size_t size) {
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+
+  int device_count = 0;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipGetDeviceCount(&device_count), "hipGetDeviceCount"));
+
+  for (int peer = 0; peer < device_count; ++peer) {
+    if (peer != executor_->device_ordinal()) {
+      auto peer_executor_or =
+          const_cast<Platform*>(executor_->GetPlatform())
+              ->ExecutorForDevice(peer);
+      if (!peer_executor_or.ok() ||
+          !executor_->CanEnablePeerAccessTo(peer_executor_or.value())) {
+        continue;
+      }
+    }
+    hipMemAccessDesc desc = {};
+    desc.location.type = hipMemLocationTypeDevice;
+    desc.location.id = peer;
+    desc.flags = hipMemAccessFlagsProtReadWrite;
+    TF_RETURN_IF_ERROR(ToStatus(
+hipMemSetAccess(ptr_ + reservation_offset, size, &desc, 1),
+        "hipMemSetAccess for peer device"));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status RocmMemoryReservation::UnMap(size_t offset, size_t size) {
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  absl::Status status = ToStatus(hipMemUnmap(ptr_ + offset, size));
+  if (status.ok()) {
+    mapped_bytes_ = mapped_bytes_ >= size ? mapped_bytes_ - size : 0;
+  }
+  return status;
+}
+
+RocmMemoryReservation::~RocmMemoryReservation() {
+  if (ptr_ == nullptr) {
+    return;
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  // Only unmap if a mapping is still active. The ScopedMapping returned by
+  // MapTo/Remap normally unmaps the range before this reservation is destroyed;
+  // calling hipMemUnmap again on an already-unmapped range fails with
+  // HIP_ERROR_InvalidValue. Tracking mapped_bytes_ avoids that redundant (and
+  // very noisy) double-unmap at teardown.
+  if (mapped_bytes_ > 0) {
+    auto unmap_status =
+        ToStatus(hipMemUnmap(ptr_, size_), "Error unmapping ROCm memory");
+    if (!unmap_status.ok()) {
+      LOG(ERROR) << unmap_status.message();
+    }
+  }
+  auto free_status = ToStatus(hipMemAddressFree(ptr_, size_),
+                              "Error freeing ROCm address range");
+  if (!free_status.ok()) {
+    LOG(ERROR) << free_status.message();
+  }
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_memory_reservation.h
+++ b/xla/stream_executor/rocm/rocm_memory_reservation.h
@@ -1,0 +1,76 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_MEMORY_RESERVATION_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_MEMORY_RESERVATION_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// RAII wrapper for a ROCm virtual address range reserved via
+// hipMemAddressReserve. Physical memory can be mapped into sub-ranges of the
+// reservation via MapTo, which also enables device access before returning.
+class RocmMemoryReservation : public MemoryReservation {
+ public:
+  // Reserves a virtual address range of at least `size` bytes using
+  // hipMemAddressReserve. StreamExecutor is used only for context activation.
+  static absl::StatusOr<std::unique_ptr<RocmMemoryReservation>> Create(
+      StreamExecutor* executor, uint64_t size);
+
+  // Returns the base address and padded size of the reserved virtual range.
+  DeviceAddressBase address() const override;
+
+  ~RocmMemoryReservation() override;
+
+  // Move is disabled to prevent double-free of the virtual address range:
+  // the destructor calls hipMemAddressFree on ptr_. Matches CudaMemoryReservation.
+  RocmMemoryReservation(RocmMemoryReservation&&) = delete;
+  RocmMemoryReservation& operator=(RocmMemoryReservation&&) = delete;
+
+ private:
+  explicit RocmMemoryReservation(StreamExecutor* executor, char* ptr,
+                                 uint64_t size);
+
+  absl::Status Map(size_t reservation_offset, size_t allocation_offset,
+                   size_t size, MemoryAllocation& allocation) override;
+
+  absl::Status SetAccess(uint64_t reservation_offset, size_t size) override;
+
+  absl::Status UnMap(size_t reservation_offset, size_t size) override;
+
+  StreamExecutor* executor_;
+  char* ptr_;  // nullptr means moved-from / released
+  uint64_t size_;
+  // Bytes currently mapped into the reservation. Kept in sync by Map()/UnMap()
+  // so the destructor can skip a redundant hipMemUnmap when the ScopedMapping
+  // that owns the mapping has already unmapped the range (which would otherwise
+  // fail with HIP_ERROR_InvalidValue).
+  uint64_t mapped_bytes_ = 0;
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_MEMORY_RESERVATION_H_

--- a/xla/stream_executor/rocm/rocm_memory_reservation_test.cc
+++ b/xla/stream_executor/rocm/rocm_memory_reservation_test.cc
@@ -145,5 +145,104 @@ TEST_F(RocmMemoryReservationTest, TwoReservationsDifferentAddresses) {
   EXPECT_NE(res1->address().opaque(), res2->address().opaque());
 }
 
+// Remap with every slice marked remap_required=false must leave the existing
+// physical backing (and therefore the data) untouched.
+TEST_F(RocmMemoryReservationTest, RemapPreservesUnchangedSlices) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc_a, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc_b, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  const size_t sa = alloc_a->address().size();
+  const size_t sb = alloc_b->address().size();
+
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, sa + sb));
+
+  MemoryReservation::MappingDescriptor descs[] = {
+      {/*reservation_offset=*/0, /*allocation_offset=*/0, sa, alloc_a.get()},
+      {/*reservation_offset=*/sa, /*allocation_offset=*/0, sb, alloc_b.get()},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(absl::MakeSpan(descs)));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor_->CreateStream());
+  void* const base = res->address().opaque();
+  DeviceAddressBase slice0(base, sizeof(uint64_t));
+  DeviceAddressBase slice1(reinterpret_cast<uint8_t*>(base) + sa,
+                           sizeof(uint64_t));
+
+  constexpr uint64_t kPatternA = 0xAAAAAAAAAAAAAAAAULL;
+  constexpr uint64_t kPatternB = 0xBBBBBBBBBBBBBBBBULL;
+  ASSERT_THAT(stream->Memcpy(&slice0, &kPatternA, sizeof(kPatternA)), IsOk());
+  ASSERT_THAT(stream->Memcpy(&slice1, &kPatternB, sizeof(kPatternB)), IsOk());
+  ASSERT_THAT(stream->BlockHostUntilDone(), IsOk());
+
+  MemoryReservation::RemappingDescriptor remaps[] = {
+      {0, 0, sa, alloc_a.get(), /*remap_required=*/false},
+      {sa, 0, sb, alloc_b.get(), /*remap_required=*/false},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping2,
+                          std::move(mapping).Remap(absl::MakeSpan(remaps)));
+  EXPECT_EQ(mapping2.mapped_address().opaque(), base);
+  EXPECT_EQ(mapping2.mapped_address().size(), sa + sb);
+
+  uint64_t v0 = 0, v1 = 0;
+  ASSERT_THAT(stream->Memcpy(&v0, slice0, sizeof(v0)), IsOk());
+  ASSERT_THAT(stream->Memcpy(&v1, slice1, sizeof(v1)), IsOk());
+  ASSERT_THAT(stream->BlockHostUntilDone(), IsOk());
+  EXPECT_EQ(v0, kPatternA);
+  EXPECT_EQ(v1, kPatternB);
+}
+
+// Remap with remap_required=true for a slice must repoint that slice at the
+// new physical allocation while preserving the slices left unchanged.
+TEST_F(RocmMemoryReservationTest, RemapRepointsRequiredSlice) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc_a, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc_b, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  const size_t sa = alloc_a->address().size();
+  const size_t sb = alloc_b->address().size();
+
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, sa + sb));
+
+  MemoryReservation::MappingDescriptor descs[] = {
+      {/*reservation_offset=*/0, /*allocation_offset=*/0, sa, alloc_a.get()},
+      {/*reservation_offset=*/sa, /*allocation_offset=*/0, sb, alloc_b.get()},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(absl::MakeSpan(descs)));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor_->CreateStream());
+  void* const base = res->address().opaque();
+  DeviceAddressBase slice0(base, sizeof(uint64_t));
+  DeviceAddressBase slice1(reinterpret_cast<uint8_t*>(base) + sa,
+                           sizeof(uint64_t));
+
+  constexpr uint64_t kPatternA = 0xAAAAAAAAAAAAAAAAULL;
+  constexpr uint64_t kPatternB = 0xBBBBBBBBBBBBBBBBULL;
+  ASSERT_THAT(stream->Memcpy(&slice0, &kPatternA, sizeof(kPatternA)), IsOk());
+  ASSERT_THAT(stream->Memcpy(&slice1, &kPatternB, sizeof(kPatternB)), IsOk());
+  ASSERT_THAT(stream->BlockHostUntilDone(), IsOk());
+
+  // Keep slice0 on alloc_a; repoint slice1 to alloc_a as well. After the remap
+  // slice1 aliases alloc_a, so reading it must observe slice0's data (kPatternA)
+  // rather than the kPatternB it previously held via alloc_b.
+  MemoryReservation::RemappingDescriptor remaps[] = {
+      {0, 0, sa, alloc_a.get(), /*remap_required=*/false},
+      {sa, 0, sb, alloc_a.get(), /*remap_required=*/true},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping2,
+                          std::move(mapping).Remap(absl::MakeSpan(remaps)));
+  EXPECT_EQ(mapping2.mapped_address().opaque(), base);
+  EXPECT_EQ(mapping2.mapped_address().size(), sa + sb);
+
+  uint64_t v0 = 0, v1 = 0;
+  ASSERT_THAT(stream->Memcpy(&v0, slice0, sizeof(v0)), IsOk());
+  ASSERT_THAT(stream->Memcpy(&v1, slice1, sizeof(v1)), IsOk());
+  ASSERT_THAT(stream->BlockHostUntilDone(), IsOk());
+  EXPECT_EQ(v0, kPatternA);
+  EXPECT_EQ(v1, kPatternA);
+}
+
 }  // namespace
 }  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_memory_reservation_test.cc
+++ b/xla/stream_executor/rocm/rocm_memory_reservation_test.cc
@@ -1,0 +1,149 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_memory_reservation.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/test.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+using absl_testing::IsOk;
+using absl_testing::StatusIs;
+
+static constexpr uint64_t kTestSize = 1024 * 1024;
+
+class FakeAllocation : public MemoryAllocation {
+ public:
+  DeviceAddressBase address() const override { return DeviceAddressBase(); }
+};
+
+class RocmMemoryReservationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    auto executor_or = platform_or.value()->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+  }
+
+  StreamExecutor* executor_ = nullptr;
+};
+
+TEST_F(RocmMemoryReservationTest, CreateReservation) {
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  EXPECT_NE(res->address().opaque(), nullptr);
+  EXPECT_GE(res->address().size(), kTestSize);
+}
+
+TEST_F(RocmMemoryReservationTest, MapToWrongType) {
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  FakeAllocation fake;
+  EXPECT_THAT(res->MapTo(0, 0, kTestSize, fake),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST_F(RocmMemoryReservationTest, MapToSingleAllocation) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  const size_t alloc_size = alloc->address().size();
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
+
+  EXPECT_EQ(mapping.mapped_address().opaque(), res->address().opaque());
+  EXPECT_EQ(mapping.mapped_address().size(), alloc_size);
+}
+
+TEST_F(RocmMemoryReservationTest, ScopedMappingUnmapsOnDestruction) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  const size_t alloc_size = alloc->address().size();
+  {
+    TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping2, res->MapTo(0, 0, alloc_size, *alloc));
+  EXPECT_NE(mapping2.mapped_address().opaque(), nullptr);
+}
+
+TEST_F(RocmMemoryReservationTest, MapToMultipleAllocations) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc1, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc2, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+
+  const size_t size1 = alloc1->address().size();
+  const size_t size2 = alloc2->address().size();
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto res, RocmMemoryReservation::Create(executor_, size1 + size2));
+  ASSERT_GE(res->address().size(), size1 + size2);
+
+  MemoryReservation::MappingDescriptor descs[] = {
+      {/*reservation_offset=*/0, /*allocation_offset=*/0, size1, alloc1.get()},
+      {/*reservation_offset=*/size1, /*allocation_offset=*/0, size2,
+       alloc2.get()},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(absl::MakeSpan(descs)));
+
+  EXPECT_EQ(mapping.mapped_address().opaque(), res->address().opaque());
+  EXPECT_EQ(mapping.mapped_address().size(), size1 + size2);
+}
+
+TEST_F(RocmMemoryReservationTest, TwoReservationsDifferentAddresses) {
+  TF_ASSERT_OK_AND_ASSIGN(auto res1,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res2,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  EXPECT_NE(res1->address().opaque(), res2->address().opaque());
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation.cc
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation.cc
@@ -1,0 +1,87 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/log/log.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/device_address.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+
+absl::StatusOr<std::unique_ptr<RocmRawMemoryAllocation>>
+RocmRawMemoryAllocation::Create(StreamExecutor* executor, uint64_t size) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  hipDevice_t device;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
+
+  hipMemAllocationProp props = {};
+  props.type = hipMemAllocationTypePinned;
+  props.location.type = hipMemLocationTypeDevice;
+  props.location.id = device;
+  props.requestedHandleTypes = hipMemHandleTypeNone;
+
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+      &granularity, &props, hipMemAllocationGranularityRecommended)));
+
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
+
+  hipMemGenericAllocationHandle_t handle;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipMemCreate(&handle, padded_size, &props, 0ULL)));
+
+  return std::unique_ptr<RocmRawMemoryAllocation>(
+      new RocmRawMemoryAllocation(executor, handle, padded_size));
+}
+
+RocmRawMemoryAllocation::RocmRawMemoryAllocation(
+    StreamExecutor* executor, hipMemGenericAllocationHandle_t handle,
+    uint64_t size)
+    : executor_(executor), handle_(handle), size_(size) {}
+
+DeviceAddressBase RocmRawMemoryAllocation::address() const {
+  // handle_ is an opaque allocation handle, not a device pointer. We expose it
+  // as a DeviceAddressBase so the base class can use opaque() for identity
+  // tracking; callers never dereference this address.
+  return DeviceAddressBase(static_cast<void*>(handle_), size_);
+}
+
+RocmRawMemoryAllocation::~RocmRawMemoryAllocation() {
+  if (handle_ == nullptr) {
+    return;
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  auto status =
+      ToStatus(hipMemRelease(handle_), "Error releasing ROCm memory");
+  if (!status.ok()) {
+    LOG(ERROR) << status.message();
+  }
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation.h
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation.h
@@ -1,0 +1,65 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_RAW_MEMORY_ALLOCATION_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_RAW_MEMORY_ALLOCATION_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// RAII wrapper for a physical memory allocation created via hipMemCreate.
+// The handle is not mapped to any virtual address; this class only manages
+// the lifetime of the hipMemGenericAllocationHandle_t.
+class RocmRawMemoryAllocation : public MemoryAllocation {
+ public:
+  // Creates a physical memory allocation of at least `size` bytes using
+  // hipMemCreate. StreamExecutor is used only for context activation.
+  static absl::StatusOr<std::unique_ptr<RocmRawMemoryAllocation>> Create(
+      StreamExecutor* executor, uint64_t size);
+
+  // Returns a DeviceAddressBase whose opaque() holds the raw
+  // hipMemGenericAllocationHandle_t cast to void*, and size() is the
+  // padded allocation size.
+  DeviceAddressBase address() const override;
+
+  hipMemGenericAllocationHandle_t GetHandle() const { return handle_; }
+
+  ~RocmRawMemoryAllocation() override;
+  RocmRawMemoryAllocation(const RocmRawMemoryAllocation&) = delete;
+  RocmRawMemoryAllocation& operator=(const RocmRawMemoryAllocation&) = delete;
+  RocmRawMemoryAllocation(RocmRawMemoryAllocation&&) = delete;
+  RocmRawMemoryAllocation& operator=(RocmRawMemoryAllocation&&) = delete;
+
+ private:
+  explicit RocmRawMemoryAllocation(StreamExecutor* executor,
+                                   hipMemGenericAllocationHandle_t handle,
+                                   uint64_t size);
+
+  StreamExecutor* executor_;
+  hipMemGenericAllocationHandle_t handle_;
+  uint64_t size_;
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_RAW_MEMORY_ALLOCATION_H_

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation_test.cc
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation_test.cc
@@ -1,0 +1,80 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+
+#include <cstdint>
+#include <memory>
+
+#include <gtest/gtest.h>
+#include "absl/status/status_matchers.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/test.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+using absl_testing::IsOk;
+
+static constexpr uint64_t kTestSize = 1024 * 1024;
+
+class RocmRawMemoryAllocationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    auto executor_or = platform_or.value()->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+  }
+
+  StreamExecutor* executor_ = nullptr;
+};
+
+TEST_F(RocmRawMemoryAllocationTest, CreateAllocation) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+
+  EXPECT_NE(alloc->GetHandle(), nullptr);
+  EXPECT_GE(alloc->address().size(), kTestSize);
+}
+
+TEST_F(RocmRawMemoryAllocationTest, AddressReflectsHandle) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+
+  EXPECT_EQ(alloc->address().opaque(),
+            static_cast<void*>(alloc->GetHandle()));
+  EXPECT_GE(alloc->address().size(), kTestSize);
+}
+
+TEST_F(RocmRawMemoryAllocationTest, SizeIsAtLeastRequested) {
+  TF_ASSERT_OK_AND_ASSIGN(auto alloc,
+                          RocmRawMemoryAllocation::Create(executor_, 1));
+
+  EXPECT_NE(alloc->GetHandle(), nullptr);
+  EXPECT_GE(alloc->address().size(), 1u);
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_vmm_allocator.cc
+++ b/xla/stream_executor/rocm/rocm_vmm_allocator.cc
@@ -1,0 +1,206 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_vmm_allocator.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include "absl/cleanup/cleanup.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+
+static hipMemAccessDesc GetVmmAccessDescriptor(int device) {
+  hipMemAccessDesc descriptor = {};
+  descriptor.location.type = hipMemLocationTypeDevice;
+  descriptor.location.id = device;
+  descriptor.flags = hipMemAccessFlagsProtReadWrite;
+  return descriptor;
+}
+
+// Allocates device memory using HIP VMM APIs. Returns the mapped pointer,
+// the padded size, and the allocation handle.
+static absl::StatusOr<
+    std::tuple<void*, uint64_t, hipMemGenericAllocationHandle_t>>
+VmmAllocate(StreamExecutor* executor, uint64_t size) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  hipDevice_t device;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
+
+  hipMemAllocationProp properties = {};
+  properties.type = hipMemAllocationTypePinned;
+  properties.location.type = hipMemLocationTypeDevice;
+  properties.location.id = device;
+  properties.requestedHandleTypes = hipMemHandleTypeNone;
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+      &granularity, &properties, hipMemAllocationGranularityRecommended)));
+
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
+  hipMemGenericAllocationHandle_t handle;
+
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipMemCreate(&handle, padded_size, &properties, 0ULL)));
+
+  hipDeviceptr_t ptr = nullptr;
+  absl::Status status = ToStatus(
+hipMemAddressReserve(&ptr, padded_size, granularity, nullptr,
+                                    0ULL));
+  if (!status.ok()) {
+    ToStatus(hipMemRelease(handle)).IgnoreError();
+    return status;
+  }
+
+  status = ToStatus(hipMemMap(ptr, padded_size, 0, handle, 0ULL));
+  if (!status.ok()) {
+    ToStatus(hipMemAddressFree(ptr, padded_size)).IgnoreError();
+    ToStatus(hipMemRelease(handle)).IgnoreError();
+    return status;
+  }
+
+  // Cleanup on error: unmap + free VA + release physical memory.
+  absl::Cleanup cleanup = [&]() {
+    ToStatus(hipMemUnmap(ptr, padded_size)).IgnoreError();
+    ToStatus(hipMemAddressFree(ptr, padded_size)).IgnoreError();
+    ToStatus(hipMemRelease(handle)).IgnoreError();
+  };
+
+  VLOG(3) << "VMM allocated " << ptr
+          << " requested size: " << size
+          << " padded size: " << padded_size
+          << " granularity: " << granularity
+          << " device: " << executor->device_ordinal();
+
+  // Set access for this device and all P2P-capable peers, matching the CUDA
+  // pattern that gates on CanEnablePeerAccessTo().
+  int device_count = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipGetDeviceCount(&device_count)));
+  for (int peer = 0; peer < device_count; peer++) {
+    if (peer != executor->device_ordinal()) {
+      auto peer_executor_or =
+          const_cast<Platform*>(executor->GetPlatform())
+              ->ExecutorForDevice(peer);
+      if (!peer_executor_or.ok() ||
+          !executor->CanEnablePeerAccessTo(peer_executor_or.value())) {
+        continue;
+      }
+    }
+    hipMemAccessDesc access_desc = GetVmmAccessDescriptor(peer);
+    TF_RETURN_IF_ERROR(
+        ToStatus(hipMemSetAccess(ptr, padded_size, &access_desc, 1)));
+  }
+
+  std::move(cleanup).Cancel();
+  return std::make_tuple(ptr, padded_size, handle);
+}
+
+static void VmmDeallocate(StreamExecutor* executor, void* ptr,
+                          uint64_t padded_size,
+                          hipMemGenericAllocationHandle_t handle) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  VLOG(3) << "VMM deallocating " << ptr
+          << " padded size: " << padded_size
+          << " device: " << executor->device_ordinal();
+
+  absl::Status status = ToStatus(hipMemUnmap(ptr, padded_size));
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to unmap VMM memory at " << ptr << ": " << status;
+  }
+  status = ToStatus(hipMemRelease(handle));
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to release VMM handle for " << ptr << ": " << status;
+  }
+  status = ToStatus(hipMemAddressFree(ptr, padded_size));
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to free VMM address at " << ptr << ": " << status;
+  }
+}
+
+namespace {
+
+class RocmVmmMemoryAllocation final : public MemoryAllocation {
+ public:
+  RocmVmmMemoryAllocation(StreamExecutor* executor, void* ptr,
+                          uint64_t requested_size, uint64_t padded_size,
+                          hipMemGenericAllocationHandle_t handle)
+      : executor_(executor),
+        ptr_(ptr),
+        requested_size_(requested_size),
+        padded_size_(padded_size),
+        handle_(handle) {}
+
+  ~RocmVmmMemoryAllocation() final {
+    if (ptr_ != nullptr) {
+      VmmDeallocate(executor_, ptr_, padded_size_, handle_);
+    }
+  }
+
+  DeviceAddressBase address() const final {
+    return DeviceAddressBase(ptr_, requested_size_);
+  }
+
+  std::string ToString() const final {
+    return absl::StrFormat(
+        "RocmVmmMemoryAllocation[device=%d, ptr=%p, size=%d, padded_size=%d]",
+        executor_->device_ordinal(), ptr_, requested_size_, padded_size_);
+  }
+
+ private:
+  StreamExecutor* executor_;
+  void* ptr_;
+  uint64_t requested_size_;
+  uint64_t padded_size_;
+  hipMemGenericAllocationHandle_t handle_;
+};
+
+}  // namespace
+
+RocmVmmAllocator::RocmVmmAllocator(StreamExecutor* executor)
+    : executor_(executor) {}
+
+absl::StatusOr<std::unique_ptr<MemoryAllocation>> RocmVmmAllocator::Allocate(
+    uint64_t size) {
+  if (size == 0) {
+    return std::make_unique<RocmVmmMemoryAllocation>(executor_, nullptr, 0, 0,
+                                                     nullptr);
+  }
+
+  TF_ASSIGN_OR_RETURN(auto result, VmmAllocate(executor_, size));
+  auto [ptr, padded_size, handle] = result;
+
+  return std::make_unique<RocmVmmMemoryAllocation>(executor_, ptr, size,
+                                                   padded_size, handle);
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_vmm_allocator.h
+++ b/xla/stream_executor/rocm/rocm_vmm_allocator.h
@@ -1,0 +1,45 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_VMM_ALLOCATOR_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_VMM_ALLOCATOR_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_allocator.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// Device memory allocator using ROCm/HIP Virtual Memory Management (VMM) APIs.
+// Returned memory allocations are always mapped to a valid device address range
+// and accessible from the device and its peers.
+class RocmVmmAllocator : public MemoryAllocator {
+ public:
+  explicit RocmVmmAllocator(StreamExecutor* executor);
+
+  absl::StatusOr<std::unique_ptr<MemoryAllocation>> Allocate(
+      uint64_t size) final;
+
+ private:
+  StreamExecutor* executor_;
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_VMM_ALLOCATOR_H_

--- a/xla/stream_executor/rocm/rocm_vmm_allocator_test.cc
+++ b/xla/stream_executor/rocm/rocm_vmm_allocator_test.cc
@@ -1,0 +1,97 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_vmm_allocator.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+class RocmVmmAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    auto executor_or = platform_or.value()->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+  }
+
+  StreamExecutor* executor_ = nullptr;
+};
+
+TEST_F(RocmVmmAllocatorTest, AllocateAndFree) {
+  RocmVmmAllocator allocator(executor_);
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
+                       allocator.Allocate(1024));
+  ASSERT_NE(allocation, nullptr);
+  EXPECT_NE(allocation->address().opaque(), nullptr);
+  EXPECT_EQ(allocation->address().size(), 1024);
+}
+
+TEST_F(RocmVmmAllocatorTest, AllocateZeroBytes) {
+  RocmVmmAllocator allocator(executor_);
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
+                       allocator.Allocate(0));
+  ASSERT_NE(allocation, nullptr);
+  EXPECT_EQ(allocation->address().opaque(), nullptr);
+}
+
+TEST_F(RocmVmmAllocatorTest, MemcpyRoundTrip) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<Stream> stream,
+                       executor_->CreateStream());
+
+  RocmVmmAllocator allocator(executor_);
+
+  constexpr int kSize = 1024;
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
+                       allocator.Allocate(kSize));
+
+  std::vector<uint8_t> host_src(kSize);
+  for (int i = 0; i < kSize; i++) {
+    host_src[i] = static_cast<uint8_t>(i);
+  }
+
+  DeviceAddress<uint8_t> addr(allocation->address());
+  ASSERT_OK(stream->MemcpyH2D(absl::MakeConstSpan(host_src), &addr));
+
+  std::vector<uint8_t> host_dst(kSize, 0);
+  ASSERT_OK(stream->MemcpyD2H(addr, absl::MakeSpan(host_dst)));
+  ASSERT_OK(stream->BlockHostUntilDone());
+
+  EXPECT_EQ(host_src, host_dst);
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/vmm_device_address_allocator.cc
+++ b/xla/stream_executor/vmm_device_address_allocator.cc
@@ -623,6 +623,20 @@ MemoryAllocation* DeviceAddressVmmAllocator::GetRawAllocation(
   return it->second.get();
 }
 
+MemoryReservation* DeviceAddressVmmAllocator::GetReservation(
+    int device_ordinal, DeviceAddressBase addr) const {
+  PerDeviceState* state = GetPerDeviceState(device_ordinal);
+  if (state == nullptr) {
+    return nullptr;
+  }
+  absl::MutexLock lock(state->mu);
+  auto it = state->reservations.find(addr.opaque());
+  if (it == state->reservations.end()) {
+    return nullptr;
+  }
+  return it->second.get();
+}
+
 uint64_t DeviceAddressVmmAllocator::GetAllocationGranularity(
     StreamExecutor* executor) const {
   PerDeviceState* state = GetPerDeviceState(executor->device_ordinal());

--- a/xla/stream_executor/vmm_device_address_allocator.cc
+++ b/xla/stream_executor/vmm_device_address_allocator.cc
@@ -234,6 +234,7 @@ void DeviceAddressVmmAllocator::DoDeallocate(PerDeviceState& state,
   state.scoped_mappings.erase(mem.opaque());
   // Erase the reservation next: its destructor frees the virtual address range.
   state.reservations.erase(mem.opaque());
+  state.allocation_ids.erase(mem.opaque());
   // Erase the raw allocation last: its destructor releases the physical memory.
   state.raw_allocations.erase(mem.opaque());
 
@@ -278,7 +279,9 @@ absl::StatusOr<DeviceAddressBase> DeviceAddressVmmAllocator::AllocateWithBudget(
 
   // Store tracking entries. Destruction order matters: scoped_mappings must
   // be erased before reservations, which must be erased before raw_allocations.
+  const uint64_t allocation_id = state.next_allocation_id++;
   state.raw_allocations.emplace(va_ptr, std::move(raw_alloc));
+  state.allocation_ids.emplace(va_ptr, allocation_id);
   state.reservations.emplace(va_ptr, std::move(reservation));
   state.scoped_mappings.emplace(va_ptr, std::move(scoped_mapping));
 
@@ -611,16 +614,29 @@ absl::StatusOr<StreamExecutor*> DeviceAddressVmmAllocator::GetStreamExecutor(
 
 MemoryAllocation* DeviceAddressVmmAllocator::GetRawAllocation(
     int device_ordinal, DeviceAddressBase addr) const {
+  std::optional<AllocationInfo> info = GetAllocationInfo(device_ordinal, addr);
+  return info.has_value() ? info->allocation : nullptr;
+}
+
+std::optional<DeviceAddressVmmAllocator::AllocationInfo>
+DeviceAddressVmmAllocator::GetAllocationInfo(int device_ordinal,
+                                             DeviceAddressBase addr) const {
   PerDeviceState* state = GetPerDeviceState(device_ordinal);
   if (state == nullptr) {
-    return nullptr;
+    return std::nullopt;
   }
   absl::MutexLock lock(state->mu);
   auto it = state->raw_allocations.find(addr.opaque());
   if (it == state->raw_allocations.end()) {
-    return nullptr;
+    return std::nullopt;
   }
-  return it->second.get();
+  auto id_it = state->allocation_ids.find(addr.opaque());
+  if (id_it == state->allocation_ids.end()) {
+    return std::nullopt;
+  }
+  return AllocationInfo{/*allocation=*/it->second.get(),
+                        /*allocation_id=*/id_it->second,
+                        /*mapped_size=*/it->second->address().size()};
 }
 
 MemoryReservation* DeviceAddressVmmAllocator::GetReservation(
@@ -650,6 +666,22 @@ std::optional<DeviceAddressBase>
 DeviceAddressVmmAllocator::TryReusePendingDeallocation(PerDeviceState& state,
                                                        uint64_t size) {
   uint64_t rounded_size = RoundUpToGranularity(state, size);
+  // Among all pending deallocations of the matching rounded size, reuse the one
+  // with the SMALLEST address rather than the first (oldest) in the deque.
+  //
+  // Why: a static executable issues its per-step allocations in a deterministic
+  // order, so if same-size buffers are always handed back out in a fixed
+  // (address-sorted) order, the k-th request of a given size reuses the same
+  // physical handle every step. That keeps the VMM allocation_id stable for
+  // command-buffer buffers, which lets the NEVER_UPDATE VA remapping SKIP them.
+  // The old "first match" policy instead shuffled handles among same-size
+  // buffers, so every one of the ~12 tiny scratch buffers looked "changed" each
+  // step and had to be unmapped+remapped -- the dominant per-step cost on ROCm,
+  // where each hipMemUnmap is expensive and serializes across peer devices.
+  // Reuse remains correct for any matching entry: stream ordering guarantees
+  // the recorded deallocation completes before work submitted after this
+  // Allocate() runs, independent of which entry is chosen.
+  auto best = state.pending_deallocations.end();
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
     if (it->kind != PendingDeallocationKind::kAllocate) {
@@ -658,19 +690,25 @@ DeviceAddressVmmAllocator::TryReusePendingDeallocation(PerDeviceState& state,
     if (RoundUpToGranularity(state, it->mem.size()) != rounded_size) {
       continue;
     }
-
-    DeviceAddressBase reused_mem(it->mem.opaque(), size);
-    VLOG(3) << absl::StreamFormat(
-        "Reusing pending deallocation: address=%p original_size=%uB "
-        "new_size=%uB rounded_size=%uB device=%d",
-        reused_mem.opaque(), it->mem.size(), size, rounded_size,
-        state.executor->device_ordinal());
-    state.pending_deallocations.erase(it);
-
-    return reused_mem;
+    if (best == state.pending_deallocations.end() ||
+        reinterpret_cast<uintptr_t>(it->mem.opaque()) <
+            reinterpret_cast<uintptr_t>(best->mem.opaque())) {
+      best = it;
+    }
+  }
+  if (best == state.pending_deallocations.end()) {
+    return std::nullopt;
   }
 
-  return std::nullopt;
+  DeviceAddressBase reused_mem(best->mem.opaque(), size);
+  VLOG(3) << absl::StreamFormat(
+      "Reusing pending deallocation: address=%p original_size=%uB "
+      "new_size=%uB rounded_size=%uB device=%d",
+      reused_mem.opaque(), best->mem.size(), size, rounded_size,
+      state.executor->device_ordinal());
+  state.pending_deallocations.erase(best);
+
+  return reused_mem;
 }
 
 uint64_t DeviceAddressVmmAllocator::RoundUpToGranularity(

--- a/xla/stream_executor/vmm_device_address_allocator.h
+++ b/xla/stream_executor/vmm_device_address_allocator.h
@@ -152,6 +152,19 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   MemoryAllocation* GetRawAllocation(int device_ordinal,
                                      DeviceAddressBase addr) const;
 
+  struct AllocationInfo {
+    MemoryAllocation* allocation;
+    uint64_t allocation_id;
+    uint64_t mapped_size;
+  };
+
+  // Returns the physical allocation backing the given virtual address plus a
+  // stable ID for the current allocator entry. Reusing a pending deallocation
+  // preserves the ID; fully freeing and recreating an entry gets a new ID even
+  // if the virtual address is reused.
+  std::optional<AllocationInfo> GetAllocationInfo(int device_ordinal,
+                                                  DeviceAddressBase addr) const;
+
   // Returns the MemoryReservation (virtual address range) for the given
   // virtual address on the specified device, or nullptr if the address was not
   // allocated by this allocator. The returned pointer is valid until the
@@ -218,11 +231,14 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
     mutable absl::Mutex mu;
     uint64_t pa_allocated ABSL_GUARDED_BY(mu) = 0;
+    // Monotonically increasing counter for stable per-allocation IDs.
+    uint64_t next_allocation_id ABSL_GUARDED_BY(mu) = 1;
     // Monotonically increasing counter for timeline sequence numbers.
     uint64_t next_seqno ABSL_GUARDED_BY(mu) = 1;
     std::deque<PendingDeallocation> pending_deallocations ABSL_GUARDED_BY(mu);
     absl::flat_hash_map<void*, std::unique_ptr<MemoryAllocation>>
         raw_allocations ABSL_GUARDED_BY(mu);
+    absl::flat_hash_map<void*, uint64_t> allocation_ids ABSL_GUARDED_BY(mu);
     absl::flat_hash_map<void*, std::unique_ptr<MemoryReservation>> reservations
         ABSL_GUARDED_BY(mu);
     absl::flat_hash_map<void*, MemoryReservation::ScopedMapping> scoped_mappings

--- a/xla/stream_executor/vmm_device_address_allocator.h
+++ b/xla/stream_executor/vmm_device_address_allocator.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <functional>
 #include <memory>
 #include <optional>
+#include <utility>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
@@ -89,6 +90,19 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     uint64_t pa_budget = UINT64_MAX;
   };
 
+  // Creates a platform-appropriate VMM allocator for the given devices,
+  // dispatching to the CUDA or ROCm implementation based on the build platform.
+  // The pa_budget for each device is computed from `memory_fraction` (or
+  // overridden by `gpu_system_memory_size` when set). Returns an error on
+  // platforms without a VMM implementation.
+  //
+  // Defined in vmm_device_address_allocator_factory.cc so this base library
+  // does not depend on the platform-specific subclasses.
+  static absl::StatusOr<std::unique_ptr<DeviceAddressVmmAllocator>> Create(
+      const Platform* platform, double memory_fraction,
+      std::optional<int64_t> gpu_system_memory_size,
+      absl::Span<const std::pair<StreamExecutor*, Stream*>> devices);
+
   ~DeviceAddressVmmAllocator() override;
 
   absl::StatusOr<ScopedDeviceAddress<uint8_t>> Allocate(
@@ -137,6 +151,13 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // allocation is deallocated.
   MemoryAllocation* GetRawAllocation(int device_ordinal,
                                      DeviceAddressBase addr) const;
+
+  // Returns the MemoryReservation (virtual address range) for the given
+  // virtual address on the specified device, or nullptr if the address was not
+  // allocated by this allocator. The returned pointer is valid until the
+  // allocation is deallocated.
+  MemoryReservation* GetReservation(int device_ordinal,
+                                    DeviceAddressBase addr) const;
 
   // Returns the VMM allocation granularity for the device associated with
   // `executor`, or 0 if the device is not registered or granularity is unknown.

--- a/xla/stream_executor/vmm_device_address_allocator_factory.cc
+++ b/xla/stream_executor/vmm_device_address_allocator_factory.cc
@@ -1,0 +1,61 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/vmm_device_address_allocator.h"
+#include "xla/tsl/platform/statusor.h"
+
+#if GOOGLE_CUDA
+#include "xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h"
+#elif TENSORFLOW_USE_ROCM
+#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
+#endif  // GOOGLE_CUDA
+
+namespace stream_executor {
+
+absl::StatusOr<std::unique_ptr<DeviceAddressVmmAllocator>>
+DeviceAddressVmmAllocator::Create(
+    const Platform* platform, double memory_fraction,
+    std::optional<int64_t> gpu_system_memory_size,
+    absl::Span<const std::pair<StreamExecutor*, Stream*>> devices) {
+#if GOOGLE_CUDA
+  TF_ASSIGN_OR_RETURN(
+      std::unique_ptr<gpu::CudaDeviceAddressVmmAllocator> allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(
+          platform, memory_fraction, gpu_system_memory_size, devices));
+  return std::unique_ptr<DeviceAddressVmmAllocator>(std::move(allocator));
+#elif TENSORFLOW_USE_ROCM
+  TF_ASSIGN_OR_RETURN(
+      std::unique_ptr<gpu::RocmDeviceAddressVmmAllocator> allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(
+          platform, memory_fraction, gpu_system_memory_size, devices));
+  return std::unique_ptr<DeviceAddressVmmAllocator>(std::move(allocator));
+#else
+  return absl::UnimplementedError(
+      "VMM allocator is only supported with CUDA or ROCm.");
+#endif  // GOOGLE_CUDA
+}
+
+}  // namespace stream_executor


### PR DESCRIPTION
## Summary

**Part 2 of 2** splitting #40236. **Stacked on #43756** (the ROCm VMM allocator) —
please review after that merges. Until #43756 lands, this PR's diff also shows the
foundation commit; the optimization itself is the second commit.

Makes `NEVER_UPDATE` command-buffer replay cheap on ROCm, so collectives can be
captured in a command buffer and replayed without the per-step re-trace tax. Two
changes on top of the VMM device-address allocator:

1. **Per-slice VA remap skip.** `DeviceAddressVmmAllocator` assigns each allocation a
   stable id and exposes it via `GetAllocationInfo()`. `GpuExecutable`'s `NEVER_UPDATE`
   remapping uses this id to remap **only** the command-buffer slices whose physical
   backing changed since the previous step, instead of remapping every slice every step.

2. **Deterministic address-order reuse.** `TryReusePendingDeallocation()` reuses the
   matching free block with the **smallest address** instead of the oldest. A static
   executable allocates in a deterministic per-step order, so address-sorted reuse hands
   the k-th same-size request the same physical handle every step → its `allocation_id`
   stays stable → the per-slice remap skips it. The previous first-match policy shuffled
   handles among same-size buffers, forcing ~12 tiny scratch buffers to be
   unmapped+remapped every step — the dominant steady-state cost on ROCm, where
   `hipMemUnmap` is expensive and serializes across peer devices.

Also: coalesced `UnMap` + single full-range `SetAccess` for peer devices (ROCm rejects
partial peer `SetAccess` with `HIP_ERROR_InvalidValue`), and VLOG(2) timing/diagnostics.

## 📊 Benchmark (for Performance Improvements)

Measured on **8× AMD Instinct MI300X (gfx942), ROCm 7.2.0**, jax `0.10.1.dev20260519`, `jax-rocm7-plugin`. The VMM `NEVER_UPDATE` fixed-VA replay path makes command-buffered collectives cheap by remapping only the physical buffers that change each step (stable `allocation_id` + deterministic address-order reuse), instead of re-tracing the command buffer every step.

### Popular models — MaxText, FSDP=8, 8 decoder layers, 30 steps — steady per-step (ms)

| model | base (no VMM) | +COLL (no VMM) | VMM (no COLL) | VMM +COLL | +COLL speedup |
|---|--:|--:|--:|--:|--:|
| Llama2-7B | 244 | 4543 | 157 | **160** | **~29×** |
| Llama3-8B | 154 | 3830 | 180 | **178** | **~21×** |
| Mixtral-8x1B (MoE) | 680 | 5573 | 710 | **701** | **~8×** |
| Llama3.1-8B | 776 | 754 | 722 | **720** | ~1.05× |
| Gemma2-9B | 1450 | 1451 | 1336 | **1337** | ~1.09× |

`base` = command buffer `FUSION,CUBLAS,CUBLASLT,CUSTOM_CALL`; `+COLL` adds `COLLECTIVES`; `VMM` = `NEVER_UPDATE`. All 20 legs pass the unmap-error gate; no model regresses.

### Synthetic microbenchmark — pmap over 8 GPUs — median per-step

| workload | BFC | VMM/ALWAYS | VMM/NEVER | VMM/CAPTURE_CMD_NEVER |
|---|--:|--:|--:|--:|
| allreduce_only | 1304 μs | 1391 μs | 1355 μs | 1386 μs |
| matmul+allreduce | 1329 μs | 1426 μs | 1390 μs | 1387 μs |
| mlp+2x_allreduce | 1638 μs | 1644 μs | 1499 μs | 1527 μs |
| heavy_matmul+ar | 185788 μs | 182451 μs | **7800 μs** | **5140 μs** |

`VMM/ALWAYS ≈ BFC` confirms the speedup comes from VA-remap replay, not the allocator itself. Small workloads sit at parity because the 8-GPU RCCL clique init dominates when there is almost no graph to replay.


## Note vs upstream
Upstream OpenXLA `TryReusePendingDeallocation` uses the same first-match policy; it's
harmless on CUDA (cheap `cuMemUnmap`) but expensive on ROCm. The address-order reuse
here is a generally-safe improvement and a good upstream candidate.

## Test plan
- [x] Re-verified on the split branches (8×MI300X, llama2_7b scan_layers=true): steady
  `coll_vmm` ≈ 152 ms vs `coll_novmm` ≈ 4806 ms (**32×**), `vmm_engaged=1`, 0 unmap errors.
- [ ] `bazel test` the ROCm `GetAllocationInfo` / `ScopedMapping::Remap` unit tests.
- [ ] Loss curves match the no-command-buffer baseline (correctness).
