### PR TITLE
[xla:gpu] When rewriting for dynamic-memcpy check that all slicing instructions are compatible

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -273,6 +273,7 @@ cc_library(
     hdrs = ["fusion_dynamic_memcpy_rewriter.h"],
     deps = [
         ":dynamic_slice_fusion",
+        "//xla:shape_util",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/pass:hlo_pass",
         "//xla/service/gpu:backend_configs_cc",

--- a/xla/backends/gpu/transforms/fusion_dynamic_memcpy_rewriter.cc
+++ b/xla/backends/gpu/transforms/fusion_dynamic_memcpy_rewriter.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/ir_emission_utils.h"
+#include "xla/shape_util.h"
 
 namespace xla::gpu {
 namespace {
@@ -38,6 +39,30 @@ namespace {
 bool HasDynamicSliceConfig(const HloInstruction* instr) {
   auto config = instr->backend_config<GpuBackendConfig>();
   return config.ok() && config->has_dynamic_slice_config();
+}
+
+bool IsSlicingInstruction(const HloInstruction* instr) {
+  return instr->opcode() == HloOpcode::kSlice ||
+         instr->opcode() == HloOpcode::kDynamicSlice ||
+         instr->opcode() == HloOpcode::kDynamicUpdateSlice;
+}
+
+bool IsSlicingInstructionCompatible(const HloInstruction* instr) {
+  if (instr->opcode() == HloOpcode::kSlice) {
+    return IsContiguousSlice(*instr) &&
+           ShapeUtil::ByteStrides(instr->operand(0)->shape()).has_value();
+  }
+
+  return HasDynamicSliceConfig(instr);
+}
+
+bool AllSlicingInstructionsCompatible(const HloComputation* computation) {
+  for (const HloInstruction* instr : computation->instructions()) {
+    if (IsSlicingInstruction(instr) && !IsSlicingInstructionCompatible(instr)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 bool IsBitcastOrReshape(const HloInstruction* instr) {
@@ -81,14 +106,29 @@ std::optional<MemcpyFusionCandidate> FindMemcpyFusionCandidate(
 }
 
 bool CanRewriteAsDynamicSliceFusion(const MemcpyFusionCandidate& candidate) {
-  auto can_resolve_copy_hero_parameters = [](HloInstruction* operand) {
+  auto resolve_copy_hero_parameters = [](HloInstruction* operand) {
     std::unique_ptr<HloInstruction> copy = HloInstruction::CreateUnary(
         operand->shape(), HloOpcode::kCopy, operand);
-    return DynamicSliceFusion::ResolveParameters(copy.get()).ok();
+    return DynamicSliceFusion::ResolveParameters(copy.get());
   };
 
-  if (!can_resolve_copy_hero_parameters(candidate.copy_operand)) {
+  auto parameters = resolve_copy_hero_parameters(candidate.copy_operand);
+  if (!parameters.ok()) {
     return false;
+  }
+
+  for (const DynamicSliceFusion::Parameter& parameter : *parameters) {
+    if (parameter.slice_config.has_value()) {
+      continue;
+    }
+
+    // Without DynamicSliceConfig, DynamicSliceFusion will pass the original
+    // parameter buffer base address to the embedded copy thunk. This is only
+    // correct for unsliced pass-through operands.
+    if (ShapeUtil::ByteSizeOf(parameter.slice_shape) !=
+        ShapeUtil::ByteSizeOf(parameter.parameter_shape)) {
+      return false;
+    }
   }
 
   if (candidate.slicing->opcode() == HloOpcode::kDynamicSlice) {
@@ -122,7 +162,9 @@ absl::StatusOr<bool> FusionDynamicMemcpyRewriter::RunImpl(
 
     std::optional<MemcpyFusionCandidate> candidate =
         FindMemcpyFusionCandidate(computation);
-    if (!candidate.has_value() || !CanRewriteAsDynamicSliceFusion(*candidate)) {
+    if (!candidate.has_value() ||
+        !AllSlicingInstructionsCompatible(computation) ||
+        !CanRewriteAsDynamicSliceFusion(*candidate)) {
       continue;
     }
 
@@ -149,7 +191,7 @@ absl::StatusOr<bool> FusionDynamicMemcpyRewriter::RunImpl(
       RETURN_IF_ERROR(candidate->slicing->ReplaceOperandWith(1, copy));
     }
 
-    // Set backend config to target DynamicSliceFusionV2.
+    // Set backend config to target dynamic slice custom fusion.
     RETURN_IF_ERROR(fusion->set_backend_config(backend_config));
 
     fusion->set_fusion_kind(HloInstruction::FusionKind::kCustom);

--- a/xla/backends/gpu/transforms/fusion_dynamic_memcpy_rewriter_test.cc
+++ b/xla/backends/gpu/transforms/fusion_dynamic_memcpy_rewriter_test.cc
@@ -75,7 +75,7 @@ std::optional<std::string> GetCustomFusionName(const HloInstruction* instr) {
   return fusion_config.custom_fusion_config().name();
 }
 
-TEST_F(FusionDynamicMemcpyRewriterTest, RewritesDsToV2Fusion) {
+TEST_F(FusionDynamicMemcpyRewriterTest, RewritesDsToDynamicSliceFusion) {
   constexpr char kHlo[] = R"(
     dynamic_slice {
       p0 = s32[4] parameter(0)
@@ -147,7 +147,7 @@ TEST_F(FusionDynamicMemcpyRewriterTest, DoesNotRewriteCall) {
       << module->ToString();
 }
 
-TEST_F(FusionDynamicMemcpyRewriterTest, RewritesDusToV2Fusion) {
+TEST_F(FusionDynamicMemcpyRewriterTest, RewritesDusToDynamicSliceFusion) {
   constexpr char kHlo[] = R"(
     dynamic_slice {
       p0 = s32[4,8,8] parameter(0)
@@ -316,6 +316,115 @@ TEST_F(FusionDynamicMemcpyRewriterTest,
     ENTRY main {
       p0 = s32[4] parameter(0)
       ROOT fusion = s32[1] fusion(p0), kind=kLoop, calls=dynamic_slice
+    })";
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHlo));
+  EXPECT_THAT(FusionDynamicMemcpyRewriter().Run(module.get()),
+              absl_testing::IsOkAndHolds(false))
+      << module->ToString();
+}
+
+TEST_F(FusionDynamicMemcpyRewriterTest,
+       DoesNotRewriteDusWithUnannotatedDynamicSliceUpdate) {
+  constexpr char kHlo[] = R"(
+    dynamic_slice {
+      p0 = s32[4,8] parameter(0)
+      p1 = s32[4,8] parameter(1)
+      p2 = s32[] parameter(2)
+      c0 = s32[] constant(0)
+
+      update = s32[1,8] dynamic-slice(p1, p2, c0),
+          dynamic_slice_sizes={1,8}
+
+      ROOT update-slice = s32[4,8] dynamic-update-slice(p0, update, p2, c0),
+          backend_config={"dynamic_slice_config":
+              {"byte_offset":"0","byte_stride":"32","loop_index":"0"}}
+    }
+
+    ENTRY main {
+      input = s32[4,8] parameter(0)
+      val = s32[4,8] parameter(1)
+      ivar = s32[] parameter(2)
+      ROOT updated = s32[4,8] fusion(input, val, ivar), kind=kLoop,
+          calls=dynamic_slice
+    })";
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHlo));
+  EXPECT_THAT(FusionDynamicMemcpyRewriter().Run(module.get()),
+              absl_testing::IsOkAndHolds(false))
+      << module->ToString();
+}
+
+TEST_F(FusionDynamicMemcpyRewriterTest, RewritesDusWithStaticSliceUpdate) {
+  constexpr char kHlo[] = R"(
+    dynamic_slice {
+      p0 = s32[4,8] parameter(0)
+      p1 = s32[4,8] parameter(1)
+      p2 = s32[] parameter(2)
+      c0 = s32[] constant(0)
+
+      update = s32[1,8] slice(p1), slice={[1:2], [0:8]}
+
+      ROOT update-slice = s32[4,8] dynamic-update-slice(p0, update, p2, c0),
+          backend_config={"dynamic_slice_config":
+              {"byte_offset":"0","byte_stride":"32","loop_index":"0"}}
+    }
+
+    ENTRY main {
+      input = s32[4,8] parameter(0)
+      val = s32[4,8] parameter(1)
+      ivar = s32[] parameter(2)
+      ROOT updated = s32[4,8] fusion(input, val, ivar), kind=kLoop,
+          calls=dynamic_slice
+    })";
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHlo));
+  EXPECT_THAT(FusionDynamicMemcpyRewriter().Run(module.get()),
+              absl_testing::IsOkAndHolds(true));
+
+  const HloInstruction* fusion =
+      module->entry_computation()->root_instruction();
+  ASSERT_EQ(fusion->opcode(), HloOpcode::kFusion);
+  EXPECT_EQ(fusion->fusion_kind(), HloInstruction::FusionKind::kCustom);
+
+  const HloInstruction* hero =
+      DynamicSliceFusion::FindHero(fusion->fused_instructions_computation());
+  ASSERT_NE(hero, nullptr);
+  EXPECT_EQ(hero->opcode(), HloOpcode::kCopy);
+
+  ASSERT_OK_AND_ASSIGN(auto parameters,
+                       DynamicSliceFusion::ResolveParameters(hero));
+  EXPECT_THAT(parameters,
+              ElementsAre(Parameter{1, ShapeUtil::MakeShape(S32, {4, 8}),
+                                    ShapeUtil::MakeShape(S32, {1, 8}),
+                                    MakeStaticConfig(32), std::nullopt}));
+}
+
+TEST_F(FusionDynamicMemcpyRewriterTest,
+       DoesNotRewriteDusWithStridedStaticSliceUpdate) {
+  constexpr char kHlo[] = R"(
+    dynamic_slice {
+      p0 = s32[4,8] parameter(0)
+      p1 = s32[4,8] parameter(1)
+      p2 = s32[] parameter(2)
+      c0 = s32[] constant(0)
+
+      update = s32[2,8] slice(p1), slice={[0:4:2], [0:8]}
+
+      ROOT update-slice = s32[4,8] dynamic-update-slice(p0, update, p2, c0),
+          backend_config={"dynamic_slice_config":
+              {"byte_offset":"0","byte_stride":"32","loop_index":"0"}}
+    }
+
+    ENTRY main {
+      input = s32[4,8] parameter(0)
+      val = s32[4,8] parameter(1)
+      ivar = s32[] parameter(2)
+      ROOT updated = s32[4,8] fusion(input, val, ivar), kind=kLoop,
+          calls=dynamic_slice
     })";
 
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,


### PR DESCRIPTION
- Tighten `FusionDynamicMemcpyRewriter` so DS/DUS memcpy fusions are rewritten only when all slicing instructions in the fusion body are compatible with the dynamic-slice custom-fusion thunk.
- Require dynamic-slice and dynamic-update-slice instructions to carry `DynamicSliceConfig`; allow static slice only when it is a contiguous byte slice with computable byte strides.
- Reject sliced hero parameters without slice config so the embedded copy thunk does not read from the unsliced parameter base address.
- Add regression tests for unannotated dynamic-slice updates, contiguous static-slice updates, and strided static-slice updates.