### PR TITLE
[xla:gpu] Emit contiguous slice fusions as d2d copies

### DIFF
--- a/xla/backends/gpu/tests/BUILD
+++ b/xla/backends/gpu/tests/BUILD
@@ -415,6 +415,7 @@ xla_test(
         "//xla/hlo/testlib:verified_hlo_module",
         "//xla/tests:hlo_pjrt_interpreter_reference_mixin",
         "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest_main",
         "@tsl//tsl/platform:statusor",
         "@tsl//tsl/platform:test",

--- a/xla/backends/gpu/tests/gpu_copy_test.cc
+++ b/xla/backends/gpu/tests/gpu_copy_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "absl/status/status_matchers.h"
+#include "absl/strings/string_view.h"
 #include "xla/backends/gpu/tests/gpu_pjrt_codegen_test.h"
 #include "xla/error_spec.h"
 #include "xla/hlo/ir/hlo_computation.h"
@@ -77,6 +78,32 @@ TEST_F(GpuCopyTest, CopyTranspose) {
                           ParseAndReturnVerifiedModule(hlo_text));
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+}
+
+TEST_F(GpuCopyTest, UseMemcpyForTrivialStaticSliceFusion) {
+  constexpr absl::string_view hlo_text = R"(
+    HloModule Test
+
+    wrapped_slice_computation {
+      param_0 = f32[8,16]{1,0} parameter(0)
+      ROOT slice = f32[3,16]{1,0} slice(param_0),
+          slice={[2:5], [0:16]}
+    }
+
+    ENTRY main {
+      param_0 = f32[8,16]{1,0} parameter(0)
+      ROOT wrapped_slice = f32[3,16]{1,0} fusion(param_0),
+          kind=kLoop, calls=wrapped_slice_computation
+    })";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> hlo_module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+
+  ASSERT_OK(CompileAndVerifyIr(std::move(hlo_module),
+                               "; CHECK-NOT: void @wrapped_slice",
+                               /*match_optimized_ir=*/false,
+                               /*run_optimization_passes=*/false));
+  EXPECT_TRUE(RunAndCompareNoHloPasses(hlo_text, ErrorSpec{1e-5, 1e-5}));
 }
 
 constexpr char kSliceMemcpyModule[] = R"(

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -572,6 +572,7 @@ cc_library(
         "//xla/service:collective_opt_utils",
         "//xla/service:hlo_creation_utils",
         "//xla/service:hlo_proto_cc",
+        "//xla/service:pattern_matcher",
         "//xla/service:shaped_slice",
         "//xla/service/gpu/model:block_level_parameters",
         "//xla/service/llvm_ir:buffer_assignment_util",

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -157,6 +157,7 @@ limitations under the License.
 #include "xla/service/hlo_creation_utils.h"
 #include "xla/service/llvm_ir/buffer_assignment_util.h"
 #include "xla/service/llvm_ir/llvm_command_line_options.h"
+#include "xla/service/pattern_matcher.h"
 #include "xla/service/shaped_slice.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
@@ -178,6 +179,8 @@ limitations under the License.
 
 namespace xla::gpu {
 namespace {
+
+namespace m = ::xla::match;
 
 absl::StatusOr<TritonKernelSource> EmitTritonFrom(
     const TritonCall& call, const std::string& kernel_name,
@@ -1361,6 +1364,12 @@ AsyncThunkSequence ThunkEmitter::EmitAsyncComputation(
 }
 
 AsyncThunkSequence ThunkEmitter::EmitFusion(const HloFusionInstruction* instr) {
+  ASSIGN_OR_RETURN(std::optional<ThunkSequence> slice_thunks,
+                   TryEmitTrivialSliceFusion(instr));
+  if (slice_thunks.has_value()) {
+    return std::move(*slice_thunks);
+  }
+
   analysis_garbage_collector_.push_back(
       std::make_unique<HloFusionAnalysis>(HloFusionAnalysis::Create(
           *instr, ir_emitter_context_->gpu_device_info())));
@@ -1383,6 +1392,55 @@ AsyncThunkSequence ThunkEmitter::EmitFusion(const HloFusionInstruction* instr) {
                     &ir_emitter_context_->buffer_assignment(), *call_graph_),
       ir_emitter_context_->mlir_context());
   return emitter->Emit(*ir_emitter_context_, *instr);
+}
+
+// Pattern match wrapped slice instruction that slices a contiguous buffer out
+// of the fusion parameter. Such trivial slices can be emitted as d2d copy.
+absl::StatusOr<std::optional<ThunkSequence>>
+ThunkEmitter::TryEmitTrivialSliceFusion(const HloFusionInstruction* instr) {
+  const HloInstruction* slice_instr = nullptr;
+  const HloInstruction* src = nullptr;
+
+  if (!Match(instr->fused_expression_root(),
+             m::Slice(&slice_instr, m::Parameter(&src, 0)))) {
+    return std::nullopt;
+  }
+  const HloSliceInstruction* slice = Cast<HloSliceInstruction>(slice_instr);
+
+  const Shape& src_shape = src->shape();
+  const Shape& dst_shape = instr->shape();
+  if (!Layout::Equal().MinorToMajorOnly()(src_shape.layout(),
+                                          dst_shape.layout()) ||
+      !IsContiguousSlice(*slice)) {
+    return std::nullopt;
+  }
+
+  auto byte_strides = ShapeUtil::ByteStrides(src_shape);
+  if (!byte_strides.has_value()) {
+    return std::nullopt;
+  }
+
+  int64_t src_byte_offset = 0;
+  for (int64_t dim = 0; dim < src_shape.dimensions().size(); ++dim) {
+    src_byte_offset += slice->slice_starts(dim) * (*byte_strides)[dim];
+  }
+
+  ASSIGN_OR_RETURN(BufferAllocation::Slice arg_slice,
+                   GetAllocationSliceForHlo(instr->operand(0)));
+  ASSIGN_OR_RETURN(BufferAllocation::Slice dst_slice,
+                   GetAllocationSliceForHlo(instr));
+
+  // Slice of the parameter buffer copied to the result buffer.
+  int64_t byte_size = ShapeUtil::ByteSizeOf(dst_shape);
+  BufferAllocation::Slice src_slice(arg_slice.allocation(),
+                                    arg_slice.offset() + src_byte_offset,
+                                    byte_size, arg_slice.element_type());
+
+  return GetThunkSequence(std::make_unique<DeviceToDeviceCopyThunk>(
+      Thunk::ThunkInfo::WithProfileAnnotation(
+          instr, ir_emitter_context_->GetNextThunkId()),
+      ShapedSlice{src_slice, dst_shape}, ShapedSlice{dst_slice, dst_shape},
+      byte_size));
 }
 
 AsyncThunkSequence ThunkEmitter::EmitDynamicSliceFusionV2(

--- a/xla/service/gpu/thunk_emitter.h
+++ b/xla/service/gpu/thunk_emitter.h
@@ -152,11 +152,12 @@ class ThunkEmitter {
 
   AsyncThunkSequence EmitFusion(const HloFusionInstruction* instr);
 
+  absl::StatusOr<std::optional<ThunkSequence>> TryEmitTrivialSliceFusion(
+      const HloFusionInstruction* instr);
+
   absl::StatusOr<ThunkSequence> EmitFftThunk(const HloFftInstruction* hlo);
 
   absl::StatusOr<ThunkSequence> EmitInfeed(const HloInfeedInstruction* hlo);
-
-
 
   absl::StatusOr<ThunkSequence> EmitNormThunk(
       const HloCustomCallInstruction* hlo);


### PR DESCRIPTION
Contiguous slices are essentially d2d memory copies, instead of emitting them as LLVM/PTX kernels, emit them as d2d copies. This saves a lot of compilation time on tiny fusions and allows CUDA to use copy engine instead of SMs and can help with compute/communication overlap.