### PR TITLE
[xla:gpu] Capture DUS fusion offset expressions

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1564,6 +1564,7 @@ cc_library(
     hdrs = ["dynamic_slice_fusion_rewriter_v2.h"],
     tags = ["gpu"],
     deps = [
+        ":dynamic_slice_fusion",
         "//xla:shape_util",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/pass:hlo_pass",
@@ -1598,6 +1599,7 @@ xla_cc_test(
         ":dynamic_slice_annotator",
         ":dynamic_slice_fusion",
         ":dynamic_slice_fusion_rewriter_v2",
+        "//xla:comparison_util",
         "//xla:shape_util",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
@@ -1607,6 +1609,7 @@ xla_cc_test(
         "//xla/service/gpu:backend_configs_cc",
         "//xla/stream_executor:platform_id",
         "//xla/stream_executor/gpu:gpu_init_impl",
+        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion.cc
@@ -36,6 +36,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/primitive_util.h"
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
@@ -45,6 +46,35 @@ limitations under the License.
 namespace xla::gpu {
 
 using Offset = DynamicSliceFusion::Offset;
+
+static bool IsScalarInteger(const Shape& shape) {
+  return ShapeUtil::IsScalar(shape) &&
+         primitive_util::IsIntegralType(shape.element_type());
+}
+
+static bool IsScalarIntegerOrPred(const Shape& shape) {
+  return IsScalarInteger(shape) ||
+         ShapeUtil::IsScalarWithElementType(shape, PRED);
+}
+
+bool Offset::IsExpr(const HloInstruction* instr) {
+  switch (instr->opcode()) {
+    case HloOpcode::kParameter:
+    case HloOpcode::kConstant:
+      return IsScalarIntegerOrPred(instr->shape());
+    case HloOpcode::kAdd:
+    case HloOpcode::kSubtract:
+    case HloOpcode::kMultiply:
+      return IsScalarInteger(instr->shape());
+    case HloOpcode::kCompare:
+      return IsScalarInteger(instr->operand(0)->shape()) &&
+             IsScalarInteger(instr->operand(1)->shape());
+    case HloOpcode::kSelect:
+      return IsScalarIntegerOrPred(instr->shape());
+    default:
+      return false;
+  }
+}
 
 Offset::Expr Offset::Constant(int64_t value) {
   return {Offset::Expr::Constant{value}};
@@ -130,11 +160,11 @@ static absl::StatusOr<int64_t> GetScalarIntegerLiteral(
   switch (constant->shape().element_type()) {
     case PRED:
       return constant->literal().GetFirstElement<bool>() ? 1 : 0;
-    case S32:
-      return constant->literal().GetFirstElement<int32_t>();
-    case S64:
-      return constant->literal().GetFirstElement<int64_t>();
     default:
+      if (std::optional<int64_t> value = constant->literal().GetFirstInteger();
+          value.has_value()) {
+        return *value;
+      }
       return Internal(
           "DynamicSliceFusion: expected integer or pred offset constant, "
           "got %s",
@@ -145,6 +175,13 @@ static absl::StatusOr<int64_t> GetScalarIntegerLiteral(
 static absl::StatusOr<Offset::Expr> BuildOffsetExpr(
     const HloInstruction* instr) {
   instr = WalkThroughBitcasts(instr);
+
+  if (!Offset::IsExpr(instr)) {
+    return Internal(
+        "DynamicSliceFusion: expected DS/DUS offset to be a scalar "
+        "expression of fusion parameters and constants, got %s",
+        instr->ToString());
+  }
 
   if (auto* parameter = DynCast<HloParameterInstruction>(instr)) {
     return Offset::Parameter(parameter->parameter_number());
@@ -185,13 +222,9 @@ static absl::StatusOr<Offset::Expr> BuildOffsetExpr(
       return Offset::Select(std::move(pred), std::move(on_true),
                             std::move(on_false));
     }
-    case HloOpcode::kConvert:
-      return BuildOffsetExpr(instr->operand(0));
     default:
-      return Internal(
-          "DynamicSliceFusion: expected DS/DUS offset to be a scalar "
-          "expression of fusion parameters and constants, got %s",
-          instr->ToString());
+      return Internal("Unsupported offset expression opcode: %s",
+                      instr->ToString());
   }
 }
 
@@ -326,8 +359,7 @@ static absl::flat_hash_set<const HloInstruction*> CollectOffsetInstructions(
     if (!offsets.insert(instr).second) {
       return;
     }
-    if (instr->opcode() == HloOpcode::kParameter ||
-        instr->opcode() == HloOpcode::kConstant) {
+    if (HloPredicateIsOp<HloOpcode::kParameter, HloOpcode::kConstant>(instr)) {
       return;
     }
     for (const HloInstruction* operand : instr->operands()) {

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion.h
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion.h
@@ -122,6 +122,12 @@ struct DynamicSliceFusion {
       Value value;
     };
 
+    // Returns whether an HLO instruction can appear as an operation or leaf in
+    // the offset expression language. Offset expressions are scalar integer
+    // computations, with scalar pred values allowed for compare/select
+    // predicates.
+    static bool IsExpr(const HloInstruction* instr);
+
     static Expr Constant(int64_t value);
     static Expr Parameter(int64_t parameter_number);
     static Expr Add(Expr lhs, Expr rhs);

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
@@ -399,20 +399,18 @@ void AddOffsetExpressionInstructions(
     return;
   }
 
-  if (clone_instruction_set.contains(instr)) {
+  if (!clone_instruction_set.insert(instr).second) {
     return;
   }
 
+  offset_instruction_set.insert(instr);
   for (HloInstruction* operand : instr->operands()) {
     AddOffsetExpressionInstructions(operand, clone_instructions,
                                     clone_instruction_set,
                                     offset_instruction_set);
   }
 
-  if (clone_instruction_set.insert(instr).second) {
-    offset_instruction_set.insert(instr);
-    clone_instructions.push_back(instr);
-  }
+  clone_instructions.push_back(instr);
 }
 
 void AddDynamicSliceOffsetExpressionInstructions(
@@ -530,6 +528,7 @@ std::optional<DynamicSliceFusionPlan> BuildFusionPlan(
   // buffer-first parameter order.
   std::vector<HloInstruction*> external_operands;
   absl::flat_hash_set<HloInstruction*> external_operand_set;
+  absl::flat_hash_set<HloInstruction*> visited_offset_instruction_set;
 
   auto collect_external_operand = [&](auto& self, HloInstruction* operand) {
     // Constants have already been sunk into the fusion body.
@@ -547,6 +546,9 @@ std::optional<DynamicSliceFusionPlan> BuildFusionPlan(
     // Only cloned offset expressions are transparent for this traversal; other
     // cloned instructions are already represented inside the fusion body.
     if (!offset_instruction_set.contains(operand)) {
+      return;
+    }
+    if (!visited_offset_instruction_set.insert(operand).second) {
       return;
     }
     // Recurse through offset expressions to find scalar leaves.

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
@@ -33,6 +33,7 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "xla/backends/gpu/transforms/dynamic_slice_fusion.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -89,8 +90,13 @@ struct SlicedResult {
 //===----------------------------------------------------------------------===//
 
 bool IsNoOp(const HloInstruction* instr) {
-  return instr->opcode() == HloOpcode::kBitcast ||
-         instr->opcode() == HloOpcode::kGetTupleElement;
+  return HloPredicateIsOp<HloOpcode::kBitcast, HloOpcode::kGetTupleElement>(
+      instr);
+}
+
+bool IsSlicingBoundary(const HloInstruction* instr) {
+  return HloPredicateIsOp<HloOpcode::kSlice, HloOpcode::kDynamicSlice,
+                          HloOpcode::kDynamicUpdateSlice>(instr);
 }
 
 bool HasDynamicSliceConfig(const HloInstruction* instr) {
@@ -379,24 +385,66 @@ std::vector<SlicedResult> ResolveSlicedResults(
 }
 
 //===----------------------------------------------------------------------===//
+// Resolve offset expressions
+//===----------------------------------------------------------------------===//
+
+// Follows `instr` operands to collect instructions that define dynamic (update)
+// slice offset expression: scalar operations computing integer offsets.
+void AddOffsetExpressionInstructions(
+    HloInstruction* instr, std::vector<HloInstruction*>& clone_instructions,
+    absl::flat_hash_set<HloInstruction*>& clone_instruction_set,
+    absl::flat_hash_set<HloInstruction*>& offset_instruction_set) {
+  if (HloPredicateIsOp<HloOpcode::kConstant, HloOpcode::kParameter>(instr) ||
+      IsSlicingBoundary(instr) || !DynamicSliceFusion::Offset::IsExpr(instr)) {
+    return;
+  }
+
+  if (clone_instruction_set.contains(instr)) {
+    return;
+  }
+
+  for (HloInstruction* operand : instr->operands()) {
+    AddOffsetExpressionInstructions(operand, clone_instructions,
+                                    clone_instruction_set,
+                                    offset_instruction_set);
+  }
+
+  if (clone_instruction_set.insert(instr).second) {
+    offset_instruction_set.insert(instr);
+    clone_instructions.push_back(instr);
+  }
+}
+
+void AddDynamicSliceOffsetExpressionInstructions(
+    HloInstruction* instr, int64_t first_offset_operand,
+    std::vector<HloInstruction*>& clone_instructions,
+    absl::flat_hash_set<HloInstruction*>& clone_instruction_set,
+    absl::flat_hash_set<HloInstruction*>& offset_instruction_set) {
+  for (int64_t i = first_offset_operand; i < instr->operand_count(); ++i) {
+    AddOffsetExpressionInstructions(instr->mutable_operand(i),
+                                    clone_instructions, clone_instruction_set,
+                                    offset_instruction_set);
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // Build fusion plan
 //===----------------------------------------------------------------------===//
 
 // Complete plan for creating a dynamic-slice fusion from a hero instruction.
 // Contains all instructions to include in the fusion body and the external
-// operands (captures).
+// operands to pass to the fusion.
 struct DynamicSliceFusionPlan {
-  // Operands of `instructions` that are not in the set — these become fusion
-  // parameters (e.g., the original buffers, loop induction variable,
-  // constants).
-  std::vector<HloInstruction*> captures;
+  // External operands needed by cloned instructions. These are operands not
+  // cloned into the fusion body, such as original buffers and scalar offset
+  // expression leaves.
+  std::vector<HloInstruction*> external_operands;
 
-  // All instructions to clone into the fusion body (topological order):
-  // slices, noops, hero, result noops, DUS instructions. The last instruction
-  // becomes the fusion root (may be a single DUS, or the hero itself when
-  // there are no DUS results). When there are multiple results,
-  // CreateFusionBody appends a tuple instruction as the root.
-  std::vector<HloInstruction*> instructions;
+  // All instructions to clone into the fusion body, in dependency order. This
+  // includes offset expression interiors, slices, noops, the hero, result
+  // noops, and DUS instructions. CreateFusionBody builds the final root from
+  // these cloned instructions.
+  std::vector<HloInstruction*> clone_instructions;
 };
 
 std::optional<DynamicSliceFusionPlan> BuildFusionPlan(
@@ -410,63 +458,111 @@ std::optional<DynamicSliceFusionPlan> BuildFusionPlan(
     return std::nullopt;
   }
 
-  std::vector<HloInstruction*> instructions;
-  absl::flat_hash_set<HloInstruction*> instruction_set;
+  // Instructions to clone into the fusion body, in dependency order.
+  std::vector<HloInstruction*> clone_instructions;
+  // Membership set for clone_instructions, used to avoid duplicate clones.
+  absl::flat_hash_set<HloInstruction*> clone_instruction_set;
+  // Subset of cloned instructions that are part of index offset expressions.
+  absl::flat_hash_set<HloInstruction*> offset_instruction_set;
 
-  auto add_instr = [&](HloInstruction* instr) {
-    if (instruction_set.insert(instr).second) {
-      instructions.push_back(instr);
+  // Instructions whose operands are scanned, in order, to discover external
+  // operands that become fusion parameters.
+  std::vector<HloInstruction*> external_operand_scan_roots;
+
+  auto add_clone_instruction = [&](HloInstruction* instr) {
+    if (clone_instruction_set.insert(instr).second) {
+      clone_instructions.push_back(instr);
     }
   };
 
   // Add sliced parameter paths (topological: slice → noops → hero).
-  for (const auto& param : sliced_params) {
-    add_instr(param.slice);
+  for (const SlicedParameter& param : sliced_params) {
+    if (param.slice->opcode() == HloOpcode::kDynamicSlice) {
+      AddDynamicSliceOffsetExpressionInstructions(
+          param.slice, 1, clone_instructions, clone_instruction_set,
+          offset_instruction_set);
+    }
+    add_clone_instruction(param.slice);
+    external_operand_scan_roots.push_back(param.slice);
     for (HloInstruction* noop : param.noops) {
-      add_instr(noop);
+      add_clone_instruction(noop);
+      external_operand_scan_roots.push_back(noop);
     }
   }
 
-  add_instr(hero);
+  add_clone_instruction(hero);
+  external_operand_scan_roots.push_back(hero);
 
   // Add sliced result paths (topological: hero → noops → DUS).
   // For passthrough results (no DUS), add the GTE chain so the hero output
   // is accessible inside the fusion.
   for (const auto& result : sliced_results) {
     for (HloInstruction* noop : result.noops) {
-      add_instr(noop);
+      add_clone_instruction(noop);
+      external_operand_scan_roots.push_back(noop);
     }
     if (result.update_slice != nullptr) {
-      add_instr(result.update_slice);
+      AddDynamicSliceOffsetExpressionInstructions(
+          result.update_slice, 2, clone_instructions, clone_instruction_set,
+          offset_instruction_set);
+      add_clone_instruction(result.update_slice);
+      external_operand_scan_roots.push_back(result.update_slice);
     }
   }
 
   // Sink constants into the fusion body instead of capturing them as
   // parameters. Constants have no operands so they go at the front.
   std::vector<HloInstruction*> constants;
-  for (HloInstruction* instr : instructions) {
+  for (HloInstruction* instr : clone_instructions) {
     for (HloInstruction* operand : instr->operands()) {
-      if (operand->opcode() == HloOpcode::kConstant &&
-          instruction_set.insert(operand).second) {
+      if (HloPredicateIsOp<HloOpcode::kConstant>(operand) &&
+          clone_instruction_set.insert(operand).second) {
         constants.push_back(operand);
       }
     }
   }
-  instructions.insert(instructions.begin(), constants.begin(), constants.end());
+  clone_instructions.insert(clone_instructions.begin(), constants.begin(),
+                            constants.end());
 
-  // Collect captures: operands of instructions that are not in the set.
-  std::vector<HloInstruction*> captures;
-  absl::flat_hash_set<HloInstruction*> capture_set;
-  for (HloInstruction* instr : instructions) {
-    for (HloInstruction* operand : instr->operands()) {
-      if (!instruction_set.contains(operand) &&
-          capture_set.insert(operand).second) {
-        captures.push_back(operand);
+  // Collect external operands by scanning cloned slice/hero/update path
+  // instructions in order. Recurse only through cloned offset expressions, so
+  // their scalar leaves become fusion parameters without disturbing the
+  // buffer-first parameter order.
+  std::vector<HloInstruction*> external_operands;
+  absl::flat_hash_set<HloInstruction*> external_operand_set;
+
+  auto collect_external_operand = [&](auto& self, HloInstruction* operand) {
+    // Constants have already been sunk into the fusion body.
+    if (HloPredicateIsOp<HloOpcode::kConstant>(operand)) {
+      return;
+    }
+    // Any non-cloned operand is external to the fusion body and must become a
+    // fusion parameter.
+    if (!clone_instruction_set.contains(operand)) {
+      if (external_operand_set.insert(operand).second) {
+        external_operands.push_back(operand);
       }
+      return;
+    }
+    // Only cloned offset expressions are transparent for this traversal; other
+    // cloned instructions are already represented inside the fusion body.
+    if (!offset_instruction_set.contains(operand)) {
+      return;
+    }
+    // Recurse through offset expressions to find scalar leaves.
+    for (HloInstruction* offset_operand : operand->operands()) {
+      self(self, offset_operand);
+    }
+  };
+
+  for (HloInstruction* instr : external_operand_scan_roots) {
+    for (HloInstruction* operand : instr->operands()) {
+      collect_external_operand(collect_external_operand, operand);
     }
   }
 
-  return DynamicSliceFusionPlan{std::move(captures), std::move(instructions)};
+  return DynamicSliceFusionPlan{std::move(external_operands),
+                                std::move(clone_instructions)};
 }
 
 //===----------------------------------------------------------------------===//
@@ -479,14 +575,15 @@ absl::StatusOr<HloComputation*> CreateFusionBody(
   HloComputation::Builder builder("dynamic-slice-fusion");
 
   absl::flat_hash_map<const HloInstruction*, HloInstruction*> instr_mapping;
-  instr_mapping.reserve(plan.captures.size() + plan.instructions.size());
+  instr_mapping.reserve(plan.external_operands.size() +
+                        plan.clone_instructions.size());
 
-  // Create parameters for captures.
-  for (const HloInstruction* capture : plan.captures) {
+  // Create fusion parameters for external operands.
+  for (const HloInstruction* operand : plan.external_operands) {
     int64_t index = instr_mapping.size();
-    instr_mapping[capture] =
+    instr_mapping[operand] =
         builder.AddInstruction(HloInstruction::CreateParameter(
-            index, capture->shape(), absl::StrCat("p", index)));
+            index, operand->shape(), absl::StrCat("p", index)));
   }
 
   auto mapped_operands = [&](HloInstruction* instr) {
@@ -499,7 +596,7 @@ absl::StatusOr<HloComputation*> CreateFusionBody(
   };
 
   // Clone instructions in topological order.
-  for (HloInstruction* instr : plan.instructions) {
+  for (HloInstruction* instr : plan.clone_instructions) {
     instr_mapping[instr] = builder.AddInstruction(
         instr->CloneWithNewOperands(instr->shape(), mapped_operands(instr)));
   }
@@ -556,9 +653,10 @@ absl::StatusOr<bool> RewriteHero(
                    CreateFusionBody(module, *plan, sliced_results, hero));
 
   HloComputation* parent = hero->parent();
-  HloInstruction* fusion = parent->AddInstruction(HloInstruction::CreateFusion(
-      fusion_body->root_instruction()->shape(),
-      HloInstruction::FusionKind::kCustom, plan->captures, fusion_body));
+  HloInstruction* fusion = parent->AddInstruction(
+      HloInstruction::CreateFusion(fusion_body->root_instruction()->shape(),
+                                   HloInstruction::FusionKind::kCustom,
+                                   plan->external_operands, fusion_body));
   module->SetAndUniquifyInstrName(fusion, "dynamic_slice_fusion");
   RETURN_IF_ERROR(SetDynamicSliceFusionBackendConfig(fusion));
 

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
@@ -1160,6 +1160,74 @@ TEST_F(DynamicSliceFusionRewriterV2Test,
 }
 
 TEST_F(DynamicSliceFusionRewriterV2Test,
+       RepeatedOffsetExpressionOperandClonedOnce) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      input = f32[8,8,8] parameter(0)
+      ivar = s32[] parameter(1)
+      c0 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      offset_base = s32[] add(ivar, c1)
+      offset = s32[] subtract(offset_base, offset_base)
+      ds = f32[1,8,8] dynamic-slice(input, offset, c0, c0),
+          dynamic_slice_sizes={1,8,8},
+          backend_config={"dynamic_slice_config":{"byte_offset":0,"byte_stride":0}}
+      bitcast = f32[8,8] bitcast(ds)
+      ROOT hero = f32[8,8] custom-call(bitcast),
+          custom_call_target="fake_target"
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       [[OFFSET_BASE:%[^ ]+]] = s32[] add(
+    ; CHECK:       [[OFFSET:%[^ ]+]] = s32[] subtract([[OFFSET_BASE]], [[OFFSET_BASE]])
+    ; CHECK:       {{.*}} dynamic-slice({{.*}}, [[OFFSET]],
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(%input, %ivar),
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_888 = ShapeUtil::MakeShape(F32, {8, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  auto offset_base = [] {
+    return Offset::Add(Offset::Parameter(1), Offset::Constant(1));
+  };
+  std::vector<Offset> offsets = {
+      {0, Offset::Subtract(offset_base(), offset_base())},
+      {1, Offset::Constant(0)},
+      {2, Offset::Constant(0)}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    const HloComputation* body = FindDsfBody(module);
+    ASSERT_NE(body, nullptr);
+    EXPECT_EQ(CountInstructionsWithOpcode(body, HloOpcode::kAdd), 1);
+    EXPECT_EQ(CountInstructionsWithOpcode(body, HloOpcode::kSubtract), 1);
+
+    auto* hero = DynamicSliceFusion::FindHero(body);
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_888, f32_188,
+                                          MakeStaticConfig(0), offsets}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test,
        DynamicUpdateSliceCapturesOffsetExpression) {
   const char* hlo = R"(
     HloModule test

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
@@ -22,16 +22,19 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "absl/algorithm/container.h"
 #include "absl/log/check.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "xla/backends/gpu/transforms/dynamic_slice_annotator.h"
 #include "xla/backends/gpu/transforms/dynamic_slice_fusion.h"
+#include "xla/comparison_util.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/hlo/pass/hlo_pass_pipeline.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/service/gpu/backend_configs.pb.h"
@@ -75,6 +78,14 @@ const HloComputation* FindDsfBody(HloModule* module) {
     }
   }
   return nullptr;
+}
+
+int64_t CountInstructionsWithOpcode(const HloComputation* computation,
+                                    HloOpcode opcode) {
+  return absl::c_count_if(computation->instructions(),
+                          [opcode](const HloInstruction* instr) {
+                            return instr->opcode() == opcode;
+                          });
 }
 
 class DynamicSliceFusionRewriterV2Test : public HloHardwareIndependentTestBase {
@@ -1032,7 +1043,8 @@ TEST_F(DynamicSliceFusionRewriterV2Test, OffsetAsLinearFunctionOfInductionVar) {
 
   const char* expected = R"(
     ; CHECK:     %dynamic-slice-fusion{{.*}} {
-    ; CHECK:       {{.*}} dynamic-slice(
+    ; CHECK:       [[OFFSET:%[^ ]+]] = s32[] multiply(
+    ; CHECK:       {{.*}} dynamic-slice({{.*}}, [[OFFSET]],
     ; CHECK:       {{.*}} bitcast(
     ; CHECK:       ROOT {{.*}} custom-call(
     ; CHECK:              custom_call_target="fake_target"
@@ -1045,13 +1057,14 @@ TEST_F(DynamicSliceFusionRewriterV2Test, OffsetAsLinearFunctionOfInductionVar) {
   )";
 
   // offset = ivar*2, byte stride dim0 = 256. stride = 2*256 = 512.
-  // Captures: input(p0), offset(p1). Constants sunk into fusion.
+  // Captures: input(p0), ivar(p1). Constants sunk into fusion.
   auto f32_888 = ShapeUtil::MakeShape(F32, {8, 8, 8});
   auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
   auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
-  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
-                                 {1, Offset::Constant(0)},
-                                 {2, Offset::Constant(0)}};
+  std::vector<Offset> offsets = {
+      {0, Offset::Multiply(Offset::Parameter(1), Offset::Constant(2))},
+      {1, Offset::Constant(0)},
+      {2, Offset::Constant(0)}};
 
   auto fusion_checks = [&](HloModule* module) {
     auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
@@ -1060,6 +1073,363 @@ TEST_F(DynamicSliceFusionRewriterV2Test, OffsetAsLinearFunctionOfInductionVar) {
                          DynamicSliceFusion::ResolveParameters(hero));
     EXPECT_THAT(params, ElementsAre(Param{0, f32_888, f32_188,
                                           MakeConfig(0, 0, 512), offsets}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test,
+       DynamicSliceCapturesSelectOffsetExpression) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      input = f32[8,8,8] parameter(0)
+      ivar = s32[] parameter(1)
+      c0_s32 = s32[] constant(0)
+      c1_s32 = s32[] constant(1)
+      c2_s32 = s32[] constant(2)
+      c7_s32 = s32[] constant(7)
+      inc = s32[] add(ivar, c1_s32)
+      is_lt = pred[] compare(inc, c2_s32), direction=LT
+      dec = s32[] subtract(c7_s32, ivar)
+      selected = s32[] select(is_lt, inc, dec)
+      ds = f32[1,8,8] dynamic-slice(input, selected, c0_s32, c0_s32),
+          dynamic_slice_sizes={1,8,8},
+          backend_config={"dynamic_slice_config":{"byte_offset":0,"byte_stride":0}}
+      bitcast = f32[8,8] bitcast(ds)
+      ROOT hero = f32[8,8] custom-call(bitcast),
+          custom_call_target="fake_target"
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       [[INC:%[^ ]+]] = s32[] add(
+    ; CHECK:       [[PRED:%[^ ]+]] = pred[] compare([[INC]],
+    ; CHECK-SAME:    direction=LT
+    ; CHECK:       [[DEC:%[^ ]+]] = s32[] subtract(
+    ; CHECK:       [[SELECT:%[^ ]+]] = s32[] select([[PRED]], [[INC]], [[DEC]])
+    ; CHECK:       {{.*}} dynamic-slice({{.*}}, [[SELECT]],
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(%input, %ivar),
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_888 = ShapeUtil::MakeShape(F32, {8, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  auto inc = [] {
+    return Offset::Add(Offset::Parameter(1), Offset::Constant(1));
+  };
+  std::vector<Offset> offsets = {
+      {0,
+       Offset::Select(
+           Offset::Compare(ComparisonDirection::kLt, inc(),
+                           Offset::Constant(2)),
+           inc(), Offset::Subtract(Offset::Constant(7), Offset::Parameter(1)))},
+      {1, Offset::Constant(0)},
+      {2, Offset::Constant(0)}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    const HloComputation* body = FindDsfBody(module);
+    ASSERT_NE(body, nullptr);
+    EXPECT_EQ(CountInstructionsWithOpcode(body, HloOpcode::kAdd), 1);
+    EXPECT_EQ(CountInstructionsWithOpcode(body, HloOpcode::kCompare), 1);
+    EXPECT_EQ(CountInstructionsWithOpcode(body, HloOpcode::kSubtract), 1);
+    EXPECT_EQ(CountInstructionsWithOpcode(body, HloOpcode::kSelect), 1);
+
+    auto* hero = DynamicSliceFusion::FindHero(body);
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_888, f32_188,
+                                          MakeStaticConfig(0), offsets}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test,
+       DynamicUpdateSliceCapturesOffsetExpression) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      input = f32[8,8] parameter(0)
+      output = f32[8,8,8] parameter(1)
+      ivar = s32[] parameter(2)
+      c0 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      hero = f32[8,8] custom-call(input),
+          custom_call_target="fake_target"
+      bitcast = f32[1,8,8] bitcast(hero)
+      offset = s32[] add(ivar, c1)
+      ROOT dus = f32[8,8,8] dynamic-update-slice(
+          output, bitcast, offset, c0, c0),
+          backend_config={"dynamic_slice_config":{"byte_offset":0,"byte_stride":0}}
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       [[OFFSET:%[^ ]+]] = s32[] add(
+    ; CHECK:       ROOT {{.*}} dynamic-update-slice({{.*}}, {{.*}}, [[OFFSET]],
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(%input, %output, %ivar),
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_888 = ShapeUtil::MakeShape(F32, {8, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<Offset> offsets = {
+      {0, Offset::Add(Offset::Parameter(2), Offset::Constant(1))},
+      {1, Offset::Constant(0)},
+      {2, Offset::Constant(0)}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    const HloComputation* body = FindDsfBody(module);
+    ASSERT_NE(body, nullptr);
+    EXPECT_EQ(CountInstructionsWithOpcode(body, HloOpcode::kAdd), 1);
+
+    auto* hero = DynamicSliceFusion::FindHero(body);
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_88, f32_88, std::nullopt,
+                                          std::nullopt}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{1, 0, f32_888, f32_188,
+                                            MakeStaticConfig(0), offsets}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test,
+       SharedOffsetExpressionClonedOnceForDSAndDUS) {
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      p0 = (s32[], f32[8,8,8], f32[8,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = f32[8,8,8] get-tuple-element(p0), index=1
+      output = f32[8,8,8] get-tuple-element(p0), index=2
+      c0 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      offset = s32[] add(ivar, c1)
+      ds = f32[1,8,8] dynamic-slice(input, offset, c0, c0),
+          dynamic_slice_sizes={1,8,8}
+      bitcast_in = f32[8,8] bitcast(ds)
+      hero = f32[8,8] custom-call(bitcast_in),
+          custom_call_target="fake_target"
+      bitcast_out = f32[1,8,8] bitcast(hero)
+      dus = f32[8,8,8] dynamic-update-slice(output, bitcast_out, offset, c0, c0)
+      ROOT result = (s32[], f32[8,8,8], f32[8,8,8]) tuple(offset, input, dus)
+    }
+
+    condition {
+      p0 = (s32[], f32[8,8,8], f32[8,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = f32[8,8,8] parameter(0)
+      output = f32[8,8,8] parameter(1)
+      c0 = s32[] constant(0)
+      tuple = (s32[], f32[8,8,8], f32[8,8,8]) tuple(c0, input, output)
+      ROOT while = (s32[], f32[8,8,8], f32[8,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       [[OFFSET:%[^ ]+]] = s32[] add(
+    ; CHECK:       {{.*}} dynamic-slice({{.*}}, [[OFFSET]],
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:       ROOT {{.*}} dynamic-update-slice({{.*}}, {{.*}}, [[OFFSET]],
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK:       {{.*}} fusion(
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_888 = ShapeUtil::MakeShape(F32, {8, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  std::vector<Offset> offsets = {
+      {0, Offset::Add(Offset::Parameter(1), Offset::Constant(1))},
+      {1, Offset::Constant(0)},
+      {2, Offset::Constant(0)}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    const HloComputation* body = FindDsfBody(module);
+    ASSERT_NE(body, nullptr);
+    EXPECT_EQ(CountInstructionsWithOpcode(body, HloOpcode::kAdd), 1);
+
+    auto* hero = DynamicSliceFusion::FindHero(body);
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_888, f32_188,
+                                          MakeConfig(0, 256, 256), offsets}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{2, 0, f32_888, f32_188,
+                                            MakeConfig(0, 256, 256), offsets}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test,
+       OffsetExpressionStopsAtNestedDynamicSlice) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      input = f32[8,8,8] parameter(0)
+      indices = s32[4] parameter(1)
+      c0 = s32[] constant(0)
+      c1 = s32[] constant(1)
+      index_slice = s32[1] dynamic-slice(indices, c0), dynamic_slice_sizes={1}
+      index_scalar = s32[] reshape(index_slice)
+      offset = s32[] add(index_scalar, c1)
+      ds = f32[1,8,8] dynamic-slice(input, offset, c0, c0),
+          dynamic_slice_sizes={1,8,8},
+          backend_config={"dynamic_slice_config":{"byte_offset":0,"byte_stride":0}}
+      bitcast = f32[8,8] bitcast(ds)
+      ROOT hero = f32[8,8] custom-call(bitcast),
+          custom_call_target="fake_target"
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       [[OFFSET:%[^ ]+]] = s32[] add(
+    ; CHECK:       {{.*}} dynamic-slice({{.*}}, [[OFFSET]],
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(%input, %index_scalar),
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_888 = ShapeUtil::MakeShape(F32, {8, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<Offset> offsets = {
+      {0, Offset::Add(Offset::Parameter(1), Offset::Constant(1))},
+      {1, Offset::Constant(0)},
+      {2, Offset::Constant(0)}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    const HloComputation* body = FindDsfBody(module);
+    ASSERT_NE(body, nullptr);
+    EXPECT_EQ(CountInstructionsWithOpcode(body, HloOpcode::kDynamicSlice), 1);
+    EXPECT_EQ(CountInstructionsWithOpcode(body, HloOpcode::kReshape), 0);
+    EXPECT_EQ(CountInstructionsWithOpcode(body, HloOpcode::kAdd), 1);
+
+    auto* hero = DynamicSliceFusion::FindHero(body);
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_888, f32_188,
+                                          MakeStaticConfig(0), offsets}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test,
+       UnsupportedOffsetRootIsCapturedAsParameter) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      input = f32[8,8,8] parameter(0)
+      ivar = s32[] parameter(1)
+      c0 = s32[] constant(0)
+      offset = s32[] maximum(ivar, c0)
+      ds = f32[1,8,8] dynamic-slice(input, offset, c0, c0),
+          dynamic_slice_sizes={1,8,8},
+          backend_config={"dynamic_slice_config":{"byte_offset":0,"byte_stride":0}}
+      bitcast = f32[8,8] bitcast(ds)
+      ROOT hero = f32[8,8] custom-call(bitcast),
+          custom_call_target="fake_target"
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} dynamic-slice(
+    ; CHECK:       ROOT {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(%input, %offset),
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_888 = ShapeUtil::MakeShape(F32, {8, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+  std::vector<Offset> offsets = {{0, Offset::Parameter(1)},
+                                 {1, Offset::Constant(0)},
+                                 {2, Offset::Constant(0)}};
+
+  auto fusion_checks = [&](HloModule* module) {
+    const HloComputation* body = FindDsfBody(module);
+    ASSERT_NE(body, nullptr);
+    EXPECT_EQ(CountInstructionsWithOpcode(body, HloOpcode::kMaximum), 0);
+
+    auto* hero = DynamicSliceFusion::FindHero(body);
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_888, f32_188,
+                                          MakeStaticConfig(0), offsets}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    EXPECT_THAT(results, ElementsAre(Result{std::nullopt, 0, f32_88, f32_88}));
   };
 
   RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_test.cc
@@ -855,6 +855,63 @@ TEST_F(DynamicSliceFusionTest, EvaluateOffsetExprMissingParameterFails) {
               ::testing::HasSubstr("Missing value for offset parameter 7"));
 }
 
+TEST_F(DynamicSliceFusionTest, OffsetIsExprChecksScalarIntegerOperations) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      p0 = s32[] parameter(0)
+      p1 = s64[] parameter(1)
+      pred_param = pred[] parameter(2)
+      float_param = f32[] parameter(3)
+      vector_param = s32[1] parameter(4)
+      c0 = s32[] constant(0)
+      c1 = s64[] constant(1)
+      pred_const = pred[] constant(true)
+      add = s32[] add(p0, c0)
+      multiply = s64[] multiply(p1, c1)
+      compare = pred[] compare(p0, c0), direction=LT
+      select = s32[] select(compare, p0, c0)
+      pred_select = pred[] select(pred_param, compare, pred_const)
+      convert = s64[] convert(p0)
+      bitcast = s32[] bitcast(p0)
+      scalar_reshape = s32[] reshape(vector_param)
+      vector_reshape = s32[1] reshape(p0)
+      maximum = s32[] maximum(p0, c0)
+      float_add = f32[] add(float_param, float_param)
+      ROOT root = (s32[], s64[], pred[], s32[], pred[], s64[], s32[],
+                   s32[], s32[1], s32[], f32[]) tuple(
+          add, multiply, compare, select, pred_select, convert,
+          bitcast, scalar_reshape, vector_reshape,
+          maximum, float_add)
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo));
+  HloComputation* c = module->entry_computation();
+
+  EXPECT_TRUE(Offset::IsExpr(c->GetInstructionWithName("p0")));
+  EXPECT_TRUE(Offset::IsExpr(c->GetInstructionWithName("p1")));
+  EXPECT_TRUE(Offset::IsExpr(c->GetInstructionWithName("pred_param")));
+  EXPECT_TRUE(Offset::IsExpr(c->GetInstructionWithName("c0")));
+  EXPECT_TRUE(Offset::IsExpr(c->GetInstructionWithName("c1")));
+  EXPECT_TRUE(Offset::IsExpr(c->GetInstructionWithName("pred_const")));
+  EXPECT_TRUE(Offset::IsExpr(c->GetInstructionWithName("add")));
+  EXPECT_TRUE(Offset::IsExpr(c->GetInstructionWithName("multiply")));
+  EXPECT_TRUE(Offset::IsExpr(c->GetInstructionWithName("compare")));
+  EXPECT_TRUE(Offset::IsExpr(c->GetInstructionWithName("select")));
+  EXPECT_TRUE(Offset::IsExpr(c->GetInstructionWithName("pred_select")));
+
+  EXPECT_FALSE(Offset::IsExpr(c->GetInstructionWithName("float_param")));
+  EXPECT_FALSE(Offset::IsExpr(c->GetInstructionWithName("vector_param")));
+  EXPECT_FALSE(Offset::IsExpr(c->GetInstructionWithName("convert")));
+  EXPECT_FALSE(Offset::IsExpr(c->GetInstructionWithName("bitcast")));
+  EXPECT_FALSE(Offset::IsExpr(c->GetInstructionWithName("scalar_reshape")));
+  EXPECT_FALSE(Offset::IsExpr(c->GetInstructionWithName("vector_reshape")));
+  EXPECT_FALSE(Offset::IsExpr(c->GetInstructionWithName("maximum")));
+  EXPECT_FALSE(Offset::IsExpr(c->GetInstructionWithName("float_add")));
+}
+
 TEST_F(DynamicSliceFusionTest, CollectOffsetParameters) {
   auto expr =
       Offset::Select(Offset::Parameter(2),


### PR DESCRIPTION
Adds offset-expression cloning to `DynamicSliceFusionRewriterV2`. The rewriter now clones supported scalar integer offset computations into the dynamic-slice fusion body instead of always capturing computed offsets as opaque fusion operands.

- Added `DynamicSliceFusion::Offset::IsExpr(const HloInstruction*)` as the shared predicate for offset expression compatibility.
- Updated V2 planning to clone offset expression interiors for dynamic-slice and dynamic-update-slice offsets.
- Keeps constants sunk into the fusion body and external scalar leaves as fusion parameters.
- Added tests covering DS/DUS offset cloning, select/compare offsets, shared offset expressions, unsupported offset roots, nested dynamic-slice boundaries, and `Offset::IsExpr` eligibility.

Leaving scalar offset computations outside of fusion body forces XLA to compile and launch tiny device kernels which is super wasteful.