### PR TITLE
[ROCm] Fix missing ROCm branches in GpuFloatSupport::IsSupported for BF16

### DIFF
--- a/xla/service/gpu/gpu_float_support.cc
+++ b/xla/service/gpu/gpu_float_support.cc
@@ -141,7 +141,13 @@ bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
     case HloOpcode::kExp:
     case HloOpcode::kLog:
       if (LowPrecisionType() == BF16) {
-        return compute_capability_.IsCuda();
+        if (compute_capability_.IsCuda()) {
+          return true;
+        }
+        if (auto* rocm_compute_capability =
+                compute_capability_.rocm_compute_capability()) {
+          return rocm_compute_capability->has_bf16_dtype_support();
+        }
       }
       return false;
     case HloOpcode::kAbs:
@@ -149,20 +155,28 @@ bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
     case HloOpcode::kMinimum:
     case HloOpcode::kNegate:
       if (LowPrecisionType() == BF16) {
-        auto* cuda_compute_capability =
-            compute_capability_.cuda_compute_capability();
-        return cuda_compute_capability != nullptr &&
-               cuda_compute_capability->IsAtLeastAmpere();
+        if (auto* cuda_compute_capability =
+                compute_capability_.cuda_compute_capability()) {
+          return cuda_compute_capability->IsAtLeastAmpere();
+        }
+        if (auto* rocm_compute_capability =
+                compute_capability_.rocm_compute_capability()) {
+          return rocm_compute_capability->has_bf16_dtype_support();
+        }
       }
       return false;
     case HloOpcode::kAdd:
     case HloOpcode::kMultiply:
     case HloOpcode::kSubtract: {
       if (LowPrecisionType() == BF16) {
-        auto* cuda_compute_capability =
-            compute_capability_.cuda_compute_capability();
-        return cuda_compute_capability != nullptr &&
-               cuda_compute_capability->IsAtLeastHopper();
+        if (auto* cuda_compute_capability =
+                compute_capability_.cuda_compute_capability()) {
+          return cuda_compute_capability->IsAtLeastHopper();
+        }
+        if (auto* rocm_compute_capability =
+                compute_capability_.rocm_compute_capability()) {
+          return rocm_compute_capability->has_packed_bf16_atomics_support();
+        }
       }
       return false;
     }

--- a/xla/service/gpu/gpu_float_support_test.cc
+++ b/xla/service/gpu/gpu_float_support_test.cc
@@ -633,6 +633,7 @@ ENTRY main {
 }
 
 TEST_F(FloatSupportTest, BF16LogAndExpOnRocmIsNormalized) {
+  // Default/unknown ROCm arch has no bf16 dtype support → normalize.
   auto cc = se::RocmComputeCapability();
   constexpr absl::string_view kHloModule = R"(
 HloModule module
@@ -653,6 +654,110 @@ ENTRY main {
                               absl::Substitute(kHloModule, "exponential")));
   EXPECT_TRUE(
       Normalize(module_exp.get(), se::GpuComputeCapability{cc}, BF16, F32));
+}
+
+TEST_F(FloatSupportTest, BF16LogAndExpOnRocmMI300IsNotNormalized) {
+  // MI300 (gfx942) has bf16 dtype support → no normalization needed.
+  auto cc = se::RocmComputeCapability("gfx942");
+  constexpr absl::string_view kHloModule = R"(
+HloModule module
+
+ENTRY main {
+      p0 = bf16[4] parameter(0)
+      ROOT r = bf16[4] $0(p0)
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module_log,
+      ParseAndReturnVerifiedModule(absl::Substitute(kHloModule, "log")));
+  EXPECT_FALSE(
+      Normalize(module_log.get(), se::GpuComputeCapability{cc}, BF16, F32));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module_exp,
+                          ParseAndReturnVerifiedModule(
+                              absl::Substitute(kHloModule, "exponential")));
+  EXPECT_FALSE(
+      Normalize(module_exp.get(), se::GpuComputeCapability{cc}, BF16, F32));
+}
+
+class Bf16UnaryOpRocmTest : public FloatSupportTest,
+                            public ::testing::WithParamInterface<HloOpcode> {};
+
+TEST_P(Bf16UnaryOpRocmTest, IsNotNormalizedOnMI300) {
+  // MI300 (gfx942) has bf16 dtype support → kAbs/kNegate should not normalize.
+  auto cc = se::RocmComputeCapability("gfx942");
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(
+                              absl::Substitute(R"(
+entry {
+  a = bf16[] parameter(0)
+  r = bf16[] $0(a)
+})",
+                                               HloOpcodeString(GetParam()))));
+  EXPECT_FALSE(
+      Normalize(module.get(), se::GpuComputeCapability{cc}, BF16, F32));
+}
+
+INSTANTIATE_TEST_SUITE_P(Bf16UnaryOpsRocm, Bf16UnaryOpRocmTest,
+                         ::testing::Values(HloOpcode::kNegate,
+                                           HloOpcode::kAbs));
+
+TEST_F(FloatSupportTest, Bf16MinMaxOnRocmMI300IsNotNormalized) {
+  // MI300 (gfx942) has bf16 dtype support → kMinimum/kMaximum should not
+  // normalize.
+  auto cc = se::RocmComputeCapability("gfx942");
+  constexpr absl::string_view kHloModule = R"(
+HloModule m
+
+ENTRY main {
+  p0 = bf16[] parameter(0)
+  p1 = bf16[] parameter(1)
+  ROOT r = bf16[] $0(p0, p1)
+})";
+
+  for (const char* op : {"minimum", "maximum"}) {
+    TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(
+                                             absl::Substitute(kHloModule, op)));
+    EXPECT_FALSE(
+        Normalize(module.get(), se::GpuComputeCapability{cc}, BF16, F32))
+        << "Expected no normalization for bf16 " << op << " on gfx942";
+  }
+}
+
+TEST_F(FloatSupportTest, BF16AddOnRocmMI300IsNotNormalized) {
+  // MI300 (gfx942) has packed bf16 atomics → kAdd should not normalize, so the
+  // scatter reducer stays as a 2-op bf16 body and gets a direct atomic.
+  auto cc = se::RocmComputeCapability("gfx942");
+  constexpr absl::string_view kHloModule = R"(
+HloModule m
+
+ENTRY main {
+  p0 = bf16[] parameter(0)
+  p1 = bf16[] parameter(1)
+  ROOT r = bf16[] add(p0, p1)
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kHloModule));
+  EXPECT_FALSE(
+      Normalize(module.get(), se::GpuComputeCapability{cc}, BF16, F32));
+}
+
+TEST_F(FloatSupportTest, BF16AddOnRocmMI200IsNormalized) {
+  // MI200 (gfx90a) lacks packed bf16 atomics → kAdd normalizes to f32.
+  auto cc = se::RocmComputeCapability("gfx90a");
+  constexpr absl::string_view kHloModule = R"(
+HloModule m
+
+ENTRY main {
+  p0 = bf16[] parameter(0)
+  p1 = bf16[] parameter(1)
+  ROOT r = bf16[] add(p0, p1)
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(kHloModule));
+  EXPECT_TRUE(Normalize(module.get(), se::GpuComputeCapability{cc}, BF16, F32));
 }
 
 TEST_F(FloatSupportTest, ScaledDotIsIgnored) {


### PR DESCRIPTION
## Problem

`GpuFloatSupport::IsSupported` had CUDA-only capability checks for several BF16 elementwise opcodes. On ROCm these always returned `false`, causing unnecessarily promote BF16 ops to F32 even on hardware that supports them natively.

All three bugs follow the same pattern: a CUDA capability check with no corresponding ROCm branch, so the function falls through to `return false`.

## Fixes

### `kAdd` / `kMultiply` / `kSubtract` + BF16

**Before:** `cuda_compute_capability->IsAtLeastHopper()` with no ROCm branch.

**Impact:** The scatter reducer body grew from 2 to 6 ops, causing `GetAtomicModifierParameters` to return `nullopt` and falling back to a 32-bit CAS spin-loop instead of `global_atomic_pk_add_bf16`. This produced a **30–66× slowdown** in `jax.ops.segment_sum` with BF16 on MI300+ hardware.

**Fix:** Return `rocm_compute_capability->has_packed_bf16_atomics_support()` (true on gfx942 / MI300, gfx950 / MI350, gfx12).

### `kExp` / `kLog` + BF16

**Before:** `compute_capability_.IsCuda()` with no ROCm branch.

**Impact:** BF16 exp/log always promoted to F32 on ROCm.

**Fix:** Return `rocm_compute_capability->has_bf16_dtype_support()` (true on MI100+, gfx11, gfx12).

### `kAbs` / `kMaximum` / `kMinimum` / `kNegate` + BF16

**Before:** `cuda_compute_capability->IsAtLeastAmpere()` with no ROCm branch.

**Impact:** BF16 elementwise unary/binary ops always promoted to F32 on ROCm.

**Fix:** Return `rocm_compute_capability->has_bf16_dtype_support()` (true on MI100+, gfx11, gfx12).

## Tests

New tests added in `gpu_float_support_test.cc`:

| Test | What it checks |
|---|---|
| `BF16LogAndExpOnRocmMI300IsNotNormalized` | gfx942: exp/log must not normalize |
| `Bf16UnaryOpRocmTest/IsNotNormalizedOnMI300` | gfx942: kNegate/kAbs must not normalize |
| `Bf16MinMaxOnRocmMI300IsNotNormalized` | gfx942: kMinimum/kMaximum must not normalize |
| `BF16AddOnRocmMI300IsNotNormalized` | gfx942: kAdd must not normalize (scatter fix) |
| `BF16AddOnRocmMI200IsNormalized` | gfx90a: kAdd correctly still normalizes (MI200 lacks packed BF16 atomics) |

The existing `BF16LogAndExpOnRocmIsNormalized` test (default/unknown ROCm arch) continues to pass, confirming no regression for pre-MI100 devices.