### PR TITLE
[XLA:GPU][codegen] Detect runner backend for GPU PjRT codegen tests

### DIFF
--- a/xla/backends/gpu/tests/BUILD
+++ b/xla/backends/gpu/tests/BUILD
@@ -76,6 +76,7 @@ cc_library(
         "//xla/service:gpu_plugin",
         "//xla/service:gpu_topology",
         "//xla/service:hlo_module_config",
+        "//xla/service:hlo_runner_interface",
         "//xla/service:llvm_compiler",
         "//xla/service/gpu:gpu_compiler",
         "//xla/tests:codegen_utils",
@@ -84,6 +85,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest_for_library",
     ],
 )

--- a/xla/backends/gpu/tests/gpu_atomic_test.cc
+++ b/xla/backends/gpu/tests/gpu_atomic_test.cc
@@ -101,10 +101,10 @@ TEST_F(GpuAtomicTest, TestAddAtomicF32) {
     }
 )";
 
-  TF_ASSERT_OK(CompileAndVerifyIr(hlo_string, is_built_with_rocm_ ? R"(
+  TF_ASSERT_OK(CompileAndVerifyIr(hlo_string, IsBuiltWithRocm() ? R"(
 CHECK: atomicrmw fadd ptr %[[ADDR:.*]], float %[[VALUE:.*]] syncscope("agent-one-as") monotonic
 )"
-                                                                  : R"(
+                                                                : R"(
 CHECK: atomicrmw fadd ptr %[[ADDR:.*]], float %[[VALUE:.*]] monotonic
 )"));
 }

--- a/xla/backends/gpu/tests/gpu_noalias_test.cc
+++ b/xla/backends/gpu/tests/gpu_noalias_test.cc
@@ -56,7 +56,7 @@ TEST_F(GpuNoAliasTest, Concat) {
   // - We only pass the same parameters once, so the kernel will have these
   // parameters: (x, y, output), and all of them will be noalias.
   const char* expected_ir;
-  if (is_built_with_rocm_) {
+  if (IsBuiltWithRocm()) {
     expected_ir = R"(
 CHECK: define amdgpu_kernel void @{{[a-zA-Z0-9_]+}}(ptr noalias align 16 dereferenceable(16) %{{[a-zA-Z0-9_]+}}, ptr noalias align 16 dereferenceable(16) %{{[a-zA-Z0-9_]+}}, ptr noalias align 256 dereferenceable(48) %{{[a-zA-Z0-9_]+}}) #0
   )";

--- a/xla/backends/gpu/tests/gpu_pjrt_codegen_test.cc
+++ b/xla/backends/gpu/tests/gpu_pjrt_codegen_test.cc
@@ -62,9 +62,7 @@ void GpuPjRtCodegenTest::CompileAndOptionallyVerifyPtx(
   CHECK_NOTNULL(gpu_compiler);
 
   std::string ptx_str;
-  gpu_compiler->SetAsmHook([&](absl::string_view ptx) {
-    ptx_str += ptx;
-  });
+  gpu_compiler->SetAsmHook([&](absl::string_view ptx) { ptx_str += ptx; });
 
   auto status_or_executable =
       CompileToExecutable(std::move(hlo_module), run_optimization_passes);
@@ -73,10 +71,10 @@ void GpuPjRtCodegenTest::CompileAndOptionallyVerifyPtx(
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<Executable> executable,
                        std::move(status_or_executable));
 
-  // On the ROCM platform the "ptx" string is not populated for the compiled
-  // executable, and hence the "ptx_str" will be empty. So disabling the
-  // pattern check on the ROCm platform
-  if (!is_built_with_rocm_) {
+  // On ROCM and oneAPI platforms the "ptx" string is not populated for the
+  // compiled executable, and hence the "ptx_str" will be empty. So disabling
+  // the pattern check on ROCm and oneAPI platforms
+  if (!IsBuiltWithRocm() && !IsBuiltWithOneAPI()) {
     absl::StatusOr<bool> filecheck_result = RunFileCheck(ptx_str, pattern);
     ASSERT_TRUE(filecheck_result.ok());
     EXPECT_TRUE(filecheck_result.value());
@@ -88,23 +86,23 @@ std::string GpuPjRtCodegenTest::MakePlatformSpecificLlvm(
   return absl::StrReplaceAll(
       input,
       {{"KERNEL_ANNOTATION",
-        is_built_with_rocm_ ? "amdgpu_kernel void" : "ptx_kernel void"},
-       {"BARRIER()", is_built_with_rocm_
+        IsBuiltWithRocm() ? "amdgpu_kernel void" : "ptx_kernel void"},
+       {"BARRIER()", IsBuiltWithRocm()
                          ? "@llvm.amdgcn.s.barrier()"
                          : "@llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)"},
-       {"SHUFFLE", is_built_with_rocm_ ? "i32 @llvm.amdgcn.ds.swizzle"
-                                       : "float @llvm.nvvm.shfl.sync.down.f32"},
-       {"TIDX", is_built_with_rocm_ ? "@llvm.amdgcn.workitem.id.x"
-                                    : "@llvm.nvvm.read.ptx.sreg.tid.x"},
-       {"LCAL", is_built_with_rocm_ ? "%[[LOGICAL_T1:.*]] = call { i1, i64 } "
-                                      "@llvm.amdgcn.if.i64(i1 %[[LOGICAL_T0]])"
-                                    : "0"},
+       {"SHUFFLE", IsBuiltWithRocm() ? "i32 @llvm.amdgcn.ds.swizzle"
+                                     : "float @llvm.nvvm.shfl.sync.down.f32"},
+       {"TIDX", IsBuiltWithRocm() ? "@llvm.amdgcn.workitem.id.x"
+                                  : "@llvm.nvvm.read.ptx.sreg.tid.x"},
+       {"LCAL", IsBuiltWithRocm() ? "%[[LOGICAL_T1:.*]] = call { i1, i64 } "
+                                    "@llvm.amdgcn.if.i64(i1 %[[LOGICAL_T0]])"
+                                  : "0"},
        {"EXTV",
-        is_built_with_rocm_
+        IsBuiltWithRocm()
             ? "%[[LOGICAL_T2:.*]] = extractvalue { i1, i64 } %[[LOGICAL_T1]], 0"
             : "0"},
-       {"BR_CAL", is_built_with_rocm_ ? "br i1 %[[LOGICAL_T2]],"
-                                      : "br i1 %[[LOGICAL_T0]]"}});
+       {"BR_CAL", IsBuiltWithRocm() ? "br i1 %[[LOGICAL_T2]],"
+                                    : "br i1 %[[LOGICAL_T0]]"}});
 }
 
 absl::StatusOr<std::unique_ptr<Executable>>

--- a/xla/backends/gpu/tests/gpu_pjrt_codegen_test.h
+++ b/xla/backends/gpu/tests/gpu_pjrt_codegen_test.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include "xla/service/compiler.h"
 #include "xla/service/executable.h"
 #include "xla/service/gpu_topology.h"
+#include "xla/service/hlo_runner_interface.h"
 
 namespace xla::gpu {
 
@@ -35,8 +36,14 @@ namespace xla::gpu {
 class GpuPjRtCodegenTest : public HloPjRtGpuTestBase {
  public:
   GpuPjRtCodegenTest() {
-    is_built_with_rocm_ =
-        device_description().gpu_compute_capability().IsRocm();
+    for (auto tag : {HloRunnerPropertyTag::kUsingGpuCuda,
+                     HloRunnerPropertyTag::kUsingGpuOneAPI,
+                     HloRunnerPropertyTag::kUsingGpuRocm}) {
+      if (test_runner().HasProperty(tag)) {
+        runner_type_ = tag;
+        break;
+      }
+    }
     compile_options_.gpu_topology = GetSingleDeviceGpuTopology(
         /*platform_version=*/"", gpu_target_config());
     compile_options_.early_exit_with_layouts = false;
@@ -77,10 +84,17 @@ class GpuPjRtCodegenTest : public HloPjRtGpuTestBase {
                                   bool match_optimized_ir = false,
                                   bool run_optimization_passes = true);
 
-  bool is_built_with_rocm_{false};
+  bool IsBuiltWithRocm() {
+    return runner_type_ == HloRunnerPropertyTag::kUsingGpuRocm;
+  }
+
+  bool IsBuiltWithOneAPI() {
+    return runner_type_ == HloRunnerPropertyTag::kUsingGpuOneAPI;
+  }
 
  private:
   Compiler::CompileOptions compile_options_;
+  HloRunnerPropertyTag::Type runner_type_{0};
 };
 
 }  // namespace xla::gpu


### PR DESCRIPTION
This PR refactors the GPU test backend detection and includes checks for oneAPI. It also skips PTX checks on oneAPI backend.
