### PR TITLE
[XLA:GPU] ROCm VMM Layer 1/4: RocmRawMemoryAllocation (hipMemCreate/hipMemRelease RAII)

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -1400,11 +1400,10 @@ cc_library(
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:memory_allocation",
         "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status:statusor",
         "@local_config_rocm//rocm:rocm_headers",
-        "@tsl//tsl/platform:errors",
-        "@tsl//tsl/platform:statusor",
     ],
 )
 

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -1383,3 +1383,51 @@ rocm_library(
     ],
     alwayslink = 1,
 )
+
+cc_library(
+    name = "rocm_raw_memory_allocation",
+    srcs = ["rocm_raw_memory_allocation.cc"],
+    hdrs = ["rocm_raw_memory_allocation.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        ":rocm_status",
+        "//xla:util",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_raw_memory_allocation_test",
+    srcs = ["rocm_raw_memory_allocation_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_platform",
+        ":rocm_platform_id",
+        ":rocm_raw_memory_allocation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test",
+    ],
+)

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation.cc
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation.cc
@@ -26,9 +26,8 @@ limitations under the License.
 #include "rocm/include/hip/hip_runtime.h"
 #include "xla/stream_executor/rocm/rocm_status.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
-#include "tsl/platform/errors.h"
-#include "tsl/platform/statusor.h"
 
 namespace stream_executor::gpu {
 
@@ -37,7 +36,7 @@ RocmRawMemoryAllocation::Create(StreamExecutor* executor, uint64_t size) {
   std::unique_ptr<ActivateContext> activation = executor->Activate();
 
   hipDevice_t device;
-  TF_RETURN_IF_ERROR(
+  RETURN_IF_ERROR(
       ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
 
   hipMemAllocationProp props = {};
@@ -47,13 +46,13 @@ RocmRawMemoryAllocation::Create(StreamExecutor* executor, uint64_t size) {
   props.requestedHandleTypes = hipMemHandleTypeNone;
 
   size_t granularity = 0;
-  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+  RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
       &granularity, &props, hipMemAllocationGranularityRecommended)));
 
   uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
 
   hipMemGenericAllocationHandle_t handle;
-  TF_RETURN_IF_ERROR(
+  RETURN_IF_ERROR(
       ToStatus(hipMemCreate(&handle, padded_size, &props, 0ULL)));
 
   return std::unique_ptr<RocmRawMemoryAllocation>(

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation.cc
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation.cc
@@ -1,0 +1,87 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/log/log.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/device_address.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+
+absl::StatusOr<std::unique_ptr<RocmRawMemoryAllocation>>
+RocmRawMemoryAllocation::Create(StreamExecutor* executor, uint64_t size) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  hipDevice_t device;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
+
+  hipMemAllocationProp props = {};
+  props.type = hipMemAllocationTypePinned;
+  props.location.type = hipMemLocationTypeDevice;
+  props.location.id = device;
+  props.requestedHandleTypes = hipMemHandleTypeNone;
+
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+      &granularity, &props, hipMemAllocationGranularityRecommended)));
+
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
+
+  hipMemGenericAllocationHandle_t handle;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipMemCreate(&handle, padded_size, &props, 0ULL)));
+
+  return std::unique_ptr<RocmRawMemoryAllocation>(
+      new RocmRawMemoryAllocation(executor, handle, padded_size));
+}
+
+RocmRawMemoryAllocation::RocmRawMemoryAllocation(
+    StreamExecutor* executor, hipMemGenericAllocationHandle_t handle,
+    uint64_t size)
+    : executor_(executor), handle_(handle), size_(size) {}
+
+DeviceAddressBase RocmRawMemoryAllocation::address() const {
+  // handle_ is an opaque allocation handle, not a device pointer. We expose it
+  // as a DeviceAddressBase so the base class can use opaque() for identity
+  // tracking; callers never dereference this address.
+  return DeviceAddressBase(static_cast<void*>(handle_), size_);
+}
+
+RocmRawMemoryAllocation::~RocmRawMemoryAllocation() {
+  if (handle_ == nullptr) {
+    return;
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  auto status =
+      ToStatus(hipMemRelease(handle_), "Error releasing ROCm memory");
+  if (!status.ok()) {
+    LOG(ERROR) << status.message();
+  }
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation.h
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation.h
@@ -1,0 +1,65 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_RAW_MEMORY_ALLOCATION_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_RAW_MEMORY_ALLOCATION_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// RAII wrapper for a physical memory allocation created via hipMemCreate.
+// The handle is not mapped to any virtual address; this class only manages
+// the lifetime of the hipMemGenericAllocationHandle_t.
+class RocmRawMemoryAllocation : public MemoryAllocation {
+ public:
+  // Creates a physical memory allocation of at least `size` bytes using
+  // hipMemCreate. StreamExecutor is used only for context activation.
+  static absl::StatusOr<std::unique_ptr<RocmRawMemoryAllocation>> Create(
+      StreamExecutor* executor, uint64_t size);
+
+  // Returns a DeviceAddressBase whose opaque() holds the raw
+  // hipMemGenericAllocationHandle_t cast to void*, and size() is the
+  // padded allocation size.
+  DeviceAddressBase address() const override;
+
+  hipMemGenericAllocationHandle_t GetHandle() const { return handle_; }
+
+  ~RocmRawMemoryAllocation() override;
+  RocmRawMemoryAllocation(const RocmRawMemoryAllocation&) = delete;
+  RocmRawMemoryAllocation& operator=(const RocmRawMemoryAllocation&) = delete;
+  RocmRawMemoryAllocation(RocmRawMemoryAllocation&&) = delete;
+  RocmRawMemoryAllocation& operator=(RocmRawMemoryAllocation&&) = delete;
+
+ private:
+  explicit RocmRawMemoryAllocation(StreamExecutor* executor,
+                                   hipMemGenericAllocationHandle_t handle,
+                                   uint64_t size);
+
+  StreamExecutor* executor_;
+  hipMemGenericAllocationHandle_t handle_;
+  uint64_t size_;
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_RAW_MEMORY_ALLOCATION_H_

--- a/xla/stream_executor/rocm/rocm_raw_memory_allocation_test.cc
+++ b/xla/stream_executor/rocm/rocm_raw_memory_allocation_test.cc
@@ -1,0 +1,80 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+
+#include <cstdint>
+#include <memory>
+
+#include <gtest/gtest.h>
+#include "absl/status/status_matchers.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/test.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+using absl_testing::IsOk;
+
+static constexpr uint64_t kTestSize = 1024 * 1024;
+
+class RocmRawMemoryAllocationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    auto executor_or = platform_or.value()->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+  }
+
+  StreamExecutor* executor_ = nullptr;
+};
+
+TEST_F(RocmRawMemoryAllocationTest, CreateAllocation) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+
+  EXPECT_NE(alloc->GetHandle(), nullptr);
+  EXPECT_GE(alloc->address().size(), kTestSize);
+}
+
+TEST_F(RocmRawMemoryAllocationTest, AddressReflectsHandle) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+
+  EXPECT_EQ(alloc->address().opaque(),
+            static_cast<void*>(alloc->GetHandle()));
+  EXPECT_GE(alloc->address().size(), kTestSize);
+}
+
+TEST_F(RocmRawMemoryAllocationTest, SizeIsAtLeastRequested) {
+  TF_ASSERT_OK_AND_ASSIGN(auto alloc,
+                          RocmRawMemoryAllocation::Create(executor_, 1));
+
+  EXPECT_NE(alloc->GetHandle(), nullptr);
+  EXPECT_GE(alloc->address().size(), 1u);
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu


### PR DESCRIPTION
# [XLA:GPU] ROCm VMM PR 1/4: `RocmRawMemoryAllocation` (hipMemCreate/hipMemRelease RAII)

## Overview — VMM allocator for ROCm/HIP

This is the first of a series of PRs that bring the **VMM (Virtual Memory
Management) allocator** to ROCm/HIP, enabling stable virtual-address allocations on
AMD GPUs (the foundation for cheap command-buffer replay of collectives via
`NEVER_UPDATE` VA-remapping). It ports the existing CUDA VMM design to HIP
(`hipMemCreate`, `hipMemAddressReserve`, `hipMemMap`, `hipMemSetAccess`,
`hipStreamWriteValue64`), replacing the all-or-nothing `hipDeviceMallocFinegrained`
approach that grants every GPU access and disables L2 cache.

The allocator is intentionally split into **4 small, stacked PRs** so each can be
reviewed in isolation (originally proposed as one large PR, #40236, now broken up per
review feedback):

- **PR 1/4 — `RocmRawMemoryAllocation`** (this PR, #43942): physical allocation, `hipMemCreate`/`hipMemRelease`.
- **PR 2/4 — `RocmMemoryReservation`** (#43943): VA reserve / map / setAccess / unmap.
- **PR 3/4 — `RocmVmmAllocator`** (#43946): all-in-one allocator (create + reserve + map + setAccess).
- **PR 4/4 — `RocmDeviceAddressVmmAllocator` + vendor-neutral factory** (#43947): timeline-based
  deferred deallocation, and PJRT enablement so `allocator=vmm` works on ROCm.

> _Update the PR numbers above if they differ._

Each PR builds only on the one below it, so the stack lands bottom-up.

---

## This PR (PR 1/4): `RocmRawMemoryAllocation`

A small RAII wrapper that owns a single **physical** memory handle created with
`hipMemCreate` and released with `hipMemRelease`. It allocates physical memory only and
is **not mapped to any virtual address** — that is PR 2/4's job. This is the lowest-level
building block; it has no callers yet, so it changes no existing behavior.

### Files
- `xla/stream_executor/rocm/rocm_raw_memory_allocation.{h,cc}` — the RAII wrapper.
- `xla/stream_executor/rocm/rocm_raw_memory_allocation_test.cc` — unit tests.
- `xla/stream_executor/rocm/BUILD` — new `cc_library` + `xla_test` targets.

~280 lines, 4 files, all additions.

### Design
`RocmRawMemoryAllocation` derives from `stream_executor::MemoryAllocation` and manages
the lifetime of one `hipMemGenericAllocationHandle_t`:

- **`Create(StreamExecutor* executor, uint64_t size)`** — activates the executor context,
  builds a `hipMemAllocationProp` for pinned device memory on the executor's device,
  queries `hipMemGetAllocationGranularity(..., Recommended)` and rounds the request up to
  that granularity (`xla::RoundUpTo`), then calls `hipMemCreate`.
- **`address()`** — exposes the handle as a `DeviceAddressBase` whose `opaque()` carries the
  `hipMemGenericAllocationHandle_t` (for identity tracking only — **not** a dereferenceable
  device pointer) and `size()` is the padded allocation size.
- **Destructor** — calls `hipMemRelease` (guarded against a null handle), logging on error.
- Non-copyable, non-movable.

This mirrors the CUDA VMM structure so the ROCm and CUDA backends stay symmetric.

**ROCm/HIP specifics:** `hipMemGenericAllocationHandle_t` is a pointer type (cast to
`void*` for `opaque()`); calls the HIP runtime directly (no `wrap::` driver shim, which
upstream removed).

---

## Testing & performance

**This PR's unit tests** — `rocm_raw_memory_allocation_test` (3 tests), AMD Instinct
MI300X (gfx942), ROCm 7.2.0:
- `CreateAllocation` — `Create` succeeds, handle is non-null.
- `AddressReflectsHandle` — `address().opaque()` matches the underlying handle.
- `SizeIsAtLeastRequested` — padded size `>=` requested size (granularity rounding).

**Feature-level performance (motivation; realized once all 4 PRs + the remap enablement
land).** Pure VMM, llama2_7b, 8 layers, 30 steps, 8× MI300X, FSDP=8, identical loss
(10.877 → 0.003):

| config | per-step |
|---|---|
| collectives in command buffer, **no VMM** (re-trace every step) | ~25.6 s |
| collectives in command buffer, **VMM `NEVER_UPDATE`** | ~0.13 s |

≈ **190× faster** steady-state, by remapping only the physical buffers that change each
step instead of re-tracing the command buffer. (This PR alone is a leaf and does not
change runtime behavior; the number is the end goal the stack delivers.)

---

## Next PR
**PR 2/4 — `RocmMemoryReservation` (#43943):** RAII wrapper around virtual-address
reservation and mapping (`hipMemAddressReserve` / `hipMemMap` / `hipMemSetAccess` /
`hipMemUnmap`), which maps the physical handle from this PR to a virtual address.
