### PR TITLE
[XLA:GPU] ROCm VMM Layer 2/4: RocmMemoryReservation (address-reserve/map/unmap RAII)

### DIFF
--- a/xla/stream_executor/memory_reservation.cc
+++ b/xla/stream_executor/memory_reservation.cc
@@ -149,20 +149,10 @@ absl::StatusOr<MemoryReservation::ScopedMapping> MemoryReservation::MapTo(
 
 // ScopedMapping::Remap
 
-absl::StatusOr<MemoryReservation::ScopedMapping>
-MemoryReservation::ScopedMapping::Remap(
-    absl::Span<const MemoryReservation::RemappingDescriptor> mappings) && {
-  if (reservation_ == nullptr) {
-    return absl::FailedPreconditionError("Remap: mapping is empty");
-  }
-  if (mappings.empty()) {
-    return absl::InvalidArgumentError("Remap: mappings must not be empty");
-  }
-
-  MemoryReservation* reservation = reservation_;
-  const size_t existing_reservation_offset = reservation_offset_;
-  const size_t existing_size = size_;
-
+absl::StatusOr<size_t>
+MemoryReservation::ScopedMapping::ValidateRemapDescriptors(
+    absl::Span<const MemoryReservation::RemappingDescriptor> mappings,
+    size_t existing_reservation_offset, size_t existing_size) {
   const size_t start_offset = mappings[0].reservation_offset;
   size_t expected_offset = start_offset;
   for (const MemoryReservation::RemappingDescriptor& desc : mappings) {
@@ -187,6 +177,79 @@ MemoryReservation::ScopedMapping::Remap(
         existing_reservation_offset + existing_size, start_offset,
         start_offset + total_size));
   }
+  return total_size;
+}
+
+absl::StatusOr<int> MemoryReservation::ScopedMapping::UnmapChangedRuns(
+    MemoryReservation* reservation,
+    absl::Span<const MemoryReservation::RemappingDescriptor> mappings,
+    std::vector<bool>& slice_mapped) {
+  // Unmap the slices whose backing physical handle changed, coalescing
+  // contiguous runs into a single UnMap. A single hipMemUnmap can release a
+  // range spanning several separately-mapped slices (the ScopedMapping
+  // destructor relies on exactly this to unmap the whole reservation in one
+  // call), so unmapping per contiguous run instead of per slice cuts the number
+  // of driver round-trips on the hot path. Unchanged slices keep their mapping,
+  // which is the whole point: it avoids the page-table churn of remapping every
+  // slice on every step.
+  int changed_count = 0;
+  for (size_t k = 0; k < mappings.size();) {
+    if (!mappings[k].remap_required) {
+      ++k;
+      continue;
+    }
+    const size_t run_start = mappings[k].reservation_offset;
+    size_t run_end = run_start;
+    size_t j = k;
+    while (j < mappings.size() && mappings[j].remap_required) {
+      run_end = mappings[j].reservation_offset + mappings[j].size;
+      ++changed_count;
+      ++j;
+    }
+    RETURN_IF_ERROR(reservation->UnMap(run_start, run_end - run_start));
+    for (size_t m = k; m < j; ++m) {
+      slice_mapped[m] = false;
+    }
+    k = j;
+  }
+  return changed_count;
+}
+
+absl::Status MemoryReservation::ScopedMapping::MapChangedSlices(
+    MemoryReservation* reservation,
+    absl::Span<const MemoryReservation::RemappingDescriptor> mappings,
+    std::vector<bool>& slice_mapped) {
+  // Map each changed slice to its new physical handle. Map must be per slice
+  // because each slice has its own backing allocation and offset.
+  for (size_t k = 0; k < mappings.size(); ++k) {
+    if (!mappings[k].remap_required) {
+      continue;
+    }
+    const MemoryReservation::RemappingDescriptor& dk = mappings[k];
+    RETURN_IF_ERROR(reservation->Map(dk.reservation_offset,
+                                     dk.allocation_offset, dk.size,
+                                     *dk.allocation));
+    slice_mapped[k] = true;
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<MemoryReservation::ScopedMapping>
+MemoryReservation::ScopedMapping::Remap(
+    absl::Span<const MemoryReservation::RemappingDescriptor> mappings) && {
+  // Checks.
+  if (reservation_ == nullptr) {
+    return absl::FailedPreconditionError("Remap: mapping is empty");
+  }
+  if (mappings.empty()) {
+    return absl::InvalidArgumentError("Remap: mappings must not be empty");
+  }
+  ASSIGN_OR_RETURN(
+      const size_t total_size,
+      ValidateRemapDescriptors(mappings, reservation_offset_, size_));
+
+  MemoryReservation* reservation = reservation_;
+  const size_t start_offset = mappings[0].reservation_offset;
 
   // Track per-slice mapped state for cleanup on failure. Every slice starts
   // mapped because this ScopedMapping owns the full range. Changed slices are
@@ -213,50 +276,15 @@ MemoryReservation::ScopedMapping::Remap(
     }
   });
 
-  // Phase 1: unmap the slices whose backing physical handle changed, coalescing
-  // contiguous runs into a single UnMap. A single hipMemUnmap can release a
-  // range spanning several separately-mapped slices (the ScopedMapping
-  // destructor relies on exactly this to unmap the whole reservation in one
-  // call), so unmapping per contiguous run instead of per slice cuts the number
-  // of driver round-trips on the hot path. Unchanged slices keep their mapping,
-  // which is the whole point: it avoids the page-table churn of remapping every
-  // slice on every step.
+  // Phase 1: unmap the slices whose backing physical handle changed.
   const absl::Time t_unmap0 = absl::Now();
-  int changed_count = 0;
-  for (size_t k = 0; k < mappings.size();) {
-    if (!mappings[k].remap_required) {
-      ++k;
-      continue;
-    }
-    const size_t run_start = mappings[k].reservation_offset;
-    size_t run_end = run_start;
-    size_t j = k;
-    while (j < mappings.size() && mappings[j].remap_required) {
-      run_end = mappings[j].reservation_offset + mappings[j].size;
-      ++changed_count;
-      ++j;
-    }
-    RETURN_IF_ERROR(reservation->UnMap(run_start, run_end - run_start));
-    for (size_t m = k; m < j; ++m) {
-      slice_mapped[m] = false;
-    }
-    k = j;
-  }
+  ASSIGN_OR_RETURN(const int changed_count,
+                   UnmapChangedRuns(reservation, mappings, slice_mapped));
   const bool any_remapped = changed_count > 0;
 
-  // Phase 2: map each changed slice to its new physical handle. Map must be per
-  // slice because each slice has its own backing allocation and offset.
+  // Phase 2: map each changed slice to its new physical handle.
   const absl::Time t_map0 = absl::Now();
-  for (size_t k = 0; k < mappings.size(); ++k) {
-    if (!mappings[k].remap_required) {
-      continue;
-    }
-    const auto& dk = mappings[k];
-    RETURN_IF_ERROR(reservation->Map(dk.reservation_offset,
-                                     dk.allocation_offset, dk.size,
-                                     *dk.allocation));
-    slice_mapped[k] = true;
-  }
+  RETURN_IF_ERROR(MapChangedSlices(reservation, mappings, slice_mapped));
 
   // Grant device access once over the FULL reservation range. On ROCm,
   // hipMemSetAccess for peer devices rejects any partial range (sub-range or

--- a/xla/stream_executor/memory_reservation.cc
+++ b/xla/stream_executor/memory_reservation.cc
@@ -236,7 +236,7 @@ MemoryReservation::ScopedMapping::Remap(
       ++changed_count;
       ++j;
     }
-    TF_RETURN_IF_ERROR(reservation->UnMap(run_start, run_end - run_start));
+    RETURN_IF_ERROR(reservation->UnMap(run_start, run_end - run_start));
     for (size_t m = k; m < j; ++m) {
       slice_mapped[m] = false;
     }
@@ -252,9 +252,9 @@ MemoryReservation::ScopedMapping::Remap(
       continue;
     }
     const auto& dk = mappings[k];
-    TF_RETURN_IF_ERROR(reservation->Map(dk.reservation_offset,
-                                        dk.allocation_offset, dk.size,
-                                        *dk.allocation));
+    RETURN_IF_ERROR(reservation->Map(dk.reservation_offset,
+                                     dk.allocation_offset, dk.size,
+                                     *dk.allocation));
     slice_mapped[k] = true;
   }
 
@@ -267,7 +267,7 @@ MemoryReservation::ScopedMapping::Remap(
   // calls.
   const absl::Time t_map1 = absl::Now();
   if (any_remapped) {
-    TF_RETURN_IF_ERROR(reservation->SetAccess(start_offset, total_size));
+    RETURN_IF_ERROR(reservation->SetAccess(start_offset, total_size));
   }
   const absl::Time t_sa1 = absl::Now();
   VLOG(2) << "Remap timing: slices=" << mappings.size()

--- a/xla/stream_executor/memory_reservation.cc
+++ b/xla/stream_executor/memory_reservation.cc
@@ -17,12 +17,15 @@ limitations under the License.
 
 #include <cstddef>
 #include <utility>
+#include <vector>
 
 #include "absl/cleanup/cleanup.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/stream_executor/device_address.h"
@@ -142,6 +145,139 @@ absl::StatusOr<MemoryReservation::ScopedMapping> MemoryReservation::MapTo(
 
   std::move(cleanup).Cancel();
   return ScopedMapping(this, start_offset, total_size);
+}
+
+// ScopedMapping::Remap
+
+absl::StatusOr<MemoryReservation::ScopedMapping>
+MemoryReservation::ScopedMapping::Remap(
+    absl::Span<const MemoryReservation::RemappingDescriptor> mappings) && {
+  if (reservation_ == nullptr) {
+    return absl::FailedPreconditionError("Remap: mapping is empty");
+  }
+  if (mappings.empty()) {
+    return absl::InvalidArgumentError("Remap: mappings must not be empty");
+  }
+
+  MemoryReservation* reservation = reservation_;
+  const size_t existing_reservation_offset = reservation_offset_;
+  const size_t existing_size = size_;
+
+  const size_t start_offset = mappings[0].reservation_offset;
+  size_t expected_offset = start_offset;
+  for (const MemoryReservation::RemappingDescriptor& desc : mappings) {
+    if (desc.reservation_offset != expected_offset) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Remap: mappings are not contiguous. Expected "
+                          "reservation_offset=%zu but got %zu",
+                          expected_offset, desc.reservation_offset));
+    }
+    if (desc.allocation == nullptr) {
+      return absl::InvalidArgumentError("Remap: allocation must not be null");
+    }
+    expected_offset += desc.size;
+  }
+  const size_t total_size = expected_offset - start_offset;
+  if (start_offset != existing_reservation_offset ||
+      total_size != existing_size) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Remap: mappings must cover the existing mapping range [%zu, %zu), got "
+        "[%zu, %zu)",
+        existing_reservation_offset,
+        existing_reservation_offset + existing_size, start_offset,
+        start_offset + total_size));
+  }
+
+  // Track per-slice mapped state for cleanup on failure. Every slice starts
+  // mapped because this ScopedMapping owns the full range. Changed slices are
+  // temporarily unmapped before being mapped to their new allocation.
+  std::vector<bool> slice_mapped(mappings.size(), true);
+
+  // Detach the prior ScopedMapping without invoking its destructor; the
+  // per-slice unmaps below replace the full-range unmap it would do.
+  reservation_ = nullptr;
+
+  // On failure, unmap every slice that is still mapped so the reservation
+  // is left in a clean (fully unmapped) state rather than partially mapped
+  // with no RAII owner.
+  auto cleanup = absl::MakeCleanup([&] {
+    for (size_t k = 0; k < mappings.size(); ++k) {
+      if (slice_mapped[k]) {
+        absl::Status s = reservation->UnMap(mappings[k].reservation_offset,
+                                            mappings[k].size);
+        if (!s.ok()) {
+          LOG(ERROR) << "Remap: cleanup failed to unmap slice at offset "
+                     << mappings[k].reservation_offset << ": " << s.message();
+        }
+      }
+    }
+  });
+
+  // Phase 1: unmap the slices whose backing physical handle changed, coalescing
+  // contiguous runs into a single UnMap. A single hipMemUnmap can release a
+  // range spanning several separately-mapped slices (the ScopedMapping
+  // destructor relies on exactly this to unmap the whole reservation in one
+  // call), so unmapping per contiguous run instead of per slice cuts the number
+  // of driver round-trips on the hot path. Unchanged slices keep their mapping,
+  // which is the whole point: it avoids the page-table churn of remapping every
+  // slice on every step.
+  const absl::Time t_unmap0 = absl::Now();
+  int changed_count = 0;
+  for (size_t k = 0; k < mappings.size();) {
+    if (!mappings[k].remap_required) {
+      ++k;
+      continue;
+    }
+    const size_t run_start = mappings[k].reservation_offset;
+    size_t run_end = run_start;
+    size_t j = k;
+    while (j < mappings.size() && mappings[j].remap_required) {
+      run_end = mappings[j].reservation_offset + mappings[j].size;
+      ++changed_count;
+      ++j;
+    }
+    TF_RETURN_IF_ERROR(reservation->UnMap(run_start, run_end - run_start));
+    for (size_t m = k; m < j; ++m) {
+      slice_mapped[m] = false;
+    }
+    k = j;
+  }
+  const bool any_remapped = changed_count > 0;
+
+  // Phase 2: map each changed slice to its new physical handle. Map must be per
+  // slice because each slice has its own backing allocation and offset.
+  const absl::Time t_map0 = absl::Now();
+  for (size_t k = 0; k < mappings.size(); ++k) {
+    if (!mappings[k].remap_required) {
+      continue;
+    }
+    const auto& dk = mappings[k];
+    TF_RETURN_IF_ERROR(reservation->Map(dk.reservation_offset,
+                                        dk.allocation_offset, dk.size,
+                                        *dk.allocation));
+    slice_mapped[k] = true;
+  }
+
+  // Grant device access once over the FULL reservation range. On ROCm,
+  // hipMemSetAccess for peer devices rejects any partial range (sub-range or
+  // even a prefix that starts at the reservation base) with
+  // HIP_ERROR_InvalidValue -- empirically only the full [start_offset,
+  // total_size) range is accepted, matching MapTo's known-good behavior. Skip it
+  // entirely when no slice changed so the steady state stays free of driver
+  // calls.
+  const absl::Time t_map1 = absl::Now();
+  if (any_remapped) {
+    TF_RETURN_IF_ERROR(reservation->SetAccess(start_offset, total_size));
+  }
+  const absl::Time t_sa1 = absl::Now();
+  VLOG(2) << "Remap timing: slices=" << mappings.size()
+          << " changed=" << changed_count << " range=" << total_size
+          << " unmap_us=" << absl::ToInt64Microseconds(t_map0 - t_unmap0)
+          << " map_us=" << absl::ToInt64Microseconds(t_map1 - t_map0)
+          << " setaccess_us=" << absl::ToInt64Microseconds(t_sa1 - t_map1);
+
+  std::move(cleanup).Cancel();
+  return ScopedMapping(reservation, start_offset, total_size);
 }
 
 }  // namespace stream_executor

--- a/xla/stream_executor/memory_reservation.h
+++ b/xla/stream_executor/memory_reservation.h
@@ -55,6 +55,17 @@ class MemoryReservation {
     MemoryAllocation* allocation;
   };
 
+  // Describes a desired post-Remap mapping for a slice of the reservation.
+  struct RemappingDescriptor {
+    size_t reservation_offset;
+    size_t allocation_offset;
+    size_t size;
+    MemoryAllocation* allocation;  // current physical handle, never null
+    // Whether this slice needs UnMap/Map/SetAccess calls. When false, the
+    // existing mapping is preserved.
+    bool remap_required;
+  };
+
   // An RAII wrapper that gives access to a contiguous slice of a memory
   // reservation backed by one or more physical memory allocations.
   // Unmaps the mapped range from the reservation on destruction.
@@ -69,6 +80,16 @@ class MemoryReservation {
     // Returns the device address range that is mapped to the physical memory
     // allocation(s) and can be accessed from the device.
     DeviceAddressBase mapped_address() const;
+
+    // Re-maps this mapping's reservation range as described by `mappings`.
+    // The descriptors must cover the same full range. For each mapping where
+    // remap_required is false, the current mapping is preserved. For the rest,
+    // the slice is unmapped and mapped to `allocation`; SetAccess is invoked
+    // once per maximal run of consecutive remapped mappings. On failure after
+    // remapping starts, Remap unmaps all slices described by `mappings`,
+    // leaving the reservation with no active mapping for the range.
+    absl::StatusOr<ScopedMapping> Remap(
+        absl::Span<const RemappingDescriptor> mappings) &&;
 
     // Returns true if this object does not own a mapping.
     bool is_null() const { return reservation_ == nullptr; }

--- a/xla/stream_executor/memory_reservation.h
+++ b/xla/stream_executor/memory_reservation.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define XLA_STREAM_EXECUTOR_MEMORY_RESERVATION_H_
 
 #include <cstddef>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -98,6 +99,30 @@ class MemoryReservation {
     // Unmaps the given range on the reservation and logs on failure.
     static void UnmapAndLogIfError(MemoryReservation* reservation,
                                    size_t reservation_offset, size_t size);
+
+    // Remap helpers. ----------------------------------------------------------
+
+    // Validates that `mappings` are contiguous, have non-null allocations, and
+    // exactly cover [existing_reservation_offset,
+    // existing_reservation_offset + existing_size). Returns the covered size.
+    static absl::StatusOr<size_t> ValidateRemapDescriptors(
+        absl::Span<const RemappingDescriptor> mappings,
+        size_t existing_reservation_offset, size_t existing_size);
+
+    // Unmaps the slices whose backing handle changed, coalescing contiguous
+    // remapped runs into a single UnMap. Clears the corresponding entries in
+    // `slice_mapped` and returns the number of changed slices.
+    static absl::StatusOr<int> UnmapChangedRuns(
+        MemoryReservation* reservation,
+        absl::Span<const RemappingDescriptor> mappings,
+        std::vector<bool>& slice_mapped);
+
+    // Maps each changed slice to its new physical handle and sets the
+    // corresponding entries in `slice_mapped`.
+    static absl::Status MapChangedSlices(
+        MemoryReservation* reservation,
+        absl::Span<const RemappingDescriptor> mappings,
+        std::vector<bool>& slice_mapped);
 
     friend class MemoryReservation;
     ScopedMapping(MemoryReservation* reservation, size_t reservation_offset,

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -1472,6 +1472,63 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "rocm_memory_reservation",
+    srcs = ["rocm_memory_reservation.cc"],
+    hdrs = ["rocm_memory_reservation.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        ":rocm_raw_memory_allocation",
+        ":rocm_status",
+        "//xla:util",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_reservation",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_memory_reservation_test",
+    srcs = ["rocm_memory_reservation_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":amdhipblaslt_plugin",
+        ":rocm_memory_reservation",
+        ":rocm_platform",
+        ":rocm_platform_id",
+        ":rocm_raw_memory_allocation",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_reservation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:statusor",
+        "@tsl//tsl/platform:test",
+    ],
+)
+
+cc_library(
     name = "rocm_vmm_allocator",
     srcs = ["rocm_vmm_allocator.cc"],
     hdrs = ["rocm_vmm_allocator.h"],

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -1489,11 +1489,11 @@ cc_library(
         "//xla/stream_executor:memory_allocation",
         "//xla/stream_executor:memory_reservation",
         "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@local_config_rocm//rocm:rocm_headers",
-        "@tsl//tsl/platform:statusor",
     ],
 )
 

--- a/xla/stream_executor/rocm/rocm_memory_reservation.cc
+++ b/xla/stream_executor/rocm/rocm_memory_reservation.cc
@@ -1,0 +1,156 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_memory_reservation.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+
+absl::StatusOr<std::unique_ptr<RocmMemoryReservation>>
+RocmMemoryReservation::Create(StreamExecutor* executor, uint64_t size) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  hipDevice_t device;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
+
+  hipMemAllocationProp props = {};
+  props.type = hipMemAllocationTypePinned;
+  props.location.type = hipMemLocationTypeDevice;
+  props.location.id = device;
+  props.requestedHandleTypes = hipMemHandleTypeNone;
+
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+      &granularity, &props, hipMemAllocationGranularityRecommended)));
+
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
+
+  void* ptr = nullptr;
+  TF_RETURN_IF_ERROR(ToStatus(
+hipMemAddressReserve(&ptr, padded_size, granularity, nullptr,
+                                    0ULL)));
+
+  return std::unique_ptr<RocmMemoryReservation>(
+      new RocmMemoryReservation(executor, static_cast<char*>(ptr), padded_size));
+}
+
+RocmMemoryReservation::RocmMemoryReservation(StreamExecutor* executor,
+                                             char* ptr, uint64_t size)
+    : executor_(executor), ptr_(ptr), size_(size) {}
+
+DeviceAddressBase RocmMemoryReservation::address() const {
+  return DeviceAddressBase(ptr_, size_);
+}
+
+absl::Status RocmMemoryReservation::Map(size_t reservation_offset,
+                                        size_t allocation_offset, size_t size,
+                                        MemoryAllocation& allocation) {
+  auto* rocm_alloc = dynamic_cast<RocmRawMemoryAllocation*>(&allocation);
+  if (rocm_alloc == nullptr) {
+    return absl::InvalidArgumentError(
+        "RocmMemoryReservation::Map requires a RocmRawMemoryAllocation");
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  absl::Status status = ToStatus(hipMemMap(ptr_ + reservation_offset, size,
+                                           allocation_offset,
+                                           rocm_alloc->GetHandle(), 0ULL));
+  if (status.ok()) {
+    mapped_bytes_ += size;
+  }
+  return status;
+}
+
+absl::Status RocmMemoryReservation::SetAccess(uint64_t reservation_offset,
+                                              size_t size) {
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+
+  int device_count = 0;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipGetDeviceCount(&device_count), "hipGetDeviceCount"));
+
+  for (int peer = 0; peer < device_count; ++peer) {
+    if (peer != executor_->device_ordinal()) {
+      auto peer_executor_or =
+          const_cast<Platform*>(executor_->GetPlatform())
+              ->ExecutorForDevice(peer);
+      if (!peer_executor_or.ok() ||
+          !executor_->CanEnablePeerAccessTo(peer_executor_or.value())) {
+        continue;
+      }
+    }
+    hipMemAccessDesc desc = {};
+    desc.location.type = hipMemLocationTypeDevice;
+    desc.location.id = peer;
+    desc.flags = hipMemAccessFlagsProtReadWrite;
+    TF_RETURN_IF_ERROR(ToStatus(
+hipMemSetAccess(ptr_ + reservation_offset, size, &desc, 1),
+        "hipMemSetAccess for peer device"));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status RocmMemoryReservation::UnMap(size_t offset, size_t size) {
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  absl::Status status = ToStatus(hipMemUnmap(ptr_ + offset, size));
+  if (status.ok()) {
+    mapped_bytes_ = mapped_bytes_ >= size ? mapped_bytes_ - size : 0;
+  }
+  return status;
+}
+
+RocmMemoryReservation::~RocmMemoryReservation() {
+  if (ptr_ == nullptr) {
+    return;
+  }
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  // Only unmap if a mapping is still active. The ScopedMapping returned by
+  // MapTo/Remap normally unmaps the range before this reservation is destroyed;
+  // calling hipMemUnmap again on an already-unmapped range fails with
+  // HIP_ERROR_InvalidValue. Tracking mapped_bytes_ avoids that redundant (and
+  // very noisy) double-unmap at teardown.
+  if (mapped_bytes_ > 0) {
+    auto unmap_status =
+        ToStatus(hipMemUnmap(ptr_, size_), "Error unmapping ROCm memory");
+    if (!unmap_status.ok()) {
+      LOG(ERROR) << unmap_status.message();
+    }
+  }
+  auto free_status = ToStatus(hipMemAddressFree(ptr_, size_),
+                              "Error freeing ROCm address range");
+  if (!free_status.ok()) {
+    LOG(ERROR) << free_status.message();
+  }
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_memory_reservation.cc
+++ b/xla/stream_executor/rocm/rocm_memory_reservation.cc
@@ -31,8 +31,8 @@ limitations under the License.
 #include "xla/stream_executor/rocm/rocm_status.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
-#include "tsl/platform/statusor.h"
 
 namespace stream_executor::gpu {
 
@@ -41,7 +41,7 @@ RocmMemoryReservation::Create(StreamExecutor* executor, uint64_t size) {
   std::unique_ptr<ActivateContext> activation = executor->Activate();
 
   hipDevice_t device;
-  TF_RETURN_IF_ERROR(
+  RETURN_IF_ERROR(
       ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
 
   hipMemAllocationProp props = {};
@@ -51,13 +51,13 @@ RocmMemoryReservation::Create(StreamExecutor* executor, uint64_t size) {
   props.requestedHandleTypes = hipMemHandleTypeNone;
 
   size_t granularity = 0;
-  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+  RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
       &granularity, &props, hipMemAllocationGranularityRecommended)));
 
   uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
 
   void* ptr = nullptr;
-  TF_RETURN_IF_ERROR(ToStatus(
+  RETURN_IF_ERROR(ToStatus(
 hipMemAddressReserve(&ptr, padded_size, granularity, nullptr,
                                     0ULL)));
 
@@ -96,7 +96,7 @@ absl::Status RocmMemoryReservation::SetAccess(uint64_t reservation_offset,
   std::unique_ptr<ActivateContext> activation = executor_->Activate();
 
   int device_count = 0;
-  TF_RETURN_IF_ERROR(
+  RETURN_IF_ERROR(
       ToStatus(hipGetDeviceCount(&device_count), "hipGetDeviceCount"));
 
   for (int peer = 0; peer < device_count; ++peer) {
@@ -113,7 +113,7 @@ absl::Status RocmMemoryReservation::SetAccess(uint64_t reservation_offset,
     desc.location.type = hipMemLocationTypeDevice;
     desc.location.id = peer;
     desc.flags = hipMemAccessFlagsProtReadWrite;
-    TF_RETURN_IF_ERROR(ToStatus(
+    RETURN_IF_ERROR(ToStatus(
 hipMemSetAccess(ptr_ + reservation_offset, size, &desc, 1),
         "hipMemSetAccess for peer device"));
   }

--- a/xla/stream_executor/rocm/rocm_memory_reservation.h
+++ b/xla/stream_executor/rocm/rocm_memory_reservation.h
@@ -1,0 +1,76 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_MEMORY_RESERVATION_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_MEMORY_RESERVATION_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// RAII wrapper for a ROCm virtual address range reserved via
+// hipMemAddressReserve. Physical memory can be mapped into sub-ranges of the
+// reservation via MapTo, which also enables device access before returning.
+class RocmMemoryReservation : public MemoryReservation {
+ public:
+  // Reserves a virtual address range of at least `size` bytes using
+  // hipMemAddressReserve. StreamExecutor is used only for context activation.
+  static absl::StatusOr<std::unique_ptr<RocmMemoryReservation>> Create(
+      StreamExecutor* executor, uint64_t size);
+
+  // Returns the base address and padded size of the reserved virtual range.
+  DeviceAddressBase address() const override;
+
+  ~RocmMemoryReservation() override;
+
+  // Move is disabled to prevent double-free of the virtual address range:
+  // the destructor calls hipMemAddressFree on ptr_. Matches CudaMemoryReservation.
+  RocmMemoryReservation(RocmMemoryReservation&&) = delete;
+  RocmMemoryReservation& operator=(RocmMemoryReservation&&) = delete;
+
+ private:
+  explicit RocmMemoryReservation(StreamExecutor* executor, char* ptr,
+                                 uint64_t size);
+
+  absl::Status Map(size_t reservation_offset, size_t allocation_offset,
+                   size_t size, MemoryAllocation& allocation) override;
+
+  absl::Status SetAccess(uint64_t reservation_offset, size_t size) override;
+
+  absl::Status UnMap(size_t reservation_offset, size_t size) override;
+
+  StreamExecutor* executor_;
+  char* ptr_;  // nullptr means moved-from / released
+  uint64_t size_;
+  // Bytes currently mapped into the reservation. Kept in sync by Map()/UnMap()
+  // so the destructor can skip a redundant hipMemUnmap when the ScopedMapping
+  // that owns the mapping has already unmapped the range (which would otherwise
+  // fail with HIP_ERROR_InvalidValue).
+  uint64_t mapped_bytes_ = 0;
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_MEMORY_RESERVATION_H_

--- a/xla/stream_executor/rocm/rocm_memory_reservation.h
+++ b/xla/stream_executor/rocm/rocm_memory_reservation.h
@@ -45,8 +45,11 @@ class RocmMemoryReservation : public MemoryReservation {
 
   ~RocmMemoryReservation() override;
 
-  // Move is disabled to prevent double-free of the virtual address range:
-  // the destructor calls hipMemAddressFree on ptr_. Matches CudaMemoryReservation.
+  // Non-movable: the base class MemoryReservation already deletes its move
+  // operations, and instances are only ever created through Create(), which
+  // returns a std::unique_ptr. Ownership is therefore transferred via the
+  // pointer, never by moving the object, so there is no moved-from state to
+  // reason about. Matches CudaMemoryReservation.
   RocmMemoryReservation(RocmMemoryReservation&&) = delete;
   RocmMemoryReservation& operator=(RocmMemoryReservation&&) = delete;
 
@@ -62,7 +65,10 @@ class RocmMemoryReservation : public MemoryReservation {
   absl::Status UnMap(size_t reservation_offset, size_t size) override;
 
   StreamExecutor* executor_;
-  char* ptr_;  // nullptr means moved-from / released
+  // Base of the reserved virtual address range. Non-null after construction
+  // (the class is non-movable and exposes no release path); the destructor's
+  // null check is purely defensive.
+  char* ptr_;
   uint64_t size_;
   // Bytes currently mapped into the reservation. Kept in sync by Map()/UnMap()
   // so the destructor can skip a redundant hipMemUnmap when the ScopedMapping

--- a/xla/stream_executor/rocm/rocm_memory_reservation_test.cc
+++ b/xla/stream_executor/rocm/rocm_memory_reservation_test.cc
@@ -1,0 +1,248 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_memory_reservation.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/platform/statusor.h"
+#include "tsl/platform/test.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+using absl_testing::IsOk;
+using absl_testing::StatusIs;
+
+static constexpr uint64_t kTestSize = 1024 * 1024;
+
+class FakeAllocation : public MemoryAllocation {
+ public:
+  DeviceAddressBase address() const override { return DeviceAddressBase(); }
+};
+
+class RocmMemoryReservationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    auto executor_or = platform_or.value()->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+  }
+
+  StreamExecutor* executor_ = nullptr;
+};
+
+TEST_F(RocmMemoryReservationTest, CreateReservation) {
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  EXPECT_NE(res->address().opaque(), nullptr);
+  EXPECT_GE(res->address().size(), kTestSize);
+}
+
+TEST_F(RocmMemoryReservationTest, MapToWrongType) {
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  FakeAllocation fake;
+  EXPECT_THAT(res->MapTo(0, 0, kTestSize, fake),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST_F(RocmMemoryReservationTest, MapToSingleAllocation) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  const size_t alloc_size = alloc->address().size();
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
+
+  EXPECT_EQ(mapping.mapped_address().opaque(), res->address().opaque());
+  EXPECT_EQ(mapping.mapped_address().size(), alloc_size);
+}
+
+TEST_F(RocmMemoryReservationTest, ScopedMappingUnmapsOnDestruction) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  const size_t alloc_size = alloc->address().size();
+  {
+    TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(0, 0, alloc_size, *alloc));
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping2, res->MapTo(0, 0, alloc_size, *alloc));
+  EXPECT_NE(mapping2.mapped_address().opaque(), nullptr);
+}
+
+TEST_F(RocmMemoryReservationTest, MapToMultipleAllocations) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc1, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc2, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+
+  const size_t size1 = alloc1->address().size();
+  const size_t size2 = alloc2->address().size();
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto res, RocmMemoryReservation::Create(executor_, size1 + size2));
+  ASSERT_GE(res->address().size(), size1 + size2);
+
+  MemoryReservation::MappingDescriptor descs[] = {
+      {/*reservation_offset=*/0, /*allocation_offset=*/0, size1, alloc1.get()},
+      {/*reservation_offset=*/size1, /*allocation_offset=*/0, size2,
+       alloc2.get()},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(absl::MakeSpan(descs)));
+
+  EXPECT_EQ(mapping.mapped_address().opaque(), res->address().opaque());
+  EXPECT_EQ(mapping.mapped_address().size(), size1 + size2);
+}
+
+TEST_F(RocmMemoryReservationTest, TwoReservationsDifferentAddresses) {
+  TF_ASSERT_OK_AND_ASSIGN(auto res1,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(auto res2,
+                          RocmMemoryReservation::Create(executor_, kTestSize));
+
+  EXPECT_NE(res1->address().opaque(), res2->address().opaque());
+}
+
+// Remap with every slice marked remap_required=false must leave the existing
+// physical backing (and therefore the data) untouched.
+TEST_F(RocmMemoryReservationTest, RemapPreservesUnchangedSlices) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc_a, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc_b, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  const size_t sa = alloc_a->address().size();
+  const size_t sb = alloc_b->address().size();
+
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, sa + sb));
+
+  MemoryReservation::MappingDescriptor descs[] = {
+      {/*reservation_offset=*/0, /*allocation_offset=*/0, sa, alloc_a.get()},
+      {/*reservation_offset=*/sa, /*allocation_offset=*/0, sb, alloc_b.get()},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(absl::MakeSpan(descs)));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor_->CreateStream());
+  void* const base = res->address().opaque();
+  DeviceAddressBase slice0(base, sizeof(uint64_t));
+  DeviceAddressBase slice1(reinterpret_cast<uint8_t*>(base) + sa,
+                           sizeof(uint64_t));
+
+  constexpr uint64_t kPatternA = 0xAAAAAAAAAAAAAAAAULL;
+  constexpr uint64_t kPatternB = 0xBBBBBBBBBBBBBBBBULL;
+  ASSERT_THAT(stream->Memcpy(&slice0, &kPatternA, sizeof(kPatternA)), IsOk());
+  ASSERT_THAT(stream->Memcpy(&slice1, &kPatternB, sizeof(kPatternB)), IsOk());
+  ASSERT_THAT(stream->BlockHostUntilDone(), IsOk());
+
+  MemoryReservation::RemappingDescriptor remaps[] = {
+      {0, 0, sa, alloc_a.get(), /*remap_required=*/false},
+      {sa, 0, sb, alloc_b.get(), /*remap_required=*/false},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping2,
+                          std::move(mapping).Remap(absl::MakeSpan(remaps)));
+  EXPECT_EQ(mapping2.mapped_address().opaque(), base);
+  EXPECT_EQ(mapping2.mapped_address().size(), sa + sb);
+
+  uint64_t v0 = 0, v1 = 0;
+  ASSERT_THAT(stream->Memcpy(&v0, slice0, sizeof(v0)), IsOk());
+  ASSERT_THAT(stream->Memcpy(&v1, slice1, sizeof(v1)), IsOk());
+  ASSERT_THAT(stream->BlockHostUntilDone(), IsOk());
+  EXPECT_EQ(v0, kPatternA);
+  EXPECT_EQ(v1, kPatternB);
+}
+
+// Remap with remap_required=true for a slice must repoint that slice at the
+// new physical allocation while preserving the slices left unchanged.
+TEST_F(RocmMemoryReservationTest, RemapRepointsRequiredSlice) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc_a, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto alloc_b, RocmRawMemoryAllocation::Create(executor_, kTestSize));
+  const size_t sa = alloc_a->address().size();
+  const size_t sb = alloc_b->address().size();
+
+  TF_ASSERT_OK_AND_ASSIGN(auto res,
+                          RocmMemoryReservation::Create(executor_, sa + sb));
+
+  MemoryReservation::MappingDescriptor descs[] = {
+      {/*reservation_offset=*/0, /*allocation_offset=*/0, sa, alloc_a.get()},
+      {/*reservation_offset=*/sa, /*allocation_offset=*/0, sb, alloc_b.get()},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping, res->MapTo(absl::MakeSpan(descs)));
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor_->CreateStream());
+  void* const base = res->address().opaque();
+  DeviceAddressBase slice0(base, sizeof(uint64_t));
+  DeviceAddressBase slice1(reinterpret_cast<uint8_t*>(base) + sa,
+                           sizeof(uint64_t));
+
+  constexpr uint64_t kPatternA = 0xAAAAAAAAAAAAAAAAULL;
+  constexpr uint64_t kPatternB = 0xBBBBBBBBBBBBBBBBULL;
+  ASSERT_THAT(stream->Memcpy(&slice0, &kPatternA, sizeof(kPatternA)), IsOk());
+  ASSERT_THAT(stream->Memcpy(&slice1, &kPatternB, sizeof(kPatternB)), IsOk());
+  ASSERT_THAT(stream->BlockHostUntilDone(), IsOk());
+
+  // Keep slice0 on alloc_a; repoint slice1 to alloc_a as well. After the remap
+  // slice1 aliases alloc_a, so reading it must observe slice0's data (kPatternA)
+  // rather than the kPatternB it previously held via alloc_b.
+  MemoryReservation::RemappingDescriptor remaps[] = {
+      {0, 0, sa, alloc_a.get(), /*remap_required=*/false},
+      {sa, 0, sb, alloc_a.get(), /*remap_required=*/true},
+  };
+  TF_ASSERT_OK_AND_ASSIGN(auto mapping2,
+                          std::move(mapping).Remap(absl::MakeSpan(remaps)));
+  EXPECT_EQ(mapping2.mapped_address().opaque(), base);
+  EXPECT_EQ(mapping2.mapped_address().size(), sa + sb);
+
+  uint64_t v0 = 0, v1 = 0;
+  ASSERT_THAT(stream->Memcpy(&v0, slice0, sizeof(v0)), IsOk());
+  ASSERT_THAT(stream->Memcpy(&v1, slice1, sizeof(v1)), IsOk());
+  ASSERT_THAT(stream->BlockHostUntilDone(), IsOk());
+  EXPECT_EQ(v0, kPatternA);
+  EXPECT_EQ(v1, kPatternA);
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu


### PR DESCRIPTION
# [XLA:GPU] ROCm VMM PR 2/4: `RocmMemoryReservation` (VA reserve / map / setAccess / unmap)

## Overview — VMM allocator for ROCm/HIP

Second of 4 stacked PRs bringing the **VMM (Virtual Memory Management) allocator** to
ROCm/HIP (split out of #40236 per review feedback). It ports the CUDA VMM design to HIP,
enabling stable virtual-address allocations on AMD GPUs.

- **PR 1/4 — `RocmRawMemoryAllocation`** (#43942): physical allocation, `hipMemCreate`/`hipMemRelease`.
- **PR 2/4 — `RocmMemoryReservation`** (this PR, #43943): VA reserve / map / setAccess / unmap.
- **PR 3/4 — `RocmVmmAllocator`** (#43946): all-in-one allocator (create + reserve + map + setAccess).
- **PR 4/4 — `RocmDeviceAddressVmmAllocator` + vendor-neutral factory** (#43947): timeline-based
  deferred deallocation, and PJRT enablement so `allocator=vmm` works on ROCm.

> _Update the PR numbers above if they differ._

---

## This PR (PR 2/4): `RocmMemoryReservation`

A RAII wrapper around a ROCm **virtual address range** reserved via
`hipMemAddressReserve`. It maps the *physical* handle from PR 1/4 into sub-ranges of the
reservation and enables device (and peer) access. It builds directly on
`RocmRawMemoryAllocation` and has no callers yet, so it changes no existing behavior.

### Files
- `xla/stream_executor/memory_reservation.{h,cc}` — the shared (vendor-neutral)
  `MemoryReservation` interface + `ScopedMapping` helper that maps a physical
  allocation into a reservation and unmaps it on scope exit.
- `xla/stream_executor/rocm/rocm_memory_reservation.{h,cc}` — the ROCm/HIP implementation.
- `xla/stream_executor/rocm/rocm_memory_reservation_test.cc` — unit tests.
- `xla/stream_executor/rocm/BUILD` — new targets.

### Design
`RocmMemoryReservation` derives from `MemoryReservation`:

- **`Create(StreamExecutor* executor, uint64_t size)`** — reserves a VA range of at least
  `size` via `hipMemAddressReserve` (size rounded to granularity).
- **`Map(reservation_offset, allocation_offset, size, allocation)`** — `hipMemMap`s a
  physical allocation into a sub-range of the reservation.
- **`SetAccess(reservation_offset, size)`** — `hipMemSetAccess` granting read/write to the
  owning device and its P2P-capable peers.
- **`UnMap(reservation_offset, size)`** — `hipMemUnmap` of a sub-range.
- **Destructor** — `hipMemAddressFree`; tracks `mapped_bytes_` so it skips a redundant
  `hipMemUnmap` already performed by the `ScopedMapping` (ROCm rejects double-unmap with
  `HIP_ERROR_InvalidValue`).
- Non-movable (prevents double-free of the VA range). Mirrors `CudaMemoryReservation`.

### ROCm/HIP specifics
- Peer access is granted across all P2P-capable devices (multi-GPU collectives otherwise
  fault with "Memory access fault by GPU node-N").
- Calls the HIP runtime directly (no `wrap::` driver shim).

---

## Testing
`rocm_memory_reservation_test` (6 tests), AMD Instinct MI300X (gfx942), ROCm 7.2.0:
- `CreateReservation`, `MapToWrongType`, `MapToSingleAllocation`,
  `ScopedMappingUnmapsOnDestruction`, `MapToMultipleAllocations`,
  `TwoReservationsDifferentAddresses`.



---

## Next PR
**PR 3/4 — `RocmVmmAllocator` (#43946):** an all-in-one `MemoryAllocator` that combines
PR 1/4 (physical create) and PR 2/4 (reserve + map + setAccess) into a single `Allocate`
call returning ready-to-use, device-addressable memory.
