### PR TITLE
[XLA:GPU] ROCm VMM Layer 3/4: RocmVmmAllocator (all-in-one create+reserve+map)

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -1428,3 +1428,53 @@ xla_cc_test(
         "@tsl//tsl/platform:test",
     ],
 )
+
+cc_library(
+    name = "rocm_vmm_allocator",
+    srcs = ["rocm_vmm_allocator.cc"],
+    hdrs = ["rocm_vmm_allocator.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_status",
+        "//xla:util",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_allocator",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/cleanup",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+        "@tsl//tsl/platform:errors",
+        "@tsl//tsl/platform:statusor",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_vmm_allocator_test",
+    srcs = ["rocm_vmm_allocator_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_platform",
+        ":rocm_vmm_allocator",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -1447,14 +1447,13 @@ cc_library(
         "//xla/stream_executor:platform",
         "//xla/stream_executor:stream_executor_h",
         "@com_google_absl//absl/cleanup",
+        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
         "@local_config_rocm//rocm:hip",  # buildcleaner: keep
         "@local_config_rocm//rocm:rocm_headers",
-        "@tsl//tsl/platform:errors",
-        "@tsl//tsl/platform:statusor",
     ],
 )
 

--- a/xla/stream_executor/rocm/rocm_vmm_allocator.cc
+++ b/xla/stream_executor/rocm/rocm_vmm_allocator.cc
@@ -1,0 +1,206 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_vmm_allocator.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include "absl/cleanup/cleanup.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+#include "tsl/platform/errors.h"
+#include "tsl/platform/statusor.h"
+
+namespace stream_executor::gpu {
+
+static hipMemAccessDesc GetVmmAccessDescriptor(int device) {
+  hipMemAccessDesc descriptor = {};
+  descriptor.location.type = hipMemLocationTypeDevice;
+  descriptor.location.id = device;
+  descriptor.flags = hipMemAccessFlagsProtReadWrite;
+  return descriptor;
+}
+
+// Allocates device memory using HIP VMM APIs. Returns the mapped pointer,
+// the padded size, and the allocation handle.
+static absl::StatusOr<
+    std::tuple<void*, uint64_t, hipMemGenericAllocationHandle_t>>
+VmmAllocate(StreamExecutor* executor, uint64_t size) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  hipDevice_t device;
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
+
+  hipMemAllocationProp properties = {};
+  properties.type = hipMemAllocationTypePinned;
+  properties.location.type = hipMemLocationTypeDevice;
+  properties.location.id = device;
+  properties.requestedHandleTypes = hipMemHandleTypeNone;
+  size_t granularity = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+      &granularity, &properties, hipMemAllocationGranularityRecommended)));
+
+  uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
+  hipMemGenericAllocationHandle_t handle;
+
+  TF_RETURN_IF_ERROR(
+      ToStatus(hipMemCreate(&handle, padded_size, &properties, 0ULL)));
+
+  hipDeviceptr_t ptr = nullptr;
+  absl::Status status = ToStatus(
+hipMemAddressReserve(&ptr, padded_size, granularity, nullptr,
+                                    0ULL));
+  if (!status.ok()) {
+    ToStatus(hipMemRelease(handle)).IgnoreError();
+    return status;
+  }
+
+  status = ToStatus(hipMemMap(ptr, padded_size, 0, handle, 0ULL));
+  if (!status.ok()) {
+    ToStatus(hipMemAddressFree(ptr, padded_size)).IgnoreError();
+    ToStatus(hipMemRelease(handle)).IgnoreError();
+    return status;
+  }
+
+  // Cleanup on error: unmap + free VA + release physical memory.
+  absl::Cleanup cleanup = [&]() {
+    ToStatus(hipMemUnmap(ptr, padded_size)).IgnoreError();
+    ToStatus(hipMemAddressFree(ptr, padded_size)).IgnoreError();
+    ToStatus(hipMemRelease(handle)).IgnoreError();
+  };
+
+  VLOG(3) << "VMM allocated " << ptr
+          << " requested size: " << size
+          << " padded size: " << padded_size
+          << " granularity: " << granularity
+          << " device: " << executor->device_ordinal();
+
+  // Set access for this device and all P2P-capable peers, matching the CUDA
+  // pattern that gates on CanEnablePeerAccessTo().
+  int device_count = 0;
+  TF_RETURN_IF_ERROR(ToStatus(hipGetDeviceCount(&device_count)));
+  for (int peer = 0; peer < device_count; peer++) {
+    if (peer != executor->device_ordinal()) {
+      auto peer_executor_or =
+          const_cast<Platform*>(executor->GetPlatform())
+              ->ExecutorForDevice(peer);
+      if (!peer_executor_or.ok() ||
+          !executor->CanEnablePeerAccessTo(peer_executor_or.value())) {
+        continue;
+      }
+    }
+    hipMemAccessDesc access_desc = GetVmmAccessDescriptor(peer);
+    TF_RETURN_IF_ERROR(
+        ToStatus(hipMemSetAccess(ptr, padded_size, &access_desc, 1)));
+  }
+
+  std::move(cleanup).Cancel();
+  return std::make_tuple(ptr, padded_size, handle);
+}
+
+static void VmmDeallocate(StreamExecutor* executor, void* ptr,
+                          uint64_t padded_size,
+                          hipMemGenericAllocationHandle_t handle) {
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  VLOG(3) << "VMM deallocating " << ptr
+          << " padded size: " << padded_size
+          << " device: " << executor->device_ordinal();
+
+  absl::Status status = ToStatus(hipMemUnmap(ptr, padded_size));
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to unmap VMM memory at " << ptr << ": " << status;
+  }
+  status = ToStatus(hipMemRelease(handle));
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to release VMM handle for " << ptr << ": " << status;
+  }
+  status = ToStatus(hipMemAddressFree(ptr, padded_size));
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to free VMM address at " << ptr << ": " << status;
+  }
+}
+
+namespace {
+
+class RocmVmmMemoryAllocation final : public MemoryAllocation {
+ public:
+  RocmVmmMemoryAllocation(StreamExecutor* executor, void* ptr,
+                          uint64_t requested_size, uint64_t padded_size,
+                          hipMemGenericAllocationHandle_t handle)
+      : executor_(executor),
+        ptr_(ptr),
+        requested_size_(requested_size),
+        padded_size_(padded_size),
+        handle_(handle) {}
+
+  ~RocmVmmMemoryAllocation() final {
+    if (ptr_ != nullptr) {
+      VmmDeallocate(executor_, ptr_, padded_size_, handle_);
+    }
+  }
+
+  DeviceAddressBase address() const final {
+    return DeviceAddressBase(ptr_, requested_size_);
+  }
+
+  std::string ToString() const final {
+    return absl::StrFormat(
+        "RocmVmmMemoryAllocation[device=%d, ptr=%p, size=%d, padded_size=%d]",
+        executor_->device_ordinal(), ptr_, requested_size_, padded_size_);
+  }
+
+ private:
+  StreamExecutor* executor_;
+  void* ptr_;
+  uint64_t requested_size_;
+  uint64_t padded_size_;
+  hipMemGenericAllocationHandle_t handle_;
+};
+
+}  // namespace
+
+RocmVmmAllocator::RocmVmmAllocator(StreamExecutor* executor)
+    : executor_(executor) {}
+
+absl::StatusOr<std::unique_ptr<MemoryAllocation>> RocmVmmAllocator::Allocate(
+    uint64_t size) {
+  if (size == 0) {
+    return std::make_unique<RocmVmmMemoryAllocation>(executor_, nullptr, 0, 0,
+                                                     nullptr);
+  }
+
+  TF_ASSIGN_OR_RETURN(auto result, VmmAllocate(executor_, size));
+  auto [ptr, padded_size, handle] = result;
+
+  return std::make_unique<RocmVmmMemoryAllocation>(executor_, ptr, size,
+                                                   padded_size, handle);
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_vmm_allocator.cc
+++ b/xla/stream_executor/rocm/rocm_vmm_allocator.cc
@@ -32,9 +32,8 @@ limitations under the License.
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/rocm/rocm_status.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
-#include "tsl/platform/errors.h"
-#include "tsl/platform/statusor.h"
 
 namespace stream_executor::gpu {
 
@@ -54,7 +53,7 @@ VmmAllocate(StreamExecutor* executor, uint64_t size) {
   std::unique_ptr<ActivateContext> activation = executor->Activate();
 
   hipDevice_t device;
-  TF_RETURN_IF_ERROR(
+  RETURN_IF_ERROR(
       ToStatus(hipDeviceGet(&device, executor->device_ordinal())));
 
   hipMemAllocationProp properties = {};
@@ -63,13 +62,13 @@ VmmAllocate(StreamExecutor* executor, uint64_t size) {
   properties.location.id = device;
   properties.requestedHandleTypes = hipMemHandleTypeNone;
   size_t granularity = 0;
-  TF_RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+  RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
       &granularity, &properties, hipMemAllocationGranularityRecommended)));
 
   uint64_t padded_size = xla::RoundUpTo<uint64_t>(size, granularity);
   hipMemGenericAllocationHandle_t handle;
 
-  TF_RETURN_IF_ERROR(
+  RETURN_IF_ERROR(
       ToStatus(hipMemCreate(&handle, padded_size, &properties, 0ULL)));
 
   hipDeviceptr_t ptr = nullptr;
@@ -104,7 +103,7 @@ hipMemAddressReserve(&ptr, padded_size, granularity, nullptr,
   // Set access for this device and all P2P-capable peers, matching the CUDA
   // pattern that gates on CanEnablePeerAccessTo().
   int device_count = 0;
-  TF_RETURN_IF_ERROR(ToStatus(hipGetDeviceCount(&device_count)));
+  RETURN_IF_ERROR(ToStatus(hipGetDeviceCount(&device_count)));
   for (int peer = 0; peer < device_count; peer++) {
     if (peer != executor->device_ordinal()) {
       auto peer_executor_or =
@@ -116,7 +115,7 @@ hipMemAddressReserve(&ptr, padded_size, granularity, nullptr,
       }
     }
     hipMemAccessDesc access_desc = GetVmmAccessDescriptor(peer);
-    TF_RETURN_IF_ERROR(
+    RETURN_IF_ERROR(
         ToStatus(hipMemSetAccess(ptr, padded_size, &access_desc, 1)));
   }
 
@@ -196,7 +195,7 @@ absl::StatusOr<std::unique_ptr<MemoryAllocation>> RocmVmmAllocator::Allocate(
                                                      nullptr);
   }
 
-  TF_ASSIGN_OR_RETURN(auto result, VmmAllocate(executor_, size));
+  ASSIGN_OR_RETURN(auto result, VmmAllocate(executor_, size));
   auto [ptr, padded_size, handle] = result;
 
   return std::make_unique<RocmVmmMemoryAllocation>(executor_, ptr, size,

--- a/xla/stream_executor/rocm/rocm_vmm_allocator.h
+++ b/xla/stream_executor/rocm/rocm_vmm_allocator.h
@@ -1,0 +1,45 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_VMM_ALLOCATOR_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_VMM_ALLOCATOR_H_
+
+#include <cstdint>
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_allocator.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// Device memory allocator using ROCm/HIP Virtual Memory Management (VMM) APIs.
+// Returned memory allocations are always mapped to a valid device address range
+// and accessible from the device and its peers.
+class RocmVmmAllocator : public MemoryAllocator {
+ public:
+  explicit RocmVmmAllocator(StreamExecutor* executor);
+
+  absl::StatusOr<std::unique_ptr<MemoryAllocation>> Allocate(
+      uint64_t size) final;
+
+ private:
+  StreamExecutor* executor_;
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_VMM_ALLOCATOR_H_

--- a/xla/stream_executor/rocm/rocm_vmm_allocator_test.cc
+++ b/xla/stream_executor/rocm/rocm_vmm_allocator_test.cc
@@ -1,0 +1,97 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_vmm_allocator.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+namespace {
+
+class RocmVmmAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    auto executor_or = platform_or.value()->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+  }
+
+  StreamExecutor* executor_ = nullptr;
+};
+
+TEST_F(RocmVmmAllocatorTest, AllocateAndFree) {
+  RocmVmmAllocator allocator(executor_);
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
+                       allocator.Allocate(1024));
+  ASSERT_NE(allocation, nullptr);
+  EXPECT_NE(allocation->address().opaque(), nullptr);
+  EXPECT_EQ(allocation->address().size(), 1024);
+}
+
+TEST_F(RocmVmmAllocatorTest, AllocateZeroBytes) {
+  RocmVmmAllocator allocator(executor_);
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
+                       allocator.Allocate(0));
+  ASSERT_NE(allocation, nullptr);
+  EXPECT_EQ(allocation->address().opaque(), nullptr);
+}
+
+TEST_F(RocmVmmAllocatorTest, MemcpyRoundTrip) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<Stream> stream,
+                       executor_->CreateStream());
+
+  RocmVmmAllocator allocator(executor_);
+
+  constexpr int kSize = 1024;
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<MemoryAllocation> allocation,
+                       allocator.Allocate(kSize));
+
+  std::vector<uint8_t> host_src(kSize);
+  for (int i = 0; i < kSize; i++) {
+    host_src[i] = static_cast<uint8_t>(i);
+  }
+
+  DeviceAddress<uint8_t> addr(allocation->address());
+  ASSERT_OK(stream->MemcpyH2D(absl::MakeConstSpan(host_src), &addr));
+
+  std::vector<uint8_t> host_dst(kSize, 0);
+  ASSERT_OK(stream->MemcpyD2H(addr, absl::MakeSpan(host_dst)));
+  ASSERT_OK(stream->BlockHostUntilDone());
+
+  EXPECT_EQ(host_src, host_dst);
+}
+
+}  // namespace
+}  // namespace stream_executor::gpu


### PR DESCRIPTION
# [XLA:GPU] ROCm VMM PR 3/4: `RocmVmmAllocator` (all-in-one VMM allocator)

## Overview — VMM allocator for ROCm/HIP

Third of 4 stacked PRs bringing the **VMM (Virtual Memory Management) allocator** to
ROCm/HIP (split out of #40236 per review feedback).

- **PR 1/4 — `RocmRawMemoryAllocation`** (#43942): physical allocation, `hipMemCreate`/`hipMemRelease`.
- **PR 2/4 — `RocmMemoryReservation`** (#43943): VA reserve / map / setAccess / unmap.
- **PR 3/4 — `RocmVmmAllocator`** (this PR, #43946): all-in-one allocator (create + reserve + map + setAccess).
- **PR 4/4 — `RocmDeviceAddressVmmAllocator` + vendor-neutral factory** (#43947): timeline-based
  deferred deallocation, and PJRT enablement so `allocator=vmm` works on ROCm.

> _Update the PR numbers above if they differ._

---

## This PR (PR 3/4): `RocmVmmAllocator`

A simple `MemoryAllocator` that combines the two lower layers into a single `Allocate`
call. Each allocation it returns is **already mapped to a valid device virtual address**
and accessible from the device and its peers — i.e. immediately usable, unlike the raw
physical handle from PR 1/4. It builds on PR 1/4 + PR 2/4 and has no callers yet, so it
changes no existing behavior.

### Files
- `xla/stream_executor/rocm/rocm_vmm_allocator.{h,cc}` — the all-in-one allocator.
- `xla/stream_executor/rocm/rocm_vmm_allocator_test.cc` — unit tests.
- `xla/stream_executor/rocm/BUILD` — new targets.

### Design
`RocmVmmAllocator` derives from `MemoryAllocator`:

- **`Allocate(uint64_t size)`** performs, in one call:
  1. `RocmRawMemoryAllocation::Create` — physical memory (PR 1/4),
  2. `RocmMemoryReservation::Create` — a VA range (PR 2/4),
  3. map the physical allocation into the reservation and `SetAccess` for the device +
     P2P-capable peers,

  returning a `MemoryAllocation` whose address is a ready-to-use device pointer.

This is the straightforward "create + reserve + map + setAccess" allocator (no deferred
deallocation / timeline reuse — that is PR 4/4). Mirrors the CUDA VMM structure.

---

## Testing
`rocm_vmm_allocator_test` (3 tests), AMD Instinct MI300X (gfx942), ROCm 7.2.0:
- `AllocateAndFree` — allocate then release succeeds.
- `AllocateZeroBytes` — zero-size request handled gracefully.
- `MemcpyRoundTrip` — host→device→host round-trip through VMM memory returns identical data
  (proves the returned address is genuinely device-accessible).

---

## Next PR
**PR 4/4 — `RocmDeviceAddressVmmAllocator` + vendor-neutral factory (#43947):** the
production allocator with GPU timeline-based deferred deallocation
(`hipStreamWriteValue64` + signal memory), deterministic VA reuse, and a
`DeviceAddressVmmAllocator::Create()` factory that the PJRT GPU client uses so
`allocator=vmm` works on ROCm.
