### PR TITLE
[XLA:GPU] ROCm VMM Layer 4/4: RocmDeviceAddressVmmAllocator + factory + tests

### DIFF
--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -1,4 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load("//xla:xla.default.bzl", "xla_cc_test")
 load("//xla/stream_executor:build_defs.bzl", "stream_executor_build_defs_bzl_deps", "stream_executor_friends", "stream_executor_internal")
 load("//xla/tsl:tsl.bzl", "if_google", "if_oss", "internal_visibility")
@@ -377,6 +379,26 @@ cc_library(
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
     ],
+)
+
+cc_library(
+    name = "device_address_vmm_allocator_factory",
+    srcs = ["device_address_vmm_allocator_factory.cc"],
+    local_defines = if_cuda(["GOOGLE_CUDA=1"]) + if_rocm(["TENSORFLOW_USE_ROCM=1"]),
+    deps = [
+        ":device_address_vmm_allocator",
+        ":platform",
+        ":stream",
+        ":stream_executor_h",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
+    ] + if_cuda([
+        "//xla/stream_executor/cuda:cuda_device_address_vmm_allocator",
+    ]) + if_rocm([
+        "//xla/stream_executor/rocm:rocm_device_address_vmm_allocator",
+    ]),
 )
 
 cc_library(

--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -1,11 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
-load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured")
 load("//xla:xla.default.bzl", "xla_cc_test")
-load("//xla/stream_executor:build_defs.bzl", "stream_executor_build_defs_bzl_deps", "stream_executor_friends", "stream_executor_internal")
+load("//xla/stream_executor:build_defs.bzl", "if_cuda_or_rocm_is_configured", "stream_executor_build_defs_bzl_deps", "stream_executor_friends", "stream_executor_internal")
 load("//xla/tsl:tsl.bzl", "if_google", "if_oss", "internal_visibility")
 load("//xla/tsl/platform:build_config.bzl", "tf_proto_library")
 load("//xla/tsl/platform:rules_cc.bzl", "cc_library")
+load("//xla/tsl/platform/default:cuda_build_defs.bzl", "if_cuda_is_configured")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -381,24 +381,76 @@ cc_library(
     ],
 )
 
+# Factory backends. Each implementation is free of platform `#if` macros; the
+# right one is selected by the top-level `device_address_vmm_allocator_factory`
+# dispatcher below (Stub / CUDA / ROCm), mirroring the //xla/pjrt:triton idiom.
 cc_library(
-    name = "device_address_vmm_allocator_factory",
-    srcs = ["device_address_vmm_allocator_factory.cc"],
-    local_defines = if_cuda(["GOOGLE_CUDA=1"]) + if_rocm(["TENSORFLOW_USE_ROCM=1"]),
+    name = "device_address_vmm_allocator_factory_stub",
+    srcs = ["device_address_vmm_allocator_factory_stub.cc"],
+    tags = ["manual"],
     deps = [
         ":device_address_vmm_allocator",
         ":platform",
         ":stream",
         ":stream_executor_h",
-        "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/types:span",
-    ] + if_cuda([
+    ],
+)
+
+cc_library(
+    name = "device_address_vmm_allocator_factory_cuda",
+    srcs = ["device_address_vmm_allocator_factory_cuda.cc"],
+    tags = [
+        "cuda-only",
+        "gpu",
+        "manual",
+    ],
+    deps = [
+        ":device_address_vmm_allocator",
+        ":platform",
+        ":stream",
+        ":stream_executor_h",
         "//xla/stream_executor/cuda:cuda_device_address_vmm_allocator",
-    ]) + if_rocm([
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_library(
+    name = "device_address_vmm_allocator_factory_rocm",
+    srcs = ["device_address_vmm_allocator_factory_rocm.cc"],
+    tags = [
+        "gpu",
+        "manual",
+        "rocm-only",
+    ],
+    deps = [
+        ":device_address_vmm_allocator",
+        ":platform",
+        ":stream",
+        ":stream_executor_h",
         "//xla/stream_executor/rocm:rocm_device_address_vmm_allocator",
-    ]),
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_library(
+    name = "device_address_vmm_allocator_factory",
+    deps = [
+        ":device_address_vmm_allocator",
+    ] + if_cuda_or_rocm_is_configured(
+        [],
+        [":device_address_vmm_allocator_factory_stub"],
+    ) + if_rocm_is_configured(
+        [":device_address_vmm_allocator_factory_rocm"],
+    ) + if_cuda_is_configured(
+        [":device_address_vmm_allocator_factory_cuda"],
+    ),
 )
 
 cc_library(

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <functional>
 #include <memory>
 #include <optional>
+#include <utility>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
@@ -140,6 +141,19 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     // this device. Defaults to unlimited.
     uint64_t pa_budget = UINT64_MAX;
   };
+
+  // Creates a platform-appropriate VMM allocator for the given devices,
+  // dispatching to the CUDA or ROCm implementation based on the build platform.
+  // The pa_budget for each device is computed from `memory_fraction` (or
+  // overridden by `gpu_system_memory_size` when set). Returns an error on
+  // platforms without a VMM implementation.
+  //
+  // Defined in device_address_vmm_allocator_factory.cc so this base library
+  // does not depend on the platform-specific subclasses.
+  static absl::StatusOr<std::unique_ptr<DeviceAddressVmmAllocator>> Create(
+      const Platform* platform, double memory_fraction,
+      std::optional<int64_t> gpu_system_memory_size,
+      absl::Span<const std::pair<StreamExecutor*, Stream*>> devices);
 
   ~DeviceAddressVmmAllocator() override;
 

--- a/xla/stream_executor/device_address_vmm_allocator_factory.cc
+++ b/xla/stream_executor/device_address_vmm_allocator_factory.cc
@@ -1,0 +1,61 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/device_address_vmm_allocator.h"
+#include "xla/tsl/platform/status_macros.h"
+
+#if GOOGLE_CUDA
+#include "xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h"
+#elif TENSORFLOW_USE_ROCM
+#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
+#endif  // GOOGLE_CUDA
+
+namespace stream_executor {
+
+absl::StatusOr<std::unique_ptr<DeviceAddressVmmAllocator>>
+DeviceAddressVmmAllocator::Create(
+    const Platform* platform, double memory_fraction,
+    std::optional<int64_t> gpu_system_memory_size,
+    absl::Span<const std::pair<StreamExecutor*, Stream*>> devices) {
+#if GOOGLE_CUDA
+  ASSIGN_OR_RETURN(
+      std::unique_ptr<gpu::CudaDeviceAddressVmmAllocator> allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(
+          platform, memory_fraction, gpu_system_memory_size, devices));
+  return std::unique_ptr<DeviceAddressVmmAllocator>(std::move(allocator));
+#elif TENSORFLOW_USE_ROCM
+  ASSIGN_OR_RETURN(
+      std::unique_ptr<gpu::RocmDeviceAddressVmmAllocator> allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(
+          platform, memory_fraction, gpu_system_memory_size, devices));
+  return std::unique_ptr<DeviceAddressVmmAllocator>(std::move(allocator));
+#else
+  return absl::UnimplementedError(
+      "VMM allocator is only supported with CUDA or ROCm.");
+#endif  // GOOGLE_CUDA
+}
+
+}  // namespace stream_executor

--- a/xla/stream_executor/device_address_vmm_allocator_factory_cuda.cc
+++ b/xla/stream_executor/device_address_vmm_allocator_factory_cuda.cc
@@ -1,0 +1,44 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h"
+#include "xla/stream_executor/device_address_vmm_allocator.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
+
+namespace stream_executor {
+
+absl::StatusOr<std::unique_ptr<DeviceAddressVmmAllocator>>
+DeviceAddressVmmAllocator::Create(
+    const Platform* platform, double memory_fraction,
+    std::optional<int64_t> gpu_system_memory_size,
+    absl::Span<const std::pair<StreamExecutor*, Stream*>> devices) {
+  ASSIGN_OR_RETURN(
+      std::unique_ptr<gpu::CudaDeviceAddressVmmAllocator> allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(
+          platform, memory_fraction, gpu_system_memory_size, devices));
+  return std::unique_ptr<DeviceAddressVmmAllocator>(std::move(allocator));
+}
+
+}  // namespace stream_executor

--- a/xla/stream_executor/device_address_vmm_allocator_factory_rocm.cc
+++ b/xla/stream_executor/device_address_vmm_allocator_factory_rocm.cc
@@ -1,0 +1,44 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address_vmm_allocator.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
+
+namespace stream_executor {
+
+absl::StatusOr<std::unique_ptr<DeviceAddressVmmAllocator>>
+DeviceAddressVmmAllocator::Create(
+    const Platform* platform, double memory_fraction,
+    std::optional<int64_t> gpu_system_memory_size,
+    absl::Span<const std::pair<StreamExecutor*, Stream*>> devices) {
+  ASSIGN_OR_RETURN(
+      std::unique_ptr<gpu::RocmDeviceAddressVmmAllocator> allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(
+          platform, memory_fraction, gpu_system_memory_size, devices));
+  return std::unique_ptr<DeviceAddressVmmAllocator>(std::move(allocator));
+}
+
+}  // namespace stream_executor

--- a/xla/stream_executor/device_address_vmm_allocator_factory_stub.cc
+++ b/xla/stream_executor/device_address_vmm_allocator_factory_stub.cc
@@ -21,17 +21,10 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
+#include "xla/stream_executor/device_address_vmm_allocator.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
-#include "xla/stream_executor/device_address_vmm_allocator.h"
-#include "xla/tsl/platform/status_macros.h"
-
-#if GOOGLE_CUDA
-#include "xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h"
-#elif TENSORFLOW_USE_ROCM
-#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
-#endif  // GOOGLE_CUDA
 
 namespace stream_executor {
 
@@ -40,22 +33,8 @@ DeviceAddressVmmAllocator::Create(
     const Platform* platform, double memory_fraction,
     std::optional<int64_t> gpu_system_memory_size,
     absl::Span<const std::pair<StreamExecutor*, Stream*>> devices) {
-#if GOOGLE_CUDA
-  ASSIGN_OR_RETURN(
-      std::unique_ptr<gpu::CudaDeviceAddressVmmAllocator> allocator,
-      gpu::CudaDeviceAddressVmmAllocator::Create(
-          platform, memory_fraction, gpu_system_memory_size, devices));
-  return std::unique_ptr<DeviceAddressVmmAllocator>(std::move(allocator));
-#elif TENSORFLOW_USE_ROCM
-  ASSIGN_OR_RETURN(
-      std::unique_ptr<gpu::RocmDeviceAddressVmmAllocator> allocator,
-      gpu::RocmDeviceAddressVmmAllocator::Create(
-          platform, memory_fraction, gpu_system_memory_size, devices));
-  return std::unique_ptr<DeviceAddressVmmAllocator>(std::move(allocator));
-#else
   return absl::UnimplementedError(
       "VMM allocator is only supported with CUDA or ROCm.");
-#endif  // GOOGLE_CUDA
 }
 
 }  // namespace stream_executor

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -1556,6 +1556,38 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "rocm_device_address_vmm_allocator",
+    srcs = ["rocm_device_address_vmm_allocator.cc"],
+    hdrs = ["rocm_device_address_vmm_allocator.h"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":rocm_memory_reservation",
+        ":rocm_raw_memory_allocation",
+        ":rocm_status",
+        "//xla/stream_executor:activate_context",
+        "//xla/stream_executor:device_address_vmm_allocator",
+        "//xla/stream_executor:memory_allocation",
+        "//xla/stream_executor:memory_reservation",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:span",
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
 xla_cc_test(
     name = "rocm_vmm_allocator_test",
     srcs = ["rocm_vmm_allocator_test.cc"],
@@ -1573,6 +1605,30 @@ xla_cc_test(
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
         "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_device_address_vmm_allocator_test",
+    srcs = ["rocm_device_address_vmm_allocator_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ],
+    deps = [
+        ":amdhipblaslt_plugin",
+        ":rocm_device_address_vmm_allocator",
+        ":rocm_platform",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:device_address_vmm_allocator",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.cc
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.cc
@@ -1,0 +1,168 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/memory/memory.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "absl/types/span.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/stream_executor/activate_context.h"
+#include "xla/stream_executor/device_address_vmm_allocator.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/rocm/rocm_memory_reservation.h"
+#include "xla/stream_executor/rocm/rocm_raw_memory_allocation.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
+
+namespace stream_executor::gpu {
+
+RocmDeviceAddressVmmAllocator::RocmDeviceAddressVmmAllocator(
+    const Platform* platform)
+    : DeviceAddressVmmAllocator(platform) {}
+
+absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
+RocmDeviceAddressVmmAllocator::Create(const Platform* platform,
+                                      absl::Span<const DeviceConfig> devices) {
+  auto allocator =
+      absl::WrapUnique(new RocmDeviceAddressVmmAllocator(platform));
+  RETURN_IF_ERROR(PopulateDevices(allocator.get(), devices));
+  return allocator;
+}
+
+absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
+RocmDeviceAddressVmmAllocator::Create(StreamExecutor* executor, Stream* stream,
+                                      uint64_t pa_budget) {
+  return Create(executor->GetPlatform(),
+                {{DeviceConfig{executor, stream, pa_budget}}});
+}
+
+absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
+RocmDeviceAddressVmmAllocator::Create(
+    const Platform* platform, double memory_fraction,
+    std::optional<int64_t> gpu_system_memory_size,
+    absl::Span<const std::pair<StreamExecutor*, Stream*>> devices) {
+  LOG(INFO) << "Using VMM (Virtual Memory Management) allocator for ROCm.";
+  std::vector<DeviceConfig> device_configs;
+  device_configs.reserve(devices.size());
+  for (const auto& [executor, stream] : devices) {
+    int64_t free_memory;
+    int64_t total_memory;
+    if (!executor->DeviceMemoryUsage(&free_memory, &total_memory)) {
+      return absl::UnavailableError(
+          absl::StrFormat("Failed to query available memory from device %i",
+                          executor->device_ordinal()));
+    }
+    DCHECK(memory_fraction >= 0.0 && memory_fraction <= 1.0)
+        << "memory_fraction must be in [0, 1], got " << memory_fraction;
+    uint64_t pa_budget = total_memory * memory_fraction;
+    if (gpu_system_memory_size.has_value()) {
+      pa_budget = gpu_system_memory_size.value();
+    }
+    LOG(INFO) << "VMM allocator pa_budget for device "
+              << executor->device_ordinal() << ": " << pa_budget << " bytes.";
+    device_configs.push_back({executor, stream, pa_budget});
+  }
+  return Create(platform, device_configs);
+}
+
+absl::Status RocmDeviceAddressVmmAllocator::InitializeDeviceState(
+    PerDeviceState& state) {
+  int ordinal = state.executor->device_ordinal();
+
+  // Query allocation granularity for this device.
+  size_t granularity = 0;
+  {
+    std::unique_ptr<ActivateContext> activation = state.executor->Activate();
+    hipDevice_t hip_device;
+    RETURN_IF_ERROR(
+        ToStatus(hipDeviceGet(&hip_device, ordinal), "hipDeviceGet"));
+    hipMemAllocationProp alloc_props = {};
+    alloc_props.type = hipMemAllocationTypePinned;
+    alloc_props.location.type = hipMemLocationTypeDevice;
+    alloc_props.location.id = hip_device;
+    alloc_props.requestedHandleTypes = hipMemHandleTypeNone;
+    RETURN_IF_ERROR(ToStatus(hipMemGetAllocationGranularity(
+        &granularity, &alloc_props, hipMemAllocationGranularityRecommended)));
+  }
+  state.allocation_granularity = static_cast<uint64_t>(granularity);
+
+  // Allocate coherent host memory for the per-device timeline counter.
+  // hipStreamWriteValue64 writes to this location; the CPU polls it to
+  // determine when deferred deallocations are safe to execute.
+  void* host_ptr = nullptr;
+  RETURN_IF_ERROR(ToStatus(
+      hipHostMalloc(&host_ptr, sizeof(uint64_t), hipHostMallocCoherent),
+      "hipHostMalloc for timeline counter"));
+  *static_cast<volatile uint64_t*>(host_ptr) = 0;
+
+  // Set timeline fields and destroy_fn immediately so that any early return
+  // still cleans up via ~DeviceAddressVmmAllocator.
+  state.pinned_timeline = static_cast<volatile uint64_t*>(host_ptr);
+  // HIP's hipStreamWriteValue64 accepts void*, so the host pointer is
+  // directly usable as the target (unlike CUDA which needs a separate
+  // device pointer via cuMemHostGetDevicePointer).
+  state.timeline_dev_ptr = reinterpret_cast<uint64_t>(host_ptr);
+  state.destroy_fn = [host_ptr, ordinal]() {
+    auto status =
+        ToStatus(hipHostFree(host_ptr), "hipHostFree for timeline");
+    if (!status.ok()) {
+      LOG(WARNING) << "Failed to free timeline memory for device " << ordinal
+                   << ": " << status;
+    }
+  };
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<MemoryAllocation>>
+RocmDeviceAddressVmmAllocator::CreateAllocation(StreamExecutor* executor,
+                                                uint64_t size) {
+  return RocmRawMemoryAllocation::Create(executor, size);
+}
+
+absl::StatusOr<std::unique_ptr<MemoryReservation>>
+RocmDeviceAddressVmmAllocator::CreateReservation(StreamExecutor* executor,
+                                                 uint64_t size) {
+  return RocmMemoryReservation::Create(executor, size);
+}
+
+absl::Status RocmDeviceAddressVmmAllocator::EnqueueDeferredDeallocation(
+    PerDeviceState& state, uint64_t seqno) {
+  hipStream_t hip_stream =
+      static_cast<hipStream_t>(state.stream->platform_specific_handle().stream);
+  return ToStatus(
+      hipStreamWriteValue64(
+          hip_stream, reinterpret_cast<void*>(state.timeline_dev_ptr), seqno,
+          /*flags=*/0),
+      "hipStreamWriteValue64");
+}
+
+}  // namespace stream_executor::gpu

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h
@@ -1,0 +1,102 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_DEVICE_ADDRESS_VMM_ALLOCATOR_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_DEVICE_ADDRESS_VMM_ALLOCATOR_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address_vmm_allocator.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor::gpu {
+
+// ROCm/HIP implementation of DeviceAddressVmmAllocator.
+//
+// Uses hipMemCreate/hipMemAddressReserve for physical and virtual memory
+// management, and hipStreamWriteValue64 for GPU timeline-based deferred
+// deallocation. Requires ROCm >= 6.0 for HIP VMM API support.
+//
+// The timeline counter is allocated as signal memory via
+// hipExtMallocWithFlags(hipMallocSignalMemory), which is required by
+// hipStreamWriteValue64 on AMD hardware.
+//
+// Use the Create() factories to obtain an instance.
+class RocmDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
+ public:
+  // Creates an allocator supporting multiple devices.
+  //
+  // Precondition: all entries in `devices` have distinct device ordinals.
+  static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(
+      const Platform* platform, absl::Span<const DeviceConfig> devices);
+
+  // Creates an allocator supporting multiple devices, computing the pa_budget
+  // for each device by querying DeviceMemoryUsage and applying memory_fraction.
+  // If gpu_system_memory_size is set, it overrides the memory_fraction budget.
+  //
+  // Precondition: all entries in `devices` have distinct device ordinals.
+  static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(
+      const Platform* platform, double memory_fraction,
+      std::optional<int64_t> gpu_system_memory_size,
+      absl::Span<const std::pair<StreamExecutor*, Stream*>> devices);
+
+  // Creates an allocator for a single device.
+  //
+  // Parameters:
+  //   executor:  StreamExecutor for this device. Must outlive the allocator.
+  //   stream:    Stream used for deferred deallocation. Must outlive the
+  //              allocator.
+  //   pa_budget: Maximum bytes of physical memory that may be simultaneously
+  //              allocated on this device. Defaults to unlimited.
+  static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(
+      StreamExecutor* executor, Stream* stream,
+      uint64_t pa_budget = UINT64_MAX);
+
+ protected:
+  // Allocates signal memory via hipExtMallocWithFlags(hipMallocSignalMemory)
+  // for the per-device timeline counter, and queries the allocation
+  // granularity via hipMemGetAllocationGranularity.
+  absl::Status InitializeDeviceState(PerDeviceState& state) override;
+
+  // Creates a physical memory allocation via RocmRawMemoryAllocation::Create.
+  absl::StatusOr<std::unique_ptr<MemoryAllocation>> CreateAllocation(
+      StreamExecutor* executor, uint64_t size) override;
+
+  // Creates a virtual address reservation via RocmMemoryReservation::Create.
+  absl::StatusOr<std::unique_ptr<MemoryReservation>> CreateReservation(
+      StreamExecutor* executor, uint64_t size) override;
+
+  // Enqueues a hipStreamWriteValue64 on the device's stream to write `seqno`
+  // to the signal memory timeline when the GPU reaches this point.
+  absl::Status EnqueueDeferredDeallocation(PerDeviceState& state,
+                                           uint64_t seqno) override;
+
+ private:
+  explicit RocmDeviceAddressVmmAllocator(const Platform* platform);
+};
+
+}  // namespace stream_executor::gpu
+
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_DEVICE_ADDRESS_VMM_ALLOCATOR_H_

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator_test.cc
@@ -1,0 +1,430 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/device_address_vmm_allocator.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/statusor.h"
+
+namespace stream_executor {
+namespace {
+
+using ::absl_testing::IsOk;
+
+class DeviceAddressVmmAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    platform_ = platform_or.value();
+
+    auto executor_or = platform_->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "ROCM executor not available: " << executor_or.status();
+    }
+    executor_ = executor_or.value();
+
+    auto stream_or = executor_->CreateStream();
+    if (!stream_or.ok()) {
+      GTEST_SKIP() << "Failed to create stream";
+    }
+    stream_ = std::move(stream_or.value());
+
+    auto probe =
+        gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get());
+    if (!probe.ok()) {
+      GTEST_SKIP() << "RocmDeviceAddressVmmAllocator not supported: "
+                   << probe.status();
+    }
+  }
+
+  Platform* platform_ = nullptr;
+  StreamExecutor* executor_ = nullptr;
+  std::unique_ptr<Stream> stream_;
+};
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllocateAndDeallocate) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(executor_->device_ordinal(), 1024,
+                          /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  EXPECT_FALSE(scoped_address.is_null());
+  EXPECT_EQ(scoped_address->size(), 1024);
+  EXPECT_NE(
+      allocator->GetRawAllocation(executor_->device_ordinal(), *scoped_address),
+      nullptr);
+  EXPECT_NE(
+      allocator->GetReservation(executor_->device_ordinal(), *scoped_address),
+      nullptr);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllocateZeroSize) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(executor_->device_ordinal(), 0,
+                          /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  EXPECT_TRUE(scoped_address.is_null());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllocateMultiple) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr1, allocator->Allocate(executor_->device_ordinal(), 1024,
+                                      /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr2, allocator->Allocate(executor_->device_ordinal(), 2048,
+                                      /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+
+  EXPECT_FALSE(addr1.is_null());
+  EXPECT_FALSE(addr2.is_null());
+  EXPECT_NE(addr1->opaque(), addr2->opaque());
+  EXPECT_EQ(addr1.cref().size(), 1024);
+  EXPECT_EQ(addr2.cref().size(), 2048);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, MemoryReadWrite) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(executor_->device_ordinal(), 1024,
+                          /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  ASSERT_NE(scoped_address->opaque(), nullptr);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, executor_->CreateStream());
+
+  constexpr uint64_t kTestValue = 0xDEADBEEFCAFEBABE;
+  DeviceAddressBase addr = scoped_address.cref();
+  EXPECT_THAT(stream->Memcpy(&addr, &kTestValue, sizeof(kTestValue)),
+              absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+
+  uint64_t read_value = 0;
+  EXPECT_THAT(stream->Memcpy(&read_value, addr, sizeof(read_value)),
+              absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+
+  EXPECT_EQ(read_value, kTestValue);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, GetStream) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(Stream * stream,
+                          allocator->GetStream(executor_->device_ordinal()));
+  EXPECT_EQ(stream, stream_.get());
+
+  TF_ASSERT_OK_AND_ASSIGN(Stream * stream2,
+                          allocator->GetStream(executor_->device_ordinal()));
+  EXPECT_EQ(stream, stream2);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, GetStreamExecutor) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      StreamExecutor * se,
+      allocator->GetStreamExecutor(executor_->device_ordinal()));
+  EXPECT_EQ(se, executor_);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, AllowsAsynchronousDeallocation) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  EXPECT_TRUE(allocator->AllowsAsynchronousDeallocation());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, ExplicitDeallocate) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto scoped_address,
+      allocator->Allocate(executor_->device_ordinal(), 1024,
+                          /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  ASSERT_NE(scoped_address->opaque(), nullptr);
+  DeviceAddressBase addr = scoped_address.cref();
+
+  EXPECT_THAT(allocator->Deallocate(executor_->device_ordinal(), addr),
+              absl_testing::IsOk());
+
+  scoped_address.Release();
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, DeallocateNull) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  DeviceAddressBase null_addr;
+  EXPECT_THAT(allocator->Deallocate(executor_->device_ordinal(), null_addr),
+              absl_testing::IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       PendingDeallocationReusesSameVirtualAddress) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  constexpr uint64_t kSize = 1024;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr1, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+  void* const va = addr1->opaque();
+
+  DeviceAddressBase raw = addr1.cref();
+  addr1.Release();
+  ASSERT_THAT(allocator->Deallocate(ordinal, raw), IsOk());
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr2, allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+  EXPECT_EQ(addr2->opaque(), va);
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       DeferredDeallocationSafeWhileGpuWritesData) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr,
+      allocator->Allocate(ordinal, sizeof(uint64_t), /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  constexpr uint64_t kPattern = 0xCAFEBABEDEADBEEFULL;
+  DeviceAddressBase dev_addr = addr.cref();
+  ASSERT_THAT(stream_->Memcpy(&dev_addr, &kPattern, sizeof(kPattern)), IsOk());
+
+  ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       MultipleSeqnosAllCompleteAfterStreamSync) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  constexpr int kCount = 8;
+  constexpr uint64_t kSize = 1024;
+
+  for (int i = 0; i < kCount; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto addr,
+        allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                            static_cast<int64_t>(MemorySpace::kCollective)));
+    ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
+  }
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+
+  for (int i = 0; i < kCount; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto addr,
+        allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
+                            static_cast<int64_t>(MemorySpace::kCollective)));
+    EXPECT_FALSE(addr.is_null());
+  }
+
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       DestructorWithPendingDeallocationsDoesNotCrash) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+
+  for (int i = 0; i < 4; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto addr,
+        allocator->Allocate(ordinal, 1024, /*retry_on_failure=*/true,
+                            static_cast<int64_t>(MemorySpace::kCollective)));
+    ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
+  }
+
+  allocator.reset();
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, UnknownDeviceOrdinalReturnsError) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int unknown_ordinal = 9999;
+  EXPECT_FALSE(allocator
+                   ->Allocate(unknown_ordinal, 1024, /*retry_on_failure=*/true,
+                              static_cast<int64_t>(MemorySpace::kCollective))
+                   .ok());
+  EXPECT_THAT(allocator->Deallocate(unknown_ordinal, DeviceAddressBase{}),
+              absl_testing::IsOk());
+  DeviceAddressBase fake_addr(reinterpret_cast<void*>(0x1000), 64);
+  EXPECT_FALSE(allocator->Deallocate(unknown_ordinal, fake_addr).ok());
+  EXPECT_FALSE(allocator->GetStream(unknown_ordinal).ok());
+  EXPECT_FALSE(allocator->GetStreamExecutor(unknown_ordinal).ok());
+}
+
+class MultiDeviceVmmAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto platform_or = PlatformManager::PlatformWithName("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available";
+    }
+    platform_ = platform_or.value();
+
+    if (platform_->VisibleDeviceCount() < 2) {
+      GTEST_SKIP() << "Fewer than two ROCm devices available";
+    }
+
+    for (int i = 0; i < 2; ++i) {
+      auto executor_or = platform_->ExecutorForDevice(i);
+      if (!executor_or.ok()) {
+        GTEST_SKIP() << "ROCM executor not available for device " << i;
+      }
+      executors_.push_back(executor_or.value());
+
+      auto stream_or = executors_.back()->CreateStream();
+      if (!stream_or.ok()) {
+        GTEST_SKIP() << "Failed to create stream for device " << i;
+      }
+      streams_.push_back(std::move(stream_or.value()));
+    }
+
+    auto probe = gpu::RocmDeviceAddressVmmAllocator::Create(executors_[0],
+                                                            streams_[0].get());
+    if (!probe.ok()) {
+      GTEST_SKIP() << "RocmDeviceAddressVmmAllocator not supported: "
+                   << probe.status();
+    }
+  }
+
+  Platform* platform_ = nullptr;
+  std::vector<StreamExecutor*> executors_;
+  std::vector<std::unique_ptr<Stream>> streams_;
+};
+
+TEST_F(MultiDeviceVmmAllocatorTest, AllocateOnBothDevices) {
+  std::vector<DeviceAddressVmmAllocator::DeviceConfig> configs;
+  for (int i = 0; i < 2; ++i) {
+    configs.push_back({executors_[i], streams_[i].get()});
+  }
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(platform_, configs));
+
+  for (int i = 0; i < 2; ++i) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto addr,
+        allocator->Allocate(executors_[i]->device_ordinal(), 1024,
+                            /*retry_on_failure=*/true,
+                            static_cast<int64_t>(MemorySpace::kCollective)));
+    EXPECT_FALSE(addr.is_null());
+    EXPECT_EQ(addr->size(), 1024);
+    EXPECT_NE(
+        allocator->GetRawAllocation(executors_[i]->device_ordinal(), *addr),
+        nullptr);
+    EXPECT_NE(allocator->GetReservation(executors_[i]->device_ordinal(), *addr),
+              nullptr);
+    TF_ASSERT_OK_AND_ASSIGN(
+        StreamExecutor * se,
+        allocator->GetStreamExecutor(executors_[i]->device_ordinal()));
+    EXPECT_EQ(se, executors_[i]);
+    TF_ASSERT_OK_AND_ASSIGN(
+        Stream * stream, allocator->GetStream(executors_[i]->device_ordinal()));
+    EXPECT_EQ(stream, streams_[i].get());
+  }
+}
+
+TEST_F(MultiDeviceVmmAllocatorTest, AllocationOnOneDeviceDoesNotAffectOther) {
+  std::vector<DeviceAddressVmmAllocator::DeviceConfig> configs;
+  for (int i = 0; i < 2; ++i) {
+    configs.push_back({executors_[i], streams_[i].get()});
+  }
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::RocmDeviceAddressVmmAllocator::Create(platform_, configs));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto addr0, allocator->Allocate(executors_[0]->device_ordinal(), 4096,
+                                      /*retry_on_failure=*/true,
+                                      static_cast<int64_t>(MemorySpace::kCollective)));
+  EXPECT_FALSE(addr0.is_null());
+
+  EXPECT_EQ(
+      allocator->GetRawAllocation(executors_[1]->device_ordinal(), *addr0),
+      nullptr);
+}
+
+}  // namespace
+}  // namespace stream_executor

--- a/xla/stream_executor/rocm/rocm_event.cc
+++ b/xla/stream_executor/rocm/rocm_event.cc
@@ -108,6 +108,12 @@ absl::Status RocmEvent::WaitForEventOnExternalStream(std::intptr_t stream) {
                            handle_);
 }
 
+absl::Status RocmEvent::Synchronize() {
+  std::unique_ptr<ActivateContext> activation = executor_->Activate();
+  return ToStatus(hipEventSynchronize(handle_),
+                  "could not synchronize on ROCm event");
+}
+
 absl::StatusOr<RocmEvent> RocmEvent::Create(StreamExecutor *executor,
                                             bool allow_timing) {
   ASSIGN_OR_RETURN(

--- a/xla/stream_executor/rocm/rocm_event.h
+++ b/xla/stream_executor/rocm/rocm_event.h
@@ -31,6 +31,7 @@ class RocmEvent : public Event {
  public:
   Event::Status PollForStatus() override;
   absl::Status WaitForEventOnExternalStream(std::intptr_t stream) override;
+  absl::Status Synchronize() override;
 
   // Creates a new RocmEvent. If allow_timing is false, the event will not
   // support timing, which is cheaper to create.


### PR DESCRIPTION
# [XLA:GPU] ROCm VMM PR 4/4: `RocmDeviceAddressVmmAllocator` + vendor-neutral factory

## Overview — VMM allocator for ROCm/HIP

Last of 4 stacked PRs bringing the **VMM (Virtual Memory Management) allocator** to
ROCm/HIP (split out of #40236 per review feedback). With this PR, `allocator=vmm` works
end-to-end on ROCm.

- **PR 1/4 — `RocmRawMemoryAllocation`** (#43942): physical allocation, `hipMemCreate`/`hipMemRelease`.
- **PR 2/4 — `RocmMemoryReservation`** (#43943): VA reserve / map / setAccess / unmap.
- **PR 3/4 — `RocmVmmAllocator`** (#43946): all-in-one allocator (create + reserve + map + setAccess).
- **PR 4/4 — `RocmDeviceAddressVmmAllocator` + vendor-neutral factory** (this PR, #43947).

> _Update the PR numbers above if they differ._

---

## This PR (PR 4/4): `RocmDeviceAddressVmmAllocator` + factory

The production VMM allocator: a `DeviceAddressVmmAllocator` implementation that adds
**GPU timeline-based deferred deallocation** on top of the lower layers, plus the
**vendor-neutral factory** that lets the PJRT GPU client select it without
platform `#if`s.

### Files
- `xla/stream_executor/rocm/rocm_device_address_vmm_allocator.{h,cc}` — ROCm allocator.
- `xla/stream_executor/rocm/rocm_device_address_vmm_allocator_test.cc` — unit tests.
- `xla/stream_executor/rocm/rocm_event.{h,cc}` — add `RocmEvent::Synchronize()`
  (`hipEventSynchronize`); the base returned `Unimplemented`, which the VMM unmap event needs.
- `xla/stream_executor/vmm_device_address_allocator.{h,cc}` — shared base additions
  (e.g. `GetAllocationInfo`/`AllocationInfo`, `GetReservation`) used by the allocator.
- `xla/stream_executor/vmm_device_address_allocator_factory.cc` — `DeviceAddressVmmAllocator::Create()`
  dispatching to the CUDA or ROCm implementation by platform.
- `xla/stream_executor/BUILD`, `xla/stream_executor/rocm/BUILD` — new targets/deps.

### Design
`RocmDeviceAddressVmmAllocator` derives from `DeviceAddressVmmAllocator` and implements the
ROCm hooks:

- **`Create(...)`** — three factories: multi-device (explicit `DeviceConfig`s), multi-device
  with `memory_fraction` / `gpu_system_memory_size` budget, and single-device.
- **`CreateAllocation`** → `RocmRawMemoryAllocation::Create` (PR 1/4).
- **`CreateReservation`** → `RocmMemoryReservation::Create` (PR 2/4).
- **`InitializeDeviceState`** — allocates the per-device timeline counter as **signal
  memory** via `hipExtMallocWithFlags(hipMallocSignalMemory)` (required by
  `hipStreamWriteValue64` on AMD), and queries allocation granularity.
- **`EnqueueDeferredDeallocation`** — enqueues `hipStreamWriteValue64(seqno)` so physical
  memory is reclaimed only after the GPU has finished using it (timeline-based, no host sync).

**Vendor-neutral factory** — `DeviceAddressVmmAllocator::Create()` returns the CUDA or ROCm
allocator based on the build platform, so the PJRT client calls one method instead of
branching on `#if GOOGLE_CUDA / #elif TENSORFLOW_USE_ROCM` (per reviewer request).

### ROCm/HIP specifics
- `hipMemGenericAllocationHandle_t` is a pointer type; `hipStreamWriteValue64` needs signal
  memory (not pinned host memory as on CUDA). Requires ROCm ≥ 6.0 for HIP VMM APIs.

---

## Testing
`rocm_device_address_vmm_allocator_test`, AMD Instinct MI300X (gfx942), ROCm 7.2.0:
- **14 single-GPU tests** — allocate/deallocate, memory read/write, stream accessors,
  deferred deallocation, VA reuse, destructor safety, error handling.
- **2 multi-GPU tests** — cross-device allocation isolation (require 2 GPUs).

## Impact
- ** ROCm code is ROCm-gated; the factory routes to the existing
  CUDA allocator under `GOOGLE_CUDA`. The `RocmEvent::Synchronize()` addition is ROCm-only.
- After this PR, `allocator=vmm` (e.g. `XLA_PYTHON_CLIENT_ALLOCATOR=vmm`) is functional on ROCm,
  previously rejected with "VMM allocator is only supported with CUDA".

---

## Feature-level performance (motivation)
Pure VMM, llama2_7b, 8 layers, 30 steps, 8× MI300X, FSDP=8, identical loss (10.877 → 0.003):

| config | per-step |
|---|---|
| collectives in command buffer, **no VMM** (re-trace every step) | ~25.6 s |
| collectives in command buffer, **VMM `NEVER_UPDATE`** | ~0.13 s |

≈ **190× faster** steady-state. (The `NEVER_UPDATE` command-buffer remap path that realizes
this lands in a separate, follow-up PR built on this allocator stack.)
