### PR TITLE
[XLA:GPU][oneAPI] Always decompose TopKs for oneAPI backend

### DIFF
--- a/xla/backends/gpu/runtime/topk_test.cc
+++ b/xla/backends/gpu/runtime/topk_test.cc
@@ -89,6 +89,11 @@ TEST_P(TopKKernelTest, TopKFloat) {
 
   auto name =
       absl::AsciiStrToUpper(PlatformUtil::CanonicalPlatformName("gpu").value());
+  // TODO(intel-tf): Remove this check once specialization for SYCL/oneAPI
+  // backend is added.
+  if (name == "SYCL") {
+    GTEST_SKIP() << "No specialization exists for SYCL/oneAPI backend.";
+  }
   se::Platform* platform = se::PlatformManager::PlatformWithName(name).value();
   se::StreamExecutor* executor = platform->ExecutorForDevice(0).value();
 
@@ -145,6 +150,11 @@ TEST_P(TopKKernelTest, TopKPackedNegative) {
 
   auto name =
       absl::AsciiStrToUpper(PlatformUtil::CanonicalPlatformName("gpu").value());
+  // TODO(intel-tf): Remove this check once specialization for SYCL/oneAPI
+  // backend is added.
+  if (name == "SYCL") {
+    GTEST_SKIP() << "No specialization exists for SYCL/oneAPI backend.";
+  }
   se::Platform* platform = se::PlatformManager::PlatformWithName(name).value();
   se::StreamExecutor* executor = platform->ExecutorForDevice(0).value();
 
@@ -199,6 +209,11 @@ TEST_P(TopKKernelTest, TopKPackedNegative) {
 TEST_P(TopKKernelTest, EnsureSerializable) {
   auto name =
       absl::AsciiStrToUpper(PlatformUtil::CanonicalPlatformName("gpu").value());
+  // TODO(intel-tf): Remove this check once specialization for SYCL/oneAPI
+  // backend is added.
+  if (name == "SYCL") {
+    GTEST_SKIP() << "No specialization exists for SYCL/oneAPI backend.";
+  }
   se::Platform* platform = se::PlatformManager::PlatformWithName(name).value();
 
   const auto [n_kb, k, batch_size, offset] = GetParam();

--- a/xla/backends/gpu/transforms/topk_specializer.cc
+++ b/xla/backends/gpu/transforms/topk_specializer.cc
@@ -122,7 +122,8 @@ class SpecializeTopkVisitor : public DfsHloRewriteVisitor {
 
   absl::Status HandleCustomCall(HloInstruction* inst) override {
     HloCustomCallInstruction* topk = DynCast<HloCustomCallInstruction>(inst);
-    if (topk == nullptr || topk->custom_call_target() != "TopK") {
+    if (topk == nullptr || topk->custom_call_target() != "TopK" ||
+        compute_capability_.IsOneAPI()) {
       return absl::OkStatus();
     }
     TF_RET_CHECK(topk->operand_count() == 1);

--- a/xla/backends/gpu/transforms/topk_specializer_test.cc
+++ b/xla/backends/gpu/transforms/topk_specializer_test.cc
@@ -131,6 +131,11 @@ void ToSortAndSlice(HloModule* module) {
 }
 
 TEST_P(TopkTest, ProducesCorrectResult) {
+  // TODO(intel-tf): Remove this check once specialization for SYCL/oneAPI
+  // backend is added.
+  if (device_description().gpu_compute_capability().IsOneAPI()) {
+    GTEST_SKIP() << "OneAPI does not support TopK custom call.";
+  }
   const auto [n_kb, k, batch_size, dtype] = GetParam();
   const size_t n = n_kb * 1024;
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> topk_module,


### PR DESCRIPTION
oneAPI backend currently lacks TopK specializations. Until those are implemented, this change always decomposes TopK operations for the oneAPI backend.
