### PR TITLE
Extract GPU executable module cache

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -696,6 +696,32 @@ bool_flag(
 )
 
 cc_library(
+    name = "gpu_executable_module_cache",
+    srcs = ["gpu_executable_module_cache.cc"],
+    hdrs = ["gpu_executable_module_cache.h"],
+    deps = [
+        "//xla:status_macros",
+        "//xla:util",
+        "//xla/service:buffer_assignment",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:module_spec",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:scoped_module_handle",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor/cuda:cuda_platform_id",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_library(
     name = "gpu_executable",
     srcs = ["gpu_executable.cc"],
     hdrs = ["gpu_executable.h"],
@@ -705,6 +731,7 @@ cc_library(
         ":buffer_allocations",
         ":dense_data_intermediate",
         ":gpu_constants",
+        ":gpu_executable_module_cache",
         ":gpu_executable_proto_cc",
         ":gpu_executable_run_options",
         ":ir_emission_utils",
@@ -773,10 +800,8 @@ cc_library(
         "//xla/stream_executor:kernel_stats",
         "//xla/stream_executor:memory_allocation",
         "//xla/stream_executor:memory_reservation",
-        "//xla/stream_executor:module_spec",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:platform_id",
-        "//xla/stream_executor:scoped_module_handle",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
         "//xla/stream_executor:vmm_device_address_allocator",

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -78,7 +78,6 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/literal.h"
-#include "xla/map_util.h"
 #include "xla/pjrt/proto/compile_options.pb.h"
 #include "xla/runtime/buffer_use.h"
 #include "xla/runtime/device_id.h"
@@ -120,11 +119,9 @@ limitations under the License.
 #include "xla/stream_executor/kernel_stats.h"
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/memory_reservation.h"
-#include "xla/stream_executor/module_spec.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_id.h"
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
-#include "xla/stream_executor/scoped_module_handle.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/stream_executor/sycl/sycl_platform_id.h"
@@ -476,6 +473,12 @@ GpuExecutable::GpuExecutable(
                                                std::move(proto));
   }
   set_module_stats(std::move(module_stats));
+
+  module_cache_constants_.reserve(constants_.size());
+  for (const ConstantInfo& info : constants_) {
+    module_cache_constants_.push_back(
+        {info.symbol_name, info.content.span(), info.allocation_index});
+  }
 
   // Populate command_buffer_allocation_indexes_ with buffer indices accessed by
   // command buffer thunks. Skip constant and zero-size allocations since they
@@ -1019,73 +1022,9 @@ absl::Status BarrierAfterExecutable(
 
 absl::StatusOr<const GpuExecutable::BufferAllocToDeviceMemoryMap*>
 GpuExecutable::ResolveConstantGlobals(se::Stream* stream) {
-  se::StreamExecutor* executor = stream->parent();
-
-  absl::MutexLock lock(module_handle_mutex_);
-  auto it = module_globals_.find(executor);
-  if (it != module_globals_.end()) {
-    return it->second.get();
-  }
-
-  se::MultiModuleLoaderSpec module_spec;
-  if (!binary().empty()) {
-    module_spec.AddCudaCubinInMemory(binary());
-  }
-  module_spec.AddCudaPtxInMemory(text().c_str());
-
-  auto globals = std::make_unique<BufferAllocToDeviceMemoryMap>();
-  se::ModuleHandle module_handle;
-  // The CUDA driver isn't able to load a PTX and a binary which are both empty.
-  // It's okay if we skip loading in this case; if the module isn't loaded, all
-  // symbol lookups will fail, just as they should for an empty module.
-  if (!(executor->GetPlatform()->id() == se::cuda::kCudaPlatformId &&
-        binary().empty() && text().empty())) {
-    ASSIGN_OR_RETURN(module_handle, executor->LoadModule(module_spec));
-  }
-
-  // A flag signalling if constant initialization submitted memcpy operations
-  // to the `stream`.
-  int submitted_mem_copies = 0;
-
-  for (const ConstantInfo& info : constants_) {
-    absl::StatusOr<se::DeviceAddressBase> global_status;
-    if (static_cast<bool>(module_handle)) {
-      global_status = executor->GetSymbol(info.symbol_name, module_handle);
-    }
-
-    se::DeviceAddressBase global;
-
-    CHECK(static_cast<bool>(module_handle) && global_status.ok());
-    // The constant was defined in the PTX and has been allocated by the CUDA
-    // driver.
-    global = *global_status;
-    XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
-        "Resolved global %s to %p", info.symbol_name, global.opaque());
-
-    if (!info.content.span().empty()) {
-      // This means the constant did not have an initializer in the PTX and
-      // therefore must be initialized by XLA here.
-      RETURN_IF_ERROR(stream->Memcpy(&global, info.content.span().data(),
-                                     info.content.span().size()));
-      submitted_mem_copies = true;
-    }
-
-    if (info.allocation_index != -1) {
-      InsertOrDie(globals.get(), info.allocation_index, global);
-    }
-  }
-
-  // Wait for the completion of all host->device transfers, to guarantee that
-  // destructor will not race with any operations in flight (deallocate
-  // xla::Literal owned by the HLO module).
-  if (submitted_mem_copies) {
-    CHECK_OK(stream->BlockHostUntilDone());
-  }
-
-  module_handles_.emplace(executor,
-                          se::ScopedModuleHandle(executor, module_handle));
-  return module_globals_.emplace(executor, std::move(globals))
-      .first->second.get();
+  return module_cache_.ResolveConstantGlobals(
+      stream, text_, absl::MakeConstSpan(binary_),
+      absl::MakeConstSpan(module_cache_constants_));
 }
 
 absl::StatusOr<se::DeviceAddressBase> GpuExecutable::BufferForAllocation(
@@ -1722,7 +1661,7 @@ absl::Status GpuExecutable::ExecuteThunks(
     // Collect the set of allocations that changed between executions.
     std::vector<std::pair<int32_t, std::string>> changed_allocations;
 
-    absl::MutexLock lock(module_handle_mutex_);
+    absl::MutexLock lock(module_allocations_mutex_);
     if (module_allocations_.find(executor) == module_allocations_.end()) {
       std::vector<se::DeviceAddressBase> allocs_addr;
       allocs_addr.reserve(buffer_allocations.size());

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -54,6 +54,7 @@ limitations under the License.
 #include "xla/service/gpu/buffer_allocations.h"
 #include "xla/service/gpu/dense_data_intermediate.h"
 #include "xla/service/gpu/gpu_executable.pb.h"
+#include "xla/service/gpu/gpu_executable_module_cache.h"
 #include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/hlo.pb.h"
 #include "xla/service/logical_buffer.h"
@@ -71,7 +72,6 @@ limitations under the License.
 #include "xla/stream_executor/kernel_stats.h"
 #include "xla/stream_executor/memory_reservation.h"
 #include "xla/stream_executor/platform.h"
-#include "xla/stream_executor/scoped_module_handle.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/xla.pb.h"
@@ -253,18 +253,14 @@ class GpuExecutable : public Executable {
                              const ServiceExecutableRunOptions* run_options);
 
   using BufferAllocToDeviceMemoryMap =
-      absl::flat_hash_map<BufferAllocation::Index, se::DeviceAddressBase>;
+      GpuExecutableModuleCache::BufferAllocToDeviceMemoryMap;
 
-  // Loads the PTX or CUBIN for this executable and initializes all
-  // constants that haven't already been initialized by the CUDA driver. Loaded
-  // modules are owned by this executable.
+  // Loads the PTX or CUBIN for this executable and initializes all constants
+  // that haven't already been initialized by the CUDA driver. Loaded modules
+  // are owned by this executable's module cache.
   //
-  // Returns a map from buffer allocation indices to device memory pointers
-  // (only for allocations that contain constants).
-  //
-  // The returned map is cached. If the above process has already been run for
-  // the given stream, it is skipped and the cached map is immediately returned
-  // instead.
+  // Returns a cached map from constant buffer allocation indices to device
+  // memory pointers.
   absl::StatusOr<const BufferAllocToDeviceMemoryMap*> ResolveConstantGlobals(
       se::Stream* stream);
 
@@ -485,22 +481,17 @@ class GpuExecutable : public Executable {
 
   int64_t debug_buffer_assignment_show_max_;
 
-  absl::Mutex module_handle_mutex_;
-  // Cache of module handles. Required to keep loaded modules alive until this
-  // executable is destroyed.
-  absl::flat_hash_map<se::StreamExecutor*, se::ScopedModuleHandle>
-      module_handles_ ABSL_GUARDED_BY(module_handle_mutex_);
-  // Cache of constant buffer allocation maps used by `ResolveConstantGlobals`.
-  absl::flat_hash_map<se::StreamExecutor*,
-                      std::unique_ptr<BufferAllocToDeviceMemoryMap>>
-      module_globals_ ABSL_GUARDED_BY(module_handle_mutex_);
+  GpuExecutableModuleCache module_cache_;
 
   // Cache previous memory allocations for current module, this is used to help
   // identify if user's model have unstable pointers by turning on VLOG(5).
+  absl::Mutex module_allocations_mutex_;
   absl::flat_hash_map<se::StreamExecutor*, std::vector<se::DeviceAddressBase>>
-      module_allocations_ ABSL_GUARDED_BY(module_handle_mutex_);
+      module_allocations_ ABSL_GUARDED_BY(module_allocations_mutex_);
 
   std::vector<ConstantInfo> constants_;
+  // Prepared once for module cache lookups; content spans alias `constants_`.
+  std::vector<GpuExecutableModuleCache::Constant> module_cache_constants_;
   const absl::flat_hash_map<ShapeIndex, OutputInfo> output_info_;
   bool enable_debug_info_manager_;
 
@@ -508,8 +499,8 @@ class GpuExecutable : public Executable {
   // btree_set for deterministic iteration order.
   absl::btree_set<BufferAllocation::Index> command_buffer_allocation_indexes_;
 
-  // Separate mutex for VA ranges to avoid contention with module_handle_mutex_
-  // during VA remapping operations which may involve GPU synchronization.
+  // Separate mutex for VA ranges to avoid contention with other executable
+  // state during VA remapping operations which may involve GPU synchronization.
   absl::Mutex va_ranges_mutex_;
   absl::node_hash_map<std::pair<se::StreamExecutor*, int>, VaRanges>
       module_va_ranges_ ABSL_GUARDED_BY(va_ranges_mutex_);

--- a/xla/service/gpu/gpu_executable_module_cache.cc
+++ b/xla/service/gpu/gpu_executable_module_cache.cc
@@ -1,0 +1,110 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/gpu_executable_module_cache.h"
+
+#include <memory>
+
+#include "absl/log/check.h"
+#include "absl/strings/str_format.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/map_util.h"
+#include "xla/status_macros.h"
+#include "xla/stream_executor/cuda/cuda_platform_id.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/module_spec.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/scoped_module_handle.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/util.h"
+
+namespace xla::gpu {
+
+absl::StatusOr<const GpuExecutableModuleCache::BufferAllocToDeviceMemoryMap*>
+GpuExecutableModuleCache::ResolveConstantGlobals(
+    se::Stream* stream, const std::string& asm_text,
+    absl::Span<const uint8_t> binary, absl::Span<const Constant> constants) {
+  se::StreamExecutor* executor = stream->parent();
+
+  absl::MutexLock lock(mutex_);
+  auto it = module_globals_.find(executor);
+  if (it != module_globals_.end()) {
+    return it->second.get();
+  }
+
+  se::MultiModuleLoaderSpec module_spec;
+  if (!binary.empty()) {
+    module_spec.AddCudaCubinInMemory(binary);
+  }
+  module_spec.AddCudaPtxInMemory(asm_text.c_str());
+
+  auto globals = std::make_unique<BufferAllocToDeviceMemoryMap>();
+  se::ModuleHandle module_handle;
+  // The CUDA driver isn't able to load a PTX and a binary which are both empty.
+  // It's okay if we skip loading in this case; if the module isn't loaded, all
+  // symbol lookups will fail, just as they should for an empty module.
+  if (!(executor->GetPlatform()->id() == se::cuda::kCudaPlatformId &&
+        binary.empty() && asm_text.empty())) {
+    ASSIGN_OR_RETURN(module_handle, executor->LoadModule(module_spec));
+  }
+
+  // A flag signalling if constant initialization submitted memcpy operations
+  // to the `stream`.
+  bool submitted_mem_copies = false;
+
+  for (const Constant& info : constants) {
+    absl::StatusOr<se::DeviceAddressBase> global_status;
+    if (static_cast<bool>(module_handle)) {
+      global_status = executor->GetSymbol(info.symbol_name, module_handle);
+    }
+
+    se::DeviceAddressBase global;
+
+    CHECK(static_cast<bool>(module_handle) && global_status.ok());
+    // The constant was defined in the PTX and has been allocated by the CUDA
+    // driver.
+    global = *global_status;
+    XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
+        "Resolved global %s to %p", info.symbol_name, global.opaque());
+
+    if (!info.content.empty()) {
+      // This means the constant did not have an initializer in the PTX and
+      // therefore must be initialized by XLA here.
+      RETURN_IF_ERROR(
+          stream->Memcpy(&global, info.content.data(), info.content.size()));
+      submitted_mem_copies = true;
+    }
+
+    if (info.allocation_index != -1) {
+      InsertOrDie(globals.get(), info.allocation_index, global);
+    }
+  }
+
+  // Wait for the completion of all host->device transfers, to guarantee that
+  // destructor will not race with any operations in flight (deallocate
+  // xla::Literal owned by the HLO module).
+  if (submitted_mem_copies) {
+    CHECK_OK(stream->BlockHostUntilDone());
+  }
+
+  module_handles_.emplace(executor,
+                          se::ScopedModuleHandle(executor, module_handle));
+  return module_globals_.emplace(executor, std::move(globals))
+      .first->second.get();
+}
+
+}  // namespace xla::gpu

--- a/xla/service/gpu/gpu_executable_module_cache.h
+++ b/xla/service/gpu/gpu_executable_module_cache.h
@@ -1,0 +1,70 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_GPU_EXECUTABLE_MODULE_CACHE_H_
+#define XLA_SERVICE_GPU_GPU_EXECUTABLE_MODULE_CACHE_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/types/span.h"
+#include "xla/service/buffer_assignment.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/scoped_module_handle.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace xla::gpu {
+
+// Owns loaded GPU modules and the resolved addresses of executable constants.
+// The cache is per GpuExecutable, keyed by StreamExecutor, and keeps module
+// handles alive until the executable is destroyed.
+class GpuExecutableModuleCache {
+ public:
+  struct Constant {
+    std::string symbol_name;
+    absl::Span<const uint8_t> content;
+    int allocation_index = -1;
+  };
+
+  using BufferAllocToDeviceMemoryMap =
+      absl::flat_hash_map<BufferAllocation::Index, se::DeviceAddressBase>;
+
+  absl::StatusOr<const BufferAllocToDeviceMemoryMap*> ResolveConstantGlobals(
+      se::Stream* stream, const std::string& asm_text,
+      absl::Span<const uint8_t> binary, absl::Span<const Constant> constants);
+
+ private:
+  absl::Mutex mutex_;
+
+  // Cache of module handles. Required to keep loaded modules alive until this
+  // cache is destroyed.
+  absl::flat_hash_map<se::StreamExecutor*, se::ScopedModuleHandle>
+      module_handles_ ABSL_GUARDED_BY(mutex_);
+
+  // Cache of constant buffer allocation maps used by ResolveConstantGlobals.
+  absl::flat_hash_map<se::StreamExecutor*,
+                      std::unique_ptr<BufferAllocToDeviceMemoryMap>>
+      module_globals_ ABSL_GUARDED_BY(mutex_);
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_SERVICE_GPU_GPU_EXECUTABLE_MODULE_CACHE_H_


### PR DESCRIPTION
📝 Summary of Changes
Extract GPU executable module loading and constant-global resolution into a new `GpuExecutableModuleCache` library. `GpuExecutable` now prepares constant descriptors once, delegates module/global resolution to the cache, and keeps unrelated allocation-debug tracking behind its own mutex.

🎯 Justification
This reduces the amount of module-loading and constant-initialization state owned directly by `GpuExecutable`, making the executable class easier to read while keeping the first refactoring PR focused and behavior-preserving.

🚀 Kind of Contribution
♻️ Cleanup

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
No new tests. Existing coverage was run:
`bazel test //xla/service/gpu:gpu_executable_test`

🧪 Execution Tests:
Not applicable for this cleanup. Focused build was also run:
`bazel build //xla/service/gpu:gpu_executable`