### PR TITLE
[ROCm] Fix invalid rocm_ci_hermetic config, wrong arch

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -294,8 +294,8 @@ common:rocm_ci --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 common:rocm_ci_hermetic --dynamic_mode=off
 common:rocm_ci_hermetic --config=rocm_clang_hermetic
-common:rocm_ci_hermetic --config="gfx908,gfx90a"
-common:rocm_ci_hermetic --repo_env="ROCM_DISTRO_VERSION=rocm_7.12.0_gfx90X"
+common:rocm_ci_hermetic --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a"
+common:rocm_ci_hermetic --repo_env=ROCM_DISTRO_VERSION="rocm_7.12.0_gfx90X"
 common:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 # This config option is used for SYCL as GPU backend.


### PR DESCRIPTION
📝 Summary of Changes
Fix invalid config usage in rocm_ci_hermetic config

🎯 Justification
There is no such a config as gfx902,gfx90a, it seems that some
invalid merge broke the bazelrc configuration

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
