### PR TITLE
[ROCm] Limit the number of actions used to schedule under rocm_rbe

### DIFF
--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -17,7 +17,7 @@ build:rocm_rbe --spawn_strategy=remote,local
 build:rocm_rbe --grpc_keepalive_time=30s
 build:rocm_rbe --remote_cache_compression
 
-test:rocm_rbe --jobs=200
+test:rocm_rbe --jobs=30
 test:rocm_rbe --remote_executor=grpcs://wardite.cluster.engflow.com
 test:rocm_rbe --remote_timeout=3600
 test:rocm_rbe --strategy=TestRunner=remote,local


### PR DESCRIPTION
📝 Summary of Changes
Limit number of actions that could be scheduled in parallel

🎯 Justification
Too many parallel actions executing affects badly amds network
we do limit this number to reduce the load

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
