### PR TITLE
[ROCm] Add GPU isolation env-file to ROCm CI container options

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -59,6 +59,7 @@ jobs:
         --security-opt=seccomp=unconfined
         --tmpfs /root/.cache/bazel:rw,exec,size=80g
         --group-add video
+        --env-file /etc/podinfo/gha-gpu-isolation-settings
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Summary

- Add `--env-file /etc/podinfo/gha-gpu-isolation-settings` to the Docker container options in `.github/workflows/rocm_ci.yml`
- The option is defined once in the `&rocm_container` YAML anchor, so it applies to both the `jax` and `xla` jobs

## Test plan

- [ ] Verify the `jax` job picks up the env-file on the AMD GPU runner
- [ ] Verify the `xla` job (via `*rocm_container` alias) picks up the env-file on the AMD GPU runner