### PR TITLE
Fix: validate string element count against shape in MakeArrayFromHost…

### DIFF
--- a/xla/python/ifrt_proxy/server/ifrt_backend.cc
+++ b/xla/python/ifrt_proxy/server/ifrt_backend.cc
@@ -110,7 +110,7 @@ absl::StatusOr<IfrtArrayRef> MakeStringArrayFromHostBuffer(
   if (static_cast<size_t>(num_elements) != string_host_buffer.size()) {
     return absl::InvalidArgumentError(absl::StrCat(
         "String host buffer has ", string_host_buffer.size(),
-        " element(s) but shape requires ", num_elements, " element(s)"));
+        " elements but shape requires ", num_elements, " elements"));
   }
   const void* data = string_host_buffer.data();
 
@@ -163,13 +163,13 @@ ParseMakeArraysFromHostBufferShardsSpecHostBufferProto(
   if (dtype.kind() == DType::kString) {
     ASSIGN_OR_RETURN(std::vector<absl::Cord> string_host_buffer,
                      DeserializeStringHostBufferFromString(*host_buffer));
-    const int64_t num_elements_shards = shape.num_elements();
-    if (static_cast<size_t>(num_elements_shards) !=
+    const int64_t num_elements = shape.num_elements();
+    if (static_cast<size_t>(num_elements) !=
             string_host_buffer.size()) {
       return absl::InvalidArgumentError(absl::StrCat(
           "String host buffer has ", string_host_buffer.size(),
-          " element(s) but shape requires ", num_elements_shards,
-          " element(s)"));
+          " elements but shape requires ", num_elements,
+          " elements"));
     }
     data = string_host_buffer.data();
     on_done_with_host_buffer = [host_buffer = std::move(host_buffer),

--- a/xla/python/ifrt_proxy/server/ifrt_backend.cc
+++ b/xla/python/ifrt_proxy/server/ifrt_backend.cc
@@ -107,8 +107,7 @@ absl::StatusOr<IfrtArrayRef> MakeStringArrayFromHostBuffer(
   ASSIGN_OR_RETURN(std::vector<absl::Cord> string_host_buffer,
                    DeserializeStringHostBufferFromString(*host_buffer));
   const int64_t num_elements = shape.num_elements();
-  if (num_elements < 0 ||
-      static_cast<size_t>(num_elements) != string_host_buffer.size()) {
+  if (static_cast<size_t>(num_elements) != string_host_buffer.size()) {
     return absl::InvalidArgumentError(absl::StrCat(
         "String host buffer has ", string_host_buffer.size(),
         " element(s) but shape requires ", num_elements, " element(s)"));
@@ -165,8 +164,7 @@ ParseMakeArraysFromHostBufferShardsSpecHostBufferProto(
     ASSIGN_OR_RETURN(std::vector<absl::Cord> string_host_buffer,
                      DeserializeStringHostBufferFromString(*host_buffer));
     const int64_t num_elements_shards = shape.num_elements();
-    if (num_elements_shards < 0 ||
-        static_cast<size_t>(num_elements_shards) !=
+    if (static_cast<size_t>(num_elements_shards) !=
             string_host_buffer.size()) {
       return absl::InvalidArgumentError(absl::StrCat(
           "String host buffer has ", string_host_buffer.size(),

--- a/xla/python/ifrt_proxy/server/ifrt_backend.cc
+++ b/xla/python/ifrt_proxy/server/ifrt_backend.cc
@@ -106,6 +106,13 @@ absl::StatusOr<IfrtArrayRef> MakeStringArrayFromHostBuffer(
     ShardingRef sharding) {
   ASSIGN_OR_RETURN(std::vector<absl::Cord> string_host_buffer,
                    DeserializeStringHostBufferFromString(*host_buffer));
+  const int64_t num_elements = shape.num_elements();
+  if (num_elements < 0 ||
+      static_cast<size_t>(num_elements) != string_host_buffer.size()) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "String host buffer has ", string_host_buffer.size(),
+        " element(s) but shape requires ", num_elements, " element(s)"));
+  }
   const void* data = string_host_buffer.data();
 
   return client->MakeArrayFromHostBuffer(
@@ -157,6 +164,15 @@ ParseMakeArraysFromHostBufferShardsSpecHostBufferProto(
   if (dtype.kind() == DType::kString) {
     ASSIGN_OR_RETURN(std::vector<absl::Cord> string_host_buffer,
                      DeserializeStringHostBufferFromString(*host_buffer));
+    const int64_t num_elements_shards = shape.num_elements();
+    if (num_elements_shards < 0 ||
+        static_cast<size_t>(num_elements_shards) !=
+            string_host_buffer.size()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "String host buffer has ", string_host_buffer.size(),
+          " element(s) but shape requires ", num_elements_shards,
+          " element(s)"));
+    }
     data = string_host_buffer.data();
     on_done_with_host_buffer = [host_buffer = std::move(host_buffer),
                                 string_host_buffer =


### PR DESCRIPTION
## Summary of Changes

Add validation that the number of deserialized string elements matches
`shape.num_elements()` before passing to `MakeArrayFromHostBuffer`.
Returns `InvalidArgumentError` on mismatch.

Apply the same check in `ParseMakeArraysFromHostBufferShardsSpecHostBufferProto`
for the `kString` branch.

## Justification

Without this check, a caller can supply a host buffer containing N string
elements alongside a shape with `num_elements() > N`, causing the consuming
loop in `pjrt_client.cc` to read past the end of the deserialized vector.

## Kind of Contribution

Bug Fix

## Unit Tests

Existing tests in `ifrt_backend_test.cc` cover the success path with matching
shape and buffer sizes and continue to pass. New mismatch cases return
`InvalidArgumentError` as expected.

## Reference

Issue Tracker- 522501454
