### PR TITLE
[ROCm] Switch to digital ocean ci runners

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -40,7 +40,7 @@ jobs:
     needs: rocm-config
     if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
     name: JAX Linux x86 AMD Instinct GPU
-    runs-on: linux-x86-64-1gpu-amd
+    runs-on: linux-xla-do-mi350x-1
     timeout-minutes: 80
     env:
       DOCKER_IMAGE: ${{ needs.rocm-config.outputs.docker-image }}
@@ -103,7 +103,7 @@ jobs:
   xla:
     needs: rocm-config
     name: XLA Linux x86 AMD Instinct GPU
-    runs-on: linux-x86-64-1gpu-amd
+    runs-on: linux-xla-do-mi350x-1
     timeout-minutes: 80
     env:
       DOCKER_IMAGE: ${{ needs.rocm-config.outputs.docker-image }}


### PR DESCRIPTION
📝 Summary of Changes
Switch labels to use DO hosted runners for GHA

🎯 Justification
We migrate all our infra into the DO cluster

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
Not relevant

🧪 Execution Tests:
Not relevat
