### PR TITLE
[ROCm] Condition the ragged-dot rewriting on the xla_gpu_experimental_use_ragged_dot_grouped_gemm flag

### DIFF
--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -799,15 +799,21 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
 
   absl::Status HandleRaggedDot(HloInstruction* instr) override {
     // The cuDNN ragged dot fusion is only available on NVIDIA/CUDA devices.
-    // On AMD ROCm, always use hipBLASLt GroupedMatMul instead, regardless of
-    // the xla_gpu_experimental_use_ragged_dot_fusion flag value.
+    // On AMD ROCm, use hipBLASLt GroupedMatMul when
+    // xla_gpu_experimental_use_ragged_dot_grouped_gemm is enabled.
     bool ragged_dot_fusion_enabled =
         gpu_version_.IsCuda() &&
         instr->GetModule()
             ->config()
             .debug_options()
             .xla_gpu_experimental_use_ragged_dot_fusion();
-    if (ragged_dot_fusion_enabled ||
+    bool grouped_gemm_enabled =
+        instr->GetModule()
+            ->config()
+            .debug_options()
+            .xla_gpu_experimental_use_ragged_dot_grouped_gemm() &&
+        instr->GetModule()->config().debug_options().xla_gpu_enable_cublaslt();
+    if (ragged_dot_fusion_enabled || !grouped_gemm_enabled ||
         !IsGpublasLtSupportedGroupedMatMul(*instr)) {
       return absl::OkStatus();
     }

--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -812,7 +812,10 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
             ->config()
             .debug_options()
             .xla_gpu_experimental_use_ragged_dot_grouped_gemm() &&
-        instr->GetModule()->config().debug_options().xla_gpu_enable_cublaslt();
+        instr->GetModule()
+            ->config()
+            .debug_options()
+            .xla_gpu_enable_cublaslt();  // NOLINT(clang-diagnostic-deprecated-declarations)
     if (ragged_dot_fusion_enabled || !grouped_gemm_enabled ||
         !IsGpublasLtSupportedGroupedMatMul(*instr)) {
       return absl::OkStatus();

--- a/xla/backends/gpu/transforms/gemm_rewriter_group_gemm_test.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter_group_gemm_test.cc
@@ -1454,6 +1454,95 @@ ENTRY test {
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-3, 1e-3}));
 }
 
+// Tests verifying that grouped GEMM rewriting is skipped when
+// xla_gpu_enable_cublaslt is disabled.
+class GroupedGemmRewriteDisabledCublasLtTest
+    : public HloPjRtInterpreterReferenceMixin<GemmRewriteTestBase> {
+ public:
+  DebugOptions GetDebugOptionsForTest() const override {
+    DebugOptions debug_options = GemmRewriteTestBase::GetDebugOptionsForTest();
+    // Explicitly disable cublaslt/hipblaslt: grouped GEMM must not be emitted.
+    debug_options.set_xla_gpu_enable_cublaslt(false);
+    debug_options.set_xla_gpu_autotune_level(0);
+    return debug_options;
+  }
+
+ protected:
+  void SetUp() override {
+    if (SkipGroupedGemmTest()) {
+      GTEST_SKIP()
+          << "Grouped GEMM is only supported on ROCm with hipBLASLt on "
+             "gfx942 or gfx950";
+    }
+  }
+};
+
+// When xla_gpu_enable_cublaslt=false the ragged-dot must NOT be rewritten into
+// a __cublas$lt$groupedMatmul custom call.
+TEST_F(GroupedGemmRewriteDisabledCublasLtTest,
+       NoGroupedGemmCustomCallWhenCublasLtDisabled) {
+  const char* hlo_text = R"(
+HloModule GroupedGemmCublasLtDisabled
+
+ENTRY AddRaggedDotsFunc {
+    p0 = f16[64,9]{1,0} parameter(0)
+    p1 = f16[2,9,8]{2,1,0} parameter(1)
+    p2 = s32[2] constant({16, 48})
+    ROOT ragged-dot = f16[64,8]{1,0} ragged-dot(p0, p1, p2),
+                      lhs_contracting_dims={1}, rhs_contracting_dims={1},
+                      lhs_ragged_dims={0}, rhs_group_dims={0}
+}
+)";
+  MatchOptimizedHlo(
+      hlo_text,
+      R"(; CHECK-NOT: custom_call_target="__cublas$lt$groupedMatmul")");
+}
+
+// Tests verifying that grouped GEMM rewriting is skipped when
+// xla_gpu_experimental_use_ragged_dot_grouped_gemm is disabled.
+class GroupedGemmRewriteDisabledFlagTest
+    : public HloPjRtInterpreterReferenceMixin<GemmRewriteTestBase> {
+ public:
+  DebugOptions GetDebugOptionsForTest() const override {
+    DebugOptions debug_options = GemmRewriteTestBase::GetDebugOptionsForTest();
+    // Explicitly disable the grouped GEMM feature flag.
+    debug_options.set_xla_gpu_experimental_use_ragged_dot_grouped_gemm(false);
+    debug_options.set_xla_gpu_enable_cublaslt(true);
+    debug_options.set_xla_gpu_autotune_level(0);
+    return debug_options;
+  }
+
+ protected:
+  void SetUp() override {
+    if (SkipGroupedGemmTest()) {
+      GTEST_SKIP()
+          << "Grouped GEMM is only supported on ROCm with hipBLASLt on "
+             "gfx942 or gfx950";
+    }
+  }
+};
+
+// When xla_gpu_experimental_use_ragged_dot_grouped_gemm=false the ragged-dot
+// must NOT be rewritten into a __cublas$lt$groupedMatmul custom call.
+TEST_F(GroupedGemmRewriteDisabledFlagTest,
+       NoGroupedGemmCustomCallWhenFlagDisabled) {
+  const char* hlo_text = R"(
+HloModule GroupedGemmFlagDisabled
+
+ENTRY AddRaggedDotsFunc {
+    p0 = f16[64,9]{1,0} parameter(0)
+    p1 = f16[2,9,8]{2,1,0} parameter(1)
+    p2 = s32[2] constant({16, 48})
+    ROOT ragged-dot = f16[64,8]{1,0} ragged-dot(p0, p1, p2),
+                      lhs_contracting_dims={1}, rhs_contracting_dims={1},
+                      lhs_ragged_dims={0}, rhs_group_dims={0}
+}
+)";
+  MatchOptimizedHlo(
+      hlo_text,
+      R"(; CHECK-NOT: custom_call_target="__cublas$lt$groupedMatmul")");
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
📝 Summary of Changes
Extend the condition in `HandleRaggedDot` to check that the flag `xla_gpu_experimental_use_ragged_dot_grouped_gemm` is set before allowing the rewriting of `ragged-dot` into `kCublasLtGroupedMatmulCallTarget`

🎯 Justification
Even though this flag is already tested before in the pipeline (`ragged-dot-rewriter`), the `gemm-rewriter` pass can be run on an HLO that contains `ragged-dot` ops. In this case, the pass could rewrite the ragged-dot even if users explicitly disable hipblaslt group-gemm by setting `xla_gpu_experimental_use_ragged_dot_grouped_gemm=false`. And this case does indeed occur when the fission backend calls this pass.
Checking the flag in this pass avoids this problem.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix