### PR TITLE
Fix FissionBackend to propagate user DebugOptions into extracted modules

### DIFF
--- a/xla/backends/gpu/autotuner/fission_backend.cc
+++ b/xla/backends/gpu/autotuner/fission_backend.cc
@@ -186,6 +186,13 @@ FissionBackend::GetFissionedAndRewrittenModule(
   const auto* fusion = Cast<HloFusionInstruction>(&fusion_instr);
   std::unique_ptr<HloModule> hlo_module =
       ExtractComputationIntoNewModule(*fusion->called_computation());
+  // ExtractComputationIntoNewModule creates a new HloModule with a default
+  // HloModuleConfig, whose DebugOptions are initialized to
+  // DefaultDebugOptionsIgnoringFlags() — not the user's values. Propagate the
+  // user-defined debug options before running any passes so that the rewriter
+  // pipeline (e.g. GemmRewriter reads xla_gpu_gemm_rewrite_size_threshold) and
+  // any subsequent PriorityFusion run observe the correct flag values.
+  hlo_module->mutable_config().set_debug_options(debug_options());
   RETURN_IF_ERROR(rewriter_pipeline_->Run(hlo_module.get()).status());
   return hlo_module;
 }

--- a/xla/backends/gpu/autotuner/fission_backend_test.cc
+++ b/xla/backends/gpu/autotuner/fission_backend_test.cc
@@ -504,6 +504,61 @@ TEST_F(CublasFissionBackendTest, CublasFallbackForBf16Bf16F32Algorithm) {
   }
 }
 
+// Verifies that user-defined DebugOptions are propagated into the module
+// extracted by GetFissionedAndRewrittenModule, so that the rewriter pipeline
+// observes the correct flag values rather than
+// DefaultDebugOptionsIgnoringFlags.
+//
+// Concretely, DefaultDebugOptionsIgnoringFlags sets
+// xla_gpu_gemm_rewrite_size_threshold = 100, while the test fixture's
+// default-constructed DebugOptions proto has the field at its proto default
+// value of 0 (meaning: rewrite ALL GEMMs regardless of size).
+//
+// The tiny 5×5 dot has a "combined size" of (5+5)*5 = 50:
+//   • Without the fix: the extracted module inherits threshold=100, so 50 < 100
+//     → the dot is treated as "tiny" and skipped by GemmRewriter, yielding no
+//     cuBLAS custom call and therefore no supported configs.
+//   • With the fix: the module gets the user's threshold=0, so 50 < 0 is false
+//     → the dot is NOT tiny → rewritten to a cuBLAS custom call → configs
+//     returned.
+TEST_F(CublasFissionBackendTest,
+       GetSupportedConfigsRespectsUserGemmRewriteSizeThreshold) {
+  // Confirm the fixture's debug options use the proto default (0), which
+  // differs from DefaultDebugOptionsIgnoringFlags() that sets it to 100.
+  EXPECT_EQ(debug_options_.xla_gpu_gemm_rewrite_size_threshold(), 0);
+
+  // A tiny f32 fusion whose dot's combined size is 50 < 100
+  // (the DefaultDebugOptionsIgnoringFlags threshold).
+  constexpr absl::string_view kTinyF32DotFusion = R"(
+    HloModule module
+
+    computation {
+      p0 = f32[5,5]{1,0} parameter(0)
+      p1 = f32[5,5]{1,0} parameter(1)
+      ROOT dot = f32[5,5]{1,0} dot(p0, p1),
+          lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    }
+
+    ENTRY main {
+      p0 = f32[5,5]{1,0} parameter(0)
+      p1 = f32[5,5]{1,0} parameter(1)
+      ROOT fusion = f32[5,5]{1,0} fusion(p0, p1),
+        kind=kCustom, calls=computation
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kTinyF32DotFusion));
+  HloInstruction* fusion = module->entry_computation()->root_instruction();
+
+  // With user's threshold=0, the tiny dot is NOT considered "too small" and
+  // must be rewritten to a cuBLAS (or hipBLASLt on ROCm) custom call.
+  // GetSupportedConfigs must therefore return at least one config.
+  ASSERT_OK_AND_ASSIGN(auto configs,
+                       fission_backend_->GetSupportedConfigs(*fusion));
+  EXPECT_THAT(configs, testing::Not(testing::IsEmpty()));
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
📝 Summary of Changes
Fix: copy the backend's stored DebugOptions (which originate from the user's HloModule config) into the extracted module's config before running the rewriter pipeline.

🎯 Justification
ExtractComputationIntoNewModule creates a new HloModule with a bare HloModuleConfig{}, whose DebugOptions are initialized to DefaultDebugOptionsIgnoringFlags() rather than the user-configured values. As a result, every pass run inside GetFissionedAndRewrittenModule (GemmRewriter, PriorityFusion, etc.) was reading default flag values instead of the user's.
This could be problematic in certain cases, for example as the default value for `xla_gpu_experimental_use_ragged_dot_grouped_gemm` is `true`, the fission backend could choose to lower `ragged-dot` using hipblaslt group-gemm even though users have explicitly disable this option by setting `xla_gpu_experimental_use_ragged_dot_grouped_gemm=false`.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

🧪 Unit Tests:
A test has been added to `fission_backend_test.cc` to verify that user defined parameter are taken into account in the passoes run by the Fission backend. (The test uses the falg  `xla_gpu_gemm_rewrite_size_threshold` and does not impment the `ragged-dot` issue described above, because the ragged-dot rewriting only applies to AMD targets.)
