### PR TITLE
[XLA:GPU][oneAPI][Bug-fix] Add ULP budget for intrinsic accuracy

### DIFF
--- a/xla/codegen/emitters/transforms/lowering_utils.h
+++ b/xla/codegen/emitters/transforms/lowering_utils.h
@@ -39,8 +39,8 @@ struct SPIRVMathOps {};
 inline auto getSPIRVMathOps() {
   return SPIRVMathOps<
       mm::AcosOp, mm::AcoshOp, mm::AsinOp, mm::AsinhOp, mm::Atan2Op, mm::AtanOp,
-      mm::AtanhOp, mm::CosOp, mm::CoshOp, mm::ExpM1Op, mm::ExpOp, mm::Log1pOp,
-      mm::LogOp, mm::SinOp, mm::SinhOp, mm::TanOp, mm::TanhOp>{};
+      mm::AtanhOp, mm::CosOp, mm::CoshOp, mm::ErfOp, mm::ExpM1Op, mm::ExpOp,
+      mm::Log1pOp, mm::LogOp, mm::SinOp, mm::SinhOp, mm::TanOp, mm::TanhOp>{};
 }
 
 template <typename Op>

--- a/xla/codegen/intrinsic/accuracy/accuracy_budget.h
+++ b/xla/codegen/intrinsic/accuracy/accuracy_budget.h
@@ -35,6 +35,7 @@ struct AccuracyBudget {
   UlpBudget cpu;
   UlpBudget gpu;
   std::optional<UlpBudget> rocm_gpu = {};
+  std::optional<UlpBudget> intel_gpu = {};
 };
 
 // Atan
@@ -133,6 +134,10 @@ constexpr AccuracyBudget kRsqrtF64Budget = {
     UlpBudget{/*regular=*/1,
               /*subnormal=*/0,
               /*special_values=*/2},
+    /*intel_gpu=*/
+    UlpBudget{/*regular=*/1,
+              /*subnormal=*/0,
+              /*special_values=*/2},
 };
 
 // Tanh
@@ -150,6 +155,10 @@ constexpr AccuracyBudget kTanhF64Budget = {
     /*gpu=*/
     {/*regular=*/1,
      /*subnormal=*/0},
+    /*rocm_gpu=*/std::nullopt,
+    /*intel_gpu=*/
+    UlpBudget{/*regular=*/2,
+              /*subnormal=*/0},
 };
 
 // Erf
@@ -162,6 +171,10 @@ constexpr AccuracyBudget kErfF32Budget = {
     /*rocm_gpu=*/
     UlpBudget{/*regular=*/3,
               /*subnormal=*/0},
+    /*intel_gpu=*/
+    UlpBudget{/*regular=*/2,
+              /*subnormal=*/0,
+              /*special_values=*/1},
 };
 
 constexpr AccuracyBudget kErfF64Budget = {
@@ -170,6 +183,10 @@ constexpr AccuracyBudget kErfF64Budget = {
     /*gpu=*/
     {/*regular=*/1,
      /*subnormal=*/0},
+    /*rocm_gpu=*/std::nullopt,
+    /*intel_gpu=*/
+    UlpBudget{/*regular=*/2,
+              /*subnormal=*/0},
 };
 
 // Sqrt

--- a/xla/codegen/intrinsic/accuracy/intrinsic_accuracy_test.cc
+++ b/xla/codegen/intrinsic/accuracy/intrinsic_accuracy_test.cc
@@ -329,6 +329,10 @@ class HloIntrinsicAccuracyParamTest
     return test_runner().HasProperty(HloRunnerPropertyTag::kUsingGpuRocm);
   }
 
+  bool is_intel_gpu() const {
+    return test_runner().HasProperty(HloRunnerPropertyTag::kUsingGpuOneAPI);
+  }
+
  private:
   template <typename T>
   void DoRunAccuracyTest(const IntrinsicAccuracyTestParam& param) {
@@ -367,10 +371,19 @@ class HloIntrinsicAccuracyParamTest
                                            result_data.size());
     LogAccuracyReport(report, ToPascalCase(param.hlo_op_name));
 
-    const UlpBudget& budget = is_cpu() ? param.budget.cpu
-                              : (is_rocm() && param.budget.rocm_gpu.has_value())
-                                  ? *param.budget.rocm_gpu
-                                  : param.budget.gpu;
+    // Select the appropriate accuracy budget based on platform
+    const UlpBudget& budget = [&]() -> const UlpBudget& {
+      if (is_cpu()) {
+        return param.budget.cpu;
+      }
+      if (is_intel_gpu() && param.budget.intel_gpu.has_value()) {
+        return *param.budget.intel_gpu;
+      }
+      if (is_rocm() && param.budget.rocm_gpu.has_value()) {
+        return *param.budget.rocm_gpu;
+      }
+      return param.budget.gpu;
+    }();
 
     EXPECT_LE(report.regular.max_ulp_error, budget.regular)
         << "Regular max ULP error " << report.regular.max_ulp_error


### PR DESCRIPTION
While many of the math functions implementation on Intel GPU satisfies the SPIR-V spec (https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Env.html#relative-error-as-ulps), the accuracy slightly differs from the [https://mpmath.org/](https://github.com/intel-innersource/frameworks.ai.openxla.xla/pull/url) library. Different backends/vendors could have different ULP budgets, for example, in `xla/codegen/intrinsic/accuracy/accuracy_budget.h`. In order to fix few failures in `//xla/codegen/intrinsic/accuracy:intrinsic_accuracy_test`, the PR adds ULP budgets for oneAPI GPU backend.
