### PR TITLE
[ROCm] Cache hipStream_t handles in ROCm executor to avoid hipStreamCreate cost

### DIFF
--- a/xla/pjrt/BUILD
+++ b/xla/pjrt/BUILD
@@ -51,6 +51,19 @@ cc_library(
     ],
 )
 
+xla_cc_test(
+    name = "worker_thread_test",
+    srcs = ["worker_thread_test.cc"],
+    deps = [
+        ":worker_thread",
+        "//xla/hlo/testlib:test",
+        "//xla/tsl/platform:env",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:env",
+    ],
+)
+
 cc_library(
     name = "pjrt_c_api_client",
     hdrs = ["pjrt_c_api_client.h"],

--- a/xla/pjrt/local_device_state.cc
+++ b/xla/pjrt/local_device_state.cc
@@ -174,6 +174,27 @@ LocalDeviceState::~LocalDeviceState() {
 
   // 2. Clear streams and stream pools to trigger all pending
   // callbacks/finalizations.
+  // Drain the callback thread before touching compute_events_.
+  //
+  // After SynchronizeAllActivity() above, all GPU host-callbacks registered
+  // via hipLaunchHostFunc / ThenExecuteCallback have been *invoked*, which
+  // means every callback_thread_->Schedule() call they contain has already
+  // been issued.  Those closures (e.g. the AndThen that calls
+  // compute_events_.pop_front()) may still be sitting in the queue or
+  // actively executing.
+  //
+  // Because compute_events_ is declared *after* callback_thread_ in the
+  // class, C++ destroys it *before* callback_thread_'s destructor joins the
+  // worker thread — creating a window where pop_front() runs on an
+  // already-destroyed deque (undefined behaviour / use-after-free).
+  //
+  // Draining the thread here closes that window: every closure enqueued
+  // before this point completes before we touch compute_events_.
+  callback_thread_->Drain();
+
+  // Explicitly delete all the streams and events to ensure that their callbacks
+  // are executed before the destruction of the LocalDeviceState and its
+  // callback threads.
   external_ready_event_streams_.clear();
   fixed_size_pool_usage_streams_.clear();
   device_to_device_streams_.clear();

--- a/xla/pjrt/worker_thread.cc
+++ b/xla/pjrt/worker_thread.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/synchronization/notification.h"
 #include "xla/tsl/platform/env.h"
 
 namespace xla {
@@ -42,6 +43,14 @@ void WorkerThread::Schedule(absl::AnyInvocable<void() &&> fn) {
   CHECK(fn != nullptr);
   absl::MutexLock lock(mu_);
   work_queue_.push(std::move(fn));
+}
+
+void WorkerThread::Drain() {
+  absl::Notification done;
+  // Schedule a sentinel closure after all currently-queued work. When the
+  // worker thread executes it, we know every prior closure has completed.
+  Schedule([&done]() { done.Notify(); });
+  done.WaitForNotification();
 }
 
 bool WorkerThread::WorkAvailable() { return !work_queue_.empty(); }

--- a/xla/pjrt/worker_thread.h
+++ b/xla/pjrt/worker_thread.h
@@ -43,6 +43,14 @@ class WorkerThread {
   // Adds 'fn' to the queue of closures to be executed by the worker thread.
   void Schedule(absl::AnyInvocable<void() &&> fn);
 
+  // Blocks the calling thread until all closures that were enqueued before this
+  // call have completed. Any closures enqueued concurrently with or after this
+  // call may or may not have run when Drain() returns.
+  //
+  // Implementation: schedules a sentinel no-op closure and waits for it to be
+  // dequeued and executed, which guarantees that all prior closures have run.
+  void Drain();
+
   // Returns true if there is any outstanding work.
   bool HasBacklog() {
     absl::MutexLock lock(mu_);

--- a/xla/pjrt/worker_thread_test.cc
+++ b/xla/pjrt/worker_thread_test.cc
@@ -107,22 +107,5 @@ TEST(WorkerThreadTest, ConsecutiveDrainsOnIdleThread) {
   thread.Drain();  // First drain on empty queue — must not deadlock.
   thread.Drain();  // Second drain on still-empty queue — must not deadlock.
 }
-
-// Drain() guarantees *prior* closures have completed.  A closure scheduled
-// *after* Drain() starts may or may not have run when Drain() returns; only
-// the work enqueued before the sentinel is guaranteed.
-TEST(WorkerThreadTest, DrainGuaranteesPriorClosuresComplete) {
-  WorkerThread thread(tsl::Env::Default(), "test");
-
-  std::atomic<int> before{0};
-
-  thread.Schedule(
-      [&before]() { before.fetch_add(1, std::memory_order_relaxed); });
-
-  thread.Drain();  // The closure above is guaranteed to have completed.
-
-  EXPECT_EQ(before.load(std::memory_order_relaxed), 1);
-}
-
 }  // namespace
 }  // namespace xla

--- a/xla/pjrt/worker_thread_test.cc
+++ b/xla/pjrt/worker_thread_test.cc
@@ -1,0 +1,128 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/pjrt/worker_thread.h"
+
+#include <atomic>
+#include <vector>
+
+#include "absl/synchronization/mutex.h"
+#include "xla/hlo/testlib/test.h"
+#include "xla/tsl/platform/env.h"
+
+namespace xla {
+namespace {
+
+// ---------------------------------------------------------------------------
+// WorkerThread::Drain() tests
+//
+// Drain() works by scheduling a sentinel closure after all currently-queued
+// work and blocking until the sentinel executes.  This guarantees that every
+// closure enqueued *before* the Drain() call has completed when Drain()
+// returns.
+
+// Calling Drain() on an idle (empty-queue) thread must return immediately
+// without deadlocking.
+TEST(WorkerThreadTest, DrainOnEmptyQueue) {
+  WorkerThread thread(tsl::Env::Default(), "test");
+  thread.Drain();  // Must not block or deadlock.
+}
+
+// All closures scheduled before Drain() must have completed when Drain()
+// returns.
+TEST(WorkerThreadTest, DrainWaitsForAllScheduledClosures) {
+  WorkerThread thread(tsl::Env::Default(), "test");
+
+  constexpr int kNumClosures = 200;
+  std::atomic<int> counter{0};
+
+  for (int i = 0; i < kNumClosures; ++i) {
+    thread.Schedule(
+        [&counter]() { counter.fetch_add(1, std::memory_order_relaxed); });
+  }
+
+  thread.Drain();
+
+  // Every closure enqueued before Drain() must have run.
+  EXPECT_EQ(counter.load(std::memory_order_relaxed), kNumClosures);
+}
+
+// Closures execute in FIFO order, and all must complete before Drain() returns.
+TEST(WorkerThreadTest, DrainPreservesExecutionOrder) {
+  WorkerThread thread(tsl::Env::Default(), "test");
+
+  constexpr int kNumClosures = 10;
+  std::vector<int> order;
+  absl::Mutex mu;
+
+  for (int i = 0; i < kNumClosures; ++i) {
+    thread.Schedule([i, &order, &mu]() {
+      absl::MutexLock lock(mu);
+      order.push_back(i);
+    });
+  }
+
+  thread.Drain();
+
+  absl::MutexLock lock(mu);
+  ASSERT_EQ(static_cast<int>(order.size()), kNumClosures);
+  for (int i = 0; i < kNumClosures; ++i) {
+    EXPECT_EQ(order[i], i) << "closure " << i << " executed out of order";
+  }
+}
+
+// Multiple sequential Drain() calls each wait only for the work enqueued
+// before that call.
+TEST(WorkerThreadTest, MultipleDrainsAreIndependent) {
+  WorkerThread thread(tsl::Env::Default(), "test");
+
+  std::atomic<int> counter{0};
+
+  for (int round = 0; round < 5; ++round) {
+    thread.Schedule(
+        [&counter]() { counter.fetch_add(1, std::memory_order_relaxed); });
+    thread.Drain();
+    // The closure for this round must have completed.
+    EXPECT_EQ(counter.load(std::memory_order_relaxed), round + 1);
+  }
+}
+
+// Drain() on an already-drained thread (second consecutive call with no
+// intervening Schedule()) returns immediately.
+TEST(WorkerThreadTest, ConsecutiveDrainsOnIdleThread) {
+  WorkerThread thread(tsl::Env::Default(), "test");
+
+  thread.Drain();  // First drain on empty queue — must not deadlock.
+  thread.Drain();  // Second drain on still-empty queue — must not deadlock.
+}
+
+// Drain() guarantees *prior* closures have completed.  A closure scheduled
+// *after* Drain() starts may or may not have run when Drain() returns; only
+// the work enqueued before the sentinel is guaranteed.
+TEST(WorkerThreadTest, DrainGuaranteesPriorClosuresComplete) {
+  WorkerThread thread(tsl::Env::Default(), "test");
+
+  std::atomic<int> before{0};
+
+  thread.Schedule(
+      [&before]() { before.fetch_add(1, std::memory_order_relaxed); });
+
+  thread.Drain();  // The closure above is guaranteed to have completed.
+
+  EXPECT_EQ(before.load(std::memory_order_relaxed), 1);
+}
+
+}  // namespace
+}  // namespace xla

--- a/xla/stream_executor/rocm/rocm_stream.cc
+++ b/xla/stream_executor/rocm/rocm_stream.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/base/casts.h"
+#include "absl/base/no_destructor.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/btree_map.h"
 #include "absl/functional/any_invocable.h"
@@ -74,9 +75,10 @@ namespace {
 //     state is destroyed rather than cached.
 //   - The GPU context is activated (executor->Activate()) for all HIP calls.
 //
-// Intentional leak: the singleton (new, never delete) holds at most one
-// vector of handles per (device, flags, priority) for the process lifetime.
-// The OS reclaims all GPU resources on exit.
+// Intentional no-destructor: the singleton holds at most one vector of handles
+// per (device, flags, priority) for the process lifetime.  absl::NoDestructor
+// avoids running the destructor at program exit (which would call
+// hipStreamDestroy after the driver may already be torn down).
 //
 // Thread safety: mu guards all map accesses.
 struct HipStreamHandleCache {
@@ -87,7 +89,7 @@ struct HipStreamHandleCache {
 };
 
 HipStreamHandleCache& GetHipStreamHandleCache() {
-  static auto* cache = new HipStreamHandleCache();  // Intentional leak.
+  static absl::NoDestructor<HipStreamHandleCache> cache;
   return *cache;
 }
 

--- a/xla/stream_executor/rocm/rocm_stream.cc
+++ b/xla/stream_executor/rocm/rocm_stream.cc
@@ -19,10 +19,14 @@ limitations under the License.
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "absl/base/casts.h"
+#include "absl/base/thread_annotations.h"
+#include "absl/container/btree_map.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -51,8 +55,67 @@ limitations under the License.
 namespace stream_executor::gpu {
 namespace {
 
+// ---------------------------------------------------------------------------
+// Process-level HIP stream handle cache
+//
+// hipStreamCreate on ROCm is expensive (~100 ms/stream). Instead of calling
+// hipStreamDestroy in RocmStream::~RocmStream() and hipStreamCreate in
+// RocmStream::Create(), idle handles are kept in this cache and reused.
+//
+// Cache key: (device_ordinal, creation_flags, creation_priority_int).
+// Flags and priority are queried from the live stream via hipStreamGetFlags /
+// hipStreamGetPriority before insertion, so a retrieved handle is guaranteed
+// to match the creation parameters of the new stream.
+//
+// Safety invariants:
+//   - A handle is inserted only after BlockHostUntilDone() confirms it is
+//     fully idle (hipStreamSynchronize ran in RocmStream::~RocmStream()).
+//   - hipStreamQuery is re-checked at insertion time; any stream in an error
+//     state is destroyed rather than cached.
+//   - The GPU context is activated (executor->Activate()) for all HIP calls.
+//
+// Intentional leak: the singleton (new, never delete) holds at most one
+// vector of handles per (device, flags, priority) for the process lifetime.
+// The OS reclaims all GPU resources on exit.
+//
+// Thread safety: mu guards all map accesses.
+struct HipStreamHandleCache {
+  absl::Mutex mu;
+  // Key: (device_ordinal, flags, priority_int)
+  absl::btree_map<std::tuple<int, unsigned int, int>, std::vector<hipStream_t>>
+      handles ABSL_GUARDED_BY(mu);
+};
+
+HipStreamHandleCache& GetHipStreamHandleCache() {
+  static auto* cache = new HipStreamHandleCache();  // Intentional leak.
+  return *cache;
+}
+
 absl::StatusOr<hipStream_t> CreateStream(StreamExecutor* executor,
                                          int priority) {
+  // XLA always creates streams with hipStreamDefault. This constant is used
+  // as part of the cache key so that if the flag changes in the future the
+  // cache will not silently return a handle with the wrong synchronisation
+  // semantics.
+  constexpr unsigned int kFlags = hipStreamDefault;
+
+  // Check the cache for an idle handle with matching (device, flags, priority).
+  {
+    auto& cache = GetHipStreamHandleCache();
+    absl::MutexLock lock(&cache.mu);
+    auto key = std::make_tuple(executor->device_ordinal(), kFlags, priority);
+    auto it = cache.handles.find(key);
+    if (it != cache.handles.end() && !it->second.empty()) {
+      hipStream_t h = it->second.back();
+      it->second.pop_back();
+      VLOG(2) << "Reusing cached HIP stream " << h << " for device "
+              << executor->device_ordinal() << " flags=" << kFlags
+              << " priority=" << priority;
+      return h;
+    }
+  }
+
+  // Cold path: create a new HIP stream.
   std::unique_ptr<ActivateContext> activation = executor->Activate();
   hipStream_t stream;
   if (priority == 0) {
@@ -211,20 +274,65 @@ void DestroyStream(StreamExecutor* executor, hipStream_t stream) {
   if (stream == nullptr) {
     return;
   }
-  hipError_t res = hipStreamQuery(stream);
-  if (res != hipSuccess) {
-    LOG(ERROR) << "stream not idle on destroy: " << ToString(res);
+
+  // Activate the device context for all HIP calls below.
+  std::unique_ptr<ActivateContext> activation = executor->Activate();
+
+  // Verify the stream is fully idle before caching.
+  // BlockHostUntilDone() ran in ~RocmStream() before this call, so under
+  // normal conditions this query always succeeds. An error here indicates a
+  // GPU fault or driver issue; destroy the stream rather than poisoning the
+  // cache with a broken handle.
+  hipError_t query_res = hipStreamQuery(stream);
+  if (query_res != hipSuccess) {
+    LOG(WARNING) << "stream not idle on destroy: " << ToString(query_res)
+                 << " — destroying instead of caching";
+    hipError_t res = hipStreamDestroy(stream);
+    if (res != hipSuccess) {
+      LOG(ERROR) << "failed to destroy ROCM stream for device "
+                 << executor->device_ordinal() << ": " << ToString(res);
+    }
+    return;
   }
 
-  std::unique_ptr<ActivateContext> activation = executor->Activate();
-  res = hipStreamDestroy(stream);
-  if (res != hipSuccess) {
-    LOG(ERROR) << "failed to destroy ROCM stream for device "
-               << executor->device_ordinal() << ": " << ToString(res);
-  } else {
-    VLOG(2) << "successfully destroyed stream " << stream << " for device "
-            << executor->device_ordinal();
+  // Query the stream's creation flags and priority so they can be used as the
+  // cache key. This guarantees a retrieved handle always matches the exact
+  // (flags, priority) the new stream would have been created with — even if
+  // XLA is changed to use hipStreamNonBlocking or non-default priorities.
+  unsigned int flags = 0;
+  int stream_priority = 0;
+  hipError_t flags_res = hipStreamGetFlags(stream, &flags);
+  if (flags_res != hipSuccess) {
+    LOG(WARNING) << "hipStreamGetFlags failed: " << ToString(flags_res)
+                 << " — destroying stream " << stream << " instead of caching";
+    hipError_t destroy_res = hipStreamDestroy(stream);
+    if (destroy_res != hipSuccess) {
+      LOG(ERROR) << "failed to destroy ROCM stream for device "
+                 << executor->device_ordinal() << ": " << ToString(destroy_res);
+    }
+    return;
   }
+  hipError_t prio_res = hipStreamGetPriority(stream, &stream_priority);
+  if (prio_res != hipSuccess) {
+    LOG(WARNING) << "hipStreamGetPriority failed: " << ToString(prio_res)
+                 << " — destroying stream " << stream << " instead of caching";
+    hipError_t destroy_res = hipStreamDestroy(stream);
+    if (destroy_res != hipSuccess) {
+      LOG(ERROR) << "failed to destroy ROCM stream for device "
+                 << executor->device_ordinal() << ": " << ToString(destroy_res);
+    }
+    return;
+  }
+
+  // Insert the verified, idle handle into the cache for reuse.
+  auto& cache = GetHipStreamHandleCache();
+  absl::MutexLock lock(&cache.mu);
+  auto key =
+      std::make_tuple(executor->device_ordinal(), flags, stream_priority);
+  cache.handles[key].push_back(stream);
+  VLOG(2) << "cached HIP stream " << stream << " for device "
+          << executor->device_ordinal() << " flags=" << flags
+          << " priority=" << stream_priority;
 }
 }  // namespace
 

--- a/xla/stream_executor/rocm/rocm_stream_test.cc
+++ b/xla/stream_executor/rocm/rocm_stream_test.cc
@@ -48,6 +48,7 @@ namespace {
 using ::testing::Each;
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;
+using ::testing::UnorderedElementsAreArray;
 
 class RocmStreamTest : public ::testing::Test {
  public:
@@ -299,6 +300,149 @@ TEST_F(RocmStreamTest, WaitForOtherStream) {
               ElementsAre(ExecutionStage::kBeforeWaitForEvent,
                           ExecutionStage::kAfterWaitForEvent,
                           ExecutionStage::kAfterWaitForStream));
+}
+
+// ---------------------------------------------------------------------------
+// HIP stream handle cache tests
+// ---------------------------------------------------------------------------
+
+// Core invariant: after a RocmStream is destroyed its underlying hipStream_t
+// is placed in the cache and returned by the very next Create() call that uses
+// the same (device, flags, priority) key.
+TEST_F(RocmStreamTest, StreamHandleIsReusedAfterDestruction) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<RocmStream> stream,
+      RocmStream::Create(&executor_.value(), /*priority=*/std::nullopt));
+  hipStream_t original_handle = stream->stream_handle();
+
+  // Destroying the stream should deposit the handle into the cache.
+  stream.reset();
+
+  // The very next Create() with identical parameters must return the cached
+  // handle rather than allocating a new one.
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<RocmStream> new_stream,
+      RocmStream::Create(&executor_.value(), /*priority=*/std::nullopt));
+
+  EXPECT_EQ(new_stream->stream_handle(), original_handle)
+      << "hipStream_t handle was not reused from the cache";
+}
+
+// The cache stores one vector of handles per key; verify that N handles can be
+// deposited and then all retrieved (in LIFO order, so the set must match).
+TEST_F(RocmStreamTest, MultipleStreamHandlesAreCachedAndReused) {
+  constexpr int kNumStreams = 4;
+  std::vector<hipStream_t> original_handles;
+  original_handles.reserve(kNumStreams);
+
+  {
+    std::vector<std::unique_ptr<RocmStream>> streams;
+    streams.reserve(kNumStreams);
+    for (int i = 0; i < kNumStreams; ++i) {
+      TF_ASSERT_OK_AND_ASSIGN(
+          auto s,
+          RocmStream::Create(&executor_.value(), /*priority=*/std::nullopt));
+      original_handles.push_back(s->stream_handle());
+      streams.push_back(std::move(s));
+    }
+    // All kNumStreams handles are deposited into the cache here.
+  }
+
+  // Every new stream must come from the cache (no fresh hipStreamCreate calls).
+  std::vector<hipStream_t> reused_handles;
+  reused_handles.reserve(kNumStreams);
+  {
+    std::vector<std::unique_ptr<RocmStream>> streams;
+    streams.reserve(kNumStreams);
+    for (int i = 0; i < kNumStreams; ++i) {
+      TF_ASSERT_OK_AND_ASSIGN(
+          auto s,
+          RocmStream::Create(&executor_.value(), /*priority=*/std::nullopt));
+      reused_handles.push_back(s->stream_handle());
+      streams.push_back(std::move(s));
+    }
+  }
+
+  EXPECT_THAT(reused_handles, UnorderedElementsAreArray(original_handles))
+      << "Not all hipStream_t handles were reused from the cache";
+}
+
+// A stream recycled from the cache must still be able to enqueue work and
+// produce correct results — i.e. the underlying HIP stream is truly idle and
+// in a valid state when it is returned from the cache.
+TEST_F(RocmStreamTest, ReusedStreamIsFullyFunctional) {
+  // Deposit one default-priority handle into the cache.
+  {
+    TF_ASSERT_OK_AND_ASSIGN(
+        std::unique_ptr<RocmStream> stream,
+        RocmStream::Create(&executor_.value(), /*priority=*/std::nullopt));
+  }
+
+  // This stream is obtained from the cache (not freshly created).
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<RocmStream> stream,
+      RocmStream::Create(&executor_.value(), /*priority=*/std::nullopt));
+
+  constexpr int kNumElements = 16;
+  DeviceAddress<uint32_t> buffer =
+      executor_->AllocateArray<uint32_t>(kNumElements, /*memory_space=*/0);
+
+  constexpr uint32_t kPattern = 0xCAFEBABE;
+  EXPECT_THAT(
+      stream->Memset32(&buffer, kPattern, kNumElements * sizeof(uint32_t)),
+      absl_testing::IsOk());
+
+  std::array<uint32_t, kNumElements> host_buffer;
+  EXPECT_THAT(stream->MemcpyD2H(buffer, absl::MakeSpan(host_buffer)),
+              absl_testing::IsOk());
+  EXPECT_THAT(stream->BlockHostUntilDone(), absl_testing::IsOk());
+  EXPECT_THAT(host_buffer, Each(kPattern));
+}
+
+// The cache key includes the stream priority.  A default-priority handle must
+// not be handed out in place of a highest-priority handle and vice versa.
+//
+// Destruction order and creation order are chosen so that the LIFO property
+// produces deterministic results whether or not Default and Highest map to the
+// same integer priority on this device:
+//
+//   Destroy order : default (Hd) first, highest (Hh) second.
+//   Create order  : highest first, default second.
+//
+// If priorities differ → separate buckets:
+//   - new_highest pops Hh from bucket_highest ✓
+//   - new_default  pops Hd from bucket_default ✓
+//
+// If priorities are the same → shared bucket [Hd, Hh] (Hh on top):
+//   - new_highest pops Hh (top of shared bucket) ✓
+//   - new_default  pops Hd (next item)            ✓
+TEST_F(RocmStreamTest, CacheIsolatesStreamsByPriority) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<RocmStream> default_stream,
+      RocmStream::Create(&executor_.value(), StreamPriority::Default));
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<RocmStream> highest_stream,
+      RocmStream::Create(&executor_.value(), StreamPriority::Highest));
+
+  hipStream_t default_handle = default_stream->stream_handle();
+  hipStream_t highest_handle = highest_stream->stream_handle();
+
+  // Destroy default first, highest second → highest handle is on top.
+  default_stream.reset();
+  highest_stream.reset();
+
+  // Create in reverse order: highest first, default second.
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<RocmStream> new_highest,
+      RocmStream::Create(&executor_.value(), StreamPriority::Highest));
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<RocmStream> new_default,
+      RocmStream::Create(&executor_.value(), StreamPriority::Default));
+
+  EXPECT_EQ(new_highest->stream_handle(), highest_handle)
+      << "Highest-priority stream did not reuse its cached hipStream_t handle";
+  EXPECT_EQ(new_default->stream_handle(), default_handle)
+      << "Default-priority stream did not reuse its cached hipStream_t handle";
 }
 
 }  // namespace


### PR DESCRIPTION
📝 Summary of Changes
This PR implements a process-level `HipStreamHandleCache` singleton directly in rocm_stream.cc. Cache key: (device_ordinal, creation_flags, creation_priority_int).

On destruction (RocmStream::~RocmStream):
  1. BlockHostUntilDone() already ran -- stream is idle.
  2. hipStreamQuery() confirms idleness; on error the handle is destroyed rather than cached (no poisoning).
  3. hipStreamGetFlags / hipStreamGetPriority are called to build the exact cache key, ensuring a retrieved handle always matches the flags and priority the new stream would have used -- even if XLA later switches to hipStreamNonBlocking.
  4. Idle handle is stored; hipStreamDestroy is skipped.

On creation (RocmStream::Create via CreateStream):
  The cache is checked first; on hit the cached handle is returned
  directly and hipStreamCreate is skipped. On miss the cold path
  calls hipStreamCreate as before.

The LocalDeviceState and RocmStream wrapper objects are still created and destroyed normally on every client instantiation. DNN state is cleaned up via DeallocateStream as usual. Only the underlying HIP queue (hipStream_t) is reused.

Also fix a latent use-after-free in `LocalDeviceState::~LocalDeviceState`:
  The fix adds `callback_thread_->Drain()` between `SynchronizeAllActivity()`
  and the explicit stream/event clears. After `Drain()` the callback thread
  is idle and `compute_events_` can be safely cleared.

🎯 Justification
On the ROCm side, creating and destroying the pjrt client takes a long time due to the creation and destruction of HIP streams.
```
Per-test overhead (8 GPU ROCm, iota_test):

CREATION (~406ms):
  Phase1 GetGpuXlaClient:      0.2ms    (negligible, singleton)
  Phase2 hipStreamCreate ×112: 385ms    ← dominant creation cost
  Phase3 EnablePeerAccess:     0.4ms    (negligible, cached)
  Phase4 BFC Allocator:        0.2ms    (negligible, no prealloc)
  Phase5 BuildDistributed:      20ms    (RCCL topology)

DESTRUCTION (~513ms):
  dtor body:                   0.05ms
  thread pool shutdown:       138ms 
  hipStreamDestroy ×112:      375ms    ← dominant destruction cost
  SyncAllActivity:              1.5ms   (device 0 only)
```
For tests, such as `iota_test` that create and destroy pjrt client 4500 times, the long delay associated with these creation and destruction of pjrt clients is a major problem.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement

🧪 Unit Tests:
Tests have been added to xla/stream_executor/rocm/rocm_stream_test.cc to verify that the the cache is working correctly.
Tests have been added in xla/pjrt/worker_thread_test.cc to check the stream is correctly drained when it is released.
