### PR TITLE
[NVIDIA GPU] Change CollectiveBroadcast op to support dynamic roots

### DIFF
--- a/xla/hlo/builder/xla_builder.cc
+++ b/xla/hlo/builder/xla_builder.cc
@@ -4586,40 +4586,16 @@ XlaOp XlaBuilder::AllToAllTupleWithDeviceList(
 XlaOp XlaBuilder::CollectiveBroadcast(
     XlaOp operand, absl::Span<const ReplicaGroup> replica_groups,
     const std::optional<ChannelHandle>& channel_id) {
-  return CollectiveBroadcastImpl(operand, CollectiveDeviceList(replica_groups),
-                                 channel_id);
+  return CollectiveBroadcastImpl({operand},
+                                 CollectiveDeviceList(replica_groups),
+                                 channel_id, /*has_dynamic_root=*/false);
 }
 
 XlaOp XlaBuilder::CollectiveBroadcastWithDeviceList(
     XlaOp operand, const CollectiveDeviceListBase& replica_groups,
     const std::optional<ChannelHandle>& channel_id) {
-  return CollectiveBroadcastImpl(operand, replica_groups, channel_id);
-}
-
-XlaOp XlaBuilder::CollectiveBroadcastImpl(
-    XlaOp operand, absl::Span<const ReplicaGroup> replica_groups,
-    const std::optional<ChannelHandle>& channel_id) {
-  return CollectiveBroadcastImpl(operand, CollectiveDeviceList(replica_groups),
-                                 channel_id);
-}
-
-XlaOp XlaBuilder::CollectiveBroadcastImpl(
-    XlaOp operand, const CollectiveDeviceListBase& replica_groups,
-    const std::optional<ChannelHandle>& channel_id) {
-  return ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
-    ASSIGN_OR_RETURN(const Shape* operand_shape, GetShapePtr(operand));
-    HloInstructionProto instr;
-    ASSIGN_OR_RETURN(Shape shape, ShapeInference::InferCollectiveBroadcastShape(
-                                      {operand_shape}));
-    *instr.mutable_shape() = shape.ToProto();
-    PopulateDeviceList(&instr, replica_groups);
-    if (channel_id.has_value()) {
-      instr.set_channel_id(channel_id->handle());
-    }
-
-    return AddInstruction(std::move(instr), HloOpcode::kCollectiveBroadcast,
-                          {operand});
-  });
+  return CollectiveBroadcastImpl({operand}, replica_groups, channel_id,
+                                 /*has_dynamic_root=*/false);
 }
 
 XlaOp XlaBuilder::CollectiveBroadcast(
@@ -4656,11 +4632,14 @@ XlaOp XlaBuilder::CollectiveBroadcastImpl(
       ASSIGN_OR_RETURN(const Shape* operand_shape, GetShapePtr(operand));
       operand_shapes.push_back(operand_shape);
     }
-    CHECK_GT(operand_shapes.size(), 1);
+    if (has_dynamic_root) {
+      TF_RET_CHECK(operand_shapes.size() > 1);
+    }
     HloInstructionProto instr;
     Shape shape;
-    ASSIGN_OR_RETURN(shape, ShapeInference::InferCollectiveBroadcastShape(
-                                operand_shapes, /*has_dynamic_root=*/true));
+    ASSIGN_OR_RETURN(
+        shape, ShapeInference::InferCollectiveBroadcastShape(
+                   operand_shapes, /*has_dynamic_root=*/has_dynamic_root));
     *instr.mutable_shape() = shape.ToProto();
     PopulateDeviceList(&instr, replica_groups);
     if (channel_id.has_value()) {
@@ -6439,6 +6418,7 @@ XlaOp CollectiveBroadcast(const absl::Span<const XlaOp> operands,
                           absl::Span<const ReplicaGroup> replica_groups,
                           const std::optional<ChannelHandle>& channel_id,
                           bool has_dynamic_root) {
+  CHECK(!operands.empty());
   return operands.at(0).builder()->CollectiveBroadcast(
       operands, replica_groups, channel_id, has_dynamic_root);
 }

--- a/xla/hlo/builder/xla_builder.cc
+++ b/xla/hlo/builder/xla_builder.cc
@@ -4622,6 +4622,56 @@ XlaOp XlaBuilder::CollectiveBroadcastImpl(
   });
 }
 
+XlaOp XlaBuilder::CollectiveBroadcast(
+    absl::Span<const XlaOp> operands,
+    absl::Span<const ReplicaGroup> replica_groups,
+    const std::optional<ChannelHandle>& channel_id, bool has_dynamic_root) {
+  return CollectiveBroadcastImpl(operands, CollectiveDeviceList(replica_groups),
+                                 channel_id, has_dynamic_root);
+}
+
+XlaOp XlaBuilder::CollectiveBroadcastWithDeviceList(
+    absl::Span<const XlaOp> operands,
+    const CollectiveDeviceListBase& replica_groups,
+    const std::optional<ChannelHandle>& channel_id, bool has_dynamic_root) {
+  return CollectiveBroadcastImpl(operands, replica_groups, channel_id,
+                                 has_dynamic_root);
+}
+
+XlaOp XlaBuilder::CollectiveBroadcastImpl(
+    absl::Span<const XlaOp> operands,
+    absl::Span<const ReplicaGroup> replica_groups,
+    const std::optional<ChannelHandle>& channel_id, bool has_dynamic_root) {
+  return CollectiveBroadcastImpl(operands, CollectiveDeviceList(replica_groups),
+                                 channel_id, has_dynamic_root);
+}
+
+XlaOp XlaBuilder::CollectiveBroadcastImpl(
+    absl::Span<const XlaOp> operands,
+    const CollectiveDeviceListBase& replica_groups,
+    const std::optional<ChannelHandle>& channel_id, bool has_dynamic_root) {
+  return ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
+    std::vector<const Shape*> operand_shapes;
+    for (const auto& operand : operands) {
+      ASSIGN_OR_RETURN(const Shape* operand_shape, GetShapePtr(operand));
+      operand_shapes.push_back(operand_shape);
+    }
+    CHECK_GT(operand_shapes.size(), 1);
+    HloInstructionProto instr;
+    Shape shape;
+    ASSIGN_OR_RETURN(shape, ShapeInference::InferCollectiveBroadcastShape(
+                                operand_shapes, /*has_dynamic_root=*/true));
+    *instr.mutable_shape() = shape.ToProto();
+    PopulateDeviceList(&instr, replica_groups);
+    if (channel_id.has_value()) {
+      instr.set_channel_id(channel_id->handle());
+    }
+    instr.set_has_dynamic_root(has_dynamic_root);
+    return AddInstruction(std::move(instr), HloOpcode::kCollectiveBroadcast,
+                          operands);
+  });
+}
+
 XlaOp XlaBuilder::CollectivePermute(
     XlaOp operand,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
@@ -6385,6 +6435,14 @@ XlaOp CollectiveBroadcast(const XlaOp operand,
                                                 channel_id);
 }
 
+XlaOp CollectiveBroadcast(const absl::Span<const XlaOp> operands,
+                          absl::Span<const ReplicaGroup> replica_groups,
+                          const std::optional<ChannelHandle>& channel_id,
+                          bool has_dynamic_root) {
+  return operands.at(0).builder()->CollectiveBroadcast(
+      operands, replica_groups, channel_id, has_dynamic_root);
+}
+
 XlaOp CollectivePermute(
     const XlaOp operand,
     const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
@@ -7073,6 +7131,14 @@ XlaOp CollectiveBroadcastWithDeviceList(
     const std::optional<ChannelHandle>& channel_id) {
   return operand.builder()->CollectiveBroadcastWithDeviceList(
       operand, replica_groups, channel_id);
+}
+
+XlaOp CollectiveBroadcastWithDeviceList(
+    absl::Span<const XlaOp> operands,
+    const CollectiveDeviceListBase& replica_groups,
+    const std::optional<ChannelHandle>& channel_id, bool has_dynamic_root) {
+  return operands.at(0).builder()->CollectiveBroadcastWithDeviceList(
+      operands, replica_groups, channel_id, has_dynamic_root);
 }
 
 }  // namespace xla

--- a/xla/hlo/builder/xla_builder.h
+++ b/xla/hlo/builder/xla_builder.h
@@ -486,7 +486,8 @@ class XlaBuilder {
   absl::StatusOr<Shape> GetShape(XlaOp op) const;
 
   // Returns the shape of the given op.
-  virtual absl::StatusOr<const Shape* absl_nonnull> GetShapePtr(XlaOp op) const;
+  virtual absl::StatusOr<const Shape * absl_nonnull> GetShapePtr(
+      XlaOp op) const;
 
   // Returns the OpSharding of the given op. If "op" has no sharding, return
   // std::nullopt.
@@ -2073,13 +2074,6 @@ class XlaBuilder {
                       const std::optional<ChannelHandle>& channel_id,
                       const std::optional<Shape>& layout,
                       std::optional<bool> use_global_device_ids, bool async);
-
-  XlaOp CollectiveBroadcastImpl(XlaOp operand,
-                                absl::Span<const ReplicaGroup> replica_groups,
-                                const std::optional<ChannelHandle>& channel_id);
-  XlaOp CollectiveBroadcastImpl(XlaOp operand,
-                                const CollectiveDeviceListBase& replica_groups,
-                                const std::optional<ChannelHandle>& channel_id);
 
   XlaOp CollectiveBroadcastImpl(absl::Span<const XlaOp> operands,
                                 absl::Span<const ReplicaGroup> replica_groups,

--- a/xla/hlo/builder/xla_builder.h
+++ b/xla/hlo/builder/xla_builder.h
@@ -1036,6 +1036,17 @@ class XlaBuilder {
       XlaOp operand, const CollectiveDeviceListBase& replica_groups,
       const std::optional<ChannelHandle>& channel_id = std::nullopt);
 
+  XlaOp CollectiveBroadcast(
+      absl::Span<const XlaOp> operands,
+      absl::Span<const ReplicaGroup> replica_groups,
+      const std::optional<ChannelHandle>& channel_id = std::nullopt,
+      bool has_dynamic_root = false);
+  XlaOp CollectiveBroadcastWithDeviceList(
+      absl::Span<const XlaOp> operands,
+      const CollectiveDeviceListBase& replica_groups,
+      const std::optional<ChannelHandle>& channel_id = std::nullopt,
+      bool has_dynamic_root = false);
+
   XlaOp CollectivePermute(
       XlaOp operand,
       const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
@@ -1859,6 +1870,14 @@ class XlaBuilder {
   friend XlaOp CollectiveBroadcastWithDeviceList(
       XlaOp operand, const CollectiveDeviceListBase& replica_groups,
       const std::optional<ChannelHandle>& channel_id);
+  friend XlaOp CollectiveBroadcast(
+      absl::Span<const XlaOp> operands,
+      absl::Span<const ReplicaGroup> replica_groups,
+      const std::optional<ChannelHandle>& channel_id, bool has_dynamic_root);
+  friend XlaOp CollectiveBroadcastWithDeviceList(
+      absl::Span<const XlaOp> operands,
+      const CollectiveDeviceListBase& replica_groups,
+      const std::optional<ChannelHandle>& channel_id, bool has_dynamic_root);
   friend XlaOp CollectivePermute(
       XlaOp operand,
       const std::vector<std::pair<int64_t, int64_t>>& source_target_pairs,
@@ -2061,6 +2080,15 @@ class XlaBuilder {
   XlaOp CollectiveBroadcastImpl(XlaOp operand,
                                 const CollectiveDeviceListBase& replica_groups,
                                 const std::optional<ChannelHandle>& channel_id);
+
+  XlaOp CollectiveBroadcastImpl(absl::Span<const XlaOp> operands,
+                                absl::Span<const ReplicaGroup> replica_groups,
+                                const std::optional<ChannelHandle>& channel_id,
+                                bool has_dynamic_root);
+  XlaOp CollectiveBroadcastImpl(absl::Span<const XlaOp> operands,
+                                const CollectiveDeviceListBase& replica_groups,
+                                const std::optional<ChannelHandle>& channel_id,
+                                bool has_dynamic_root);
 
   XlaOp CollectivePermuteImpl(
       XlaOp operand,
@@ -3166,6 +3194,17 @@ XlaOp CollectiveBroadcast(
 XlaOp CollectiveBroadcastWithDeviceList(
     XlaOp operand, const CollectiveDeviceListBase& replica_groups,
     const std::optional<ChannelHandle>& channel_id = std::nullopt);
+
+XlaOp CollectiveBroadcast(
+    absl::Span<const XlaOp> operands,
+    absl::Span<const ReplicaGroup> replica_groups,
+    const std::optional<ChannelHandle>& channel_id = std::nullopt,
+    bool has_dynamic_root = false);
+XlaOp CollectiveBroadcastWithDeviceList(
+    absl::Span<const XlaOp> operands,
+    const CollectiveDeviceListBase& replica_groups,
+    const std::optional<ChannelHandle>& channel_id = std::nullopt,
+    bool has_dynamic_root = false);
 
 // Enqueues an collective operation that sends and receives data cross replicas.
 //

--- a/xla/hlo/builder/xla_builder_test.cc
+++ b/xla/hlo/builder/xla_builder_test.cc
@@ -974,7 +974,7 @@ TEST(XlaBuilderTest, CollectiveBroadcastWithDynamicRoot) {
   replica_group.add_replica_ids(1);
   CollectiveBroadcast({x, root}, {replica_group}, std::nullopt,
                       /*has_dynamic_root=*/true);
-  TF_ASSERT_OK_AND_ASSIGN(const auto module, BuildHloModule(b));
+  ASSERT_OK_AND_ASSIGN(const auto module, BuildHloModule(b));
   EXPECT_EQ(GetRoot(*module)->opcode(), HloOpcode::kCollectiveBroadcast);
 }
 

--- a/xla/hlo/builder/xla_builder_test.cc
+++ b/xla/hlo/builder/xla_builder_test.cc
@@ -964,6 +964,56 @@ TEST(XlaBuilderTest, CollectiveBroadcast) {
   EXPECT_EQ(GetRoot(*module)->opcode(), HloOpcode::kCollectiveBroadcast);
 }
 
+TEST(XlaBuilderTest, CollectiveBroadcastWithDynamicRoot) {
+  XlaBuilder b(TestName());
+  auto x = Parameter(&b, 0, ShapeUtil::MakeShape(F32, {5, 7}), "x");
+  auto root = Parameter(&b, 1, ShapeUtil::MakeShape(S32, {1}), "root");
+
+  ReplicaGroup replica_group;
+  replica_group.add_replica_ids(0);
+  replica_group.add_replica_ids(1);
+  CollectiveBroadcast({x, root}, {replica_group}, std::nullopt,
+                      /*has_dynamic_root=*/true);
+  TF_ASSERT_OK_AND_ASSIGN(const auto module, BuildHloModule(b));
+  EXPECT_EQ(GetRoot(*module)->opcode(), HloOpcode::kCollectiveBroadcast);
+}
+
+TEST(XlaBuilderTest, CollectiveBroadcastWithDynamicRootFailWithOpMismatch) {
+  XlaBuilder b(TestName());
+  auto x = Parameter(&b, 0, ShapeUtil::MakeShape(F32, {5, 7}), "x");
+  auto root = Parameter(&b, 1, ShapeUtil::MakeShape(S32, {2}), "root");
+
+  ReplicaGroup replica_group;
+  replica_group.add_replica_ids(0);
+  replica_group.add_replica_ids(1);
+  CollectiveBroadcast({x, root}, {replica_group}, std::nullopt,
+                      /*has_dynamic_root=*/true);
+  absl::Status status = b.Build().status();
+
+  ASSERT_FALSE(status.ok());
+  EXPECT_THAT(
+      status.message(),
+      HasSubstr(
+          "the same number of elements as the number of non-root operands"));
+}
+
+TEST(XlaBuilderTest,
+     CollectiveBroadcastWithDynamicRootFailWithRootDimMismatch) {
+  XlaBuilder b(TestName());
+  auto x = Parameter(&b, 0, ShapeUtil::MakeShape(F32, {5, 7}), "x");
+  auto root = Parameter(&b, 1, ShapeUtil::MakeShape(S32, {2, 1}), "root");
+
+  ReplicaGroup replica_group;
+  replica_group.add_replica_ids(0);
+  replica_group.add_replica_ids(1);
+  CollectiveBroadcast({x, root}, {replica_group}, std::nullopt,
+                      /*has_dynamic_root=*/true);
+  absl::Status status = b.Build().status();
+
+  ASSERT_FALSE(status.ok());
+  EXPECT_THAT(status.message(), HasSubstr("a 1-D array of S32"));
+}
+
 TEST(XlaBuilderTest, CollectivePermute) {
   XlaBuilder b(TestName());
   auto x = Parameter(&b, 0, ShapeUtil::MakeShape(F32, {5, 7}), "x");

--- a/xla/hlo/ir/hlo_instruction.cc
+++ b/xla/hlo/ir/hlo_instruction.cc
@@ -857,8 +857,10 @@ absl::StatusOr<std::unique_ptr<HloInstruction>> HloInstruction::CreateFromProto(
         channel_id = proto.channel_id();
       }
       auto device_list = CollectiveDeviceListBase::DeviceListFromProto(proto);
-      instruction = CreateCollectiveBroadcast(
-          shape, all_operands(), std::move(device_list), false, channel_id);
+      bool has_dynamic_root = proto.has_dynamic_root();
+      instruction = CreateCollectiveBroadcast(shape, all_operands(),
+                                              std::move(device_list), false,
+                                              channel_id, has_dynamic_root);
       break;
     }
     case HloOpcode::kCollectivePermute:
@@ -1909,20 +1911,21 @@ HloInstruction::CreateRaggedAllToAll(
 HloInstruction::CreateCollectiveBroadcast(
     const Shape& shape, absl::Span<HloInstruction* const> operands,
     std::shared_ptr<CollectiveDeviceListBase> device_list,
-    bool constrain_layout, const std::optional<int64_t>& channel_id) {
+    bool constrain_layout, const std::optional<int64_t>& channel_id,
+    bool has_dynamic_root) {
   return std::make_unique<HloCollectiveBroadcastInstruction>(
       HloOpcode::kCollectiveBroadcast, shape, operands, std::move(device_list),
-      constrain_layout, channel_id);
+      constrain_layout, channel_id, has_dynamic_root);
 }
 
 /* static */ std::unique_ptr<HloInstruction>
 HloInstruction::CreateCollectiveBroadcast(
     const Shape& shape, absl::Span<HloInstruction* const> operands,
     absl::Span<const ReplicaGroup> replica_groups, bool constrain_layout,
-    const std::optional<int64_t>& channel_id) {
+    const std::optional<int64_t>& channel_id, bool has_dynamic_root) {
   return CreateCollectiveBroadcast(
       shape, operands, std::make_shared<CollectiveDeviceList>(replica_groups),
-      constrain_layout, channel_id);
+      constrain_layout, channel_id, has_dynamic_root);
 }
 
 /* static */ std::unique_ptr<HloInstruction>

--- a/xla/hlo/ir/hlo_instruction.h
+++ b/xla/hlo/ir/hlo_instruction.h
@@ -767,13 +767,14 @@ class HloInstruction {
   static std::unique_ptr<HloInstruction> CreateCollectiveBroadcast(
       const Shape& shape, absl::Span<HloInstruction* const> operand,
       std::shared_ptr<CollectiveDeviceListBase> device_list,
-      bool constrain_layout, const std::optional<int64_t>& channel_id);
+      bool constrain_layout, const std::optional<int64_t>& channel_id,
+      bool has_dynamic_root = false);
 
   ABSL_DEPRECATED("Use CollectiveDeviceList instead of list of ReplicaGroup.")
   static std::unique_ptr<HloInstruction> CreateCollectiveBroadcast(
       const Shape& shape, absl::Span<HloInstruction* const> operand,
       absl::Span<const ReplicaGroup> replica_groups, bool constrain_layout,
-      const std::optional<int64_t>& channel_id);
+      const std::optional<int64_t>& channel_id, bool has_dynamic_root = false);
 
   // Creates a communication instruction that permutes data cross replicas.
   // Data is sent/received according to the (source_replica_id,

--- a/xla/hlo/ir/hlo_instructions.cc
+++ b/xla/hlo/ir/hlo_instructions.cc
@@ -1360,23 +1360,26 @@ HloCollectiveBroadcastInstruction::HloCollectiveBroadcastInstruction(
     HloOpcode opcode, const Shape& shape,
     absl::Span<HloInstruction* const> operands,
     std::shared_ptr<CollectiveDeviceListBase> device_list,
-    bool constrain_layout, const std::optional<int64_t>& channel_id)
+    bool constrain_layout, const std::optional<int64_t>& channel_id,
+    bool has_dynamic_root)
     : HloCollectiveInstruction(opcode, shape, operands, std::move(device_list),
-                               constrain_layout, channel_id) {}
+                               constrain_layout, channel_id),
+      has_dynamic_root_(has_dynamic_root) {}
 
 HloCollectiveBroadcastInstruction::HloCollectiveBroadcastInstruction(
     HloOpcode opcode, const Shape& shape,
     absl::Span<HloInstruction* const> operands,
     absl::Span<const ReplicaGroup> replica_groups, bool constrain_layout,
-    const std::optional<int64_t>& channel_id)
+    const std::optional<int64_t>& channel_id, bool has_dynamic_root)
     : HloCollectiveBroadcastInstruction(
           opcode, shape, operands,
           std::make_shared<CollectiveDeviceList>(replica_groups),
-          constrain_layout, channel_id) {}
+          constrain_layout, channel_id, has_dynamic_root) {}
 
 void HloCollectiveBroadcastInstruction::ToProto(
     HloInstructionProto* proto) const {
   HloCollectiveInstruction::ToProto(proto);
+  proto->set_has_dynamic_root(has_dynamic_root());
 }
 
 std::unique_ptr<HloInstruction>
@@ -1385,7 +1388,16 @@ HloCollectiveBroadcastInstruction::CloneWithNewOperandsImpl(
     HloCloneContext* /*context*/) const {
   return std::make_unique<HloCollectiveBroadcastInstruction>(
       opcode(), shape, new_operands, device_list(), constrain_layout(),
-      channel_id());
+      channel_id(), has_dynamic_root());
+}
+
+void HloCollectiveBroadcastInstruction::PrintExtraAttributesImpl(
+    AttributePrinter& printer, const HloPrintOptions& options) const {
+  HloCollectiveInstruction::PrintExtraAttributesImpl(printer, options);
+  printer.Next([this](Printer* printer) {
+    printer->Append("has_dynamic_root=");
+    printer->Append(has_dynamic_root() ? "true" : "false");
+  });
 }
 
 HloCollectivePermuteInstruction::HloCollectivePermuteInstruction(

--- a/xla/hlo/ir/hlo_instructions.h
+++ b/xla/hlo/ir/hlo_instructions.h
@@ -985,26 +985,32 @@ class HloCollectiveBroadcastInstruction : public HloCollectiveInstruction {
       HloOpcode opcode, const Shape& shape,
       absl::Span<HloInstruction* const> operands,
       std::shared_ptr<CollectiveDeviceListBase> device_list,
-      bool constrain_layout, const std::optional<int64_t>& channel_id);
+      bool constrain_layout, const std::optional<int64_t>& channel_id,
+      bool has_dynamic_root = false);
 
   ABSL_DEPRECATED("Use CollectiveDeviceList instead of list of ReplicaGroup.")
   explicit HloCollectiveBroadcastInstruction(
       HloOpcode opcode, const Shape& shape,
       absl::Span<HloInstruction* const> operands,
       absl::Span<const ReplicaGroup> replica_groups, bool constrain_layout,
-      const std::optional<int64_t>& channel_id);
+      const std::optional<int64_t>& channel_id, bool has_dynamic_root = false);
 
   void ToProto(HloInstructionProto* proto) const override;
 
   static bool ClassOf(const HloInstruction* hlo) {
     return hlo->opcode() == HloOpcode::kCollectiveBroadcast;
   }
+  bool has_dynamic_root() const { return has_dynamic_root_; }
 
  private:
   // Implementation for non-common logic of CloneWithNewOperands.
   std::unique_ptr<HloInstruction> CloneWithNewOperandsImpl(
       const Shape& shape, absl::Span<HloInstruction* const> new_operands,
       HloCloneContext* context) const override;
+  void PrintExtraAttributesImpl(AttributePrinter& printer,
+                                const HloPrintOptions& options) const override;
+
+  bool has_dynamic_root_;
 };
 
 class HloCollectivePermuteInstruction : public HloChannelInstruction {

--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -2027,7 +2027,7 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
           *shape, operands, std::move(device_list), channel_id));
     }
     case HloOpcode::kCollectiveBroadcast: {
-      bool has_dynamic_root;
+      optional<bool> has_dynamic_root;
       attrs["has_dynamic_root"] = {/*required=*/false, AttrTy::kBool,
                                    &has_dynamic_root};
       std::unique_ptr<CollectiveDeviceListBase> device_list =
@@ -2042,7 +2042,7 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
       }
       return builder->AddInstruction(HloInstruction::CreateCollectiveBroadcast(
           *shape, operands, std::move(device_list), false, channel_id,
-          has_dynamic_root));
+          has_dynamic_root ? *has_dynamic_root : false));
     }
     case HloOpcode::kCollectivePermute:
     case HloOpcode::kCollectivePermuteStart: {

--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -47,9 +47,9 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 #include "absl/types/span.h"
-#include "Eigen/Core"
 #include "xla/tsl/platform/status_macros.h"
 #include "google/protobuf/descriptor.h"
+#include "Eigen/Core"
 #include "xla/array.h"
 #include "xla/comparison_util.h"
 #include "xla/hlo/ir/collective_op_group_mode.h"
@@ -2027,6 +2027,9 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
           *shape, operands, std::move(device_list), channel_id));
     }
     case HloOpcode::kCollectiveBroadcast: {
+      bool has_dynamic_root;
+      attrs["has_dynamic_root"] = {/*required=*/false, AttrTy::kBool,
+                                   &has_dynamic_root};
       std::unique_ptr<CollectiveDeviceListBase> device_list =
           std::make_unique<CollectiveDeviceList>(std::vector<ReplicaGroup>{});
       attrs["replica_groups"] = {
@@ -2038,7 +2041,8 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
         return nullptr;
       }
       return builder->AddInstruction(HloInstruction::CreateCollectiveBroadcast(
-          *shape, operands, std::move(device_list), false, channel_id));
+          *shape, operands, std::move(device_list), false, channel_id,
+          has_dynamic_root));
     }
     case HloOpcode::kCollectivePermute:
     case HloOpcode::kCollectivePermuteStart: {

--- a/xla/hlo/parser/hlo_parser_test.cc
+++ b/xla/hlo/parser/hlo_parser_test.cc
@@ -2370,7 +2370,21 @@ R"(HloModule CollectiveBroadcast, entry_computation_layout={(f32[128,32]{0,1})->
 
 ENTRY CollectiveBroadcast {
   input = f32[128,32]{0,1} parameter(0)
-  ROOT cb = f32[128,32]{0,1} collective-broadcast(input), replica_groups={{1,0},{2,3}}
+  ROOT cb = f32[128,32]{0,1} collective-broadcast(input), replica_groups={{1,0},{2,3}}, has_dynamic_root=false
+}
+
+)",
+/*replica_count=*/4,
+},
+// collective-broadcast with dynamic root
+{
+"CollectiveBroadcastDynamicRoot",
+R"(HloModule CollectiveBroadcast, entry_computation_layout={(f32[128,32]{0,1}, f32[1]{0})->f32[128,32]{0,1}}, replica_count=4
+
+ENTRY CollectiveBroadcast {
+  input = f32[128,32]{0,1} parameter(0)
+  root = f32[1]{0} parameter(1)
+  ROOT cb = f32[128,32]{0,1} collective-broadcast(input, root), replica_groups={{1,0},{2,3}}, has_dynamic_root=true
 }
 
 )",

--- a/xla/hlo/translate/tests/stablehlo.mlir
+++ b/xla/hlo/translate/tests/stablehlo.mlir
@@ -1171,7 +1171,7 @@ func.func @main(%arg0: tensor<f32>, %arg1: tensor<f32>, %arg2: tensor<f32>) -> t
 // CHECK:       ENTRY %[[$main_3:[^ ]+]]
 // CHECK-NEXT:  %[[Arg_0_1:[^ ]+]] = f32[128,32] parameter(0)
 // CHECK-NEXT:  ROOT %[[collective_broadcast_2:[^ ]+]] = f32[128,32] collective-broadcast(%[[Arg_0_1]]), channel_id=1,
-// CHECK-SAME{LITERAL}: replica_groups={{0,1},{2,3}}, metadata=
+// CHECK-SAME{LITERAL}: replica_groups={{0,1},{2,3}}, has_dynamic_root=false, metadata=
 
 func.func @main(%arg0: tensor<128x32xf32>) -> tensor<128x32xf32> {
   %0 = "stablehlo.collective_broadcast"(%arg0) <{channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>, replica_groups = dense<[[0, 1], [2, 3]]> : tensor<2x2xi64>}> : (tensor<128x32xf32>) -> tensor<128x32xf32>

--- a/xla/service/hlo.proto
+++ b/xla/service/hlo.proto
@@ -126,7 +126,7 @@ enum CustomCallApiVersion {
 }
 
 // Serialization of HloInstruction.
-// Next ID: 100
+// Next ID: 101
 message HloInstructionProto {
   reserved 10;
   reserved "parameter_name";
@@ -430,6 +430,10 @@ message HloInstructionProto {
 
   // Convolution sparsity config.
   SparsityConfig sparsity_config = 98;
+
+  // For collective-broadcast: indicates the last operand is a scalar
+  // root rank index rather than a data tensor to broadcast.
+  bool has_dynamic_root = 100;
 }
 
 // Serialization of HloComputation.

--- a/xla/service/shape_inference.cc
+++ b/xla/service/shape_inference.cc
@@ -2786,10 +2786,11 @@ ShapeInference::InferScalarBroadcastShape(absl::Span<const Shape> shapes) {
 ShapeInference::InferCollectiveBroadcastShape(
     absl::Span<const Shape* const> operand_shapes, bool has_dynamic_root) {
   if (has_dynamic_root) {
-    RETURN_IF_ERROR(
-        ExpectArray(*(operand_shapes.back()),
-                    "last operand of collective-broadcast with dynamic root"));
+    TF_RET_CHECK(operand_shapes.size() > 1);
     const Shape& dynamic_root = *operand_shapes.back();
+    RETURN_IF_ERROR(
+        ExpectArray(dynamic_root,
+                    "last operand of collective-broadcast with dynamic root"));
 
     TF_RET_CHECK(dynamic_root.IsArray() && dynamic_root.element_type() == S32 &&
                  dynamic_root.dimensions().size() == 1 &&
@@ -2800,7 +2801,12 @@ ShapeInference::InferCollectiveBroadcastShape(
            "of "
            "non-root operands, but got "
         << ShapeUtil::HumanString(dynamic_root);
-    return ShapeUtil::MakeTupleShapeWithPtrs(operand_shapes);
+    absl::Span<const Shape* const> data_operand_shapes =
+        operand_shapes.first(operand_shapes.size() - 1);
+    if (data_operand_shapes.size() == 1) {
+      return *data_operand_shapes[0];
+    }
+    return ShapeUtil::MakeTupleShapeWithPtrs(data_operand_shapes);
   }
   RETURN_IF_ERROR(
       ExpectArray(*(operand_shapes[0]), "operand of collective-broadcast"));

--- a/xla/service/shape_inference.cc
+++ b/xla/service/shape_inference.cc
@@ -2784,7 +2784,24 @@ ShapeInference::InferScalarBroadcastShape(absl::Span<const Shape> shapes) {
 
 /* static */ absl::StatusOr<Shape>
 ShapeInference::InferCollectiveBroadcastShape(
-    absl::Span<const Shape* const> operand_shapes) {
+    absl::Span<const Shape* const> operand_shapes, bool has_dynamic_root) {
+  if (has_dynamic_root) {
+    RETURN_IF_ERROR(
+        ExpectArray(*(operand_shapes.back()),
+                    "last operand of collective-broadcast with dynamic root"));
+    const Shape& dynamic_root = *operand_shapes.back();
+
+    TF_RET_CHECK(dynamic_root.IsArray() && dynamic_root.element_type() == S32 &&
+                 dynamic_root.dimensions().size() == 1 &&
+                 ShapeUtil::ElementsIn(dynamic_root) ==
+                     (operand_shapes.size() - 1))
+        << "The last operand of collective-broadcast with dynamic root must be "
+           "a 1-D array of S32 with the same number of elements as the number "
+           "of "
+           "non-root operands, but got "
+        << ShapeUtil::HumanString(dynamic_root);
+    return ShapeUtil::MakeTupleShapeWithPtrs(operand_shapes);
+  }
   RETURN_IF_ERROR(
       ExpectArray(*(operand_shapes[0]), "operand of collective-broadcast"));
   return *(operand_shapes[0]);

--- a/xla/service/shape_inference.h
+++ b/xla/service/shape_inference.h
@@ -185,7 +185,8 @@ class ShapeInference {
 
   // Infers the shape of a collective broadcast operation.
   static absl::StatusOr<Shape> InferCollectiveBroadcastShape(
-      absl::Span<const Shape* const> operand_shapes);
+      absl::Span<const Shape* const> operand_shapes,
+      bool has_dynamic_root = false);
 
   // Infers the shape of a collective permute operation.
   static absl::StatusOr<Shape> InferCollectivePermuteShape(

--- a/xla/service/shape_inference_test.cc
+++ b/xla/service/shape_inference_test.cc
@@ -4918,6 +4918,30 @@ TEST_F(ShapeInferenceTest, UnboundedCollectiveBroadcast) {
       << " expected: " << ShapeUtil::HumanString(expected);
 }
 
+TEST_F(ShapeInferenceTest, UnboundedCollectiveBroadcastWithDynamicRoot) {
+  ASSERT_OK_AND_ASSIGN(const Shape operand, ParseShape("f32[?, 10]"));
+  ASSERT_OK_AND_ASSIGN(const Shape roots, ParseShape("s32[1]"));
+  ASSERT_OK_AND_ASSIGN(const Shape expected, ParseShape("f32[?, 10]"));
+  ASSERT_OK_AND_ASSIGN(
+      const Shape inferred_shape,
+      ShapeInference::InferCollectiveBroadcastShape(
+          /*operand_shapes=*/{&operand, &roots}, /*has_dynamic_root=*/true));
+  EXPECT_TRUE(ShapeUtil::Equal(inferred_shape, expected))
+      << "inferred: " << ShapeUtil::HumanString(inferred_shape)
+      << " expected: " << ShapeUtil::HumanString(expected);
+}
+
+TEST_F(ShapeInferenceTest,
+       UnboundedCollectiveBroadcastWithMismatchedDynamicRootOperand) {
+  ASSERT_OK_AND_ASSIGN(const Shape operand, ParseShape("f32[?, 10]"));
+  ASSERT_OK_AND_ASSIGN(const Shape expected, ParseShape("f32[?, 10]"));
+  const absl::StatusOr<Shape> inferred_shape =
+      ShapeInference::InferCollectiveBroadcastShape(
+          /*operand_shapes=*/{&operand}, /*has_dynamic_root=*/true);
+  EXPECT_THAT(inferred_shape.status().message(),
+              HasSubstr("operand_shapes.size() > 1"));
+}
+
 TEST_F(ShapeInferenceTest, CollectivePermute) {
   TF_ASSERT_OK_AND_ASSIGN(const Shape operand, ParseShape("f32[8, 8]"));
   TF_ASSERT_OK_AND_ASSIGN(const Shape expected, ParseShape("f32[8, 8]"));


### PR DESCRIPTION
The current CollectiveBroadcast op hardcodes the root to be the rank 0 in the replica group, this doesn't provide the right level of flexibility. Almost all communication libraries support having dynamic root in the broadcast API. This PR extends the current CB op to take dynamic root determined through an attribute.
1. added an optional "has_dynamic_root" attribute to the CB op
2. once it's set to true, CB op will expect at least 2 operands: the last operand will be a flat array of s32 values which indicate the roots, all other operands will be the inputs. The number of roots should be the same as the number of non-root inputs.
```
  input = f32[128,32]{0,1} parameter(0)
  root = f32[1]{0} parameter(1)
  cb = f32[128,32]{0,1} collective-broadcast(input, root), replica_groups={{1,0},{2,3}}, has_dynamic_root=true
```
This is the PR for the frontend changes including hlo parser and xla builder.
Runtime support is in another pr.