### PR TITLE
[XLA:GPU] Drain VMM allocator pending operations in CUDA destructor

### DIFF
--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.cc
@@ -48,6 +48,14 @@ CudaDeviceAddressVmmAllocator::CudaDeviceAddressVmmAllocator(
     const Platform* platform)
     : DeviceAddressVmmAllocator(platform) {}
 
+CudaDeviceAddressVmmAllocator::~CudaDeviceAddressVmmAllocator() {
+  absl::Status status = SynchronizeAllPendingOperations();
+  if (!status.ok()) {
+    LOG(FATAL) << "Failed to synchronize pending CUDA VMM deallocations: "
+               << status;
+  }
+}
+
 absl::StatusOr<std::unique_ptr<CudaDeviceAddressVmmAllocator>>
 CudaDeviceAddressVmmAllocator::Create(const Platform* platform,
                                       absl::Span<const DeviceConfig> devices) {

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h
@@ -44,6 +44,8 @@ namespace stream_executor::gpu {
 // the device does not meet the compute capability requirement.
 class CudaDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
  public:
+  ~CudaDeviceAddressVmmAllocator() override;
+
   // Creates an allocator supporting multiple devices.
   //
   // Returns an error if any device does not support cuStreamWriteValue64

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -125,41 +125,22 @@ absl::Status DeviceAddressVmmAllocator::PopulateDevices(
 }
 
 DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
+  absl::Status status = SynchronizeAllPendingOperations();
+  CHECK(status.ok()) << status;
+
   for (auto& [ordinal, state] : per_device_) {
-    // Briefly acquire the lock to read the last pending seqno.
-    uint64_t last_seqno = 0;
-    {
-      absl::MutexLock lock(state->mu);
-      if (!state->pending_deallocations.empty()) {
-        last_seqno = state->pending_deallocations.back().seqno;
-      }
-    }
-
-    // Spin-wait for any pending GPU work to complete before freeing physical
-    // memory. pinned_timeline is not ABSL_GUARDED_BY and last_seqno is a local.
-    if (state->pinned_timeline != nullptr && last_seqno > 0) {
-      while (LoadTimeline(state->pinned_timeline) < last_seqno) {
-        absl::SleepFor(kGpuTimelinePollInterval);
-      }
-    }
-
-    {
-      absl::MutexLock lock(state->mu);
-      for (auto& pending : state->pending_deallocations) {
-        if (pending.kind == PendingDeallocationKind::kAllocate) {
-          DoDeallocate(*state, pending.mem);
-        } else {
-          DoUnMap(*state, pending.mem);
-        }
-      }
-      state->pending_deallocations.clear();
-    }
-
     // Free platform-specific per-device resources (e.g. pinned timeline).
     if (state->destroy_fn) {
       state->destroy_fn();
     }
   }
+}
+
+absl::Status DeviceAddressVmmAllocator::SynchronizeAllPendingOperations() {
+  for (auto& [ordinal, state] : per_device_) {
+    RETURN_IF_ERROR(SynchronizePendingOperations(ordinal));
+  }
+  return absl::OkStatus();
 }
 
 DeviceAddressVmmAllocator::PerDeviceState*

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -267,6 +267,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   static absl::Status PopulateDevices(DeviceAddressVmmAllocator* allocator,
                                       absl::Span<const DeviceConfig> devices);
 
+  // Drains pending stream-ordered allocator operations for all devices.
+  absl::Status SynchronizeAllPendingOperations();
+
   // Validates device capabilities and initializes timeline fields
   // (pinned_timeline, timeline_dev_ptr, allocation_granularity) in state.
   // state.executor, state.stream, and state.pa_budget are already set.


### PR DESCRIPTION
📝 Summary of Changes
Adds a shared `SynchronizeAllPendingOperations()` helper to `DeviceAddressVmmAllocator` and calls it from `CudaDeviceAddressVmmAllocator` destruction before CUDA-specific teardown is gone.

🎯 Justification
This is a small stack precursor for the VMM allocator reuse/batched-teardown work. Later PRs need the concrete CUDA subclass to drain pending stream-ordered operations while CUDA timeline enqueue support is still available.

🚀 Kind of Contribution
♻️ Cleanup

📊 Benchmark (for Performance Improvements)
N/A.

🧪 Unit Tests:
No new tests were added.

🧪 Execution Tests:
Not run locally. Validation: `git diff --check` for this stack split.
