### PR TITLE
[XLA:GPU] Extract VMM allocator reservation helpers

### DIFF
--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -171,6 +171,26 @@ DeviceAddressVmmAllocator::GetPerDeviceState(int device_ordinal) const {
   return it->second.get();
 }
 
+absl::StatusOr<DeviceAddressBase>
+DeviceAddressVmmAllocator::ValidateReservationRange(
+    MemoryReservation* reservation, uint64_t reservation_offset,
+    uint64_t size) const {
+  if (reservation == nullptr) {
+    return absl::InvalidArgumentError("reservation must not be null");
+  }
+
+  DeviceAddressBase address = reservation->address();
+  if (reservation_offset > address.size() ||
+      size > address.size() - reservation_offset) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "reservation range is out of bounds: offset=%uB, size=%uB, "
+        "reservation_size=%uB",
+        reservation_offset, size, address.size()));
+  }
+
+  return address.GetByteSlice(reservation_offset, size);
+}
+
 void DeviceAddressVmmAllocator::ProcessCompletedPendingDeallocations(
     PerDeviceState& state) {
   // Single atomic read covers all entries whose seqno is <= completed.
@@ -326,20 +346,9 @@ DeviceAddressVmmAllocator::Allocate(
     return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
                                         this);
   }
-  if (reservation == nullptr) {
-    return absl::InvalidArgumentError(
-        "VMM mapped allocation requires a non-null reservation");
-  }
-  DeviceAddressBase reservation_range = reservation->address();
-  if (reservation_offset > reservation_range.size() ||
-      mapping_size > reservation_range.size() - reservation_offset) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "Reservation range [%u, %u) is outside reservation size %u",
-        reservation_offset, reservation_offset + mapping_size,
-        reservation_range.size()));
-  }
-  DeviceAddressBase reservation_address =
-      reservation_range.GetByteSlice(reservation_offset, mapping_size);
+  ASSIGN_OR_RETURN(
+      DeviceAddressBase reservation_address,
+      ValidateReservationRange(reservation, reservation_offset, mapping_size));
 
   PerDeviceState* state = GetPerDeviceState(device_ordinal);
   if (state == nullptr) {
@@ -577,20 +586,9 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
     return absl::InvalidArgumentError(
         "DeviceAddressVmmAllocator::Map requires a non-null source address");
   }
-  if (reservation == nullptr) {
-    return absl::InvalidArgumentError(
-        "DeviceAddressVmmAllocator::Map requires a non-null reservation");
-  }
-  DeviceAddressBase reservation_range = reservation->address();
-  if (reservation_offset > reservation_range.size() ||
-      size > reservation_range.size() - reservation_offset) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "Reservation range [%u, %u) is outside reservation size %u",
-        reservation_offset, reservation_offset + size,
-        reservation_range.size()));
-  }
-  DeviceAddressBase reservation_address =
-      reservation_range.GetByteSlice(reservation_offset, size);
+  ASSIGN_OR_RETURN(
+      DeviceAddressBase reservation_address,
+      ValidateReservationRange(reservation, reservation_offset, size));
 
   PerDeviceState* state = GetPerDeviceState(device_ordinal);
   if (state == nullptr) {
@@ -643,20 +641,9 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
   if (size == 0) {
     return absl::OkStatus();
   }
-  if (reservation == nullptr) {
-    return absl::InvalidArgumentError(
-        "DeviceAddressVmmAllocator::UnMap requires a non-null reservation");
-  }
-  DeviceAddressBase reservation_range = reservation->address();
-  if (reservation_offset > reservation_range.size() ||
-      size > reservation_range.size() - reservation_offset) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "Reservation range [%u, %u) is outside reservation size %u",
-        reservation_offset, reservation_offset + size,
-        reservation_range.size()));
-  }
-  DeviceAddressBase reservation_address =
-      reservation_range.GetByteSlice(reservation_offset, size);
+  ASSIGN_OR_RETURN(
+      DeviceAddressBase reservation_address,
+      ValidateReservationRange(reservation, reservation_offset, size));
 
   PerDeviceState* state = GetPerDeviceState(device_ordinal);
   if (state == nullptr) {

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -285,6 +285,12 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // registered. No lock needed — per_device_ is read-only after construction.
   PerDeviceState* GetPerDeviceState(int device_ordinal) const;
 
+  // Validates a caller-owned reservation slice and returns the corresponding
+  // DeviceAddressBase.
+  absl::StatusOr<DeviceAddressBase> ValidateReservationRange(
+      MemoryReservation* reservation, uint64_t reservation_offset,
+      uint64_t size) const;
+
   absl::StatusOr<DeviceAddressBase> AllocateWithBudget(PerDeviceState& state,
                                                        uint64_t size)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);


### PR DESCRIPTION
📝 Summary of Changes
Extracts shared reservation range validation for mapped Allocate(), Map(), and UnMap(), replacing duplicated null and bounds checks without changing allocator behavior.

🎯 Justification
This keeps the mechanical validation cleanup separate from the AllocationRecord migration and stale-reuse behavior, making the following PRs easier to review.

🚀 Kind of Contribution
♻️ Cleanup

📊 Benchmark (for Performance Improvements)
N/A.

🧪 Unit Tests:
No new tests were added. Validation: `bazel build //xla/stream_executor:device_address_vmm_allocator //xla/stream_executor/cuda:cuda_device_address_vmm_allocator` passed on the final stack.

