### PR TITLE
[XLA:GPU] Batch VMM allocator deferred teardown

### DIFF
--- a/xla/service/gpu/gpu_executable_va_remap_allocator_test.cc
+++ b/xla/service/gpu/gpu_executable_va_remap_allocator_test.cc
@@ -173,14 +173,6 @@ class TestVmmAllocator final : public se::DeviceAddressVmmAllocator {
     return allocator;
   }
 
-  ~TestVmmAllocator() override {
-    // Draining needs EnqueueDeferredDeallocation(), which is pure virtual in
-    // the base and unusable once this subclass has been destroyed, so the base
-    // destructor requires subclasses to drain themselves.
-    absl::Status status = SynchronizeAllPendingOperations();
-    EXPECT_TRUE(status.ok()) << status;
-  }
-
   TestMemoryReservation* last_reservation() const { return last_reservation_; }
   const void* last_created_allocation_address() const {
     return last_created_allocation_address_;
@@ -249,6 +241,7 @@ class GpuExecutableVaRemapAllocatorTest : public ::testing::Test {
  protected:
   void SetUp() override {
     ON_CALL(executor_, device_ordinal()).WillByDefault(Return(0));
+    ON_CALL(executor_, SynchronizeAllActivity()).WillByDefault(Return(true));
     ON_CALL(stream_, parent()).WillByDefault(Return(&executor_));
     run_options_.set_stream(&stream_);
     service_run_options_ = ServiceExecutableRunOptions(run_options_);

--- a/xla/service/gpu/gpu_executable_va_remap_allocator_test.cc
+++ b/xla/service/gpu/gpu_executable_va_remap_allocator_test.cc
@@ -173,6 +173,14 @@ class TestVmmAllocator final : public se::DeviceAddressVmmAllocator {
     return allocator;
   }
 
+  ~TestVmmAllocator() override {
+    // Draining needs EnqueueDeferredDeallocation(), which is pure virtual in
+    // the base and unusable once this subclass has been destroyed, so the base
+    // destructor requires subclasses to drain themselves.
+    absl::Status status = SynchronizeAllPendingOperations();
+    EXPECT_TRUE(status.ok()) << status;
+  }
+
   TestMemoryReservation* last_reservation() const { return last_reservation_; }
   const void* last_created_allocation_address() const {
     return last_created_allocation_address_;
@@ -496,7 +504,7 @@ TEST_F(GpuExecutableVaRemapAllocatorTest,
 }
 
 TEST_F(GpuExecutableVaRemapAllocatorTest,
-       ExecutionScopeRetriesFailedAliasRelease) {
+       ExecutionScopeAliasReleaseRetriesFailedBatchFlush) {
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<TestVmmAllocator> vmm_allocator,
                        CreateAllocator());
 
@@ -543,15 +551,23 @@ TEST_F(GpuExecutableVaRemapAllocatorTest,
          std::optional<absl::Span<const BufferAllocation::Index>>) {
         return absl::OkStatus();
       });
-  EXPECT_FALSE(status.ok());
+  // Deferred teardown is batched, so the alias release only queues the unmap
+  // and does not enqueue a timeline write. The injected failure is therefore
+  // not consumed here and the release itself succeeds.
+  EXPECT_TRUE(status.ok()) << status;
   ASSERT_NE(vmm_allocator->last_reservation(), nullptr);
+  // The mapping stays alive as stale state until the pending unmap completes.
   EXPECT_EQ(vmm_allocator->last_reservation()->active_mapping_count(), 1);
   EXPECT_EQ(buffer_allocations.GetDeviceAddress(0).opaque(),
             param_buffer.cref().opaque());
 
-  // ReleaseStepAliases retains the failed alias. Destroying the execution
-  // scope retries UnMap after the one-shot injected failure.
   scope.reset();
+  // The first flush is what enqueues the batch marker, so this is where the
+  // one-shot injected failure surfaces. A failed flush leaves the batch open
+  // with its entries still pending rather than dropping them.
+  EXPECT_FALSE(
+      vmm_allocator->SynchronizePendingOperations(/*device_ordinal=*/0).ok());
+  // Retrying flushes the same batch and drains it.
   ASSERT_OK(vmm_allocator->SynchronizePendingOperations(/*device_ordinal=*/0));
   EXPECT_EQ(vmm_allocator->last_reservation()->active_mapping_count(), 0);
 }

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.cc
@@ -49,13 +49,7 @@ CudaDeviceAddressVmmAllocator::CudaDeviceAddressVmmAllocator(
     std::optional<int64_t> reclaim_exempt_memory_space)
     : DeviceAddressVmmAllocator(platform, reclaim_exempt_memory_space) {}
 
-CudaDeviceAddressVmmAllocator::~CudaDeviceAddressVmmAllocator() {
-  absl::Status status = SynchronizeAllPendingOperations();
-  if (!status.ok()) {
-    LOG(FATAL) << "Failed to synchronize pending CUDA VMM deallocations: "
-               << status;
-  }
-}
+CudaDeviceAddressVmmAllocator::~CudaDeviceAddressVmmAllocator() = default;
 
 absl::StatusOr<std::unique_ptr<CudaDeviceAddressVmmAllocator>>
 CudaDeviceAddressVmmAllocator::Create(

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h
@@ -74,9 +74,10 @@ class CudaDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
   //
   // Parameters:
   //   executor:  StreamExecutor for this device. Must outlive the allocator.
-  //   stream:    Stream used for deferred deallocation. Must outlive the
-  //              allocator. This should typically be the main compute stream
-  //              from ServiceExecutableRunOptions.
+  //   stream:    Stream used for deferred deallocation. Must remain valid for
+  //              allocator operations other than destruction. This should
+  //              typically be the main compute stream from
+  //              ServiceExecutableRunOptions.
   //   pa_budget: Maximum bytes of physical memory that may be simultaneously
   //              allocated on this device. Defaults to unlimited.
   static absl::StatusOr<std::unique_ptr<CudaDeviceAddressVmmAllocator>> Create(

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h
@@ -36,7 +36,7 @@ namespace stream_executor::gpu {
 // CUDA implementation of DeviceAddressVmmAllocator.
 //
 // Uses cuMemCreate/cuMemAddressReserve for physical and virtual memory
-// management, and cuStreamWriteValue64 for GPU timeline-based deferred
+// management, and cuStreamWriteValue64 for batched GPU timeline-based deferred
 // deallocation. Requires compute capability >= 7.0 (Volta and later) for
 // cuStreamWriteValue64 support.
 //
@@ -99,7 +99,8 @@ class CudaDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
       StreamExecutor* executor, uint64_t size) override;
 
   // Enqueues a cuStreamWriteValue64 on the device's stream to write `seqno`
-  // to the pinned timeline when the GPU reaches this point in the stream.
+  // to the pinned timeline when the GPU reaches this batched deallocation point
+  // in the stream.
   absl::Status EnqueueDeferredDeallocation(PerDeviceState& state,
                                            uint64_t seqno) override;
 

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -1211,11 +1211,10 @@ TEST_F(DeviceAddressVmmAllocatorTest,
   ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
 }
 
-// Verifies that the destructor correctly spin-waits on the pinned timeline
-// counter until all pending GPU timeline writes complete, then frees the
-// physical memory without crashing.
+// Verifies that destruction synchronizes through the executor and directly
+// retires pending state without accessing the allocator stream.
 TEST_F(DeviceAddressVmmAllocatorTest,
-       DestructorWithPendingDeallocationsDoesNotCrash) {
+       DestructorWithDestroyedStreamAndPendingDeallocationsDoesNotCrash) {
   ASSERT_OK_AND_ASSIGN(
       auto allocator,
       gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
@@ -1231,9 +1230,9 @@ TEST_F(DeviceAddressVmmAllocatorTest,
     ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
   }
 
-  // Destroy without an explicit stream sync. The destructor must enqueue the
-  // trailing batch marker, wait for it to reach pinned_timeline, then free each
-  // virtual address safely.
+  // The stream may be destroyed before the allocator. Destruction must not try
+  // to enqueue the trailing batch marker through this now-dangling pointer.
+  stream_.reset();
   allocator.reset();  // Must not crash or leak.
 }
 

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -1079,7 +1079,7 @@ TEST_F(DeviceAddressVmmAllocatorTest,
 }
 
 TEST_F(DeviceAddressVmmAllocatorTest, DeallocateNull) {
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       auto allocator,
       gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
 
@@ -1092,9 +1092,10 @@ TEST_F(DeviceAddressVmmAllocatorTest, DeallocateNull) {
 // --- Timeline / sequence-number design tests ---
 //
 // These tests exercise the cuStreamWriteValue64-based deferred deallocation
-// mechanism. Each pending Deallocate() call records an increasing seqno and
-// enqueues a GPU timeline write; the CPU checks the pinned counter to decide
-// when memory is safe to free.
+// mechanism. Consecutive pending Deallocate() and UnMap() calls share a batch
+// sequence number. The allocator enqueues one trailing GPU timeline write when
+// the batch is flushed, and the CPU checks the pinned counter to decide when
+// the batch is safe to complete.
 
 // Verifies that TryReusePendingDeallocation returns the same virtual address
 // when a new allocation of the same rounded size is requested immediately
@@ -1102,34 +1103,34 @@ TEST_F(DeviceAddressVmmAllocatorTest, DeallocateNull) {
 // all prior GPU work finishes before any new work submitted after Allocate.
 TEST_F(DeviceAddressVmmAllocatorTest,
        PendingDeallocationReusesSameVirtualAddress) {
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       auto allocator,
       gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
 
   const int ordinal = executor_->device_ordinal();
   constexpr uint64_t kSize = 1024;
 
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       auto addr1,
       allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
                           static_cast<int64_t>(MemorySpace::kCollective)));
   void* const va = addr1->opaque();
 
-  // Deallocate: timeline write is enqueued but VA is not freed yet.
+  // Deallocate opens a trailing batch, but the VA is not freed yet. Reusing the
+  // pending entry below cancels it before a timeline write is needed.
   DeviceAddressBase raw = addr1.cref();
   addr1.Release();
   ASSERT_THAT(allocator->Deallocate(ordinal, raw), IsOk());
 
   // Allocate the same size — TryReusePendingDeallocation should match the
   // pending entry and return the identical virtual address.
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       auto addr2,
       allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
                           static_cast<int64_t>(MemorySpace::kCollective)));
   EXPECT_EQ(addr2->opaque(), va);
 
-  // Sync to drain all pending GPU timeline writes before the allocator
-  // is destroyed.
+  // Drain any unrelated GPU work before the allocator is destroyed.
   ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
 }
 
@@ -1138,13 +1139,13 @@ TEST_F(DeviceAddressVmmAllocatorTest,
 // AFTER the memcpy, so the physical memory is not freed until the GPU finishes.
 TEST_F(DeviceAddressVmmAllocatorTest,
        DeferredDeallocationSafeWhileGpuWritesData) {
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       auto allocator,
       gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
 
   const int ordinal = executor_->device_ordinal();
 
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       auto addr,
       allocator->Allocate(ordinal, sizeof(uint64_t), /*retry_on_failure=*/true,
                           static_cast<int64_t>(MemorySpace::kCollective)));
@@ -1154,22 +1155,21 @@ TEST_F(DeviceAddressVmmAllocatorTest,
   DeviceAddressBase dev_addr = addr.cref();
   ASSERT_THAT(stream_->Memcpy(&dev_addr, &kPattern, sizeof(kPattern)), IsOk());
 
-  // Deallocate while the memcpy is still queued. The seqno timeline write is
-  // appended to the stream AFTER the memcpy, so the VA cannot be reused until
-  // the GPU advances past it.
+  // Deallocate while the memcpy is still queued. Synchronization below flushes
+  // the batch marker after the memcpy, so teardown cannot run early.
   ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
 
-  // Sync: both the memcpy and the timeline write execute in order.
+  // Flush and wait: both the memcpy and the batch timeline write execute in
+  // order.
   // No crash here means the physical memory was not freed prematurely.
-  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
 }
 
-// Allocates and deallocates N buffers, recording a distinct seqno for each.
-// After a single stream sync all seqnos have been written by the GPU, so
-// re-allocating the same size should succeed by reusing the pending entries.
+// Allocates and deallocates N buffers in one batch. One allocator sync flushes
+// the trailing marker and completes every entry sharing the batch sequence.
 TEST_F(DeviceAddressVmmAllocatorTest,
-       MultipleSeqnosAllCompleteAfterStreamSync) {
-  TF_ASSERT_OK_AND_ASSIGN(
+       BatchedDeallocationsCompleteAfterAllocatorSync) {
+  ASSERT_OK_AND_ASSIGN(
       auto allocator,
       gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
 
@@ -1177,31 +1177,38 @@ TEST_F(DeviceAddressVmmAllocatorTest,
   constexpr int kCount = 8;
   constexpr uint64_t kSize = 1024;
 
-  // Allocate kCount buffers and immediately queue their deallocation.
-  // Each Deallocate increments next_seqno and enqueues a timeline write.
+  std::vector<ScopedDeviceAddress<uint8_t>> addresses;
+  addresses.reserve(kCount);
   for (int i = 0; i < kCount; ++i) {
-    TF_ASSERT_OK_AND_ASSIGN(
+    ASSERT_OK_AND_ASSIGN(
         auto addr,
         allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
                             static_cast<int64_t>(MemorySpace::kCollective)));
-    ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
+    addresses.push_back(std::move(addr));
   }
 
-  // Sync the stream: all kCount timeline writes (seqnos 1..kCount) complete.
-  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+  // Queue every distinct buffer before another allocation can reuse it. These
+  // deallocations share one sequence number and one trailing timeline write.
+  for (auto& address : addresses) {
+    ASSERT_THAT(allocator->Deallocate(ordinal, address.Release()), IsOk());
+  }
 
-  // Each new Allocate call finds a matching pending entry via
-  // TryReusePendingDeallocation (or via ProcessCompletedPendingDeallocations
-  // once the pending queue is exhausted).
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+
+  // Every allocation succeeds after the completed batch releases its physical
+  // allocations.
+  addresses.clear();
   for (int i = 0; i < kCount; ++i) {
-    TF_ASSERT_OK_AND_ASSIGN(
+    ASSERT_OK_AND_ASSIGN(
         auto addr,
         allocator->Allocate(ordinal, kSize, /*retry_on_failure=*/true,
                             static_cast<int64_t>(MemorySpace::kCollective)));
     EXPECT_FALSE(addr.is_null());
+    addresses.push_back(std::move(addr));
   }
 
-  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+  addresses.clear();
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
 }
 
 // Verifies that the destructor correctly spin-waits on the pinned timeline
@@ -1209,7 +1216,7 @@ TEST_F(DeviceAddressVmmAllocatorTest,
 // physical memory without crashing.
 TEST_F(DeviceAddressVmmAllocatorTest,
        DestructorWithPendingDeallocationsDoesNotCrash) {
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       auto allocator,
       gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
 
@@ -1217,16 +1224,16 @@ TEST_F(DeviceAddressVmmAllocatorTest,
 
   // Queue several deallocations without syncing the stream first.
   for (int i = 0; i < 4; ++i) {
-    TF_ASSERT_OK_AND_ASSIGN(
+    ASSERT_OK_AND_ASSIGN(
         auto addr,
         allocator->Allocate(ordinal, 1024, /*retry_on_failure=*/true,
                             static_cast<int64_t>(MemorySpace::kCollective)));
     ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
   }
 
-  // Destroy without an explicit stream sync. The destructor must spin on the
-  // pinned_timeline until the GPU writes all pending seqnos, then free
-  // each virtual address safely.
+  // Destroy without an explicit stream sync. The destructor must enqueue the
+  // trailing batch marker, wait for it to reach pinned_timeline, then free each
+  // virtual address safely.
   allocator.reset();  // Must not crash or leak.
 }
 

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include <algorithm>
 #include <cstdint>
-#include <deque>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -477,7 +476,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocation(
 
   DeviceAddressBase reused_mem(record->allocator_key(), request.size);
   MoveAllocatorRecordToActive(state, *record, request.size);
-  ErasePendingDeallocationAt(state, pending_it);
+  state.pending_deallocations.erase(pending_it);
   return reused_mem;
 }
 
@@ -692,7 +691,7 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
 
       DeviceAddressBase reused_mem(record.allocator_key(), size);
       MoveAllocatorRecordToActive(*state, record, size);
-      ErasePendingDeallocationAt(*state, it);
+      state->pending_deallocations.erase(it);
 
       return reused_mem;
     }
@@ -838,9 +837,9 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   // Move the returned allocator address out of active ownership and keep its
   // mapping alive as stale state until the stream reaches `seqno`.
   record.MarkAllocatorStale(seqno);
-  state->pending_deallocations.push_back(PendingDeallocation{
-      PendingDeallocationKind::kAllocation, seqno, record.allocator_address()});
-  AddOpenDeallocationBatchEntry(*state, reclaimable_bytes);
+  state->pending_deallocations.push_back(
+      PendingDeallocation{PendingDeallocationKind::kAllocation, seqno,
+                          record.allocator_address(), reclaimable_bytes});
   return absl::OkStatus();
 }
 
@@ -1120,28 +1119,55 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
 
 // UnMap/deferred teardown helpers.
 
+DeviceAddressVmmAllocator::OpenDeallocationBatchSize
+DeviceAddressVmmAllocator::OpenBatchSize(const PerDeviceState& state) const {
+  OpenDeallocationBatchSize size;
+  if (state.open_deallocation_batch_seqno == 0) {
+    return size;
+  }
+  // Entries are appended in non-decreasing seqno order, so the open batch is
+  // the trailing run carrying the open seqno. Walking it costs at most
+  // kMaxOpenDeallocationBatchEntries steps.
+  for (auto it = state.pending_deallocations.rbegin();
+       it != state.pending_deallocations.rend(); ++it) {
+    if (it->seqno != state.open_deallocation_batch_seqno) {
+      break;
+    }
+    ++size.entries;
+    if (std::numeric_limits<uint64_t>::max() - size.bytes <
+        it->reclaimable_bytes) {
+      size.bytes = std::numeric_limits<uint64_t>::max();
+    } else {
+      size.bytes += it->reclaimable_bytes;
+    }
+  }
+  return size;
+}
+
 absl::Status
 DeviceAddressVmmAllocator::FlushOpenDeallocationBatchIfNeededForEntry(
     PerDeviceState& state, uint64_t reclaimable_bytes) {
   if (state.open_deallocation_batch_seqno == 0) {
-    CHECK_EQ(state.open_deallocation_batch_entries, 0);
-    CHECK_EQ(state.open_deallocation_batch_bytes, 0);
     return absl::OkStatus();
   }
 
-  CHECK_GT(state.open_deallocation_batch_entries, 0);
-  bool entry_limit =
-      state.open_deallocation_batch_entries >= kMaxOpenDeallocationBatchEntries;
+  const OpenDeallocationBatchSize size = OpenBatchSize(state);
+  if (size.entries == 0) {
+    // Every entry of the open batch was cancelled by reuse. The seqno was never
+    // written to the timeline, so let the incoming entry take it over.
+    return absl::OkStatus();
+  }
+
+  bool entry_limit = size.entries >= kMaxOpenDeallocationBatchEntries;
   // `reclaimable_bytes == 0` (UnMap) never moves the byte total, so it can
-  // never trip the byte limit. `open_deallocation_batch_bytes == 0` means the
-  // open batch holds only such zero-byte entries; flushing it early would emit
-  // a timeline write without releasing any physical memory, so let the incoming
-  // entry join it instead even if that entry alone exceeds the limit.
+  // never trip the byte limit. `size.bytes == 0` means the open batch holds
+  // only such zero-byte entries; flushing it early would emit a timeline write
+  // without releasing any physical memory, so let the incoming entry join it
+  // instead even if that entry alone exceeds the limit.
   bool byte_limit =
-      reclaimable_bytes > 0 && state.open_deallocation_batch_bytes > 0 &&
-      (state.open_deallocation_batch_bytes >= kMaxOpenDeallocationBatchBytes ||
-       reclaimable_bytes > kMaxOpenDeallocationBatchBytes -
-                               state.open_deallocation_batch_bytes);
+      reclaimable_bytes > 0 && size.bytes > 0 &&
+      (size.bytes >= kMaxOpenDeallocationBatchBytes ||
+       reclaimable_bytes > kMaxOpenDeallocationBatchBytes - size.bytes);
   if (!entry_limit && !byte_limit) {
     return absl::OkStatus();
   }
@@ -1152,70 +1178,25 @@ DeviceAddressVmmAllocator::FlushOpenDeallocationBatchIfNeededForEntry(
 uint64_t DeviceAddressVmmAllocator::GetOrCreateOpenDeallocationBatchSeqno(
     PerDeviceState& state) {
   if (state.open_deallocation_batch_seqno == 0) {
-    CHECK_EQ(state.open_deallocation_batch_entries, 0);
-    CHECK_EQ(state.open_deallocation_batch_bytes, 0);
     state.open_deallocation_batch_seqno = state.next_seqno++;
   }
   return state.open_deallocation_batch_seqno;
 }
 
-void DeviceAddressVmmAllocator::AddOpenDeallocationBatchEntry(
-    PerDeviceState& state, uint64_t reclaimable_bytes) {
-  CHECK_NE(state.open_deallocation_batch_seqno, 0);
-  ++state.open_deallocation_batch_entries;
-  if (std::numeric_limits<uint64_t>::max() -
-          state.open_deallocation_batch_bytes <
-      reclaimable_bytes) {
-    state.open_deallocation_batch_bytes = std::numeric_limits<uint64_t>::max();
-  } else {
-    state.open_deallocation_batch_bytes += reclaimable_bytes;
-  }
-}
-
-void DeviceAddressVmmAllocator::ErasePendingDeallocationAt(
-    PerDeviceState& state, std::deque<PendingDeallocation>::iterator it) {
-  CHECK(it != state.pending_deallocations.end());
-  if (it->seqno == state.open_deallocation_batch_seqno) {
-    uint64_t reclaimable_bytes = 0;
-    if (it->kind == PendingDeallocationKind::kAllocation) {
-      auto record_it =
-          state.records_by_allocator_address.find(it->addr.opaque());
-      CHECK(record_it != state.records_by_allocator_address.end());
-      reclaimable_bytes = record_it->second->raw_allocation()->address().size();
-      CHECK_GT(reclaimable_bytes, 0);
-    }
-    CHECK_GT(state.open_deallocation_batch_entries, 0);
-    --state.open_deallocation_batch_entries;
-    CHECK_GE(state.open_deallocation_batch_bytes, reclaimable_bytes);
-    state.open_deallocation_batch_bytes -= reclaimable_bytes;
-    if (state.open_deallocation_batch_entries == 0) {
-      state.open_deallocation_batch_seqno = 0;
-      state.open_deallocation_batch_bytes = 0;
-    }
-  }
-  state.pending_deallocations.erase(it);
-}
-
 absl::Status DeviceAddressVmmAllocator::FlushOpenDeallocationBatch(
     PerDeviceState& state) {
   if (state.open_deallocation_batch_seqno == 0) {
-    CHECK_EQ(state.open_deallocation_batch_entries, 0);
-    CHECK_EQ(state.open_deallocation_batch_bytes, 0);
     return absl::OkStatus();
   }
 
-  if (state.open_deallocation_batch_entries == 0) {
-    state.open_deallocation_batch_seqno = 0;
-    state.open_deallocation_batch_bytes = 0;
-    return absl::OkStatus();
+  // An open batch whose entries were all cancelled by reuse needs no marker;
+  // just close it so the next batch starts from a fresh sequence number.
+  if (OpenBatchSize(state).entries > 0) {
+    RETURN_IF_ERROR(EnqueueDeferredDeallocation(
+        state, state.open_deallocation_batch_seqno));
   }
-
-  const uint64_t seqno = state.open_deallocation_batch_seqno;
-  RETURN_IF_ERROR(EnqueueDeferredDeallocation(state, seqno));
 
   state.open_deallocation_batch_seqno = 0;
-  state.open_deallocation_batch_entries = 0;
-  state.open_deallocation_batch_bytes = 0;
   return absl::OkStatus();
 }
 
@@ -1225,7 +1206,7 @@ void DeviceAddressVmmAllocator::ErasePendingDeallocation(
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
     if (it->kind == kind && it->addr.IsSameAs(addr)) {
-      ErasePendingDeallocationAt(state, it);
+      state.pending_deallocations.erase(it);
       return;
     }
   }
@@ -1288,7 +1269,7 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocationByKey(
     if (it->kind == key.kind && it->seqno == key.seqno &&
         it->addr.IsSameAs(key.addr)) {
       PendingDeallocation pending = *it;
-      ErasePendingDeallocationAt(state, it);
+      state.pending_deallocations.erase(it);
       CompletePendingDeallocation(state, pending);
       return;
     }
@@ -1400,9 +1381,9 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
   // stream marker will be enqueued for the whole batch when it is flushed.
   uint64_t seqno = GetOrCreateOpenDeallocationBatchSeqno(*state);
   record->MarkReservationStale(seqno);
-  state->pending_deallocations.push_back(PendingDeallocation{
-      PendingDeallocationKind::kMap, seqno, reservation_address});
-  AddOpenDeallocationBatchEntry(*state, /*reclaimable_bytes=*/0);
+  state->pending_deallocations.push_back(
+      PendingDeallocation{PendingDeallocationKind::kMap, seqno,
+                          reservation_address, /*reclaimable_bytes=*/0});
   return absl::OkStatus();
 }
 

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -50,6 +50,17 @@ namespace {
 
 thread_local const xla::DeviceAssignment* current_device_assignment = nullptr;
 
+// Bounds on how much deferred teardown may accumulate in a single open batch
+// before it is flushed with a stream timeline write.
+//
+// Batching trades timeline writes against reclaim latency: entries in an open
+// batch have no stream marker yet, so their physical memory cannot be released
+// until something forces a flush. These limits cap that exposure while still
+// collapsing the common burst of back-to-back Deallocate()/UnMap() calls into
+// one write. The entry limit bounds per-batch bookkeeping for workloads that
+// free many small buffers; the byte limit bounds how much physical memory can
+// sit unreclaimable while the batch stays open. A single entry larger than the
+// byte limit still gets its own batch rather than being rejected.
 constexpr int64_t kMaxOpenDeallocationBatchEntries = 64;
 constexpr uint64_t kMaxOpenDeallocationBatchBytes = 64ull << 20;
 
@@ -231,27 +242,19 @@ absl::Status DeviceAddressVmmAllocator::PopulateDevices(
 DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
   for (auto& device : per_device_) {
     auto& state = device.second;
-    uint64_t last_seqno = 0;
     {
+      // Draining requires EnqueueDeferredDeallocation(), which is pure virtual
+      // in this class and therefore unusable once the subclass destructor has
+      // run. Subclasses must call SynchronizeAllPendingOperations() themselves;
+      // all this destructor can do is verify that they did.
       absl::MutexLock lock(state->mu);
       CHECK_EQ(state->open_deallocation_batch_seqno, 0)
           << "DeviceAddressVmmAllocator subclasses must flush open "
              "deallocation batches before the base destructor runs.";
-      if (!state->pending_deallocations.empty()) {
-        last_seqno = state->pending_deallocations.back().seqno;
-      }
-    }
-
-    if (last_seqno > 0) {
-      absl::MutexLock lock(state->mu);
-      absl::Status drain_status = WaitUntilSeqno(*state, last_seqno);
-      CHECK(drain_status.ok()) << drain_status;
-      while (!state->pending_deallocations.empty() &&
-             state->pending_deallocations.front().seqno <= last_seqno) {
-        PendingDeallocation pending = state->pending_deallocations.front();
-        state->pending_deallocations.pop_front();
-        CompletePendingDeallocation(*state, pending);
-      }
+      CHECK(state->pending_deallocations.empty())
+          << "DeviceAddressVmmAllocator subclasses must call "
+             "SynchronizeAllPendingOperations() before the base destructor "
+             "runs.";
     }
 
     // Free platform-specific per-device resources (e.g. pinned timeline).
@@ -263,20 +266,7 @@ DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
 
 absl::Status DeviceAddressVmmAllocator::SynchronizeAllPendingOperations() {
   for (auto& device : per_device_) {
-    auto& state = device.second;
-    absl::MutexLock lock(state->mu);
-    RETURN_IF_ERROR(FlushOpenDeallocationBatch(
-        *state, DeallocationBatchFlushReason::kDestructor));
-    if (!state->pending_deallocations.empty()) {
-      uint64_t target_seqno = state->pending_deallocations.back().seqno;
-      RETURN_IF_ERROR(WaitUntilSeqno(*state, target_seqno));
-      while (!state->pending_deallocations.empty() &&
-             state->pending_deallocations.front().seqno <= target_seqno) {
-        PendingDeallocation pending = state->pending_deallocations.front();
-        state->pending_deallocations.pop_front();
-        CompletePendingDeallocation(*state, pending);
-      }
-    }
+    RETURN_IF_ERROR(SynchronizePendingOperations(device.first));
   }
   return absl::OkStatus();
 }
@@ -311,24 +301,28 @@ absl::StatusOr<Stream*> DeviceAddressVmmAllocator::GetStream(
   return state->stream;
 }
 
+absl::Status DeviceAddressVmmAllocator::DrainPendingDeallocations(
+    PerDeviceState& state) {
+  RETURN_IF_ERROR(FlushOpenDeallocationBatch(state));
+  if (state.pending_deallocations.empty()) {
+    return absl::OkStatus();
+  }
+  uint64_t target_seqno = state.pending_deallocations.back().seqno;
+  RETURN_IF_ERROR(WaitUntilSeqno(state, target_seqno));
+  while (!state.pending_deallocations.empty() &&
+         state.pending_deallocations.front().seqno <= target_seqno) {
+    PendingDeallocation pending = state.pending_deallocations.front();
+    state.pending_deallocations.pop_front();
+    CompletePendingDeallocation(state, pending);
+  }
+  return absl::OkStatus();
+}
+
 absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
     int device_ordinal) {
   ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
   absl::MutexLock lock(state->mu);
-  RETURN_IF_ERROR(
-      FlushOpenDeallocationBatch(*state, DeallocationBatchFlushReason::kSync));
-  if (state->pending_deallocations.empty()) {
-    return absl::OkStatus();
-  }
-  uint64_t target_seqno = state->pending_deallocations.back().seqno;
-  RETURN_IF_ERROR(WaitUntilSeqno(*state, target_seqno));
-  while (!state->pending_deallocations.empty() &&
-         state->pending_deallocations.front().seqno <= target_seqno) {
-    PendingDeallocation pending = state->pending_deallocations.front();
-    state->pending_deallocations.pop_front();
-    CompletePendingDeallocation(*state, pending);
-  }
-  return absl::OkStatus();
+  return DrainPendingDeallocations(*state);
 }
 
 absl::StatusOr<StreamExecutor*> DeviceAddressVmmAllocator::GetStreamExecutor(
@@ -592,8 +586,7 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
     // already be past their stream timeline point. Complete ready allocator
     // deallocations first, without blocking for later pending work and without
     // destroying unrelated stale reservation mappings that may be reused.
-    RETURN_IF_ERROR(
-        FlushOpenDeallocationBatch(state, DeallocationBatchFlushReason::kWait));
+    RETURN_IF_ERROR(FlushOpenDeallocationBatch(state));
     CompleteReadyAllocatorDeallocationsForReclaim(
         state, LoadTimeline(state.pinned_timeline));
     result = try_fresh();
@@ -1139,6 +1132,11 @@ DeviceAddressVmmAllocator::FlushOpenDeallocationBatchIfNeededForEntry(
   CHECK_GT(state.open_deallocation_batch_entries, 0);
   bool entry_limit =
       state.open_deallocation_batch_entries >= kMaxOpenDeallocationBatchEntries;
+  // `reclaimable_bytes == 0` (UnMap) never moves the byte total, so it can
+  // never trip the byte limit. `open_deallocation_batch_bytes == 0` means the
+  // open batch holds only such zero-byte entries; flushing it early would emit
+  // a timeline write without releasing any physical memory, so let the incoming
+  // entry join it instead even if that entry alone exceeds the limit.
   bool byte_limit =
       reclaimable_bytes > 0 && state.open_deallocation_batch_bytes > 0 &&
       (state.open_deallocation_batch_bytes >= kMaxOpenDeallocationBatchBytes ||
@@ -1148,9 +1146,7 @@ DeviceAddressVmmAllocator::FlushOpenDeallocationBatchIfNeededForEntry(
     return absl::OkStatus();
   }
 
-  return FlushOpenDeallocationBatch(
-      state, entry_limit ? DeallocationBatchFlushReason::kEntryLimit
-                         : DeallocationBatchFlushReason::kByteLimit);
+  return FlushOpenDeallocationBatch(state);
 }
 
 uint64_t DeviceAddressVmmAllocator::GetOrCreateOpenDeallocationBatchSeqno(
@@ -1201,7 +1197,7 @@ void DeviceAddressVmmAllocator::ErasePendingDeallocationAt(
 }
 
 absl::Status DeviceAddressVmmAllocator::FlushOpenDeallocationBatch(
-    PerDeviceState& state, DeallocationBatchFlushReason /*reason*/) {
+    PerDeviceState& state) {
   if (state.open_deallocation_batch_seqno == 0) {
     CHECK_EQ(state.open_deallocation_batch_entries, 0);
     CHECK_EQ(state.open_deallocation_batch_bytes, 0);
@@ -1246,8 +1242,7 @@ void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
 
 absl::Status DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
                                                        uint64_t target_seqno) {
-  RETURN_IF_ERROR(
-      FlushOpenDeallocationBatch(state, DeallocationBatchFlushReason::kWait));
+  RETURN_IF_ERROR(FlushOpenDeallocationBatch(state));
 
   // Release the lock before spin-waiting to avoid stalling other threads for
   // potentially milliseconds while the GPU drains its work queue.
@@ -1329,6 +1324,14 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
   CHECK(!record.reservation_active());
   if (record.reservation_stale()) {
     CHECK(record.has_reservation_alias());
+    // The paired mapping is torn down here without a separate timeline wait,
+    // which is only safe because its stream marker cannot be later than the one
+    // already reached for `pending`. A record is unmappable once its allocator
+    // address is stale, so the UnMap() that staled this alias necessarily ran
+    // before the Deallocate() that staled the allocator address, and batch
+    // sequence numbers are assigned in that same order. Without this invariant
+    // the alias could sit in a still-open batch with no stream marker at all.
+    CHECK_LE(record.reservation_stale_seqno(), pending.seqno);
     CompletePendingDeallocationByKey(
         state, PendingDeallocationKey{PendingDeallocationKind::kMap,
                                       record.reservation_stale_seqno(),

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -239,21 +239,37 @@ absl::Status DeviceAddressVmmAllocator::PopulateDevices(
 }
 
 DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
+  // Synchronize every device before releasing resources on any device. Work on
+  // one device can access mappings owned by another device, so releasing each
+  // device immediately after synchronizing it would race with peer work that is
+  // still running elsewhere.
+  //
+  // Synchronize unconditionally: all pending entries for a previously flushed
+  // batch can be cancelled by reuse while its timeline write is still in
+  // flight. The pinned timeline must remain alive until that write has
+  // completed.
+  for (const auto& [ordinal, state] : per_device_) {
+    // Do not hold state.mu while synchronizing. Completing device work can run
+    // host callbacks that need allocator locks.
+    CHECK(state->executor->SynchronizeAllActivity())
+        << "Failed to synchronize device " << ordinal
+        << " before destroying DeviceAddressVmmAllocator.";
+  }
+
   for (auto& device : per_device_) {
     auto& state = device.second;
     {
-      // Draining requires EnqueueDeferredDeallocation(), which is pure virtual
-      // in this class and therefore unusable once the subclass destructor has
-      // run. Subclasses must call SynchronizeAllPendingOperations() themselves;
-      // all this destructor can do is verify that they did.
       absl::MutexLock lock(state->mu);
-      CHECK_EQ(state->open_deallocation_batch_seqno, 0)
-          << "DeviceAddressVmmAllocator subclasses must flush open "
-             "deallocation batches before the base destructor runs.";
-      CHECK(state->pending_deallocations.empty())
-          << "DeviceAddressVmmAllocator subclasses must call "
-             "SynchronizeAllPendingOperations() before the base destructor "
-             "runs.";
+      // All device work is complete, including work protected by an open batch.
+      // Retire pending entries directly: virtual timeline-enqueue methods are
+      // no longer callable after the derived destructor has run, and the stream
+      // is allowed to have been destroyed already.
+      state->open_deallocation_batch_seqno = 0;
+      while (!state->pending_deallocations.empty()) {
+        PendingDeallocation pending = state->pending_deallocations.front();
+        state->pending_deallocations.pop_front();
+        CompletePendingDeallocation(*state, pending);
+      }
     }
 
     // Free platform-specific per-device resources (e.g. pinned timeline).

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -50,6 +50,9 @@ namespace {
 
 thread_local const xla::DeviceAssignment* current_device_assignment = nullptr;
 
+constexpr int64_t kMaxOpenDeallocationBatchEntries = 64;
+constexpr uint64_t kMaxOpenDeallocationBatchBytes = 64ull << 20;
+
 }  // namespace
 
 DeviceAddressVmmAllocator::DeviceAssignmentScope::DeviceAssignmentScope(
@@ -226,11 +229,31 @@ absl::Status DeviceAddressVmmAllocator::PopulateDevices(
 }
 
 DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
-  absl::Status status = SynchronizeAllPendingOperations();
-  CHECK(status.ok()) << status;
-
   for (auto& device : per_device_) {
     auto& state = device.second;
+    uint64_t last_seqno = 0;
+    {
+      absl::MutexLock lock(state->mu);
+      CHECK_EQ(state->open_deallocation_batch_seqno, 0)
+          << "DeviceAddressVmmAllocator subclasses must flush open "
+             "deallocation batches before the base destructor runs.";
+      if (!state->pending_deallocations.empty()) {
+        last_seqno = state->pending_deallocations.back().seqno;
+      }
+    }
+
+    if (last_seqno > 0) {
+      absl::MutexLock lock(state->mu);
+      absl::Status drain_status = WaitUntilSeqno(*state, last_seqno);
+      CHECK(drain_status.ok()) << drain_status;
+      while (!state->pending_deallocations.empty() &&
+             state->pending_deallocations.front().seqno <= last_seqno) {
+        PendingDeallocation pending = state->pending_deallocations.front();
+        state->pending_deallocations.pop_front();
+        CompletePendingDeallocation(*state, pending);
+      }
+    }
+
     // Free platform-specific per-device resources (e.g. pinned timeline).
     if (state->destroy_fn) {
       state->destroy_fn();
@@ -240,7 +263,20 @@ DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
 
 absl::Status DeviceAddressVmmAllocator::SynchronizeAllPendingOperations() {
   for (auto& device : per_device_) {
-    RETURN_IF_ERROR(SynchronizePendingOperations(device.first));
+    auto& state = device.second;
+    absl::MutexLock lock(state->mu);
+    RETURN_IF_ERROR(FlushOpenDeallocationBatch(
+        *state, DeallocationBatchFlushReason::kDestructor));
+    if (!state->pending_deallocations.empty()) {
+      uint64_t target_seqno = state->pending_deallocations.back().seqno;
+      RETURN_IF_ERROR(WaitUntilSeqno(*state, target_seqno));
+      while (!state->pending_deallocations.empty() &&
+             state->pending_deallocations.front().seqno <= target_seqno) {
+        PendingDeallocation pending = state->pending_deallocations.front();
+        state->pending_deallocations.pop_front();
+        CompletePendingDeallocation(*state, pending);
+      }
+    }
   }
   return absl::OkStatus();
 }
@@ -279,11 +315,13 @@ absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
     int device_ordinal) {
   ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
   absl::MutexLock lock(state->mu);
+  RETURN_IF_ERROR(
+      FlushOpenDeallocationBatch(*state, DeallocationBatchFlushReason::kSync));
   if (state->pending_deallocations.empty()) {
     return absl::OkStatus();
   }
   uint64_t target_seqno = state->pending_deallocations.back().seqno;
-  WaitUntilSeqno(*state, target_seqno);
+  RETURN_IF_ERROR(WaitUntilSeqno(*state, target_seqno));
   while (!state->pending_deallocations.empty() &&
          state->pending_deallocations.front().seqno <= target_seqno) {
     PendingDeallocation pending = state->pending_deallocations.front();
@@ -465,7 +503,7 @@ DeviceAddressVmmAllocator::EnsureReservationAvailableForFreshMapping(
     // VA is still protected by stream order. Complete only that conflicting
     // stale record, then rescan because another thread may have changed the
     // allocator state while the lock was released.
-    uint64_t pending_completion_seqno = 0;
+    std::optional<PendingDeallocationKey> pending_completion_key;
     {
       auto stale_overlap = FindOverlappingRecord(
           state, request.reservation_address, AddressRole::kBoth,
@@ -474,18 +512,22 @@ DeviceAddressVmmAllocator::EnsureReservationAvailableForFreshMapping(
         CHECK(!stale_overlap->is_active);
         AllocationRecord& record = *stale_overlap->record;
         if (stale_overlap->is_allocator) {
-          pending_completion_seqno = record.allocator_stale_seqno();
+          pending_completion_key = PendingDeallocationKey{
+              PendingDeallocationKind::kAllocation,
+              record.allocator_stale_seqno(), record.allocator_address()};
         } else {
           CHECK(record.reservation_stale());
-          pending_completion_seqno = record.reservation_stale_seqno();
+          pending_completion_key = PendingDeallocationKey{
+              PendingDeallocationKind::kMap, record.reservation_stale_seqno(),
+              record.reservation_address()};
         }
       }
     }
-    if (pending_completion_seqno == 0) {
+    if (!pending_completion_key.has_value()) {
       break;
     }
-    WaitUntilSeqno(state, pending_completion_seqno);
-    CompletePendingDeallocationBySeqno(state, pending_completion_seqno);
+    RETURN_IF_ERROR(WaitUntilSeqno(state, pending_completion_key->seqno));
+    CompletePendingDeallocationByKey(state, *pending_completion_key);
   }
 
   // At this point stale exact overlaps have been drained. Any remaining
@@ -550,6 +592,8 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
     // already be past their stream timeline point. Complete ready allocator
     // deallocations first, without blocking for later pending work and without
     // destroying unrelated stale reservation mappings that may be reused.
+    RETURN_IF_ERROR(
+        FlushOpenDeallocationBatch(state, DeallocationBatchFlushReason::kWait));
     CompleteReadyAllocatorDeallocationsForReclaim(
         state, LoadTimeline(state.pinned_timeline));
     result = try_fresh();
@@ -566,7 +610,7 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
     uint64_t accumulated_size = 0;
     uint64_t rounded_size = RoundUpToGranularity(state, reclaim_size);
     uint64_t target_seqno = 0;
-    std::vector<uint64_t> selected;
+    std::vector<PendingDeallocationKey> selected;
 
     // Target 1.1x the requested size to provide some headroom.
     uint64_t target_size = rounded_size + rounded_size / 10;
@@ -587,16 +631,17 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
       CHECK_GT(reclaimable_bytes, 0);
       accumulated_size += reclaimable_bytes;
       target_seqno = std::max(target_seqno, pending.seqno);
-      selected.push_back(pending.seqno);
+      selected.push_back(
+          PendingDeallocationKey{pending.kind, pending.seqno, pending.addr});
       if (accumulated_size >= target_size) {
         break;
       }
     }
 
     if (!selected.empty()) {
-      WaitUntilSeqno(state, target_seqno);
-      for (uint64_t seqno : selected) {
-        CompletePendingDeallocationBySeqno(state, seqno);
+      RETURN_IF_ERROR(WaitUntilSeqno(state, target_seqno));
+      for (const PendingDeallocationKey& key : selected) {
+        CompletePendingDeallocationByKey(state, key);
       }
     }
     result = try_fresh();
@@ -789,16 +834,20 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
       "on device ordinal %d",
       mem.opaque(), mem.size(), state->executor->device_ordinal());
 
-  // Assign the next sequence number and enqueue a GPU write to the pinned
-  // timeline when the stream reaches this point. The CPU polls the timeline
-  // value to know when it is safe to free the memory.
-  uint64_t seqno = state->next_seqno++;
-  RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
+  const uint64_t reclaimable_bytes = record.raw_allocation()->address().size();
+  CHECK_GT(reclaimable_bytes, 0);
+  RETURN_IF_ERROR(
+      FlushOpenDeallocationBatchIfNeededForEntry(*state, reclaimable_bytes));
+
+  // Assign this deferred Deallocate to the current per-device trailing batch.
+  // One stream marker will be enqueued for the whole batch when it is flushed.
+  uint64_t seqno = GetOrCreateOpenDeallocationBatchSeqno(*state);
   // Move the returned allocator address out of active ownership and keep its
   // mapping alive as stale state until the stream reaches `seqno`.
   record.MarkAllocatorStale(seqno);
   state->pending_deallocations.push_back(PendingDeallocation{
       PendingDeallocationKind::kAllocation, seqno, record.allocator_address()});
+  AddOpenDeallocationBatchEntry(*state, reclaimable_bytes);
   return absl::OkStatus();
 }
 
@@ -939,7 +988,7 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
   // a third attempt can install or reuse the requested mapping.
   constexpr int kMaxStaleMappingWaits = 2;
   for (int wait_count = 0;; ++wait_count) {
-    uint64_t pending_completion_seqno = 0;
+    std::optional<PendingDeallocationKey> pending_completion_key;
     {
       // Keep record pointers inside this scope so none survives a wait that
       // releases state.mu.
@@ -972,11 +1021,14 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
       if (source_record->reservation_stale()) {
         CHECK(source_record->has_reservation_alias());
         if (!source_record->reservation_matches(request.reservation_address)) {
-          pending_completion_seqno = source_record->reservation_stale_seqno();
+          pending_completion_key =
+              PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                     source_record->reservation_stale_seqno(),
+                                     source_record->reservation_address()};
         }
       }
 
-      if (pending_completion_seqno == 0) {
+      if (!pending_completion_key.has_value()) {
         auto stale_reservation_overlap = FindOverlappingRecord(
             state, request.reservation_address, AddressRole::kReservation,
             RecordState::kStale, OverlapKind::kExact);
@@ -995,21 +1047,27 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
                                      request.reservation_address);
             return absl::OkStatus();
           }
-          pending_completion_seqno = stale_record.reservation_stale_seqno();
+          pending_completion_key =
+              PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                     stale_record.reservation_stale_seqno(),
+                                     stale_record.reservation_address()};
         }
       }
 
-      if (pending_completion_seqno == 0) {
+      if (!pending_completion_key.has_value()) {
         auto stale_allocator_overlap = FindOverlappingRecord(
             state, request.reservation_address, AddressRole::kAllocator,
             RecordState::kStale, OverlapKind::kExact);
         if (stale_allocator_overlap.has_value()) {
           AllocationRecord& stale_record = *stale_allocator_overlap->record;
-          pending_completion_seqno = stale_record.allocator_stale_seqno();
+          pending_completion_key =
+              PendingDeallocationKey{PendingDeallocationKind::kAllocation,
+                                     stale_record.allocator_stale_seqno(),
+                                     stale_record.allocator_address()};
         }
       }
 
-      if (pending_completion_seqno == 0) {
+      if (!pending_completion_key.has_value()) {
         // Map() aliases the beginning of the source allocation into the
         // caller's VA slice. No physical allocation or PA accounting is added.
         ASSIGN_OR_RETURN(
@@ -1036,9 +1094,9 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
       }
     }
 
-    CHECK_NE(pending_completion_seqno, 0);
-    WaitUntilSeqno(state, pending_completion_seqno);
-    CompletePendingDeallocationBySeqno(state, pending_completion_seqno);
+    CHECK(pending_completion_key.has_value());
+    RETURN_IF_ERROR(WaitUntilSeqno(state, pending_completion_key->seqno));
+    CompletePendingDeallocationByKey(state, *pending_completion_key);
   }
 }
 
@@ -1069,10 +1127,100 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
 
 // UnMap/deferred teardown helpers.
 
+absl::Status
+DeviceAddressVmmAllocator::FlushOpenDeallocationBatchIfNeededForEntry(
+    PerDeviceState& state, uint64_t reclaimable_bytes) {
+  if (state.open_deallocation_batch_seqno == 0) {
+    CHECK_EQ(state.open_deallocation_batch_entries, 0);
+    CHECK_EQ(state.open_deallocation_batch_bytes, 0);
+    return absl::OkStatus();
+  }
+
+  CHECK_GT(state.open_deallocation_batch_entries, 0);
+  bool entry_limit =
+      state.open_deallocation_batch_entries >= kMaxOpenDeallocationBatchEntries;
+  bool byte_limit =
+      reclaimable_bytes > 0 && state.open_deallocation_batch_bytes > 0 &&
+      (state.open_deallocation_batch_bytes >= kMaxOpenDeallocationBatchBytes ||
+       reclaimable_bytes > kMaxOpenDeallocationBatchBytes -
+                               state.open_deallocation_batch_bytes);
+  if (!entry_limit && !byte_limit) {
+    return absl::OkStatus();
+  }
+
+  return FlushOpenDeallocationBatch(
+      state, entry_limit ? DeallocationBatchFlushReason::kEntryLimit
+                         : DeallocationBatchFlushReason::kByteLimit);
+}
+
+uint64_t DeviceAddressVmmAllocator::GetOrCreateOpenDeallocationBatchSeqno(
+    PerDeviceState& state) {
+  if (state.open_deallocation_batch_seqno == 0) {
+    CHECK_EQ(state.open_deallocation_batch_entries, 0);
+    CHECK_EQ(state.open_deallocation_batch_bytes, 0);
+    state.open_deallocation_batch_seqno = state.next_seqno++;
+  }
+  return state.open_deallocation_batch_seqno;
+}
+
+void DeviceAddressVmmAllocator::AddOpenDeallocationBatchEntry(
+    PerDeviceState& state, uint64_t reclaimable_bytes) {
+  CHECK_NE(state.open_deallocation_batch_seqno, 0);
+  ++state.open_deallocation_batch_entries;
+  if (std::numeric_limits<uint64_t>::max() -
+          state.open_deallocation_batch_bytes <
+      reclaimable_bytes) {
+    state.open_deallocation_batch_bytes = std::numeric_limits<uint64_t>::max();
+  } else {
+    state.open_deallocation_batch_bytes += reclaimable_bytes;
+  }
+}
+
 void DeviceAddressVmmAllocator::ErasePendingDeallocationAt(
     PerDeviceState& state, std::deque<PendingDeallocation>::iterator it) {
   CHECK(it != state.pending_deallocations.end());
+  if (it->seqno == state.open_deallocation_batch_seqno) {
+    uint64_t reclaimable_bytes = 0;
+    if (it->kind == PendingDeallocationKind::kAllocation) {
+      auto record_it =
+          state.records_by_allocator_address.find(it->addr.opaque());
+      CHECK(record_it != state.records_by_allocator_address.end());
+      reclaimable_bytes = record_it->second->raw_allocation()->address().size();
+      CHECK_GT(reclaimable_bytes, 0);
+    }
+    CHECK_GT(state.open_deallocation_batch_entries, 0);
+    --state.open_deallocation_batch_entries;
+    CHECK_GE(state.open_deallocation_batch_bytes, reclaimable_bytes);
+    state.open_deallocation_batch_bytes -= reclaimable_bytes;
+    if (state.open_deallocation_batch_entries == 0) {
+      state.open_deallocation_batch_seqno = 0;
+      state.open_deallocation_batch_bytes = 0;
+    }
+  }
   state.pending_deallocations.erase(it);
+}
+
+absl::Status DeviceAddressVmmAllocator::FlushOpenDeallocationBatch(
+    PerDeviceState& state, DeallocationBatchFlushReason /*reason*/) {
+  if (state.open_deallocation_batch_seqno == 0) {
+    CHECK_EQ(state.open_deallocation_batch_entries, 0);
+    CHECK_EQ(state.open_deallocation_batch_bytes, 0);
+    return absl::OkStatus();
+  }
+
+  if (state.open_deallocation_batch_entries == 0) {
+    state.open_deallocation_batch_seqno = 0;
+    state.open_deallocation_batch_bytes = 0;
+    return absl::OkStatus();
+  }
+
+  const uint64_t seqno = state.open_deallocation_batch_seqno;
+  RETURN_IF_ERROR(EnqueueDeferredDeallocation(state, seqno));
+
+  state.open_deallocation_batch_seqno = 0;
+  state.open_deallocation_batch_entries = 0;
+  state.open_deallocation_batch_bytes = 0;
+  return absl::OkStatus();
 }
 
 void DeviceAddressVmmAllocator::ErasePendingDeallocation(
@@ -1096,8 +1244,11 @@ void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
   record.ReactivateAllocator(new_size);
 }
 
-void DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
-                                               uint64_t target_seqno) {
+absl::Status DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
+                                                       uint64_t target_seqno) {
+  RETURN_IF_ERROR(
+      FlushOpenDeallocationBatch(state, DeallocationBatchFlushReason::kWait));
+
   // Release the lock before spin-waiting to avoid stalling other threads for
   // potentially milliseconds while the GPU drains its work queue.
   state.mu.unlock();
@@ -1110,11 +1261,12 @@ void DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
   }
 
   state.mu.lock();
+  return absl::OkStatus();
 }
 
 void DeviceAddressVmmAllocator::CompleteReadyAllocatorDeallocationsForReclaim(
     PerDeviceState& state, uint64_t completed_seqno) {
-  std::vector<uint64_t> selected;
+  std::vector<PendingDeallocationKey> selected;
   for (const PendingDeallocation& pending : state.pending_deallocations) {
     if (pending.seqno > completed_seqno ||
         pending.kind == PendingDeallocationKind::kMap) {
@@ -1126,20 +1278,22 @@ void DeviceAddressVmmAllocator::CompleteReadyAllocatorDeallocationsForReclaim(
         record_it->second->memory_space() == reclaim_exempt_memory_space_) {
       continue;
     }
-    selected.push_back(pending.seqno);
+    selected.push_back(
+        PendingDeallocationKey{pending.kind, pending.seqno, pending.addr});
   }
-  for (uint64_t seqno : selected) {
-    CompletePendingDeallocationBySeqno(state, seqno);
+  for (const PendingDeallocationKey& key : selected) {
+    CompletePendingDeallocationByKey(state, key);
   }
 }
 
-void DeviceAddressVmmAllocator::CompletePendingDeallocationBySeqno(
-    PerDeviceState& state, uint64_t seqno) {
+void DeviceAddressVmmAllocator::CompletePendingDeallocationByKey(
+    PerDeviceState& state, const PendingDeallocationKey& key) {
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
-    if (it->seqno == seqno) {
+    if (it->kind == key.kind && it->seqno == key.seqno &&
+        it->addr.IsSameAs(key.addr)) {
       PendingDeallocation pending = *it;
-      state.pending_deallocations.erase(it);
+      ErasePendingDeallocationAt(state, it);
       CompletePendingDeallocation(state, pending);
       return;
     }
@@ -1175,7 +1329,10 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
   CHECK(!record.reservation_active());
   if (record.reservation_stale()) {
     CHECK(record.has_reservation_alias());
-    CompletePendingDeallocationBySeqno(state, record.reservation_stale_seqno());
+    CompletePendingDeallocationByKey(
+        state, PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                      record.reservation_stale_seqno(),
+                                      record.reservation_address()});
     CHECK(!record.has_reservation_alias());
   }
   uint64_t physical_size = record.raw_allocation()->address().size();
@@ -1233,11 +1390,16 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
         "range passed to Map");
   }
 
-  uint64_t seqno = state->next_seqno++;
-  RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
+  RETURN_IF_ERROR(FlushOpenDeallocationBatchIfNeededForEntry(
+      *state, /*reclaimable_bytes=*/0));
+
+  // Assign this deferred UnMap to the current per-device trailing batch. One
+  // stream marker will be enqueued for the whole batch when it is flushed.
+  uint64_t seqno = GetOrCreateOpenDeallocationBatchSeqno(*state);
   record->MarkReservationStale(seqno);
   state->pending_deallocations.push_back(PendingDeallocation{
       PendingDeallocationKind::kMap, seqno, reservation_address});
+  AddOpenDeallocationBatchEntry(*state, /*reclaimable_bytes=*/0);
   return absl::OkStatus();
 }
 

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -109,9 +109,11 @@ namespace stream_executor {
 // stale reservation mapping are rejected.
 //
 // Deallocate() and UnMap() are stream-ordered deferred operations. The
-// allocator assigns the affected address record a per-device sequence number,
-// moves it from active tracking to stale tracking, and appends a pending entry
-// with the operation kind, sequence number, and address. The stale
+// allocator assigns the affected address record a per-device batch sequence
+// number, moves it from active tracking to stale tracking, and appends a
+// pending entry with the operation kind, sequence number, and address. A
+// trailing timeline write is enqueued for the open batch when the allocator
+// needs to observe the timeline or when the batch limit is reached. The stale
 // AllocationRecord keeps the raw allocation, any allocator-owned reservation,
 // and ScopedMapping objects alive until the stream reaches that sequence
 // number, so kernels already submitted to the stream can keep using the old VA.
@@ -391,6 +393,15 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     DeviceAddressBase addr;
   };
 
+  // Stable identity for one pending operation. A batch shares one sequence
+  // number, so the operation kind and address are also needed to select an
+  // entry after WaitUntilSeqno() temporarily releases state.mu.
+  struct PendingDeallocationKey {
+    PendingDeallocationKind kind;
+    uint64_t seqno;
+    DeviceAddressBase addr;
+  };
+
   struct PerDeviceState {
     StreamExecutor* executor;
     Stream* stream;
@@ -421,6 +432,24 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     uint64_t pa_allocated ABSL_GUARDED_BY(mu) = 0;
     // Monotonically increasing counter for timeline sequence numbers.
     uint64_t next_seqno ABSL_GUARDED_BY(mu) = 1;
+    // Open trailing batch of deferred deallocations. Pending entries in the
+    // open batch have been moved to stale state but do not have a stream
+    // timeline write yet. We batch because many Deallocate()/UnMap() calls can
+    // be issued back-to-back on the host, and one stream marker is enough to
+    // protect all stale mappings in that host-side batch. This avoids paying a
+    // GPU timeline write for every individual address.
+    //
+    // Example, starting with next_seqno=1 and no open batch:
+    //   Deallocate(A) creates open batch seqno 1, records A -> 1, next_seqno=2.
+    //   UnMap(R) reuses open batch seqno 1, records R -> 1.
+    //   Deallocate(B) also records B -> 1.
+    //   FlushOpenDeallocationBatch() enqueues one stream write for seqno 1 and
+    //   resets open_deallocation_batch_seqno to 0. A/R/B remain pending with
+    //   seqno 1 until the device timeline reaches 1.
+    //   The next deferred operation opens a new batch with seqno 2.
+    uint64_t open_deallocation_batch_seqno ABSL_GUARDED_BY(mu) = 0;
+    int64_t open_deallocation_batch_entries ABSL_GUARDED_BY(mu) = 0;
+    uint64_t open_deallocation_batch_bytes ABSL_GUARDED_BY(mu) = 0;
     std::deque<PendingDeallocation> pending_deallocations ABSL_GUARDED_BY(mu);
     // Owns AllocationRecord objects. Key is the allocator address pointer
     // (`AllocationRecord::allocator_address().opaque()`), including the
@@ -450,7 +479,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   static absl::Status PopulateDevices(DeviceAddressVmmAllocator* allocator,
                                       absl::Span<const DeviceConfig> devices);
 
-  // Drains all pending operations for all devices.
+  // Flushes open deallocation batches and drains all pending operations for all
+  // devices. Subclasses with platform-specific timeline enqueue implementations
+  // must call this from their destructor before the base destructor runs.
   absl::Status SynchronizeAllPendingOperations();
 
   // Validates device capabilities and initializes timeline fields
@@ -467,6 +498,14 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
                                                    uint64_t seqno) = 0;
 
  private:
+  enum class DeallocationBatchFlushReason {
+    kEntryLimit,
+    kByteLimit,
+    kWait,
+    kSync,
+    kDestructor,
+  };
+
   // Common helpers.
 
   // Returns pointer into per_device_ map, or NotFound if device_ordinal is not
@@ -597,9 +636,34 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   // UnMap/deferred teardown helpers.
 
-  // Removes a pending entry when a stale record is reused.
+  // Flushes the current open deallocation batch before adding a new entry if
+  // keeping it open would exceed the configured entry or reclaimable-byte
+  // limit.
+  absl::Status FlushOpenDeallocationBatchIfNeededForEntry(
+      PerDeviceState& state, uint64_t reclaimable_bytes)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Returns the sequence number for the current open deallocation batch,
+  // creating a new batch if necessary.
+  uint64_t GetOrCreateOpenDeallocationBatchSeqno(PerDeviceState& state)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Records that a pending entry was added to the current open deallocation
+  // batch. The batch sequence must already have been created.
+  void AddOpenDeallocationBatchEntry(PerDeviceState& state,
+                                     uint64_t reclaimable_bytes)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Removes pending entries while maintaining open-batch counters for entries
+  // that have not yet received their trailing stream marker.
   void ErasePendingDeallocationAt(PerDeviceState& state,
                                   std::deque<PendingDeallocation>::iterator it)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Enqueues one stream timeline write for the current open deallocation batch,
+  // if any pending entries remain in that batch.
+  absl::Status FlushOpenDeallocationBatch(PerDeviceState& state,
+                                          DeallocationBatchFlushReason reason)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Removes the matching pending entry when a stale record is reused.
@@ -615,7 +679,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // Waits for the device timeline to reach `target_seqno`. Temporarily releases
   // and reacquires state.mu around the blocking wait. This does not complete
   // pending entries by itself.
-  void WaitUntilSeqno(PerDeviceState& state, uint64_t target_seqno)
+  absl::Status WaitUntilSeqno(PerDeviceState& state, uint64_t target_seqno)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Completes ready allocator-address deallocations for PA reclaim while
@@ -633,10 +697,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Finds, erases, and completes the selected pending entry if it is still
-  // present. Sequence numbers uniquely identify operations on a device; another
-  // thread may already have reused or completed the entry while state.mu was
-  // released.
-  void CompletePendingDeallocationBySeqno(PerDeviceState& state, uint64_t seqno)
+  // present. Another thread may already have reused or completed the entry
+  // while state.mu was released.
+  void CompletePendingDeallocationByKey(PerDeviceState& state,
+                                        const PendingDeallocationKey& key)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Device ordinal -> per-device allocator state. Populated at construction by

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -146,7 +146,8 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   struct DeviceConfig {
     // StreamExecutor for this device. Must outlive the allocator.
     StreamExecutor* executor;
-    // Stream used for deferred deallocation. Must outlive the allocator.
+    // Stream used for deferred deallocation. Must remain valid for allocator
+    // operations other than destruction.
     Stream* stream;
     // Maximum bytes of physical memory that may be allocated simultaneously on
     // this device. Defaults to unlimited.
@@ -490,11 +491,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
                                       absl::Span<const DeviceConfig> devices);
 
   // Flushes open deallocation batches and drains all pending operations for all
-  // devices. Subclasses with platform-specific timeline enqueue implementations
-  // must call this from their destructor before the base destructor runs:
-  // draining needs EnqueueDeferredDeallocation(), which is no longer callable
-  // once the subclass has been destroyed. The base destructor CHECK-fails if
-  // pending work remains.
+  // devices. The configured streams must remain valid for this explicit
+  // synchronization. Destruction instead synchronizes each StreamExecutor and
+  // retires pending state without accessing the streams.
   absl::Status SynchronizeAllPendingOperations();
 
   // Validates device capabilities and initializes timeline fields

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -391,6 +391,11 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     // Allocator address for allocation deallocations; reservation address for
     // kMap.
     DeviceAddressBase addr;
+    // Physical bytes released when this entry completes; 0 for kMap, which only
+    // drops a reservation alias. Stored here rather than re-derived from the
+    // AllocationRecord so that open-batch accounting reads exactly the value
+    // that was accounted when the entry was queued.
+    uint64_t reclaimable_bytes;
   };
 
   // Stable identity for one pending operation. A batch shares one sequence
@@ -447,9 +452,14 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     //   resets open_deallocation_batch_seqno to 0. A/R/B remain pending with
     //   seqno 1 until the device timeline reaches 1.
     //   The next deferred operation opens a new batch with seqno 2.
+    //
+    // Only the sequence number is stored. The batch's entry and byte totals are
+    // the trailing run of `pending_deallocations` carrying this seqno (entries
+    // are appended in non-decreasing seqno order, so that run is contiguous),
+    // and are computed on demand by OpenDeallocationBatchSize(). Keeping them
+    // derived means cancelling an entry -- which happens whenever a stale
+    // record is reused -- needs no batch bookkeeping at all.
     uint64_t open_deallocation_batch_seqno ABSL_GUARDED_BY(mu) = 0;
-    int64_t open_deallocation_batch_entries ABSL_GUARDED_BY(mu) = 0;
-    uint64_t open_deallocation_batch_bytes ABSL_GUARDED_BY(mu) = 0;
     std::deque<PendingDeallocation> pending_deallocations ABSL_GUARDED_BY(mu);
     // Owns AllocationRecord objects. Key is the allocator address pointer
     // (`AllocationRecord::allocator_address().opaque()`), including the
@@ -631,6 +641,19 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   // UnMap/deferred teardown helpers.
 
+  // Entry and reclaimable-byte totals of the trailing open deallocation batch.
+  struct OpenDeallocationBatchSize {
+    int64_t entries = 0;
+    // Saturating: a total that would overflow is reported as uint64 max, which
+    // still compares correctly against the byte limit.
+    uint64_t bytes = 0;
+  };
+
+  // Sums the trailing run of pending entries carrying the open batch seqno.
+  // Returns all zeroes when no batch is open. Bounded by the batch entry limit.
+  OpenDeallocationBatchSize OpenBatchSize(const PerDeviceState& state) const
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
   // Flushes the current open deallocation batch before adding a new entry if
   // keeping it open would exceed the configured entry or reclaimable-byte
   // limit.
@@ -641,18 +664,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // Returns the sequence number for the current open deallocation batch,
   // creating a new batch if necessary.
   uint64_t GetOrCreateOpenDeallocationBatchSeqno(PerDeviceState& state)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Records that a pending entry was added to the current open deallocation
-  // batch. The batch sequence must already have been created.
-  void AddOpenDeallocationBatchEntry(PerDeviceState& state,
-                                     uint64_t reclaimable_bytes)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Removes pending entries while maintaining open-batch counters for entries
-  // that have not yet received their trailing stream marker.
-  void ErasePendingDeallocationAt(PerDeviceState& state,
-                                  std::deque<PendingDeallocation>::iterator it)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Enqueues one stream timeline write for the current open deallocation batch,

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -481,7 +481,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   // Flushes open deallocation batches and drains all pending operations for all
   // devices. Subclasses with platform-specific timeline enqueue implementations
-  // must call this from their destructor before the base destructor runs.
+  // must call this from their destructor before the base destructor runs:
+  // draining needs EnqueueDeferredDeallocation(), which is no longer callable
+  // once the subclass has been destroyed. The base destructor CHECK-fails if
+  // pending work remains.
   absl::Status SynchronizeAllPendingOperations();
 
   // Validates device capabilities and initializes timeline fields
@@ -498,14 +501,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
                                                    uint64_t seqno) = 0;
 
  private:
-  enum class DeallocationBatchFlushReason {
-    kEntryLimit,
-    kByteLimit,
-    kWait,
-    kSync,
-    kDestructor,
-  };
-
   // Common helpers.
 
   // Returns pointer into per_device_ map, or NotFound if device_ordinal is not
@@ -662,8 +657,14 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   // Enqueues one stream timeline write for the current open deallocation batch,
   // if any pending entries remain in that batch.
-  absl::Status FlushOpenDeallocationBatch(PerDeviceState& state,
-                                          DeallocationBatchFlushReason reason)
+  absl::Status FlushOpenDeallocationBatch(PerDeviceState& state)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Flushes the open deallocation batch, waits for the device timeline to reach
+  // the last pending sequence number, and completes every pending entry up to
+  // it. Shared by SynchronizePendingOperations() and, transitively,
+  // SynchronizeAllPendingOperations().
+  absl::Status DrainPendingDeallocations(PerDeviceState& state)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Removes the matching pending entry when a stale record is reused.

--- a/xla/stream_executor/device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/device_address_vmm_allocator_test.cc
@@ -116,6 +116,10 @@ class TestDeviceAddressVmmAllocator final : public DeviceAddressVmmAllocator {
     return allocator;
   }
 
+  ~TestDeviceAddressVmmAllocator() override {
+    EXPECT_THAT(SynchronizeAllPendingOperations(), absl_testing::IsOk());
+  }
+
   int allocation_count() const { return allocation_count_; }
 
  protected:
@@ -274,6 +278,39 @@ TEST_F(DeviceAddressVmmAllocatorTest,
       auto second,
       allocator->Allocate(/*device_ordinal=*/0, kGranularity,
                           /*retry_on_failure=*/false, /*memory_space=*/0));
+  EXPECT_EQ(allocator->allocation_count(), 2);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       BatchedUnmapAndDeallocateReclaimSelectedAllocation) {
+  auto reservation = std::make_unique<TestMemoryReservation>(kGranularity);
+  const DeviceAddressVmmAllocator::DeviceConfig config = Config(kGranularity);
+  ASSERT_OK_AND_ASSIGN(auto allocator, TestDeviceAddressVmmAllocator::Create(
+                                           &platform_, {config}));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto mapped,
+      allocator->Allocate(
+          /*device_ordinal=*/0, /*allocation_size=*/kGranularity,
+          /*retry_on_failure=*/false, /*memory_space=*/0, reservation.get(),
+          /*reservation_offset=*/0, /*mapping_size=*/kGranularity,
+          /*return_reservation_address=*/false));
+  EXPECT_EQ(reservation->active_mapping_count(), 1);
+
+  ASSERT_THAT(allocator->UnMap(/*device_ordinal=*/0, reservation.get(),
+                               /*reservation_offset=*/0, kGranularity),
+              absl_testing::IsOk());
+  ASSERT_THAT(allocator->Deallocate(/*device_ordinal=*/0, mapped.Release()),
+              absl_testing::IsOk());
+
+  // UnMap() and Deallocate() share one batch sequence number. Reclaim must
+  // select the allocation entry rather than the earlier map entry with the
+  // same sequence number, then complete the paired stale mapping.
+  ASSERT_OK_AND_ASSIGN(
+      auto replacement,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/false, /*memory_space=*/0));
+  EXPECT_EQ(reservation->active_mapping_count(), 0);
   EXPECT_EQ(allocator->allocation_count(), 2);
 }
 

--- a/xla/stream_executor/device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/device_address_vmm_allocator_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 
 #include <gmock/gmock.h>
@@ -106,18 +107,16 @@ class TestDeviceAddressVmmAllocator final : public DeviceAddressVmmAllocator {
  public:
   static absl::StatusOr<std::unique_ptr<TestDeviceAddressVmmAllocator>> Create(
       const Platform* platform, absl::Span<const DeviceConfig> devices,
-      uint64_t physical_size_padding = 0) {
+      uint64_t physical_size_padding = 0,
+      std::function<void(int)> on_device_destroy = nullptr) {
     auto allocator = std::unique_ptr<TestDeviceAddressVmmAllocator>(
-        new TestDeviceAddressVmmAllocator(platform, physical_size_padding));
+        new TestDeviceAddressVmmAllocator(platform, physical_size_padding,
+                                          on_device_destroy));
     absl::Status status = PopulateDevices(allocator.get(), devices);
     if (!status.ok()) {
       return status;
     }
     return allocator;
-  }
-
-  ~TestDeviceAddressVmmAllocator() override {
-    EXPECT_THAT(SynchronizeAllPendingOperations(), absl_testing::IsOk());
   }
 
   int allocation_count() const { return allocation_count_; }
@@ -127,7 +126,14 @@ class TestDeviceAddressVmmAllocator final : public DeviceAddressVmmAllocator {
     state.allocation_granularity = kGranularity;
     auto* timeline = new uint64_t(0);
     state.pinned_timeline = timeline;
-    state.destroy_fn = [timeline] { delete timeline; };
+    int ordinal = state.executor->device_ordinal();
+    state.destroy_fn = [timeline, ordinal,
+                        on_device_destroy = on_device_destroy_] {
+      delete timeline;
+      if (on_device_destroy) {
+        on_device_destroy(ordinal);
+      }
+    };
     return absl::OkStatus();
   }
 
@@ -152,11 +158,14 @@ class TestDeviceAddressVmmAllocator final : public DeviceAddressVmmAllocator {
 
  private:
   TestDeviceAddressVmmAllocator(const Platform* platform,
-                                uint64_t physical_size_padding)
+                                uint64_t physical_size_padding,
+                                std::function<void(int)> on_device_destroy)
       : DeviceAddressVmmAllocator(platform),
-        physical_size_padding_(physical_size_padding) {}
+        physical_size_padding_(physical_size_padding),
+        on_device_destroy_(on_device_destroy) {}
 
   uint64_t physical_size_padding_;
+  std::function<void(int)> on_device_destroy_;
   int allocation_count_ = 0;
 };
 
@@ -164,6 +173,7 @@ class DeviceAddressVmmAllocatorTest : public ::testing::Test {
  protected:
   void SetUp() override {
     ON_CALL(executor_, device_ordinal()).WillByDefault(Return(0));
+    ON_CALL(executor_, SynchronizeAllActivity()).WillByDefault(Return(true));
     ON_CALL(stream_, parent()).WillByDefault(Return(&executor_));
   }
 
@@ -175,6 +185,78 @@ class DeviceAddressVmmAllocatorTest : public ::testing::Test {
   NiceMock<MockStreamExecutor> executor_;
   NiceMock<MockStream> stream_;
 };
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       DestructorSynchronizesExecutorWithoutPendingOperations) {
+  EXPECT_CALL(executor_, SynchronizeAllActivity()).WillOnce(Return(true));
+  ASSERT_OK_AND_ASSIGN(auto allocator, TestDeviceAddressVmmAllocator::Create(
+                                           &platform_, {Config(UINT64_MAX)}));
+
+  allocator.reset();
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       DestructorSynchronizesAllExecutorsBeforeReleasingDeviceResources) {
+  bool device_0_synchronized = false;
+  bool device_1_synchronized = false;
+  EXPECT_CALL(executor_, SynchronizeAllActivity()).WillOnce([&] {
+    device_0_synchronized = true;
+    return true;
+  });
+
+  NiceMock<MockStreamExecutor> executor_1;
+  NiceMock<MockStream> stream_1;
+  ON_CALL(executor_1, device_ordinal()).WillByDefault(Return(1));
+  ON_CALL(stream_1, parent()).WillByDefault(Return(&executor_1));
+  EXPECT_CALL(executor_1, SynchronizeAllActivity()).WillOnce([&] {
+    device_1_synchronized = true;
+    return true;
+  });
+
+  auto reservation_0 = std::make_unique<TestMemoryReservation>(kGranularity);
+  auto reservation_1 = std::make_unique<TestMemoryReservation>(kGranularity);
+  int destroyed_devices = 0;
+  auto on_device_destroy = [&](int ordinal) {
+    EXPECT_TRUE(device_0_synchronized);
+    EXPECT_TRUE(device_1_synchronized);
+    if (ordinal == 0) {
+      EXPECT_EQ(reservation_0->active_mapping_count(), 0);
+    } else {
+      EXPECT_EQ(ordinal, 1);
+      EXPECT_EQ(reservation_1->active_mapping_count(), 0);
+    }
+    ++destroyed_devices;
+  };
+  const DeviceAddressVmmAllocator::DeviceConfig config_0 = Config(UINT64_MAX);
+  const DeviceAddressVmmAllocator::DeviceConfig config_1 = {
+      &executor_1, &stream_1, UINT64_MAX};
+  ASSERT_OK_AND_ASSIGN(auto allocator,
+                       TestDeviceAddressVmmAllocator::Create(
+                           &platform_, {config_0, config_1},
+                           /*physical_size_padding=*/0, on_device_destroy));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto address_0,
+      allocator->Allocate(
+          /*device_ordinal=*/0, /*allocation_size=*/kGranularity,
+          /*retry_on_failure=*/true, /*memory_space=*/0, reservation_0.get(),
+          /*reservation_offset=*/0, /*mapping_size=*/kGranularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto address_1,
+      allocator->Allocate(
+          /*device_ordinal=*/1, /*allocation_size=*/kGranularity,
+          /*retry_on_failure=*/true, /*memory_space=*/0, reservation_1.get(),
+          /*reservation_offset=*/0, /*mapping_size=*/kGranularity));
+  EXPECT_EQ(reservation_0->active_mapping_count(), 1);
+  EXPECT_EQ(reservation_1->active_mapping_count(), 1);
+  ASSERT_THAT(allocator->Deallocate(/*device_ordinal=*/0, address_0.Release()),
+              absl_testing::IsOk());
+  ASSERT_THAT(allocator->Deallocate(/*device_ordinal=*/1, address_1.Release()),
+              absl_testing::IsOk());
+
+  allocator.reset();
+  EXPECT_EQ(destroyed_devices, 2);
+}
 
 TEST_F(DeviceAddressVmmAllocatorTest, RetryFlagDoesNotDisablePendingReclaim) {
   const DeviceAddressVmmAllocator::DeviceConfig config =

--- a/xla/stream_executor/device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/device_address_vmm_allocator_test.cc
@@ -283,34 +283,42 @@ TEST_F(DeviceAddressVmmAllocatorTest,
 
 TEST_F(DeviceAddressVmmAllocatorTest,
        BatchedUnmapAndDeallocateReclaimSelectedAllocation) {
-  auto reservation = std::make_unique<TestMemoryReservation>(kGranularity);
+  auto backing = std::make_unique<TestMemoryReservation>(kGranularity);
+  auto alias = std::make_unique<TestMemoryReservation>(kGranularity);
   const DeviceAddressVmmAllocator::DeviceConfig config = Config(kGranularity);
   ASSERT_OK_AND_ASSIGN(auto allocator, TestDeviceAddressVmmAllocator::Create(
                                            &platform_, {config}));
 
+  // The mapped overload returns the reservation slice as the allocator address,
+  // so the record is kAllocateAndMap. A later plain Allocate() cannot satisfy
+  // itself from such a record by reuse, which forces it through reclaim below.
   ASSERT_OK_AND_ASSIGN(
-      auto mapped,
-      allocator->Allocate(
-          /*device_ordinal=*/0, /*allocation_size=*/kGranularity,
-          /*retry_on_failure=*/false, /*memory_space=*/0, reservation.get(),
-          /*reservation_offset=*/0, /*mapping_size=*/kGranularity,
-          /*return_reservation_address=*/false));
-  EXPECT_EQ(reservation->active_mapping_count(), 1);
+      auto mapped, allocator->Allocate(
+                       /*device_ordinal=*/0, /*allocation_size=*/kGranularity,
+                       /*retry_on_failure=*/false, /*memory_space=*/0,
+                       backing.get(), /*reservation_offset=*/0,
+                       /*mapping_size=*/kGranularity));
+  ASSERT_THAT(allocator->Map(/*device_ordinal=*/0, mapped.cref(), alias.get(),
+                             /*reservation_offset=*/0, kGranularity),
+              absl_testing::IsOk());
+  EXPECT_EQ(alias->active_mapping_count(), 1);
 
-  ASSERT_THAT(allocator->UnMap(/*device_ordinal=*/0, reservation.get(),
+  // Queue the alias teardown and the allocation teardown back to back so both
+  // land in the same open batch and share one sequence number.
+  ASSERT_THAT(allocator->UnMap(/*device_ordinal=*/0, alias.get(),
                                /*reservation_offset=*/0, kGranularity),
               absl_testing::IsOk());
   ASSERT_THAT(allocator->Deallocate(/*device_ordinal=*/0, mapped.Release()),
               absl_testing::IsOk());
 
-  // UnMap() and Deallocate() share one batch sequence number. Reclaim must
-  // select the allocation entry rather than the earlier map entry with the
-  // same sequence number, then complete the paired stale mapping.
+  // Reclaim skips kMap entries, so it must select the allocation entry rather
+  // than the map entry carrying the same sequence number, and must then
+  // complete the paired stale mapping instead of leaving the alias mapped.
   ASSERT_OK_AND_ASSIGN(
       auto replacement,
       allocator->Allocate(/*device_ordinal=*/0, kGranularity,
                           /*retry_on_failure=*/false, /*memory_space=*/0));
-  EXPECT_EQ(reservation->active_mapping_count(), 0);
+  EXPECT_EQ(alias->active_mapping_count(), 0);
   EXPECT_EQ(allocator->allocation_count(), 2);
 }
 

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.cc
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.cc
@@ -49,13 +49,7 @@ RocmDeviceAddressVmmAllocator::RocmDeviceAddressVmmAllocator(
     std::optional<int64_t> reclaim_exempt_memory_space)
     : DeviceAddressVmmAllocator(platform, reclaim_exempt_memory_space) {}
 
-RocmDeviceAddressVmmAllocator::~RocmDeviceAddressVmmAllocator() {
-  absl::Status status = SynchronizeAllPendingOperations();
-  if (!status.ok()) {
-    LOG(FATAL) << "Failed to synchronize pending ROCm VMM deallocations: "
-               << status;
-  }
-}
+RocmDeviceAddressVmmAllocator::~RocmDeviceAddressVmmAllocator() = default;
 
 absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
 RocmDeviceAddressVmmAllocator::Create(

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.cc
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.cc
@@ -49,6 +49,14 @@ RocmDeviceAddressVmmAllocator::RocmDeviceAddressVmmAllocator(
     std::optional<int64_t> reclaim_exempt_memory_space)
     : DeviceAddressVmmAllocator(platform, reclaim_exempt_memory_space) {}
 
+RocmDeviceAddressVmmAllocator::~RocmDeviceAddressVmmAllocator() {
+  absl::Status status = SynchronizeAllPendingOperations();
+  if (!status.ok()) {
+    LOG(FATAL) << "Failed to synchronize pending ROCm VMM deallocations: "
+               << status;
+  }
+}
+
 absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
 RocmDeviceAddressVmmAllocator::Create(
     const Platform* platform, absl::Span<const DeviceConfig> devices,

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h
@@ -70,8 +70,8 @@ class RocmDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
   //
   // Parameters:
   //   executor:  StreamExecutor for this device. Must outlive the allocator.
-  //   stream:    Stream used for deferred deallocation. Must outlive the
-  //              allocator.
+  //   stream:    Stream used for deferred deallocation. Must remain valid for
+  //              allocator operations other than destruction.
   //   pa_budget: Maximum bytes of physical memory that may be simultaneously
   //              allocated on this device. Defaults to unlimited.
   static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h
@@ -36,7 +36,7 @@ namespace stream_executor::gpu {
 // ROCm/HIP implementation of DeviceAddressVmmAllocator.
 //
 // Uses hipMemCreate/hipMemAddressReserve for physical and virtual memory
-// management, and hipStreamWriteValue64 for GPU timeline-based deferred
+// management, and hipStreamWriteValue64 for batched GPU timeline-based deferred
 // deallocation. Requires ROCm >= 6.0 for HIP VMM API support.
 //
 // The timeline counter is allocated as signal memory via
@@ -46,6 +46,8 @@ namespace stream_executor::gpu {
 // Use the Create() factories to obtain an instance.
 class RocmDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
  public:
+  ~RocmDeviceAddressVmmAllocator() override;
+
   // Creates an allocator supporting multiple devices.
   //
   // Precondition: all entries in `devices` have distinct device ordinals.
@@ -91,7 +93,8 @@ class RocmDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
       StreamExecutor* executor, uint64_t size) override;
 
   // Enqueues a hipStreamWriteValue64 on the device's stream to write `seqno`
-  // to the signal memory timeline when the GPU reaches this point.
+  // to the signal memory timeline when the GPU reaches this batched
+  // deallocation point in the stream.
   absl::Status EnqueueDeferredDeallocation(PerDeviceState& state,
                                            uint64_t seqno) override;
 

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator_test.cc
@@ -304,21 +304,24 @@ TEST_F(DeviceAddressVmmAllocatorTest,
 }
 
 TEST_F(DeviceAddressVmmAllocatorTest,
-       DestructorWithPendingDeallocationsDoesNotCrash) {
-  TF_ASSERT_OK_AND_ASSIGN(
+       DestructorWithDestroyedStreamAndPendingDeallocationsDoesNotCrash) {
+  ASSERT_OK_AND_ASSIGN(
       auto allocator,
       gpu::RocmDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
 
   const int ordinal = executor_->device_ordinal();
 
   for (int i = 0; i < 4; ++i) {
-    TF_ASSERT_OK_AND_ASSIGN(
+    ASSERT_OK_AND_ASSIGN(
         auto addr,
         allocator->Allocate(ordinal, 1024, /*retry_on_failure=*/true,
                             static_cast<int64_t>(MemorySpace::kCollective)));
     ASSERT_THAT(allocator->Deallocate(ordinal, addr.Release()), IsOk());
   }
 
+  // The stream may be destroyed before the allocator. Destruction must
+  // synchronize through the executor and retire pending state directly.
+  stream_.reset();
   allocator.reset();
 }
 


### PR DESCRIPTION
📝 **Summary of Changes**

Batches deferred teardown in `DeviceAddressVmmAllocator` so that a burst of `Deallocate()` / `UnMap()` calls costs **one** GPU timeline write instead of one per address.

Previously every deferred operation assigned its own sequence number and immediately enqueued a `cuStreamWriteValue64` / `hipStreamWriteValue64` marker. Since one marker already protects every stale mapping queued before it, that per-address write was redundant.

Now each device keeps an **open trailing batch**. Deferred operations join the open batch and share its sequence number; a single marker is enqueued when the batch is flushed by:

- the entry limit (64) or the reclaimable-byte limit (64 MiB),
- `WaitUntilSeqno()` — anything that needs to observe the timeline flushes first,
- `SynchronizePendingOperations()`.

Allocator destruction uses a separate stream-independent path: it first quiesces every registered executor, then retires pending state directly without touching the allocator streams.

Supporting changes:

- **`PendingDeallocation` carries its own `reclaimable_bytes`, and open-batch totals are derived, not tracked.** Only the batch seqno lives on `PerDeviceState`; entries are appended in non-decreasing seqno order, so the open batch is the trailing run carrying that seqno and `OpenBatchSize()` sums it on demand. Cancelling an entry (which happens on every stale-record reuse) is a plain deque erase with no batch bookkeeping, so the add and remove paths cannot disagree.
- **Entry selection no longer relies on the sequence number being unique.** A batch shares one seqno, so `CompletePendingDeallocationByKey()` selects on `(kind, seqno, addr)` — necessary because `WaitUntilSeqno()` temporarily releases `state.mu`, after which a bare seqno would no longer name a single entry.
- **Stream-independent destruction.** The base VMM destructor synchronizes every registered `StreamExecutor` before releasing resources on any device, then retires pending records and timeline storage directly. CUDA and ROCm keep defaulted derived destructors, so the stream must outlive operational allocator calls but need not outlive allocator destruction. The executor must still outlive the allocator.

🎯 **Justification**

Removes redundant stream timeline writes on the deallocation path. The batch limits are not arbitrary: every entry in a batch shares one seqno, so the non-blocking reclaim path (`CompleteReadyAllocatorDeallocationsForReclaim()`) cannot free *anything* in a batch until that batch's marker lands. Bounding batch size bounds the granularity of non-blocking reclaim; an unbounded batch would push every reclaim into the blocking wait.

🚀 **Kind of Contribution**

⚡️ Performance Improvement, ♻️ Cleanup

📊 **Benchmark (for Performance Improvements)**

None collected.

🧪 **Unit Tests**

`//xla/stream_executor:device_address_vmm_allocator_test` 

- `BatchedUnmapAndDeallocateReclaimSelectedAllocation` (new)
- `RetryFlagDoesNotDisablePendingReclaim`
- `RetryDisabledStillReusesCompatiblePendingAllocation`
- `RetryFlagDoesNotDisableMappedPendingReclaim`
- `PhysicalAllocationSizeControlsBudgetAccounting`
- `DestructorSynchronizesExecutorWithoutPendingOperations` (new)
- `DestructorSynchronizesAllExecutorsBeforeReleasingDeviceResources` (new)
- CUDA/ROCm `DestructorWithDestroyedStreamAndPendingDeallocationsDoesNotCrash` (updated)



🧪 **Execution Tests**

`//xla/pjrt/gpu:se_gpu_pjrt_client_test_b200` with `--test_filter=VmmTest.VmmAllocatorE2ETest` (local CUDA CC 10.7).
