### PR TITLE
[XLA:GPU] Add VMM allocator debug statistics

### DIFF
--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.cc
@@ -35,12 +35,12 @@ limitations under the License.
 #include "xla/stream_executor/cuda/cuda_memory_reservation.h"
 #include "xla/stream_executor/cuda/cuda_raw_memory_allocation.h"
 #include "xla/stream_executor/cuda/cuda_status.h"
+#include "xla/stream_executor/device_address_vmm_allocator.h"
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/memory_reservation.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
-#include "xla/stream_executor/device_address_vmm_allocator.h"
 
 namespace stream_executor::gpu {
 

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h
@@ -36,7 +36,7 @@ namespace stream_executor::gpu {
 // CUDA implementation of DeviceAddressVmmAllocator.
 //
 // Uses cuMemCreate/cuMemAddressReserve for physical and virtual memory
-// management, and cuStreamWriteValue64 for GPU timeline-based deferred
+// management, and cuStreamWriteValue64 for batched GPU timeline-based deferred
 // deallocation. Requires compute capability >= 7.0 (Volta and later) for
 // cuStreamWriteValue64 support.
 //
@@ -97,7 +97,8 @@ class CudaDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
       StreamExecutor* executor, uint64_t size) override;
 
   // Enqueues a cuStreamWriteValue64 on the device's stream to write `seqno`
-  // to the pinned timeline when the GPU reaches this point in the stream.
+  // to the pinned timeline when the GPU reaches this batched deallocation point
+  // in the stream.
   absl::Status EnqueueDeferredDeallocation(PerDeviceState& state,
                                            uint64_t seqno) override;
 

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h
@@ -24,12 +24,12 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
+#include "xla/stream_executor/device_address_vmm_allocator.h"
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/memory_reservation.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
-#include "xla/stream_executor/device_address_vmm_allocator.h"
 
 namespace stream_executor::gpu {
 
@@ -101,7 +101,6 @@ class CudaDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
   absl::Status EnqueueDeferredDeallocation(PerDeviceState& state,
                                            uint64_t seqno) override;
 
- private:
   explicit CudaDeviceAddressVmmAllocator(const Platform* platform);
 };
 

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -92,6 +92,20 @@ DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
   CHECK(allocator_address_mapping_.has_value());
 }
 
+DeviceAddressVmmAllocator::PendingDeallocationKind
+DeviceAddressVmmAllocator::AllocationRecord::pending_deallocation_kind() const {
+  switch (kind_) {
+    case Kind::kAllocate:
+      return PendingDeallocationKind::kAllocate;
+    case Kind::kAllocateAndMapReturnMapAddr:
+      return PendingDeallocationKind::kAllocateAndMapReturnMapAddr;
+    case Kind::kAllocateAndMapReturnNewAddr:
+      return PendingDeallocationKind::kAllocateAndMapReturnNewAddr;
+  }
+  LOG(FATAL) << "Unknown AllocationRecord kind";
+  return PendingDeallocationKind::kAllocate;
+}
+
 DeviceAddressBase
 DeviceAddressVmmAllocator::AllocationRecord::reservation_address() const {
   CHECK(reservation_address_.has_value());
@@ -102,6 +116,36 @@ bool DeviceAddressVmmAllocator::AllocationRecord::reservation_mapping_matches(
     DeviceAddressBase address) const {
   return reservation_address_mapping_.has_value() &&
          reservation_address_mapping_->mapped_address().IsSameAs(address);
+}
+
+void DeviceAddressVmmAllocator::AllocationRecord::MarkAllocatorStale(
+    uint64_t seqno) {
+  CHECK(allocator_active());
+  CHECK(!allocator_stale());
+  CHECK(has_allocator_address_mapping());
+  CHECK_NE(seqno, 0);
+  allocator_state_ = AllocatorState::kStale;
+  allocator_stale_seqno_ = seqno;
+}
+
+void DeviceAddressVmmAllocator::AllocationRecord::ReactivateAllocator(
+    uint64_t new_size) {
+  CHECK(!allocator_active());
+  CHECK(allocator_stale());
+  CHECK(has_allocator_address_mapping());
+  allocator_address_ = DeviceAddressBase(allocator_address_.opaque(), new_size);
+  allocator_state_ = AllocatorState::kActive;
+  allocator_stale_seqno_ = 0;
+}
+
+void DeviceAddressVmmAllocator::AllocationRecord::CompleteStaleAllocator() {
+  CHECK(!allocator_active());
+  CHECK(allocator_stale());
+  CHECK(!reservation_active());
+  CHECK(!reservation_stale());
+  allocator_address_mapping_.reset();
+  allocator_address_reservation_.reset();
+  raw_allocation_.reset();
 }
 
 // Interval between CPU polls of the GPU-written deallocation timeline while
@@ -214,11 +258,11 @@ void DeviceAddressVmmAllocator::ProcessCompletedPendingDeallocations(
     if (state.pending_deallocations.front().seqno > completed) {
       break;
     }
-    if (state.pending_deallocations.front().kind ==
-        PendingDeallocationKind::kAllocate) {
-      DoDeallocate(state, state.pending_deallocations.front().mem);
+    if (state.pending_deallocations.front().kind !=
+        PendingDeallocationKind::kMap) {
+      DoDeallocate(state, state.pending_deallocations.front().addr);
     } else {
-      DoUnMap(state, state.pending_deallocations.front().mem);
+      DoUnMap(state, state.pending_deallocations.front().addr);
     }
     state.pending_deallocations.pop_front();
   }
@@ -239,8 +283,8 @@ void DeviceAddressVmmAllocator::WaitPendingDeallocationsToComplete(
   uint64_t target_size = rounded_size + rounded_size / 10;
 
   for (const auto& pending : state.pending_deallocations) {
-    if (pending.kind == PendingDeallocationKind::kAllocate) {
-      accumulated_size += RoundUpToGranularity(state, pending.mem.size());
+    if (pending.kind != PendingDeallocationKind::kMap) {
+      accumulated_size += pending.reclaimable_bytes;
     }
     target_seqno = pending.seqno;
     ++count_to_wait;
@@ -273,10 +317,10 @@ void DeviceAddressVmmAllocator::WaitPendingDeallocationsToComplete(
   state.mu.lock();
 
   for (auto& item : selected) {
-    if (item.kind == PendingDeallocationKind::kAllocate) {
-      DoDeallocate(state, item.mem);
+    if (item.kind != PendingDeallocationKind::kMap) {
+      DoDeallocate(state, item.addr);
     } else {
-      DoUnMap(state, item.mem);
+      DoUnMap(state, item.addr);
     }
   }
 }
@@ -287,18 +331,20 @@ void DeviceAddressVmmAllocator::DoDeallocate(PerDeviceState& state,
       "Actually freeing virtual address %p (size=%uB) on device ordinal %d",
       mem.opaque(), mem.size(), state.executor->device_ordinal());
 
-  // Erase the ScopedMapping first: its destructor unmaps the physical memory
-  // from the virtual address range.
-  state.scoped_mappings.erase(mem.opaque());
-  // Erase the reservation next: its destructor frees the virtual address range.
-  state.reservations.erase(mem.opaque());
-  // Erase the raw allocation last: its destructor releases the physical memory.
-  state.raw_allocations.erase(mem.opaque());
-  state.multi_device_allocations.erase(mem.opaque());
-
-  uint64_t rounded_size = RoundUpToGranularity(state, mem.size());
-  DCHECK_GE(state.pa_allocated, rounded_size);
-  state.pa_allocated -= rounded_size;
+  auto record_it = state.records_by_allocator_address.find(mem.opaque());
+  CHECK(record_it != state.records_by_allocator_address.end());
+  CHECK(record_it->second->allocator_stale());
+  CHECK(record_it->second->allocator_matches(mem));
+  AllocationRecord& record = *record_it->second;
+  CHECK(!record.allocator_active());
+  if (record.raw_allocation() != nullptr) {
+    uint64_t rounded_size =
+        RoundUpToGranularity(state, record.raw_allocation()->address().size());
+    DCHECK_GE(state.pa_allocated, rounded_size);
+    state.pa_allocated -= rounded_size;
+  }
+  record.CompleteStaleAllocator();
+  CHECK_EQ(state.records_by_allocator_address.erase(mem.opaque()), 1);
 }
 
 void DeviceAddressVmmAllocator::DoUnMap(PerDeviceState& state,
@@ -310,8 +356,26 @@ void DeviceAddressVmmAllocator::DoUnMap(PerDeviceState& state,
   state.stale_reservation_mappings.erase(mem.opaque());
 }
 
+void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
+    PerDeviceState& state, AllocationRecord::Kind kind,
+    DeviceAddressBase allocator_address,
+    std::shared_ptr<MemoryAllocation> raw_allocation,
+    std::unique_ptr<MemoryReservation> reservation,
+    MemoryReservation::ScopedMapping mapping, uint64_t allocated_size,
+    bool multi_device) {
+  void* va_ptr = allocator_address.opaque();
+  auto record = std::make_unique<AllocationRecord>(
+      kind, allocator_address, std::move(raw_allocation),
+      std::move(reservation), std::move(mapping), multi_device);
+  auto insert_result =
+      state.records_by_allocator_address.emplace(va_ptr, std::move(record));
+  CHECK(insert_result.second);
+  state.pa_allocated += allocated_size;
+  return va_ptr;
+}
+
 absl::StatusOr<DeviceAddressBase> DeviceAddressVmmAllocator::AllocateWithBudget(
-    PerDeviceState& state, uint64_t size) {
+    PerDeviceState& state, uint64_t size, bool multi_device) {
   uint64_t rounded_size = RoundUpToGranularity(state, size);
   if (state.pa_allocated + rounded_size > state.pa_budget) {
     return absl::ResourceExhaustedError(absl::StrFormat(
@@ -333,15 +397,12 @@ absl::StatusOr<DeviceAddressBase> DeviceAddressVmmAllocator::AllocateWithBudget(
       reservation->MapTo(/*reservation_offset=*/0, /*allocation_offset=*/0,
                          padded_size, *raw_alloc));
 
-  void* va_ptr = reservation->address().opaque();
-
-  // Store tracking entries. Destruction order matters: scoped_mappings must
-  // be erased before reservations, which must be erased before raw_allocations.
-  state.raw_allocations.emplace(va_ptr, std::move(raw_alloc));
-  state.reservations.emplace(va_ptr, std::move(reservation));
-  state.scoped_mappings.emplace(va_ptr, std::move(scoped_mapping));
-
-  state.pa_allocated += rounded_size;
+  auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
+  DeviceAddressBase allocator_address(reservation->address().opaque(), size);
+  void* va_ptr = TrackAllocatorAddressMappedAllocation(
+      state, AllocationRecord::Kind::kAllocate, allocator_address,
+      std::move(shared_raw), std::move(reservation), std::move(scoped_mapping),
+      rounded_size, multi_device);
   // Return the original requested size, not the padded size.
   return DeviceAddressBase(va_ptr, size);
 }
@@ -374,7 +435,8 @@ DeviceAddressVmmAllocator::Allocate(
           reservation_address.opaque()) ||
       state->stale_reservation_mappings.contains(
           reservation_address.opaque()) ||
-      state->raw_allocations.contains(reservation_address.opaque())) {
+      state->records_by_allocator_address.contains(
+          reservation_address.opaque())) {
     return absl::FailedPreconditionError(
         "Reservation address is already tracked by this allocator");
   }
@@ -400,41 +462,35 @@ DeviceAddressVmmAllocator::Allocate(
       MemoryReservation::ScopedMapping reservation_mapping,
       reservation->MapTo(reservation_offset, /*allocation_offset=*/0,
                          mapping_size, *raw_alloc));
+  auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
 
-  std::unique_ptr<MemoryReservation> allocator_reservation;
-  MemoryReservation::ScopedMapping allocator_mapping;
-  DeviceAddressBase allocator_address = reservation_address;
-
-  if (!return_reservation_address) {
-    ASSIGN_OR_RETURN(allocator_reservation,
-                     CreateReservation(state->executor, allocation_size));
-    ASSIGN_OR_RETURN(allocator_mapping,
-                     allocator_reservation->MapTo(
-                         /*reservation_offset=*/0, /*allocation_offset=*/0,
-                         padded_size, *raw_alloc));
-    allocator_address = DeviceAddressBase(
-        allocator_reservation->address().opaque(), allocation_size);
+  if (return_reservation_address) {
+    TrackAllocatorAddressMappedAllocation(
+        *state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
+        reservation_address, std::move(shared_raw), nullptr,
+        std::move(reservation_mapping), rounded_size, multi_device);
+    return ScopedDeviceAddress<uint8_t>(reservation_address, device_ordinal,
+                                        this);
   }
 
-  void* allocator_ptr = allocator_address.opaque();
-  state->raw_allocations.emplace(allocator_ptr, std::move(raw_alloc));
-  state->scoped_mappings.emplace(allocator_ptr, std::move(allocator_mapping));
-  if (allocator_reservation != nullptr) {
-    state->reservations.emplace(allocator_ptr,
-                                std::move(allocator_reservation));
-    state->active_reservation_mappings.emplace(
-        reservation_address.opaque(),
-        ReservationMapping{allocator_address, reservation_address, reservation,
-                           reservation_offset, mapping_size,
-                           std::move(reservation_mapping)});
-  } else {
-    state->scoped_mappings[allocator_ptr] = std::move(reservation_mapping);
-  }
+  ASSIGN_OR_RETURN(auto allocator_reservation,
+                   CreateReservation(state->executor, allocation_size));
+  ASSIGN_OR_RETURN(auto allocator_mapping,
+                   allocator_reservation->MapTo(
+                       /*reservation_offset=*/0, /*allocation_offset=*/0,
+                       padded_size, *shared_raw));
+  DeviceAddressBase allocator_address(allocator_reservation->address().opaque(),
+                                      allocation_size);
+  TrackAllocatorAddressMappedAllocation(
+      *state, AllocationRecord::Kind::kAllocateAndMapReturnNewAddr,
+      allocator_address, std::move(shared_raw), std::move(allocator_reservation),
+      std::move(allocator_mapping), rounded_size, multi_device);
+  state->active_reservation_mappings.emplace(
+      reservation_address.opaque(),
+      ReservationMapping{allocator_address, reservation_address, reservation,
+                         reservation_offset, mapping_size,
+                         std::move(reservation_mapping)});
 
-  state->pa_allocated += rounded_size;
-  if (multi_device) {
-    state->multi_device_allocations.insert({allocator_ptr, true});
-  }
   return ScopedDeviceAddress<uint8_t>(allocator_address, device_ordinal, this);
 }
 
@@ -503,26 +559,24 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
     return ScopedDeviceAddress<uint8_t>(*reused, device_ordinal, this);
   }
 
-  absl::StatusOr<DeviceAddressBase> result = AllocateWithBudget(*state, size);
+  absl::StatusOr<DeviceAddressBase> result =
+      AllocateWithBudget(*state, size, multi_device);
 
   // If allocation failed (e.g., out of memory), try processing pending
   // deallocations to free memory, then retry.
   if (!result.ok()) {
     ProcessCompletedPendingDeallocations(*state);
-    result = AllocateWithBudget(*state, size);
+    result = AllocateWithBudget(*state, size, multi_device);
   }
 
   if (!result.ok()) {
     WaitPendingDeallocationsToComplete(*state, size);
-    result = AllocateWithBudget(*state, size);
+    result = AllocateWithBudget(*state, size, multi_device);
   }
 
   if (!result.ok()) {
     return result.status();
   }
-
-  if (multi_device)
-    state->multi_device_allocations.insert({result->opaque(), true});
 
   VLOG(3) << absl::StreamFormat(
       "Allocated virtual address %p (%uB) on device ordinal %d",
@@ -541,7 +595,10 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
 
   absl::MutexLock lock(state->mu);
 
-  if (!state->raw_allocations.contains(mem.opaque())) {
+  auto record_it = state->records_by_allocator_address.find(mem.opaque());
+  if (record_it == state->records_by_allocator_address.end() ||
+      !record_it->second->allocator_active() ||
+      !record_it->second->allocator_matches(mem)) {
     if (state->active_reservation_mappings.contains(mem.opaque()) ||
         state->stale_reservation_mappings.contains(mem.opaque())) {
       return absl::InvalidArgumentError(
@@ -552,6 +609,7 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
         "DeviceAddressVmmAllocator::Deallocate received an unknown address %p",
         mem.opaque()));
   }
+  AllocationRecord& record = *record_it->second;
 
   for (const auto& [_, mapping] : state->active_reservation_mappings) {
     if (mapping.allocator_address.IsSameAs(mem)) {
@@ -566,16 +624,21 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
       "on device ordinal %d",
       mem.opaque(), mem.size(), device_ordinal);
 
-  bool multi_device = state->multi_device_allocations.erase(mem.opaque()) > 0;
-
   // Assign the next sequence number and enqueue a GPU write to the pinned
   // timeline when the stream reaches this point. The CPU polls the timeline
   // value to know when it is safe to free the memory.
   uint64_t seqno = state->next_seqno++;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
 
-  state->pending_deallocations.push_back(
-      {PendingDeallocationKind::kAllocate, mem, seqno, multi_device});
+  CHECK(record.allocator_active());
+  CHECK(!record.allocator_stale());
+  CHECK(record.has_allocator_address_mapping());
+  const uint64_t reclaimable_bytes =
+      RoundUpToGranularity(*state, record.raw_allocation()->address().size());
+  record.MarkAllocatorStale(seqno);
+  state->pending_deallocations.push_back({record.pending_deallocation_kind(),
+                                          seqno, record.allocator_address(),
+                                          reclaimable_bytes});
 
   return absl::OkStatus();
 }
@@ -599,18 +662,22 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
   ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
 
   absl::MutexLock lock(state->mu);
-  auto raw_it = state->raw_allocations.find(addr.opaque());
-  if (raw_it == state->raw_allocations.end()) {
+  auto record_it = state->records_by_allocator_address.find(addr.opaque());
+  if (record_it == state->records_by_allocator_address.end() ||
+      !record_it->second->allocator_active() ||
+      !record_it->second->allocator_matches(addr)) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "DeviceAddressVmmAllocator::Map received an unknown allocator address "
         "%p",
         addr.opaque()));
   }
-  if (size > raw_it->second->address().size()) {
+  AllocationRecord& record = *record_it->second;
+  MemoryAllocation* raw_allocation = record.raw_allocation();
+  if (size > raw_allocation->address().size()) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "DeviceAddressVmmAllocator::Map size %u exceeds raw allocation size "
         "%u",
-        size, raw_it->second->address().size()));
+        size, raw_allocation->address().size()));
   }
   if (state->active_reservation_mappings.contains(
           reservation_address.opaque()) ||
@@ -629,7 +696,7 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
   ASSIGN_OR_RETURN(
       MemoryReservation::ScopedMapping scoped_mapping,
       reservation->MapTo(reservation_offset, /*allocation_offset=*/0, size,
-                         *raw_it->second));
+                         *raw_allocation));
   state->active_reservation_mappings.emplace(
       reservation_address.opaque(),
       ReservationMapping{addr, reservation_address, reservation,
@@ -674,7 +741,8 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
   state->stale_reservation_mappings.emplace(reservation_address.opaque(),
                                             std::move(mapping));
   state->pending_deallocations.push_back(
-      {PendingDeallocationKind::kMap, reservation_address, seqno});
+      {PendingDeallocationKind::kMap, seqno, reservation_address,
+       /*reclaimable_bytes=*/0});
   return absl::OkStatus();
 }
 
@@ -705,11 +773,11 @@ absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
     absl::MutexLock lock(state->mu);
     while (!state->pending_deallocations.empty() &&
            state->pending_deallocations.front().seqno <= target_seqno) {
-      if (state->pending_deallocations.front().kind ==
-          PendingDeallocationKind::kAllocate) {
-        DoDeallocate(*state, state->pending_deallocations.front().mem);
+      if (state->pending_deallocations.front().kind !=
+          PendingDeallocationKind::kMap) {
+        DoDeallocate(*state, state->pending_deallocations.front().addr);
       } else {
-        DoUnMap(*state, state->pending_deallocations.front().mem);
+        DoUnMap(*state, state->pending_deallocations.front().addr);
       }
       state->pending_deallocations.pop_front();
     }
@@ -732,11 +800,13 @@ MemoryAllocation* DeviceAddressVmmAllocator::GetRawAllocation(
   }
   PerDeviceState* state = *state_or;
   absl::MutexLock lock(state->mu);
-  auto it = state->raw_allocations.find(addr.opaque());
-  if (it == state->raw_allocations.end()) {
+  auto it = state->records_by_allocator_address.find(addr.opaque());
+  if (it == state->records_by_allocator_address.end() ||
+      !it->second->allocator_active() ||
+      !it->second->allocator_matches(addr)) {
     return nullptr;
   }
-  return it->second.get();
+  return it->second->raw_allocation();
 }
 
 MemoryReservation* DeviceAddressVmmAllocator::GetReservation(
@@ -747,11 +817,13 @@ MemoryReservation* DeviceAddressVmmAllocator::GetReservation(
   }
   PerDeviceState* state = *state_or;
   absl::MutexLock lock(state->mu);
-  auto it = state->reservations.find(addr.opaque());
-  if (it == state->reservations.end()) {
+  auto it = state->records_by_allocator_address.find(addr.opaque());
+  if (it == state->records_by_allocator_address.end() ||
+      !it->second->allocator_active() ||
+      !it->second->allocator_matches(addr)) {
     return nullptr;
   }
-  return it->second.get();
+  return it->second->allocator_address_reservation();
 }
 
 uint64_t DeviceAddressVmmAllocator::GetAllocationGranularity(
@@ -765,6 +837,18 @@ uint64_t DeviceAddressVmmAllocator::GetAllocationGranularity(
   return state->allocation_granularity;
 }
 
+void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
+    PerDeviceState& state, AllocationRecord& record, uint64_t new_size) {
+  CHECK(!record.allocator_active());
+  CHECK(record.allocator_stale());
+  CHECK(record.has_allocator_address_mapping());
+  void* allocator_va = record.allocator_key();
+  auto record_it = state.records_by_allocator_address.find(allocator_va);
+  CHECK(record_it != state.records_by_allocator_address.end());
+  CHECK_EQ(record_it->second.get(), &record);
+  record.ReactivateAllocator(new_size);
+}
+
 std::optional<DeviceAddressBase>
 DeviceAddressVmmAllocator::TryReusePendingDeallocation(PerDeviceState& state,
                                                        uint64_t size,
@@ -775,25 +859,27 @@ DeviceAddressVmmAllocator::TryReusePendingDeallocation(PerDeviceState& state,
     if (it->kind != PendingDeallocationKind::kAllocate) {
       continue;
     }
-    if (it->multi_device != multi_device) {
+    auto record_it = state.records_by_allocator_address.find(it->addr.opaque());
+    CHECK(record_it != state.records_by_allocator_address.end());
+    AllocationRecord& record = *record_it->second;
+    CHECK(record.allocator_stale());
+    CHECK(record.allocator_matches(it->addr));
+    if (record.multi_device() != multi_device) {
       continue;
     }
-    if (!state.reservations.contains(it->mem.opaque())) {
-      continue;
-    }
-    if (RoundUpToGranularity(state, it->mem.size()) != rounded_size) {
+    if (RoundUpToGranularity(state, record.allocator_address().size()) !=
+        rounded_size) {
       continue;
     }
 
-    DeviceAddressBase reused_mem(it->mem.opaque(), size);
+    DeviceAddressBase reused_mem(record.allocator_key(), size);
     VLOG(3) << absl::StreamFormat(
         "Reusing pending deallocation: address=%p original_size=%uB "
         "new_size=%uB rounded_size=%uB device=%d",
-        reused_mem.opaque(), it->mem.size(), size, rounded_size,
+        reused_mem.opaque(), record.allocator_address().size(), size, rounded_size,
         state.executor->device_ordinal());
+    MoveAllocatorRecordToActive(state, record, size);
     state.pending_deallocations.erase(it);
-    if (multi_device)
-      state.multi_device_allocations.insert({reused_mem.opaque(), true});
 
     return reused_mem;
   }

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -16,12 +16,15 @@ limitations under the License.
 #include "xla/stream_executor/device_address_vmm_allocator.h"
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
 #include <limits>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -29,8 +32,10 @@ limitations under the License.
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include "absl/log/vlog_is_on.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
@@ -236,6 +241,64 @@ static bool AddressRangesOverlap(DeviceAddressBase lhs, DeviceAddressBase rhs) {
          AddressStart(rhs) < AddressEnd(lhs);
 }
 
+struct DebugStatsRow {
+  std::string operation;
+  std::string api_calls;
+  std::string allocation_reuse;
+  std::string allocator_va_reuse;
+  std::string reservation_va_reuse;
+};
+
+struct DebugStatsWidths {
+  size_t operation;
+  size_t api_calls;
+  size_t allocation_reuse;
+  size_t allocator_va_reuse;
+  size_t reservation_va_reuse;
+};
+
+static std::string DebugStatsCount(uint64_t count) {
+  return absl::StrFormat("%u", count);
+}
+
+static std::string DebugStatsReuse(uint64_t reuse, uint64_t api_calls) {
+  double percent = api_calls == 0 ? 0.0 : 100.0 * reuse / api_calls;
+  return absl::StrFormat("%u (%5.2f%%)", reuse, percent);
+}
+
+static std::string PadLeft(std::string value, size_t width) {
+  if (value.size() < width) {
+    value.insert(0, width - value.size(), ' ');
+  }
+  return value;
+}
+
+static std::string PadRight(std::string value, size_t width) {
+  if (value.size() < width) {
+    value.append(width - value.size(), ' ');
+  }
+  return value;
+}
+
+static void AppendDebugStatsSeparator(std::string* table,
+                                      const DebugStatsWidths& widths) {
+  absl::StrAppend(table, "|", std::string(widths.operation + 2, '-'), "|",
+                  std::string(widths.api_calls + 2, '-'), "|",
+                  std::string(widths.allocation_reuse + 2, '-'), "|",
+                  std::string(widths.allocator_va_reuse + 2, '-'), "|",
+                  std::string(widths.reservation_va_reuse + 2, '-'), "|\n");
+}
+
+static void AppendDebugStatsRow(std::string* table, const DebugStatsRow& row,
+                                const DebugStatsWidths& widths) {
+  absl::StrAppend(
+      table, "| ", PadRight(row.operation, widths.operation), " | ",
+      PadLeft(row.api_calls, widths.api_calls), " | ",
+      PadLeft(row.allocation_reuse, widths.allocation_reuse), " | ",
+      PadLeft(row.allocator_va_reuse, widths.allocator_va_reuse), " | ",
+      PadLeft(row.reservation_va_reuse, widths.reservation_va_reuse), " |\n");
+}
+
 DeviceAddressVmmAllocator::DeviceAddressVmmAllocator(const Platform* platform)
     : DeviceAddressAllocator(platform) {}
 
@@ -295,6 +358,10 @@ DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
       state->destroy_fn();
     }
   }
+
+  if (VLOG_IS_ON(1)) {
+    VLOG(1) << "\n" << DebugStatsTable();
+  }
 }
 
 absl::Status DeviceAddressVmmAllocator::SynchronizeAllPendingOperations() {
@@ -309,6 +376,112 @@ absl::Status DeviceAddressVmmAllocator::SynchronizeAllPendingOperations() {
     }
   }
   return absl::OkStatus();
+}
+
+std::string DeviceAddressVmmAllocator::DebugStatsTable() const {
+  auto load = [](const std::atomic<uint64_t>& counter) {
+    return counter.load(std::memory_order_relaxed);
+  };
+
+  const uint64_t allocate_calls = load(debug_stats_.allocate_calls);
+  const uint64_t mapped_allocate_return_reservation_address_calls =
+      load(debug_stats_.mapped_allocate_return_reservation_address_calls);
+  const uint64_t mapped_allocate_return_allocator_address_calls =
+      load(debug_stats_.mapped_allocate_return_allocator_address_calls);
+  const uint64_t map_calls = load(debug_stats_.map_calls);
+
+  std::array<DebugStatsRow, 7> rows = {{
+      {"Operation", "API Calls", "Allocation Reuse", "Allocator VA Reuse",
+       "Reservation VA Reuse"},
+      {"Allocate(size)", DebugStatsCount(allocate_calls),
+       DebugStatsReuse(load(debug_stats_.allocate_allocation_reuse),
+                       allocate_calls),
+       "-", "-"},
+      {"Allocate(..., return_reservation_address=true)",
+       DebugStatsCount(mapped_allocate_return_reservation_address_calls),
+       DebugStatsReuse(
+           load(
+               debug_stats_
+                   .mapped_allocate_return_reservation_address_allocation_reuse),
+           mapped_allocate_return_reservation_address_calls),
+       DebugStatsReuse(
+           load(
+               debug_stats_
+                   .mapped_allocate_return_reservation_address_allocator_va_reuse),
+           mapped_allocate_return_reservation_address_calls),
+       "-"},
+      {"Allocate(..., return_reservation_address=false)",
+       DebugStatsCount(mapped_allocate_return_allocator_address_calls),
+       DebugStatsReuse(
+           load(debug_stats_
+                    .mapped_allocate_return_allocator_address_allocation_reuse),
+           mapped_allocate_return_allocator_address_calls),
+       DebugStatsReuse(
+           load(
+               debug_stats_
+                   .mapped_allocate_return_allocator_address_allocator_va_reuse),
+           mapped_allocate_return_allocator_address_calls),
+       DebugStatsReuse(
+           load(
+               debug_stats_
+                   .mapped_allocate_return_allocator_address_reservation_va_reuse),
+           mapped_allocate_return_allocator_address_calls)},
+      {"Map(addr, reservation, ...)", DebugStatsCount(map_calls), "-", "-",
+       DebugStatsReuse(load(debug_stats_.map_reservation_va_reuse), map_calls)},
+      {"Deallocate()", DebugStatsCount(load(debug_stats_.deallocate_calls)),
+       "-", "-", "-"},
+      {"UnMap()", DebugStatsCount(load(debug_stats_.unmap_calls)), "-", "-",
+       "-"},
+  }};
+
+  DebugStatsWidths widths{
+      /*operation=*/0,
+      /*api_calls=*/0,
+      /*allocation_reuse=*/0,
+      /*allocator_va_reuse=*/0,
+      /*reservation_va_reuse=*/0,
+  };
+  for (const DebugStatsRow& row : rows) {
+    widths.operation = std::max(widths.operation, row.operation.size());
+    widths.api_calls = std::max(widths.api_calls, row.api_calls.size());
+    widths.allocation_reuse =
+        std::max(widths.allocation_reuse, row.allocation_reuse.size());
+    widths.allocator_va_reuse =
+        std::max(widths.allocator_va_reuse, row.allocator_va_reuse.size());
+    widths.reservation_va_reuse =
+        std::max(widths.reservation_va_reuse, row.reservation_va_reuse.size());
+  }
+
+  std::string table = "DeviceAddressVmmAllocator debug statistics:\n";
+  AppendDebugStatsSeparator(&table, widths);
+  AppendDebugStatsRow(&table, rows[0], widths);
+  AppendDebugStatsSeparator(&table, widths);
+  for (size_t i = 1; i < rows.size(); ++i) {
+    AppendDebugStatsRow(&table, rows[i], widths);
+  }
+  AppendDebugStatsSeparator(&table, widths);
+  absl::StrAppend(
+      &table, "\nDeferred deallocation batch statistics:\n", "  Flushes: ",
+      DebugStatsCount(load(debug_stats_.deallocation_batch_flushes)), "\n",
+      "    by entry limit: ",
+      DebugStatsCount(
+          load(debug_stats_.deallocation_batch_flushes_by_entry_limit)),
+      "\n", "    by byte limit: ",
+      DebugStatsCount(
+          load(debug_stats_.deallocation_batch_flushes_by_byte_limit)),
+      "\n", "    by wait/reclaim: ",
+      DebugStatsCount(load(debug_stats_.deallocation_batch_flushes_by_wait)),
+      "\n", "    by sync: ",
+      DebugStatsCount(load(debug_stats_.deallocation_batch_flushes_by_sync)),
+      "\n", "    by destructor: ",
+      DebugStatsCount(
+          load(debug_stats_.deallocation_batch_flushes_by_destructor)),
+      "\n", "  Entries flushed: ",
+      DebugStatsCount(load(debug_stats_.deallocation_batch_entries_flushed)),
+      "\n", "  Reclaimable bytes flushed: ",
+      DebugStatsCount(load(debug_stats_.deallocation_batch_bytes_flushed)),
+      "\n");
+  return table;
 }
 
 // Common helpers and accessors.
@@ -564,6 +737,7 @@ absl::StatusOr<ScopedDeviceAddress<uint8_t>>
 DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
                                     bool /*retry_on_failure*/,
                                     int64_t /*memory_space*/) {
+  debug_stats_.allocate_calls.fetch_add(1, std::memory_order_relaxed);
   if (size == 0) {
     return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
                                         this);
@@ -596,6 +770,8 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
       }
 
       DeviceAddressBase reused_mem(record.allocator_key(), size);
+      debug_stats_.allocate_allocation_reuse.fetch_add(
+          1, std::memory_order_relaxed);
       MoveAllocatorRecordToActive(*state, record, size);
       ErasePendingDeallocationAt(*state, it);
 
@@ -659,6 +835,14 @@ DeviceAddressVmmAllocator::Allocate(
     int64_t /*memory_space*/, MemoryReservation* reservation,
     uint64_t reservation_offset, uint64_t mapping_size,
     bool return_reservation_address) {
+  if (return_reservation_address) {
+    debug_stats_.mapped_allocate_return_reservation_address_calls.fetch_add(
+        1, std::memory_order_relaxed);
+  } else {
+    debug_stats_.mapped_allocate_return_allocator_address_calls.fetch_add(
+        1, std::memory_order_relaxed);
+  }
+
   // Keep zero-sized mapped allocation consistent with regular Allocate(): no
   // physical allocation or mapping is created, so the requested mapping size
   // must also be zero.
@@ -739,6 +923,13 @@ DeviceAddressVmmAllocator::Allocate(
         }
 
         DeviceAddressBase reused_mem(record.allocator_key(), allocation_size);
+        debug_stats_.mapped_allocate_return_allocator_address_allocation_reuse
+            .fetch_add(1, std::memory_order_relaxed);
+        debug_stats_.mapped_allocate_return_allocator_address_allocator_va_reuse
+            .fetch_add(1, std::memory_order_relaxed);
+        debug_stats_
+            .mapped_allocate_return_allocator_address_reservation_va_reuse
+            .fetch_add(1, std::memory_order_relaxed);
         // Reactivate both aliases: the returned allocator VA and the external
         // reservation VA. This cancels the pending allocator teardown and the
         // paired pending kMap unmap for the reservation mapping.
@@ -788,6 +979,10 @@ DeviceAddressVmmAllocator::Allocate(
       return std::nullopt;
     }
 
+    debug_stats_.mapped_allocate_return_reservation_address_allocation_reuse
+        .fetch_add(1, std::memory_order_relaxed);
+    debug_stats_.mapped_allocate_return_reservation_address_allocator_va_reuse
+        .fetch_add(1, std::memory_order_relaxed);
     auto pending_it = state->pending_deallocations.end();
     // The record is indexed by allocator address, but the FIFO queue owns the
     // stream-ordered allocator teardown. Find the queue entry so reuse can
@@ -974,6 +1169,7 @@ DeviceAddressVmmAllocator::Allocate(
 
 absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
                                                    DeviceAddressBase mem) {
+  debug_stats_.deallocate_calls.fetch_add(1, std::memory_order_relaxed);
   if (mem.is_null()) {
     return absl::OkStatus();
   }
@@ -1131,6 +1327,7 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
                                             MemoryReservation* reservation,
                                             uint64_t reservation_offset,
                                             uint64_t size) {
+  debug_stats_.map_calls.fetch_add(1, std::memory_order_relaxed);
   ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
   if (size == 0) {
     return absl::OkStatus();
@@ -1234,6 +1431,8 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
         CHECK(stale_record.has_reservation_address());
         CHECK(stale_record.reservation_matches(reservation_address));
         if (stale_record.raw_allocation() == raw_allocation) {
+          debug_stats_.map_reservation_va_reuse.fetch_add(
+              1, std::memory_order_relaxed);
           MoveReservationRecordToActive(*state, stale_record);
           ErasePendingDeallocation(*state, PendingDeallocationKind::kMap,
                                    reservation_address);
@@ -1399,7 +1598,7 @@ void DeviceAddressVmmAllocator::ErasePendingDeallocationAt(
 }
 
 absl::Status DeviceAddressVmmAllocator::FlushOpenDeallocationBatch(
-    PerDeviceState& state, DeallocationBatchFlushReason /*reason*/) {
+    PerDeviceState& state, DeallocationBatchFlushReason reason) {
   if (state.open_deallocation_batch_seqno == 0) {
     CHECK_EQ(state.open_deallocation_batch_entries, 0);
     CHECK_EQ(state.open_deallocation_batch_bytes, 0);
@@ -1413,7 +1612,38 @@ absl::Status DeviceAddressVmmAllocator::FlushOpenDeallocationBatch(
   }
 
   const uint64_t seqno = state.open_deallocation_batch_seqno;
+  const int64_t entries = state.open_deallocation_batch_entries;
+  const uint64_t bytes = state.open_deallocation_batch_bytes;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(state, seqno));
+
+  debug_stats_.deallocation_batch_flushes.fetch_add(1,
+                                                    std::memory_order_relaxed);
+  debug_stats_.deallocation_batch_entries_flushed.fetch_add(
+      static_cast<uint64_t>(entries), std::memory_order_relaxed);
+  debug_stats_.deallocation_batch_bytes_flushed.fetch_add(
+      bytes, std::memory_order_relaxed);
+  switch (reason) {
+    case DeallocationBatchFlushReason::kEntryLimit:
+      debug_stats_.deallocation_batch_flushes_by_entry_limit.fetch_add(
+          1, std::memory_order_relaxed);
+      break;
+    case DeallocationBatchFlushReason::kByteLimit:
+      debug_stats_.deallocation_batch_flushes_by_byte_limit.fetch_add(
+          1, std::memory_order_relaxed);
+      break;
+    case DeallocationBatchFlushReason::kWait:
+      debug_stats_.deallocation_batch_flushes_by_wait.fetch_add(
+          1, std::memory_order_relaxed);
+      break;
+    case DeallocationBatchFlushReason::kSync:
+      debug_stats_.deallocation_batch_flushes_by_sync.fetch_add(
+          1, std::memory_order_relaxed);
+      break;
+    case DeallocationBatchFlushReason::kDestructor:
+      debug_stats_.deallocation_batch_flushes_by_destructor.fetch_add(
+          1, std::memory_order_relaxed);
+      break;
+  }
 
   state.open_deallocation_batch_seqno = 0;
   state.open_deallocation_batch_entries = 0;
@@ -1645,6 +1875,7 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
                                               MemoryReservation* reservation,
                                               uint64_t reservation_offset,
                                               uint64_t size) {
+  debug_stats_.unmap_calls.fetch_add(1, std::memory_order_relaxed);
   ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
   if (size == 0) {
     return absl::OkStatus();

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -15,13 +15,16 @@ limitations under the License.
 
 #include "xla/stream_executor/device_address_vmm_allocator.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <optional>
 #include <utility>
 #include <vector>
 
+#include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -38,14 +41,16 @@ limitations under the License.
 #include "xla/stream_executor/device_address_allocator.h"
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
-#include "xla/tsl/platform/statusor.h"
 
 namespace stream_executor {
 
 namespace {
+
 thread_local const xla::DeviceAssignment* current_device_assignment = nullptr;
+
 }  // namespace
 
 DeviceAddressVmmAllocator::DeviceAssignmentScope::DeviceAssignmentScope(
@@ -142,10 +147,51 @@ void DeviceAddressVmmAllocator::AllocationRecord::CompleteStaleAllocator() {
   CHECK(!allocator_active());
   CHECK(allocator_stale());
   CHECK(!reservation_active());
-  CHECK(!reservation_stale());
   allocator_address_mapping_.reset();
   allocator_address_reservation_.reset();
   raw_allocation_.reset();
+}
+
+void DeviceAddressVmmAllocator::AllocationRecord::AddActiveReservationAlias(
+    DeviceAddressBase reservation_address,
+    MemoryReservation::ScopedMapping reservation_address_mapping) {
+  CHECK(!has_reservation_alias());
+  CHECK(!reservation_address.is_null());
+  reservation_address_ = reservation_address;
+  reservation_address_mapping_.emplace(std::move(reservation_address_mapping));
+  reservation_state_ = ReservationState::kActive;
+}
+
+void DeviceAddressVmmAllocator::AllocationRecord::MarkReservationStale(
+    uint64_t seqno) {
+  CHECK(reservation_active());
+  CHECK(!reservation_stale());
+  CHECK(has_reservation_address());
+  CHECK(reservation_address_mapping_.has_value());
+  CHECK_NE(seqno, 0);
+  reservation_state_ = ReservationState::kStale;
+  reservation_stale_seqno_ = seqno;
+}
+
+void DeviceAddressVmmAllocator::AllocationRecord::ReactivateReservation() {
+  CHECK(!reservation_active());
+  CHECK(reservation_stale());
+  CHECK(has_reservation_address());
+  CHECK(reservation_address_mapping_.has_value());
+  reservation_state_ = ReservationState::kActive;
+  reservation_stale_seqno_ = 0;
+}
+
+void DeviceAddressVmmAllocator::AllocationRecord::CompleteStaleReservation() {
+  if (!reservation_stale()) {
+    return;
+  }
+  CHECK(!reservation_active());
+  CHECK(has_reservation_address());
+  reservation_address_mapping_.reset();
+  reservation_address_.reset();
+  reservation_state_ = ReservationState::kNone;
+  reservation_stale_seqno_ = 0;
 }
 
 // Interval between CPU polls of the GPU-written deallocation timeline while
@@ -203,7 +249,8 @@ DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
   absl::Status status = SynchronizeAllPendingOperations();
   CHECK(status.ok()) << status;
 
-  for (auto& [ordinal, state] : per_device_) {
+  for (auto& device : per_device_) {
+    auto& state = device.second;
     // Free platform-specific per-device resources (e.g. pinned timeline).
     if (state->destroy_fn) {
       state->destroy_fn();
@@ -212,11 +259,13 @@ DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
 }
 
 absl::Status DeviceAddressVmmAllocator::SynchronizeAllPendingOperations() {
-  for (auto& [ordinal, state] : per_device_) {
-    RETURN_IF_ERROR(SynchronizePendingOperations(ordinal));
+  for (auto& device : per_device_) {
+    RETURN_IF_ERROR(SynchronizePendingOperations(device.first));
   }
   return absl::OkStatus();
 }
+
+// Common helpers and accessors.
 
 absl::StatusOr<DeviceAddressVmmAllocator::PerDeviceState*>
 DeviceAddressVmmAllocator::GetPerDeviceState(int device_ordinal) const {
@@ -230,131 +279,99 @@ DeviceAddressVmmAllocator::GetPerDeviceState(int device_ordinal) const {
   return it->second.get();
 }
 
-absl::StatusOr<DeviceAddressBase>
-DeviceAddressVmmAllocator::ValidateReservationRange(
-    MemoryReservation* reservation, uint64_t reservation_offset,
-    uint64_t size) const {
-  if (reservation == nullptr) {
-    return absl::InvalidArgumentError("reservation must not be null");
+uint64_t DeviceAddressVmmAllocator::RoundUpToGranularity(
+    const PerDeviceState& state, uint64_t size) const {
+  if (state.allocation_granularity == 0) {
+    return size;
   }
-
-  DeviceAddressBase address = reservation->address();
-  if (reservation_offset > address.size() ||
-      size > address.size() - reservation_offset) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "reservation range is out of bounds: offset=%uB, size=%uB, "
-        "reservation_size=%uB",
-        reservation_offset, size, address.size()));
-  }
-
-  return address.GetByteSlice(reservation_offset, size);
+  return ((size + state.allocation_granularity - 1) /
+          state.allocation_granularity) *
+         state.allocation_granularity;
 }
 
-void DeviceAddressVmmAllocator::ProcessCompletedPendingDeallocations(
-    PerDeviceState& state) {
-  // Single atomic read covers all entries whose seqno is <= completed.
-  uint64_t completed = LoadTimeline(state.pinned_timeline);
-  while (!state.pending_deallocations.empty()) {
-    if (state.pending_deallocations.front().seqno > completed) {
-      break;
-    }
-    if (state.pending_deallocations.front().kind !=
-        PendingDeallocationKind::kMap) {
-      DoDeallocate(state, state.pending_deallocations.front().addr);
-    } else {
-      DoUnMap(state, state.pending_deallocations.front().addr);
-    }
-    state.pending_deallocations.pop_front();
-  }
+absl::StatusOr<Stream*> DeviceAddressVmmAllocator::GetStream(
+    int device_ordinal) {
+  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
+  return state->stream;
 }
 
-void DeviceAddressVmmAllocator::WaitPendingDeallocationsToComplete(
-    PerDeviceState& state, uint64_t size) {
-  if (state.pending_deallocations.empty()) {
-    return;
+absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
+    int device_ordinal) {
+  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
+  absl::MutexLock lock(state->mu);
+  if (state->pending_deallocations.empty()) {
+    return absl::OkStatus();
   }
-
-  uint64_t accumulated_size = 0;
-  size_t count_to_wait = 0;
-  uint64_t rounded_size = RoundUpToGranularity(state, size);
-  uint64_t target_seqno = 0;
-
-  // Target 1.1x the requested size to provide some headroom.
-  uint64_t target_size = rounded_size + rounded_size / 10;
-
-  for (const auto& pending : state.pending_deallocations) {
-    if (pending.kind != PendingDeallocationKind::kMap) {
-      accumulated_size += pending.reclaimable_bytes;
-    }
-    target_seqno = pending.seqno;
-    ++count_to_wait;
-    if (accumulated_size >= target_size) {
-      break;
-    }
-  }
-
-  // Move selected entries out of the deque while holding the lock, so no
-  // other thread can observe or free them.
-  std::vector<PendingDeallocation> selected;
-  selected.reserve(count_to_wait);
-  for (size_t i = 0; i < count_to_wait; ++i) {
-    selected.push_back(std::move(state.pending_deallocations.front()));
-    state.pending_deallocations.pop_front();
-  }
-
-  // Release the lock before spin-waiting to avoid stalling other threads for
-  // potentially milliseconds while the GPU drains its work queue.
-  state.mu.unlock();
-
-  // Poll until the GPU writes a timeline value >= target_seqno.
-  // Since timeline values are written in stream order, this guarantees all
-  // earlier pending deallocations have also completed.
-  while (LoadTimeline(state.pinned_timeline) < target_seqno) {
-    absl::SleepFor(kGpuTimelinePollInterval);
-  }
-
-  // Reacquire the lock before modifying the maps.
-  state.mu.lock();
-
-  for (auto& item : selected) {
-    if (item.kind != PendingDeallocationKind::kMap) {
-      DoDeallocate(state, item.addr);
-    } else {
-      DoUnMap(state, item.addr);
-    }
-  }
+  return WaitAndDrainPendingDeallocationsUntilSeqno(
+      *state, state->pending_deallocations.back().seqno);
 }
 
-void DeviceAddressVmmAllocator::DoDeallocate(PerDeviceState& state,
-                                             DeviceAddressBase mem) {
-  VLOG(3) << absl::StreamFormat(
-      "Actually freeing virtual address %p (size=%uB) on device ordinal %d",
-      mem.opaque(), mem.size(), state.executor->device_ordinal());
+absl::StatusOr<StreamExecutor*> DeviceAddressVmmAllocator::GetStreamExecutor(
+    int device_ordinal) const {
+  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
+  return state->executor;
+}
 
-  auto record_it = state.records_by_allocator_address.find(mem.opaque());
-  CHECK(record_it != state.records_by_allocator_address.end());
-  CHECK(record_it->second->allocator_stale());
-  CHECK(record_it->second->allocator_matches(mem));
-  AllocationRecord& record = *record_it->second;
-  CHECK(!record.allocator_active());
-  if (record.raw_allocation() != nullptr) {
-    uint64_t rounded_size =
-        RoundUpToGranularity(state, record.raw_allocation()->address().size());
-    DCHECK_GE(state.pa_allocated, rounded_size);
-    state.pa_allocated -= rounded_size;
+MemoryAllocation* DeviceAddressVmmAllocator::GetRawAllocation(
+    int device_ordinal, DeviceAddressBase addr) const {
+  absl::StatusOr<PerDeviceState*> state_or = GetPerDeviceState(device_ordinal);
+  if (!state_or.ok()) {
+    return nullptr;
   }
-  record.CompleteStaleAllocator();
-  CHECK_EQ(state.records_by_allocator_address.erase(mem.opaque()), 1);
+  PerDeviceState* state = *state_or;
+  absl::MutexLock lock(state->mu);
+
+  // Allocator addresses are keyed directly by their VA. Stale records remain in
+  // this map until deferred teardown completes, so require both active state
+  // and an exact address-range match before exposing the backing allocation.
+  auto allocation_it = state->records_by_allocator_address.find(addr.opaque());
+  if (allocation_it != state->records_by_allocator_address.end() &&
+      allocation_it->second->allocator_active() &&
+      allocation_it->second->allocator_matches(addr)) {
+    return allocation_it->second->raw_allocation();
+  }
+
+  // Reservation aliases created by Map() or by Allocate(...,
+  // return_reservation_address=false) are tracked in a separate active-only
+  // index. Stale or already-unmapped aliases intentionally return nullptr.
+  auto reservation_it = state->active_reservation_records.find(addr.opaque());
+  if (reservation_it != state->active_reservation_records.end()) {
+    return reservation_it->second->raw_allocation();
+  }
+  return nullptr;
 }
 
-void DeviceAddressVmmAllocator::DoUnMap(PerDeviceState& state,
-                                        DeviceAddressBase mem) {
-  VLOG(3) << absl::StreamFormat(
-      "Actually unmapping reservation address %p (size=%uB) on device ordinal "
-      "%d",
-      mem.opaque(), mem.size(), state.executor->device_ordinal());
-  state.stale_reservation_mappings.erase(mem.opaque());
+MemoryReservation* DeviceAddressVmmAllocator::GetReservation(
+    int device_ordinal, DeviceAddressBase addr) const {
+  absl::StatusOr<PerDeviceState*> state_or = GetPerDeviceState(device_ordinal);
+  if (!state_or.ok()) {
+    return nullptr;
+  }
+  PerDeviceState* state = *state_or;
+  absl::MutexLock lock(state->mu);
+
+  auto allocation_it = state->records_by_allocator_address.find(addr.opaque());
+  if (allocation_it != state->records_by_allocator_address.end() &&
+      allocation_it->second->allocator_active() &&
+      allocation_it->second->allocator_matches(addr)) {
+    return allocation_it->second->allocator_address_reservation();
+  }
+
+  return nullptr;
 }
+
+uint64_t DeviceAddressVmmAllocator::GetAllocationGranularity(
+    StreamExecutor* executor) const {
+  absl::StatusOr<PerDeviceState*> state_or =
+      GetPerDeviceState(executor->device_ordinal());
+  if (!state_or.ok()) {
+    return 0;
+  }
+  PerDeviceState* state = *state_or;
+  return state->allocation_granularity;
+}
+
+// Allocate helpers.
 
 void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
     PerDeviceState& state, AllocationRecord::Kind kind,
@@ -374,39 +391,219 @@ void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
   return va_ptr;
 }
 
-absl::StatusOr<DeviceAddressBase> DeviceAddressVmmAllocator::AllocateWithBudget(
-    PerDeviceState& state, uint64_t size, bool multi_device) {
-  uint64_t rounded_size = RoundUpToGranularity(state, size);
-  if (state.pa_allocated + rounded_size > state.pa_budget) {
-    return absl::ResourceExhaustedError(absl::StrFormat(
-        "Not enough PA budget for allocation: pa_allocated=%uB, "
-        "rounded_size=%uB, pa_budget=%uB",
-        state.pa_allocated, rounded_size, state.pa_budget));
+// Shared pending-reclaim retry flow:
+//
+// TryWithPendingReclaim(reclaim_size, try_reuse, try_fresh)
+//           │
+//           ▼
+// ┌─────────────────────────────────┐
+// │ try_reuse()                     │──found──► return reused address
+// └─────────────────────────────────┘
+//           │ not found
+//           ▼
+// ┌─────────────────────────────────┐
+// │ try_fresh()                     │──OK──► return fresh address
+// └─────────────────────────────────┘
+//           │ ResourceExhausted
+//           ▼
+// ┌─────────────────────────────────┐
+// │ Process completed pending       │
+// │ operations                      │
+// └─────────────────────────────────┘
+//           │
+//           ▼
+// ┌─────────────────────────────────┐
+// │ try_fresh()                     │──OK──► return fresh address
+// └─────────────────────────────────┘
+//           │ ResourceExhausted
+//           ▼
+// ┌─────────────────────────────────┐
+// │ Wait for pending operations     │
+// │ to reclaim enough memory        │
+// └─────────────────────────────────┘
+//           │
+//           ▼
+// ┌─────────────────────────────────┐
+// │ try_fresh()                     │──OK──► return fresh address
+// └─────────────────────────────────┘
+//           │ failed
+//           ▼
+//       return error
+template <typename TryReuseFn, typename TryFreshFn>
+absl::StatusOr<DeviceAddressBase>
+DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
+                                                 uint64_t reclaim_size,
+                                                 TryReuseFn try_reuse,
+                                                 TryFreshFn try_fresh) {
+  // First try to reactivate a compatible pending deallocation without waiting.
+  // Reuse is stream-order safe and avoids both a fresh VMM allocation and any
+  // host-side wait for the GPU timeline.
+  ASSIGN_OR_RETURN(std::optional<DeviceAddressBase> reused, try_reuse());
+  if (reused.has_value()) {
+    return *reused;
   }
 
-  // Create physical memory allocation (e.g. cuMemCreate).
-  ASSIGN_OR_RETURN(auto raw_alloc, CreateAllocation(state.executor, size));
-  const uint64_t padded_size = raw_alloc->address().size();
+  // If no pending entry matches, try the normal fresh allocation path. Most
+  // calls should finish here; the reclaim paths below are only for PA budget
+  // pressure or allocator-level allocation failures.
+  absl::StatusOr<DeviceAddressBase> result = try_fresh();
 
-  // Reserve virtual address range (e.g. cuMemAddressReserve).
-  ASSIGN_OR_RETURN(auto reservation, CreateReservation(state.executor, size));
+  if (absl::IsResourceExhausted(result.status())) {
+    // A ResourceExhausted error may be stale: some pending deallocations can
+    // already be past their stream timeline point. Complete ready allocator
+    // deallocations first, without blocking for later pending work and without
+    // destroying unrelated stale reservation mappings that may be reused.
+    CompleteReadyAllocatorDeallocationsForReclaim(
+        state, LoadTimeline(state.pinned_timeline));
+    result = try_fresh();
+  }
 
-  // Map physical memory into the virtual address range and enable access.
-  ASSIGN_OR_RETURN(
-      auto scoped_mapping,
-      reservation->MapTo(/*reservation_offset=*/0, /*allocation_offset=*/0,
-                         padded_size, *raw_alloc));
+  if (absl::IsResourceExhausted(result.status())) {
+    // If completed pending work was not enough, wait until enough queued frees
+    // should be reclaimable for this request, then retry once more. This is the
+    // only path that may block while the GPU drains earlier stream work.
+    // Select enough pending allocator-address deallocations to cover this
+    // request, then wait for the selected tail seqno to become safe. Unrelated
+    // kMap entries do not own physical memory, so leave them stale and
+    // reusable.
+    if (!state.pending_deallocations.empty()) {
+      uint64_t accumulated_size = 0;
+      uint64_t rounded_size = RoundUpToGranularity(state, reclaim_size);
+      uint64_t target_seqno = 0;
+      std::vector<PendingDeallocationKey> selected;
 
-  auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
-  DeviceAddressBase allocator_address(reservation->address().opaque(), size);
-  void* va_ptr = TrackAllocatorAddressMappedAllocation(
-      state, AllocationRecord::Kind::kAllocate, allocator_address,
-      std::move(shared_raw), std::move(reservation), std::move(scoped_mapping),
-      rounded_size, multi_device);
-  // Return the original requested size, not the padded size.
-  return DeviceAddressBase(va_ptr, size);
+      // Target 1.1x the requested size to provide some headroom.
+      uint64_t target_size = rounded_size + rounded_size / 10;
+
+      for (const PendingDeallocation& pending : state.pending_deallocations) {
+        if (pending.kind == PendingDeallocationKind::kMap) {
+          continue;
+        }
+        auto record_it =
+            state.records_by_allocator_address.find(pending.addr.opaque());
+        CHECK(record_it != state.records_by_allocator_address.end());
+        CHECK(record_it->second->allocator_stale());
+        CHECK(record_it->second->allocator_matches(pending.addr));
+        CHECK(record_it->second->raw_allocation() != nullptr);
+        accumulated_size += RoundUpToGranularity(
+            state, record_it->second->raw_allocation()->address().size());
+        target_seqno = std::max(target_seqno, pending.seqno);
+        selected.push_back(
+            PendingDeallocationKey{pending.kind, pending.seqno, pending.addr});
+        if (accumulated_size >= target_size) {
+          break;
+        }
+      }
+
+      if (!selected.empty()) {
+        RETURN_IF_ERROR(WaitUntilSeqno(state, target_seqno));
+        for (const PendingDeallocationKey& key : selected) {
+          CompletePendingDeallocationByKey(state, key);
+        }
+      }
+    }
+    result = try_fresh();
+  }
+
+  return result;
 }
 
+// Allocate() reuses pending kAllocate entries, otherwise tries a fresh
+// allocator-address mapping.
+absl::StatusOr<ScopedDeviceAddress<uint8_t>>
+DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
+                                    bool /*retry_on_failure*/,
+                                    int64_t /*memory_space*/) {
+  if (size == 0) {
+    return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
+                                        this);
+  }
+
+  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
+  const bool multi_device = CurrentMultiDevice();
+
+  absl::MutexLock lock(state->mu);
+  auto try_reuse = [&]() ABSL_NO_THREAD_SAFETY_ANALYSIS
+      -> absl::StatusOr<std::optional<DeviceAddressBase>> {
+    uint64_t rounded_size = RoundUpToGranularity(*state, size);
+    for (auto it = state->pending_deallocations.begin();
+         it != state->pending_deallocations.end(); ++it) {
+      if (it->kind != PendingDeallocationKind::kAllocate) {
+        continue;
+      }
+      auto record_it =
+          state->records_by_allocator_address.find(it->addr.opaque());
+      CHECK(record_it != state->records_by_allocator_address.end());
+      AllocationRecord& record = *record_it->second;
+      CHECK(record.allocator_stale());
+      CHECK(record.allocator_matches(it->addr));
+      if (record.multi_device() != multi_device) {
+        continue;
+      }
+      if (RoundUpToGranularity(*state, record.allocator_address().size()) !=
+          rounded_size) {
+        continue;
+      }
+
+      DeviceAddressBase reused_mem(record.allocator_key(), size);
+      MoveAllocatorRecordToActive(*state, record, size);
+      ErasePendingDeallocationAt(*state, it);
+
+      return std::optional<DeviceAddressBase>(reused_mem);
+    }
+
+    return std::optional<DeviceAddressBase>();
+  };
+  auto try_fresh =
+      [&]()
+          ABSL_NO_THREAD_SAFETY_ANALYSIS -> absl::StatusOr<DeviceAddressBase> {
+    uint64_t rounded_size = RoundUpToGranularity(*state, size);
+    if (state->pa_allocated + rounded_size > state->pa_budget) {
+      return absl::StatusOr<DeviceAddressBase>(
+          absl::ResourceExhaustedError(absl::StrFormat(
+              "Not enough PA budget for allocation: pa_allocated=%uB, "
+              "rounded_size=%uB, pa_budget=%uB",
+              state->pa_allocated, rounded_size, state->pa_budget)));
+    }
+
+    ASSIGN_OR_RETURN(auto raw_alloc, CreateAllocation(state->executor, size));
+    const uint64_t padded_size = raw_alloc->address().size();
+
+    ASSIGN_OR_RETURN(auto reservation,
+                     CreateReservation(state->executor, size));
+
+    ASSIGN_OR_RETURN(
+        auto scoped_mapping,
+        reservation->MapTo(/*reservation_offset=*/0, /*allocation_offset=*/0,
+                           padded_size, *raw_alloc));
+
+    auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
+    DeviceAddressBase allocator_address(reservation->address().opaque(), size);
+    void* va_ptr = TrackAllocatorAddressMappedAllocation(
+        *state, AllocationRecord::Kind::kAllocate, allocator_address,
+        std::move(shared_raw), std::move(reservation),
+        std::move(scoped_mapping), rounded_size, multi_device);
+    // Return the original requested size, not the padded size.
+    return absl::StatusOr<DeviceAddressBase>(DeviceAddressBase(va_ptr, size));
+  };
+
+  absl::StatusOr<DeviceAddressBase> result =
+      TryWithPendingReclaim(*state, size, try_reuse, try_fresh);
+
+  if (!result.ok()) {
+    return result.status();
+  }
+
+  VLOG(3) << absl::StreamFormat(
+      "Allocated virtual address %p (%uB) on device ordinal %d",
+      result->opaque(), size, device_ordinal);
+
+  return ScopedDeviceAddress<uint8_t>(*result, device_ordinal, this);
+}
+
+// Mapped Allocate() creates fresh physical memory and maps it into the caller
+// reservation. It keeps the same externally visible ownership model as the
+// previous map-based bookkeeping, but records the lifetime in AllocationRecord.
 absl::StatusOr<ScopedDeviceAddress<uint8_t>>
 DeviceAddressVmmAllocator::Allocate(
     int device_ordinal, uint64_t allocation_size, bool /*retry_on_failure*/,
@@ -422,19 +619,18 @@ DeviceAddressVmmAllocator::Allocate(
     return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
                                         this);
   }
+
+  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
+  const bool multi_device = CurrentMultiDevice();
+
   ASSIGN_OR_RETURN(
       DeviceAddressBase reservation_address,
       ValidateReservationRange(reservation, reservation_offset, mapping_size));
 
-  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
-
-  const bool multi_device = CurrentMultiDevice();
-
   absl::MutexLock lock(state->mu);
-  if (state->active_reservation_mappings.contains(
+  if (state->active_reservation_records.contains(
           reservation_address.opaque()) ||
-      state->stale_reservation_mappings.contains(
-          reservation_address.opaque()) ||
+      state->stale_reservation_records.contains(reservation_address.opaque()) ||
       state->records_by_allocator_address.contains(
           reservation_address.opaque())) {
     return absl::FailedPreconditionError(
@@ -473,116 +669,31 @@ DeviceAddressVmmAllocator::Allocate(
                                         this);
   }
 
-  ASSIGN_OR_RETURN(auto allocator_reservation,
+  ASSIGN_OR_RETURN(auto allocator_address_reservation,
                    CreateReservation(state->executor, allocation_size));
-  ASSIGN_OR_RETURN(auto allocator_mapping,
-                   allocator_reservation->MapTo(
+  ASSIGN_OR_RETURN(auto allocator_address_mapping,
+                   allocator_address_reservation->MapTo(
                        /*reservation_offset=*/0, /*allocation_offset=*/0,
                        padded_size, *shared_raw));
-  DeviceAddressBase allocator_address(allocator_reservation->address().opaque(),
-                                      allocation_size);
-  TrackAllocatorAddressMappedAllocation(
-      *state, AllocationRecord::Kind::kAllocateAndMapReturnNewAddr,
-      allocator_address, std::move(shared_raw), std::move(allocator_reservation),
-      std::move(allocator_mapping), rounded_size, multi_device);
-  state->active_reservation_mappings.emplace(
-      reservation_address.opaque(),
-      ReservationMapping{allocator_address, reservation_address, reservation,
-                         reservation_offset, mapping_size,
-                         std::move(reservation_mapping)});
+
+  void* allocator_va = allocator_address_reservation->address().opaque();
+  DeviceAddressBase allocator_address(allocator_va, allocation_size);
+  auto record = std::make_unique<AllocationRecord>(
+      AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
+      std::move(shared_raw), std::move(allocator_address_reservation),
+      std::move(allocator_address_mapping), multi_device);
+  record->AddActiveReservationAlias(reservation_address,
+                                    std::move(reservation_mapping));
+  AllocationRecord* record_ptr = record.get();
+  auto record_insert = state->records_by_allocator_address.emplace(
+      allocator_va, std::move(record));
+  CHECK(record_insert.second);
+  auto reservation_insert = state->active_reservation_records.emplace(
+      reservation_address.opaque(), record_ptr);
+  CHECK(reservation_insert.second);
+  state->pa_allocated += rounded_size;
 
   return ScopedDeviceAddress<uint8_t>(allocator_address, device_ordinal, this);
-}
-
-// Allocation flow with retry:
-//
-// Allocate(device_ordinal, size)
-//           │
-//           ▼
-// ┌─────────────────────────────────┐
-// │ Reuse pending deallocation      │──found──► return
-// │ with matching size?             │
-// └─────────────────────────────────┘
-//           │ not found
-//           ▼
-// ┌─────────────────────────────────┐
-// │ Allocate new physical +         │──OK──► return
-// │ virtual memory                  │
-// └─────────────────────────────────┘
-//           │ failed
-//           ▼
-// ┌─────────────────────────────────┐
-// │ Free any GPU-completed          │
-// │ pending deallocations           │
-// │ (non-blocking)                  │
-// └─────────────────────────────────┘
-//           │
-//           ▼
-// ┌─────────────────────────────────┐
-// │ Allocate new physical +         │──OK──► return
-// │ virtual memory                  │
-// └─────────────────────────────────┘
-//           │ failed
-//           ▼
-// ┌─────────────────────────────────┐
-// │ Block until GPU frees           │
-// │ enough pending memory           │
-// └─────────────────────────────────┘
-//           │
-//           ▼
-// ┌─────────────────────────────────┐
-// │ Allocate new physical +         │──OK──► return
-// │ virtual memory                  │
-// └─────────────────────────────────┘
-//           │ failed
-//           ▼
-//    ResourceExhaustedError
-absl::StatusOr<ScopedDeviceAddress<uint8_t>>
-DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
-                                    bool /*retry_on_failure*/,
-                                    int64_t /*memory_space*/) {
-  if (size == 0) {
-    return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
-                                        this);
-  }
-
-  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
-
-  const bool multi_device = CurrentMultiDevice();
-
-  absl::MutexLock lock(state->mu);
-
-  // Try to reuse a completed pending deallocation with matching size.
-  std::optional<DeviceAddressBase> reused =
-      TryReusePendingDeallocation(*state, size, multi_device);
-  if (reused.has_value()) {
-    return ScopedDeviceAddress<uint8_t>(*reused, device_ordinal, this);
-  }
-
-  absl::StatusOr<DeviceAddressBase> result =
-      AllocateWithBudget(*state, size, multi_device);
-
-  // If allocation failed (e.g., out of memory), try processing pending
-  // deallocations to free memory, then retry.
-  if (!result.ok()) {
-    ProcessCompletedPendingDeallocations(*state);
-    result = AllocateWithBudget(*state, size, multi_device);
-  }
-
-  if (!result.ok()) {
-    WaitPendingDeallocationsToComplete(*state, size);
-    result = AllocateWithBudget(*state, size, multi_device);
-  }
-
-  if (!result.ok()) {
-    return result.status();
-  }
-
-  VLOG(3) << absl::StreamFormat(
-      "Allocated virtual address %p (%uB) on device ordinal %d",
-      result->opaque(), size, device_ordinal);
-
-  return ScopedDeviceAddress<uint8_t>(*result, device_ordinal, this);
 }
 
 absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
@@ -599,48 +710,72 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   if (record_it == state->records_by_allocator_address.end() ||
       !record_it->second->allocator_active() ||
       !record_it->second->allocator_matches(mem)) {
-    if (state->active_reservation_mappings.contains(mem.opaque()) ||
-        state->stale_reservation_mappings.contains(mem.opaque())) {
-      return absl::InvalidArgumentError(
-          "DeviceAddressVmmAllocator::Deallocate does not accept reservation "
-          "alias addresses; use UnMap instead");
-    }
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "DeviceAddressVmmAllocator::Deallocate received an unknown address %p",
+    return absl::NotFoundError(absl::StrFormat(
+        "virtual address %p is not an active allocator address returned by "
+        "Allocate()",
         mem.opaque()));
   }
   AllocationRecord& record = *record_it->second;
-
-  for (const auto& [_, mapping] : state->active_reservation_mappings) {
-    if (mapping.allocator_address.IsSameAs(mem)) {
-      return absl::FailedPreconditionError(
-          "DeviceAddressVmmAllocator::Deallocate requires active reservation "
-          "aliases to be released with UnMap first");
-    }
+  CHECK(!state->active_reservation_records.contains(mem.opaque()));
+  if (record.reservation_active()) {
+    CHECK(record.has_reservation_address());
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Deallocate() requires the active reservation alias at virtual address "
+        "%p (%uB) to be released with UnMap() first",
+        record.reservation_address().opaque(),
+        record.reservation_address().size()));
   }
 
   VLOG(3) << absl::StreamFormat(
       "Queueing deferred deallocation for virtual address %p (size=%uB) "
       "on device ordinal %d",
-      mem.opaque(), mem.size(), device_ordinal);
+      mem.opaque(), mem.size(), state->executor->device_ordinal());
+
+  const uint64_t reclaimable_bytes =
+      RoundUpToGranularity(*state, record.raw_allocation()->address().size());
 
   // Assign the next sequence number and enqueue a GPU write to the pinned
   // timeline when the stream reaches this point. The CPU polls the timeline
   // value to know when it is safe to free the memory.
   uint64_t seqno = state->next_seqno++;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
-
+  // Move the returned allocator address out of active ownership and keep its
+  // mapping alive as stale state until the stream reaches `seqno`.
   CHECK(record.allocator_active());
   CHECK(!record.allocator_stale());
   CHECK(record.has_allocator_address_mapping());
-  const uint64_t reclaimable_bytes =
-      RoundUpToGranularity(*state, record.raw_allocation()->address().size());
+  void* allocator_va = record.allocator_key();
+  auto allocator_record_it =
+      state->records_by_allocator_address.find(allocator_va);
+  CHECK(allocator_record_it != state->records_by_allocator_address.end());
+  CHECK_EQ(allocator_record_it->second.get(), &record);
   record.MarkAllocatorStale(seqno);
-  state->pending_deallocations.push_back({record.pending_deallocation_kind(),
-                                          seqno, record.allocator_address(),
-                                          reclaimable_bytes});
-
+  state->pending_deallocations.push_back(
+      PendingDeallocation{record.pending_deallocation_kind(), seqno,
+                          record.allocator_address(), reclaimable_bytes});
   return absl::OkStatus();
+}
+
+// Map helpers.
+
+absl::StatusOr<DeviceAddressBase>
+DeviceAddressVmmAllocator::ValidateReservationRange(
+    MemoryReservation* reservation, uint64_t reservation_offset,
+    uint64_t size) const {
+  if (reservation == nullptr) {
+    return absl::InvalidArgumentError("reservation must not be null");
+  }
+
+  DeviceAddressBase address = reservation->address();
+  if (reservation_offset > address.size() ||
+      size > address.size() - reservation_offset) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "reservation range is out of bounds: offset=%uB, size=%uB, "
+        "reservation_size=%uB",
+        reservation_offset, size, address.size()));
+  }
+
+  return address.GetByteSlice(reservation_offset, size);
 }
 
 absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
@@ -648,193 +783,101 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
                                             MemoryReservation* reservation,
                                             uint64_t reservation_offset,
                                             uint64_t size) {
+  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
   if (size == 0) {
     return absl::OkStatus();
   }
   if (addr.is_null()) {
-    return absl::InvalidArgumentError(
-        "DeviceAddressVmmAllocator::Map requires a non-null source address");
+    return absl::InvalidArgumentError("addr must not be null");
   }
+
+  // Map() does not allocate a VA range. It maps the physical allocation backing
+  // `addr` into the caller-owned reservation slice, so validate the slice
+  // before taking the allocator lock.
   ASSIGN_OR_RETURN(
       DeviceAddressBase reservation_address,
       ValidateReservationRange(reservation, reservation_offset, size));
 
-  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
-
   absl::MutexLock lock(state->mu);
-  auto record_it = state->records_by_allocator_address.find(addr.opaque());
-  if (record_it == state->records_by_allocator_address.end() ||
-      !record_it->second->allocator_active() ||
-      !record_it->second->allocator_matches(addr)) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "DeviceAddressVmmAllocator::Map received an unknown allocator address "
-        "%p",
-        addr.opaque()));
-  }
-  AllocationRecord& record = *record_it->second;
-  MemoryAllocation* raw_allocation = record.raw_allocation();
+  auto resolve_source_record =
+      [&]()
+          ABSL_NO_THREAD_SAFETY_ANALYSIS -> absl::StatusOr<AllocationRecord*> {
+    auto allocation_it =
+        state->records_by_allocator_address.find(addr.opaque());
+    if (allocation_it == state->records_by_allocator_address.end() ||
+        !allocation_it->second->allocator_active() ||
+        !allocation_it->second->allocator_matches(addr)) {
+      return absl::NotFoundError(absl::StrFormat(
+          "addr %p is not an active allocator address, when trying to "
+          "do map of VA reservation to existing physical allocation, we "
+          "requires the buffer being mapped to is being allocated through "
+          "DeviceAddressVmmAllocator, check the allocator type for the "
+          "buffer.",
+          addr.opaque()));
+    }
+    return allocation_it->second.get();
+  };
+
+  // Resolve the source address to the raw physical allocation that is currently
+  // mapped there. Any active allocator address returned by this allocator is
+  // accepted as a Map() source.
+  ASSIGN_OR_RETURN(AllocationRecord * source_record, resolve_source_record());
+  MemoryAllocation* raw_allocation = source_record->raw_allocation();
   if (size > raw_allocation->address().size()) {
     return absl::InvalidArgumentError(absl::StrFormat(
-        "DeviceAddressVmmAllocator::Map size %u exceeds raw allocation size "
-        "%u",
+        "mapping size must not exceed physical allocation size: "
+        "mapping_size=%uB, allocation_size=%uB",
         size, raw_allocation->address().size()));
   }
-  if (state->active_reservation_mappings.contains(
+  if (state->active_reservation_records.contains(
           reservation_address.opaque()) ||
-      state->stale_reservation_mappings.contains(
-          reservation_address.opaque())) {
+      state->stale_reservation_records.contains(reservation_address.opaque())) {
     return absl::FailedPreconditionError(
         "Reservation address is already tracked by this allocator");
   }
-  for (const auto& [_, mapping] : state->active_reservation_mappings) {
-    if (mapping.allocator_address.IsSameAs(addr)) {
-      return absl::FailedPreconditionError(
-          "Allocator address already has an active reservation alias");
-    }
+  if (source_record->reservation_active()) {
+    return absl::FailedPreconditionError(
+        "Allocator address already has an active reservation alias");
+  }
+  if (source_record->reservation_stale()) {
+    return absl::FailedPreconditionError(
+        "Allocator address already has a pending reservation alias");
   }
 
-  ASSIGN_OR_RETURN(
-      MemoryReservation::ScopedMapping scoped_mapping,
-      reservation->MapTo(reservation_offset, /*allocation_offset=*/0, size,
-                         *raw_allocation));
-  state->active_reservation_mappings.emplace(
-      reservation_address.opaque(),
-      ReservationMapping{addr, reservation_address, reservation,
-                         reservation_offset, size, std::move(scoped_mapping)});
+  // Install the reservation address mapping to the raw physical allocation. The
+  // allocation_offset is zero because Map() aliases the beginning of
+  // the source allocation; callers pass the target VA location through
+  // `reservation_offset`.
+  ASSIGN_OR_RETURN(auto mapping, reservation->MapTo(reservation_offset,
+                                                    /*allocation_offset=*/0,
+                                                    size, *raw_allocation));
+  DeviceAddressBase mapped = mapping.mapped_address();
+  // The reservation slice was computed before locking. Verify the platform
+  // returned the exact reservation address before recording allocator
+  // bookkeeping.
+  if (!mapped.IsSameAs(reservation_address)) {
+    return absl::InternalError(absl::StrFormat(
+        "Map() mapped unexpected virtual address: expected=%p, actual=%p",
+        reservation_address.opaque(), mapped.opaque()));
+  }
+  // Track this as a Map()-owned reservation alias. This only updates the
+  // reservation-address index; no new physical allocation is created, so
+  // pa_allocated does not change.
+  CHECK(!source_record->reservation_active());
+  CHECK(!source_record->reservation_stale());
+  source_record->AddActiveReservationAlias(mapped, std::move(mapping));
+  auto mapping_insert_result =
+      state->active_reservation_records.emplace(mapped.opaque(), source_record);
+  CHECK(mapping_insert_result.second);
   return absl::OkStatus();
 }
 
-absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
-                                              MemoryReservation* reservation,
-                                              uint64_t reservation_offset,
-                                              uint64_t size) {
-  if (size == 0) {
-    return absl::OkStatus();
-  }
-  ASSIGN_OR_RETURN(
-      DeviceAddressBase reservation_address,
-      ValidateReservationRange(reservation, reservation_offset, size));
+// UnMap/deferred teardown helpers.
 
-  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
-
-  absl::MutexLock lock(state->mu);
-  auto it =
-      state->active_reservation_mappings.find(reservation_address.opaque());
-  if (it == state->active_reservation_mappings.end()) {
-    return absl::InvalidArgumentError(
-        "DeviceAddressVmmAllocator::UnMap received an untracked reservation "
-        "address");
-  }
-  if (it->second.reservation != reservation ||
-      it->second.reservation_offset != reservation_offset ||
-      it->second.size != size) {
-    return absl::InvalidArgumentError(
-        "DeviceAddressVmmAllocator::UnMap requires the same full reservation "
-        "range passed to Map");
-  }
-
-  uint64_t seqno = state->next_seqno++;
-  RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
-
-  ReservationMapping mapping = std::move(it->second);
-  state->active_reservation_mappings.erase(it);
-  state->stale_reservation_mappings.emplace(reservation_address.opaque(),
-                                            std::move(mapping));
-  state->pending_deallocations.push_back(
-      {PendingDeallocationKind::kMap, seqno, reservation_address,
-       /*reclaimable_bytes=*/0});
-  return absl::OkStatus();
-}
-
-absl::StatusOr<Stream*> DeviceAddressVmmAllocator::GetStream(
-    int device_ordinal) {
-  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
-  return state->stream;
-}
-
-absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
-    int device_ordinal) {
-  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
-
-  uint64_t target_seqno;
-  {
-    absl::MutexLock lock(state->mu);
-    if (state->pending_deallocations.empty()) {
-      return absl::OkStatus();
-    }
-    target_seqno = state->pending_deallocations.back().seqno;
-  }
-
-  while (LoadTimeline(state->pinned_timeline) < target_seqno) {
-    absl::SleepFor(kGpuTimelinePollInterval);
-  }
-
-  {
-    absl::MutexLock lock(state->mu);
-    while (!state->pending_deallocations.empty() &&
-           state->pending_deallocations.front().seqno <= target_seqno) {
-      if (state->pending_deallocations.front().kind !=
-          PendingDeallocationKind::kMap) {
-        DoDeallocate(*state, state->pending_deallocations.front().addr);
-      } else {
-        DoUnMap(*state, state->pending_deallocations.front().addr);
-      }
-      state->pending_deallocations.pop_front();
-    }
-  }
-
-  return absl::OkStatus();
-}
-
-absl::StatusOr<StreamExecutor*> DeviceAddressVmmAllocator::GetStreamExecutor(
-    int device_ordinal) const {
-  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
-  return state->executor;
-}
-
-MemoryAllocation* DeviceAddressVmmAllocator::GetRawAllocation(
-    int device_ordinal, DeviceAddressBase addr) const {
-  absl::StatusOr<PerDeviceState*> state_or = GetPerDeviceState(device_ordinal);
-  if (!state_or.ok()) {
-    return nullptr;
-  }
-  PerDeviceState* state = *state_or;
-  absl::MutexLock lock(state->mu);
-  auto it = state->records_by_allocator_address.find(addr.opaque());
-  if (it == state->records_by_allocator_address.end() ||
-      !it->second->allocator_active() ||
-      !it->second->allocator_matches(addr)) {
-    return nullptr;
-  }
-  return it->second->raw_allocation();
-}
-
-MemoryReservation* DeviceAddressVmmAllocator::GetReservation(
-    int device_ordinal, DeviceAddressBase addr) const {
-  absl::StatusOr<PerDeviceState*> state_or = GetPerDeviceState(device_ordinal);
-  if (!state_or.ok()) {
-    return nullptr;
-  }
-  PerDeviceState* state = *state_or;
-  absl::MutexLock lock(state->mu);
-  auto it = state->records_by_allocator_address.find(addr.opaque());
-  if (it == state->records_by_allocator_address.end() ||
-      !it->second->allocator_active() ||
-      !it->second->allocator_matches(addr)) {
-    return nullptr;
-  }
-  return it->second->allocator_address_reservation();
-}
-
-uint64_t DeviceAddressVmmAllocator::GetAllocationGranularity(
-    StreamExecutor* executor) const {
-  absl::StatusOr<PerDeviceState*> state_or =
-      GetPerDeviceState(executor->device_ordinal());
-  if (!state_or.ok()) {
-    return 0;
-  }
-  PerDeviceState* state = *state_or;
-  return state->allocation_granularity;
+void DeviceAddressVmmAllocator::ErasePendingDeallocationAt(
+    PerDeviceState& state, std::deque<PendingDeallocation>::iterator it) {
+  CHECK(it != state.pending_deallocations.end());
+  state.pending_deallocations.erase(it);
 }
 
 void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
@@ -849,52 +892,210 @@ void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
   record.ReactivateAllocator(new_size);
 }
 
-std::optional<DeviceAddressBase>
-DeviceAddressVmmAllocator::TryReusePendingDeallocation(PerDeviceState& state,
-                                                       uint64_t size,
-                                                       bool multi_device) {
-  uint64_t rounded_size = RoundUpToGranularity(state, size);
-  for (auto it = state.pending_deallocations.begin();
-       it != state.pending_deallocations.end(); ++it) {
-    if (it->kind != PendingDeallocationKind::kAllocate) {
-      continue;
-    }
-    auto record_it = state.records_by_allocator_address.find(it->addr.opaque());
-    CHECK(record_it != state.records_by_allocator_address.end());
-    AllocationRecord& record = *record_it->second;
-    CHECK(record.allocator_stale());
-    CHECK(record.allocator_matches(it->addr));
-    if (record.multi_device() != multi_device) {
-      continue;
-    }
-    if (RoundUpToGranularity(state, record.allocator_address().size()) !=
-        rounded_size) {
-      continue;
-    }
-
-    DeviceAddressBase reused_mem(record.allocator_key(), size);
-    VLOG(3) << absl::StreamFormat(
-        "Reusing pending deallocation: address=%p original_size=%uB "
-        "new_size=%uB rounded_size=%uB device=%d",
-        reused_mem.opaque(), record.allocator_address().size(), size, rounded_size,
-        state.executor->device_ordinal());
-    MoveAllocatorRecordToActive(state, record, size);
-    state.pending_deallocations.erase(it);
-
-    return reused_mem;
-  }
-
-  return std::nullopt;
+void DeviceAddressVmmAllocator::MoveReservationRecordToStale(
+    PerDeviceState& state, AllocationRecord& record, uint64_t seqno) {
+  CHECK(record.reservation_active());
+  CHECK(!record.reservation_stale());
+  CHECK(record.has_reservation_address());
+  void* reservation_va = record.reservation_key();
+  CHECK_EQ(state.active_reservation_records.erase(reservation_va), 1);
+  auto insert_result =
+      state.stale_reservation_records.emplace(reservation_va, &record);
+  CHECK(insert_result.second);
+  record.MarkReservationStale(seqno);
 }
 
-uint64_t DeviceAddressVmmAllocator::RoundUpToGranularity(
-    const PerDeviceState& state, uint64_t size) const {
-  if (state.allocation_granularity == 0) {
-    return size;
+void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
+    PerDeviceState& state, AllocationRecord& record) {
+  if (!record.reservation_stale()) {
+    return;
   }
-  return ((size + state.allocation_granularity - 1) /
-          state.allocation_granularity) *
-         state.allocation_granularity;
+  CHECK(!record.reservation_active());
+  CHECK(record.has_reservation_address());
+  void* reservation_va = record.reservation_key();
+  auto stale_it = state.stale_reservation_records.find(reservation_va);
+  if (stale_it != state.stale_reservation_records.end()) {
+    CHECK_EQ(stale_it->second, &record);
+    state.stale_reservation_records.erase(stale_it);
+  }
+  record.CompleteStaleReservation();
+}
+
+absl::Status DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
+                                                       uint64_t target_seqno) {
+  // Release the lock before spin-waiting to avoid stalling other threads for
+  // potentially milliseconds while the GPU drains its work queue.
+  state.mu.unlock();
+
+  // Poll until the GPU writes a timeline value >= target_seqno.
+  // Since timeline values are written in stream order, this guarantees all
+  // selected pending operations have completed.
+  while (LoadTimeline(state.pinned_timeline) < target_seqno) {
+    absl::SleepFor(kGpuTimelinePollInterval);
+  }
+
+  state.mu.lock();
+  return absl::OkStatus();
+}
+
+absl::Status
+DeviceAddressVmmAllocator::WaitAndDrainPendingDeallocationsUntilSeqno(
+    PerDeviceState& state, uint64_t target_seqno) {
+  RETURN_IF_ERROR(WaitUntilSeqno(state, target_seqno));
+  while (!state.pending_deallocations.empty() &&
+         state.pending_deallocations.front().seqno <= target_seqno) {
+    PendingDeallocation pending = state.pending_deallocations.front();
+    state.pending_deallocations.pop_front();
+    CompletePendingDeallocation(state, pending);
+  }
+  return absl::OkStatus();
+}
+
+void DeviceAddressVmmAllocator::CompleteReadyAllocatorDeallocationsForReclaim(
+    PerDeviceState& state, uint64_t completed_seqno) {
+  std::vector<PendingDeallocationKey> selected;
+  for (const PendingDeallocation& pending : state.pending_deallocations) {
+    if (pending.seqno > completed_seqno ||
+        pending.kind == PendingDeallocationKind::kMap) {
+      continue;
+    }
+    selected.push_back(
+        PendingDeallocationKey{pending.kind, pending.seqno, pending.addr});
+  }
+  for (const PendingDeallocationKey& key : selected) {
+    CompletePendingDeallocationByKey(state, key);
+  }
+}
+
+bool DeviceAddressVmmAllocator::CompletePendingDeallocationByKey(
+    PerDeviceState& state, const PendingDeallocationKey& key) {
+  for (auto it = state.pending_deallocations.begin();
+       it != state.pending_deallocations.end(); ++it) {
+    if (it->kind == key.kind && it->seqno == key.seqno &&
+        it->addr.IsSameAs(key.addr)) {
+      PendingDeallocation pending = *it;
+      state.pending_deallocations.erase(it);
+      CompletePendingDeallocation(state, pending);
+      return true;
+    }
+  }
+  return false;
+}
+
+void DeviceAddressVmmAllocator::CompletePendingDeallocation(
+    PerDeviceState& state, const PendingDeallocation& pending) {
+  if (pending.kind == PendingDeallocationKind::kMap) {
+    auto record_it =
+        state.stale_reservation_records.find(pending.addr.opaque());
+    CHECK(record_it != state.stale_reservation_records.end());
+    CHECK_EQ(record_it->second->reservation_stale_seqno(), pending.seqno);
+    CompleteStaleReservationMapping(state, *record_it->second);
+    return;
+  }
+
+  auto record_it =
+      state.records_by_allocator_address.find(pending.addr.opaque());
+  CHECK(record_it != state.records_by_allocator_address.end());
+  CHECK(record_it->second->allocator_stale());
+  CHECK(record_it->second->allocator_matches(pending.addr));
+  CHECK_EQ(record_it->second->pending_deallocation_kind(), pending.kind);
+  CHECK_EQ(record_it->second->allocator_stale_seqno(), pending.seqno);
+  // Complete allocator-address teardown. If this allocation still has an
+  // explicitly unmapped stale reservation alias, drop that mapping first, then
+  // release allocator VA state and physical allocation accounting.
+  AllocationRecord& record = *record_it->second;
+  CHECK(!record.allocator_active());
+  CHECK(!record.reservation_active());
+  if (record.reservation_stale()) {
+    CHECK(record.has_reservation_address());
+    PendingDeallocationKey reservation_key{PendingDeallocationKind::kMap,
+                                           record.reservation_stale_seqno(),
+                                           record.reservation_address()};
+    for (auto it = state.pending_deallocations.begin();
+         it != state.pending_deallocations.end(); ++it) {
+      if (it->kind == reservation_key.kind &&
+          it->seqno == reservation_key.seqno &&
+          it->addr.IsSameAs(reservation_key.addr)) {
+        state.pending_deallocations.erase(it);
+        break;
+      }
+    }
+    CompleteStaleReservationMapping(state, record);
+  }
+  void* allocator_va = record.allocator_key();
+  auto owning_record_it = state.records_by_allocator_address.find(allocator_va);
+  CHECK(owning_record_it != state.records_by_allocator_address.end());
+  CHECK_EQ(owning_record_it->second.get(), &record);
+
+  if (record.raw_allocation() != nullptr) {
+    uint64_t released_size =
+        RoundUpToGranularity(state, record.raw_allocation()->address().size());
+    DCHECK_GE(state.pa_allocated, released_size);
+    state.pa_allocated -= released_size;
+  }
+  record.CompleteStaleAllocator();
+  CHECK_EQ(state.records_by_allocator_address.erase(allocator_va), 1);
+}
+
+absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
+                                              MemoryReservation* reservation,
+                                              uint64_t reservation_offset,
+                                              uint64_t size) {
+  ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
+  if (size == 0) {
+    return absl::OkStatus();
+  }
+
+  // Map() and Allocate(..., return_reservation_address=false) record
+  // reservation mappings by the mapped reservation VA. Reconstruct the same
+  // reservation slice here so callers do not need to hold a ScopedMapping.
+  ASSIGN_OR_RETURN(
+      DeviceAddressBase reservation_address,
+      ValidateReservationRange(reservation, reservation_offset, size));
+
+  absl::MutexLock lock(state->mu);
+  // UnMap() only accepts the exact active reservation range previously created
+  // by Map() or Allocate(..., return_reservation_address=false). Allocator
+  // addresses and subranges are not valid UnMap() inputs.
+  auto active_it =
+      state->active_reservation_records.find(reservation_address.opaque());
+  if (active_it == state->active_reservation_records.end()) {
+    auto stale_it =
+        state->stale_reservation_records.find(reservation_address.opaque());
+    if (stale_it != state->stale_reservation_records.end()) {
+      CHECK(stale_it->second->has_reservation_address());
+    }
+    if (stale_it != state->stale_reservation_records.end() &&
+        stale_it->second->reservation_matches(reservation_address)) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "reservation range at virtual address %p (%uB) is already pending "
+          "UnMap()",
+          reservation_address.opaque(), reservation_address.size()));
+    }
+    return absl::NotFoundError(absl::StrFormat(
+        "UnMap() requires an exact active reservation range created by Map() "
+        "or Allocate(..., return_reservation_address=false): virtual address "
+        "%p (%uB)",
+        reservation_address.opaque(), reservation_address.size()));
+  }
+  AllocationRecord* record = active_it->second;
+  CHECK(record->reservation_active());
+  CHECK(!record->reservation_stale());
+  CHECK(record->has_reservation_address());
+  if (!record->reservation_matches(reservation_address)) {
+    return absl::InvalidArgumentError(
+        "DeviceAddressVmmAllocator::UnMap requires the same full reservation "
+        "range passed to Map");
+  }
+  CHECK(record->reservation_mapping_matches(reservation_address));
+
+  uint64_t seqno = state->next_seqno++;
+  RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
+  MoveReservationRecordToStale(*state, *record, seqno);
+  state->pending_deallocations.push_back(
+      PendingDeallocation{PendingDeallocationKind::kMap, seqno,
+                          reservation_address, /*reclaimable_bytes=*/0});
+  return absl::OkStatus();
 }
 
 }  // namespace stream_executor

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -210,6 +211,26 @@ static constexpr absl::Duration kGpuTimelinePollInterval =
 // std::atomic<uint64_t>* would discard the volatile qualifier.
 static uint64_t LoadTimeline(const volatile uint64_t* pinned_timeline) {
   return __atomic_load_n(pinned_timeline, __ATOMIC_ACQUIRE);
+}
+
+static uintptr_t AddressStart(DeviceAddressBase address) {
+  return reinterpret_cast<uintptr_t>(address.opaque());
+}
+
+static uintptr_t AddressEnd(DeviceAddressBase address) {
+  uintptr_t start = AddressStart(address);
+  if (std::numeric_limits<uintptr_t>::max() - start < address.size()) {
+    return std::numeric_limits<uintptr_t>::max();
+  }
+  return start + address.size();
+}
+
+static bool AddressRangesOverlap(DeviceAddressBase lhs, DeviceAddressBase rhs) {
+  if (lhs.is_null() || rhs.is_null() || lhs.size() == 0 || rhs.size() == 0) {
+    return false;
+  }
+  return AddressStart(lhs) < AddressEnd(rhs) &&
+         AddressStart(rhs) < AddressEnd(lhs);
 }
 
 DeviceAddressVmmAllocator::DeviceAddressVmmAllocator(const Platform* platform)
@@ -601,99 +622,325 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
   return ScopedDeviceAddress<uint8_t>(*result, device_ordinal, this);
 }
 
-// Mapped Allocate() creates fresh physical memory and maps it into the caller
-// reservation. It keeps the same externally visible ownership model as the
-// previous map-based bookkeeping, but records the lifetime in AllocationRecord.
+// Mapped Allocate() reuses matching pending mapped deallocations, otherwise
+// tries fresh physical allocation and maps it into the caller reservation.
 absl::StatusOr<ScopedDeviceAddress<uint8_t>>
 DeviceAddressVmmAllocator::Allocate(
     int device_ordinal, uint64_t allocation_size, bool /*retry_on_failure*/,
     int64_t /*memory_space*/, MemoryReservation* reservation,
     uint64_t reservation_offset, uint64_t mapping_size,
     bool return_reservation_address) {
-  if (allocation_size != mapping_size) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "VMM mapped allocation size (%u) must equal mapping size (%u)",
-        allocation_size, mapping_size));
-  }
+  // Keep zero-sized mapped allocation consistent with regular Allocate(): no
+  // physical allocation or mapping is created, so the requested mapping size
+  // must also be zero.
   if (allocation_size == 0) {
+    if (mapping_size != 0) {
+      return absl::InvalidArgumentError(
+          "mapping_size must be zero when allocation_size is zero");
+    }
     return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
                                         this);
+  }
+  // A mapped allocation with a nonzero physical allocation must establish a
+  // nonempty mapping into the caller-owned reservation.
+  if (mapping_size == 0) {
+    return absl::InvalidArgumentError(
+        "mapping_size must be nonzero for mapped Allocate");
+  }
+  if (allocation_size != mapping_size) {
+    return absl::InvalidArgumentError(
+        "allocation_size must equal mapping_size for mapped Allocate");
   }
 
   ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
   const bool multi_device = CurrentMultiDevice();
 
+  // Validate the caller-owned reservation slice before taking the allocator
+  // lock. `reservation_address` is the VA that must either be reactivated from
+  // a pending deallocation or freshly mapped below.
   ASSIGN_OR_RETURN(
       DeviceAddressBase reservation_address,
       ValidateReservationRange(reservation, reservation_offset, mapping_size));
 
   absl::MutexLock lock(state->mu);
-  if (state->active_reservation_records.contains(
-          reservation_address.opaque()) ||
-      state->stale_reservation_records.contains(reservation_address.opaque()) ||
-      state->records_by_allocator_address.contains(
-          reservation_address.opaque())) {
-    return absl::FailedPreconditionError(
-        "Reservation address is already tracked by this allocator");
+  // First try to satisfy the request from a compatible pending deallocation
+  // for the same reservation-derived returned allocator address.
+  auto try_reuse = [&]() ABSL_NO_THREAD_SAFETY_ANALYSIS
+      -> absl::StatusOr<std::optional<DeviceAddressBase>> {
+    if (!return_reservation_address) {
+      // This mode returns a distinct allocator-owned VA while also mapping that
+      // allocation into the caller-owned reservation. Reuse is possible only
+      // when a pending kAllocateAndMapReturnNewAddr record still has both sides
+      // stale and its reservation side exactly matches this request.
+      for (auto it = state->pending_deallocations.begin();
+           it != state->pending_deallocations.end(); ++it) {
+        if (it->kind != PendingDeallocationKind::kAllocateAndMapReturnNewAddr) {
+          continue;
+        }
+        auto record_it =
+            state->records_by_allocator_address.find(it->addr.opaque());
+        CHECK(record_it != state->records_by_allocator_address.end());
+        AllocationRecord& record = *record_it->second;
+        CHECK(record.allocator_stale());
+        CHECK(record.allocator_matches(it->addr));
+        CHECK_EQ(record.pending_deallocation_kind(),
+                 PendingDeallocationKind::kAllocateAndMapReturnNewAddr);
+        if (record.multi_device() != multi_device) {
+          continue;
+        }
+        if (!record.reservation_stale()) {
+          continue;
+        }
+        CHECK(record.has_reservation_address());
+        // The allocator address can be reused for command-buffer update-free
+        // execution only if the external reservation VA is also the same VA the
+        // command buffer captured.
+        if (!record.reservation_matches(reservation_address)) {
+          continue;
+        }
+        if (record.raw_allocation()->address().size() < allocation_size) {
+          // The old mapping is the right VA but not enough physical memory.
+          // Wait for its deferred teardown to finish, then let the fresh path
+          // create a larger allocation and install a new mapping.
+          RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
+              *state, PendingDeallocationKey{record.pending_deallocation_kind(),
+                                             record.allocator_stale_seqno(),
+                                             record.allocator_address()}));
+          return std::nullopt;
+        }
+
+        DeviceAddressBase reused_mem(record.allocator_key(), allocation_size);
+        // Reactivate both aliases: the returned allocator VA and the external
+        // reservation VA. This cancels the pending allocator teardown and the
+        // paired pending kMap unmap for the reservation mapping.
+        MoveAllocatorRecordToActive(*state, record, allocation_size);
+        MoveReservationRecordToActive(*state, record);
+        ErasePendingDeallocationAt(*state, it);
+        ErasePendingDeallocation(*state, PendingDeallocationKind::kMap,
+                                 reservation_address);
+        return reused_mem;
+      }
+      return std::nullopt;
+    }
+
+    // Look for a pending deallocation that already owns the requested
+    // reservation VA as its returned allocator address. Reusing it keeps the
+    // same virtual address mapped and avoids waiting for the GPU timeline when
+    // the pending raw allocation is compatible with this request.
+    auto record_it =
+        state->records_by_allocator_address.find(reservation_address.opaque());
+    if (record_it == state->records_by_allocator_address.end()) {
+      return std::nullopt;
+    }
+    AllocationRecord& record = *record_it->second;
+    if (!record.allocator_stale()) {
+      return std::nullopt;
+    }
+    if (record.pending_deallocation_kind() !=
+        PendingDeallocationKind::kAllocateAndMapReturnMapAddr) {
+      return std::nullopt;
+    }
+    if (record.multi_device() != multi_device) {
+      return std::nullopt;
+    }
+    if (!record.allocator_matches(reservation_address)) {
+      return std::nullopt;
+    }
+
+    // Allocate(..., return_reservation_address=true) returns the reservation
+    // VA as an owning allocator address. If the pending raw allocation is too
+    // small for the new request, wait for the old mapping to drain so the fresh
+    // path can remap this reservation VA to a larger raw allocation.
+    if (record.raw_allocation()->address().size() < allocation_size) {
+      RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
+          *state, PendingDeallocationKey{record.pending_deallocation_kind(),
+                                         record.allocator_stale_seqno(),
+                                         record.allocator_address()}));
+      return std::nullopt;
+    }
+
+    auto pending_it = state->pending_deallocations.end();
+    // The record is indexed by allocator address, but the FIFO queue owns the
+    // stream-ordered allocator teardown. Find the queue entry so reuse can
+    // cancel it while leaving explicit pending kMap entries untouched.
+    for (auto it = state->pending_deallocations.begin();
+         it != state->pending_deallocations.end(); ++it) {
+      if (it->kind == PendingDeallocationKind::kAllocateAndMapReturnMapAddr &&
+          it->addr.IsSameAs(reservation_address)) {
+        pending_it = it;
+        break;
+      }
+    }
+    CHECK(pending_it != state->pending_deallocations.end());
+    MoveAllocatorRecordToActive(*state, record, allocation_size);
+    ErasePendingDeallocationAt(*state, pending_it);
+    return reservation_address;
+  };
+  // If no pending entry can be reused, allocate fresh physical memory and map
+  // it into the caller reservation. When return_reservation_address is false
+  // this also creates an allocator-owned address; otherwise the reservation
+  // address is the returned allocator address.
+  auto try_fresh =
+      [&]()
+          ABSL_NO_THREAD_SAFETY_ANALYSIS -> absl::StatusOr<DeviceAddressBase> {
+    // If the requested reservation VA is only present in the deferred queue,
+    // wait for that queued unmap/deallocation to complete before installing a
+    // fresh mapping. Active mappings are still rejected below.
+    while (true) {
+      // Partial overlaps are never reusable: the allocator tracks whole mapped
+      // ranges, so a caller must request the exact same reservation slice
+      // before stale state can be waited on or reactivated.
+      if (auto overlap = FindOverlappingRecord(
+              *state, reservation_address, /*include_allocator=*/true,
+              /*include_reservation=*/true, /*include_active=*/true,
+              /*include_stale=*/true, /*exact_only=*/false,
+              /*partial_only=*/true)) {
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "reservation range at %p (%uB) partially overlaps %s %s range at "
+            "%p "
+            "(%uB); reservation mappings must be managed with the same full "
+            "range",
+            reservation_address.opaque(), reservation_address.size(),
+            overlap->is_active ? "active" : "stale",
+            overlap->is_allocator ? "allocator" : "reservation",
+            overlap->tracked_address.opaque(),
+            overlap->tracked_address.size()));
+      }
+      // An exact stale overlap means the previous mapping for this reservation
+      // VA is still protected by stream order. Complete only that conflicting
+      // stale record, then rescan because another thread may have changed the
+      // allocator state while the lock was released.
+      auto stale_overlap = FindOverlappingRecord(
+          *state, reservation_address, /*include_allocator=*/true,
+          /*include_reservation=*/true, /*include_active=*/false,
+          /*include_stale=*/true, /*exact_only=*/true,
+          /*partial_only=*/false);
+      if (!stale_overlap.has_value()) {
+        break;
+      }
+      RETURN_IF_ERROR(WaitAndCompleteStaleOverlap(*state, *stale_overlap));
+    }
+
+    // At this point stale exact overlaps have been drained. Any remaining
+    // overlap is active ownership of the requested reservation range and must
+    // be reported as a duplicate mapping attempt instead of remapped underneath
+    // existing users.
+    if (FindOverlappingRecord(*state, reservation_address,
+                              /*include_allocator=*/true,
+                              /*include_reservation=*/true,
+                              /*include_active=*/true,
+                              /*include_stale=*/false,
+                              /*exact_only=*/false,
+                              /*partial_only=*/false)
+            .has_value()) {
+      return absl::AlreadyExistsError(absl::StrFormat(
+          "reservation range is already tracked at virtual address %p",
+          reservation_address.opaque()));
+    }
+
+    uint64_t rounded_size = RoundUpToGranularity(*state, allocation_size);
+    if (return_reservation_address) {
+      // The returned allocator address is the caller-owned reservation VA. The
+      // record is keyed by that VA and owns only the raw allocation plus the
+      // scoped mapping into the external reservation.
+      if (state->pa_allocated + rounded_size > state->pa_budget) {
+        return absl::ResourceExhaustedError(absl::StrFormat(
+            "Not enough PA budget for mapping: pa_allocated=%uB, "
+            "rounded_size=%uB, pa_budget=%uB",
+            state->pa_allocated, rounded_size, state->pa_budget));
+      }
+
+      ASSIGN_OR_RETURN(auto raw_alloc,
+                       CreateAllocation(state->executor, allocation_size));
+      if (mapping_size > raw_alloc->address().size()) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "physical allocation is smaller than requested mapping: "
+            "allocation_size=%uB, mapping_size=%uB",
+            raw_alloc->address().size(), mapping_size));
+      }
+
+      ASSIGN_OR_RETURN(
+          auto scoped_mapping,
+          reservation->MapTo(reservation_offset, /*allocation_offset=*/0,
+                             mapping_size, *raw_alloc));
+      auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
+
+      TrackAllocatorAddressMappedAllocation(
+          *state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
+          reservation_address, std::move(shared_raw), nullptr,
+          std::move(scoped_mapping), rounded_size, multi_device);
+
+      return reservation_address;
+    }
+
+    // This mode creates two VAs for the same raw allocation: an allocator-owned
+    // VA returned to the caller, and a non-owning alias in the caller
+    // reservation used by captured command buffers.
+    if (state->pa_allocated + rounded_size > state->pa_budget) {
+      return absl::ResourceExhaustedError(absl::StrFormat(
+          "Not enough PA budget for allocation: pa_allocated=%uB, "
+          "rounded_size=%uB, pa_budget=%uB",
+          state->pa_allocated, rounded_size, state->pa_budget));
+    }
+
+    ASSIGN_OR_RETURN(auto raw_alloc,
+                     CreateAllocation(state->executor, allocation_size));
+    const uint64_t padded_size = raw_alloc->address().size();
+    if (mapping_size > padded_size) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "mapping size must not exceed physical allocation size: "
+          "mapping_size=%uB, allocation_size=%uB",
+          mapping_size, padded_size));
+    }
+
+    ASSIGN_OR_RETURN(auto allocator_address_reservation,
+                     CreateReservation(state->executor, allocation_size));
+    ASSIGN_OR_RETURN(auto allocator_address_mapping,
+                     allocator_address_reservation->MapTo(
+                         /*reservation_offset=*/0, /*allocation_offset=*/0,
+                         padded_size, *raw_alloc));
+    ASSIGN_OR_RETURN(
+        auto reservation_address_mapping,
+        reservation->MapTo(reservation_offset, /*allocation_offset=*/0,
+                           mapping_size, *raw_alloc));
+
+    auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
+    // Record the paired allocation: the allocator-owned returned VA owns the
+    // raw allocation, and the caller reservation VA is a non-owning alias.
+    void* allocator_va = allocator_address_reservation->address().opaque();
+    DeviceAddressBase allocator_address(allocator_va, allocation_size);
+    auto record = std::make_unique<AllocationRecord>(
+        AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
+        std::move(shared_raw), std::move(allocator_address_reservation),
+        std::move(allocator_address_mapping), multi_device);
+    record->AddActiveReservationAlias(reservation_address,
+                                      std::move(reservation_address_mapping));
+    AllocationRecord* record_ptr = record.get();
+    auto record_insert = state->records_by_allocator_address.emplace(
+        allocator_va, std::move(record));
+    CHECK(record_insert.second);
+    auto reservation_insert = state->active_reservation_records.emplace(
+        reservation_address.opaque(), record_ptr);
+    CHECK(reservation_insert.second);
+    state->pa_allocated += rounded_size;
+
+    return DeviceAddressBase(allocator_va, allocation_size);
+  };
+
+  // The shared retry helper handles PA-budget pressure: try reuse, try fresh,
+  // complete already-finished pending work on ResourceExhausted, and finally
+  // wait for enough pending deallocations only if necessary.
+  absl::StatusOr<DeviceAddressBase> result =
+      TryWithPendingReclaim(*state, allocation_size, try_reuse, try_fresh);
+
+  if (!result.ok()) {
+    return result.status();
   }
 
-  uint64_t rounded_size = RoundUpToGranularity(*state, allocation_size);
-  if (state->pa_allocated + rounded_size > state->pa_budget) {
-    return absl::ResourceExhaustedError(absl::StrFormat(
-        "Not enough PA budget for allocation: pa_allocated=%uB, "
-        "rounded_size=%uB, pa_budget=%uB",
-        state->pa_allocated, rounded_size, state->pa_budget));
-  }
-
-  ASSIGN_OR_RETURN(auto raw_alloc,
-                   CreateAllocation(state->executor, allocation_size));
-  const uint64_t padded_size = raw_alloc->address().size();
-  if (mapping_size > padded_size) {
-    return absl::InvalidArgumentError(
-        absl::StrFormat("Mapping size %u exceeds raw allocation size %u",
-                        mapping_size, padded_size));
-  }
-
-  ASSIGN_OR_RETURN(
-      MemoryReservation::ScopedMapping reservation_mapping,
-      reservation->MapTo(reservation_offset, /*allocation_offset=*/0,
-                         mapping_size, *raw_alloc));
-  auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
-
-  if (return_reservation_address) {
-    TrackAllocatorAddressMappedAllocation(
-        *state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
-        reservation_address, std::move(shared_raw), nullptr,
-        std::move(reservation_mapping), rounded_size, multi_device);
-    return ScopedDeviceAddress<uint8_t>(reservation_address, device_ordinal,
-                                        this);
-  }
-
-  ASSIGN_OR_RETURN(auto allocator_address_reservation,
-                   CreateReservation(state->executor, allocation_size));
-  ASSIGN_OR_RETURN(auto allocator_address_mapping,
-                   allocator_address_reservation->MapTo(
-                       /*reservation_offset=*/0, /*allocation_offset=*/0,
-                       padded_size, *shared_raw));
-
-  void* allocator_va = allocator_address_reservation->address().opaque();
-  DeviceAddressBase allocator_address(allocator_va, allocation_size);
-  auto record = std::make_unique<AllocationRecord>(
-      AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
-      std::move(shared_raw), std::move(allocator_address_reservation),
-      std::move(allocator_address_mapping), multi_device);
-  record->AddActiveReservationAlias(reservation_address,
-                                    std::move(reservation_mapping));
-  AllocationRecord* record_ptr = record.get();
-  auto record_insert = state->records_by_allocator_address.emplace(
-      allocator_va, std::move(record));
-  CHECK(record_insert.second);
-  auto reservation_insert = state->active_reservation_records.emplace(
-      reservation_address.opaque(), record_ptr);
-  CHECK(reservation_insert.second);
-  state->pa_allocated += rounded_size;
-
-  return ScopedDeviceAddress<uint8_t>(allocator_address, device_ordinal, this);
+  // For return_reservation_address=true this is `reservation_address`; for
+  // return_reservation_address=false it is the allocator-owned address paired
+  // with the reservation mapping.
+  return ScopedDeviceAddress<uint8_t>(*result, device_ordinal, this);
 }
 
 absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
@@ -778,6 +1025,77 @@ DeviceAddressVmmAllocator::ValidateReservationRange(
   return address.GetByteSlice(reservation_offset, size);
 }
 
+std::optional<DeviceAddressVmmAllocator::OverlappingRecord>
+DeviceAddressVmmAllocator::FindOverlappingRecord(
+    PerDeviceState& state, DeviceAddressBase address, bool include_allocator,
+    bool include_reservation, bool include_active, bool include_stale,
+    bool exact_only, bool partial_only) const {
+  CHECK(!(exact_only && partial_only));
+
+  auto matches = [&](DeviceAddressBase tracked_address) {
+    if (exact_only) {
+      return tracked_address.IsSameAs(address);
+    }
+    if (partial_only) {
+      // Partial overlap means the ranges intersect but are not the same full
+      // ownership range.
+      return AddressRangesOverlap(tracked_address, address) &&
+             !tracked_address.IsSameAs(address);
+    }
+    return AddressRangesOverlap(tracked_address, address);
+  };
+
+  auto check_record = [&](AllocationRecord* record,
+                          DeviceAddressBase tracked_address, bool is_allocator,
+                          bool is_active) -> std::optional<OverlappingRecord> {
+    if (matches(tracked_address)) {
+      return OverlappingRecord{record, tracked_address, is_allocator,
+                               is_active};
+    }
+    return std::nullopt;
+  };
+
+  if (include_allocator) {
+    for (const auto& [_, record_owner] : state.records_by_allocator_address) {
+      AllocationRecord* record = record_owner.get();
+      CHECK_NE(record->allocator_active(), record->allocator_stale());
+      bool include_record = (include_active && record->allocator_active()) ||
+                            (include_stale && record->allocator_stale());
+      if (!include_record) {
+        continue;
+      }
+      if (auto overlap =
+              check_record(record, record->allocator_address(),
+                           /*is_allocator=*/true,
+                           /*is_active=*/record->allocator_active())) {
+        return overlap;
+      }
+    }
+  }
+  if (include_reservation && include_active) {
+    for (const auto& [_, record] : state.active_reservation_records) {
+      CHECK(record->has_reservation_address());
+      if (auto overlap = check_record(record, record->reservation_address(),
+                                      /*is_allocator=*/false,
+                                      /*is_active=*/true)) {
+        return overlap;
+      }
+    }
+  }
+  if (include_reservation && include_stale) {
+    for (const auto& [_, record] : state.stale_reservation_records) {
+      CHECK(record->has_reservation_address());
+      if (auto overlap = check_record(record, record->reservation_address(),
+                                      /*is_allocator=*/false,
+                                      /*is_active=*/false)) {
+        return overlap;
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+
 absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
                                             DeviceAddressBase addr,
                                             MemoryReservation* reservation,
@@ -829,19 +1147,130 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
         "mapping_size=%uB, allocation_size=%uB",
         size, raw_allocation->address().size()));
   }
-  if (state->active_reservation_records.contains(
-          reservation_address.opaque()) ||
-      state->stale_reservation_records.contains(reservation_address.opaque())) {
-    return absl::FailedPreconditionError(
-        "Reservation address is already tracked by this allocator");
+  auto reject_partial_overlap =
+      [&]() ABSL_NO_THREAD_SAFETY_ANALYSIS -> absl::Status {
+    if (auto overlap = FindOverlappingRecord(
+            *state, reservation_address, /*include_allocator=*/true,
+            /*include_reservation=*/true, /*include_active=*/true,
+            /*include_stale=*/true, /*exact_only=*/false,
+            /*partial_only=*/true)) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "reservation range at %p (%uB) partially overlaps %s %s range at %p "
+          "(%uB); reservation mappings must be managed with the same full "
+          "range",
+          reservation_address.opaque(), reservation_address.size(),
+          overlap->is_active ? "active" : "stale",
+          overlap->is_allocator ? "allocator" : "reservation",
+          overlap->tracked_address.opaque(), overlap->tracked_address.size()));
+    }
+    return absl::OkStatus();
+  };
+  RETURN_IF_ERROR(reject_partial_overlap());
+
+  while (true) {
+    std::optional<PendingDeallocationKey> pending_completion_key;
+
+    if (source_record->reservation_active()) {
+      return absl::AlreadyExistsError(absl::StrFormat(
+          "allocator address %p already has an active reservation mapping at "
+          "%p",
+          addr.opaque(), source_record->reservation_address().opaque()));
+    }
+
+    if (source_record->reservation_stale()) {
+      CHECK(source_record->has_reservation_address());
+      if (!source_record->reservation_matches(reservation_address)) {
+        pending_completion_key =
+            PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                   source_record->reservation_stale_seqno(),
+                                   source_record->reservation_address()};
+      }
+    }
+
+    if (!pending_completion_key.has_value()) {
+      auto stale_reservation_overlap = FindOverlappingRecord(
+          *state, reservation_address, /*include_allocator=*/false,
+          /*include_reservation=*/true, /*include_active=*/false,
+          /*include_stale=*/true, /*exact_only=*/true,
+          /*partial_only=*/false);
+      if (stale_reservation_overlap.has_value()) {
+        AllocationRecord& stale_record = *stale_reservation_overlap->record;
+
+        // UnMap() defers destroying the ScopedMapping until the GPU reaches the
+        // recorded stream point. If the caller maps the same reservation
+        // address to the same raw allocation before that point, the old mapping
+        // is still valid; move it back to the active maps instead of unmapping
+        // and remapping.
+        CHECK(stale_record.has_reservation_address());
+        CHECK(stale_record.reservation_matches(reservation_address));
+        if (stale_record.raw_allocation() == raw_allocation) {
+          MoveReservationRecordToActive(*state, stale_record);
+          ErasePendingDeallocation(*state, PendingDeallocationKind::kMap,
+                                   reservation_address);
+          return absl::OkStatus();
+        }
+
+        // The same reservation address is waiting to unmap from a different raw
+        // allocation. Creating a new mapping now would overwrite an in-flight
+        // mapping that earlier GPU work may still use, so wait until that
+        // deferred unmap has completed, then rescan from the start.
+        pending_completion_key =
+            PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                   stale_record.reservation_stale_seqno(),
+                                   stale_record.reservation_address()};
+      } else {
+        auto stale_allocator_overlap = FindOverlappingRecord(
+            *state, reservation_address, /*include_allocator=*/true,
+            /*include_reservation=*/false, /*include_active=*/false,
+            /*include_stale=*/true, /*exact_only=*/true,
+            /*partial_only=*/false);
+        if (stale_allocator_overlap.has_value()) {
+          AllocationRecord& stale_record = *stale_allocator_overlap->record;
+          pending_completion_key =
+              PendingDeallocationKey{stale_record.pending_deallocation_kind(),
+                                     stale_record.allocator_stale_seqno(),
+                                     stale_record.allocator_address()};
+        }
+      }
+    }
+
+    if (!pending_completion_key.has_value()) {
+      break;
+    }
+    if (pending_completion_key->kind == PendingDeallocationKind::kMap) {
+      RETURN_IF_ERROR(WaitAndCompleteStaleReservationMapping(
+          *state, *pending_completion_key));
+    } else {
+      RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
+          *state, *pending_completion_key));
+    }
+    // Waiting releases the allocator lock. Another thread may have deallocated
+    // or remapped `addr` while this thread was waiting, so resolve it again
+    // before either reactivating another pending unmap or creating a fresh map.
+    ASSIGN_OR_RETURN(source_record, resolve_source_record());
+    raw_allocation = source_record->raw_allocation();
+    RETURN_IF_ERROR(reject_partial_overlap());
+    if (size > raw_allocation->address().size()) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "mapping size must not exceed physical allocation size: "
+          "mapping_size=%uB, allocation_size=%uB",
+          size, raw_allocation->address().size()));
+    }
   }
-  if (source_record->reservation_active()) {
-    return absl::FailedPreconditionError(
-        "Allocator address already has an active reservation alias");
-  }
-  if (source_record->reservation_stale()) {
-    return absl::FailedPreconditionError(
-        "Allocator address already has a pending reservation alias");
+  // A fresh Map() must have exclusive ownership of the reservation address.
+  // Reject active mappings and still-stale deferred mappings before installing
+  // the new ScopedMapping.
+  if (FindOverlappingRecord(*state, reservation_address,
+                            /*include_allocator=*/true,
+                            /*include_reservation=*/true,
+                            /*include_active=*/true,
+                            /*include_stale=*/true,
+                            /*exact_only=*/false,
+                            /*partial_only=*/false)
+          .has_value()) {
+    return absl::AlreadyExistsError(absl::StrFormat(
+        "reservation range is already tracked at virtual address %p",
+        reservation_address.opaque()));
   }
 
   // Install the reservation address mapping to the raw physical allocation. The
@@ -880,6 +1309,18 @@ void DeviceAddressVmmAllocator::ErasePendingDeallocationAt(
   state.pending_deallocations.erase(it);
 }
 
+void DeviceAddressVmmAllocator::ErasePendingDeallocation(
+    PerDeviceState& state, PendingDeallocationKind kind,
+    DeviceAddressBase addr) {
+  for (auto it = state.pending_deallocations.begin();
+       it != state.pending_deallocations.end(); ++it) {
+    if (it->kind == kind && it->addr.IsSameAs(addr)) {
+      ErasePendingDeallocationAt(state, it);
+      return;
+    }
+  }
+}
+
 void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
     PerDeviceState& state, AllocationRecord& record, uint64_t new_size) {
   CHECK(!record.allocator_active());
@@ -903,6 +1344,19 @@ void DeviceAddressVmmAllocator::MoveReservationRecordToStale(
       state.stale_reservation_records.emplace(reservation_va, &record);
   CHECK(insert_result.second);
   record.MarkReservationStale(seqno);
+}
+
+void DeviceAddressVmmAllocator::MoveReservationRecordToActive(
+    PerDeviceState& state, AllocationRecord& record) {
+  CHECK(!record.reservation_active());
+  CHECK(record.reservation_stale());
+  CHECK(record.has_reservation_address());
+  void* reservation_va = record.reservation_key();
+  CHECK_EQ(state.stale_reservation_records.erase(reservation_va), 1);
+  auto insert_result =
+      state.active_reservation_records.emplace(reservation_va, &record);
+  CHECK(insert_result.second);
+  record.ReactivateReservation();
 }
 
 void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
@@ -980,6 +1434,41 @@ bool DeviceAddressVmmAllocator::CompletePendingDeallocationByKey(
     }
   }
   return false;
+}
+
+absl::Status
+DeviceAddressVmmAllocator::WaitAndCompleteStaleAllocatorDeallocation(
+    PerDeviceState& state, const PendingDeallocationKey& key) {
+  CHECK_NE(key.kind, PendingDeallocationKind::kMap);
+  RETURN_IF_ERROR(WaitUntilSeqno(state, key.seqno));
+  CompletePendingDeallocationByKey(state, key);
+  return absl::OkStatus();
+}
+
+absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleReservationMapping(
+    PerDeviceState& state, const PendingDeallocationKey& key) {
+  CHECK_EQ(key.kind, PendingDeallocationKind::kMap);
+  RETURN_IF_ERROR(WaitUntilSeqno(state, key.seqno));
+  CompletePendingDeallocationByKey(state, key);
+  return absl::OkStatus();
+}
+
+absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleOverlap(
+    PerDeviceState& state, const OverlappingRecord& overlap) {
+  CHECK(!overlap.is_active);
+  if (overlap.is_allocator) {
+    AllocationRecord& record = *overlap.record;
+    return WaitAndCompleteStaleAllocatorDeallocation(
+        state, PendingDeallocationKey{record.pending_deallocation_kind(),
+                                      record.allocator_stale_seqno(),
+                                      record.allocator_address()});
+  }
+  CHECK(overlap.record->reservation_stale());
+  CHECK(overlap.record->has_reservation_address());
+  return WaitAndCompleteStaleReservationMapping(
+      state, PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                    overlap.record->reservation_stale_seqno(),
+                                    overlap.record->reservation_address()});
 }
 
 void DeviceAddressVmmAllocator::CompletePendingDeallocation(

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -66,6 +66,44 @@ bool DeviceAddressVmmAllocator::CurrentMultiDevice() {
              1;
 }
 
+DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
+    Kind kind, DeviceAddressBase allocator_address,
+    std::shared_ptr<MemoryAllocation> raw_allocation,
+    std::unique_ptr<MemoryReservation> allocator_address_reservation,
+    MemoryReservation::ScopedMapping allocator_address_mapping,
+    bool multi_device)
+    : kind_(kind),
+      allocator_address_(allocator_address),
+      raw_allocation_(std::move(raw_allocation)),
+      multi_device_(multi_device),
+      allocator_address_reservation_(std::move(allocator_address_reservation)),
+      allocator_address_mapping_(std::move(allocator_address_mapping)) {
+  CHECK(raw_allocation_ != nullptr);
+  CHECK(!allocator_address_.is_null());
+  switch (kind_) {
+    case Kind::kAllocate:
+    case Kind::kAllocateAndMapReturnNewAddr:
+      CHECK(allocator_address_reservation_ != nullptr);
+      break;
+    case Kind::kAllocateAndMapReturnMapAddr:
+      CHECK(allocator_address_reservation_ == nullptr);
+      break;
+  }
+  CHECK(allocator_address_mapping_.has_value());
+}
+
+DeviceAddressBase
+DeviceAddressVmmAllocator::AllocationRecord::reservation_address() const {
+  CHECK(reservation_address_.has_value());
+  return *reservation_address_;
+}
+
+bool DeviceAddressVmmAllocator::AllocationRecord::reservation_mapping_matches(
+    DeviceAddressBase address) const {
+  return reservation_address_mapping_.has_value() &&
+         reservation_address_mapping_->mapped_address().IsSameAs(address);
+}
+
 // Interval between CPU polls of the GPU-written deallocation timeline while
 // waiting for deferred frees to become safe. The 50us value is a conservative
 // initial tradeoff: long enough to avoid busy-spinning a CPU core and short

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -52,6 +52,9 @@ namespace {
 
 thread_local const xla::DeviceAssignment* current_device_assignment = nullptr;
 
+constexpr int64_t kMaxOpenDeallocationBatchEntries = 64;
+constexpr uint64_t kMaxOpenDeallocationBatchBytes = 64ull << 20;
+
 }  // namespace
 
 DeviceAddressVmmAllocator::DeviceAssignmentScope::DeviceAssignmentScope(
@@ -267,11 +270,26 @@ absl::Status DeviceAddressVmmAllocator::PopulateDevices(
 }
 
 DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
-  absl::Status status = SynchronizeAllPendingOperations();
-  CHECK(status.ok()) << status;
-
   for (auto& device : per_device_) {
     auto& state = device.second;
+    uint64_t last_seqno = 0;
+    {
+      absl::MutexLock lock(state->mu);
+      CHECK_EQ(state->open_deallocation_batch_seqno, 0)
+          << "DeviceAddressVmmAllocator subclasses must flush open "
+             "deallocation batches before the base destructor runs.";
+      if (!state->pending_deallocations.empty()) {
+        last_seqno = state->pending_deallocations.back().seqno;
+      }
+    }
+
+    if (last_seqno > 0) {
+      absl::MutexLock lock(state->mu);
+      absl::Status drain_status =
+          WaitAndDrainPendingDeallocationsUntilSeqno(*state, last_seqno);
+      CHECK(drain_status.ok()) << drain_status;
+    }
+
     // Free platform-specific per-device resources (e.g. pinned timeline).
     if (state->destroy_fn) {
       state->destroy_fn();
@@ -281,7 +299,14 @@ DeviceAddressVmmAllocator::~DeviceAddressVmmAllocator() {
 
 absl::Status DeviceAddressVmmAllocator::SynchronizeAllPendingOperations() {
   for (auto& device : per_device_) {
-    RETURN_IF_ERROR(SynchronizePendingOperations(device.first));
+    auto& state = device.second;
+    absl::MutexLock lock(state->mu);
+    RETURN_IF_ERROR(FlushOpenDeallocationBatch(
+        *state, DeallocationBatchFlushReason::kDestructor));
+    if (!state->pending_deallocations.empty()) {
+      RETURN_IF_ERROR(WaitAndDrainPendingDeallocationsUntilSeqno(
+          *state, state->pending_deallocations.back().seqno));
+    }
   }
   return absl::OkStatus();
 }
@@ -320,6 +345,8 @@ absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
     int device_ordinal) {
   ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
   absl::MutexLock lock(state->mu);
+  RETURN_IF_ERROR(
+      FlushOpenDeallocationBatch(*state, DeallocationBatchFlushReason::kSync));
   if (state->pending_deallocations.empty()) {
     return absl::OkStatus();
   }
@@ -474,6 +501,8 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
     // already be past their stream timeline point. Complete ready allocator
     // deallocations first, without blocking for later pending work and without
     // destroying unrelated stale reservation mappings that may be reused.
+    RETURN_IF_ERROR(
+        FlushOpenDeallocationBatch(state, DeallocationBatchFlushReason::kWait));
     CompleteReadyAllocatorDeallocationsForReclaim(
         state, LoadTimeline(state.pinned_timeline));
     result = try_fresh();
@@ -980,12 +1009,12 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
 
   const uint64_t reclaimable_bytes =
       RoundUpToGranularity(*state, record.raw_allocation()->address().size());
+  RETURN_IF_ERROR(
+      FlushOpenDeallocationBatchIfNeededForEntry(*state, reclaimable_bytes));
 
-  // Assign the next sequence number and enqueue a GPU write to the pinned
-  // timeline when the stream reaches this point. The CPU polls the timeline
-  // value to know when it is safe to free the memory.
-  uint64_t seqno = state->next_seqno++;
-  RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
+  // Assign this deferred Deallocate to the current per-device trailing batch.
+  // One stream marker will be enqueued for the whole batch when it is flushed.
+  uint64_t seqno = GetOrCreateOpenDeallocationBatchSeqno(*state);
   // Move the returned allocator address out of active ownership and keep its
   // mapping alive as stale state until the stream reaches `seqno`.
   CHECK(record.allocator_active());
@@ -1000,6 +1029,7 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   state->pending_deallocations.push_back(
       PendingDeallocation{record.pending_deallocation_kind(), seqno,
                           record.allocator_address(), reclaimable_bytes});
+  AddOpenDeallocationBatchEntry(*state, reclaimable_bytes);
   return absl::OkStatus();
 }
 
@@ -1303,10 +1333,92 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
 
 // UnMap/deferred teardown helpers.
 
+absl::Status
+DeviceAddressVmmAllocator::FlushOpenDeallocationBatchIfNeededForEntry(
+    PerDeviceState& state, uint64_t reclaimable_bytes) {
+  if (state.open_deallocation_batch_seqno == 0) {
+    CHECK_EQ(state.open_deallocation_batch_entries, 0);
+    CHECK_EQ(state.open_deallocation_batch_bytes, 0);
+    return absl::OkStatus();
+  }
+
+  CHECK_GT(state.open_deallocation_batch_entries, 0);
+  bool entry_limit =
+      state.open_deallocation_batch_entries >= kMaxOpenDeallocationBatchEntries;
+  bool byte_limit =
+      reclaimable_bytes > 0 && state.open_deallocation_batch_bytes > 0 &&
+      (state.open_deallocation_batch_bytes >= kMaxOpenDeallocationBatchBytes ||
+       reclaimable_bytes > kMaxOpenDeallocationBatchBytes -
+                               state.open_deallocation_batch_bytes);
+  if (!entry_limit && !byte_limit) {
+    return absl::OkStatus();
+  }
+
+  return FlushOpenDeallocationBatch(
+      state, entry_limit ? DeallocationBatchFlushReason::kEntryLimit
+                         : DeallocationBatchFlushReason::kByteLimit);
+}
+
+uint64_t DeviceAddressVmmAllocator::GetOrCreateOpenDeallocationBatchSeqno(
+    PerDeviceState& state) {
+  if (state.open_deallocation_batch_seqno == 0) {
+    CHECK_EQ(state.open_deallocation_batch_entries, 0);
+    CHECK_EQ(state.open_deallocation_batch_bytes, 0);
+    state.open_deallocation_batch_seqno = state.next_seqno++;
+  }
+  return state.open_deallocation_batch_seqno;
+}
+
+void DeviceAddressVmmAllocator::AddOpenDeallocationBatchEntry(
+    PerDeviceState& state, uint64_t reclaimable_bytes) {
+  CHECK_NE(state.open_deallocation_batch_seqno, 0);
+  ++state.open_deallocation_batch_entries;
+  if (std::numeric_limits<uint64_t>::max() -
+          state.open_deallocation_batch_bytes <
+      reclaimable_bytes) {
+    state.open_deallocation_batch_bytes = std::numeric_limits<uint64_t>::max();
+  } else {
+    state.open_deallocation_batch_bytes += reclaimable_bytes;
+  }
+}
+
 void DeviceAddressVmmAllocator::ErasePendingDeallocationAt(
     PerDeviceState& state, std::deque<PendingDeallocation>::iterator it) {
   CHECK(it != state.pending_deallocations.end());
+  if (it->seqno == state.open_deallocation_batch_seqno) {
+    CHECK_GT(state.open_deallocation_batch_entries, 0);
+    --state.open_deallocation_batch_entries;
+    CHECK_GE(state.open_deallocation_batch_bytes, it->reclaimable_bytes);
+    state.open_deallocation_batch_bytes -= it->reclaimable_bytes;
+    if (state.open_deallocation_batch_entries == 0) {
+      state.open_deallocation_batch_seqno = 0;
+      state.open_deallocation_batch_bytes = 0;
+    }
+  }
   state.pending_deallocations.erase(it);
+}
+
+absl::Status DeviceAddressVmmAllocator::FlushOpenDeallocationBatch(
+    PerDeviceState& state, DeallocationBatchFlushReason /*reason*/) {
+  if (state.open_deallocation_batch_seqno == 0) {
+    CHECK_EQ(state.open_deallocation_batch_entries, 0);
+    CHECK_EQ(state.open_deallocation_batch_bytes, 0);
+    return absl::OkStatus();
+  }
+
+  if (state.open_deallocation_batch_entries == 0) {
+    state.open_deallocation_batch_seqno = 0;
+    state.open_deallocation_batch_bytes = 0;
+    return absl::OkStatus();
+  }
+
+  const uint64_t seqno = state.open_deallocation_batch_seqno;
+  RETURN_IF_ERROR(EnqueueDeferredDeallocation(state, seqno));
+
+  state.open_deallocation_batch_seqno = 0;
+  state.open_deallocation_batch_entries = 0;
+  state.open_deallocation_batch_bytes = 0;
+  return absl::OkStatus();
 }
 
 void DeviceAddressVmmAllocator::ErasePendingDeallocation(
@@ -1377,6 +1489,9 @@ void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
 
 absl::Status DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
                                                        uint64_t target_seqno) {
+  RETURN_IF_ERROR(
+      FlushOpenDeallocationBatch(state, DeallocationBatchFlushReason::kWait));
+
   // Release the lock before spin-waiting to avoid stalling other threads for
   // potentially milliseconds while the GPU drains its work queue.
   state.mu.unlock();
@@ -1578,12 +1693,17 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
   }
   CHECK(record->reservation_mapping_matches(reservation_address));
 
-  uint64_t seqno = state->next_seqno++;
-  RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
+  RETURN_IF_ERROR(FlushOpenDeallocationBatchIfNeededForEntry(
+      *state, /*reclaimable_bytes=*/0));
+
+  // Assign this deferred UnMap to the current per-device trailing batch. One
+  // stream marker will be enqueued for the whole batch when it is flushed.
+  uint64_t seqno = GetOrCreateOpenDeallocationBatchSeqno(*state);
   MoveReservationRecordToStale(*state, *record, seqno);
   state->pending_deallocations.push_back(
       PendingDeallocation{PendingDeallocationKind::kMap, seqno,
                           reservation_address, /*reclaimable_bytes=*/0});
+  AddOpenDeallocationBatchEntry(*state, /*reclaimable_bytes=*/0);
   return absl::OkStatus();
 }
 

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -293,28 +293,106 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // Lifetime record for one raw physical allocation. The initial migration adds
   // this next to the existing maps; later changes move allocator and reservation
   // address ownership into this record.
-  struct AllocationRecord {
-    PendingDeallocationKind kind = PendingDeallocationKind::kAllocate;
-    DeviceAddressBase allocator_address;
-    std::shared_ptr<MemoryAllocation> raw_allocation;
-    bool multi_device = false;
+  //
+  // TODO(b/44173): Add transition methods as allocator and reservation
+  // bookkeeping migrate to AllocationRecord. Callers should not directly mutate
+  // record state because allocator-address and reservation-address lifetimes
+  // must move through active/stale/completed states consistently.
+  class AllocationRecord {
+   public:
+    enum class Kind {
+      kAllocate,
+      kAllocateAndMapReturnMapAddr,
+      kAllocateAndMapReturnNewAddr,
+    };
+
+    enum class AllocatorState {
+      kActive,
+      kStale,
+    };
+
+    enum class ReservationState {
+      kNone,
+      kActive,
+      kStale,
+    };
+
+    AllocationRecord(Kind kind, DeviceAddressBase allocator_address,
+                     std::shared_ptr<MemoryAllocation> raw_allocation,
+                     std::unique_ptr<MemoryReservation>
+                         allocator_address_reservation,
+                     MemoryReservation::ScopedMapping allocator_address_mapping,
+                     bool multi_device);
+    AllocationRecord(const AllocationRecord&) = delete;
+    AllocationRecord& operator=(const AllocationRecord&) = delete;
+    AllocationRecord(AllocationRecord&&) = default;
+    AllocationRecord& operator=(AllocationRecord&&) = default;
+
+    Kind kind() const { return kind_; }
+    DeviceAddressBase allocator_address() const { return allocator_address_; }
+    void* allocator_key() const { return allocator_address_.opaque(); }
+    bool allocator_active() const {
+      return allocator_state_ == AllocatorState::kActive;
+    }
+    bool allocator_stale() const {
+      return allocator_state_ == AllocatorState::kStale;
+    }
+    bool allocator_matches(DeviceAddressBase address) const {
+      return allocator_address_.IsSameAs(address);
+    }
+    uint64_t allocator_stale_seqno() const { return allocator_stale_seqno_; }
+    bool multi_device() const { return multi_device_; }
+    MemoryAllocation* raw_allocation() const { return raw_allocation_.get(); }
+    MemoryReservation* allocator_address_reservation() const {
+      return allocator_address_reservation_.get();
+    }
+    bool has_allocator_address_mapping() const {
+      return allocator_address_mapping_.has_value();
+    }
+
+    bool has_reservation_alias() const {
+      return reservation_state_ != ReservationState::kNone;
+    }
+    bool reservation_active() const {
+      return reservation_state_ == ReservationState::kActive;
+    }
+    bool reservation_stale() const {
+      return reservation_state_ == ReservationState::kStale;
+    }
+    bool has_reservation_address() const {
+      return reservation_address_.has_value();
+    }
+    DeviceAddressBase reservation_address() const;
+    void* reservation_key() const { return reservation_address().opaque(); }
+    bool reservation_matches(DeviceAddressBase address) const {
+      return has_reservation_address() &&
+             reservation_address_->IsSameAs(address);
+    }
+    uint64_t reservation_stale_seqno() const {
+      return reservation_stale_seqno_;
+    }
+    bool reservation_mapping_matches(DeviceAddressBase address) const;
+
+   private:
+    Kind kind_;
+    DeviceAddressBase allocator_address_;
+    std::shared_ptr<MemoryAllocation> raw_allocation_;
+    bool multi_device_;
 
     // Present for Allocate() and
     // Allocate(..., return_reservation_address=false).
-    std::unique_ptr<MemoryReservation> allocator_address_reservation;
+    std::unique_ptr<MemoryReservation> allocator_address_reservation_;
     // Present while the allocator address is active or stale.
-    std::optional<MemoryReservation::ScopedMapping> allocator_address_mapping;
+    std::optional<MemoryReservation::ScopedMapping> allocator_address_mapping_;
 
     // Present while a reservation alias is active or stale.
-    std::optional<DeviceAddressBase> reservation_address;
-    std::optional<MemoryReservation::ScopedMapping> reservation_address_mapping;
+    std::optional<DeviceAddressBase> reservation_address_;
+    std::optional<MemoryReservation::ScopedMapping> reservation_address_mapping_;
 
-    bool allocator_active = false;
-    bool allocator_stale = false;
-    bool reservation_active = false;
-    bool reservation_stale = false;
-    uint64_t allocator_stale_seqno = 0;
-    uint64_t reservation_stale_seqno = 0;
+    AllocatorState allocator_state_ = AllocatorState::kActive;
+    ReservationState reservation_state_ = ReservationState::kNone;
+    uint64_t allocator_stale_seqno_ = 0;
+    uint64_t reservation_stale_seqno_ = 0;
   };
 
   struct PerDeviceState {

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -108,24 +108,28 @@ namespace stream_executor {
 // only reservation addresses created by Map() or by
 // Allocate(..., return_reservation_address=false). Passing an allocator address
 // to UnMap(), or a reservation address to Deallocate(), is an error.
-// Each allocator address may have at most one active reservation-address alias.
+// Each allocator address may have at most one active or stale
+// reservation-address alias.
 //
 // Deallocate() and UnMap() are stream-ordered deferred operations. The
-// allocator records a per-device sequence number for the affected address and
-// keeps the old mapping or allocation alive until the stream reaches that
-// sequence number, so kernels already submitted to the stream can keep using
-// the old VA. When the sequence completes, dropping the ScopedMapping objects
-// performs the real unmap, then the allocator releases any owned reservation
-// and raw physical memory.
+// allocator assigns the affected address record a per-device sequence number,
+// moves it from active tracking to stale tracking, and appends a pending entry
+// with the operation kind, sequence number, and address. The stale
+// AllocationRecord keeps the raw allocation, any allocator-owned reservation,
+// and ScopedMapping objects alive until the stream reaches that sequence
+// number, so kernels already submitted to the stream can keep using the old VA.
+// When the sequence completes, dropping the ScopedMapping objects performs the
+// real unmap, then the allocator releases any owned reservation and raw
+// physical memory.
 //
-// Concrete subclasses implement the platform-specific virtual methods
+// Each registered device has independent state protected by its own mutex, so
+// operations on different devices can proceed in parallel. The per-device map
+// is populated at construction time and is not modified afterward. Concrete
+// subclasses implement the platform-specific virtual methods
 // (InitializeDeviceState, CreateAllocation, CreateReservation,
 // EnqueueDeferredDeallocation) and expose platform-specific Create() factories.
 // Subclasses must also set PerDeviceState::destroy_fn in InitializeDeviceState
 // to release platform-specific resources such as pinned timeline memory.
-//
-// This allocator is thread-safe for concurrent use by multiple threads across
-// any registered devices.
 class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
  public:
   // Per-device configuration supplied at construction.
@@ -221,7 +225,8 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // range until all previously enqueued work on the allocator stream has
   // completed.
   // The caller must pass the same full reservation range that created the
-  // mapping. The reservation-derived allocator address returned by
+  // mapping.
+  // The reservation-derived allocator address returned by
   // Allocate(..., return_reservation_address=true) is not a reservation
   // address for this API and must be released with Deallocate() instead.
   //
@@ -285,37 +290,14 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     kMap,
   };
 
-  struct PendingDeallocation {
-    PendingDeallocationKind kind = PendingDeallocationKind::kAllocate;
-    // GPU stream sequence number recorded at deallocation time. When the
-    // pinned_timeline value reaches this seqno, the memory is safe to free.
-    uint64_t seqno = 0;
-    // Allocator address for allocation deallocations; reservation address for
-    // kMap.
-    DeviceAddressBase addr;
-    // Rounded physical-allocation bytes that become reclaimable when this
-    // pending operation completes. kMap entries do not own physical memory and
-    // therefore use zero.
-    uint64_t reclaimable_bytes = 0;
-  };
-
-  struct ReservationMapping {
-    DeviceAddressBase allocator_address;
-    DeviceAddressBase reservation_address;
-    MemoryReservation* reservation = nullptr;
-    uint64_t reservation_offset = 0;
-    uint64_t size = 0;
-    MemoryReservation::ScopedMapping scoped_mapping;
-  };
-
-  // Lifetime record for one raw physical allocation. The initial migration adds
-  // this next to the existing maps; later changes move allocator and reservation
-  // address ownership into this record.
+  // Lifetime record for one raw physical allocation.
   //
-  // TODO(b/44173): Add reservation-address transition methods as reservation
-  // bookkeeping migrates to AllocationRecord. Callers should not directly
-  // mutate record state because allocator-address and reservation-address
-  // lifetimes must move through active/stale/completed states consistently.
+  // The record is owned by records_by_allocator_address while either the
+  // allocator address or a reservation-address alias is active, stale, or
+  // pending completion. Active indexes are callable by public APIs. Stale
+  // indexes are no longer callable by users, but still keep mappings alive
+  // until the stream-ordered deferred operation completes or a later Allocate()
+  // or Map() reuses them.
   class AllocationRecord {
    public:
     enum class Kind {
@@ -335,12 +317,12 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       kStale,
     };
 
-    AllocationRecord(Kind kind, DeviceAddressBase allocator_address,
-                     std::shared_ptr<MemoryAllocation> raw_allocation,
-                     std::unique_ptr<MemoryReservation>
-                         allocator_address_reservation,
-                     MemoryReservation::ScopedMapping allocator_address_mapping,
-                     bool multi_device);
+    AllocationRecord(
+        Kind kind, DeviceAddressBase allocator_address,
+        std::shared_ptr<MemoryAllocation> raw_allocation,
+        std::unique_ptr<MemoryReservation> allocator_address_reservation,
+        MemoryReservation::ScopedMapping allocator_address_mapping,
+        bool multi_device);
     AllocationRecord(const AllocationRecord&) = delete;
     AllocationRecord& operator=(const AllocationRecord&) = delete;
     AllocationRecord(AllocationRecord&&) = default;
@@ -396,6 +378,13 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     void ReactivateAllocator(uint64_t new_size);
     void CompleteStaleAllocator();
 
+    void AddActiveReservationAlias(
+        DeviceAddressBase reservation_address,
+        MemoryReservation::ScopedMapping reservation_address_mapping);
+    void MarkReservationStale(uint64_t seqno);
+    void ReactivateReservation();
+    void CompleteStaleReservation();
+
    private:
     Kind kind_;
     DeviceAddressBase allocator_address_;
@@ -410,12 +399,39 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
     // Present while a reservation alias is active or stale.
     std::optional<DeviceAddressBase> reservation_address_;
-    std::optional<MemoryReservation::ScopedMapping> reservation_address_mapping_;
+    std::optional<MemoryReservation::ScopedMapping>
+        reservation_address_mapping_;
 
     AllocatorState allocator_state_ = AllocatorState::kActive;
     ReservationState reservation_state_ = ReservationState::kNone;
     uint64_t allocator_stale_seqno_ = 0;
     uint64_t reservation_stale_seqno_ = 0;
+  };
+
+  // Queue entry for a stream-ordered deferred operation. The heavy resources
+  // live in AllocationRecord; this entry only says which stale address becomes
+  // safe to complete when the GPU timeline reaches `seqno`.
+  struct PendingDeallocation {
+    PendingDeallocationKind kind = PendingDeallocationKind::kAllocate;
+    // GPU stream sequence number recorded at deallocation time. When the
+    // pinned_timeline value reaches this seqno, the memory is safe to free.
+    uint64_t seqno = 0;
+    // Allocator address for allocation deallocations; reservation address for
+    // kMap.
+    DeviceAddressBase addr;
+    // Rounded physical-allocation bytes that become reclaimable when this
+    // pending operation completes. kMap entries do not own physical memory and
+    // therefore use zero.
+    uint64_t reclaimable_bytes = 0;
+  };
+
+  // Stable identity for a pending operation. Iterators into
+  // pending_deallocations must not be kept across waits because
+  // WaitUntilSeqno() releases state.mu.
+  struct PendingDeallocationKey {
+    PendingDeallocationKind kind = PendingDeallocationKind::kAllocate;
+    uint64_t seqno = 0;
+    DeviceAddressBase addr;
   };
 
   struct PerDeviceState {
@@ -449,11 +465,21 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     // Monotonically increasing counter for timeline sequence numbers.
     uint64_t next_seqno ABSL_GUARDED_BY(mu) = 1;
     std::deque<PendingDeallocation> pending_deallocations ABSL_GUARDED_BY(mu);
+    // Owns AllocationRecord objects. Key is the allocator address pointer
+    // (`AllocationRecord::allocator_address().opaque()`), including the
+    // reservation-derived allocator address returned by
+    // Allocate(..., return_reservation_address=true). Allocator-address
+    // active/stale state is stored in
+    // AllocationRecord::allocator_active()/allocator_stale().
     absl::flat_hash_map<void*, std::unique_ptr<AllocationRecord>>
         records_by_allocator_address ABSL_GUARDED_BY(mu);
-    absl::flat_hash_map<void*, ReservationMapping> active_reservation_mappings
+
+    // Active/stale reservation-address indexes. Keys are reservation alias
+    // pointers (`AllocationRecord::reservation_address().opaque()`) created by
+    // Map() or by Allocate(..., return_reservation_address=false).
+    absl::flat_hash_map<void*, AllocationRecord*> active_reservation_records
         ABSL_GUARDED_BY(mu);
-    absl::flat_hash_map<void*, ReservationMapping> stale_reservation_mappings
+    absl::flat_hash_map<void*, AllocationRecord*> stale_reservation_records
         ABSL_GUARDED_BY(mu);
   };
 
@@ -468,7 +494,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   static absl::Status PopulateDevices(DeviceAddressVmmAllocator* allocator,
                                       absl::Span<const DeviceConfig> devices);
 
-  // Drains pending stream-ordered allocator operations for all devices.
+  // Drains all pending operations for all devices.
   absl::Status SynchronizeAllPendingOperations();
 
   // Validates device capabilities and initializes timeline fields
@@ -485,16 +511,25 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
                                                    uint64_t seqno) = 0;
 
  private:
+  // Common helpers.
+
   // Returns pointer into per_device_ map, or NotFound if device_ordinal is not
   // registered. No lock needed: per_device_ is read-only after construction.
   absl::StatusOr<PerDeviceState*> GetPerDeviceState(int device_ordinal) const;
 
-  // Validates a caller-owned reservation slice and returns the corresponding
-  // DeviceAddressBase.
-  absl::StatusOr<DeviceAddressBase> ValidateReservationRange(
-      MemoryReservation* reservation, uint64_t reservation_offset,
-      uint64_t size) const;
+  // Round up size to the device's allocation granularity.
+  uint64_t RoundUpToGranularity(const PerDeviceState& state,
+                                uint64_t size) const;
 
+  // True iff the calling thread is inside a multi-device DeviceAssignmentScope.
+  static bool CurrentMultiDevice();
+
+  // Allocate helpers.
+
+  // Records a raw allocation mapped at an owning allocator address. Takes
+  // ownership of `reservation` when the allocator address was allocator-owned;
+  // reservation-backed returned addresses pass nullptr here. Charges
+  // `allocated_size` to the PA budget and returns the allocator VA pointer.
   void* TrackAllocatorAddressMappedAllocation(
       PerDeviceState& state, AllocationRecord::Kind kind,
       DeviceAddressBase allocator_address,
@@ -503,53 +538,83 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       MemoryReservation::ScopedMapping mapping, uint64_t allocated_size,
       bool multi_device) ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  absl::StatusOr<DeviceAddressBase> AllocateWithBudget(PerDeviceState& state,
-                                                       uint64_t size,
-                                                       bool multi_device)
+  // Shared allocation retry policy. First calls `try_reuse` to reactivate
+  // compatible pending state without blocking, then calls `try_fresh`. On
+  // ResourceExhausted, it completes ready pending entries and, if needed, waits
+  // for enough pending frees to reclaim approximately `reclaim_size` bytes.
+  template <typename TryReuseFn, typename TryFreshFn>
+  absl::StatusOr<DeviceAddressBase> TryWithPendingReclaim(PerDeviceState& state,
+                                                          uint64_t reclaim_size,
+                                                          TryReuseFn try_reuse,
+                                                          TryFreshFn try_fresh)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  // Process any pending deallocations whose timeline sequence numbers have
-  // been passed by the GPU.
-  void ProcessCompletedPendingDeallocations(PerDeviceState& state)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+  // Map helpers.
 
-  // Wait for enough pending deallocations to complete to free at least 'size'
-  // bytes. Selects deallocations from the front of the queue until their
-  // cumulative size meets or exceeds the requested size, then spin-waits on
-  // the GPU timeline counter and performs the deallocations.
-  // Temporarily releases and reacquires state.mu around the blocking wait.
-  void WaitPendingDeallocationsToComplete(PerDeviceState& state, uint64_t size)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+  // Validates a caller-owned reservation slice and returns the corresponding
+  // DeviceAddressBase. Rejects null reservations and out-of-bounds
+  // offset/size pairs before any allocator bookkeeping is mutated.
+  absl::StatusOr<DeviceAddressBase> ValidateReservationRange(
+      MemoryReservation* reservation, uint64_t reservation_offset,
+      uint64_t size) const;
 
-  // Actually perform the synchronous deallocation.
-  void DoDeallocate(PerDeviceState& state, DeviceAddressBase mem)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+  // UnMap/deferred teardown helpers.
 
-  // Actually perform the synchronous unmap for a stale reservation alias.
-  void DoUnMap(PerDeviceState& state, DeviceAddressBase mem)
+  // Removes a pending entry when a stale record is reused.
+  void ErasePendingDeallocationAt(PerDeviceState& state,
+                                  std::deque<PendingDeallocation>::iterator it)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   void MoveAllocatorRecordToActive(PerDeviceState& state,
                                    AllocationRecord& record, uint64_t new_size)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  // Try to reuse a pending deallocation with matching rounded size.
-  // Returns the reused address if found, or std::nullopt if no match.
-  // Reuse is safe because any new work submitted after Allocate() returns is
-  // enqueued on the same stream after the recorded deallocation event, so GPU
-  // stream ordering guarantees the old work finishes before the new work runs.
-  std::optional<DeviceAddressBase> TryReusePendingDeallocation(
-      PerDeviceState& state, uint64_t size, bool multi_device)
+  void MoveReservationRecordToStale(PerDeviceState& state,
+                                    AllocationRecord& record, uint64_t seqno)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  // True iff the calling thread is inside a multi-device DeviceAssignmentScope.
-  static bool CurrentMultiDevice();
+  void CompleteStaleReservationMapping(PerDeviceState& state,
+                                       AllocationRecord& record)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  // Round up size to the device's allocation granularity.
-  uint64_t RoundUpToGranularity(const PerDeviceState& state,
-                                uint64_t size) const;
+  // Waits for the device timeline to reach `target_seqno`. Temporarily releases
+  // and reacquires state.mu around the blocking wait. This does not complete
+  // pending entries by itself.
+  absl::Status WaitUntilSeqno(PerDeviceState& state, uint64_t target_seqno)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  // Populated at construction; never modified. Safe to read without a lock.
+  // Waits for pending operations through `target_seqno`, then completes all
+  // still-pending operations up to that sequence. Used only when preserving
+  // stale mappings for future reuse is no longer useful.
+  absl::Status WaitAndDrainPendingDeallocationsUntilSeqno(PerDeviceState& state,
+                                                          uint64_t target_seqno)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Completes ready allocator-address deallocations for PA reclaim while
+  // leaving unrelated kMap entries stale and reusable.
+  void CompleteReadyAllocatorDeallocationsForReclaim(PerDeviceState& state,
+                                                     uint64_t completed_seqno)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Completes a pending operation whose stream sequence has passed by dropping
+  // its ScopedMappings, allocator-owned reservation, and raw allocation
+  // reference. This is where VA unmap, reservation release, and PA budget
+  // accounting happen.
+  void CompletePendingDeallocation(PerDeviceState& state,
+                                   const PendingDeallocation& pending)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Finds, erases, and completes the selected pending entry if it is still
+  // present. Returns false if another thread already reused or completed it
+  // while state.mu was released.
+  bool CompletePendingDeallocationByKey(PerDeviceState& state,
+                                        const PendingDeallocationKey& key)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Device ordinal -> per-device allocator state. Populated at construction by
+  // PopulateDevices() and never modified afterward, so map lookup is safe
+  // without an allocator-wide lock. Each PerDeviceState owns its own mutex for
+  // mutable allocation and pending-deallocation state.
   absl::flat_hash_map<int, std::unique_ptr<PerDeviceState>> per_device_;
 };
 

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -114,9 +114,11 @@ namespace stream_executor {
 // stale reservation mapping are rejected.
 //
 // Deallocate() and UnMap() are stream-ordered deferred operations. The
-// allocator assigns the affected address record a per-device sequence number,
-// moves it from active tracking to stale tracking, and appends a pending entry
-// with the operation kind, sequence number, and address. The stale
+// allocator assigns the affected address record a per-device batch sequence
+// number, moves it from active tracking to stale tracking, and appends a
+// pending entry with the operation kind, sequence number, and address. A
+// trailing timeline write is enqueued for the open batch when the allocator
+// needs to observe the timeline or when the batch limit is reached. The stale
 // AllocationRecord keeps the raw allocation, any allocator-owned reservation,
 // and ScopedMapping objects alive until the stream reaches that sequence
 // number, so kernels already submitted to the stream can keep using the old VA.
@@ -475,6 +477,24 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     uint64_t pa_allocated ABSL_GUARDED_BY(mu) = 0;
     // Monotonically increasing counter for timeline sequence numbers.
     uint64_t next_seqno ABSL_GUARDED_BY(mu) = 1;
+    // Open trailing batch of deferred deallocations. Pending entries in the
+    // open batch have been moved to stale state but do not have a stream
+    // timeline write yet. We batch because many Deallocate()/UnMap() calls can
+    // be issued back-to-back on the host, and one stream marker is enough to
+    // protect all stale mappings in that host-side batch. This avoids paying a
+    // GPU timeline write for every individual address.
+    //
+    // Example, starting with next_seqno=1 and no open batch:
+    //   Deallocate(A) creates open batch seqno 1, records A -> 1, next_seqno=2.
+    //   UnMap(R) reuses open batch seqno 1, records R -> 1.
+    //   Deallocate(B) also records B -> 1.
+    //   FlushOpenDeallocationBatch() enqueues one stream write for seqno 1 and
+    //   resets open_deallocation_batch_seqno to 0. A/R/B remain pending with
+    //   seqno 1 until the device timeline reaches 1.
+    //   The next deferred operation opens a new batch with seqno 2.
+    uint64_t open_deallocation_batch_seqno ABSL_GUARDED_BY(mu) = 0;
+    int64_t open_deallocation_batch_entries ABSL_GUARDED_BY(mu) = 0;
+    uint64_t open_deallocation_batch_bytes ABSL_GUARDED_BY(mu) = 0;
     std::deque<PendingDeallocation> pending_deallocations ABSL_GUARDED_BY(mu);
     // Owns AllocationRecord objects. Key is the allocator address pointer
     // (`AllocationRecord::allocator_address().opaque()`), including the
@@ -505,7 +525,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   static absl::Status PopulateDevices(DeviceAddressVmmAllocator* allocator,
                                       absl::Span<const DeviceConfig> devices);
 
-  // Drains all pending operations for all devices.
+  // Flushes open deallocation batches and drains all pending operations for all
+  // devices. Subclasses with platform-specific timeline enqueue implementations
+  // must call this from their destructor before the base destructor runs.
   absl::Status SynchronizeAllPendingOperations();
 
   // Validates device capabilities and initializes timeline fields
@@ -522,6 +544,14 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
                                                    uint64_t seqno) = 0;
 
  private:
+  enum class DeallocationBatchFlushReason {
+    kEntryLimit,
+    kByteLimit,
+    kWait,
+    kSync,
+    kDestructor,
+  };
+
   // Common helpers.
 
   // Returns pointer into per_device_ map, or NotFound if device_ordinal is not
@@ -587,9 +617,34 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   // UnMap/deferred teardown helpers.
 
-  // Removes a pending entry when a stale record is reused.
+  // Flushes the current open deallocation batch before adding a new entry if
+  // keeping it open would exceed the configured entry or reclaimable-byte
+  // limit.
+  absl::Status FlushOpenDeallocationBatchIfNeededForEntry(
+      PerDeviceState& state, uint64_t reclaimable_bytes)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Returns the sequence number for the current open deallocation batch,
+  // creating a new batch if necessary.
+  uint64_t GetOrCreateOpenDeallocationBatchSeqno(PerDeviceState& state)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Records that a pending entry was added to the current open deallocation
+  // batch. The batch sequence must already have been created.
+  void AddOpenDeallocationBatchEntry(PerDeviceState& state,
+                                     uint64_t reclaimable_bytes)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Removes pending entries while maintaining open-batch counters for entries
+  // that have not yet received their trailing stream marker.
   void ErasePendingDeallocationAt(PerDeviceState& state,
                                   std::deque<PendingDeallocation>::iterator it)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Enqueues one stream timeline write for the current open deallocation batch,
+  // if any pending entries remain in that batch.
+  absl::Status FlushOpenDeallocationBatch(PerDeviceState& state,
+                                          DeallocationBatchFlushReason reason)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Removes the matching pending entry when a stale record is reused.

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -268,17 +268,35 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
  protected:
   enum class PendingDeallocationKind {
+    // Deferred Deallocate() of an Allocate() result backed by an
+    // allocator-owned reservation.
     kAllocate,
+    // Deferred Deallocate() of an
+    // Allocate(..., return_reservation_address=true) result. The allocator
+    // address is a caller-owned reservation range.
+    kAllocateAndMapReturnMapAddr,
+    // Deferred Deallocate() of an
+    // Allocate(..., return_reservation_address=false) result. The record has
+    // an allocator-owned returned address and may also have a non-owning caller
+    // reservation mapping to unmap.
+    kAllocateAndMapReturnNewAddr,
+    // Deferred completion of a Map()-owned reservation address. The reservation
+    // address is a non-owning alias of an existing raw allocation.
     kMap,
   };
 
   struct PendingDeallocation {
     PendingDeallocationKind kind = PendingDeallocationKind::kAllocate;
-    DeviceAddressBase mem;
     // GPU stream sequence number recorded at deallocation time. When the
     // pinned_timeline value reaches this seqno, the memory is safe to free.
     uint64_t seqno = 0;
-    bool multi_device = false;
+    // Allocator address for allocation deallocations; reservation address for
+    // kMap.
+    DeviceAddressBase addr;
+    // Rounded physical-allocation bytes that become reclaimable when this
+    // pending operation completes. kMap entries do not own physical memory and
+    // therefore use zero.
+    uint64_t reclaimable_bytes = 0;
   };
 
   struct ReservationMapping {
@@ -294,10 +312,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // this next to the existing maps; later changes move allocator and reservation
   // address ownership into this record.
   //
-  // TODO(b/44173): Add transition methods as allocator and reservation
-  // bookkeeping migrate to AllocationRecord. Callers should not directly mutate
-  // record state because allocator-address and reservation-address lifetimes
-  // must move through active/stale/completed states consistently.
+  // TODO(b/44173): Add reservation-address transition methods as reservation
+  // bookkeeping migrates to AllocationRecord. Callers should not directly
+  // mutate record state because allocator-address and reservation-address
+  // lifetimes must move through active/stale/completed states consistently.
   class AllocationRecord {
    public:
     enum class Kind {
@@ -329,6 +347,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     AllocationRecord& operator=(AllocationRecord&&) = default;
 
     Kind kind() const { return kind_; }
+    PendingDeallocationKind pending_deallocation_kind() const;
     DeviceAddressBase allocator_address() const { return allocator_address_; }
     void* allocator_key() const { return allocator_address_.opaque(); }
     bool allocator_active() const {
@@ -372,6 +391,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       return reservation_stale_seqno_;
     }
     bool reservation_mapping_matches(DeviceAddressBase address) const;
+
+    void MarkAllocatorStale(uint64_t seqno);
+    void ReactivateAllocator(uint64_t new_size);
+    void CompleteStaleAllocator();
 
    private:
     Kind kind_;
@@ -426,14 +449,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     // Monotonically increasing counter for timeline sequence numbers.
     uint64_t next_seqno ABSL_GUARDED_BY(mu) = 1;
     std::deque<PendingDeallocation> pending_deallocations ABSL_GUARDED_BY(mu);
-    absl::flat_hash_map<void*, std::unique_ptr<MemoryAllocation>>
-        raw_allocations ABSL_GUARDED_BY(mu);
-    absl::flat_hash_map<void*, std::unique_ptr<MemoryReservation>> reservations
-        ABSL_GUARDED_BY(mu);
-    absl::flat_hash_map<void*, MemoryReservation::ScopedMapping> scoped_mappings
-        ABSL_GUARDED_BY(mu);
-    absl::flat_hash_map<void*, bool> multi_device_allocations
-        ABSL_GUARDED_BY(mu);
     absl::flat_hash_map<void*, std::unique_ptr<AllocationRecord>>
         records_by_allocator_address ABSL_GUARDED_BY(mu);
     absl::flat_hash_map<void*, ReservationMapping> active_reservation_mappings
@@ -480,8 +495,17 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       MemoryReservation* reservation, uint64_t reservation_offset,
       uint64_t size) const;
 
+  void* TrackAllocatorAddressMappedAllocation(
+      PerDeviceState& state, AllocationRecord::Kind kind,
+      DeviceAddressBase allocator_address,
+      std::shared_ptr<MemoryAllocation> raw_allocation,
+      std::unique_ptr<MemoryReservation> reservation,
+      MemoryReservation::ScopedMapping mapping, uint64_t allocated_size,
+      bool multi_device) ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
   absl::StatusOr<DeviceAddressBase> AllocateWithBudget(PerDeviceState& state,
-                                                       uint64_t size)
+                                                       uint64_t size,
+                                                       bool multi_device)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Process any pending deallocations whose timeline sequence numbers have
@@ -503,6 +527,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   // Actually perform the synchronous unmap for a stale reservation alias.
   void DoUnMap(PerDeviceState& state, DeviceAddressBase mem)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  void MoveAllocatorRecordToActive(PerDeviceState& state,
+                                   AllocationRecord& record, uint64_t new_size)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Try to reuse a pending deallocation with matching rounded size.

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -108,8 +108,10 @@ namespace stream_executor {
 // only reservation addresses created by Map() or by
 // Allocate(..., return_reservation_address=false). Passing an allocator address
 // to UnMap(), or a reservation address to Deallocate(), is an error.
-// Each allocator address may have at most one active or stale
-// reservation-address alias.
+// Each allocator address may have at most one active reservation-address alias.
+// A reservation mapping is owned as the same full range that created it:
+// partial UnMap(), Map(), or Allocate() operations that overlap an active or
+// stale reservation mapping are rejected.
 //
 // Deallocate() and UnMap() are stream-ordered deferred operations. The
 // allocator assigns the affected address record a per-device sequence number,
@@ -121,6 +123,15 @@ namespace stream_executor {
 // When the sequence completes, dropping the ScopedMapping objects performs the
 // real unmap, then the allocator releases any owned reservation and raw
 // physical memory.
+//
+// Stale records are also the fast reuse path. Allocate() first looks for a
+// compatible stale allocator address before creating new VMM state. Map() does
+// the same for a stale reservation mapping: if the requested reservation
+// address is still mapped to the same raw physical allocation, the allocator
+// reactivates the old mapping instead of unmapping and remapping. If a
+// requested reservation address is still stale for a different raw allocation,
+// Map() waits for that deferred unmap to complete before installing the new
+// mapping.
 //
 // Each registered device has independent state protected by its own mutex, so
 // operations on different devices can proceed in parallel. The per-device map
@@ -225,7 +236,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // range until all previously enqueued work on the allocator stream has
   // completed.
   // The caller must pass the same full reservation range that created the
-  // mapping.
+  // mapping; partial ranges that overlap a tracked mapping are rejected.
   // The reservation-derived allocator address returned by
   // Allocate(..., return_reservation_address=true) is not a reservation
   // address for this API and must be released with Deallocate() instead.
@@ -558,11 +569,33 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       MemoryReservation* reservation, uint64_t reservation_offset,
       uint64_t size) const;
 
+  struct OverlappingRecord {
+    AllocationRecord* record = nullptr;
+    DeviceAddressBase tracked_address;
+    bool is_allocator = false;
+    bool is_active = false;
+  };
+
+  // Finds a tracked allocator or reservation range that overlaps `address`.
+  // `exact_only` returns only identical ranges; `partial_only` returns only
+  // non-identical overlapping ranges; both false returns any overlap.
+  std::optional<OverlappingRecord> FindOverlappingRecord(
+      PerDeviceState& state, DeviceAddressBase address, bool include_allocator,
+      bool include_reservation, bool include_active, bool include_stale,
+      bool exact_only, bool partial_only) const
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
   // UnMap/deferred teardown helpers.
 
   // Removes a pending entry when a stale record is reused.
   void ErasePendingDeallocationAt(PerDeviceState& state,
                                   std::deque<PendingDeallocation>::iterator it)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Removes the matching pending entry when a stale record is reused.
+  void ErasePendingDeallocation(PerDeviceState& state,
+                                PendingDeallocationKind kind,
+                                DeviceAddressBase addr)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   void MoveAllocatorRecordToActive(PerDeviceState& state,
@@ -571,6 +604,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   void MoveReservationRecordToStale(PerDeviceState& state,
                                     AllocationRecord& record, uint64_t seqno)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  void MoveReservationRecordToActive(PerDeviceState& state,
+                                     AllocationRecord& record)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   void CompleteStaleReservationMapping(PerDeviceState& state,
@@ -609,6 +646,24 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // while state.mu was released.
   bool CompletePendingDeallocationByKey(PerDeviceState& state,
                                         const PendingDeallocationKey& key)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Waits for and completes the selected allocator-address deallocation, if it
+  // is still pending after the wait.
+  absl::Status WaitAndCompleteStaleAllocatorDeallocation(
+      PerDeviceState& state, const PendingDeallocationKey& key)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Waits for and completes a stale reservation-address mapping queued by
+  // UnMap().
+  absl::Status WaitAndCompleteStaleReservationMapping(
+      PerDeviceState& state, const PendingDeallocationKey& key)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Completes only the stale allocator or reservation mapping that conflicts
+  // with the current request, leaving unrelated stale mappings reusable.
+  absl::Status WaitAndCompleteStaleOverlap(PerDeviceState& state,
+                                           const OverlappingRecord& overlap)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Device ordinal -> per-device allocator state. Populated at construction by

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -16,11 +16,13 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_DEVICE_ADDRESS_VMM_ALLOCATOR_H_
 #define XLA_STREAM_EXECUTOR_DEVICE_ADDRESS_VMM_ALLOCATOR_H_
 
+#include <atomic>
 #include <cstdint>
 #include <deque>
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
@@ -544,6 +546,40 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
                                                    uint64_t seqno) = 0;
 
  private:
+  struct DebugStats {
+    std::atomic<uint64_t> allocate_calls{0};
+    std::atomic<uint64_t> allocate_allocation_reuse{0};
+
+    std::atomic<uint64_t> mapped_allocate_return_reservation_address_calls{0};
+    std::atomic<uint64_t>
+        mapped_allocate_return_reservation_address_allocation_reuse{0};
+    std::atomic<uint64_t>
+        mapped_allocate_return_reservation_address_allocator_va_reuse{0};
+
+    std::atomic<uint64_t> mapped_allocate_return_allocator_address_calls{0};
+    std::atomic<uint64_t>
+        mapped_allocate_return_allocator_address_allocation_reuse{0};
+    std::atomic<uint64_t>
+        mapped_allocate_return_allocator_address_allocator_va_reuse{0};
+    std::atomic<uint64_t>
+        mapped_allocate_return_allocator_address_reservation_va_reuse{0};
+
+    std::atomic<uint64_t> map_calls{0};
+    std::atomic<uint64_t> map_reservation_va_reuse{0};
+
+    std::atomic<uint64_t> deallocate_calls{0};
+    std::atomic<uint64_t> unmap_calls{0};
+
+    std::atomic<uint64_t> deallocation_batch_flushes{0};
+    std::atomic<uint64_t> deallocation_batch_flushes_by_entry_limit{0};
+    std::atomic<uint64_t> deallocation_batch_flushes_by_byte_limit{0};
+    std::atomic<uint64_t> deallocation_batch_flushes_by_wait{0};
+    std::atomic<uint64_t> deallocation_batch_flushes_by_sync{0};
+    std::atomic<uint64_t> deallocation_batch_flushes_by_destructor{0};
+    std::atomic<uint64_t> deallocation_batch_entries_flushed{0};
+    std::atomic<uint64_t> deallocation_batch_bytes_flushed{0};
+  };
+
   enum class DeallocationBatchFlushReason {
     kEntryLimit,
     kByteLimit,
@@ -551,6 +587,8 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     kSync,
     kDestructor,
   };
+
+  std::string DebugStatsTable() const;
 
   // Common helpers.
 
@@ -726,6 +764,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // without an allocator-wide lock. Each PerDeviceState owns its own mutex for
   // mutable allocation and pending-deallocation state.
   absl::flat_hash_map<int, std::unique_ptr<PerDeviceState>> per_device_;
+  DebugStats debug_stats_;
 };
 
 }  // namespace stream_executor


### PR DESCRIPTION
📝 Summary of Changes
Adds debug counters and a formatted VLOG table for VMM allocator API calls, reuse outcomes, and deferred-deallocation batch flushing.

🎯 Justification
This keeps observability out of the behavioral PRs while preserving the same final content as the original extracted PR.

🚀 Kind of Contribution
♻️ Cleanup

📊 Benchmark (for Performance Improvements)
N/A.

🧪 Unit Tests:
No new tests were added. Validation: `bazel build //xla/stream_executor:device_address_vmm_allocator //xla/stream_executor/cuda:cuda_device_address_vmm_allocator` passed on the final stack.

🧪 Execution Tests:
Not run locally.
