### PR TITLE
[XLA:GPU] Add VMM allocator stale mapping reuse

### DIFF
--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -212,6 +213,26 @@ static uint64_t LoadTimeline(const volatile uint64_t* pinned_timeline) {
   return __atomic_load_n(pinned_timeline, __ATOMIC_ACQUIRE);
 }
 
+static uintptr_t AddressStart(DeviceAddressBase address) {
+  return reinterpret_cast<uintptr_t>(address.opaque());
+}
+
+static uintptr_t AddressEnd(DeviceAddressBase address) {
+  uintptr_t start = AddressStart(address);
+  if (std::numeric_limits<uintptr_t>::max() - start < address.size()) {
+    return std::numeric_limits<uintptr_t>::max();
+  }
+  return start + address.size();
+}
+
+static bool AddressRangesOverlap(DeviceAddressBase lhs, DeviceAddressBase rhs) {
+  if (lhs.is_null() || rhs.is_null() || lhs.size() == 0 || rhs.size() == 0) {
+    return false;
+  }
+  return AddressStart(lhs) < AddressEnd(rhs) &&
+         AddressStart(rhs) < AddressEnd(lhs);
+}
+
 DeviceAddressVmmAllocator::DeviceAddressVmmAllocator(const Platform* platform)
     : DeviceAddressAllocator(platform) {}
 
@@ -322,11 +343,10 @@ MemoryAllocation* DeviceAddressVmmAllocator::GetRawAllocation(
   absl::MutexLock lock(state->mu);
 
   // Allocator addresses are keyed directly by their VA. Stale records remain in
-  // this map until deferred teardown completes, so require both active state
-  // and an exact address-range match before exposing the backing allocation.
+  // this map until deferred teardown completes, so expose their backing
+  // allocation for diagnostics/reuse checks until the pending operation drains.
   auto allocation_it = state->records_by_allocator_address.find(addr.opaque());
   if (allocation_it != state->records_by_allocator_address.end() &&
-      allocation_it->second->allocator_active() &&
       allocation_it->second->allocator_matches(addr)) {
     return allocation_it->second->raw_allocation();
   }
@@ -601,98 +621,325 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
   return ScopedDeviceAddress<uint8_t>(*result, device_ordinal, this);
 }
 
-// Mapped Allocate() creates fresh physical memory and maps it into the caller
-// reservation. It keeps the same externally visible ownership model as the
-// previous map-based bookkeeping, but records the lifetime in AllocationRecord.
+// Mapped Allocate() reuses matching pending mapped deallocations, otherwise
+// tries fresh physical allocation and maps it into the caller reservation.
 absl::StatusOr<ScopedDeviceAddress<uint8_t>>
 DeviceAddressVmmAllocator::Allocate(
     int device_ordinal, uint64_t allocation_size, bool /*retry_on_failure*/,
     int64_t /*memory_space*/, MemoryReservation* reservation,
     uint64_t reservation_offset, uint64_t mapping_size,
     bool return_reservation_address) {
-  if (allocation_size != mapping_size) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "VMM mapped allocation size (%u) must equal mapping size (%u)",
-        allocation_size, mapping_size));
-  }
+  // Keep zero-sized mapped allocation consistent with regular Allocate(): no
+  // physical allocation or mapping is created, so the requested mapping size
+  // must also be zero.
   if (allocation_size == 0) {
+    if (mapping_size != 0) {
+      return absl::InvalidArgumentError(
+          "mapping_size must be zero when allocation_size is zero");
+    }
     return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
                                         this);
+  }
+  // A mapped allocation with a nonzero physical allocation must establish a
+  // nonempty mapping into the caller-owned reservation.
+  if (mapping_size == 0) {
+    return absl::InvalidArgumentError(
+        "mapping_size must be nonzero for mapped Allocate");
+  }
+  if (allocation_size != mapping_size) {
+    return absl::InvalidArgumentError(
+        "allocation_size must equal mapping_size for mapped Allocate");
   }
 
   ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
   const bool multi_device = CurrentMultiDevice();
 
+  // Validate the caller-owned reservation slice before taking the allocator
+  // lock. `reservation_address` is the VA that must either be reactivated from
+  // a pending deallocation or freshly mapped below.
   ASSIGN_OR_RETURN(
       DeviceAddressBase reservation_address,
       ValidateReservationRange(reservation, reservation_offset, mapping_size));
 
   absl::MutexLock lock(state->mu);
-  if (state->active_reservation_records.contains(
-          reservation_address.opaque()) ||
-      state->stale_reservation_records.contains(reservation_address.opaque()) ||
-      state->records_by_allocator_address.contains(
-          reservation_address.opaque())) {
-    return absl::FailedPreconditionError(
-        "Reservation address is already tracked by this allocator");
+  // First try to satisfy the request from a compatible pending deallocation
+  // for the same reservation-derived returned allocator address.
+  auto try_reuse = [&]() ABSL_NO_THREAD_SAFETY_ANALYSIS
+      -> absl::StatusOr<std::optional<DeviceAddressBase>> {
+    if (!return_reservation_address) {
+      // This mode returns a distinct allocator-owned VA while also mapping that
+      // allocation into the caller-owned reservation. Reuse is possible only
+      // when a pending kAllocateAndMapReturnNewAddr record still has both sides
+      // stale and its reservation side exactly matches this request.
+      for (auto it = state->pending_deallocations.begin();
+           it != state->pending_deallocations.end(); ++it) {
+        if (it->kind != PendingDeallocationKind::kAllocateAndMapReturnNewAddr) {
+          continue;
+        }
+        auto record_it =
+            state->records_by_allocator_address.find(it->addr.opaque());
+        CHECK(record_it != state->records_by_allocator_address.end());
+        AllocationRecord& record = *record_it->second;
+        CHECK(record.allocator_stale());
+        CHECK(record.allocator_matches(it->addr));
+        CHECK_EQ(record.pending_deallocation_kind(),
+                 PendingDeallocationKind::kAllocateAndMapReturnNewAddr);
+        if (record.multi_device() != multi_device) {
+          continue;
+        }
+        if (!record.reservation_stale()) {
+          continue;
+        }
+        CHECK(record.has_reservation_address());
+        // The allocator address can be reused for command-buffer update-free
+        // execution only if the external reservation VA is also the same VA the
+        // command buffer captured.
+        if (!record.reservation_matches(reservation_address)) {
+          continue;
+        }
+        if (record.raw_allocation()->address().size() < allocation_size) {
+          // The old mapping is the right VA but not enough physical memory.
+          // Wait for its deferred teardown to finish, then let the fresh path
+          // create a larger allocation and install a new mapping.
+          RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
+              *state, PendingDeallocationKey{record.pending_deallocation_kind(),
+                                             record.allocator_stale_seqno(),
+                                             record.allocator_address()}));
+          return std::nullopt;
+        }
+
+        DeviceAddressBase reused_mem(record.allocator_key(), allocation_size);
+        // Reactivate both aliases: the returned allocator VA and the external
+        // reservation VA. This cancels the pending allocator teardown and the
+        // paired pending kMap unmap for the reservation mapping.
+        MoveAllocatorRecordToActive(*state, record, allocation_size);
+        MoveReservationRecordToActive(*state, record);
+        ErasePendingDeallocationAt(*state, it);
+        ErasePendingDeallocation(*state, PendingDeallocationKind::kMap,
+                                 reservation_address);
+        return reused_mem;
+      }
+      return std::nullopt;
+    }
+
+    // Look for a pending deallocation that already owns the requested
+    // reservation VA as its returned allocator address. Reusing it keeps the
+    // same virtual address mapped and avoids waiting for the GPU timeline when
+    // the pending raw allocation is compatible with this request.
+    auto record_it =
+        state->records_by_allocator_address.find(reservation_address.opaque());
+    if (record_it == state->records_by_allocator_address.end()) {
+      return std::nullopt;
+    }
+    AllocationRecord& record = *record_it->second;
+    if (!record.allocator_stale()) {
+      return std::nullopt;
+    }
+    if (record.pending_deallocation_kind() !=
+        PendingDeallocationKind::kAllocateAndMapReturnMapAddr) {
+      return std::nullopt;
+    }
+    if (record.multi_device() != multi_device) {
+      return std::nullopt;
+    }
+    if (!record.allocator_matches(reservation_address)) {
+      return std::nullopt;
+    }
+
+    // Allocate(..., return_reservation_address=true) returns the reservation
+    // VA as an owning allocator address. If the pending raw allocation is too
+    // small for the new request, wait for the old mapping to drain so the fresh
+    // path can remap this reservation VA to a larger raw allocation.
+    if (record.raw_allocation()->address().size() < allocation_size) {
+      RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
+          *state, PendingDeallocationKey{record.pending_deallocation_kind(),
+                                         record.allocator_stale_seqno(),
+                                         record.allocator_address()}));
+      return std::nullopt;
+    }
+
+    auto pending_it = state->pending_deallocations.end();
+    // The record is indexed by allocator address, but the FIFO queue owns the
+    // stream-ordered allocator teardown. Find the queue entry so reuse can
+    // cancel it while leaving explicit pending kMap entries untouched.
+    for (auto it = state->pending_deallocations.begin();
+         it != state->pending_deallocations.end(); ++it) {
+      if (it->kind == PendingDeallocationKind::kAllocateAndMapReturnMapAddr &&
+          it->addr.IsSameAs(reservation_address)) {
+        pending_it = it;
+        break;
+      }
+    }
+    CHECK(pending_it != state->pending_deallocations.end());
+    MoveAllocatorRecordToActive(*state, record, allocation_size);
+    ErasePendingDeallocationAt(*state, pending_it);
+    return reservation_address;
+  };
+  // If no pending entry can be reused, allocate fresh physical memory and map
+  // it into the caller reservation. When return_reservation_address is false
+  // this also creates an allocator-owned address; otherwise the reservation
+  // address is the returned allocator address.
+  auto try_fresh =
+      [&]()
+          ABSL_NO_THREAD_SAFETY_ANALYSIS -> absl::StatusOr<DeviceAddressBase> {
+    // If the requested reservation VA is only present in the deferred queue,
+    // wait for that queued unmap/deallocation to complete before installing a
+    // fresh mapping. Active mappings are still rejected below.
+    while (true) {
+      // Partial overlaps are never reusable: the allocator tracks whole mapped
+      // ranges, so a caller must request the exact same reservation slice
+      // before stale state can be waited on or reactivated.
+      if (auto overlap = FindOverlappingRecord(
+              *state, reservation_address, /*include_allocator=*/true,
+              /*include_reservation=*/true, /*include_active=*/true,
+              /*include_stale=*/true, /*exact_only=*/false,
+              /*partial_only=*/true)) {
+        return absl::FailedPreconditionError(absl::StrFormat(
+            "reservation range at %p (%uB) partially overlaps %s %s range at "
+            "%p "
+            "(%uB); reservation mappings must be managed with the same full "
+            "range",
+            reservation_address.opaque(), reservation_address.size(),
+            overlap->is_active ? "active" : "stale",
+            overlap->is_allocator ? "allocator" : "reservation",
+            overlap->tracked_address.opaque(),
+            overlap->tracked_address.size()));
+      }
+      // An exact stale overlap means the previous mapping for this reservation
+      // VA is still protected by stream order. Complete only that conflicting
+      // stale record, then rescan because another thread may have changed the
+      // allocator state while the lock was released.
+      auto stale_overlap = FindOverlappingRecord(
+          *state, reservation_address, /*include_allocator=*/true,
+          /*include_reservation=*/true, /*include_active=*/false,
+          /*include_stale=*/true, /*exact_only=*/true,
+          /*partial_only=*/false);
+      if (!stale_overlap.has_value()) {
+        break;
+      }
+      RETURN_IF_ERROR(WaitAndCompleteStaleOverlap(*state, *stale_overlap));
+    }
+
+    // At this point stale exact overlaps have been drained. Any remaining
+    // overlap is active ownership of the requested reservation range and must
+    // be reported as a duplicate mapping attempt instead of remapped underneath
+    // existing users.
+    if (FindOverlappingRecord(*state, reservation_address,
+                              /*include_allocator=*/true,
+                              /*include_reservation=*/true,
+                              /*include_active=*/true,
+                              /*include_stale=*/false,
+                              /*exact_only=*/false,
+                              /*partial_only=*/false)
+            .has_value()) {
+      return absl::AlreadyExistsError(absl::StrFormat(
+          "reservation range is already tracked at virtual address %p",
+          reservation_address.opaque()));
+    }
+
+    uint64_t rounded_size = RoundUpToGranularity(*state, allocation_size);
+    if (return_reservation_address) {
+      // The returned allocator address is the caller-owned reservation VA. The
+      // record is keyed by that VA and owns only the raw allocation plus the
+      // scoped mapping into the external reservation.
+      if (state->pa_allocated + rounded_size > state->pa_budget) {
+        return absl::ResourceExhaustedError(absl::StrFormat(
+            "Not enough PA budget for mapping: pa_allocated=%uB, "
+            "rounded_size=%uB, pa_budget=%uB",
+            state->pa_allocated, rounded_size, state->pa_budget));
+      }
+
+      ASSIGN_OR_RETURN(auto raw_alloc,
+                       CreateAllocation(state->executor, allocation_size));
+      if (mapping_size > raw_alloc->address().size()) {
+        return absl::InvalidArgumentError(absl::StrFormat(
+            "physical allocation is smaller than requested mapping: "
+            "allocation_size=%uB, mapping_size=%uB",
+            raw_alloc->address().size(), mapping_size));
+      }
+
+      ASSIGN_OR_RETURN(
+          auto scoped_mapping,
+          reservation->MapTo(reservation_offset, /*allocation_offset=*/0,
+                             mapping_size, *raw_alloc));
+      auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
+
+      TrackAllocatorAddressMappedAllocation(
+          *state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
+          reservation_address, std::move(shared_raw), nullptr,
+          std::move(scoped_mapping), rounded_size, multi_device);
+
+      return reservation_address;
+    }
+
+    // This mode creates two VAs for the same raw allocation: an allocator-owned
+    // VA returned to the caller, and a non-owning alias in the caller
+    // reservation used by captured command buffers.
+    if (state->pa_allocated + rounded_size > state->pa_budget) {
+      return absl::ResourceExhaustedError(absl::StrFormat(
+          "Not enough PA budget for allocation: pa_allocated=%uB, "
+          "rounded_size=%uB, pa_budget=%uB",
+          state->pa_allocated, rounded_size, state->pa_budget));
+    }
+
+    ASSIGN_OR_RETURN(auto raw_alloc,
+                     CreateAllocation(state->executor, allocation_size));
+    const uint64_t padded_size = raw_alloc->address().size();
+    if (mapping_size > padded_size) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "mapping size must not exceed physical allocation size: "
+          "mapping_size=%uB, allocation_size=%uB",
+          mapping_size, padded_size));
+    }
+
+    ASSIGN_OR_RETURN(auto allocator_address_reservation,
+                     CreateReservation(state->executor, allocation_size));
+    ASSIGN_OR_RETURN(auto allocator_address_mapping,
+                     allocator_address_reservation->MapTo(
+                         /*reservation_offset=*/0, /*allocation_offset=*/0,
+                         padded_size, *raw_alloc));
+    ASSIGN_OR_RETURN(
+        auto reservation_address_mapping,
+        reservation->MapTo(reservation_offset, /*allocation_offset=*/0,
+                           mapping_size, *raw_alloc));
+
+    auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
+    // Record the paired allocation: the allocator-owned returned VA owns the
+    // raw allocation, and the caller reservation VA is a non-owning alias.
+    void* allocator_va = allocator_address_reservation->address().opaque();
+    DeviceAddressBase allocator_address(allocator_va, allocation_size);
+    auto record = std::make_unique<AllocationRecord>(
+        AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
+        std::move(shared_raw), std::move(allocator_address_reservation),
+        std::move(allocator_address_mapping), multi_device);
+    record->AddActiveReservationAlias(reservation_address,
+                                      std::move(reservation_address_mapping));
+    AllocationRecord* record_ptr = record.get();
+    auto record_insert = state->records_by_allocator_address.emplace(
+        allocator_va, std::move(record));
+    CHECK(record_insert.second);
+    auto reservation_insert = state->active_reservation_records.emplace(
+        reservation_address.opaque(), record_ptr);
+    CHECK(reservation_insert.second);
+    state->pa_allocated += rounded_size;
+
+    return DeviceAddressBase(allocator_va, allocation_size);
+  };
+
+  // The shared retry helper handles PA-budget pressure: try reuse, try fresh,
+  // complete already-finished pending work on ResourceExhausted, and finally
+  // wait for enough pending deallocations only if necessary.
+  absl::StatusOr<DeviceAddressBase> result =
+      TryWithPendingReclaim(*state, allocation_size, try_reuse, try_fresh);
+
+  if (!result.ok()) {
+    return result.status();
   }
 
-  uint64_t rounded_size = RoundUpToGranularity(*state, allocation_size);
-  if (state->pa_allocated + rounded_size > state->pa_budget) {
-    return absl::ResourceExhaustedError(absl::StrFormat(
-        "Not enough PA budget for allocation: pa_allocated=%uB, "
-        "rounded_size=%uB, pa_budget=%uB",
-        state->pa_allocated, rounded_size, state->pa_budget));
-  }
-
-  ASSIGN_OR_RETURN(auto raw_alloc,
-                   CreateAllocation(state->executor, allocation_size));
-  const uint64_t padded_size = raw_alloc->address().size();
-  if (mapping_size > padded_size) {
-    return absl::InvalidArgumentError(
-        absl::StrFormat("Mapping size %u exceeds raw allocation size %u",
-                        mapping_size, padded_size));
-  }
-
-  ASSIGN_OR_RETURN(
-      MemoryReservation::ScopedMapping reservation_mapping,
-      reservation->MapTo(reservation_offset, /*allocation_offset=*/0,
-                         mapping_size, *raw_alloc));
-  auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
-
-  if (return_reservation_address) {
-    TrackAllocatorAddressMappedAllocation(
-        *state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
-        reservation_address, std::move(shared_raw), nullptr,
-        std::move(reservation_mapping), rounded_size, multi_device);
-    return ScopedDeviceAddress<uint8_t>(reservation_address, device_ordinal,
-                                        this);
-  }
-
-  ASSIGN_OR_RETURN(auto allocator_address_reservation,
-                   CreateReservation(state->executor, allocation_size));
-  ASSIGN_OR_RETURN(auto allocator_address_mapping,
-                   allocator_address_reservation->MapTo(
-                       /*reservation_offset=*/0, /*allocation_offset=*/0,
-                       padded_size, *shared_raw));
-  void* allocator_va = allocator_address_reservation->address().opaque();
-  DeviceAddressBase allocator_address(allocator_va, allocation_size);
-  auto record = std::make_unique<AllocationRecord>(
-      AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
-      std::move(shared_raw), std::move(allocator_address_reservation),
-      std::move(allocator_address_mapping), multi_device);
-  record->AddActiveReservationAlias(reservation_address,
-                                    std::move(reservation_mapping));
-  AllocationRecord* record_ptr = record.get();
-  auto record_insert = state->records_by_allocator_address.emplace(
-      allocator_va, std::move(record));
-  CHECK(record_insert.second);
-  auto reservation_insert = state->active_reservation_records.emplace(
-      reservation_address.opaque(), record_ptr);
-  CHECK(reservation_insert.second);
-  state->pa_allocated += rounded_size;
-
-  return ScopedDeviceAddress<uint8_t>(allocator_address, device_ordinal, this);
+  // For return_reservation_address=true this is `reservation_address`; for
+  // return_reservation_address=false it is the allocator-owned address paired
+  // with the reservation mapping.
+  return ScopedDeviceAddress<uint8_t>(*result, device_ordinal, this);
 }
 
 absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
@@ -777,6 +1024,77 @@ DeviceAddressVmmAllocator::ValidateReservationRange(
   return address.GetByteSlice(reservation_offset, size);
 }
 
+std::optional<DeviceAddressVmmAllocator::OverlappingRecord>
+DeviceAddressVmmAllocator::FindOverlappingRecord(
+    PerDeviceState& state, DeviceAddressBase address, bool include_allocator,
+    bool include_reservation, bool include_active, bool include_stale,
+    bool exact_only, bool partial_only) const {
+  CHECK(!(exact_only && partial_only));
+
+  auto matches = [&](DeviceAddressBase tracked_address) {
+    if (exact_only) {
+      return tracked_address.IsSameAs(address);
+    }
+    if (partial_only) {
+      // Partial overlap means the ranges intersect but are not the same full
+      // ownership range.
+      return AddressRangesOverlap(tracked_address, address) &&
+             !tracked_address.IsSameAs(address);
+    }
+    return AddressRangesOverlap(tracked_address, address);
+  };
+
+  auto check_record = [&](AllocationRecord* record,
+                          DeviceAddressBase tracked_address, bool is_allocator,
+                          bool is_active) -> std::optional<OverlappingRecord> {
+    if (matches(tracked_address)) {
+      return OverlappingRecord{record, tracked_address, is_allocator,
+                               is_active};
+    }
+    return std::nullopt;
+  };
+
+  if (include_allocator) {
+    for (const auto& [_, record_owner] : state.records_by_allocator_address) {
+      AllocationRecord* record = record_owner.get();
+      CHECK_NE(record->allocator_active(), record->allocator_stale());
+      bool include_record = (include_active && record->allocator_active()) ||
+                            (include_stale && record->allocator_stale());
+      if (!include_record) {
+        continue;
+      }
+      if (auto overlap =
+              check_record(record, record->allocator_address(),
+                           /*is_allocator=*/true,
+                           /*is_active=*/record->allocator_active())) {
+        return overlap;
+      }
+    }
+  }
+  if (include_reservation && include_active) {
+    for (const auto& [_, record] : state.active_reservation_records) {
+      CHECK(record->has_reservation_address());
+      if (auto overlap = check_record(record, record->reservation_address(),
+                                      /*is_allocator=*/false,
+                                      /*is_active=*/true)) {
+        return overlap;
+      }
+    }
+  }
+  if (include_reservation && include_stale) {
+    for (const auto& [_, record] : state.stale_reservation_records) {
+      CHECK(record->has_reservation_address());
+      if (auto overlap = check_record(record, record->reservation_address(),
+                                      /*is_allocator=*/false,
+                                      /*is_active=*/false)) {
+        return overlap;
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+
 absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
                                             DeviceAddressBase addr,
                                             MemoryReservation* reservation,
@@ -828,19 +1146,130 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
         "mapping_size=%uB, allocation_size=%uB",
         size, raw_allocation->address().size()));
   }
-  if (state->active_reservation_records.contains(
-          reservation_address.opaque()) ||
-      state->stale_reservation_records.contains(reservation_address.opaque())) {
-    return absl::FailedPreconditionError(
-        "Reservation address is already tracked by this allocator");
+  auto reject_partial_overlap =
+      [&]() ABSL_NO_THREAD_SAFETY_ANALYSIS -> absl::Status {
+    if (auto overlap = FindOverlappingRecord(
+            *state, reservation_address, /*include_allocator=*/true,
+            /*include_reservation=*/true, /*include_active=*/true,
+            /*include_stale=*/true, /*exact_only=*/false,
+            /*partial_only=*/true)) {
+      return absl::FailedPreconditionError(absl::StrFormat(
+          "reservation range at %p (%uB) partially overlaps %s %s range at %p "
+          "(%uB); reservation mappings must be managed with the same full "
+          "range",
+          reservation_address.opaque(), reservation_address.size(),
+          overlap->is_active ? "active" : "stale",
+          overlap->is_allocator ? "allocator" : "reservation",
+          overlap->tracked_address.opaque(), overlap->tracked_address.size()));
+    }
+    return absl::OkStatus();
+  };
+  RETURN_IF_ERROR(reject_partial_overlap());
+
+  while (true) {
+    std::optional<PendingDeallocationKey> pending_completion_key;
+
+    if (source_record->reservation_active()) {
+      return absl::AlreadyExistsError(absl::StrFormat(
+          "allocator address %p already has an active reservation mapping at "
+          "%p",
+          addr.opaque(), source_record->reservation_address().opaque()));
+    }
+
+    if (source_record->reservation_stale()) {
+      CHECK(source_record->has_reservation_address());
+      if (!source_record->reservation_matches(reservation_address)) {
+        pending_completion_key =
+            PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                   source_record->reservation_stale_seqno(),
+                                   source_record->reservation_address()};
+      }
+    }
+
+    if (!pending_completion_key.has_value()) {
+      auto stale_reservation_overlap = FindOverlappingRecord(
+          *state, reservation_address, /*include_allocator=*/false,
+          /*include_reservation=*/true, /*include_active=*/false,
+          /*include_stale=*/true, /*exact_only=*/true,
+          /*partial_only=*/false);
+      if (stale_reservation_overlap.has_value()) {
+        AllocationRecord& stale_record = *stale_reservation_overlap->record;
+
+        // UnMap() defers destroying the ScopedMapping until the GPU reaches the
+        // recorded stream point. If the caller maps the same reservation
+        // address to the same raw allocation before that point, the old mapping
+        // is still valid; move it back to the active maps instead of unmapping
+        // and remapping.
+        CHECK(stale_record.has_reservation_address());
+        CHECK(stale_record.reservation_matches(reservation_address));
+        if (stale_record.raw_allocation() == raw_allocation) {
+          MoveReservationRecordToActive(*state, stale_record);
+          ErasePendingDeallocation(*state, PendingDeallocationKind::kMap,
+                                   reservation_address);
+          return absl::OkStatus();
+        }
+
+        // The same reservation address is waiting to unmap from a different raw
+        // allocation. Creating a new mapping now would overwrite an in-flight
+        // mapping that earlier GPU work may still use, so wait until that
+        // deferred unmap has completed, then rescan from the start.
+        pending_completion_key =
+            PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                   stale_record.reservation_stale_seqno(),
+                                   stale_record.reservation_address()};
+      } else {
+        auto stale_allocator_overlap = FindOverlappingRecord(
+            *state, reservation_address, /*include_allocator=*/true,
+            /*include_reservation=*/false, /*include_active=*/false,
+            /*include_stale=*/true, /*exact_only=*/true,
+            /*partial_only=*/false);
+        if (stale_allocator_overlap.has_value()) {
+          AllocationRecord& stale_record = *stale_allocator_overlap->record;
+          pending_completion_key =
+              PendingDeallocationKey{stale_record.pending_deallocation_kind(),
+                                     stale_record.allocator_stale_seqno(),
+                                     stale_record.allocator_address()};
+        }
+      }
+    }
+
+    if (!pending_completion_key.has_value()) {
+      break;
+    }
+    if (pending_completion_key->kind == PendingDeallocationKind::kMap) {
+      RETURN_IF_ERROR(WaitAndCompleteStaleReservationMapping(
+          *state, *pending_completion_key));
+    } else {
+      RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
+          *state, *pending_completion_key));
+    }
+    // Waiting releases the allocator lock. Another thread may have deallocated
+    // or remapped `addr` while this thread was waiting, so resolve it again
+    // before either reactivating another pending unmap or creating a fresh map.
+    ASSIGN_OR_RETURN(source_record, resolve_source_record());
+    raw_allocation = source_record->raw_allocation();
+    RETURN_IF_ERROR(reject_partial_overlap());
+    if (size > raw_allocation->address().size()) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "mapping size must not exceed physical allocation size: "
+          "mapping_size=%uB, allocation_size=%uB",
+          size, raw_allocation->address().size()));
+    }
   }
-  if (source_record->reservation_active()) {
-    return absl::FailedPreconditionError(
-        "Allocator address already has an active reservation alias");
-  }
-  if (source_record->reservation_stale()) {
-    return absl::FailedPreconditionError(
-        "Allocator address already has a pending reservation alias");
+  // A fresh Map() must have exclusive ownership of the reservation address.
+  // Reject active mappings and still-stale deferred mappings before installing
+  // the new ScopedMapping.
+  if (FindOverlappingRecord(*state, reservation_address,
+                            /*include_allocator=*/true,
+                            /*include_reservation=*/true,
+                            /*include_active=*/true,
+                            /*include_stale=*/true,
+                            /*exact_only=*/false,
+                            /*partial_only=*/false)
+          .has_value()) {
+    return absl::AlreadyExistsError(absl::StrFormat(
+        "reservation range is already tracked at virtual address %p",
+        reservation_address.opaque()));
   }
 
   // Install the reservation address mapping to the raw physical allocation. The
@@ -879,6 +1308,18 @@ void DeviceAddressVmmAllocator::ErasePendingDeallocationAt(
   state.pending_deallocations.erase(it);
 }
 
+void DeviceAddressVmmAllocator::ErasePendingDeallocation(
+    PerDeviceState& state, PendingDeallocationKind kind,
+    DeviceAddressBase addr) {
+  for (auto it = state.pending_deallocations.begin();
+       it != state.pending_deallocations.end(); ++it) {
+    if (it->kind == kind && it->addr.IsSameAs(addr)) {
+      ErasePendingDeallocationAt(state, it);
+      return;
+    }
+  }
+}
+
 void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
     PerDeviceState& state, AllocationRecord& record, uint64_t new_size) {
   CHECK(!record.allocator_active());
@@ -902,6 +1343,19 @@ void DeviceAddressVmmAllocator::MoveReservationRecordToStale(
       state.stale_reservation_records.emplace(reservation_va, &record);
   CHECK(insert_result.second);
   record.MarkReservationStale(seqno);
+}
+
+void DeviceAddressVmmAllocator::MoveReservationRecordToActive(
+    PerDeviceState& state, AllocationRecord& record) {
+  CHECK(!record.reservation_active());
+  CHECK(record.reservation_stale());
+  CHECK(record.has_reservation_address());
+  void* reservation_va = record.reservation_key();
+  CHECK_EQ(state.stale_reservation_records.erase(reservation_va), 1);
+  auto insert_result =
+      state.active_reservation_records.emplace(reservation_va, &record);
+  CHECK(insert_result.second);
+  record.ReactivateReservation();
 }
 
 void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
@@ -979,6 +1433,41 @@ bool DeviceAddressVmmAllocator::CompletePendingDeallocationByKey(
     }
   }
   return false;
+}
+
+absl::Status
+DeviceAddressVmmAllocator::WaitAndCompleteStaleAllocatorDeallocation(
+    PerDeviceState& state, const PendingDeallocationKey& key) {
+  CHECK_NE(key.kind, PendingDeallocationKind::kMap);
+  RETURN_IF_ERROR(WaitUntilSeqno(state, key.seqno));
+  CompletePendingDeallocationByKey(state, key);
+  return absl::OkStatus();
+}
+
+absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleReservationMapping(
+    PerDeviceState& state, const PendingDeallocationKey& key) {
+  CHECK_EQ(key.kind, PendingDeallocationKind::kMap);
+  RETURN_IF_ERROR(WaitUntilSeqno(state, key.seqno));
+  CompletePendingDeallocationByKey(state, key);
+  return absl::OkStatus();
+}
+
+absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleOverlap(
+    PerDeviceState& state, const OverlappingRecord& overlap) {
+  CHECK(!overlap.is_active);
+  if (overlap.is_allocator) {
+    AllocationRecord& record = *overlap.record;
+    return WaitAndCompleteStaleAllocatorDeallocation(
+        state, PendingDeallocationKey{record.pending_deallocation_kind(),
+                                      record.allocator_stale_seqno(),
+                                      record.allocator_address()});
+  }
+  CHECK(overlap.record->reservation_stale());
+  CHECK(overlap.record->has_reservation_address());
+  return WaitAndCompleteStaleReservationMapping(
+      state, PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                    overlap.record->reservation_stale_seqno(),
+                                    overlap.record->reservation_address()});
 }
 
 void DeviceAddressVmmAllocator::CompletePendingDeallocation(

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -111,8 +111,10 @@ namespace stream_executor {
 // only reservation addresses created by Map() or by
 // Allocate(..., return_reservation_address=false). Passing an allocator address
 // to UnMap(), or a reservation address to Deallocate(), is an error.
-// Each allocator address may have at most one active or stale
-// reservation-address alias.
+// Each allocator address may have at most one active reservation-address alias.
+// A reservation mapping is owned as the same full range that created it:
+// partial UnMap(), Map(), or Allocate() operations that overlap an active or
+// stale reservation mapping are rejected.
 //
 // Deallocate() and UnMap() are stream-ordered deferred operations. The
 // allocator assigns the affected address record a per-device sequence number,
@@ -124,6 +126,15 @@ namespace stream_executor {
 // When the sequence completes, dropping the ScopedMapping objects performs the
 // real unmap, then the allocator releases any owned reservation and raw
 // physical memory.
+//
+// Stale records are also the fast reuse path. Allocate() first looks for a
+// compatible stale allocator address before creating new VMM state. Map() does
+// the same for a stale reservation mapping: if the requested reservation
+// address is still mapped to the same raw physical allocation, the allocator
+// reactivates the old mapping instead of unmapping and remapping. If a
+// requested reservation address is still stale for a different raw allocation,
+// Map() waits for that deferred unmap to complete before installing the new
+// mapping.
 //
 // Each registered device has independent state protected by its own mutex, so
 // operations on different devices can proceed in parallel. The per-device map
@@ -241,7 +252,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // range until all previously enqueued work on the allocator stream has
   // completed.
   // The caller must pass the same full reservation range that created the
-  // mapping.
+  // mapping; partial ranges that overlap a tracked mapping are rejected.
   // The reservation-derived allocator address returned by
   // Allocate(..., return_reservation_address=true) is not a reservation
   // address for this API and must be released with Deallocate() instead.
@@ -574,11 +585,33 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       MemoryReservation* reservation, uint64_t reservation_offset,
       uint64_t size) const;
 
+  struct OverlappingRecord {
+    AllocationRecord* record = nullptr;
+    DeviceAddressBase tracked_address;
+    bool is_allocator = false;
+    bool is_active = false;
+  };
+
+  // Finds a tracked allocator or reservation range that overlaps `address`.
+  // `exact_only` returns only identical ranges; `partial_only` returns only
+  // non-identical overlapping ranges; both false returns any overlap.
+  std::optional<OverlappingRecord> FindOverlappingRecord(
+      PerDeviceState& state, DeviceAddressBase address, bool include_allocator,
+      bool include_reservation, bool include_active, bool include_stale,
+      bool exact_only, bool partial_only) const
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
   // UnMap/deferred teardown helpers.
 
   // Removes a pending entry when a stale record is reused.
   void ErasePendingDeallocationAt(PerDeviceState& state,
                                   std::deque<PendingDeallocation>::iterator it)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Removes the matching pending entry when a stale record is reused.
+  void ErasePendingDeallocation(PerDeviceState& state,
+                                PendingDeallocationKind kind,
+                                DeviceAddressBase addr)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   void MoveAllocatorRecordToActive(PerDeviceState& state,
@@ -587,6 +620,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   void MoveReservationRecordToStale(PerDeviceState& state,
                                     AllocationRecord& record, uint64_t seqno)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  void MoveReservationRecordToActive(PerDeviceState& state,
+                                     AllocationRecord& record)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   void CompleteStaleReservationMapping(PerDeviceState& state,
@@ -625,6 +662,24 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // while state.mu was released.
   bool CompletePendingDeallocationByKey(PerDeviceState& state,
                                         const PendingDeallocationKey& key)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Waits for and completes the selected allocator-address deallocation, if it
+  // is still pending after the wait.
+  absl::Status WaitAndCompleteStaleAllocatorDeallocation(
+      PerDeviceState& state, const PendingDeallocationKey& key)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Waits for and completes a stale reservation-address mapping queued by
+  // UnMap().
+  absl::Status WaitAndCompleteStaleReservationMapping(
+      PerDeviceState& state, const PendingDeallocationKey& key)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Completes only the stale allocator or reservation mapping that conflicts
+  // with the current request, leaving unrelated stale mappings reusable.
+  absl::Status WaitAndCompleteStaleOverlap(PerDeviceState& state,
+                                           const OverlappingRecord& overlap)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Device ordinal -> per-device allocator state. Populated at construction by


### PR DESCRIPTION
📝 Summary of Changes
This PR teaches `DeviceAddressVmmAllocator` to reuse VMM mappings that are no longer owned by a caller but are still kept alive by the allocator's stream-ordered deferred teardown queue.

The allocator already has to keep recently deallocated virtual addresses and mappings alive until the GPU stream reaches the deferred deallocation point. Before this change, a later allocation that wanted the same virtual address would usually wait for the old mapping to drain, tear it down, and then create/map fresh VMM state. This PR uses that stale-but-still-valid state as a fast path when it is safe and compatible.

The main behavior changes are:

- Regular `Allocate()` first checks for a compatible stale allocator address before creating a new raw allocation, reservation, and mapping.
- Mapped `Allocate(..., MemoryReservation*, ...)` can reuse stale reservation-backed mappings in both modes:
  - `return_reservation_address=true`: the caller reservation address is also the returned allocator address, so a matching stale allocator record can be reactivated directly.
  - `return_reservation_address=false`: the allocator-owned returned address and the caller reservation alias can both be reactivated when the stale record matches the requested reservation range.
- `Map()` can reactivate a stale reservation alias when the requested reservation range still maps the same raw allocation.
- Fresh mapping paths now detect tracked allocator/reservation range overlaps. Partial overlaps are rejected because the allocator owns and releases mappings as full ranges. Exact stale overlaps are waited on and completed before installing a new mapping.
- PA-budget retry behavior is centralized through `TryWithPendingReclaim()`: try reuse first, try a fresh allocation next, reclaim already-completed pending frees if needed, and only block on pending stream work when reclaim is necessary.
- `GetRawAllocation()` continues to expose a raw allocation for stale allocator addresses until deferred teardown actually drains and removes the record. This matches the allocator's existing stream-ordered lifetime model.

In short, this keeps virtual addresses and VMM mappings stable when possible, while preserving the existing rule that stale state can only be reused after ownership has moved out of the public active API surface.

🎯 Justification
This reduces VMM teardown/remap churn for allocation patterns that reuse the same virtual address ranges. That matters for GPU command-buffer style execution, where captured virtual addresses are valuable and replacing mappings can force extra synchronization or command-buffer update work.

The change is intentionally limited to the `AllocationRecord`-based VMM allocator bookkeeping. It does not add a new public API. Instead, it makes the existing deferred deallocation machinery smarter:

- compatible stale state is reactivated without waiting for the GPU timeline;
- incompatible stale state is still protected by stream ordering;
- overlapping mappings are handled explicitly instead of relying on exact-address map lookups only;
- unrelated pending deallocations are not drained unless PA-budget pressure makes reclaim necessary.

🚀 Kind of Contribution
⚡️ Performance Improvement, ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
No benchmark results were collected for this draft split.

Expected benefit: fewer VMM unmap/remap operations and fewer blocking waits when allocation requests can reuse stale allocator or reservation mappings. The workloads expected to benefit are GPU command-buffer workflows that repeatedly allocate/map the same reservation-backed virtual address ranges.

🧪 Unit Tests:
No new test files were added in this PR. The change is covered by existing CUDA VMM allocator tests that exercise allocation, mapped allocation, pending deallocation, stale-address reuse, multi-device reuse isolation, and reservation alias mapping behavior.

Local validation run:

```bash
bazel build //xla/stream_executor:device_address_vmm_allocator
bazel test --test_output=errors //xla/stream_executor/cuda:cuda_device_address_vmm_allocator_test
```

Both commands passed locally.

🧪 Execution Tests:
The existing CUDA allocator execution test was run locally:

```bash
bazel test --test_output=errors //xla/stream_executor/cuda:cuda_device_address_vmm_allocator_test
```

Result: passed.
