### PR TITLE
[CI] Fix clang-tidy base branch fetch

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -42,7 +42,9 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           BASE_REF="${GITHUB_BASE_REF:-main}"
-          git fetch origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" --depth=100
+          # Keep this fetch unshallow so clang-tidy can find the merge base even
+          # when the PR branch is more than checkout fetch-depth commits behind.
+          git fetch origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
       - name: Configure Workspace
       # The actual compute capability does not matter. This allows deviceless run for this pipeline.
       # The common configs ensure that bazel query and bazel build don't refetch repo mappings.

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -38,10 +38,11 @@ jobs:
           # This is better than 0 since we don't want to fetch everything as well.
           fetch-depth: '100'
           persist-credentials: false
-      - name: "Update main branch"
+      - name: "Update base branch"
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git fetch origin main
+          BASE_REF="${GITHUB_BASE_REF:-main}"
+          git fetch origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" --depth=100
       - name: Configure Workspace
       # The actual compute capability does not matter. This allows deviceless run for this pipeline.
       # The common configs ensure that bazel query and bazel build don't refetch repo mappings.


### PR DESCRIPTION
📝 Summary of Changes
Fetch the actual pull request base branch in `.github/workflows/clang_tidy.yml` instead of always fetching `main`.

🎯 Justification
Stacked PRs can target a non-`main` branch. The workflow sets `TARGET_REF` from `github.base_ref`, but previously only fetched `main`, so clang-tidy could fail before analysis with `fatal: Not a valid object name origin/<base-ref>`. Fetching the base branch into `refs/remotes/origin/<base-ref>` makes the existing `TARGET_REF` value resolvable.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N/A.

🧪 Unit Tests:
N/A. Workflow-only change.

🧪 Execution Tests:
Validated locally with:

```bash
git diff --check
BASE_REF=pr1_vmm_allocator_rename; git fetch origin "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" --depth=100 --no-tags
```
