### PR TITLE
[GPU] Fix thunk_emitter build failure.

### DIFF
--- a/xla/backends/gpu/runtime/thunk.h
+++ b/xla/backends/gpu/runtime/thunk.h
@@ -506,7 +506,7 @@ class ThunkSequence : public std::vector<std::unique_ptr<Thunk>> {
       : std::vector<std::unique_ptr<Thunk>>(std::move(thunks)) {};
   ThunkSequence(const ThunkSequence&) = delete;
 
-  ThunkSequence& operator=(ThunkSequence&) = delete;
+  ThunkSequence& operator=(const ThunkSequence&) = delete;
   ThunkSequence& operator=(ThunkSequence&&) = default;
 
   explicit ThunkSequence(int64_t len)


### PR DESCRIPTION
📝 Summary of Changes
ThunkSequence declared its deleted copy-assignment operator with a non-const parameter which breaks std::optional<ThunkSequence> in libstdc++ ("explicitly-defaulted copy assignment operator is const, but a member or base requires it to be non-const").

🚀 Kind of Contribution
🐛 Bug Fix
