### PR TITLE
Fix heap OOB read in Literal::CreateFromProto via unchecked dynamic_sizes

### DIFF
--- a/xla/literal.cc
+++ b/xla/literal.cc
@@ -2558,6 +2558,15 @@ absl::Status LiteralBase::Piece::CopyFromProto(const LiteralProto& proto) {
   if (shape.is_dynamic()) {
     TF_RET_CHECK(proto.dynamic_sizes_size() == shape.dimensions().size());
     for (int64_t i = 0; i < shape.dimensions().size(); ++i) {
+      if (shape.is_dynamic_dimension(i)) {
+        const int32_t dynamic_size = proto.dynamic_sizes(i);
+        if (dynamic_size < 0 || dynamic_size > shape.dimensions(i)) {
+          return InvalidArgument(
+              "LiteralProto dynamic_sizes[%d] = %d is out of range [0, %d] "
+              "for dimension %d with static bound %d",
+              i, dynamic_size, shape.dimensions(i), i, shape.dimensions(i));
+        }
+      }
       SetDynamicSize(i, proto.dynamic_sizes(i));
     }
   }

--- a/xla/literal_test.cc
+++ b/xla/literal_test.cc
@@ -2728,6 +2728,80 @@ TEST_F(LiteralUtilTest, InvalidProtoMissingLayout) {
   EXPECT_THAT(status.message(), HasSubstr("LiteralProto has no layout"));
 }
 
+TEST_F(LiteralUtilTest, InvalidProtoDynamicSizeExceedsBound) {
+  // Regression test: dynamic_sizes that exceed the static dimension bound must
+  // be rejected by CreateFromProto.  Before the fix, the poisoned value was
+  // silently stored via Piece::SetDynamicSize (which lacked the CHECK_GE
+  // present in MutableLiteralBase::SetDynamicSize), leading to a heap OOB read
+  // in CopyElementsWithDynamicBound when ToStatic() was called.
+  LiteralProto proto;
+
+  // Shape: f32[<=4] — rank 1, 1 dynamic dim, static bound = 4.
+  ShapeProto* shape = proto.mutable_shape();
+  shape->set_element_type(F32);
+  shape->add_dimensions(4);
+  shape->add_is_dynamic_dimension(true);
+  LayoutProto* layout = shape->mutable_layout();
+  layout->add_minor_to_major(0);
+
+  // Provide exactly 4 float values (matches static bound).
+  proto.add_f32s(1.0f);
+  proto.add_f32s(2.0f);
+  proto.add_f32s(3.0f);
+  proto.add_f32s(4.0f);
+
+  // dynamic_sizes[0] = 100 — exceeds the static bound of 4.
+  proto.add_dynamic_sizes(100);
+
+  absl::Status status = Literal::CreateFromProto(proto).status();
+  ASSERT_FALSE(status.ok());
+  EXPECT_THAT(status.message(), HasSubstr("dynamic_sizes"));
+  EXPECT_THAT(status.message(), HasSubstr("out of range"));
+}
+
+TEST_F(LiteralUtilTest, InvalidProtoDynamicSizeNegative) {
+  // Negative dynamic_sizes must also be rejected.
+  LiteralProto proto;
+  ShapeProto* shape = proto.mutable_shape();
+  shape->set_element_type(F32);
+  shape->add_dimensions(4);
+  shape->add_is_dynamic_dimension(true);
+  LayoutProto* layout = shape->mutable_layout();
+  layout->add_minor_to_major(0);
+  proto.add_f32s(1.0f);
+  proto.add_f32s(2.0f);
+  proto.add_f32s(3.0f);
+  proto.add_f32s(4.0f);
+  proto.add_dynamic_sizes(-1);
+
+  absl::Status status = Literal::CreateFromProto(proto).status();
+  ASSERT_FALSE(status.ok());
+  EXPECT_THAT(status.message(), HasSubstr("dynamic_sizes"));
+  EXPECT_THAT(status.message(), HasSubstr("out of range"));
+}
+
+TEST_F(LiteralUtilTest, ValidProtoDynamicSizeWithinBound) {
+  // A dynamic_size within the static bound must still be accepted.
+  LiteralProto proto;
+  ShapeProto* shape = proto.mutable_shape();
+  shape->set_element_type(F32);
+  shape->add_dimensions(4);
+  shape->add_is_dynamic_dimension(true);
+  LayoutProto* layout = shape->mutable_layout();
+  layout->add_minor_to_major(0);
+  proto.add_f32s(1.0f);
+  proto.add_f32s(2.0f);
+  proto.add_f32s(3.0f);
+  proto.add_f32s(4.0f);
+  proto.add_dynamic_sizes(2);
+
+  TF_ASSERT_OK_AND_ASSIGN(Literal literal, Literal::CreateFromProto(proto));
+  EXPECT_EQ(literal.GetDynamicSize(0), 2);
+  auto static_literal = literal.ToStatic();
+  EXPECT_EQ(static_literal.shape(), ShapeUtil::MakeShape(F32, {2}));
+  EXPECT_TRUE(static_literal.shape().is_static());
+}
+
 TEST_F(LiteralUtilTest, InvalidProtoTooFewTupleElements) {
   // Proto has the too few tuple elements.
   LiteralProto proto;


### PR DESCRIPTION
## Summary

`Piece::CopyFromProto` accepts `dynamic_sizes` values from a serialized `LiteralProto` and passes them directly to `Piece::SetDynamicSize` without validating that they fall within `[0, shape.dimensions(i)]`. Unlike the public `MutableLiteralBase::SetDynamicSize` (which has `CHECK_GE`), the internal `Piece::SetDynamicSize` stores the value unconditionally, breaking the invariant `dynamic_size <= static_dimension_bound`.

A subsequent call to `ToStatic()` reads the poisoned dynamic size and uses it as the copy count in `CopyElementsWithDynamicBound` / `std::copy_n`, causing an **out-of-bounds heap read**.

## Reproduction

```
// Shape: f32[<=4]{0}, data = [1,2,3,4], dynamic_sizes = [100]
LiteralProto proto = BuildPoisonedProto();
auto literal = Literal::CreateFromProto(proto).value();  // succeeds (BUG)
literal.GetDynamicSize(0);  // returns 100 (invariant broken)
literal.ToStatic();  // heap-buffer-overflow READ of size 400
```

AddressSanitizer confirms:
```
==3895==ERROR: AddressSanitizer: stack-buffer-overflow
READ of size 400 at 0x7b86c9300340 thread T0
SCARINESS: 41 (multi-byte-read-stack-buffer-overflow)
```

## Fix

Add bounds validation in `CopyFromProto` before calling `SetDynamicSize`: for each dynamic dimension, reject `dynamic_sizes[i]` outside `[0, shape.dimensions(i)]` with `InvalidArgument`.

## Tests added

- `InvalidProtoDynamicSizeExceedsBound`: `dynamic_sizes=[100]` on `f32[<=4]` -> rejected
- `InvalidProtoDynamicSizeNegative`: `dynamic_sizes=[-1]` -> rejected
- `ValidProtoDynamicSizeWithinBound`: `dynamic_sizes=[2]` on `f32[<=4]` -> accepted, `ToStatic()` produces `f32[2]`