### PR TITLE
[xla:gpu] Improve gpu/collectives logging

### DIFF
--- a/xla/backends/gpu/collectives/gpu_clique_rendezvous.cc
+++ b/xla/backends/gpu/collectives/gpu_clique_rendezvous.cc
@@ -75,19 +75,19 @@ absl::StatusOr<std::shared_ptr<GpuCliqueRendezvous>> GpuCliqueRendezvous::Join(
         "GpuClique rendezvous is not supported for non-local cliques");
   }
 
-  VLOG(3) << absl::StrFormat("rank=[%d] Join gpu clique rendezvous: %s",
-                             rank.value(), clique_key.ToString());
+  VLOG(3) << absl::StrFormat("rank=[%v] Join gpu clique rendezvous: %v", rank,
+                             clique_key);
 
   std::string rendezvous_name =
-      absl::StrFormat("GpuCliqueRendezvous for %s", clique_key.ToString());
+      absl::StrFormat("GpuCliqueRendezvous for %v", clique_key);
   GpuCliqueRendezvousKey rendezvous_key = {clique_key};
   RankData rendezvous_value = {rank, std::move(data)};
 
   // A callback for rendezvous to construct the GpuCliqueRendezvous.
   auto callback = [&](absl::Span<RankData*> values) {
-    VLOG(3) << absl::StrFormat("[ranks=%s] Complete gpu clique rendezvous: %s",
+    VLOG(3) << absl::StrFormat("[ranks=%s] Complete gpu clique rendezvous: %v",
                                absl::StrJoin(values, ",", RankFormatter{}),
-                               clique_key.ToString());
+                               clique_key);
 
     absl::btree_map<RankId, tsl::UniqueAny> data;
     for (auto* value : values) {

--- a/xla/backends/gpu/collectives/gpu_cliques.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques.cc
@@ -1022,7 +1022,7 @@ static absl::Status AbortCliquesWithIncarnations(
   // to be aborted, so that they can cancel pending collective operations.
   for (auto& [cache_key, lockable_clique] : cliques) {
     if (CliqueKeyContainsIncarnation(cache_key.second, incarnation_set)) {
-      VLOG(1) << "Canceling pending GPU clique " << cache_key.second.ToString();
+      VLOG(1) << "Canceling pending GPU clique " << cache_key.second;
       lockable_clique->Cancel();
     }
   }
@@ -1037,25 +1037,24 @@ static absl::Status AbortCliquesWithIncarnations(
     std::vector<std::unique_ptr<tsl::Thread>> threads;
     for (auto& [cache_key, lockable_clique] : cliques) {
       if (!CliqueKeyContainsIncarnation(cache_key.second, incarnation_set)) {
-        VLOG(1) << "Not aborting GPU clique " << cache_key.second.ToString()
+        VLOG(1) << "Not aborting GPU clique " << cache_key.second
                 << " because it does not include a stale incarnation";
         continue;
       }
 
       auto abort = [&result, &result_mu, key = cache_key.second,
                     lockable_clique = &lockable_clique]() {
-        VLOG(1) << "Aborting GPU clique " << key.ToString();
+        VLOG(1) << "Aborting GPU clique " << key;
         if (absl::Status s = (*lockable_clique)->Abort(); !s.ok()) {
           LOG(ERROR) << "Error aborting GPU clique " << key << ": " << s;
           absl::MutexLock lock(result_mu);
           result = std::move(s);
         } else {
-          VLOG(1) << "Aborted GPU clique " << key.ToString();
+          VLOG(1) << "Aborted GPU clique " << key;
         }
       };
 
-      VLOG(1) << "Launching thread to abort GPU clique "
-              << cache_key.second.ToString();
+      VLOG(1) << "Launching thread to abort GPU clique " << cache_key.second;
       threads.push_back(absl::WrapUnique(tsl::Env::Default()->StartThread(
           tsl::ThreadOptions(), "abort", abort)));
     }
@@ -1067,9 +1066,9 @@ static absl::Status AbortCliquesWithIncarnations(
     bool erase =
         CliqueKeyContainsIncarnation(cache_key.second, incarnation_set);
     if (erase) {
-      VLOG(1) << "Removing GPU clique " << cache_key.second.ToString();
+      VLOG(1) << "Removing GPU clique " << cache_key.second;
     } else {
-      VLOG(1) << "Not removing GPU clique " << cache_key.second.ToString()
+      VLOG(1) << "Not removing GPU clique " << cache_key.second
               << " because it does not include a stale incarnation";
     }
     return erase;

--- a/xla/backends/gpu/collectives/gpu_communicator.h
+++ b/xla/backends/gpu/collectives/gpu_communicator.h
@@ -226,6 +226,11 @@ class GpuCommunicator : public Communicator {
                                         const Executor& executor) {
     return Unimplemented("LaunchWaitSignal is not implemented");
   }
+
+  template <typename Sink>
+  friend void AbslStringify(Sink& sink, const GpuCommunicator& comm) {
+    absl::Format(&sink, "%s", comm.ToString());
+  }
 };
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/nccl_collectives.cc
+++ b/xla/backends/gpu/collectives/nccl_collectives.cc
@@ -248,6 +248,11 @@ static auto DeviceRanksToString(
   });
 }
 
+static auto DevicesToString(absl::Span<const GlobalDeviceId> devices) {
+  return absl::StrFormat("%zu:[%s]", devices.size(),
+                         HumanReadableDevices(devices));
+}
+
 static ncclComm_t Cast(const Communicator* comm) {
   auto* nccl_communicator = absl::down_cast<const NcclCommunicator*>(comm);
   CHECK(nccl_communicator != nullptr) << "Unsupported XLA communicator";
@@ -362,10 +367,11 @@ NcclCollectives::CreateCommunicatorsWithCancel(
   VLOG(1) << absl::StreamFormat(
       "[%s] [ranks=%s] Initialize NCCL (compiled with %s, linked with %s) "
       "communicators for %d local devices (out of %d global devices); "
-      "size(id)=%zu; fingerprint(id)=%v",
+      "devices=%s; size(id)=%zu; fingerprint(id)=%v",
       DeviceOrdinalsToString(ranks), DeviceRanksToString(ranks),
       FormatNcclVersion(NCCL_VERSION_CODE), FormatNcclVersion(nccl_version),
-      ranks.size(), clique_key.num_devices(), clique_ids->size(),
+      ranks.size(), clique_key.num_devices(),
+      DevicesToString(clique_key.devices()), clique_ids->size(),
       clique_ids->fingerprint());
 
   const auto& gpu_config =
@@ -424,9 +430,12 @@ NcclCollectives::CreateCommunicatorsWithCancel(
 
     absl::Time init_done = absl::Now();
     VLOG(1) << absl::StreamFormat(
-        "[%d] [rank=%v] Initialized NCCL communicator for rank %v of %d in %v",
-        device_ordinal, ranks[i].rank, ranks[i].rank, num_ranks,
-        init_done - init_start);
+        "[%d] [rank=%v] Initialized NCCL communicator %p for rank %v of %d "
+        "in %v; devices=%s; size(id)=%zu; fingerprint(id)=%v",
+        device_ordinal, ranks[i].rank, static_cast<const void*>(comm),
+        ranks[i].rank, num_ranks, init_done - init_start,
+        DevicesToString(clique_key.devices()), clique_ids->size(),
+        clique_ids->fingerprint());
 
     return comm;
   };
@@ -443,8 +452,8 @@ NcclCollectives::CreateCommunicatorsWithCancel(
                                    cancel, gpu_config.async_execution);
       if (!comm.ok()) {
         LOG(ERROR) << absl::StreamFormat(
-            "[%d] [rank=%v] Failed to create NCCL communicator: %s",
-            DeviceOrdinal(ranks[i]), ranks[i].rank, comm.status().ToString());
+            "[%d] [rank=%v] Failed to create NCCL communicator: %v",
+            DeviceOrdinal(ranks[i]), ranks[i].rank, comm.status());
       }
       return Cast(std::move(comm));
     });
@@ -493,23 +502,25 @@ NcclCollectives::SplitCommunicatorsWithCancel(
     });
 
     absl::Time split_start = absl::Now();
+    ncclComm_t parent_comm = Cast(comms[i]);
     VLOG(1) << absl::StreamFormat(
-        "[%d] [rank=%v] Split NCCL communicator %p with color %d "
-        "and key %v",
-        device_ordinal, rank, static_cast<const void*>(comms[i]), color, key);
+        "[%d] [rank=%v] Split NCCL communicator %p with color %d and key %v",
+        device_ordinal, rank, static_cast<const void*>(parent_comm), color,
+        key);
 
     ASSIGN_OR_RETURN(ncclConfig_t comm_config,
                      AsNcclConfig(gpu_config, stream_executors[i]));
 
     ncclComm_t split_comm;
-    XLA_NCCL_RETURN_IF_ERROR(ncclCommSplit(Cast(comms[i]), color, key.value(),
+    XLA_NCCL_RETURN_IF_ERROR(ncclCommSplit(parent_comm, color, key.value(),
                                            &split_comm, &comm_config));
 
     absl::Time split_done = absl::Now();
     VLOG(1) << absl::StreamFormat(
-        "[%d] [rank=%v] Split NCCL communicator %p with color %d "
+        "[%d] [rank=%v] Split NCCL communicator %p -> %p with color %d "
         "and key %v in %v",
-        device_ordinal, rank, static_cast<const void*>(comms[i]), color, key,
+        device_ordinal, rank, static_cast<const void*>(parent_comm),
+        static_cast<const void*>(split_comm), color, key,
         split_done - split_start);
 
     return split_comm;
@@ -527,8 +538,8 @@ NcclCollectives::SplitCommunicatorsWithCancel(
                                    cancel, gpu_config.async_execution);
       if (!comm.ok()) {
         LOG(ERROR) << absl::StreamFormat(
-            "[%d] [rank=%v] Failed to split NCCL communicator: %s",
-            DeviceOrdinal(ranks[i]), ranks[i].rank, comm.status().ToString());
+            "[%d] [rank=%v] Failed to split NCCL communicator: %v",
+            DeviceOrdinal(ranks[i]), ranks[i].rank, comm.status());
       }
       return Cast(std::move(comm));
     });

--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -166,9 +166,8 @@ NcclCommunicator::NcclCommunicator(se::StreamExecutor* stream_executor,
       executor_(std::move(executor)),
       cancel_(std::move(cancel)),
       capabilities_(GetCapabilities(comm_)) {
-  VLOG(1) << absl::StreamFormat("[%d] Created NCCL communicator %s",
-                                stream_executor_->device_ordinal(),
-                                this->ToString());
+  VLOG(1) << absl::StreamFormat("[%d] Created NCCL communicator %v",
+                                stream_executor_->device_ordinal(), *this);
 }
 
 bool NcclCommunicator::SupportsDeviceComm() const {
@@ -939,8 +938,7 @@ NcclDeviceCommunicator::NcclDeviceCommunicator(const NcclCommunicator* comm,
 
 NcclDeviceCommunicator::~NcclDeviceCommunicator() {
   VLOG(3) << absl::StreamFormat(
-      "Destroy NCCL device comm %s constructed for %s", this->ToString(),
-      comm_->ToString());
+      "Destroy NCCL device comm %v constructed for %v", *this, *comm_);
 
   DCHECK(comm_ && comm_->stream_executor()) << "StreamExecutor is unavailable";
   auto activation = comm_->stream_executor()->Activate();
@@ -955,7 +953,7 @@ absl::StatusOr<std::unique_ptr<NcclDeviceCommunicator>>
 NcclDeviceCommunicator::CreateFrom(const NcclCommunicator& comm,
                                    const Requirements& requirements) {
   VLOG(3) << absl::StreamFormat(
-      "Create NCCL device comm from %s: lsa_barrier_count=%d", comm.ToString(),
+      "Create NCCL device comm from %v: lsa_barrier_count=%d", comm,
       requirements.lsa_barrier_count);
 
   DCHECK(comm.stream_executor()) << "StreamExecutor is unavailable";

--- a/xla/backends/gpu/collectives/nvshmem_communicator.cc
+++ b/xla/backends/gpu/collectives/nvshmem_communicator.cc
@@ -148,7 +148,7 @@ NvshmemCommunicator::NvshmemCommunicator(NvshmemCollectives* collectives)
 }
 
 absl::Status NvshmemCommunicator::Abort() {
-  VLOG(1) << "Abort NVSHMEM communicator: " << ToString();
+  VLOG(1) << "Abort NVSHMEM communicator: " << *this;
   if (aborted_) {
     return FailedPrecondition("NvshmemCommunicator aborted");
   }
@@ -165,7 +165,7 @@ absl::Status NvshmemCommunicator::Abort() {
 
 absl::Status NvshmemCommunicator::Barrier(
     const Communicator::Executor& executor) {
-  VLOG(1) << "Barrier NVSHMEM communicator: " << ToString();
+  VLOG(1) << "Barrier NVSHMEM communicator: " << *this;
   if (aborted_) {
     return FailedPrecondition("NvshmemCommunicator aborted");
   }
@@ -183,7 +183,7 @@ absl::Status NvshmemCommunicator::Barrier(
   return absl::OkStatus();
 }
 absl::StatusOr<size_t> NvshmemCommunicator::NumRanks() const {
-  VLOG(5) << "Get the number of ranks in NVSHMEM communicator: " << ToString();
+  VLOG(5) << "Get the number of ranks in NVSHMEM communicator: " << *this;
   if (aborted_) {
     return absl::FailedPreconditionError("NvshmemCommunicator aborted");
   }
@@ -201,7 +201,7 @@ absl::StatusOr<size_t> NvshmemCommunicator::NumRanks() const {
 }
 
 absl::StatusOr<size_t> NvshmemCommunicator::CurrentRank() {
-  VLOG(5) << "Get current rank in NVSHMEM communicator: " << ToString();
+  VLOG(5) << "Get current rank in NVSHMEM communicator: " << *this;
   if (aborted_) {
     return absl::FailedPreconditionError("NvshmemCommunicator aborted");
   }
@@ -449,7 +449,7 @@ Future<> NvshmemCommunicator::Send(se::DeviceAddressBase recv_buffer,
                                    se::DeviceAddressBase send_buffer,
                                    PrimitiveType dtype, size_t count,
                                    RankId peer, const Executor& executor) {
-  VLOG(1) << "Send NVSHMEM communicator: " << ToString();
+  VLOG(1) << "Send NVSHMEM communicator: " << *this;
   if (aborted_) {
     return absl::FailedPreconditionError("NvshmemCommunicator aborted");
   }
@@ -467,7 +467,7 @@ Future<> NvshmemCommunicator::Recv(se::DeviceAddressBase recv_buffer,
                                    se::DeviceAddressBase send_buffer,
                                    PrimitiveType dtype, size_t count,
                                    RankId peer, const Executor& executor) {
-  VLOG(1) << "Recv NVSHMEM communicator: " << ToString();
+  VLOG(1) << "Recv NVSHMEM communicator: " << *this;
   if (aborted_) {
     return absl::FailedPreconditionError("NvshmemCommunicator aborted");
   }
@@ -482,7 +482,7 @@ Future<> NvshmemCommunicator::Recv(se::DeviceAddressBase recv_buffer,
 }
 
 absl::Status NvshmemCommunicator::Quiet(const Executor& executor) {
-  VLOG(1) << "Quiet NVSHMEM communicator: " << ToString();
+  VLOG(1) << "Quiet NVSHMEM communicator: " << *this;
   if (aborted_) {
     return absl::FailedPreconditionError("NvshmemCommunicator aborted");
   }
@@ -496,7 +496,7 @@ absl::Status NvshmemCommunicator::Quiet(const Executor& executor) {
 }
 
 absl::Status NvshmemCommunicator::Fence() {
-  VLOG(1) << "Fence NVSHMEM communicator: " << ToString();
+  VLOG(1) << "Fence NVSHMEM communicator: " << *this;
   if (aborted_) {
     return absl::FailedPreconditionError("NvshmemCommunicator aborted");
   }


### PR DESCRIPTION
**NFC**: Changing logging to improve debuggability

Quality of life improvement by adding more details to NCCL collectives logging, now you can see identity of the created communicator and identity of the split communicator, and can easily trace communicator lifecycle from the logs:

```
[0] [rank=0] Initialized NCCL communicator 0x70ebfc0bdc20 for rank 0 of 2 in 192.514143ms; devices=2:[0,1]; size(id)=1; fingerprint(id)=1197051945
[1] [rank=1] Initialized NCCL communicator 0x70ea600084d0 for rank 1 of 2 in 192.511322ms; devices=2:[0,1]; size(id)=1; fingerprint(id)=1197051945
...
[0,1] [ranks=0,1] Split 2 NCCL communicators using color 0 and keys [0,1]
[0] [rank=0] Split NCCL communicator 0x70ebfc0bdc20 with color 0 and key 0
[0] [rank=0] Split NCCL communicator 0x70ebfc0bdc20 -> 0x70ea60513490 with color 0 and key 0 in 168.850032ms
[1] [rank=1] Split NCCL communicator 0x70ea600084d0 with color 0 and key 1
[1] [rank=1] Split NCCL communicator 0x70ea600084d0 -> 0x70eb467f4f70 with color 0 and key 1 in 168.843012ms
```