### PR TITLE
[NVIDIA GPU] Thunk change for dynamic root collective bcast

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -2520,9 +2520,12 @@ cc_library(
         "//xla/stream_executor:stream",
         "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -2516,6 +2516,7 @@ cc_library(
         "//xla/runtime:buffer_use",
         "//xla/service:buffer_assignment",
         "//xla/stream_executor:device_address",
+        "//xla/stream_executor:memory_allocation",
         "//xla/stream_executor:stream",
         "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/base",

--- a/xla/backends/gpu/runtime/collective_broadcast_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_broadcast_thunk.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "absl/base/casts.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
@@ -41,6 +42,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/xla_data.pb.h"
 
@@ -48,10 +50,12 @@ namespace xla::gpu {
 
 CollectiveBroadcastThunk::CollectiveBroadcastThunk(ThunkInfo thunk_info,
                                                    CollectiveConfig config,
-                                                   std::vector<Buffer> buffers)
+                                                   std::vector<Buffer> buffers,
+                                                   bool has_dynamic_root)
     : CollectiveThunk(Thunk::kCollectiveBroadcast, thunk_info,
                       std::move(buffers)),
-      config_(config) {}
+      config_(config),
+      has_dynamic_root_(has_dynamic_root) {}
 
 CollectiveBroadcastThunk::CollectiveBroadcastThunk(
     ThunkInfo thunk_info, const HloCollectiveBroadcastInstruction* instr,
@@ -59,7 +63,7 @@ CollectiveBroadcastThunk::CollectiveBroadcastThunk(
     : CollectiveThunk(Thunk::kCollectiveBroadcast, thunk_info,
                       std::move(buffers)),
       config_(GetCollectiveConfig(instr, std::nullopt)),
-      cb_metadata_({has_dynamic_root, {}}) {}
+      has_dynamic_root_(has_dynamic_root) {}
 
 /*static*/ absl::Status CollectiveBroadcastThunk::CheckImplementable(
     const HloInstruction* instr, int64_t replica_count,
@@ -74,15 +78,19 @@ CollectiveBroadcastThunk::CollectiveBroadcastThunk(
 
 absl::Status CollectiveBroadcastThunk::Initialize(
     const InitializeParams& params) {
-  if (cb_metadata_.has_dynamic_root && !initialized_) {
-    se::StreamExecutor* executor = params.executor;
+  se::StreamExecutor* executor = params.executor;
+  CollectiveBroadcastMetadata* cb_metadata = nullptr;
+  {
+    absl::MutexLock lock(mutex_);
+    cb_metadata = per_executor_cb_metadata_[executor].get();
+  }
+  if (has_dynamic_root_ && cb_metadata && cb_metadata->bcast_roots == nullptr) {
     // Last operand is the dynamic root buffer which contains actual root ranks
-    cb_metadata_.num_roots = buffers().size() - 1;
+    cb_metadata->num_roots = buffers().size() - 1;
     ASSIGN_OR_RETURN(
         std::unique_ptr<se::MemoryAllocation> alloc,
-        executor->HostMemoryAllocate(cb_metadata_.num_roots * sizeof(int32_t)));
-    cb_metadata_.bcast_roots = std::move(alloc);
-    initialized_ = true;
+        executor->HostMemoryAllocate(cb_metadata->num_roots * sizeof(int32_t)));
+    cb_metadata->bcast_roots = std::move(alloc);
   }
   return absl::OkStatus();
 }
@@ -122,49 +130,50 @@ absl::StatusOr<ThunkProto> CollectiveBroadcastThunk::ToProto() const {
 
   return proto;
 }
-absl::Status LoadCollectiveBroadcastRoots(
-    se::Stream& stream, DeviceBufferPair roots_device_buffer,
-    CollectiveBroadcastMetadata& cb_metadata) {
-  RETURN_IF_ERROR(stream.Memcpy(cb_metadata.bcast_roots->address().opaque(),
-                                roots_device_buffer.source_buffer,
-                                roots_device_buffer.source_buffer.size()));
-  // Wait for the copies to complete.
-  if (absl::Status blocked = stream.BlockHostUntilDone(); !blocked.ok()) {
-    return absl::InternalError(
-        absl::StrFormat("Failed to copy dynamic roots on stream %p: %s",
-                        &stream, blocked.message()));
-  }
 
-  return absl::OkStatus();
-}
 absl::Status CollectiveBroadcastThunk::RunCollective(
     const ExecuteParams& params, const GpuCliqueKey& clique_key,
     se::Stream& stream, Communicator& comm) {
   ASSIGN_OR_RETURN(std::vector<DeviceBufferPair> device_buffers,
                    ConvertToDeviceBuffers(params.buffer_allocations, buffers(),
                                           config_.operand_element_type));
-  if (cb_metadata_.has_dynamic_root) {
-    RETURN_IF_ERROR(LoadCollectiveBroadcastRoots(stream, device_buffers.back(),
-                                                 cb_metadata_));
+  CollectiveBroadcastMetadata* cb_metadata = nullptr;
+  {
+    absl::MutexLock lock(mutex_);
+    cb_metadata = per_executor_cb_metadata_[stream.parent()].get();
   }
 
   return ::xla::gpu::RunCollectiveBroadcast(device_buffers, stream, comm,
-                                            cb_metadata_);
+                                            cb_metadata);
 }
 
 absl::Status RunCollectiveBroadcast(std::vector<DeviceBufferPair>& buffers,
                                     se::Stream& stream, Communicator& comm,
-                                    CollectiveBroadcastMetadata& cb_metadata) {
+                                    CollectiveBroadcastMetadata* cb_metadata,
+                                    bool has_dynamic_root) {
+  if (has_dynamic_root && cb_metadata) {
+    DeviceBufferPair& roots_device_buffer = buffers.back();
+    CHECK(cb_metadata->bcast_roots != nullptr);
+    RETURN_IF_ERROR(stream.Memcpy(cb_metadata->bcast_roots->address().opaque(),
+                                  roots_device_buffer.source_buffer,
+                                  roots_device_buffer.source_buffer.size()));
+    // Wait for the copies to complete.
+    if (absl::Status blocked = stream.BlockHostUntilDone(); !blocked.ok()) {
+      return absl::InternalError(
+          absl::StrFormat("Failed to copy dynamic roots on stream %p: %s",
+                          &stream, blocked.message()));
+    }
+  }
   auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
   Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
     RankId root = RankId(0);
     for (int64_t i = 0; i < buffers.size(); ++i) {
       const DeviceBufferPair& buffer = buffers[i];
-      if (cb_metadata.has_dynamic_root) {
+      if (has_dynamic_root && cb_metadata) {
         // If dynamic root is enabled, the actual root rank is read from the
         // last buffer and can be different for each broadcast.
         int32_t* roots_ptr = reinterpret_cast<int32_t*>(
-            cb_metadata.bcast_roots->address().opaque());
+            cb_metadata->bcast_roots->address().opaque());
         root = RankId(roots_ptr[i]);
       }
       se::DeviceAddressBase src_addr = buffer.source_buffer;

--- a/xla/backends/gpu/runtime/collective_broadcast_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_broadcast_thunk.cc
@@ -55,10 +55,11 @@ CollectiveBroadcastThunk::CollectiveBroadcastThunk(ThunkInfo thunk_info,
 
 CollectiveBroadcastThunk::CollectiveBroadcastThunk(
     ThunkInfo thunk_info, const HloCollectiveBroadcastInstruction* instr,
-    std::vector<Buffer> buffers, bool p2p_memcpy_enabled)
+    std::vector<Buffer> buffers, bool p2p_memcpy_enabled, bool has_dynamic_root)
     : CollectiveThunk(Thunk::kCollectiveBroadcast, thunk_info,
                       std::move(buffers)),
-      config_(GetCollectiveConfig(instr, std::nullopt)) {}
+      config_(GetCollectiveConfig(instr, std::nullopt)),
+      cb_metadata_({has_dynamic_root, {}}) {}
 
 /*static*/ absl::Status CollectiveBroadcastThunk::CheckImplementable(
     const HloInstruction* instr, int64_t replica_count,
@@ -69,6 +70,21 @@ CollectiveBroadcastThunk::CollectiveBroadcastThunk(
 /*static*/ CollectiveOpGroupMode CollectiveBroadcastThunk::GetGroupMode(
     const HloCollectiveBroadcastInstruction* inst) {
   return GetCollectiveConfig(inst, std::nullopt).group_mode;
+}
+
+absl::Status CollectiveBroadcastThunk::Initialize(
+    const InitializeParams& params) {
+  if (cb_metadata_.has_dynamic_root && !initialized_) {
+    se::StreamExecutor* executor = params.executor;
+    // Last operand is the dynamic root buffer which contains actual root ranks
+    cb_metadata_.num_roots = buffers().size() - 1;
+    ASSIGN_OR_RETURN(
+        std::unique_ptr<se::MemoryAllocation> alloc,
+        executor->HostMemoryAllocate(cb_metadata_.num_roots * sizeof(int32_t)));
+    cb_metadata_.bcast_roots = std::move(alloc);
+    initialized_ = true;
+  }
+  return absl::OkStatus();
 }
 
 absl::StatusOr<std::unique_ptr<CollectiveBroadcastThunk>>
@@ -106,28 +122,58 @@ absl::StatusOr<ThunkProto> CollectiveBroadcastThunk::ToProto() const {
 
   return proto;
 }
+absl::Status LoadCollectiveBroadcastRoots(
+    se::Stream& stream, DeviceBufferPair roots_device_buffer,
+    CollectiveBroadcastMetadata& cb_metadata) {
+  RETURN_IF_ERROR(stream.Memcpy(cb_metadata.bcast_roots->address().opaque(),
+                                roots_device_buffer.source_buffer,
+                                roots_device_buffer.source_buffer.size()));
+  // Wait for the copies to complete.
+  if (absl::Status blocked = stream.BlockHostUntilDone(); !blocked.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("Failed to copy dynamic roots on stream %p: %s",
+                        &stream, blocked.message()));
+  }
 
+  return absl::OkStatus();
+}
 absl::Status CollectiveBroadcastThunk::RunCollective(
     const ExecuteParams& params, const GpuCliqueKey& clique_key,
     se::Stream& stream, Communicator& comm) {
   ASSIGN_OR_RETURN(std::vector<DeviceBufferPair> device_buffers,
                    ConvertToDeviceBuffers(params.buffer_allocations, buffers(),
                                           config_.operand_element_type));
-  return ::xla::gpu::RunCollectiveBroadcast(device_buffers, stream, comm);
+  if (cb_metadata_.has_dynamic_root) {
+    RETURN_IF_ERROR(LoadCollectiveBroadcastRoots(stream, device_buffers.back(),
+                                                 cb_metadata_));
+  }
+
+  return ::xla::gpu::RunCollectiveBroadcast(device_buffers, stream, comm,
+                                            cb_metadata_);
 }
 
 absl::Status RunCollectiveBroadcast(std::vector<DeviceBufferPair>& buffers,
-                                    se::Stream& stream, Communicator& comm) {
+                                    se::Stream& stream, Communicator& comm,
+                                    CollectiveBroadcastMetadata& cb_metadata) {
   auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
   Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
-    for (auto buffer : buffers) {
+    RankId root = RankId(0);
+    for (int64_t i = 0; i < buffers.size(); ++i) {
+      const DeviceBufferPair& buffer = buffers[i];
+      if (cb_metadata.has_dynamic_root) {
+        // If dynamic root is enabled, the actual root rank is read from the
+        // last buffer and can be different for each broadcast.
+        int32_t* roots_ptr = reinterpret_cast<int32_t*>(
+            cb_metadata.bcast_roots->address().opaque());
+        root = RankId(roots_ptr[i]);
+      }
       se::DeviceAddressBase src_addr = buffer.source_buffer;
       se::DeviceAddressBase dest_addr = buffer.destination_buffer;
       RETURN_IF_ERROR(gpu_comm->LaunchBroadcast(
           // Always use rank 0 since we always broadcast from the first id
           // in replica_groups
-          src_addr, dest_addr, buffer.element_type, buffer.element_count,
-          RankId(0), GpuCollectives::On(stream)));
+          src_addr, dest_addr, buffer.element_type, buffer.element_count, root,
+          GpuCollectives::On(stream)));
     }
     return absl::OkStatus();
   });

--- a/xla/backends/gpu/runtime/collective_broadcast_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_broadcast_thunk.cc
@@ -78,14 +78,19 @@ CollectiveBroadcastThunk::CollectiveBroadcastThunk(
 
 absl::Status CollectiveBroadcastThunk::Initialize(
     const InitializeParams& params) {
-  se::StreamExecutor* executor = params.executor;
-  CollectiveBroadcastMetadata* cb_metadata = nullptr;
-  {
-    absl::MutexLock lock(mutex_);
-    cb_metadata = per_executor_cb_metadata_[executor].get();
+  if (!has_dynamic_root_) {
+    return absl::OkStatus();
   }
-  if (has_dynamic_root_ && cb_metadata && cb_metadata->bcast_roots == nullptr) {
-    // Last operand is the dynamic root buffer which contains actual root ranks
+  se::StreamExecutor* executor = params.executor;
+  absl::MutexLock lock(mutex_);
+  std::unique_ptr<CollectiveBroadcastMetadata>& cb_metadata =
+      per_executor_cb_metadata_[executor];
+  if (cb_metadata == nullptr) {
+    cb_metadata = std::make_unique<CollectiveBroadcastMetadata>();
+  }
+  if (cb_metadata->bcast_roots == nullptr) {
+    // The last buffer holds the runtime-selected root ranks (one S32 per
+    // broadcast); all other buffers are the data being broadcast.
     cb_metadata->num_roots = buffers().size() - 1;
     ASSIGN_OR_RETURN(
         std::unique_ptr<se::MemoryAllocation> alloc,
@@ -111,8 +116,9 @@ CollectiveBroadcastThunk::FromProto(
     buffers.push_back(buffer);
   }
 
-  return std::make_unique<CollectiveBroadcastThunk>(std::move(thunk_info),
-                                                    config, std::move(buffers));
+  return std::make_unique<CollectiveBroadcastThunk>(
+      std::move(thunk_info), config, std::move(buffers),
+      thunk_proto.has_dynamic_root());
 }
 
 absl::StatusOr<ThunkProto> CollectiveBroadcastThunk::ToProto() const {
@@ -127,6 +133,7 @@ absl::StatusOr<ThunkProto> CollectiveBroadcastThunk::ToProto() const {
   }
 
   *thunk_proto->mutable_collective_config() = config_.ToProto();
+  thunk_proto->set_has_dynamic_root(has_dynamic_root_);
 
   return proto;
 }
@@ -144,7 +151,7 @@ absl::Status CollectiveBroadcastThunk::RunCollective(
   }
 
   return ::xla::gpu::RunCollectiveBroadcast(device_buffers, stream, comm,
-                                            cb_metadata);
+                                            cb_metadata, has_dynamic_root_);
 }
 
 absl::Status RunCollectiveBroadcast(std::vector<DeviceBufferPair>& buffers,
@@ -164,10 +171,14 @@ absl::Status RunCollectiveBroadcast(std::vector<DeviceBufferPair>& buffers,
                           &stream, blocked.message()));
     }
   }
+  // With a dynamic root, the last buffer only carries the per-broadcast root
+  // ranks and must not itself be broadcast.
+  const int64_t num_broadcasts =
+      (has_dynamic_root && cb_metadata) ? buffers.size() - 1 : buffers.size();
   auto* gpu_comm = absl::down_cast<GpuCommunicator*>(&comm);
   Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
     RankId root = RankId(0);
-    for (int64_t i = 0; i < buffers.size(); ++i) {
+    for (int64_t i = 0; i < num_broadcasts; ++i) {
       const DeviceBufferPair& buffer = buffers[i];
       if (has_dynamic_root && cb_metadata) {
         // If dynamic root is enabled, the actual root rank is read from the

--- a/xla/backends/gpu/runtime/collective_broadcast_thunk.h
+++ b/xla/backends/gpu/runtime/collective_broadcast_thunk.h
@@ -27,6 +27,8 @@ limitations under the License.
 #include <cstdint>
 #include <vector>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
@@ -40,9 +42,8 @@ limitations under the License.
 namespace xla::gpu {
 
 struct CollectiveBroadcastMetadata {
-  bool has_dynamic_root;
   int64_t num_roots;
-  std::unique_ptr<se::MemoryAllocation> bcast_roots;
+  std::unique_ptr<se::MemoryAllocation> bcast_roots = nullptr;
 };
 // Thunk that performs a collective broadcast.
 class CollectiveBroadcastThunk : public CollectiveThunk {
@@ -66,7 +67,8 @@ class CollectiveBroadcastThunk : public CollectiveThunk {
                            bool p2p_memcpy_enabled = false,
                            bool has_dynamic_root = false);
   CollectiveBroadcastThunk(ThunkInfo thunk_info, CollectiveConfig config,
-                           std::vector<Buffer> buffers);
+                           std::vector<Buffer> buffers,
+                           bool has_dynamic_root = false);
   absl::Status Initialize(const InitializeParams& params) override;
 
   static absl::StatusOr<std::unique_ptr<CollectiveBroadcastThunk>> FromProto(
@@ -84,13 +86,17 @@ class CollectiveBroadcastThunk : public CollectiveThunk {
 
  private:
   const CollectiveConfig config_;
-  CollectiveBroadcastMetadata cb_metadata_;
-  bool initialized_ = false;
+  mutable absl::Mutex mutex_;
+  absl::flat_hash_map<se::StreamExecutor*,
+                      std::unique_ptr<CollectiveBroadcastMetadata>>
+      per_executor_cb_metadata_ ABSL_GUARDED_BY(mutex_);
+  bool has_dynamic_root_;
 };
 
 absl::Status RunCollectiveBroadcast(std::vector<DeviceBufferPair>& buffers,
                                     se::Stream& stream, Communicator& comm,
-                                    CollectiveBroadcastMetadata& cb_metadata);
+                                    CollectiveBroadcastMetadata* cb_metadata,
+                                    bool has_dynamic_root = false);
 
 }  // namespace xla::gpu
 

--- a/xla/backends/gpu/runtime/collective_broadcast_thunk.h
+++ b/xla/backends/gpu/runtime/collective_broadcast_thunk.h
@@ -34,10 +34,16 @@ limitations under the License.
 #include "xla/core/collectives/communicator.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/stream.h"
 
 namespace xla::gpu {
 
+struct CollectiveBroadcastMetadata {
+  bool has_dynamic_root;
+  int64_t num_roots;
+  std::unique_ptr<se::MemoryAllocation> bcast_roots;
+};
 // Thunk that performs a collective broadcast.
 class CollectiveBroadcastThunk : public CollectiveThunk {
  public:
@@ -57,9 +63,11 @@ class CollectiveBroadcastThunk : public CollectiveThunk {
   CollectiveBroadcastThunk(ThunkInfo thunk_info,
                            const HloCollectiveBroadcastInstruction* instr,
                            std::vector<Buffer> buffers,
-                           bool p2p_memcpy_enabled = false);
+                           bool p2p_memcpy_enabled = false,
+                           bool has_dynamic_root = false);
   CollectiveBroadcastThunk(ThunkInfo thunk_info, CollectiveConfig config,
                            std::vector<Buffer> buffers);
+  absl::Status Initialize(const InitializeParams& params) override;
 
   static absl::StatusOr<std::unique_ptr<CollectiveBroadcastThunk>> FromProto(
       ThunkInfo thunk_info, const CollectiveBroadcastThunkProto& thunk_proto,
@@ -76,10 +84,13 @@ class CollectiveBroadcastThunk : public CollectiveThunk {
 
  private:
   const CollectiveConfig config_;
+  CollectiveBroadcastMetadata cb_metadata_;
+  bool initialized_ = false;
 };
 
 absl::Status RunCollectiveBroadcast(std::vector<DeviceBufferPair>& buffers,
-                                    se::Stream& stream, Communicator& comm);
+                                    se::Stream& stream, Communicator& comm,
+                                    CollectiveBroadcastMetadata& cb_metadata);
 
 }  // namespace xla::gpu
 

--- a/xla/backends/gpu/runtime/collective_broadcast_thunk_multigpu_test.cc
+++ b/xla/backends/gpu/runtime/collective_broadcast_thunk_multigpu_test.cc
@@ -47,9 +47,13 @@ static constexpr int kNumDevices = 2;
 static constexpr int64_t kLength = 4;
 static constexpr int64_t kByteLength = sizeof(float) * kLength;
 
-static CollectiveConfig MakeCollectiveBroadcastConfig() {
+static CollectiveConfig MakeCollectiveBroadcastConfig(
+    bool has_dynamic_root = false) {
   CollectiveConfig config;
   config.operand_element_type = {F32};
+  if (has_dynamic_root) {
+    config.operand_element_type.push_back(S32);
+  }
   config.group_mode = COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA;
 
   ReplicaGroup replica_group;
@@ -60,8 +64,9 @@ static CollectiveConfig MakeCollectiveBroadcastConfig() {
   return config;
 }
 
-static CollectiveBroadcastThunk MakeThunk(const BufferAllocation& alloc_src,
-                                          const BufferAllocation& alloc_dst) {
+static CollectiveBroadcastThunk MakeThunk(
+    const BufferAllocation& alloc_src, const BufferAllocation& alloc_dst,
+    const BufferAllocation* alloc_root = nullptr) {
   ShapedSlice src_slice{BufferAllocation::Slice(&alloc_src, 0, kByteLength),
                         ShapeUtil::MakeShape(F32, {kLength})};
   ShapedSlice dst_slice{BufferAllocation::Slice(&alloc_dst, 0, kByteLength),
@@ -71,8 +76,22 @@ static CollectiveBroadcastThunk MakeThunk(const BufferAllocation& alloc_src,
                                  .destination_buffer = dst_slice,
                                  .source_memory_space = 0,
                                  .destination_memory_space = 0};
-  return CollectiveBroadcastThunk(Thunk::ThunkInfo(),
-                                  MakeCollectiveBroadcastConfig(), {buffer});
+  std::vector<CollectiveThunk::Buffer> buffers = {buffer};
+  if (alloc_root) {
+    ShapedSlice root_slice{
+        BufferAllocation::Slice(alloc_root, 0, sizeof(int32_t)),
+        ShapeUtil::MakeShape(S32, {1})};
+    CollectiveThunk::Buffer root_buffer{.element_count = 1,
+                                        .source_buffer = root_slice,
+                                        .destination_buffer = root_slice,
+                                        .source_memory_space = 0,
+                                        .destination_memory_space = 0};
+    buffers.push_back(root_buffer);
+  }
+  bool has_dynamic_root = (alloc_root != nullptr);
+  return CollectiveBroadcastThunk(
+      Thunk::ThunkInfo(), MakeCollectiveBroadcastConfig(has_dynamic_root),
+      buffers, has_dynamic_root);
 }
 
 using DeviceTestSlot = CollectiveThunkMultiGpuTestState;
@@ -125,8 +144,12 @@ static absl::Status VerifyOutput(se::Stream& stream, se::DeviceAddressBase dst,
 
 static absl::Status SetupDeviceSlot(int device_ordinal, DeviceTestSlot& slot,
                                     CollectiveBroadcastThunk& thunk,
-                                    const DeviceAssignment& device_assignment) {
+                                    const DeviceAssignment& device_assignment,
+                                    int64_t dynamic_root_buffer_size = 0) {
   std::vector<int64_t> buffer_sizes = DeviceBufferSizes();
+  if (dynamic_root_buffer_size > 0) {
+    buffer_sizes.push_back(dynamic_root_buffer_size);
+  }
   return SetupCollectiveThunkDevice(device_ordinal, kNumDevices, buffer_sizes,
                                     thunk, device_assignment, slot);
 }
@@ -247,6 +270,27 @@ TEST(CollectiveBroadcastThunkMultiGpuTest, RecordCommandBufferUpdate) {
   ASSERT_OK(RunOnDevices(
       kNumDevices, "collective_broadcast_update",
       [&](int d) { return RunUpdatePhase(slots[d], thunk, d, /*phase=*/3); }));
+}
+
+TEST(CollectiveBroadcastThunkMultiGpuTest, ExecuteOnStreamWithDynamicRoot) {
+  if (!HasEnoughGpus(kNumDevices)) {
+    GTEST_SKIP() << "Test requires at least " << kNumDevices << " GPUs";
+  }
+
+  DeviceAssignment device_assignment = MakeDeviceAssignment(kNumDevices);
+  BufferAllocation alloc_src(/*index=*/0, kByteLength, /*color=*/0);
+  BufferAllocation alloc_dst(/*index=*/1, kByteLength, /*color=*/0);
+  BufferAllocation alloc_root(/*index=*/2, sizeof(int32_t), /*color=*/0);
+
+  CollectiveBroadcastThunk thunk = MakeThunk(alloc_src, alloc_dst, &alloc_root);
+  std::vector<DeviceTestSlot> slots(kNumDevices);
+
+  ASSERT_OK(RunOnDevices(
+      kNumDevices, "collective_broadcast_execute", [&](int d) -> absl::Status {
+        RETURN_IF_ERROR(SetupDeviceSlot(d, slots[d], thunk, device_assignment,
+                                        alloc_root.size()));
+        return RunExecuteOnStreamPhase(slots[d], thunk, d, /*phase=*/1);
+      }));
 }
 
 }  // namespace

--- a/xla/backends/gpu/runtime/thunk.proto
+++ b/xla/backends/gpu/runtime/thunk.proto
@@ -455,6 +455,9 @@ message CollectiveBroadcastThunkProto {
   reserved 1;  // Was async_events_unique_id.
   repeated CollectiveBufferProto buffers = 2;
   CollectiveConfigProto collective_config = 3;
+  // When true, the last buffer holds the runtime-selected root rank per
+  // broadcast and is not itself broadcast.
+  bool has_dynamic_root = 4;
 }
 
 message CollectiveGroupThunkProto {

--- a/xla/backends/gpu/tests/collective_ops_e2e_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_e2e_test.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "absl/strings/substitute.h"
 #include "absl/types/span.h"
 #include "xla/array.h"
 #include "xla/backends/gpu/tests/collective_ops_e2e_test_base.h"
@@ -396,6 +397,62 @@ TEST_P(AsyncCollectiveOps, AsyncCollectiveBroadcast) {
   ASSERT_EQ(results.size(), kNumReplicas);
   LiteralTestUtil::ExpectR1Equal<uint32_t>({11, 11}, results[0]);
   LiteralTestUtil::ExpectR1Equal<uint32_t>({11, 11}, results[1]);
+}
+
+TEST_P(AsyncCollectiveOps, AsyncCollectiveBroadcastDynamicRoot) {
+  // The broadcast root rank is not encoded in `replica_groups` (whose first
+  // member would be the static root); instead it is supplied at run time by the
+  // trailing S32 operand. With `replica_groups={{0, 1}}` a static broadcast
+  // would source from replica 0 (value 10), so selecting root rank 1 at run
+  // time (replica 1, value 11) proves the root is chosen dynamically.
+  constexpr absl::string_view kModuleTemplate = R"(
+  HloModule test
+  ENTRY test_computation {
+    replica = u32[] replica-id()
+    ten = u32[] constant(10)
+    sum = u32[] add(replica, ten)
+    p = u32[2] broadcast(sum), dimensions={}
+    root = s32[1] constant({$0})
+    bcast = u32[2] collective-broadcast(p, root),
+        replica_groups={{0, 1}}, has_dynamic_root=true
+    ROOT res = copy(bcast)
+  }
+  )";
+  const int64_t kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "Test requires at least " << kNumReplicas << " devices ("
+      << device_count() << " available)";
+
+  // (root rank -> broadcast value seen by every replica).
+  for (const auto& [root_rank, expected] :
+       std::vector<std::pair<int, uint32_t>>{{0, 10}, {1, 11}}) {
+    TF_ASSERT_OK_AND_ASSIGN(
+        auto module,
+        ParseAndReturnVerifiedModule(
+            absl::Substitute(kModuleTemplate, root_rank), kNumReplicas));
+
+    TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
+                            ExecuteReplicated(std::move(module)));
+
+    const HloModule* hlo_module = execution_result.optimized_module;
+    HloInstruction* cb_start =
+        FindInstruction(hlo_module, HloOpcode::kAsyncStart);
+    HloInstruction* cb_done =
+        FindInstruction(hlo_module, HloOpcode::kAsyncDone);
+    ASSERT_THAT(cb_start, NotNull());
+    ASSERT_THAT(cb_done, NotNull());
+    EXPECT_EQ(IsAsync(cb_start), enable_async_);
+    EXPECT_TRUE(Cast<HloCollectiveBroadcastInstruction>(
+                    cb_start->async_wrapped_instruction())
+                    ->has_dynamic_root());
+
+    const std::vector<Literal>& results = execution_result.results;
+    ASSERT_EQ(results.size(), kNumReplicas);
+    for (int i = 0; i < kNumReplicas; ++i) {
+      LiteralTestUtil::ExpectR1Equal<uint32_t>({expected, expected},
+                                               results[i]);
+    }
+  }
 }
 
 TEST_P(CollectivesModeOps, AllGather) {

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -374,10 +374,9 @@ absl::StatusOr<std::string> CanonicalGemmHlo(
          BackendConfigWrapper(gpu_config).GetRawString();
 }
 
-ThunkEmitter::ThunkEmitter(
-    IrEmitterContext* absl_nonnull ir_emitter_context,
-    llvm_ir::LLVMCommandLineOptionsReleasableLock* absl_nonnull
-        llvm_options_lock)
+ThunkEmitter::ThunkEmitter(IrEmitterContext* absl_nonnull ir_emitter_context,
+                           llvm_ir::LLVMCommandLineOptionsReleasableLock*
+                               absl_nonnull llvm_options_lock)
     : ir_emitter_context_(ir_emitter_context),
       send_recv_events_(std::make_shared<HostSendRecvAsyncEvents>()),
       call_graph_(CallGraph::Build(&ir_emitter_context->hlo_module())),
@@ -1339,7 +1338,7 @@ AsyncThunkSequence ThunkEmitter::EmitTritonCustomCall(
               buffer_assignment = &ir_emitter_context_->buffer_assignment(),
               &gpu_device_info = ir_emitter_context_->gpu_device_info()](
                  TritonWrapperResult result) mutable
-                 -> xla::Future<KernelReuseCache::Entry> {
+             -> xla::Future<KernelReuseCache::Entry> {
           auto local_module =
               std::move(result.kernel_source).thread_safe_module();
 
@@ -1392,24 +1391,24 @@ AsyncThunkSequence ThunkEmitter::EmitTritonCustomCall(
 
   Thunk::ThunkInfo thunk_info = Thunk::ThunkInfo::WithProfileAnnotation(
       instr, ir_emitter_context_->GetNextThunkId());
-  return status_or_entry.Map(
-      [thunk_info = std::move(thunk_info),
-       kernel_arguments = std::move(kernel_arguments),
-       call_zeroed_outputs = std::move(call_zeroed_outputs)](
-          const KernelReuseCache::Entry* entry) mutable
-          -> absl::StatusOr<ThunkSequence> {
-        ASSIGN_OR_RETURN(CustomKernel custom_kernel,
-                         kernel::CreateOwnedCubinCustomKernel(
-                             entry->kernel_name, entry->binary,
-                             kernel_arguments.args().size(),
-                             entry->launch_dimensions.block_counts(),
-                             entry->launch_dimensions.thread_counts_per_block(),
-                             entry->shmem_bytes));
-        return ThunkSequence::Of<CustomKernelThunk>(
-            std::move(thunk_info), std::move(custom_kernel),
-            std::move(kernel_arguments), entry->use_pdl, call_zeroed_outputs,
-            entry->tma_metadata);
-      });
+  return status_or_entry.Map([thunk_info = std::move(thunk_info),
+                              kernel_arguments = std::move(kernel_arguments),
+                              call_zeroed_outputs =
+                                  std::move(call_zeroed_outputs)](
+                                 const KernelReuseCache::Entry* entry) mutable
+                             -> absl::StatusOr<ThunkSequence> {
+    ASSIGN_OR_RETURN(
+        CustomKernel custom_kernel,
+        kernel::CreateOwnedCubinCustomKernel(
+            entry->kernel_name, entry->binary, kernel_arguments.args().size(),
+            entry->launch_dimensions.block_counts(),
+            entry->launch_dimensions.thread_counts_per_block(),
+            entry->shmem_bytes));
+    return ThunkSequence::Of<CustomKernelThunk>(
+        std::move(thunk_info), std::move(custom_kernel),
+        std::move(kernel_arguments), entry->use_pdl, call_zeroed_outputs,
+        entry->tma_metadata);
+  });
 }
 
 AsyncThunkSequence ThunkEmitter::EmitAsyncComputation(
@@ -1988,6 +1987,14 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveThunk(
           << "; partition count: " << partition_count
           << "; operand count: " << operand_count;
 
+  // A collective-broadcast may select its root rank at runtime, in which case
+  // the last operand is a root-rank vector rather than data to broadcast.
+  bool has_dynamic_root = false;
+  if constexpr (std::is_same_v<HloInstType,
+                               HloCollectiveBroadcastInstruction>) {
+    has_dynamic_root = inst->has_dynamic_root();
+  }
+
   // Stash relevant information in CollectiveThunk::Buffer even if
   // we may not generate an CollectiveThunk.
   std::vector<CollectiveThunk::Buffer> buffers;
@@ -2036,9 +2043,21 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveThunk(
     }
   } else {
     // For other operations simply zip operands with results.
-    for (int64_t i = 0; i < operand_count; i++) {
+    //
+    // A collective-broadcast with a dynamic root carries an extra trailing
+    // operand: a 1-D S32 vector holding the runtime-selected root rank for each
+    // data operand. That operand has no corresponding output, so it is not
+    // zipped with a result; instead it is mapped to its own allocation and
+    // consumed separately by the thunk.
+    int64_t num_data_operands =
+        has_dynamic_root ? operand_count - 1 : operand_count;
+    for (int64_t i = 0; i < num_data_operands; i++) {
       ShapeIndex idx = GetDstShapeIndex(async_start, inst, i, kind);
       RETURN_IF_ERROR(add_buffer(inst->operand(i), async_start, idx));
+    }
+    if (has_dynamic_root) {
+      const HloInstruction* roots = inst->operand(operand_count - 1);
+      RETURN_IF_ERROR(add_buffer(roots, roots, ShapeIndex({})));
     }
   }
 
@@ -2088,9 +2107,18 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveThunk(
     thunks = EmitCollectiveKernelThunk(std::move(thunk_info), buffers, inst,
                                        collective_config);
   } else {
-    if constexpr (std::is_constructible_v<
-                      CollectiveThunkType, Thunk::ThunkInfo, decltype(inst),
-                      std::vector<CollectiveThunk::Buffer>>) {
+    if constexpr (std::is_same_v<CollectiveThunkType,
+                                 CollectiveBroadcastThunk>) {
+      // CollectiveBroadcastThunk needs the dynamic-root flag so it can treat
+      // the trailing root-rank buffer specially at run time.
+      thunks = ThunkSequence::Of<CollectiveThunkType>(
+          thunk_info, inst, /*buffers=*/std::move(buffers),
+          ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p(),
+          has_dynamic_root);
+    } else if constexpr (std::is_constructible_v<
+                             CollectiveThunkType, Thunk::ThunkInfo,
+                             decltype(inst),
+                             std::vector<CollectiveThunk::Buffer>>) {
       thunks = ThunkSequence::Of<CollectiveThunkType>(
           thunk_info, inst, /*buffers=*/std::move(buffers));
     } else {


### PR DESCRIPTION
Follow-up pr of [this](https://github.com/openxla/xla/pull/44145).
This adds a metadata to the collectivfe broadcast thunk to host the cpu buffers for root ranks.
Ranks will be copied to host for each invocation.
I will push the e2e test after the above pr is merged so it doesn't fail all the CIs.