### PR TITLE
ifrt_proxy: validate peer-supplied string count before writing into preallocated host buffer

### DIFF
--- a/xla/python/ifrt_proxy/client/array.cc
+++ b/xla/python/ifrt_proxy/client/array.cc
@@ -722,7 +722,8 @@ tsl::Future<> Array::CopyToStringHostBuffer(
   auto on_ready = [promise = std::move(promise),
                    host_buffer_store = rpc_helper_->host_buffer_store(),
                    host_buffer_handle,
-                   dst_buffer = static_cast<absl::Cord*>(data)](
+                   dst_buffer = static_cast<absl::Cord*>(data),
+                   num_elements = static_cast<size_t>(shape_.num_elements())](
                       absl::StatusOr<std::shared_ptr<CopyToHostBufferResponse>>
                           resp) mutable {
     if (!resp.ok()) {
@@ -731,7 +732,7 @@ tsl::Future<> Array::CopyToStringHostBuffer(
     }
     host_buffer_store->Lookup(host_buffer_handle)
         .OnReady([promise = std::move(promise), dst_buffer, host_buffer_store,
-                  host_buffer_handle](
+                  host_buffer_handle, num_elements](
                      absl::StatusOr<absl::Cord> array_contents) mutable {
           absl::Cleanup cleanup = [&]() {
             host_buffer_store->Delete(host_buffer_handle)
@@ -751,7 +752,7 @@ tsl::Future<> Array::CopyToStringHostBuffer(
           }
           auto deserialization_status =
               DeserializeFromCordIntoPreallocatedStringHostBuffer(
-                  *array_contents, dst_buffer);
+                  *array_contents, num_elements, dst_buffer);
           promise.Set(deserialization_status);
         });
   };

--- a/xla/python/ifrt_proxy/client/array.cc
+++ b/xla/python/ifrt_proxy/client/array.cc
@@ -723,7 +723,7 @@ tsl::Future<> Array::CopyToStringHostBuffer(
                    host_buffer_store = rpc_helper_->host_buffer_store(),
                    host_buffer_handle,
                    dst_buffer = static_cast<absl::Cord*>(data),
-                   num_elements = static_cast<size_t>(shape_.num_elements())](
+                   num_elements = shape_.num_elements()](
                       absl::StatusOr<std::shared_ptr<CopyToHostBufferResponse>>
                           resp) mutable {
     if (!resp.ok()) {

--- a/xla/python/ifrt_proxy/common/array_util.cc
+++ b/xla/python/ifrt_proxy/common/array_util.cc
@@ -206,17 +206,15 @@ absl::Status DeserializeFromCordIntoPreallocatedStringHostBuffer(
         "Failed to parse serialized string buffer");
   }
 
-  // The element count is supplied by the peer (the proxy server, or an attacker
-  // on an insecure transport). `preallocated_buffer` was sized from the local
-  // array shape, so a peer that reports a different number of strings than the
-  // buffer holds would otherwise cause an out-of-bounds write. Require an exact
-  // match before writing any element.
+  // `preallocated_buffer` was sized from the array shape, while the serialized
+  // buffer carries its own string count. Reject a mismatch before writing any
+  // element so an inconsistent buffer cannot write past the end of
+  // `preallocated_buffer`. This mirrors the element-count validation on the
+  // server-side string deserialization path.
   if (static_cast<size_t>(string_array_proto.strings_size()) != num_elements) {
     return absl::InvalidArgumentError(absl::StrCat(
-        "Number of strings in serialized buffer (",
-        string_array_proto.strings_size(),
-        ") does not match the preallocated host buffer element count (",
-        num_elements, ")"));
+        "String host buffer has ", string_array_proto.strings_size(),
+        " elements but shape requires ", num_elements, " elements"));
   }
 
   auto* current_cord = preallocated_buffer;

--- a/xla/python/ifrt_proxy/common/array_util.cc
+++ b/xla/python/ifrt_proxy/common/array_util.cc
@@ -192,7 +192,7 @@ absl::StatusOr<std::vector<absl::Cord>> DeserializeStringHostBufferFromString(
 }
 
 absl::Status DeserializeFromCordIntoPreallocatedStringHostBuffer(
-    const absl::Cord& serialized_string_buffer, size_t num_elements,
+    const absl::Cord& serialized_string_buffer, int64_t num_elements,
     absl::Cord* preallocated_buffer) {
   proto::StringArrayContents string_array_proto;
 
@@ -211,7 +211,7 @@ absl::Status DeserializeFromCordIntoPreallocatedStringHostBuffer(
   // element so an inconsistent buffer cannot write past the end of
   // `preallocated_buffer`. This mirrors the element-count validation on the
   // server-side string deserialization path.
-  if (static_cast<size_t>(string_array_proto.strings_size()) != num_elements) {
+  if (string_array_proto.strings_size() != num_elements) {
     return absl::InvalidArgumentError(absl::StrCat(
         "String host buffer has ", string_array_proto.strings_size(),
         " elements but shape requires ", num_elements, " elements"));

--- a/xla/python/ifrt_proxy/common/array_util.cc
+++ b/xla/python/ifrt_proxy/common/array_util.cc
@@ -192,7 +192,7 @@ absl::StatusOr<std::vector<absl::Cord>> DeserializeStringHostBufferFromString(
 }
 
 absl::Status DeserializeFromCordIntoPreallocatedStringHostBuffer(
-    const absl::Cord& serialized_string_buffer,
+    const absl::Cord& serialized_string_buffer, size_t num_elements,
     absl::Cord* preallocated_buffer) {
   proto::StringArrayContents string_array_proto;
 
@@ -204,6 +204,19 @@ absl::Status DeserializeFromCordIntoPreallocatedStringHostBuffer(
 #endif
     return absl::InvalidArgumentError(
         "Failed to parse serialized string buffer");
+  }
+
+  // The element count is supplied by the peer (the proxy server, or an attacker
+  // on an insecure transport). `preallocated_buffer` was sized from the local
+  // array shape, so a peer that reports a different number of strings than the
+  // buffer holds would otherwise cause an out-of-bounds write. Require an exact
+  // match before writing any element.
+  if (static_cast<size_t>(string_array_proto.strings_size()) != num_elements) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Number of strings in serialized buffer (",
+        string_array_proto.strings_size(),
+        ") does not match the preallocated host buffer element count (",
+        num_elements, ")"));
   }
 
   auto* current_cord = preallocated_buffer;

--- a/xla/python/ifrt_proxy/common/array_util.h
+++ b/xla/python/ifrt_proxy/common/array_util.h
@@ -95,7 +95,7 @@ absl::StatusOr<std::vector<absl::Cord>> DeserializeStringHostBufferFromString(
 // elements encoded in `serialized_string_buffer` is validated against
 // `num_elements` before any element is written; a mismatch returns an error.
 absl::Status DeserializeFromCordIntoPreallocatedStringHostBuffer(
-    const absl::Cord& serialized_string_buffer, size_t num_elements,
+    const absl::Cord& serialized_string_buffer, int64_t num_elements,
     absl::Cord* preallocated_buffer);
 
 }  // namespace proxy

--- a/xla/python/ifrt_proxy/common/array_util.h
+++ b/xla/python/ifrt_proxy/common/array_util.h
@@ -90,11 +90,12 @@ absl::StatusOr<std::unique_ptr<std::string>> SerializeStringHostBuffer(
 absl::StatusOr<std::vector<absl::Cord>> DeserializeStringHostBufferFromString(
     absl::string_view serialized_string_buffer);
 
-// Callers must ensure that the `preallocated_buffer` consists of `N`
-// `absl::Cord` objects, where N is the number of string elements in the
-// `serialized_string_buffer`.
+// `preallocated_buffer` points to `num_elements` default-constructed
+// `absl::Cord` objects. The number of string elements encoded in
+// `serialized_string_buffer` is provided by the (potentially untrusted) peer,
+// so it is validated against `num_elements` before any element is written.
 absl::Status DeserializeFromCordIntoPreallocatedStringHostBuffer(
-    const absl::Cord& serialized_string_buffer,
+    const absl::Cord& serialized_string_buffer, size_t num_elements,
     absl::Cord* preallocated_buffer);
 
 }  // namespace proxy

--- a/xla/python/ifrt_proxy/common/array_util.h
+++ b/xla/python/ifrt_proxy/common/array_util.h
@@ -91,9 +91,9 @@ absl::StatusOr<std::vector<absl::Cord>> DeserializeStringHostBufferFromString(
     absl::string_view serialized_string_buffer);
 
 // `preallocated_buffer` points to `num_elements` default-constructed
-// `absl::Cord` objects. The number of string elements encoded in
-// `serialized_string_buffer` is provided by the (potentially untrusted) peer,
-// so it is validated against `num_elements` before any element is written.
+// `absl::Cord` objects, sized from the array shape. The number of string
+// elements encoded in `serialized_string_buffer` is validated against
+// `num_elements` before any element is written; a mismatch returns an error.
 absl::Status DeserializeFromCordIntoPreallocatedStringHostBuffer(
     const absl::Cord& serialized_string_buffer, size_t num_elements,
     absl::Cord* preallocated_buffer);

--- a/xla/python/ifrt_proxy/common/array_util_test.cc
+++ b/xla/python/ifrt_proxy/common/array_util_test.cc
@@ -208,10 +208,11 @@ TEST(StringHostBufferTest,
   TF_ASSERT_OK_AND_ASSIGN(auto serialized, SerializeStringHostBuffer(input));
 
   std::vector<absl::Cord> deserialized(input.size());
-  ASSERT_THAT(DeserializeFromCordIntoPreallocatedStringHostBuffer(
-                  absl::Cord(*serialized), deserialized.size(),
-                  deserialized.data()),
-              absl_testing::IsOk());
+  ASSERT_THAT(
+      DeserializeFromCordIntoPreallocatedStringHostBuffer(
+          absl::Cord(*serialized), static_cast<int64_t>(deserialized.size()),
+          deserialized.data()),
+      absl_testing::IsOk());
 
   EXPECT_EQ(deserialized, input);
 }

--- a/xla/python/ifrt_proxy/common/array_util_test.cc
+++ b/xla/python/ifrt_proxy/common/array_util_test.cc
@@ -209,7 +209,8 @@ TEST(StringHostBufferTest,
 
   std::vector<absl::Cord> deserialized(input.size());
   ASSERT_THAT(DeserializeFromCordIntoPreallocatedStringHostBuffer(
-                  absl::Cord(*serialized), deserialized.data()),
+                  absl::Cord(*serialized), deserialized.size(),
+                  deserialized.data()),
               absl_testing::IsOk());
 
   EXPECT_EQ(deserialized, input);


### PR DESCRIPTION
## Summary

`DeserializeFromCordIntoPreallocatedStringHostBuffer` (`xla/python/ifrt_proxy/common/array_util.cc`) writes one `absl::Cord` per string element of a `StringArrayContents` proto into `preallocated_buffer`, advancing a raw pointer with no bounds check. The buffer is sized by the caller `Array::CopyToStringHostBuffer` from the local array shape (`shape_.num_elements()`), while the element count is read from the proto returned by the IFRT proxy server. The two were never reconciled: the header documented "callers must ensure that the `preallocated_buffer` consists of `N` ... objects" as an unenforced invariant, and the call site did not enforce it.

A proxy server that returns a `StringArrayContents` with more `strings` than the client buffer holds, or an attacker injecting a response on an insecure transport (`GetClientCredentialsPossiblyInsecure`), causes an out-of-bounds heap write of peer-controlled `absl::Cord` objects past the destination buffer.

The peer function `DeserializeStringHostBufferFromString` is not affected because it returns a freshly grown vector.

## Fix

Pass the destination element count into `DeserializeFromCordIntoPreallocatedStringHostBuffer` and reject any serialized count that does not match before writing. The caller threads `shape_.num_elements()`, and the unit test is updated for the new signature.

## Testing

Exercised the deserialize routine with the real `StringArrayContents` proto and `absl::Cord` under `-DNDEBUG -fsanitize=address,undefined`. Before the change, a serialized buffer carrying more strings than the preallocated destination triggers `heap-buffer-overflow` in `absl::Cord::operator=` inside the write loop. After the change the mismatched count is rejected with `InvalidArgumentError`, and a well-formed buffer round-trips unchanged.
