### PR TITLE
[xla:gpu] Allow S(0) buffers to use S(1) allocations

### DIFF
--- a/xla/pjrt/compiled_memory_stats.cc
+++ b/xla/pjrt/compiled_memory_stats.cc
@@ -43,34 +43,38 @@ void CompiledMemoryStats::PopulateBufferStatsFromAllocations(
   host_alias_size_in_bytes = 0;
 
   for (const BufferAllocation* alloc : allocs) {
-    // All logical buffers assigned to a buffer allocation share a color.
-    // With buffer assigner's default colorer the color happens to be the
-    // memory space of the underlying HLO value. Callers may choose other
-    // colorers, however, e.g.:
-    // https://github.com/openxla/xla/blob/50c6489cb058881cc65622605c9c55029abebc5b/xla/service/gpu/compile_module_to_llvm_ir.cc#L152
-    // Until buffer allocations provide a stronger guarantee about colors,
-    // we sanity-check that the default coloring behavior was used.
-    int64_t alloc_memory_space = -1;
+    // Backends may use BufferAssigner::CanUseAllocation to deliberately pack
+    // multiple compatible colors into a single allocation. CompiledMemoryStats
+    // only separates host from device memory, so do not require exact color
+    // equality here. We still sanity-check that an allocation does not mix host
+    // and device assignments.
+    int64_t alloc_memory_kind = -1;
     for (const auto& [value, _] : alloc->assigned_buffers()) {
       const HloPosition& defining_position = value->defining_position();
       int64_t memory_space = Layout::kDefaultMemorySpace;
       if (defining_position.shape().has_layout()) {
         memory_space = defining_position.shape().layout().memory_space();
       }
-      if (alloc_memory_space == -1) {
-        alloc_memory_space = memory_space;
+      int64_t memory_kind = memory_space == Layout::kHostMemorySpace
+                                ? Layout::kHostMemorySpace
+                                : Layout::kDefaultMemorySpace;
+      if (alloc_memory_kind == -1) {
+        alloc_memory_kind = memory_kind;
       } else {
-        CHECK(alloc_memory_space == memory_space &&
-              "expected same memory space for all assignments in allocation");
+        CHECK(alloc_memory_kind == memory_kind &&
+              "expected same host/device memory kind for all assignments in "
+              "allocation");
       }
     }
-    if (alloc_memory_space == -1) {
+    if (alloc_memory_kind == -1) {
       // But if assignments are not available, then we have to assume that the
       // default coloring behavior was used.
-      alloc_memory_space = alloc->color();
+      alloc_memory_kind = alloc->color() == Layout::kHostMemorySpace
+                              ? Layout::kHostMemorySpace
+                              : Layout::kDefaultMemorySpace;
     }
 
-    bool is_host = alloc_memory_space == Layout::kHostMemorySpace;
+    bool is_host = alloc_memory_kind == Layout::kHostMemorySpace;
     int64_t size = alloc->size();
     if (alloc->is_entry_computation_parameter()) {
       if (is_host) {

--- a/xla/service/buffer_assignment.cc
+++ b/xla/service/buffer_assignment.cc
@@ -347,10 +347,10 @@ absl::Status BufferAllocation::AddAssignment(const HloValue& buffer,
   CHECK_LE(offset + size, size_)
       << "LogicalBuffer " << buffer
       << " size out of range at offset: " << offset << " with size: " << size;
-  if (!(IsPreallocatedTempBuffer() && color() != 0)) {
+  if (IsInputOrOutput()) {
     TF_RET_CHECK(buffer.color() == color())
         << "Buffer color " << buffer.color() << " for buffer " << buffer
-        << " does not match allocation color " << color()
+        << " does not match input/output allocation color " << color()
         << ". This could be caused by an unusable donated buffer.";
   }
   OffsetSize offset_size;
@@ -518,6 +518,20 @@ std::string BufferAllocation::ToString() const {
                   " value: %s (size=%d,offset=%d): %s\n",
                   buffer->ToShortString(), offset_size.size, offset_size.offset,
                   ShapeUtil::HumanStringWithLayout(buffer->shape())));
+  }
+  // Report any buffers that reused this allocation's free space despite having
+  // a different color. They are already listed above; this makes the
+  // cross-color reuse explicit for humans reading the dump.
+  if (!cross_color_buffers_.empty()) {
+    std::vector<const HloValue*> sorted_reused(cross_color_buffers_.begin(),
+                                               cross_color_buffers_.end());
+    absl::c_sort(sorted_reused, &CompareHloValuesById);
+    StrAppend(&output, " reused by buffers of a different color:\n");
+    for (const HloValue* buffer : sorted_reused) {
+      StrAppend(&output,
+                absl::StrFormat("  value: %s (color=%d)\n",
+                                buffer->ToShortString(), buffer->color()));
+    }
   }
   return output;
 }
@@ -875,6 +889,13 @@ absl::Status BufferAssignment::CombineTempAllocations(
           temp_allocation.peak_buffers_.begin(),
           temp_allocation.peak_buffers_.end());
     }
+
+    // Carry over the cross-color reuse reporting info from the absorbed
+    // allocation so the combined allocation's dump still reflects it.
+    combined_allocation->cross_color_buffers_.insert(
+        combined_allocation->cross_color_buffers_.end(),
+        temp_allocation.cross_color_buffers_.begin(),
+        temp_allocation.cross_color_buffers_.end());
 
     if (temp_buffer_color.has_value()) {
       if (combined_allocation->color() == 0) {
@@ -1595,7 +1616,21 @@ absl::StatusOr<bool> BufferAssigner::MaybeAssignBuffer(
           << " to allocation: " << *allocation;
 
   ASSIGN_OR_RETURN(auto buffer_color, hlo_buffer.color());
-  if (buffer_color != allocation->color()) {
+
+  // Input/output allocations are backed by caller-provided or live-out storage,
+  // so buffer assignment cannot strengthen their runtime allocation
+  // requirements after the fact. Temporary allocations can use the backend's
+  // directional color-assignment predicate below.
+  if (allocation->IsInputOrOutput() && buffer_color != allocation->color()) {
+    VLOG(4) << "Cannot assign: input/output allocation has color "
+            << allocation->color() << ", but buffer has color " << buffer_color
+            << ".";
+    return false;
+  }
+
+  // This is a storage-compatibility check, not recoloring: the buffer keeps its
+  // HLO color even when it can use an allocation with a different color.
+  if (!opts_.can_use_allocation(buffer_color, allocation->color())) {
     VLOG(4) << "Can't assign: buffer has color " << buffer_color
             << " and allocation has color " << allocation->color() << ".";
     return false;
@@ -1736,7 +1771,7 @@ absl::StatusOr<bool> BufferAssigner::MaybeAssignBuffer(
       assignment->AddAssignment(allocation, hlo_buffer, /*offset=*/0,
                                 assignment->HloBufferSize(hlo_buffer)));
   return true;
-}  // namespace xla
+}
 
 absl::Status BufferAssigner::AssignSingleHloBuffer(
     const HloBuffer* hlo_buffer, bool is_thread_local,
@@ -2027,6 +2062,226 @@ BufferAssigner::SplitBuffersByPrivateStackComputation(
   return computation_map;
 }
 
+std::vector<LogicalBuffer::Color> BufferAssigner::SortColorsForCanUseAllocation(
+    absl::Span<const LogicalBuffer::Color> colors) const {
+  std::vector<LogicalBuffer::Color> sorted(colors.begin(), colors.end());
+
+  // If buffers of color A can use allocations of color B (but not the reverse),
+  // process B first so that B's fixed-size heap is materialized and available
+  // for opportunistic reuse before A's buffers are heap-simulated. When the
+  // predicate is symmetric (same group) or unrelated in both directions, fall
+  // back to a stable order by numeric color.
+  absl::c_sort(sorted, [&](LogicalBuffer::Color a, LogicalBuffer::Color b) {
+    const bool a_uses_b = opts_.can_use_allocation(a, b);
+    const bool b_uses_a = opts_.can_use_allocation(b, a);
+    // If the relation is asymmetric, the color that can use the other's
+    // allocations must come later; otherwise fall back to numeric color.
+    return (a_uses_b != b_uses_a) ? b_uses_a : a < b;
+  });
+
+  return sorted;
+}
+
+namespace {
+// A whole HloBuffer that is a candidate for being placed into an existing,
+// compatible temp allocation. `size` is the buffer's allocation size, cached
+// because it is the (hot) sort key.
+struct ReuseCandidate {
+  const HloBuffer* hlo_buffer;
+  int64_t size;
+};
+
+// A spot found inside an existing allocation where a candidate fits.
+// `allocation` is the destination; `offset` is where to place the candidate;
+// `slack` is the leftover free space in the gap (used to pick the tightest,
+// i.e. best, fit).
+struct ReusePlacement {
+  BufferAllocation* allocation;
+  int64_t offset;
+  int64_t slack;
+};
+
+// Finds the best-fit free gap (the fitting gap that leaves the least leftover
+// slack) of at least `size` bytes, aligned to `alignment`, inside `allocation`;
+// returns nullopt if it does not fit. `blocking` are the byte ranges already
+// occupied by buffers that conflict with the candidate; ranges not listed are
+// treated as free.
+std::optional<ReusePlacement> FindBestFitGap(
+    BufferAllocation& allocation, int64_t size, int64_t alignment,
+    std::vector<BufferAllocation::OffsetSize> blocking) {
+  // Placing a candidate larger than the whole allocation would require growing
+  // it, which we never do.
+  if (size > allocation.size()) {
+    return std::nullopt;
+  }
+  absl::c_sort(blocking, [](const BufferAllocation::OffsetSize& a,
+                            const BufferAllocation::OffsetSize& b) {
+    return a.offset < b.offset;
+  });
+
+  // Sentinel so the trailing free space [last_blocking_end, size) is handled by
+  // the loop like any other gap.
+  blocking.push_back({allocation.size(), 0});
+
+  // Sweep left to right. `free_start` is the first byte not covered by a
+  // blocking range seen so far; [free_start, blocking_range.offset) is the next
+  // free gap. We keep the gap with the least leftover slack.
+  std::optional<ReusePlacement> best;
+  int64_t free_start = 0;
+  for (const BufferAllocation::OffsetSize& blocking_range : blocking) {
+    int64_t offset = RoundUpTo(free_start, alignment);
+    int64_t slack = blocking_range.offset - (offset + size);
+    if (slack >= 0 && (!best.has_value() || slack < best->slack)) {
+      best = ReusePlacement{&allocation, offset, slack};
+    }
+    free_start =
+        std::max(free_start, blocking_range.offset + blocking_range.size);
+  }
+  return best;
+}
+
+}  // namespace
+
+absl::StatusOr<int64_t> BufferAssigner::ReuseCompatibleTempHeaps(
+    absl::flat_hash_set<const HloValue*>* values,
+    LogicalBuffer::Color buffer_color, BufferAssignment* assignment) {
+  // Opportunistically packs whole buffers of `buffer_color` into the free space
+  // of allocations already materialized for a *different*, compatible color,
+  // WITHOUT growing those allocations. This is what lets GPU S(0) temps live in
+  // the holes of the (large, mostly-idle) S(1) collective allocation while
+  // keeping that allocation honestly colored S(1), so the runtime allocates it
+  // from the S(1) pool with no special-casing.
+  //
+  // Colors are processed in SortColorsForCanUseAllocation order, so by the time
+  // we assign `buffer_color`, every allocation it is allowed to reuse has
+  // already been materialized. A value that is placed here is removed from
+  // `values`, so the caller will not heap-simulate a separate allocation for
+  // it.
+  //
+  // We only run when the module is fully scheduled, because placement relies on
+  // exact live ranges to prove two buffers can share storage.
+  if (values->empty() ||
+      !assignment->hlo_live_range().total_order_scheduled()) {
+    return 0;
+  }
+
+  const auto& live_ranges = assignment->hlo_live_range().buffer_live_ranges();
+
+  // Step 1: Collect the destination allocations we are allowed to reuse: the
+  // already-materialized temp allocations of a different but compatible color.
+  std::vector<BufferAllocation*> destinations;
+  for (BufferAllocation& allocation : assignment->allocations_) {
+    if (allocation.color() != buffer_color &&
+        allocation.IsPreallocatedTempBuffer() &&
+        opts_.can_use_allocation(buffer_color, allocation.color())) {
+      destinations.push_back(&allocation);
+    }
+  }
+  if (destinations.empty()) {
+    return 0;
+  }
+
+  // Step 2: Collect movable candidates.
+  std::vector<ReuseCandidate> candidates;
+  absl::flat_hash_set<const HloBuffer*> seen_buffers;
+  for (const HloValue* value : *values) {
+    const HloBuffer& hlo_buffer =
+        assignment->alias_analysis().GetBufferContainingValue(*value);
+
+    // Check if we already processed this buffer via another of its values.
+    auto [it, inserted] = seen_buffers.insert(&hlo_buffer);
+    if (!inserted) {
+      continue;
+    }
+
+    // We can only move a buffer as a whole (all its aliased values together),
+    // because the values share storage by construction. A buffer is movable
+    // only if every one of its values is still unassigned (present in
+    // `values`), has the color we are currently processing, and has a known
+    // live range.
+    auto is_moveable = [&](const HloValue* buffer_value) {
+      return values->contains(buffer_value) &&
+             buffer_value->color() == buffer_color &&
+             live_ranges.contains(buffer_value);
+    };
+
+    if (absl::c_all_of(hlo_buffer.values(), is_moveable)) {
+      candidates.push_back(
+          ReuseCandidate{&hlo_buffer, assignment->HloBufferSize(hlo_buffer)});
+    }
+  }
+
+  // Step 3: Try the largest buffers first; they are the hardest to fit into a
+  // gap, and placing them frees the most space in `buffer_color`'s own heap.
+  // Ties broken by buffer id (a stable unique key) for deterministic output.
+  absl::c_sort(candidates, [](const auto& a, const auto& b) {
+    return (a.size != b.size) ? (a.size > b.size)
+                              : (a.hlo_buffer->id() < b.hlo_buffer->id());
+  });
+
+  // Returns true if any value of `candidate` is live at the same time as
+  // `other_value`. If so, they cannot occupy overlapping storage.
+  auto candidate_interferes_with = [&](const ReuseCandidate& candidate,
+                                       const HloValue* other_value) {
+    auto& other_range = live_ranges.at(other_value);
+    return absl::c_any_of(
+        candidate.hlo_buffer->values(), [&](const HloValue* value) {
+          return LiveRangeInterferes(value, live_ranges.at(value), other_value,
+                                     other_range, assignment);
+        });
+  };
+
+  // Finds the best-fit free gap into which `candidate` fits inside
+  // `allocation`, or nullopt if it does not fit. A gap is free if no buffer
+  // occupying it is live at the same time as the candidate.
+  auto find_placement = [&](const ReuseCandidate& candidate,
+                            BufferAllocation& allocation) {
+    // Collect the byte ranges that block the candidate: only buffers whose live
+    // range overlaps the candidate's. Non-overlapping buffers are invisible
+    // because the candidate can safely reuse their storage.
+    std::vector<BufferAllocation::OffsetSize> blocking;
+    for (const auto& [assigned_value, offset_size] :
+         allocation.assigned_buffers()) {
+      if (candidate_interferes_with(candidate, assigned_value)) {
+        blocking.push_back(offset_size);
+      }
+    }
+    int64_t alignment = assignment->color_alignment_(allocation.color());
+    return FindBestFitGap(allocation, candidate.size, alignment,
+                          std::move(blocking));
+  };
+
+  // Step 4: Place each candidate into the first compatible allocation where it
+  // fits, committing through the normal AddAssignment path.
+  int64_t placed_buffers = 0;
+  for (const ReuseCandidate& candidate : candidates) {
+    for (BufferAllocation* allocation : destinations) {
+      std::optional<ReusePlacement> placement =
+          find_placement(candidate, *allocation);
+      if (!placement.has_value()) {
+        continue;
+      }
+      // Commit: assign the whole buffer at the chosen offset and drop its
+      // values from `values` so the caller does not allocate a separate heap
+      // for them. The buffer keeps its own color; only the storage is shared.
+      RETURN_IF_ERROR(
+          assignment->AddAssignment(allocation, *candidate.hlo_buffer,
+                                    placement->offset, candidate.size));
+      for (const HloValue* value : candidate.hlo_buffer->values()) {
+        allocation->cross_color_buffers_.push_back(value);
+        values->erase(value);
+      }
+      VLOG(2) << "Reused temp allocation #" << allocation->index() << " (color "
+              << allocation->color() << ") for buffer color " << buffer_color
+              << ": " << candidate.hlo_buffer->ToString() << " at offset "
+              << placement->offset;
+      ++placed_buffers;
+      break;
+    }
+  }
+  return placed_buffers;
+}
+
 absl::Status BufferAssigner::AssignPresetBuffers(
     absl::flat_hash_set<const HloBuffer*>* assigned_buffers,
     BufferAssignment* assignment) {
@@ -2262,8 +2517,24 @@ absl::Status BufferAssigner::AssignBuffersWithSequentialOrdering(
       auto color = single_colored_set.first;
       sorted_colors.emplace(sorted_colors.end(), color);
     }
-    absl::c_sort(sorted_colors);
+    sorted_colors = SortColorsForCanUseAllocation(sorted_colors);
+
     for (auto color : sorted_colors) {
+      // First try to place this color's buffers into the free space of already-
+      // materialized compatible allocations (earlier colors). Whatever fits is
+      // removed from color_map[color] and will not get its own allocation.
+      ASSIGN_OR_RETURN(
+          int64_t reused_buffers,
+          ReuseCompatibleTempHeaps(&color_map[color], color, assignment));
+      VLOG(2) << "Placed " << reused_buffers << " buffers of color " << color
+              << " into existing compatible temp allocations";
+
+      // All buffers were placed into existing allocations. Nothing left to
+      // heap-simulate for this color.
+      if (color_map[color].empty()) {
+        continue;
+      }
+
       VLOG(2) << "Simulating heap for color " << color;
       int64_t alignment = assignment->color_alignment_(color);
       HeapSimulator::Options options;
@@ -2562,6 +2833,10 @@ absl::Status BufferAssigner::AssignBuffersFromHeapSimulator(
       allocation->set_page_id(page_index++);
     }
     for (const auto& [value, chunk] : heap_result.chunk_map) {
+      TF_RET_CHECK(
+          opts_.can_use_allocation(value->color(), allocation->color()))
+          << "Buffer color " << value->color() << " for buffer " << *value
+          << " cannot use temp allocation color " << allocation->color() << ".";
       RETURN_IF_ERROR(assignment->AddAssignment(allocation, *value,
                                                 chunk.offset, chunk.size));
     }

--- a/xla/service/buffer_assignment.h
+++ b/xla/service/buffer_assignment.h
@@ -340,6 +340,20 @@ class BufferAllocation {
     return peak_buffers_;
   }
 
+  // Returns the buffers placed in this allocation whose own color differs from
+  // the allocation color, i.e. buffers that reused this allocation's free space
+  // when CanUseAllocation allows cross-color reuse (e.g. GPU S(0) temps placed
+  // in an S(1) allocation).
+  //
+  // These buffers are deliberately NOT among the peak-driving buffers reported
+  // by PeakMemoryLogicalBuffers, which come from the heap trace that sized this
+  // allocation. They are carved into pre-existing holes and never grew the
+  // allocation, so they are not part of its sizing attribution (this says
+  // nothing about whether they happen to be live at the allocation's peak).
+  const std::vector<const HloValue*>& CrossColorBuffers() const {
+    return cross_color_buffers_;
+  }
+
   // Get the number of bytes lost to fragmentation. This is equal to the
   // difference between the size of the allocation and the size of the maximal
   // live set.
@@ -431,8 +445,14 @@ class BufferAllocation {
   int64_t fragmentation_bytes_ = 0;
   std::vector<HeapSimulatorTrace> heap_traces_;
 
-  // Set of buffers live at the point of peak memory usage for this allocation.
+  // Set of buffers live at the point of peak memory usage for this allocation;
+  // i.e. the buffers that drove the allocation's size.
   std::vector<const HloValue*> peak_buffers_;
+
+  // Buffers placed in this allocation whose own color differs from the
+  // allocation color (placed into pre-existing holes by cross-color reuse,
+  // without growing the allocation).
+  std::vector<const HloValue*> cross_color_buffers_;
 };
 
 // Add stream operators for nicer output of CHECK/RET_CHECK failures.
@@ -754,6 +774,20 @@ class BufferAssigner {
  public:
   using Colorer =
       std::function<absl::Status(HloAliasAnalysis*, const HloOrdering&)>;
+
+  // Returns true if a buffer with `buffer_color` can use an allocation with
+  // `allocation_color`.
+  //
+  // Some memory spaces are backed by the same physical memory but have
+  // directional placement constraints. For example, GPU S(0) is ordinary HBM
+  // and S(1) is collective/symmetric HBM. S(1) allocations satisfy stricter
+  // alignment and symmetric-offset requirements, so a buffer that only requires
+  // S(0) may be placed in an S(1) allocation. The reverse is not generally
+  // safe: an S(0) allocation may not satisfy the extra S(1) runtime
+  // requirements.
+  using CanUseAllocation = std::function<bool(
+      BufferValue::Color buffer_color, BufferValue::Color allocation_color)>;
+
   using MustNotLiveOut = std::function<bool(
       const HloAliasAnalysis&, const HloInstruction*, const ShapeIndex&)>;
   using PrivateStacks = absl::flat_hash_map<BufferValue::Color,
@@ -772,6 +806,10 @@ class BufferAssigner {
 
     // Functor used to assign colors to newly allocated logical buffers.
     Colorer colorer = DefaultColorer();
+
+    // Functor used to decide whether a buffer of one color can use an
+    // allocation of another color. Defaults to strict equality.
+    CanUseAllocation can_use_allocation = DefaultCanUseAllocation();
 
     // An optional function that returns true if the given instruction can't
     // live out of a computation.
@@ -802,6 +840,25 @@ class BufferAssigner {
     // default module config's device memory size.
     std::function<int64_t(LogicalBuffer::Color)> color_memory_limit;
   };
+
+  static CanUseAllocation DefaultCanUseAllocation() {
+    return [](BufferValue::Color buffer_color,
+              BufferValue::Color allocation_color) {
+      return buffer_color == allocation_color;
+    };
+  }
+
+  // Returns a CanUseAllocation predicate that allows same-color allocation use
+  // and one extra directional pair: buffers of `from_color` may use allocations
+  // of `to_color`.
+  static CanUseAllocation AllowCrossColorReuse(BufferValue::Color from_color,
+                                               BufferValue::Color to_color) {
+    return [from_color, to_color](BufferValue::Color buffer_color,
+                                  BufferValue::Color allocation_color) {
+      return buffer_color == allocation_color ||
+             (buffer_color == from_color && allocation_color == to_color);
+    };
+  }
 
   static Colorer DefaultColorer() {
     return [](HloAliasAnalysis* alias_analysis, const HloOrdering&) {
@@ -891,6 +948,27 @@ class BufferAssigner {
           heap_buffer_interval_compare,
       std::optional<BufferAssignment::BufferIsolationOptions>
           isolation_options);
+
+  // Orders colors so that if buffers of color A can use allocations of color B
+  // (but not the reverse), B is simulated before A. This lets the fixed-size B
+  // heap be available for opportunistic reuse before A's remaining buffers are
+  // heap-simulated. Colors with no directional relation are ordered by numeric
+  // color for stability.
+  std::vector<LogicalBuffer::Color> SortColorsForCanUseAllocation(
+      absl::Span<const LogicalBuffer::Color> colors) const;
+
+  // Tries to place whole buffers of `buffer_color` into the free space of
+  // already-materialized compatible temp allocations (those of a different
+  // color C where can_use_allocation(buffer_color, C) holds), without
+  // increasing the destination allocation sizes. `values` are the
+  // still-unassigned HloValues of this color; those that fit are assigned to
+  // the destination allocation and removed from `values`. Relies on colors
+  // being processed in SortColorsForCanUseAllocation order, so all compatible
+  // destinations are already materialized. Returns the number of buffers
+  // placed.
+  absl::StatusOr<int64_t> ReuseCompatibleTempHeaps(
+      absl::flat_hash_set<const HloValue*>* values,
+      LogicalBuffer::Color buffer_color, BufferAssignment* assignment);
 
   // Isolates the buffers packed by heap simulator using the provided isolation
   // options. Please see the documentation for BufferIsolationConfig for more

--- a/xla/service/buffer_assignment_test.cc
+++ b/xla/service/buffer_assignment_test.cc
@@ -119,10 +119,13 @@ class BufferAssignmentTest : public HloHardwareIndependentTestBase {
  protected:
   ~BufferAssignmentTest() override = default;
 
-  std::unique_ptr<BufferAssignment> RunBufferAssignment(HloModule* module,
-                                                        int64_t alignment = 1) {
+  std::unique_ptr<BufferAssignment> RunBufferAssignment(
+      HloModule* module, int64_t alignment = 1,
+      BufferAssigner::CanUseAllocation can_use_allocation =
+          BufferAssigner::DefaultCanUseAllocation()) {
     BufferAssigner::Options opts;
     opts.allocate_buffers_for_constants = true;
+    opts.can_use_allocation = std::move(can_use_allocation);
     return BufferAssigner::Run(
                module, std::make_unique<DependencyHloOrdering>(module),
                &BufferSizeBytes, &alias_info_,
@@ -207,11 +210,15 @@ class BufferAssignmentTest : public HloHardwareIndependentTestBase {
 
   std::unique_ptr<BufferAssignment> RunBufferAssignmentWithInstructionSequence(
       HloModule* module, absl::Span<HloInstruction* const> instruction_sequence,
-      int64_t alignment = 1) {
+      int64_t alignment = 1,
+      BufferAssigner::CanUseAllocation can_use_allocation =
+          BufferAssigner::DefaultCanUseAllocation()) {
     HloSchedule schedule(module);
     schedule.set_sequence(module->entry_computation(), instruction_sequence);
+    CHECK_OK(schedule.Update());
     BufferAssigner::Options opts;
     opts.allocate_buffers_for_constants = true;
+    opts.can_use_allocation = std::move(can_use_allocation);
     return BufferAssigner::Run(
                module, std::make_unique<SequentialHloOrdering>(schedule),
                &BufferSizeBytes, &alias_info_,
@@ -542,9 +549,8 @@ TEST_F(BufferAssignmentTest, Basic) {
   module->AddEntryComputation(builder.Build());
 
   auto buffers_orig = RunBufferAssignment(module.get());
-  TF_ASSERT_OK_AND_ASSIGN(
-      std::unique_ptr<BufferAssignment> buffers,
-      ConvertToProtoAndBack(buffers_orig.get(), module.get()));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<BufferAssignment> buffers,
+                       ConvertToProtoAndBack(buffers_orig.get(), module.get()));
 
   // Distinct input buffers were assigned for parameters.
   BufferAllocation paramscalar_buffer =
@@ -610,9 +616,8 @@ TEST_F(BufferAssignmentTest, BasicToFromProto) {
   auto buffers_orig = RunBufferAssignment(module.get());
 
   // Dump the original buffer assignment into a proto and read it back.
-  TF_ASSERT_OK_AND_ASSIGN(
-      std::unique_ptr<BufferAssignment> buffers_from_proto,
-      ConvertToProtoAndBack(buffers_orig.get(), module.get()));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<BufferAssignment> buffers_from_proto,
+                       ConvertToProtoAndBack(buffers_orig.get(), module.get()));
 
   EXPECT_EQ(buffers_from_proto->GetStats().parameter_allocation_bytes, 804);
   EXPECT_EQ(buffers_from_proto->GetStats().maybe_live_out_allocation_bytes,
@@ -664,24 +669,24 @@ TEST_F(BufferAssignmentTest, AliasedParamCanBeReused) {
   //    |                           |
   //    + -------- Aliased ---------+
 
-  auto builder = HloComputation::Builder(TestName());
+  const char* const hlo_text = R"(
+HloModule test, input_output_alias={ {}: (0, {}, may-alias) }
 
-  auto param = builder.AddInstruction(
-      HloInstruction::CreateParameter(0, f32vec100_, "p0"));
-  auto neg_1 = builder.AddInstruction(
-      HloInstruction::CreateUnary(f32vec100_, HloOpcode::kNegate, param));
-  auto neg_2 = builder.AddInstruction(
-      HloInstruction::CreateUnary(f32vec100_, HloOpcode::kNegate, neg_1));
+ENTRY main {
+  p0 = f32[100]{0} parameter(0)
+  neg1 = f32[100]{0} negate(p0)
+  ROOT neg2 = f32[100]{0} negate(neg1)
+}
+)";
 
-  auto module = CreateNewVerifiedModule();
-  module->AddEntryComputation(builder.Build());
-
-  TF_ASSERT_OK(module->input_output_alias_config().SetUpAlias({}, 0, {}));
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_text));
+  HloInstruction* param = FindInstruction(module.get(), "p0");
+  HloInstruction* neg_1 = FindInstruction(module.get(), "neg1");
+  HloInstruction* neg_2 = FindInstruction(module.get(), "neg2");
 
   auto buffers_orig = RunBufferAssignment(module.get());
-  TF_ASSERT_OK_AND_ASSIGN(
-      std::unique_ptr<BufferAssignment> buffers,
-      ConvertToProtoAndBack(buffers_orig.get(), module.get()));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<BufferAssignment> buffers,
+                       ConvertToProtoAndBack(buffers_orig.get(), module.get()));
 
   BufferAllocation param_buffer = GetAssignedInputAllocation(*buffers, param);
   BufferAllocation neg_1_buffer = GetAllocation(*buffers, neg_1, {});
@@ -690,6 +695,177 @@ TEST_F(BufferAssignmentTest, AliasedParamCanBeReused) {
   // Everything use one buffer.
   EXPECT_EQ(param_buffer.index(), neg_1_buffer.index());
   EXPECT_EQ(neg_2_buffer.index(), neg_1_buffer.index());
+}
+
+TEST_F(BufferAssignmentTest, CanUseAllocationDoesNotMixInputOutputColors) {
+  // Even when a backend allows S(0) temps to be assigned to S(1) temp
+  // allocations, input/output allocations must match raw colors. They are
+  // caller-provided or live-out storage, so buffer assignment cannot strengthen
+  // their runtime allocation requirements after the fact.
+  //
+  // p0 S(1) -X- (neg1 S(0)) -- (neg2 S(1))
+  //    |                                   |
+  //    + -------------- Aliased -----------+
+
+  const char* const hlo_text = R"(
+HloModule test, input_output_alias={ {}: (0, {}, may-alias) }
+
+ENTRY main {
+  p0 = f32[100]{0:S(1)} parameter(0)
+  neg1 = f32[100]{0} negate(p0)
+  ROOT neg2 = f32[100]{0:S(1)} negate(neg1)
+}
+)";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_text));
+
+  std::unique_ptr<BufferAssignment> buffers =
+      RunBufferAssignment(module.get(), /*alignment=*/1,
+                          BufferAssigner::AllowCrossColorReuse(0, 1));
+
+  HloInstruction* param = FindInstruction(module.get(), "p0");
+  HloInstruction* neg_1 = FindInstruction(module.get(), "neg1");
+  HloInstruction* neg_2 = FindInstruction(module.get(), "neg2");
+
+  BufferAllocation param_buffer = GetAssignedInputAllocation(*buffers, param);
+  BufferAllocation neg_1_buffer = GetAllocation(*buffers, neg_1, {});
+  BufferAllocation neg_2_buffer = GetAllocation(*buffers, neg_2, {});
+
+  EXPECT_TRUE(param_buffer.is_entry_computation_parameter());
+  EXPECT_TRUE(param_buffer.is_parameter_aliased_with_output());
+  EXPECT_EQ(param_buffer.color(), 1);
+  EXPECT_EQ(buffers->dataflow_analysis().GetUniqueValueAt(neg_1, {}).color(),
+            0);
+
+  EXPECT_NE(param_buffer.index(), neg_1_buffer.index());
+  EXPECT_EQ(param_buffer.index(), neg_2_buffer.index());
+}
+
+TEST_F(BufferAssignmentTest, CanUseAllocationReusesCrossColorTempAllocation) {
+  // AllowCrossColorReuse enables directional temp reuse: an S(0) temp may be
+  // placed in already-free space inside an S(1) temp allocation, while keeping
+  // its raw HLO color and without increasing the S(1) allocation size.
+
+  const char* const hlo_text = R"(
+HloModule test
+
+add_s {
+  lhs = f32[] parameter(0)
+  rhs = f32[] parameter(1)
+  ROOT add = f32[] add(lhs, rhs)
+}
+
+ENTRY main {
+  p0 = f32[2048]{0} parameter(0)
+  p1 = f32[1024]{0} parameter(1)
+  neg0 = f32[2048]{0:S(1)} negate(p0)
+  zero = f32[] constant(0)
+  r1 = f32[] reduce(neg0, zero), dimensions={0}, to_apply=add_s
+  neg1 = f32[1024]{0} negate(p1)
+  r0 = f32[] reduce(neg1, zero), dimensions={0}, to_apply=add_s
+  ROOT out = f32[] add(r1, r0)
+}
+)";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_text));
+
+  HloInstruction* p0 = FindInstruction(module.get(), "p0");
+  HloInstruction* p1 = FindInstruction(module.get(), "p1");
+  HloInstruction* neg0 = FindInstruction(module.get(), "neg0");
+  HloInstruction* zero = FindInstruction(module.get(), "zero");
+  HloInstruction* r1 = FindInstruction(module.get(), "r1");
+  HloInstruction* neg1 = FindInstruction(module.get(), "neg1");
+  HloInstruction* r0 = FindInstruction(module.get(), "r0");
+  HloInstruction* out = FindInstruction(module.get(), "out");
+
+  std::vector<HloInstruction*> sequence = {p0, p1,   neg0, zero,
+                                           r1, neg1, r0,   out};
+  auto assignment = RunBufferAssignmentWithInstructionSequence(
+      module.get(), sequence, /*alignment=*/1,
+      BufferAssigner::AllowCrossColorReuse(0, 1));
+
+  const HloValue& neg0_value =
+      assignment->dataflow_analysis().GetUniqueValueAt(neg0, {});
+  const HloValue& neg1_value =
+      assignment->dataflow_analysis().GetUniqueValueAt(neg1, {});
+  const BufferAllocation& neg0_allocation =
+      GetAllocation(*assignment, neg0, {});
+  const BufferAllocation& neg1_allocation =
+      GetAllocation(*assignment, neg1, {});
+
+  // The S(0) buffer is placed inside the S(1) allocation, which keeps its S(1)
+  // color and is not grown to make room.
+  EXPECT_EQ(neg0_value.color(), 1);
+  EXPECT_EQ(neg1_value.color(), 0);
+  EXPECT_EQ(neg0_allocation.index(), neg1_allocation.index());
+  EXPECT_EQ(neg0_allocation.color(), 1);
+  EXPECT_TRUE(neg0_allocation.IsPreallocatedTempBuffer());
+  EXPECT_EQ(neg0_allocation.size(), BufferSizeBytes(neg0_value));
+  EXPECT_TRUE(neg0_allocation.assigned_buffers().contains(&neg1_value));
+
+  // The S(0) buffer is reported as a cross-color reuse on the S(1) allocation
+  // (informational only); the allocation's own S(1) buffer is not.
+  EXPECT_THAT(neg0_allocation.CrossColorBuffers(),
+              ::testing::Contains(&neg1_value));
+  EXPECT_THAT(neg0_allocation.CrossColorBuffers(),
+              ::testing::Not(::testing::Contains(&neg0_value)));
+}
+
+TEST_F(BufferAssignmentTest,
+       CanUseAllocationDoesNotGrowCrossColorTempAllocation) {
+  // Cross-color reuse is opportunistic. If an S(0) temp does not fit in the
+  // existing S(1) allocation, it remains in an S(0) allocation instead of
+  // increasing the S(1) allocation size.
+
+  const char* const hlo_text = R"(
+HloModule test
+
+add_s {
+  lhs = f32[] parameter(0)
+  rhs = f32[] parameter(1)
+  ROOT add = f32[] add(lhs, rhs)
+}
+
+ENTRY main {
+  p0 = f32[1024]{0} parameter(0)
+  p1 = f32[2048]{0} parameter(1)
+  neg0 = f32[1024]{0:S(1)} negate(p0)
+  zero = f32[] constant(0)
+  r1 = f32[] reduce(neg0, zero), dimensions={0}, to_apply=add_s
+  neg1 = f32[2048]{0} negate(p1)
+  r0 = f32[] reduce(neg1, zero), dimensions={0}, to_apply=add_s
+  ROOT out = f32[] add(r1, r0)
+}
+)";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_text));
+
+  HloInstruction* p0 = FindInstruction(module.get(), "p0");
+  HloInstruction* p1 = FindInstruction(module.get(), "p1");
+  HloInstruction* neg0 = FindInstruction(module.get(), "neg0");
+  HloInstruction* zero = FindInstruction(module.get(), "zero");
+  HloInstruction* r1 = FindInstruction(module.get(), "r1");
+  HloInstruction* neg1 = FindInstruction(module.get(), "neg1");
+  HloInstruction* r0 = FindInstruction(module.get(), "r0");
+  HloInstruction* out = FindInstruction(module.get(), "out");
+
+  std::vector<HloInstruction*> sequence = {p0, p1,   neg0, zero,
+                                           r1, neg1, r0,   out};
+  auto assignment = RunBufferAssignmentWithInstructionSequence(
+      module.get(), sequence, /*alignment=*/1,
+      BufferAssigner::AllowCrossColorReuse(0, 1));
+
+  const HloValue& neg0_value =
+      assignment->dataflow_analysis().GetUniqueValueAt(neg0, {});
+  const BufferAllocation& neg0_allocation =
+      GetAllocation(*assignment, neg0, {});
+  const BufferAllocation& neg1_allocation =
+      GetAllocation(*assignment, neg1, {});
+
+  EXPECT_NE(neg0_allocation.index(), neg1_allocation.index());
+  EXPECT_EQ(neg0_allocation.color(), 1);
+  EXPECT_EQ(neg0_allocation.size(), BufferSizeBytes(neg0_value));
+  EXPECT_EQ(neg1_allocation.color(), 0);
 }
 
 TEST_F(BufferAssignmentTest, AddCannotReuse) {
@@ -719,9 +895,8 @@ TEST_F(BufferAssignmentTest, AddCannotReuse) {
   module->AddEntryComputation(builder.Build());
 
   auto buffers_orig = RunBufferAssignmentNoBuffersReuseForAdd(module.get());
-  TF_ASSERT_OK_AND_ASSIGN(
-      std::unique_ptr<BufferAssignment> buffers,
-      ConvertToProtoAndBack(buffers_orig.get(), module.get()));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<BufferAssignment> buffers,
+                       ConvertToProtoAndBack(buffers_orig.get(), module.get()));
 
   // Distinct input buffers were assigned for parameters.
   BufferAllocation paramscalar_buffer =
@@ -1039,9 +1214,8 @@ TEST_F(BufferAssignmentTest, PresetAssignmentsWhile) {
   auto buffers_orig = RunBufferAssignmentWithPresetAssignments(
       module.get(), std::move(preset_assignments));
 
-  TF_ASSERT_OK_AND_ASSIGN(
-      std::unique_ptr<BufferAssignment> buffers,
-      ConvertToProtoAndBack(buffers_orig.get(), module.get()));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<BufferAssignment> buffers,
+                       ConvertToProtoAndBack(buffers_orig.get(), module.get()));
 
   // All assigned buffers are aliased so they should have the same offset and
   // size.
@@ -1085,9 +1259,8 @@ TEST_F(BufferAssignmentTest, MultipleUsersForNode) {
 
   auto buffers_orig = RunBufferAssignment(module.get());
 
-  TF_ASSERT_OK_AND_ASSIGN(
-      std::unique_ptr<BufferAssignment> buffers,
-      ConvertToProtoAndBack(buffers_orig.get(), module.get()));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<BufferAssignment> buffers,
+                       ConvertToProtoAndBack(buffers_orig.get(), module.get()));
 
   // Input buffers were assigned for parameters.
   BufferAllocation paramscalar_buffer =
@@ -1420,7 +1593,7 @@ TEST_F(BufferAssignmentTest, NoReuseLiveBuffer) {
   module->AddEntryComputation(builder.Build());
   auto assignment_orig = RunBufferAssignment(module.get());
 
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<BufferAssignment> assignment,
       ConvertToProtoAndBack(assignment_orig.get(), module.get()));
 
@@ -1461,7 +1634,7 @@ TEST_F(BufferAssignmentTest, NoReuseAliasedBuffer) {
   module->AddEntryComputation(builder.Build());
   auto assignment_orig = RunBufferAssignment(module.get());
 
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<BufferAssignment> assignment,
       ConvertToProtoAndBack(assignment_orig.get(), module.get()));
 
@@ -1874,8 +2047,8 @@ TEST_F(BufferAssignmentTest, CustomCallAliasedBuffer) {
     }
   )";
 
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::HloModule> module,
-                          ParseAndReturnUnverifiedModule(kModuleString));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::HloModule> module,
+                       ParseAndReturnUnverifiedModule(kModuleString));
   std::unique_ptr<BufferAssignment> assignment =
       RunBufferAssignment(module.get());
   HloInstruction* custom_call = module->entry_computation()->root_instruction();
@@ -2025,7 +2198,7 @@ TEST_F(BufferAssignmentTest, TupleBufferNotReused) {
   module->AddEntryComputation(builder.Build());
   auto assignment_orig = RunBufferAssignment(module.get());
 
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<BufferAssignment> assignment,
       ConvertToProtoAndBack(assignment_orig.get(), module.get()));
 
@@ -2368,7 +2541,7 @@ ENTRY test_module {
   ROOT negate = s32[] negate(gte)
 })";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_text));
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_text));
   auto assignment = RunBufferAssignmentWithSequentialOrdering(module.get());
   const BufferAllocation& buffer =
       GetTopLevelAllocation(*assignment, FindInstruction(module.get(), "copy"));
@@ -2405,7 +2578,7 @@ ENTRY main {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
   HloInstruction* parameter =
       m->entry_computation()->GetInstructionWithName("get-tuple-element.4");
   HloInstruction* dus1 =
@@ -2449,7 +2622,7 @@ ENTRY main {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
   HloInstruction* constant_1 =
       m->entry_computation()->GetInstructionWithName("constant.1.1");
   HloInstruction* constant_2 =
@@ -2602,8 +2775,8 @@ TEST_F(WhileBufferAssignmentTest, TwoForwardWhileLoops) {
   EXPECT_EQ(assignment->GetUniqueSlice(weights1, {}).value(),
             assignment->GetUniqueSlice(while1, {1}).value());
 
-  TF_ASSERT_OK_AND_ASSIGN(Shape shape,
-                          assignment->GetShapeForUniqueSlice(while1, {1}));
+  ASSERT_OK_AND_ASSIGN(Shape shape,
+                       assignment->GetShapeForUniqueSlice(while1, {1}));
   EXPECT_EQ(shape, data_shape_);
 }
 
@@ -2647,7 +2820,7 @@ ENTRY %test_module {
   ROOT %bcast = s32[1024,1024]{1,0} broadcast(s32[] %while.1), dimensions={}
 })";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(module_str));
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(module_str));
 
   // Run CopyInsertion and check if the graph constructed above doesn't need
   // any copies inserted for BufferAssignment to run.
@@ -2669,12 +2842,11 @@ ENTRY %test_module {
 
   // Run buffer assignment.
   auto assignment = RunBufferAssignment(m.get());
-  TF_ASSERT_OK_AND_ASSIGN(auto slice_param,
-                          assignment->GetUniqueSlice(param, {}));
-  TF_ASSERT_OK_AND_ASSIGN(auto slice_while0,
-                          assignment->GetUniqueSlice(while0, {}));
-  TF_ASSERT_OK_AND_ASSIGN(auto slice_while1,
-                          assignment->GetUniqueSlice(while1, {}));
+  ASSERT_OK_AND_ASSIGN(auto slice_param, assignment->GetUniqueSlice(param, {}));
+  ASSERT_OK_AND_ASSIGN(auto slice_while0,
+                       assignment->GetUniqueSlice(while0, {}));
+  ASSERT_OK_AND_ASSIGN(auto slice_while1,
+                       assignment->GetUniqueSlice(while1, {}));
 
   // The parameter slice is part of the while0's colocation set (init value),
   // but not merged into the while1's colocation set.
@@ -2715,7 +2887,7 @@ ENTRY %test_module {
   ROOT %bcast = s32[1024,1024]{1,0} broadcast(s32[] %while.1), dimensions={}
 })";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(module_str));
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(module_str));
 
   // Run CopyInsertion and check if the graph constructed above doesn't need
   // any copies inserted for BufferAssignment to run.
@@ -2737,12 +2909,12 @@ ENTRY %test_module {
 
   // Run buffer assignment.
   auto assignment = RunBufferAssignment(m.get());
-  TF_ASSERT_OK_AND_ASSIGN(auto slice_constant,
-                          assignment->GetUniqueSlice(constant, {}));
-  TF_ASSERT_OK_AND_ASSIGN(auto slice_while0,
-                          assignment->GetUniqueSlice(while0, {}));
-  TF_ASSERT_OK_AND_ASSIGN(auto slice_while1,
-                          assignment->GetUniqueSlice(while1, {}));
+  ASSERT_OK_AND_ASSIGN(auto slice_constant,
+                       assignment->GetUniqueSlice(constant, {}));
+  ASSERT_OK_AND_ASSIGN(auto slice_while0,
+                       assignment->GetUniqueSlice(while0, {}));
+  ASSERT_OK_AND_ASSIGN(auto slice_while1,
+                       assignment->GetUniqueSlice(while1, {}));
 
   // The constant slice is part of the while0's colocation set (init value), but
   // not merged into the while1's colocation set.
@@ -2837,7 +3009,7 @@ TEST_F(WhileBufferAssignmentTest, ColocatedBuffers) {
   // Create a sequential order among all the instructions in the entry
   // computation, since the issue this test stresses depends on the order the
   // nodes are traversed during BufferAssignment.
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       HloSchedule schedule,
       ScheduleModule(module.get(), &alias_info_, [](const BufferValue& buffer) {
         return ShapeUtil::ByteSizeOf(buffer.shape(),
@@ -2850,7 +3022,7 @@ TEST_F(WhileBufferAssignmentTest, ColocatedBuffers) {
 
   BufferAssigner::Options opts;
   opts.allocate_buffers_for_constants = true;
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       auto assignment,
       BufferAssigner::Run(
           module.get(), std::make_unique<SequentialHloOrdering>(schedule),
@@ -2858,21 +3030,21 @@ TEST_F(WhileBufferAssignmentTest, ColocatedBuffers) {
           [](LogicalBuffer::Color) { return 1; }, std::move(opts)));
 
   // The result tuple elements must be assigned with different buffers.
-  TF_ASSERT_OK_AND_ASSIGN(auto slice0, assignment->GetUniqueSlice(tuple, {0}));
-  TF_ASSERT_OK_AND_ASSIGN(auto slice1, assignment->GetUniqueSlice(tuple, {1}));
+  ASSERT_OK_AND_ASSIGN(auto slice0, assignment->GetUniqueSlice(tuple, {0}));
+  ASSERT_OK_AND_ASSIGN(auto slice1, assignment->GetUniqueSlice(tuple, {1}));
   EXPECT_NE(slice0, slice1);
 
   // while0 and while1 result buffers must be equal to slice1.
-  TF_ASSERT_OK_AND_ASSIGN(auto slice_while0,
-                          assignment->GetUniqueSlice(while0, {}));
-  TF_ASSERT_OK_AND_ASSIGN(auto slice_while1,
-                          assignment->GetUniqueSlice(while1, {}));
+  ASSERT_OK_AND_ASSIGN(auto slice_while0,
+                       assignment->GetUniqueSlice(while0, {}));
+  ASSERT_OK_AND_ASSIGN(auto slice_while1,
+                       assignment->GetUniqueSlice(while1, {}));
   EXPECT_EQ(slice1, slice_while0);
   EXPECT_EQ(slice1, slice_while1);
 
   // while2 result buffer must be equal to slice0.
-  TF_ASSERT_OK_AND_ASSIGN(auto slice_while2,
-                          assignment->GetUniqueSlice(while2, {}));
+  ASSERT_OK_AND_ASSIGN(auto slice_while2,
+                       assignment->GetUniqueSlice(while2, {}));
   EXPECT_EQ(slice0, slice_while2);
 }
 
@@ -2952,7 +3124,7 @@ TEST_F(BufferAssignmentTest, TwoCalls) {
 
   {
     FlattenCallGraph flatten;
-    TF_ASSERT_OK_AND_ASSIGN(bool result, flatten.Run(module.get()));
+    ASSERT_OK_AND_ASSIGN(bool result, flatten.Run(module.get()));
     EXPECT_TRUE(result);
     std::unique_ptr<CallGraph> call_graph = CallGraph::Build(module.get());
   }
@@ -2984,8 +3156,7 @@ ENTRY Main {
 
   HloModuleConfig config;
   config.set_debug_options(GetDebugOptionsFromFlags());
-  TF_ASSERT_OK_AND_ASSIGN(auto m,
-                          ParseAndReturnVerifiedModule(hlo_text, config));
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text, config));
 
   auto buffers = RunBufferAssignment(m.get());
 
@@ -3041,7 +3212,7 @@ ENTRY %main (a: f32[4096], b: f32[4096]) -> f32[4096] {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
 
   auto buffers = RunBufferAssignmentWithSequentialOrdering(m.get());
 
@@ -3098,7 +3269,7 @@ ENTRY %main (a: f32[4096], b: f32[4096]) -> f32[4096] {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
 
   auto colorer = [](HloAliasAnalysis* alias_analysis, const HloOrdering&) {
     for (const HloBuffer& buffer : alias_analysis->buffers()) {
@@ -3208,7 +3379,7 @@ ENTRY %main (a: f32[4096], b: f32[4096]) -> f32[4096] {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
 
   auto colorer = [](HloAliasAnalysis* alias_analysis, const HloOrdering&) {
     for (const HloBuffer& buffer : alias_analysis->buffers()) {
@@ -3308,8 +3479,7 @@ TEST_F(BufferAssignmentTest, AsyncCallImplicitSharding) {
   }
   )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto module,
-                          ParseAndReturnUnverifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnUnverifiedModule(hlo_string));
 
   auto buffers = RunBufferAssignmentWithSequentialOrdering(module.get());
 
@@ -3340,7 +3510,7 @@ ENTRY %main (a: f32[4096]) -> f32[4096] {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
   auto buffers = RunBufferAssignmentWithSequentialOrdering(m.get());
 
   HloInstruction* neg_0 = FindInstruction(m.get(), "neg_0");
@@ -3364,7 +3534,7 @@ ENTRY %main (a: f32[4096]) -> f32[4096] {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(hlo_text));
   auto buffers = RunBufferAssignmentWithSequentialOrdering(m.get());
 
   HloInstruction* neg_0 = FindInstruction(m.get(), "neg_0");
@@ -3392,7 +3562,7 @@ ENTRY %test_module {
   ROOT add3 = s32[4,1024]{1,0} add(add2, bcast1)
 })";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(module_str));
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(module_str));
 
   // First run buffer assignment as usual.
   std::unique_ptr<BufferAssignment> nonisolation_assignment =
@@ -3500,7 +3670,7 @@ ENTRY %test_module {
 4,"<4 bcast @0>",0,4194304,4,5,0,"",""
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(module_str));
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(module_str));
   HloInstruction* const param0 = FindInstruction(m.get(), "param.0");
   HloInstruction* const param1 = FindInstruction(m.get(), "param.1");
   HloInstruction* const mul = FindInstruction(m.get(), "mul");
@@ -3562,7 +3732,7 @@ TEST_F(WhileBufferAssignmentTest, WhileLoopsInterferingResultRange) {
 
   {
     FlattenCallGraph flatten;
-    TF_ASSERT_OK_AND_ASSIGN(bool result, flatten.Run(module.get()));
+    ASSERT_OK_AND_ASSIGN(bool result, flatten.Run(module.get()));
     EXPECT_TRUE(result);
   }
 
@@ -3746,9 +3916,8 @@ TEST(BufferAllocationSliceProtoTest, RoundTripProto) {
                                          /*size=*/100);
 
   // Convert to proto
-  TF_ASSERT_OK_AND_ASSIGN(
-      xla::buffer_assignment::BufferAllocationSliceProto proto,
-      original_slice.ToProto());
+  ASSERT_OK_AND_ASSIGN(xla::buffer_assignment::BufferAllocationSliceProto proto,
+                       original_slice.ToProto());
 
   // Convert back from proto
   std::vector<BufferAllocation> allocations_for_from_proto = {
@@ -3756,7 +3925,7 @@ TEST(BufferAllocationSliceProtoTest, RoundTripProto) {
       original_alloc,
       BufferAllocation(/*index=*/2, /*size=*/600, /*color=*/0),
   };
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       BufferAllocation::Slice round_tripped_slice,
       BufferAllocation::Slice::FromProto(proto, allocations_for_from_proto));
 
@@ -3903,7 +4072,7 @@ TEST(ComputePeakMemoryTest, SimpleAllocation) {
   event2->set_buffer_id(0);
   event2->set_kind(HeapSimulatorTrace::Event::FREE);
 
-  TF_ASSERT_OK_AND_ASSIGN(auto result, ComputePeakMemorySizes(proto, hlo));
+  ASSERT_OK_AND_ASSIGN(auto result, ComputePeakMemorySizes(proto, hlo));
   EXPECT_EQ(result.padded, 10);
   EXPECT_EQ(result.unpadded, 10);
   EXPECT_EQ(ValueOrDie(ComputePeakMemory(proto)), 10);
@@ -3927,7 +4096,7 @@ TEST(ComputePeakMemoryTest, PaddedAllocation) {
   event2->set_buffer_id(0);
   event2->set_kind(HeapSimulatorTrace::Event::FREE);
 
-  TF_ASSERT_OK_AND_ASSIGN(auto result, ComputePeakMemorySizes(proto, hlo));
+  ASSERT_OK_AND_ASSIGN(auto result, ComputePeakMemorySizes(proto, hlo));
   EXPECT_THAT(result, FieldsAre(64, 36));
   EXPECT_EQ(ValueOrDie(ComputePeakMemory(proto)), 64);
 }
@@ -3970,7 +4139,7 @@ TEST(ComputePeakMemoryTest, MultipleBuffersSomePadded) {
   event4->set_buffer_id(buffer1->id());
   event4->set_kind(HeapSimulatorTrace::Event::FREE);
 
-  TF_ASSERT_OK_AND_ASSIGN(auto result, ComputePeakMemorySizes(proto, hlo));
+  ASSERT_OK_AND_ASSIGN(auto result, ComputePeakMemorySizes(proto, hlo));
   EXPECT_THAT(result, FieldsAre(84, 56));
   EXPECT_EQ(ValueOrDie(ComputePeakMemory(proto)), 84);
 }
@@ -4545,8 +4714,8 @@ TEST(ComputeLogicalBufferUnpaddedSizesTest, Basic) {
   buffer1->set_size(456);
   SetUnpaddedSize(computation, /*id=*/11, /*size=*/400);
 
-  TF_ASSERT_OK_AND_ASSIGN(auto sizes,
-                          ComputeLogicalBufferUnpaddedSizes(hlo, proto));
+  ASSERT_OK_AND_ASSIGN(auto sizes,
+                       ComputeLogicalBufferUnpaddedSizes(hlo, proto));
 
   EXPECT_EQ(sizes.size(), 2);
   EXPECT_EQ(sizes[0], 100);
@@ -4847,7 +5016,7 @@ TEST_F(BufferAssignmentTest, FastMergeFallbackWithZeroMemoryLimit) {
       buffer_assignment::BufferAssignmentAlgorithmProto::FAST_SPLIT;
   opts.color_memory_limit = [](LogicalBuffer::Color) -> int64_t { return 0; };
 
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       auto assignment,
       BufferAssigner::Run(
           module.get(), std::make_unique<DependencyHloOrdering>(module.get()),
@@ -4875,7 +5044,7 @@ TEST_F(BufferAssignmentTest, FastMergeFallbackWithLowMemoryLimit) {
   // memory limit is 0.
   opts.color_memory_limit = [](LogicalBuffer::Color) -> int64_t { return 100; };
 
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       auto assignment,
       BufferAssigner::Run(
           module.get(), std::make_unique<DependencyHloOrdering>(module.get()),
@@ -4947,7 +5116,7 @@ TEST_F(BufferAssignmentTest, MultiPage) {
   opts.allocate_buffers_for_constants = true;
   opts.colorer = BufferAssigner::DefaultColorer();
 
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<xla::BufferAssignment> buffers,
       BufferAssigner::Run(
           module.get(),

--- a/xla/service/gpu/compile_module_to_llvm_ir.cc
+++ b/xla/service/gpu/compile_module_to_llvm_ir.cc
@@ -175,6 +175,15 @@ absl::StatusOr<std::unique_ptr<BufferAssignment>> RunBufferAssignment(
   opts.allocate_buffers_for_constants = true;
   opts.colorer = CreateColorer(options);
   opts.temp_buffer_color = color;
+
+  // Allow S(0) buffers to reuse S(1) temp allocations. S(1) allocations
+  // satisfy stricter alignment and symmetric-offset requirements, so they are
+  // valid storage for S(0) buffers. Keep this directional: S(1) buffers must
+  // not be assigned to S(0) allocations.
+  opts.can_use_allocation = BufferAssigner::AllowCrossColorReuse(
+      static_cast<int>(MemorySpaceColor::kDefault),
+      static_cast<int>(MemorySpaceColor::kCollective));
+
   std::unique_ptr<HloOrdering> hlo_ordering;
   switch (options.xla_gpu_command_buffer_scheduling_mode()) {
     case DebugOptions::CONCURRENT:


### PR DESCRIPTION
  - Add `BufferAssigner::CanUseColor`, a construction-time predicate that decides whether a buffer with one HLO color can use an allocation with another color.
  - Keep input/output allocations strict: they must match the raw buffer color, since caller-provided/live-out storage cannot have its runtime requirements strengthened during buffer assignment.
  - Use `CanUseColor` in GPU buffer assignment to allow `S(0)` buffers to use `S(1)` temp allocations, while still rejecting `S(1)` buffers in `S(0)` allocations.

  In XLA:GPU, `S(1)` is used for symmetric collective operations. Without this change, a collective operation with large parameters/results can effectively reserve a whole allocation that is unused most of the time. By allowing `S(0)` temp buffers to use `S(1)` allocations, XLA can significantly reduce memory usage.