### PR TITLE
[ROCm] Fix invalid rocm redist version in bzlrc

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -295,7 +295,7 @@ common:rocm_ci --@local_config_rocm//rocm:rocm_path_type=hermetic
 common:rocm_ci_hermetic --dynamic_mode=off
 common:rocm_ci_hermetic --config=rocm_clang_hermetic
 common:rocm_ci_hermetic --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a"
-common:rocm_ci_hermetic --repo_env=ROCM_DISTRO_VERSION="rocm_7.12.0_gfx90X"
+common:rocm_ci_hermetic --repo_env=ROCM_DISTRO_VERSION="rocm_7.12.0_gfx90a"
 common:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 # This config option is used for SYCL as GPU backend.


### PR DESCRIPTION
📝 Summary of Changes
Fix invalid rocm redist version in heremtic config

🎯 Justification
The version we had in our bazelrc doesn't exist in our redist file:
https://github.com/google-ml-infra/rules_ml_toolchain/blob/main/gpu/rocm/rocm_redist.bzl

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
