### PR TITLE
[XLA:GPU] Achieve command buffer persisitent address through DeviceAddressVmmAllocator va-remapping APIs

### DIFF
--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -171,7 +171,6 @@ cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/functional:any_invocable",
         "@com_google_absl//absl/functional:bind_front",

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -430,6 +430,139 @@ TEST_F(DeviceAddressVmmAllocatorTest,
 }
 
 TEST_F(DeviceAddressVmmAllocatorTest,
+       MapWaitsForPendingDestinationAndSourceAliases) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  const uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+
+  ASSERT_OK_AND_ASSIGN(
+      auto source_reservation,
+      gpu::CudaMemoryReservation::Create(executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto destination_reservation,
+      gpu::CudaMemoryReservation::Create(executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+  ASSERT_OK_AND_ASSIGN(
+      auto destination_occupant,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+  auto* source_raw_allocation =
+      allocator->GetRawAllocation(ordinal, source.cref());
+  ASSERT_NE(source_raw_allocation, nullptr);
+  DeviceAddressBase source_reservation_address =
+      source_reservation->address().GetByteSlice(/*offset_bytes=*/0,
+                                                 granularity);
+  DeviceAddressBase destination_reservation_address =
+      destination_reservation->address().GetByteSlice(/*offset_bytes=*/0,
+                                                      granularity);
+
+  ASSERT_THAT(allocator->Map(ordinal, source.cref(), source_reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+  constexpr uint64_t kPattern = 0x123456789ABCDEF0ULL;
+  ASSERT_THAT(
+      stream_->Memcpy(&source_reservation_address, &kPattern, sizeof(kPattern)),
+      IsOk());
+  ASSERT_THAT(allocator->UnMap(ordinal, source_reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+
+  ASSERT_THAT(allocator->Map(ordinal, destination_occupant.cref(),
+                             destination_reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->UnMap(ordinal, destination_reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+
+  ASSERT_THAT(
+      allocator->Map(ordinal, source.cref(), destination_reservation.get(),
+                     /*reservation_offset=*/0, granularity),
+      IsOk());
+  EXPECT_EQ(
+      allocator->GetRawAllocation(ordinal, destination_reservation_address),
+      source_raw_allocation);
+  uint64_t read_value = 0;
+  ASSERT_THAT(stream_->Memcpy(&read_value, destination_reservation_address,
+                              sizeof(read_value)),
+              IsOk());
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+  EXPECT_EQ(read_value, kPattern);
+
+  ASSERT_THAT(allocator->UnMap(ordinal, destination_reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, source.Release()), IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, destination_occupant.Release()),
+              IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       MapRejectsActiveDestinationWithoutDrainingStaleSourceAlias) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  const uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+
+  ASSERT_OK_AND_ASSIGN(
+      auto source_reservation,
+      gpu::CudaMemoryReservation::Create(executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto destination_reservation,
+      gpu::CudaMemoryReservation::Create(executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+  ASSERT_OK_AND_ASSIGN(
+      auto destination_occupant,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  ASSERT_THAT(allocator->Map(ordinal, source.cref(), source_reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->UnMap(ordinal, source_reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->Map(ordinal, destination_occupant.cref(),
+                             destination_reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+
+  EXPECT_THAT(
+      allocator->Map(ordinal, source.cref(), destination_reservation.get(),
+                     /*reservation_offset=*/0, granularity),
+      absl_testing::StatusIs(
+          absl::StatusCode::kAlreadyExists,
+          ::testing::HasSubstr("reservation range is already tracked")));
+  EXPECT_THAT(
+      allocator->UnMap(ordinal, source_reservation.get(),
+                       /*reservation_offset=*/0, granularity),
+      absl_testing::StatusIs(absl::StatusCode::kFailedPrecondition,
+                             ::testing::HasSubstr("already pending UnMap()")));
+
+  ASSERT_THAT(allocator->UnMap(ordinal, destination_reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, source.Release()), IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, destination_occupant.Release()),
+              IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
        MapRejectsPartialOverlapWithStaleReservationMapping) {
   ASSERT_OK_AND_ASSIGN(
       auto allocator,

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -372,6 +372,64 @@ TEST_F(DeviceAddressVmmAllocatorTest,
 }
 
 TEST_F(DeviceAddressVmmAllocatorTest,
+       MapWaitsForPendingUnMapBeforeMappingSameSourceToDifferentReservation) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  const uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+
+  ASSERT_OK_AND_ASSIGN(auto old_reservation, gpu::CudaMemoryReservation::Create(
+                                                 executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(auto new_reservation, gpu::CudaMemoryReservation::Create(
+                                                 executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+  auto* raw_allocation = allocator->GetRawAllocation(ordinal, source.cref());
+  ASSERT_NE(raw_allocation, nullptr);
+  DeviceAddressBase old_reservation_address =
+      old_reservation->address().GetByteSlice(/*offset_bytes=*/0, granularity);
+  DeviceAddressBase new_reservation_address =
+      new_reservation->address().GetByteSlice(/*offset_bytes=*/0, granularity);
+  ASSERT_NE(old_reservation_address.opaque(), new_reservation_address.opaque());
+
+  ASSERT_THAT(allocator->Map(ordinal, source.cref(), old_reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+  constexpr uint64_t kPattern = 0x123456789ABCDEF0ULL;
+  ASSERT_THAT(
+      stream_->Memcpy(&old_reservation_address, &kPattern, sizeof(kPattern)),
+      IsOk());
+  ASSERT_THAT(allocator->UnMap(ordinal, old_reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  EXPECT_EQ(allocator->GetRawAllocation(ordinal, old_reservation_address),
+            nullptr);
+
+  ASSERT_THAT(allocator->Map(ordinal, source.cref(), new_reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+  EXPECT_EQ(allocator->GetRawAllocation(ordinal, new_reservation_address),
+            raw_allocation);
+  uint64_t read_value = 0;
+  ASSERT_THAT(
+      stream_->Memcpy(&read_value, new_reservation_address, sizeof(read_value)),
+      IsOk());
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+  EXPECT_EQ(read_value, kPattern);
+
+  ASSERT_THAT(allocator->UnMap(ordinal, new_reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, source.Release()), IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
        MapRejectsPartialOverlapWithStaleReservationMapping) {
   ASSERT_OK_AND_ASSIGN(
       auto allocator,

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -1186,6 +1186,21 @@ DeviceAddressVmmAllocator::EvaluateMapTarget(
         source_record.reservation_address().opaque()));
   }
 
+  // Reject an active destination before waiting for a stale source alias. A
+  // failed Map() must not drain unrelated pending state.
+  if (FindOverlappingRecord(state, request.reservation_address,
+                            /*include_allocator=*/true,
+                            /*include_reservation=*/true,
+                            /*include_active=*/true,
+                            /*include_stale=*/false,
+                            /*exact_only=*/false,
+                            /*partial_only=*/false)
+          .has_value()) {
+    return absl::AlreadyExistsError(absl::StrFormat(
+        "reservation range is already tracked at virtual address %p",
+        request.reservation_address.opaque()));
+  }
+
   if (source_record.reservation_stale()) {
     CHECK(source_record.has_reservation_address());
     if (!source_record.reservation_matches(request.reservation_address)) {
@@ -1253,8 +1268,12 @@ DeviceAddressVmmAllocator::EvaluateMapTarget(
 absl::StatusOr<DeviceAddressVmmAllocator::PreparedMapTarget>
 DeviceAddressVmmAllocator::PrepareMapTarget(PerDeviceState& state,
                                             const MapRequest& request) {
+  // One source can have one stale alias and the destination can have one stale
+  // occupant. Without concurrent changes, at most two waits are needed before
+  // a third attempt can install or reuse the requested mapping.
+  constexpr int kMaxStaleMappingWaits = 2;
   bool first_attempt = true;
-  while (true) {
+  for (int wait_count = 0;; ++wait_count) {
     std::optional<PendingDeallocationKey> pending_completion_key;
     {
       // Keep record pointers inside this scope so none survives a wait that
@@ -1292,6 +1311,11 @@ DeviceAddressVmmAllocator::PrepareMapTarget(PerDeviceState& state,
               PreparedMapTarget::Action::kReusedStaleMapping};
         case MapTargetEvaluation::Action::kWait:
           CHECK(evaluation.pending_completion_key.has_value());
+          if (wait_count == kMaxStaleMappingWaits) {
+            return absl::AbortedError(
+                "Map() allocator state changed repeatedly while waiting for "
+                "stale mappings; retry Map()");
+          }
           pending_completion_key = evaluation.pending_completion_key;
           break;
       }

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -703,8 +703,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       AllocationRecord& source_record) const
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  // Resolves conflicts for a Map() request. Every wait is followed by a fresh
-  // source lookup and validation because waiting temporarily releases state.mu.
+  // Resolves up to two stale conflicts for a Map() request. Every wait is
+  // followed by a fresh source lookup and validation because waiting
+  // temporarily releases state.mu.
   absl::StatusOr<PreparedMapTarget> PrepareMapTarget(PerDeviceState& state,
                                                      const MapRequest& request)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -134,7 +134,9 @@ namespace stream_executor {
 // reactivates the old mapping instead of unmapping and remapping. If a
 // requested reservation address is still stale for a different raw allocation,
 // Map() waits for that deferred unmap to complete before installing the new
-// mapping.
+// mapping. If the source allocation has a stale alias in a different
+// reservation, Map() likewise waits for that alias before mapping the source
+// into the requested reservation.
 //
 // Each registered device has independent state protected by its own mutex, so
 // operations on different devices can proceed in parallel. The per-device map


### PR DESCRIPTION
📝 Summary of Changes
This PR is the command-buffer VMM allocation step in the stack:

Previous PR: https://github.com/openxla/xla/pull/44355
Next PR: https://github.com/openxla/xla/pull/44296

This change routes command-buffer execution allocation through `GpuExecutableBufferAllocator` using `se::DeviceAddressVmmAllocator`:

- Creates executable/executor-scoped VMM remapping state for command-buffer allocation indexes.
- Reserves a stable virtual address range and assigns deterministic offsets for command-buffer-visible allocations.
- Allocates command-buffer temp/live-out buffers through the VMM allocator when VA remapping is active.
- Maps entry-parameter buffers into reservation-backed aliases for command-buffer execution, then unmaps those aliases after execution.
- Synchronizes pending VMM operations when the executable-scoped allocator is destroyed.
- Keeps returned-output/live-out policy inside `GpuExecutableBufferAllocator` so returned buffers expose the expected physical allocation address instead of a reservation alias.
- Moves command-buffer update-mode/index collection and returned-output allocation-index collection into `GpuExecutableBufferAllocator`, keeping `GpuExecutable` and PJRT call sites focused on scope creation, allocation generation, execution, and teardown.
- Leaves PJRT teardown behavior and existing `buffer_allocations` naming unchanged.

🎯 Justification
Command-buffer replay is sensitive to device address changes. VMM reservations let XLA present stable virtual addresses for buffers captured by command buffers while still allowing the physical backing allocations, including parameter buffers, to vary between executions.

Centralizing this policy in `GpuExecutableBufferAllocator` keeps the VMM reservation, remapping, returned-output handling, and command-buffer allocation-index collection in one owner. That makes the `GpuExecutable` and PJRT execution paths smaller and prepares the follow-up command-buffer update-info runtime change in #44296.

🚀 Kind of Contribution
⚡️ Performance Improvement, ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not run locally. This PR adds the runtime allocation/remapping plumbing expected to reduce command-buffer update overhead for VMM-capable command-buffer executions, especially with `xla_gpu_command_buffer_update_mode=NEVER_UPDATE` or `CAPTURE_CMD_NEVER_UPDATE`.

🧪 Unit Tests:
No new unit tests were added in this PR. Existing focused coverage was run:

`bazel test //xla/service/gpu:gpu_executable_test`

🧪 Execution Tests:
No new execution tests were added. Focused PJRT build coverage was run:

`bazel build //xla/pjrt/gpu:se_gpu_pjrt_client`
