### PR TITLE
Clean up CUPTI V2 subscriber fallback handling

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -415,6 +415,7 @@ cc_library(
             ":cupti_utils",
             "//xla/stream_executor/cuda:cuda_status",
             "//xla/tsl/platform:errors",
+            "//xla/tsl/platform:status_macros",
             "@com_google_absl//absl/base",
             "@com_google_absl//absl/base:core_headers",
             "@com_google_absl//absl/cleanup",
@@ -428,7 +429,7 @@ cc_library(
             "@local_config_cuda//cuda:cupti_headers",
             "@tsl//tsl/platform:errors",
         ],
-    ) + ["//xla/tsl/platform:status_macros"],
+    ),
 )
 
 cc_library(
@@ -723,6 +724,7 @@ cc_library(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/synchronization",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cupti_headers",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:platform_port",
         "@tsl//tsl/platform:thread_annotations",

--- a/xla/backends/profiler/gpu/cupti_buffer_events.cc
+++ b/xla/backends/profiler/gpu/cupti_buffer_events.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/backends/profiler/gpu/cupti_interface.h"
 #include "xla/backends/profiler/gpu/cupti_marker_data_parser.h"
@@ -577,13 +578,16 @@ void AddSynchronizationActivityEvent(
 
 static absl::Status ConvertActivityBuffer(
     CuptiEventCollectorDelegate &collector, uint8_t *buffer, const size_t size,
+    CUpti_SubscriberHandle subscriber, bool use_v2_records,
     const size_t max_activity_event_count, size_t &total_activity_event_count,
-    size_t &dropped_activity_event_count) {
-  CuptiInterface *cupti_interface = GetCuptiInterface();
+    size_t &dropped_activity_event_count, CuptiInterface *cupti_interface) {
   CUpti_Activity *record = nullptr;
   while (true) {
     CUptiResult status =
-        cupti_interface->ActivityGetNextRecord(buffer, size, &record);
+        use_v2_records
+            ? cupti_interface->ActivityGetNextRecordV2(subscriber, buffer, size,
+                                                       &record)
+            : cupti_interface->ActivityGetNextRecord(buffer, size, &record);
     if (status == CUPTI_SUCCESS) {
       if (total_activity_event_count >= max_activity_event_count) {
         dropped_activity_event_count++;
@@ -766,12 +770,14 @@ AnnotationMap::AnnotationInfo AnnotationMap::LookUp(
 }
 
 CuptiActivityBufferManager::ActivityBufferAndSize::ActivityBufferAndSize(
-    uint8_t *p, size_t sz)
+    uint8_t *p, size_t sz, CUpti_SubscriberHandle sub, bool use_v2)
     : buffer(p,
              [](uint8_t *p) {
                if (p != nullptr) tsl::port::AlignedFree(p);
              }),
-      size(sz) {}
+      size(sz),
+      subscriber(sub),
+      use_v2_records(use_v2) {}
 
 void AddActivityBufferListEventsTo(
     CuptiEventCollectorDelegate &collector,
@@ -784,9 +790,10 @@ void AddActivityBufferListEventsTo(
         std::move(buffer_list.front()));
     buffer_list.pop_front();
     ConvertActivityBuffer(collector, buffer_and_size.buffer.get(),
-                          buffer_and_size.size, max_activity_event_count,
-                          total_activity_event_count,
-                          dropped_activity_event_count)
+                          buffer_and_size.size, buffer_and_size.subscriber,
+                          buffer_and_size.use_v2_records,
+                          max_activity_event_count, total_activity_event_count,
+                          dropped_activity_event_count, GetCuptiInterface())
         .IgnoreError();
   }
 }

--- a/xla/backends/profiler/gpu/cupti_buffer_events.h
+++ b/xla/backends/profiler/gpu/cupti_buffer_events.h
@@ -32,6 +32,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
 #include "xla/tsl/profiler/utils/buffer_pool.h"
 #include "xla/tsl/profiler/utils/lock_free_queue.h"
 #include "tsl/platform/thread_annotations.h"
@@ -338,7 +339,11 @@ class CuptiActivityBufferManager {
   struct ActivityBufferAndSize {
     std::unique_ptr<uint8_t, std::function<void(uint8_t*)>> buffer;
     size_t size;  // size in bytes for the events filled by CUPTI.
-    explicit ActivityBufferAndSize(uint8_t* p = nullptr, size_t sz = 0);
+    CUpti_SubscriberHandle subscriber;
+    bool use_v2_records;
+    explicit ActivityBufferAndSize(uint8_t* p = nullptr, size_t sz = 0,
+                                   CUpti_SubscriberHandle sub = nullptr,
+                                   bool use_v2 = false);
   };
 
   explicit CuptiActivityBufferManager(size_t buffer_size_in_bytes)
@@ -350,9 +355,11 @@ class CuptiActivityBufferManager {
 
   void ReclaimBuffer(uint8_t* p) { buffer_pool_.ReclaimBuffer(p); }
 
-  void CacheCuptiFilledActivityBuffer(uint8_t* p, size_t sz) {
+  void CacheCuptiFilledActivityBuffer(uint8_t* p, size_t sz,
+                                      CUpti_SubscriberHandle subscriber,
+                                      bool use_v2_records) {
     absl::MutexLock lock(buffer_mutex_);
-    cached_buffers_.emplace_back(p, sz);
+    cached_buffers_.emplace_back(p, sz, subscriber, use_v2_records);
   }
 
   std::list<ActivityBufferAndSize> PopCachedBuffers() {

--- a/xla/backends/profiler/gpu/cupti_error_manager.cc
+++ b/xla/backends/profiler/gpu/cupti_error_manager.cc
@@ -109,6 +109,21 @@ CUptiResult CuptiErrorManager::ActivityGetNextRecord(
   return error;
 }
 
+CUptiResult CuptiErrorManager::ActivityGetNextRecordV2(
+    CUpti_SubscriberHandle subscriber, uint8_t* buffer,
+    size_t valid_buffer_size_bytes, CUpti_Activity** record) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult error = interface_->ActivityGetNextRecordV2(
+      subscriber, buffer, valid_buffer_size_bytes, record);
+  if (error == CUPTI_ERROR_NOT_SUPPORTED || error == CUPTI_ERROR_UNKNOWN) {
+    return ActivityGetNextRecord(buffer, valid_buffer_size_bytes, record);
+  }
+  ALLOW_ERROR(error, CUPTI_ERROR_MAX_LIMIT_REACHED);
+  ALLOW_ERROR(error, CUPTI_ERROR_INVALID_KIND);
+  LOG_AND_DISABLE_IF_ERROR(error);
+  return error;
+}
+
 CUptiResult CuptiErrorManager::ActivityGetNumDroppedRecords(CUcontext context,
                                                             uint32_t stream_id,
                                                             size_t* dropped) {
@@ -192,6 +207,8 @@ CUptiResult CuptiErrorManager::ActivityUseSystemThreadIdV2(
     CUpti_SubscriberHandle subscriber) {
   IGNORE_CALL_IF_DISABLED;
   CUptiResult error = interface_->ActivityUseSystemThreadIdV2(subscriber);
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_SUPPORTED);
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_COMPATIBLE);
   LOG_AND_DISABLE_IF_ERROR(error);
   return error;
 }
@@ -199,6 +216,8 @@ CUptiResult CuptiErrorManager::ActivityUseSystemThreadIdV2(
 CUptiResult CuptiErrorManager::ActivityUsePerThreadBufferV2() {
   IGNORE_CALL_IF_DISABLED;
   CUptiResult error = interface_->ActivityUsePerThreadBufferV2();
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_SUPPORTED);
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_COMPATIBLE);
   LOG_AND_DISABLE_IF_ERROR(error);
   return error;
 }
@@ -229,6 +248,17 @@ CUptiResult CuptiErrorManager::GetDeviceId(CUcontext context,
 CUptiResult CuptiErrorManager::GetTimestamp(uint64_t* timestamp) {
   IGNORE_CALL_IF_DISABLED;
   CUptiResult error = interface_->GetTimestamp(timestamp);
+  LOG_AND_DISABLE_IF_ERROR(error);
+  return error;
+}
+
+CUptiResult CuptiErrorManager::GetTimestampV2(CUpti_SubscriberHandle subscriber,
+                                              uint64_t* timestamp) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult error = interface_->GetTimestampV2(subscriber, timestamp);
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_SUPPORTED);
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_COMPATIBLE);
+  ALLOW_ERROR(error, CUPTI_ERROR_UNKNOWN);
   LOG_AND_DISABLE_IF_ERROR(error);
   return error;
 }
@@ -304,8 +334,8 @@ CUptiResult CuptiErrorManager::SubscribeV2(CUpti_SubscriberHandle* subscriber,
     auto f = std::bind(&CuptiErrorManager::Unsubscribe, this, *subscriber);
     RegisterUndoFunction(f);
   }
+  // Optional V2 subscriber path unavailable; callers can fall back to V1.
   ALLOW_ERROR(error, CUPTI_ERROR_NOT_SUPPORTED);
-  ALLOW_ERROR(error, CUPTI_ERROR_UNKNOWN);
   LOG_AND_DISABLE_IF_ERROR(error);
   return error;
 }

--- a/xla/backends/profiler/gpu/cupti_error_manager.h
+++ b/xla/backends/profiler/gpu/cupti_error_manager.h
@@ -61,6 +61,11 @@ class CuptiErrorManager : public xla::profiler::CuptiInterface {
                                     size_t valid_buffer_size_bytes,
                                     CUpti_Activity** record) override;
 
+  CUptiResult ActivityGetNextRecordV2(CUpti_SubscriberHandle subscriber,
+                                      uint8_t* buffer,
+                                      size_t valid_buffer_size_bytes,
+                                      CUpti_Activity** record) override;
+
   // Reports the number of dropped activity records.
   CUptiResult ActivityGetNumDroppedRecords(CUcontext context,
                                            uint32_t stream_id,
@@ -105,6 +110,9 @@ class CuptiErrorManager : public xla::profiler::CuptiInterface {
 
   // Returns CUPTI timestamp.
   CUptiResult GetTimestamp(uint64_t* timestamp) override;
+
+  CUptiResult GetTimestampV2(CUpti_SubscriberHandle subscriber,
+                             uint64_t* timestamp) override;
 
   // Explicitly destroys and cleans up all resources associated with CUPTI in
   // the current process.

--- a/xla/backends/profiler/gpu/cupti_error_manager_test.cc
+++ b/xla/backends/profiler/gpu/cupti_error_manager_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "xla/backends/profiler/gpu/cupti_error_manager.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -48,6 +49,10 @@ using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::Sequence;
 using ::testing::StrictMock;
+
+bool TimestampV2FallsBackToLegacy(CUptiResult status) {
+  return status == CUPTI_ERROR_NOT_SUPPORTED || status == CUPTI_ERROR_UNKNOWN;
+}
 
 // Needed to create different cupti tracer for each test cases.
 class TestableCuptiTracer : public CuptiTracer {
@@ -97,6 +102,79 @@ class CuptiErrorManagerTest : public ::testing::Test {
     MemCopyD2H();
   }
 
+  void VerifyV2SubscribeRetainedWhenTimestampV2Returns(
+      CUptiResult timestamp_status) {
+    EXPECT_FALSE(CuptiDisabled());
+
+    Sequence s1;
+    auto* const v2_subscriber =
+        reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+
+    EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
+        .InSequence(s1)
+        .WillOnce([&](CUpti_SubscriberHandle* subscriber,
+                      CUpti_CallbackFunc /*callback*/, void* /*userdata*/) {
+          *subscriber = v2_subscriber;
+          return CUPTI_SUCCESS;
+        });
+    EXPECT_CALL(*mock_, GetTimestampV2(v2_subscriber, _))
+        .InSequence(s1)
+        .WillOnce(Return(timestamp_status));
+
+    const int resource_cb_count = IsCudaNewEnoughForGraphTraceTest() ? 5 : 0;
+    if (resource_cb_count > 0) {
+      EXPECT_CALL(*mock_,
+                  EnableCallback(1, v2_subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
+          .Times(resource_cb_count)
+          .InSequence(s1)
+          .WillRepeatedly(Return(CUPTI_SUCCESS));
+    }
+    EXPECT_CALL(*mock_,
+                EnableCallback(1, v2_subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
+                               CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
+        .InSequence(s1)
+        .WillOnce(Return(CUPTI_SUCCESS));
+    if (resource_cb_count > 0) {
+      EXPECT_CALL(*mock_,
+                  EnableCallback(0, v2_subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
+          .Times(resource_cb_count)
+          .InSequence(s1)
+          .WillRepeatedly(Return(CUPTI_SUCCESS));
+    }
+    EXPECT_CALL(*mock_,
+                EnableCallback(0, v2_subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
+                               CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
+        .InSequence(s1)
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED))
+        .InSequence(s1)
+        .WillOnce(Return(CUPTI_SUCCESS));
+    if (TimestampV2FallsBackToLegacy(timestamp_status)) {
+      EXPECT_CALL(*mock_, GetTimestamp(_))
+          .InSequence(s1)
+          .WillOnce([](uint64_t* timestamp) {
+            *timestamp = 2;
+            return CUPTI_SUCCESS;
+          });
+    }
+    EXPECT_CALL(*mock_, Unsubscribe(v2_subscriber))
+        .InSequence(s1)
+        .WillOnce(Return(CUPTI_SUCCESS));
+
+    CuptiTracerOptions options;
+    options.cbids_selected.push_back(CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel);
+    EnableProfiling(options);
+
+    EXPECT_FALSE(CuptiDisabled());
+    DisableProfiling();
+    EXPECT_FALSE(CuptiDisabled());
+    if (TimestampV2FallsBackToLegacy(timestamp_status)) {
+      EXPECT_EQ(cupti_collector_->GetTracingEndTimeNs(), 2);
+    } else {
+      EXPECT_EQ(cupti_collector_->GetTracingEndTimeNs(), 0);
+    }
+  }
+
   // Pointer to MockCupti passed to CuptiBase constructor.
   // Used to inject failures to be handled by CuptiErrorManager.
   // Wrapped in StrictMock so unexpected calls cause a test failure.
@@ -123,6 +201,12 @@ TEST_F(CuptiErrorManagerTest, GpuTraceActivityEnableTest) {
       .WillOnce([](CUpti_SubscriberHandle* subscriber,
                    CUpti_CallbackFunc /*callback*/, void* /*userdata*/) {
         *subscriber = reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+        return CUPTI_SUCCESS;
+      });
+  EXPECT_CALL(*mock_, GetTimestampV2(_, _))
+      .InSequence(s1)
+      .WillOnce([](CUpti_SubscriberHandle /*subscriber*/, uint64_t* timestamp) {
+        *timestamp = 1;
         return CUPTI_SUCCESS;
       });
   const int cb_enable_times = IsCudaNewEnoughForGraphTraceTest() ? 6 : 1;
@@ -179,6 +263,12 @@ TEST_F(CuptiErrorManagerTest, GpuTraceAutoEnableTest) {
       .WillOnce([](CUpti_SubscriberHandle* subscriber,
                    CUpti_CallbackFunc /*callback*/, void* /*userdata*/) {
         *subscriber = reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+        return CUPTI_SUCCESS;
+      });
+  EXPECT_CALL(*mock_, GetTimestampV2(_, _))
+      .InSequence(s1)
+      .WillOnce([](CUpti_SubscriberHandle /*subscriber*/, uint64_t* timestamp) {
+        *timestamp = 1;
         return CUPTI_SUCCESS;
       });
   const int cb_enable_times = IsCudaNewEnoughForGraphTraceTest() ? 5 : 0;
@@ -241,6 +331,232 @@ TEST_F(CuptiErrorManagerTest, GpuTraceAutoEnableTest) {
   EXPECT_TRUE(CuptiDisabled());
   DisableProfiling();  // CUPTI calls are ignored
   EXPECT_TRUE(CuptiDisabled());
+}
+
+TEST_F(CuptiErrorManagerTest, KeepsV2SubscribeWhenTimestampV2Unsupported) {
+  VerifyV2SubscribeRetainedWhenTimestampV2Returns(CUPTI_ERROR_NOT_SUPPORTED);
+}
+
+TEST_F(CuptiErrorManagerTest, KeepsV2SubscribeWhenTimestampV2Unknown) {
+  VerifyV2SubscribeRetainedWhenTimestampV2Returns(CUPTI_ERROR_UNKNOWN);
+}
+
+TEST_F(CuptiErrorManagerTest, KeepsV2SubscribeWhenTimestampV2NotCompatible) {
+  VerifyV2SubscribeRetainedWhenTimestampV2Returns(CUPTI_ERROR_NOT_COMPATIBLE);
+}
+
+TEST_F(CuptiErrorManagerTest,
+       ReusesV2SubscriberAndActivityCallbacksWhenRequested) {
+  EXPECT_FALSE(CuptiDisabled());
+
+  Sequence s1;
+  auto* const v2_subscriber =
+      reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+
+  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
+      .InSequence(s1)
+      .WillOnce([&](CUpti_SubscriberHandle* subscriber,
+                    CUpti_CallbackFunc /*callback*/, void* /*userdata*/) {
+        *subscriber = v2_subscriber;
+        return CUPTI_SUCCESS;
+      });
+  EXPECT_CALL(*mock_, GetTimestampV2(v2_subscriber, _))
+      .InSequence(s1)
+      .WillOnce([](CUpti_SubscriberHandle /*subscriber*/, uint64_t* timestamp) {
+        *timestamp = 1;
+        return CUPTI_SUCCESS;
+      });
+
+  const int resource_cb_count = IsCudaNewEnoughForGraphTraceTest() ? 5 : 0;
+  if (resource_cb_count > 0) {
+    EXPECT_CALL(*mock_,
+                EnableCallback(1, v2_subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
+        .Times(resource_cb_count)
+        .InSequence(s1)
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
+  }
+  EXPECT_CALL(*mock_,
+              EnableCallback(1, v2_subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
+                             CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(v2_subscriber))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityRegisterCallbacksV2(v2_subscriber, _, _))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_,
+              ActivityEnableV2(v2_subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  if (resource_cb_count > 0) {
+    EXPECT_CALL(*mock_,
+                EnableCallback(0, v2_subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
+        .Times(resource_cb_count)
+        .InSequence(s1)
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
+  }
+  EXPECT_CALL(*mock_,
+              EnableCallback(0, v2_subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
+                             CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_,
+              ActivityDisableV2(v2_subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, GetTimestampV2(v2_subscriber, _))
+      .InSequence(s1)
+      .WillOnce([](CUpti_SubscriberHandle /*subscriber*/, uint64_t* timestamp) {
+        *timestamp = 2;
+        return CUPTI_SUCCESS;
+      });
+
+  EXPECT_CALL(*mock_, GetTimestampV2(v2_subscriber, _))
+      .InSequence(s1)
+      .WillOnce([](CUpti_SubscriberHandle /*subscriber*/, uint64_t* timestamp) {
+        *timestamp = 3;
+        return CUPTI_SUCCESS;
+      });
+  if (resource_cb_count > 0) {
+    EXPECT_CALL(*mock_,
+                EnableCallback(1, v2_subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
+        .Times(resource_cb_count)
+        .InSequence(s1)
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
+  }
+  EXPECT_CALL(*mock_,
+              EnableCallback(1, v2_subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
+                             CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(v2_subscriber))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_,
+              ActivityEnableV2(v2_subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  if (resource_cb_count > 0) {
+    EXPECT_CALL(*mock_,
+                EnableCallback(0, v2_subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
+        .Times(resource_cb_count)
+        .InSequence(s1)
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
+  }
+  EXPECT_CALL(*mock_,
+              EnableCallback(0, v2_subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
+                             CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_,
+              ActivityDisableV2(v2_subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, GetTimestampV2(v2_subscriber, _))
+      .InSequence(s1)
+      .WillOnce([](CUpti_SubscriberHandle /*subscriber*/, uint64_t* timestamp) {
+        *timestamp = 4;
+        return CUPTI_SUCCESS;
+      });
+
+  CuptiTracerOptions options;
+  options.reuse_cupti_v2_subscriber = true;
+  options.activities_selected.push_back(CUPTI_ACTIVITY_KIND_KERNEL);
+  options.cbids_selected.push_back(CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel);
+  EnableProfiling(options);
+  DisableProfiling();
+  EnableProfiling(options);
+  DisableProfiling();
+
+  EXPECT_FALSE(CuptiDisabled());
+}
+
+TEST_F(CuptiErrorManagerTest,
+       ActivityUseSystemThreadIdV2NotCompatibleDoesNotDisableCupti) {
+  auto* const v2_subscriber =
+      reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+  EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(v2_subscriber))
+      .WillOnce(Return(CUPTI_ERROR_NOT_COMPATIBLE));
+
+  EXPECT_EQ(cupti_error_manager_->ActivityUseSystemThreadIdV2(v2_subscriber),
+            CUPTI_ERROR_NOT_COMPATIBLE);
+  EXPECT_FALSE(CuptiDisabled());
+}
+
+TEST_F(CuptiErrorManagerTest,
+       ActivityUsePerThreadBufferV2NotCompatibleDoesNotDisableCupti) {
+  EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
+      .WillOnce(Return(CUPTI_ERROR_NOT_COMPATIBLE));
+
+  EXPECT_EQ(cupti_error_manager_->ActivityUsePerThreadBufferV2(),
+            CUPTI_ERROR_NOT_COMPATIBLE);
+  EXPECT_FALSE(CuptiDisabled());
+}
+
+TEST_F(CuptiErrorManagerTest, ActivityGetNextRecordV2NotSupportedFallsBack) {
+  EXPECT_FALSE(CuptiDisabled());
+
+  Sequence s1;
+  uint8_t buffer[1] = {};
+  CUpti_Activity activity = {};
+  CUpti_Activity* record = nullptr;
+
+  EXPECT_CALL(*mock_, ActivityGetNextRecordV2(_, buffer, sizeof(buffer), _))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_ERROR_NOT_SUPPORTED));
+  EXPECT_CALL(*mock_, ActivityGetNextRecord(buffer, sizeof(buffer), _))
+      .InSequence(s1)
+      .WillOnce([&](uint8_t* /*buffer*/, size_t /*valid_buffer_size_bytes*/,
+                    CUpti_Activity** record) {
+        *record = &activity;
+        return CUPTI_SUCCESS;
+      });
+
+  EXPECT_EQ(cupti_error_manager_->ActivityGetNextRecordV2(
+                /*subscriber=*/nullptr, buffer, sizeof(buffer), &record),
+            CUPTI_SUCCESS);
+  EXPECT_EQ(record, &activity);
+  EXPECT_FALSE(CuptiDisabled());
+}
+
+TEST_F(CuptiErrorManagerTest, ActivityGetNextRecordV2UnknownFallsBack) {
+  EXPECT_FALSE(CuptiDisabled());
+
+  Sequence s1;
+  uint8_t buffer[1] = {};
+  CUpti_Activity activity = {};
+  CUpti_Activity* record = nullptr;
+
+  EXPECT_CALL(*mock_, ActivityGetNextRecordV2(_, buffer, sizeof(buffer), _))
+      .InSequence(s1)
+      .WillOnce(Return(CUPTI_ERROR_UNKNOWN));
+  EXPECT_CALL(*mock_, ActivityGetNextRecord(buffer, sizeof(buffer), _))
+      .InSequence(s1)
+      .WillOnce([&](uint8_t* /*buffer*/, size_t /*valid_buffer_size_bytes*/,
+                    CUpti_Activity** record) {
+        *record = &activity;
+        return CUPTI_SUCCESS;
+      });
+
+  EXPECT_EQ(cupti_error_manager_->ActivityGetNextRecordV2(
+                /*subscriber=*/nullptr, buffer, sizeof(buffer), &record),
+            CUPTI_SUCCESS);
+  EXPECT_EQ(record, &activity);
+  EXPECT_FALSE(CuptiDisabled());
 }
 
 }  // namespace test

--- a/xla/backends/profiler/gpu/cupti_interface.h
+++ b/xla/backends/profiler/gpu/cupti_interface.h
@@ -91,6 +91,11 @@ class CuptiInterface {
                                             size_t valid_buffer_size_bytes,
                                             CUpti_Activity** record) = 0;
 
+  virtual CUptiResult ActivityGetNextRecordV2(CUpti_SubscriberHandle subscriber,
+                                              uint8_t* buffer,
+                                              size_t valid_buffer_size_bytes,
+                                              CUpti_Activity** record) = 0;
+
   virtual CUptiResult ActivityGetNumDroppedRecords(CUcontext context,
                                                    uint32_t stream_id,
                                                    size_t* dropped) = 0;
@@ -133,6 +138,9 @@ class CuptiInterface {
   virtual CUptiResult GetDeviceId(CUcontext context, uint32_t* deviceId) = 0;
 
   virtual CUptiResult GetTimestamp(uint64_t* timestamp) = 0;
+
+  virtual CUptiResult GetTimestampV2(CUpti_SubscriberHandle subscriber,
+                                     uint64_t* timestamp) = 0;
 
   virtual CUptiResult Finalize() = 0;
 

--- a/xla/backends/profiler/gpu/cupti_tracer.cc
+++ b/xla/backends/profiler/gpu/cupti_tracer.cc
@@ -1702,6 +1702,10 @@ uint64_t CuptiTracer::GetLegacyTimestamp() const {
       cupti_interface_->GetTimestamp(&tsc) == CUPTI_SUCCESS) {
     return tsc;
   }
+  LOG_FIRST_N(WARNING, 1)
+      << "CUPTI GetTimestamp failed; returning timestamp 0. Events that "
+         "depend on this timestamp may be dropped during time normalization.";
+  // Return 0 to mark the timestamp unavailable so profiling can continue.
   return 0;
 }
 
@@ -1740,7 +1744,12 @@ uint64_t CuptiTracer::GetTimestampForCurrentSubscriber() const {
   if (use_legacy_timestamp_with_v2_subscriber_) {
     return GetLegacyTimestamp();
   }
-  // Return 0 rather than mixing V1 and V2 timestamp domains.
+  LOG_FIRST_N(WARNING, 1)
+      << "CUPTI timestamp is unavailable for the current V2 subscriber state; "
+         "returning timestamp 0.";
+  // Return 0 to mark the timestamp unavailable for this V2 subscriber state so
+  // profiling can continue. Events that depend on this timestamp may be dropped
+  // during time normalization.
   return 0;
 }
 

--- a/xla/backends/profiler/gpu/cupti_tracer.cc
+++ b/xla/backends/profiler/gpu/cupti_tracer.cc
@@ -1037,15 +1037,16 @@ class CuptiDriverApiHookWithActivityApi : public CuptiDriverApiHook {
                                 CUpti_CallbackId cbid,
                                 const CUpti_CallbackData* cbdata) override {
     // Stash away the current Cupti timestamp into cbdata.
-    *cbdata->correlationData =
-        option_.required_callback_api_events ? CuptiTracer::GetTimestamp() : 0;
+    *cbdata->correlationData = option_.required_callback_api_events
+                                   ? tracer_->GetTimestampForCurrentSubscriber()
+                                   : 0;
     return absl::OkStatus();
   }
   absl::Status OnDriverApiExit(int device_id, CUpti_CallbackDomain domain,
                                CUpti_CallbackId cbid,
                                const CUpti_CallbackData* cbdata) override {
     // Grab timestamp for API exit. API entry timestamp saved in cbdata.
-    uint64_t end_tsc = CuptiTracer::GetTimestamp();
+    uint64_t end_tsc = tracer_->GetTimestampForCurrentSubscriber();
     uint64_t start_tsc = *cbdata->correlationData;
     TrackContext(cbid, cbdata->context);
     return AddDriverApiCallbackEvent(tracer_, cupti_interface_, device_id,
@@ -1104,6 +1105,11 @@ const char* GetCuptiErrorString(CuptiInterface* cupti_interface,
     cupti_interface->GetResultString(err, &err_str);
   }
   return err_str;
+}
+
+bool IsTimestampV2Unavailable(CUptiResult status) {
+  // This helper is only for the optional subscriber-scoped timestamp path.
+  return status == CUPTI_ERROR_NOT_SUPPORTED || status == CUPTI_ERROR_UNKNOWN;
 }
 
 bool& IsCuptiHardwareEventSystemEnabled() {
@@ -1228,33 +1234,42 @@ void CuptiTracer::Disable() {
     pm_sampling_enabled_ = false;
   }
 
-  // ActivityDisableV2 needs the subscriber handle still valid; disable
-  // activities before API tracing (which calls Unsubscribe) only in the V2
-  // subscriber path.
+  auto collect_trace_data = [&](uint64_t tracing_end_time_ns) {
+    collector_->SetTracingEndTimeNs(tracing_end_time_ns);
+
+    // The callback API events must be processed before activity API buffers
+    // because the AnnotationMap is populated from the callback API events and
+    // queried by the activity API events.
+    collector_->OnTracerCollectedCallbackData(
+        GatherCallbackAnnotationsAndEvents(/*stop_recording=*/true),
+        IsCallbackApiEventsRequired());
+
+    if (activity_buffers_) {
+      auto cached_buffers = activity_buffers_->PopCachedBuffers();
+      activity_buffers_.reset();
+      collector_->OnTracerCachedActivityBuffers(std::move(cached_buffers));
+    }
+  };
+
+  // Activity V2 cleanup needs the subscriber handle alive until cached buffers
+  // are parsed with subscriber-scoped record APIs.
   if (using_v2_subscriber_api_) {
+    DisableApiTracing(/*unsubscribe=*/false).IgnoreError();
     DisableActivityTracing().IgnoreError();
-    DisableApiTracing().IgnoreError();
+    cupti_driver_api_hook_->SyncAndFlush().IgnoreError();
+    collect_trace_data(GetTimestampForCurrentSubscriber());
+    DisableApiTracing(
+        /*unsubscribe=*/!option_->reuse_cupti_v2_subscriber)
+        .IgnoreError();
+    cupti_interface_->CleanUp();
+    Finalize().IgnoreError();
   } else {
     DisableApiTracing().IgnoreError();
     DisableActivityTracing().IgnoreError();
-  }
-  cupti_interface_->CleanUp();
-  Finalize().IgnoreError();
-  cupti_driver_api_hook_->SyncAndFlush().IgnoreError();
-
-  collector_->SetTracingEndTimeNs(GetTimestamp());
-
-  // The callback API events must be processed before activity API buffers
-  // because the AnnotationMap is populated from the callback API events and
-  // queried by the activity API events.
-  collector_->OnTracerCollectedCallbackData(
-      GatherCallbackAnnotationsAndEvents(/*stop_recording=*/true),
-      IsCallbackApiEventsRequired());
-
-  if (activity_buffers_) {
-    auto cached_buffers = activity_buffers_->PopCachedBuffers();
-    activity_buffers_.reset();
-    collector_->OnTracerCachedActivityBuffers(std::move(cached_buffers));
+    cupti_interface_->CleanUp();
+    Finalize().IgnoreError();
+    cupti_driver_api_hook_->SyncAndFlush().IgnoreError();
+    collect_trace_data(GetTimestamp());
   }
 
   if (cupti_dropped_activity_event_count_ > 0) {
@@ -1271,6 +1286,8 @@ void CuptiTracer::Disable() {
   option_.reset();
   cupti_driver_api_hook_.reset();
   using_v2_subscriber_api_ = false;
+  using_v2_timestamp_api_ = false;
+  use_legacy_timestamp_with_v2_subscriber_ = false;
   tsl::profiler::AnnotationStack::Enable(false);
 }
 
@@ -1414,6 +1431,8 @@ absl::Status CuptiTracer::EnableApiTracing() {
 
   PrepareCallbackStart();
   using_v2_subscriber_api_ = false;
+  using_v2_timestamp_api_ = false;
+  use_legacy_timestamp_with_v2_subscriber_ = false;
 
   VLOG(1) << "Enable subscriber";
   // Subscribe can return CUPTI_ERROR_MAX_LIMIT_REACHED.
@@ -1421,15 +1440,35 @@ absl::Status CuptiTracer::EnableApiTracing() {
   // like nvprof, Nvidia Visual Profiler, Nsight Compute, Nsight Systems.
   CUptiResult subscribe_status = CUPTI_ERROR_NOT_SUPPORTED;
   if (option_->prefer_cupti_v2) {
-    subscribe_status = cupti_interface_->SubscribeV2(
-        &subscriber_, (CUpti_CallbackFunc)ApiCallback, this);
+    if (subscriber_ != nullptr) {
+      subscribe_status = CUPTI_SUCCESS;
+      using_v2_subscriber_api_ = true;
+    } else {
+      subscribe_status = cupti_interface_->SubscribeV2(
+          &subscriber_, (CUpti_CallbackFunc)ApiCallback, this);
+    }
     if (subscribe_status == CUPTI_SUCCESS) {
       using_v2_subscriber_api_ = true;
+      uint64_t unused_timestamp = 0;
+      CUptiResult timestamp_status =
+          cupti_interface_->GetTimestampV2(subscriber_, &unused_timestamp);
+      if (timestamp_status == CUPTI_SUCCESS) {
+        using_v2_timestamp_api_ = true;
+      } else if (IsTimestampV2Unavailable(timestamp_status)) {
+        use_legacy_timestamp_with_v2_subscriber_ = true;
+      } else if (timestamp_status != CUPTI_ERROR_NOT_COMPATIBLE) {
+        if (!cupti_interface_->Disabled()) {
+          cupti_interface_->Unsubscribe(subscriber_);
+        }
+        subscriber_ = nullptr;
+        v2_activity_callbacks_registered_ = false;
+        using_v2_subscriber_api_ = false;
+        subscribe_status = timestamp_status;
+      }
     }
   }
   if (!using_v2_subscriber_api_) {
-    if (subscribe_status == CUPTI_ERROR_NOT_SUPPORTED ||
-        subscribe_status == CUPTI_ERROR_UNKNOWN) {
+    if (subscribe_status == CUPTI_ERROR_NOT_SUPPORTED) {
       subscribe_status = cupti_interface_->Subscribe(
           &subscriber_, (CUpti_CallbackFunc)ApiCallback, this);
     }
@@ -1469,32 +1508,34 @@ absl::Status CuptiTracer::EnableApiTracing() {
   return absl::OkStatus();
 }
 
-absl::Status CuptiTracer::DisableApiTracing() {
-  if (!api_tracing_enabled_) {
-    return absl::OkStatus();
-  }
+absl::Status CuptiTracer::DisableApiTracing(bool unsubscribe) {
+  if (api_tracing_enabled_) {
+    api_tracing_enabled_ = false;
 
-  api_tracing_enabled_ = false;
-
-  absl::Span<const CUpti_CallbackIdResource> res_cbids =
-      cuda_versions::GetCudaGraphTracingResourceCbids();
-  for (auto cbid : res_cbids) {
-    RETURN_IF_CUPTI_ERROR(EnableCallback(0 /* DISABLE */, subscriber_,
-                                         CUPTI_CB_DOMAIN_RESOURCE, cbid));
-  }
-
-  if (!option_->cbids_selected.empty()) {
-    for (auto cbid : option_->cbids_selected) {
+    absl::Span<const CUpti_CallbackIdResource> res_cbids =
+        cuda_versions::GetCudaGraphTracingResourceCbids();
+    for (auto cbid : res_cbids) {
       RETURN_IF_CUPTI_ERROR(EnableCallback(0 /* DISABLE */, subscriber_,
-                                           CUPTI_CB_DOMAIN_DRIVER_API, cbid));
+                                           CUPTI_CB_DOMAIN_RESOURCE, cbid));
     }
-  } else {
-    RETURN_IF_CUPTI_ERROR(
-        EnableDomain(0 /* DISABLE */, subscriber_, CUPTI_CB_DOMAIN_DRIVER_API));
+
+    if (!option_->cbids_selected.empty()) {
+      for (auto cbid : option_->cbids_selected) {
+        RETURN_IF_CUPTI_ERROR(EnableCallback(0 /* DISABLE */, subscriber_,
+                                             CUPTI_CB_DOMAIN_DRIVER_API, cbid));
+      }
+    } else {
+      RETURN_IF_CUPTI_ERROR(EnableDomain(0 /* DISABLE */, subscriber_,
+                                         CUPTI_CB_DOMAIN_DRIVER_API));
+    }
   }
 
-  VLOG(1) << "Disable subscriber";
-  RETURN_IF_CUPTI_ERROR(Unsubscribe(subscriber_));
+  if (unsubscribe && subscriber_ != nullptr) {
+    VLOG(1) << "Disable subscriber";
+    RETURN_IF_CUPTI_ERROR(Unsubscribe(subscriber_));
+    subscriber_ = nullptr;
+    v2_activity_callbacks_registered_ = false;
+  }
   return absl::OkStatus();
 }
 
@@ -1566,9 +1607,13 @@ absl::Status CuptiTracer::EnableActivityTracing() {
     }
 
     if (using_v2_subscriber_api_) {
-      RETURN_IF_CUPTI_ERROR(ActivityRegisterCallbacksV2(
-          subscriber_, RequestCuptiActivityBuffer_v2,
-          ProcessCuptiActivityBuffer_v2));
+      if (!v2_activity_callbacks_registered_) {
+        // Register activity callbacks once per retained V2 subscriber.
+        RETURN_IF_CUPTI_ERROR(ActivityRegisterCallbacksV2(
+            subscriber_, RequestCuptiActivityBuffer_v2,
+            ProcessCuptiActivityBuffer_v2));
+        v2_activity_callbacks_registered_ = true;
+      }
       VLOG(1) << "Enabling activity tracing (V2) for "
               << option_->activities_selected.size() << " activities";
       for (auto activity : option_->activities_selected) {
@@ -1648,6 +1693,54 @@ absl::Status CuptiTracer::Finalize() {
   }
   // Return 0 on error. If an activity timestamp is 0, the activity will be
   // dropped during time normalization.
+  return 0;
+}
+
+uint64_t CuptiTracer::GetLegacyTimestamp() const {
+  uint64_t tsc;
+  if (cupti_interface_ != nullptr &&
+      cupti_interface_->GetTimestamp(&tsc) == CUPTI_SUCCESS) {
+    return tsc;
+  }
+  return 0;
+}
+
+uint64_t CuptiTracer::GetTimestampForProfilerStart() const {
+  if (subscriber_ == nullptr || cupti_interface_ == nullptr) {
+    return CuptiTracer::GetTimestamp();
+  }
+
+  if (use_legacy_timestamp_with_v2_subscriber_) {
+    return GetLegacyTimestamp();
+  }
+
+  uint64_t tsc;
+  CUptiResult timestamp_status =
+      cupti_interface_->GetTimestampV2(subscriber_, &tsc);
+  if (timestamp_status == CUPTI_SUCCESS) {
+    return tsc;
+  }
+  if (IsTimestampV2Unavailable(timestamp_status)) {
+    return GetLegacyTimestamp();
+  }
+  // Do not probe legacy timestamps in an incompatible V2 subscriber state.
+  return 0;
+}
+
+uint64_t CuptiTracer::GetTimestampForCurrentSubscriber() const {
+  uint64_t tsc;
+  if (!using_v2_subscriber_api_ || subscriber_ == nullptr ||
+      cupti_interface_ == nullptr) {
+    return CuptiTracer::GetTimestamp();
+  }
+  if (using_v2_timestamp_api_ &&
+      cupti_interface_->GetTimestampV2(subscriber_, &tsc) == CUPTI_SUCCESS) {
+    return tsc;
+  }
+  if (use_legacy_timestamp_with_v2_subscriber_) {
+    return GetLegacyTimestamp();
+  }
+  // Return 0 rather than mixing V1 and V2 timestamp domains.
   return 0;
 }
 
@@ -1807,7 +1900,9 @@ void CuptiTracer::RequestActivityBuffer(uint8_t** buffer, size_t* size) {
   *size = activity_buffers_->GetBufferSizeInBytes();
 }
 
-static size_t CountCuptiActivityEvent(uint8_t* buffer, size_t size) {
+static size_t CountCuptiActivityEvent(uint8_t* buffer, size_t size,
+                                      CUpti_SubscriberHandle subscriber,
+                                      bool use_v2_records) {
   size_t total_event_count = 0;
   if (size == 0 || buffer == nullptr) {
     return total_event_count;
@@ -1815,8 +1910,12 @@ static size_t CountCuptiActivityEvent(uint8_t* buffer, size_t size) {
   CuptiInterface* cupti_interface = GetCuptiInterface();
   CUpti_Activity* record = nullptr;
   while (true) {
-    if (cupti_interface->ActivityGetNextRecord(buffer, size, &record) ==
-        CUPTI_SUCCESS) {
+    CUptiResult status =
+        use_v2_records
+            ? cupti_interface->ActivityGetNextRecordV2(subscriber, buffer, size,
+                                                       &record)
+            : cupti_interface->ActivityGetNextRecord(buffer, size, &record);
+    if (status == CUPTI_SUCCESS) {
       ++total_event_count;
     } else {
       break;
@@ -1855,7 +1954,8 @@ absl::Status CuptiTracer::ProcessActivityBuffer(CUcontext context,
     }
   }
 
-  size_t event_count_in_buffer = CountCuptiActivityEvent(buffer, size);
+  size_t event_count_in_buffer = CountCuptiActivityEvent(
+      buffer, size, subscriber_, using_v2_subscriber_api_);
   auto max_activity_event_count =
       collector_->GetOptions().max_activity_api_events;
   if (max_activity_event_count > 0 &&
@@ -1875,7 +1975,8 @@ absl::Status CuptiTracer::ProcessActivityBuffer(CUcontext context,
   // valid size some where. All the saved activity buffer will be handled
   // after the profiling is stopped.
   VLOG(3) << "Caching CUPTI activity buffer of size:" << size;
-  activity_buffers_->CacheCuptiFilledActivityBuffer(buffer, size);
+  activity_buffers_->CacheCuptiFilledActivityBuffer(buffer, size, subscriber_,
+                                                    using_v2_subscriber_api_);
   buffer = nullptr;  // So cleanup will not free it as it was saved already
 
   return absl::OkStatus();
@@ -1885,11 +1986,12 @@ absl::Status CuptiTracer::ProcessActivityBuffer(CUcontext context,
   if (CuptiTracer::NumGpus() == 0) {
     return ErrorWithHostname("No GPU detected.");
   }
-  if (CuptiTracer::GetCuptiTracerSingleton()->NeedRootAccess()) {
+  CuptiTracer* cupti_tracer = CuptiTracer::GetCuptiTracerSingleton();
+  if (cupti_tracer->NeedRootAccess()) {
     return ErrorWithHostname(
         "Insufficient privilege to run libcupti (you need root permission).");
   }
-  if (CuptiTracer::GetTimestamp() == 0) {
+  if (cupti_tracer->GetTimestampForProfilerStart() == 0) {
     return ErrorWithHostname(
         "Failed to load libcupti (is it installed and accessible?)");
   }

--- a/xla/backends/profiler/gpu/cupti_tracer.h
+++ b/xla/backends/profiler/gpu/cupti_tracer.h
@@ -52,6 +52,8 @@ struct CuptiTracerOptions {
   std::vector<CUpti_ActivityKind> activities_selected;
   // Whether to call cuptiFinalize.
   bool cupti_finalize = false;
+  // Whether to keep and reuse XLA's V2 CUPTI subscriber across sessions.
+  bool reuse_cupti_v2_subscriber = false;
   // Whether to prefer CUPTI V2 multi-subscriber APIs when available.
   bool prefer_cupti_v2 = true;
   // Whether to call cuCtxSynchronize for each device before Stop().
@@ -142,6 +144,8 @@ class CuptiTracer {
                                      uint8_t* buffer, size_t size);
 
   static uint64_t GetTimestamp();
+  uint64_t GetTimestampForProfilerStart() const;
+  uint64_t GetTimestampForCurrentSubscriber() const;
   static int NumGpus();
   // Returns the error (if any) when using libcupti.
   static std::string ErrorIfAny();
@@ -191,10 +195,11 @@ class CuptiTracer {
 
   absl::Status EnableApiTracing();
   absl::Status EnableActivityTracing();
-  absl::Status DisableApiTracing();
+  absl::Status DisableApiTracing(bool unsubscribe = true);
   absl::Status DisableActivityTracing();
   absl::Status Finalize();
   void ConfigureActivityUnifiedMemoryCounter(bool enable);
+  uint64_t GetLegacyTimestamp() const;
   absl::Status HandleNVTXCallback(CUpti_CallbackId cbid,
                                   const CUpti_CallbackData* cbdata);
   absl::Status HandleDriverApiCallback(CUpti_CallbackId cbid,
@@ -215,8 +220,11 @@ class CuptiTracer {
   // Cupti handle for driver or runtime API callbacks. Cupti permits a single
   // subscriber to be active at any time and can be used to trace Cuda runtime
   // as and driver calls for all contexts and devices.
-  CUpti_SubscriberHandle subscriber_;  // valid when api_tracing_enabled_.
+  CUpti_SubscriberHandle subscriber_ = nullptr;
   bool using_v2_subscriber_api_ = false;
+  bool using_v2_timestamp_api_ = false;
+  bool use_legacy_timestamp_with_v2_subscriber_ = false;
+  bool v2_activity_callbacks_registered_ = false;
 
   bool activity_tracing_enabled_ = false;
 

--- a/xla/backends/profiler/gpu/cupti_tracer_options_utils.cc
+++ b/xla/backends/profiler/gpu/cupti_tracer_options_utils.cc
@@ -84,6 +84,10 @@ absl::Status UpdateCuptiTracerOptionsFromProfilerOptions(
       [&](bool value) { tracer_options.enable_nvtx_tracking = value; }));
 
   RETURN_IF_ERROR(SetValue<bool>(
+      profile_options, "gpu_reuse_cupti_v2_subscriber", input_keys,
+      [&](bool value) { tracer_options.reuse_cupti_v2_subscriber = value; }));
+
+  RETURN_IF_ERROR(SetValue<bool>(
       profile_options, "gpu_aggregated_tracing", input_keys,
       [&](bool value) { collector_options.aggregated_tracing = value; }));
 

--- a/xla/backends/profiler/gpu/cupti_wrapper.cc
+++ b/xla/backends/profiler/gpu/cupti_wrapper.cc
@@ -92,11 +92,13 @@ bool SetAllowMultipleSubscribersIfSupported(Params* params) {
   return false;
 }
 
-// Older CUPTI headers do not define CUPTI_ACTIVITY_ATTR_THREAD_ID_TYPE. Use the
-// CUDA 13.2 enum value so this file can compile with those headers; weak V2
-// symbol checks still decide runtime availability.
-constexpr auto kCuptiActivityAttrThreadIdType =
+// Keep optional V2 paths buildable with older CUPTI headers; weak symbol checks
+// still decide runtime availability.
+constexpr CUpti_ActivityAttribute kCuptiActivityAttrPerThreadActivityBuffer =
+    static_cast<CUpti_ActivityAttribute>(9);
+constexpr CUpti_ActivityAttribute kCuptiActivityAttrThreadIdType =
     static_cast<CUpti_ActivityAttribute>(21);
+constexpr int kCuptiErrorMultipleSubscribersNotSupported = 39;
 
 }  // namespace
 
@@ -111,9 +113,14 @@ extern "C" {
 [[gnu::weak]] CUptiResult cuptiActivityDisable_v2(
     CUpti_SubscriberHandle subscriber, CUpti_ActivityKind kind,
     CuptiActivityConfigAbi* cfg);
+[[gnu::weak]] CUptiResult cuptiActivityGetNextRecord_v2(
+    CUpti_SubscriberHandle subscriber, uint8_t* buffer,
+    size_t valid_buffer_size_bytes, CUpti_Activity** record);
 [[gnu::weak]] CUptiResult cuptiActivitySetAttribute_v2(
     CUpti_SubscriberHandle subscriber, CUpti_ActivityAttribute attr,
     size_t* valueSize, void* value);
+[[gnu::weak]] CUptiResult cuptiGetTimestamp_v2(
+    CUpti_SubscriberHandle subscriber, uint64_t* timestamp);
 [[gnu::weak]] CUptiResult cuptiSubscribe_v2(CUpti_SubscriberHandle* subscriber,
                                             CUpti_CallbackFunc callback,
                                             void* userdata,
@@ -136,6 +143,16 @@ CUptiResult CuptiWrapper::ActivityGetNextRecord(uint8_t* buffer,
                                                 size_t valid_buffer_size_bytes,
                                                 CUpti_Activity** record) {
   return cuptiActivityGetNextRecord(buffer, valid_buffer_size_bytes, record);
+}
+
+CUptiResult CuptiWrapper::ActivityGetNextRecordV2(
+    CUpti_SubscriberHandle subscriber, uint8_t* buffer,
+    size_t valid_buffer_size_bytes, CUpti_Activity** record) {
+  if (cuptiActivityGetNextRecord_v2 == nullptr) {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+  return cuptiActivityGetNextRecord_v2(subscriber, buffer,
+                                       valid_buffer_size_bytes, record);
 }
 
 CUptiResult CuptiWrapper::ActivityGetNumDroppedRecords(CUcontext context,
@@ -212,8 +229,8 @@ CUptiResult CuptiWrapper::ActivityUsePerThreadBufferV2() {
   uint8_t use_per_thread = 1;
   size_t size = sizeof(use_per_thread);
   return ActivitySetAttributeV2(
-      /*subscriber=*/nullptr, CUPTI_ACTIVITY_ATTR_PER_THREAD_ACTIVITY_BUFFER,
-      &size, &use_per_thread);
+      /*subscriber=*/nullptr, kCuptiActivityAttrPerThreadActivityBuffer, &size,
+      &use_per_thread);
 }
 
 CUptiResult CuptiWrapper::ActivityUsePerThreadBuffer() {
@@ -244,6 +261,14 @@ CUptiResult CuptiWrapper::GetDeviceId(CUcontext context, uint32_t* deviceId) {
 
 CUptiResult CuptiWrapper::GetTimestamp(uint64_t* timestamp) {
   return cuptiGetTimestamp(timestamp);
+}
+
+CUptiResult CuptiWrapper::GetTimestampV2(CUpti_SubscriberHandle subscriber,
+                                         uint64_t* timestamp) {
+  if (cuptiGetTimestamp_v2 == nullptr) {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+  return cuptiGetTimestamp_v2(subscriber, timestamp);
 }
 
 CUptiResult CuptiWrapper::Finalize() { return cuptiFinalize(); }
@@ -281,7 +306,7 @@ CUptiResult CuptiWrapper::SubscribeV2(CUpti_SubscriberHandle* subscriber,
   }
   CUptiResult result =
       cuptiSubscribe_v2(subscriber, callback, userdata, &params);
-  if (result == CUPTI_ERROR_MULTIPLE_SUBSCRIBERS_NOT_SUPPORTED) {
+  if (static_cast<int>(result) == kCuptiErrorMultipleSubscribersNotSupported) {
     return CUPTI_ERROR_NOT_SUPPORTED;
   }
   return result;

--- a/xla/backends/profiler/gpu/cupti_wrapper.h
+++ b/xla/backends/profiler/gpu/cupti_wrapper.h
@@ -47,6 +47,11 @@ class CuptiWrapper : public xla::profiler::CuptiInterface {
                                     size_t valid_buffer_size_bytes,
                                     CUpti_Activity** record) override;
 
+  CUptiResult ActivityGetNextRecordV2(CUpti_SubscriberHandle subscriber,
+                                      uint8_t* buffer,
+                                      size_t valid_buffer_size_bytes,
+                                      CUpti_Activity** record) override;
+
   CUptiResult ActivityGetNumDroppedRecords(CUcontext context,
                                            uint32_t stream_id,
                                            size_t* dropped) override;
@@ -86,6 +91,9 @@ class CuptiWrapper : public xla::profiler::CuptiInterface {
   CUptiResult GetDeviceId(CUcontext context, uint32_t* deviceId) override;
 
   CUptiResult GetTimestamp(uint64_t* timestamp) override;
+
+  CUptiResult GetTimestampV2(CUpti_SubscriberHandle subscriber,
+                             uint64_t* timestamp) override;
 
   // cuptiFinalize is only defined in CUDA8 and above.
   // To enable it in CUDA8, the environment variable CUPTI_ENABLE_FINALIZE must
@@ -250,6 +258,11 @@ class CuptiWrapperStub : public xla::profiler::CuptiInterface {
                                     size_t valid_buffer_size_bytes,
                                     CUpti_Activity** record) override;
 
+  CUptiResult ActivityGetNextRecordV2(CUpti_SubscriberHandle subscriber,
+                                      uint8_t* buffer,
+                                      size_t valid_buffer_size_bytes,
+                                      CUpti_Activity** record) override;
+
   CUptiResult ActivityGetNumDroppedRecords(CUcontext context,
                                            uint32_t stream_id,
                                            size_t* dropped) override;
@@ -289,6 +302,9 @@ class CuptiWrapperStub : public xla::profiler::CuptiInterface {
   CUptiResult GetDeviceId(CUcontext context, uint32_t* deviceId) override;
 
   CUptiResult GetTimestamp(uint64_t* timestamp) override;
+
+  CUptiResult GetTimestampV2(CUpti_SubscriberHandle subscriber,
+                             uint64_t* timestamp) override;
 
   // cuptiFinalize is only defined in CUDA8 and above.
   // To enable it in CUDA8, the environment variable CUPTI_ENABLE_FINALIZE must

--- a/xla/backends/profiler/gpu/cupti_wrapper_stub.cc
+++ b/xla/backends/profiler/gpu/cupti_wrapper_stub.cc
@@ -45,6 +45,12 @@ CUptiResult CuptiWrapperStub::ActivityGetNextRecord(
   return CUPTI_ERROR_MAX_LIMIT_REACHED;
 }
 
+CUptiResult CuptiWrapperStub::ActivityGetNextRecordV2(
+    CUpti_SubscriberHandle /*subscriber*/, uint8_t* /*buffer*/,
+    size_t /*valid_buffer_size_bytes*/, CUpti_Activity** /*record*/) {
+  return CUPTI_ERROR_MAX_LIMIT_REACHED;
+}
+
 CUptiResult CuptiWrapperStub::ActivityGetNumDroppedRecords(CUcontext context,
                                                            uint32_t stream_id,
                                                            size_t* dropped) {
@@ -112,6 +118,11 @@ CUptiResult CuptiWrapperStub::GetDeviceId(CUcontext context,
 
 CUptiResult CuptiWrapperStub::GetTimestamp(uint64_t* timestamp) {
   return cuptiGetTimestamp(timestamp);
+}
+
+CUptiResult CuptiWrapperStub::GetTimestampV2(
+    CUpti_SubscriberHandle /*subscriber*/, uint64_t* timestamp) {
+  return GetTimestamp(timestamp);
 }
 
 CUptiResult CuptiWrapperStub::Finalize() { return CUPTI_SUCCESS; }

--- a/xla/backends/profiler/gpu/device_tracer_cuda.cc
+++ b/xla/backends/profiler/gpu/device_tracer_cuda.cc
@@ -130,7 +130,7 @@ absl::Status GpuTracer::DoStart() {
     collector_options.num_gpus = num_gpus;
   }
 
-  uint64_t start_gputime_ns = CuptiTracer::GetTimestamp();
+  uint64_t start_gputime_ns = cupti_tracer_->GetTimestampForProfilerStart();
   uint64_t start_walltime_ns = tsl::profiler::GetCurrentTimeNanos();
   cupti_collector_ = CreateCuptiCollector(collector_options, start_walltime_ns,
                                           start_gputime_ns);

--- a/xla/backends/profiler/gpu/mock_cupti.h
+++ b/xla/backends/profiler/gpu/mock_cupti.h
@@ -48,6 +48,10 @@ class MockCupti : public xla::profiler::CuptiInterface {
               (uint8_t* buffer, size_t valid_buffer_size_bytes,
                CUpti_Activity** record),
               (override));
+  MOCK_METHOD(CUptiResult, ActivityGetNextRecordV2,
+              (CUpti_SubscriberHandle subscriber, uint8_t* buffer,
+               size_t valid_buffer_size_bytes, CUpti_Activity** record),
+              (override));
   MOCK_METHOD(CUptiResult, ActivityGetNumDroppedRecords,
               (CUcontext context, uint32_t stream_id, size_t* dropped),
               (override));
@@ -85,6 +89,9 @@ class MockCupti : public xla::profiler::CuptiInterface {
   MOCK_METHOD(CUptiResult, GetDeviceId, (CUcontext context, uint32_t* deviceId),
               (override));
   MOCK_METHOD(CUptiResult, GetTimestamp, (uint64_t* timestamp), (override));
+  MOCK_METHOD(CUptiResult, GetTimestampV2,
+              (CUpti_SubscriberHandle subscriber, uint64_t* timestamp),
+              (override));
   MOCK_METHOD(CUptiResult, Finalize, (), (override));
   MOCK_METHOD(CUptiResult, EnableCallback,
               (uint32_t enable, CUpti_SubscriberHandle subscriber,

--- a/xla/tsl/cuda/cupti.symbols
+++ b/xla/tsl/cuda/cupti.symbols
@@ -18,6 +18,7 @@ cuptiActivityFlushAll
 cuptiActivityFlushPeriod
 cuptiActivityGetAttribute
 cuptiActivityGetNextRecord
+cuptiActivityGetNextRecord_v2
 cuptiActivityGetNumDroppedRecords
 cuptiActivityGetNvtxExtPayloadAttr
 cuptiActivityGetNvtxExtPayloadEntryTypeInfo
@@ -91,6 +92,7 @@ cuptiGetStreamId
 cuptiGetStreamIdEx
 cuptiGetThreadIdType
 cuptiGetTimestamp
+cuptiGetTimestamp_v2
 cuptiGetVersion
 cuptiKernelReplaySubscribeUpdate
 cuptiMetricCreateEventGroupSets


### PR DESCRIPTION
📝 Summary of Changes
 Make CUPTI V2 subscriber fallback handling more robust.

This change adds CUPTI wrapper/interface coverage for subscriber-scoped V2 timestamp and activity-record APIs, updates tracer timestamp selection for V2 subscribers, and preserves legacy fallback behavior when V2 APIs are unavailable. It also keeps the V2 subscriber alive until cached activity buffers are parsed, supports optional V2 subscriber reuse across profiling sessions, and adds targeted tests for timestamp fallback, retained subscriber reuse, V2 activity callback reuse, and tolerated V2 API errors.

🎯 Justification
  This is important for profiler compatibility across CUPTI versions while preserving CUPTI V2 subscriber support.

 In CUPTI 13.2, using the legacy `cuptiGetTimestamp()` with a V2 subscriber is allowed. In CUPTI 13.3, `cuptiGetTimestamp_v2()` is introduced and required for the V2 subscriber path. The implementation therefore probes `cuptiGetTimestamp_v2()` when available, uses it on success, and falls back to legacy `cuptiGetTimestamp()` for compatibility when CUPTI reports `CUPTI_ERROR_NOT_SUPPORTED` or `CUPTI_ERROR_UNKNOWN`.

 `CUPTI_ERROR_NOT_COMPATIBLE` is handled separately because it indicates that the legacy timestamp path should not be probed in the current V2 subscriber state. In that case, the tracer returns `0` rather than mixing timestamp APIs in an unsupported state.

 This benefits GPU profiling workloads that run with newer CUPTI V2 multi-subscriber support, while keeping profiler behavior compatible with CUDA/CUPTI installations that do not yet expose the full 13.3 V2 timestamp API.

🚀 Kind of Contribution
🐛 Bug Fix, ♻️ Cleanup, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Not applicable.

🧪 Unit Tests:
  Added/updated `//xla/backends/profiler/gpu:cupti_error_manager_test` coverage for:
  - V2 timestamp unavailable fallback paths
  - V2 timestamp `NOT_COMPATIBLE` handling
  - retained V2 subscriber reuse
  - V2 activity callback registration reuse
  - V2 attribute errors that should not disable CUPTI
  - V2 activity-record parsing fallback behavior

🧪 Execution Tests:
  No new execution tests were added.
