### PR TITLE
[xla:gpu] Use correct API to resolve NCCL symmetric memory peer_addr()

### DIFF
--- a/xla/backends/gpu/collectives/nccl_symmetric_memory.cc
+++ b/xla/backends/gpu/collectives/nccl_symmetric_memory.cc
@@ -99,16 +99,20 @@ NcclSymmetricMemory::multimem_addr() const {
 
 absl::StatusOr<stream_executor::DeviceAddressBase>
 NcclSymmetricMemory::peer_addr(RankId peer) const {
-#if (NCCL_VERSION_CODE >= 22900) || defined(USE_NCCL_HOST_API)
+#if (NCCL_VERSION_CODE >= 22902) || defined(USE_NCCL_HOST_API)
   void* peer_addr = nullptr;
   XLA_NCCL_RETURN_IF_ERROR(
-      ncclGetLsaDevicePointer(win_, 0, peer.value(), &peer_addr));
+      ncclGetPeerDevicePointer(win_, 0, peer.value(), &peer_addr));
   if (peer_addr) {
     return stream_executor::DeviceAddressBase(peer_addr, addr_.size());
   }
-#endif
+  return absl::FailedPreconditionError(absl::StrFormat(
+      "Peer rank %d is not load/store accessible from this rank",
+      peer.value()));
+#else
   return absl::UnimplementedError(
-      "Peer address not supported on this NCCL version or device");
+      "Peer address requires ncclGetPeerDevicePointer (NCCL >= 2.29.2)");
+#endif
 }
 
 std::string NcclSymmetricMemory::ToString() const {

--- a/xla/core/collectives/symmetric_memory.h
+++ b/xla/core/collectives/symmetric_memory.h
@@ -46,7 +46,12 @@ class SymmetricMemory {
     return absl::UnimplementedError("Multimem not supported");
   }
 
-  // Returns an address of the symmetrical memory on a peer device.
+  // Returns an address of the symmetric memory on a peer device.
+  //
+  // The rank argument is in the same rank space as the collective clique that
+  // created this memory. Backends are responsible for translating it to any
+  // backend-local rank space needed by their memory access API.
+  //
   // Useful for clients who need to pass peer addresses directly as a kernel
   // arguments instead of calculating a peer address from the kernel itself.
   virtual absl::StatusOr<stream_executor::DeviceAddressBase> peer_addr(

--- a/xla/tsl/cuda/BUILD.bazel
+++ b/xla/tsl/cuda/BUILD.bazel
@@ -378,6 +378,7 @@ cc_library(
         # keep sorted
         "//xla/tsl/platform:logging",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/strings:string_view",
         "@local_config_cuda//cuda:cuda_headers",
         "@local_config_nccl//:nccl_headers",
         "@tsl//tsl/platform:dso_loader",

--- a/xla/tsl/cuda/nccl.symbols
+++ b/xla/tsl/cuda/nccl.symbols
@@ -27,6 +27,7 @@ ncclGetErrorString
 ncclGetLastError
 ncclGetLsaDevicePointer
 ncclGetLsaMultimemDevicePointer
+ncclGetPeerDevicePointer
 ncclGetUniqueId
 ncclGetVersion
 ncclGroupEnd


### PR DESCRIPTION
`ncclGetLsaDevicePointer` requires LSA rank which is different from `RankId`, use `ncclGetPeerDevicePointer` API which correctly does peer rank to LSA rank conversion.