### PR TITLE
[XLA:CPU] Fix binary add post-op rank mismatch for oneDNN ndims requirement

### DIFF
--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -375,6 +375,16 @@ absl::StatusOr<Shape> AdjustAddendShape(const HloInstruction* contraction,
           },
           addend->shape());
     }
+
+    // oneDNN requires binary post-op source dimensions to match
+    // the destination dimensions. Prepend dimensions with size 1 if needed.
+    auto addend_rank = addend->shape().dimensions().size();
+    auto output_rank = contraction->shape().dimensions().size();
+    if (addend_rank < output_rank) {
+      std::vector<int64_t> ones(output_rank - addend_rank, 1);
+      return ShapeUtil::InsertDimensionsAtIndex(addend->shape(), 0, ones);
+    }
+
     return addend->shape();
   }
   if (broadcast_instr->opcode() != HloOpcode::kBroadcast) {

--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -381,6 +381,9 @@ absl::StatusOr<Shape> AdjustAddendShape(const HloInstruction* contraction,
     auto addend_rank = addend->shape().dimensions().size();
     auto output_rank = contraction->shape().dimensions().size();
     if (addend_rank < output_rank) {
+      VLOG(2) << "AdjustAddendShape: addend_rank=" << addend_rank
+                << " < output_rank=" << output_rank
+                << ", prepending " << (output_rank - addend_rank) << " dimensions";
       std::vector<int64_t> ones(output_rank - addend_rank, 1);
       return ShapeUtil::InsertDimensionsAtIndex(addend->shape(), 0, ones);
     }

--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -375,7 +375,6 @@ absl::StatusOr<Shape> AdjustAddendShape(const HloInstruction* contraction,
           },
           addend->shape());
     }
-
     return addend->shape();
   }
   if (broadcast_instr->opcode() != HloOpcode::kBroadcast) {

--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -376,18 +376,6 @@ absl::StatusOr<Shape> AdjustAddendShape(const HloInstruction* contraction,
           addend->shape());
     }
 
-    // oneDNN requires binary post-op source dimensions to match
-    // the destination dimensions. Prepend dimensions with size 1 if needed.
-    auto addend_rank = addend->shape().dimensions().size();
-    auto output_rank = contraction->shape().dimensions().size();
-    if (addend_rank < output_rank) {
-      VLOG(2) << "AdjustAddendShape: addend_rank=" << addend_rank
-                << " < output_rank=" << output_rank
-                << ", prepending " << (output_rank - addend_rank) << " dimensions";
-      std::vector<int64_t> ones(output_rank - addend_rank, 1);
-      return ShapeUtil::InsertDimensionsAtIndex(addend->shape(), 0, ones);
-    }
-
     return addend->shape();
   }
   if (broadcast_instr->opcode() != HloOpcode::kBroadcast) {
@@ -899,6 +887,21 @@ class OneDnnContractionRewriteVisitor : public DfsHloRewriteVisitor {
       // Alias output buffers to addend for in-place accumulation
       if (kind == OneDnnFusionConfig::SUM) {
         custom_call->set_output_to_operand_aliasing({{{}, {addend_idx, {}}}});
+      } else if (kind == OneDnnFusionConfig::BINARY_ADD) {
+        // oneDNN's binary post-op operand must match the output rank. Expand a
+        // lower-rank addend with leading size-1 dimensions via a Bitcast.
+        const Shape& out_shape = contraction->shape();
+        int64_t missed_rank = out_shape.dimensions().size() -
+                              addend->shape().dimensions().size();
+        if (missed_rank > 0) {
+          std::vector<int64_t> ones(missed_rank, 1);
+          Shape expanded_shape =
+              ShapeUtil::InsertDimensionsAtIndex(addend->shape(), 0, ones);
+          auto* expanded_addend = custom_call->AddInstruction(
+              HloInstruction::CreateBitcast(expanded_shape, addend));
+          RETURN_IF_ERROR(custom_call->ReplaceOperandWithDifferentShape(
+              addend_idx, expanded_addend));
+        }
       }
 
       fusions_config->add_ops(kind);

--- a/xla/service/cpu/tests/restricted/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/restricted/onednn_matmul_test.cc
@@ -1927,5 +1927,33 @@ TEST_F(MatmulTest, BiasAlongNonLastDimShouldNotFuseAsBias) {
   MatchOptimizedHlo(matmul_module_str, fused_matmul_binary_add_);
 }
 
+TEST_F(MatmulTest, AddendRankLessThanOutputRankLayoutPreserved) {
+  // This test verifies that when an addend has lower rank than the output
+  // and dimensions need to be prepended in AdjustAddendShape (with NO
+  // broadcast instruction in the matched pattern), the layout (including
+  // minor_to_major) is correctly preserved via ShapeUtil::InsertDimensionsAtIndex.
+  // Previously, manual dimension manipulation would clear and re-add
+  // dimensions without updating the layout, causing shape mismatch issues.
+  //
+  // The addend comes from a bitcast (which matches the m::Op(&addend) pattern,
+  // so optional_addend_broadcast is NULL), and has lower rank than the output,
+  // triggering the addend_rank < output_rank path with InsertDimensionsAtIndex.
+  const char* matmul_module_str = R"(
+  HloModule matmul.addend.rank.test.f32
+
+  ENTRY matmul.addend.rank.test.f32 {
+    arg0.1 = f32[4,8,128,64] parameter(0)
+    arg0.2 = f32[4,8,64,128] parameter(1)
+    dot.0 = f32[4,8,128,128] dot(arg0.1, arg0.2), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+    arg0.3 = f32[16384] parameter(2)
+    bitcast.0 = f32[128,128] bitcast(arg0.3)
+    broadcast.0 = f32[4,8,128,128] broadcast(bitcast.0), dimensions={2,3}
+    ROOT add.0 = f32[4,8,128,128] add(dot.0, broadcast.0)
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str, fused_matmul_binary_add_);
+}
+
 }  // namespace cpu
 }  // namespace xla

--- a/xla/service/cpu/tests/restricted/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/restricted/onednn_matmul_test.cc
@@ -1927,28 +1927,25 @@ TEST_F(MatmulTest, BiasAlongNonLastDimShouldNotFuseAsBias) {
   MatchOptimizedHlo(matmul_module_str, fused_matmul_binary_add_);
 }
 
-TEST_F(MatmulTest, AddendRankLessThanOutputRankLayoutPreserved) {
-  // This test verifies that when an addend has lower rank than the output
-  // and dimensions need to be prepended in AdjustAddendShape (with NO
-  // broadcast instruction in the matched pattern), the layout (including
-  // minor_to_major) is correctly preserved via ShapeUtil::InsertDimensionsAtIndex.
-  // Previously, manual dimension manipulation would clear and re-add
-  // dimensions without updating the layout, causing shape mismatch issues.
-  //
-  // The addend comes from a bitcast (which matches the m::Op(&addend) pattern,
-  // so optional_addend_broadcast is NULL), and has lower rank than the output,
-  // triggering the addend_rank < output_rank path with InsertDimensionsAtIndex.
+// Exercises the BINARY_ADD operand rank reconciliation in the rewriter.
+// The dot output is rank 4 ([4,8,128,128]), but it is reshaped to rank 3
+// ([32,128,128]) before the add, whose addend broadcasts a [128,128] constant.
+// After shape adjustment the fused addend stays rank 3 ([1,128,128]) while the
+// custom-call output is the rank-4 dot shape, so the rewriter must prepend a
+// leading size-1 dimension to the addend (yielding rank 4) before oneDNN sees
+// it. Without that, oneDNN aborts with a dst/bin_po src1 dimension mismatch.
+TEST_F(MatmulTest, BinaryAddAddendLowerRankThanOutput) {
   const char* matmul_module_str = R"(
-  HloModule matmul.addend.rank.test.f32
+  HloModule matmul.binary_add.rank.test.f32
 
-  ENTRY matmul.addend.rank.test.f32 {
+  ENTRY matmul.binary_add.rank.test.f32 {
     arg0.1 = f32[4,8,128,64] parameter(0)
     arg0.2 = f32[4,8,64,128] parameter(1)
     dot.0 = f32[4,8,128,128] dot(arg0.1, arg0.2), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
-    arg0.3 = f32[16384] parameter(2)
-    bitcast.0 = f32[128,128] bitcast(arg0.3)
-    broadcast.0 = f32[4,8,128,128] broadcast(bitcast.0), dimensions={2,3}
-    ROOT add.0 = f32[4,8,128,128] add(dot.0, broadcast.0)
+    reshape.0 = f32[32,128,128] reshape(dot.0)
+    const.0 = f32[128,128] constant({...})
+    broadcast.0 = f32[32,128,128] broadcast(const.0), dimensions={1,2}
+    ROOT add.0 = f32[32,128,128] add(reshape.0, broadcast.0)
   })";
 
   EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));


### PR DESCRIPTION
📝 Summary of Changes
Fix rank mismatch in oneDNN binary add post-ops. 



