### PR TITLE
[ROCm] [XLA:GPU] Emit BF16 scaled dot as plain dot

### DIFF
--- a/xla/codegen/xtile/codegen/dot_algorithms.cc
+++ b/xla/codegen/xtile/codegen/dot_algorithms.cc
@@ -75,10 +75,97 @@ mlir::stablehlo::Precision XlaPrecisionToStableHloPrecision(
 
 namespace {
 
+Value EmitStableHloDotAndAdd(mlir::ImplicitLocOpBuilder& b, Value lhs,
+                             Value rhs, Value acc, PrecisionSpec precision_spec,
+                             mlir::stablehlo::DotDimensionNumbersAttr dims) {
+  auto precision_config = mlir::stablehlo::PrecisionConfigAttr::get(
+      b.getContext(), {precision_spec.lhs_operand_precision,
+                       precision_spec.rhs_operand_precision});
+  auto dot = mlir::stablehlo::DotGeneralOp::create(
+      b, acc.getType(), lhs, rhs, dims,
+      /*precision_config=*/precision_config,
+      /*algorithm=*/
+      stablehlo::ConvertDotAlgorithm(precision_spec.algorithm, &b));
+
+  auto add_result =
+      mlir::isa<mlir::IntegerType>(dot.getResult().getType().getElementType())
+          ? mlir::arith::AddIOp::create(b, acc, dot)
+          : mlir::arith::AddFOp::create(b, acc, dot);
+  return add_result->getResult(0);
+}
+
+}  // namespace
+
+namespace {
+
+Value DequantizeOperand(mlir::ImplicitLocOpBuilder& b, Value operand,
+                        Value scale) {
+  auto operand_type = mlir::cast<mlir::RankedTensorType>(operand.getType());
+  auto scale_type = mlir::cast<mlir::RankedTensorType>(scale.getType());
+  if (scale_type.getRank() == 0) {
+    return operand;
+  }
+  mlir::Type elem_type = operand_type.getElementType();
+  mlir::Type scale_elem_type = scale_type.getElementType();
+
+  Value typed_scale = scale;
+  if (scale_elem_type != elem_type) {
+    auto converted_type =
+        mlir::RankedTensorType::get(scale_type.getShape(), elem_type);
+    typed_scale = mlir::stablehlo::ConvertOp::create(b, converted_type, scale);
+  }
+
+  int64_t rank = operand_type.getRank();
+  CHECK_EQ(rank, scale_type.getRank())
+      << "operand and scale must have the same rank";
+
+  llvm::SmallVector<int64_t> expanded_shape;
+  llvm::SmallVector<int64_t> broadcast_dims;
+  expanded_shape.reserve(2 * rank);
+  broadcast_dims.reserve(rank);
+  for (int64_t result_idx = 0, i = 0; i < rank; ++i, ++result_idx) {
+    int64_t op_dim = operand_type.getShape()[i];
+    int64_t sc_dim = scale_type.getShape()[i];
+    CHECK_EQ(op_dim % sc_dim, 0)
+        << "operand dim " << op_dim << " not divisible by scale dim " << sc_dim
+        << " at index " << i;
+    expanded_shape.push_back(sc_dim);
+    broadcast_dims.push_back(result_idx);
+    if (op_dim != sc_dim) {
+      result_idx++;
+      expanded_shape.push_back(op_dim / sc_dim);
+    }
+  }
+  auto expanded_type = mlir::RankedTensorType::get(expanded_shape, elem_type);
+  Value expanded = mlir::stablehlo::BroadcastInDimOp::create(
+      b, expanded_type, typed_scale, b.getDenseI64ArrayAttr(broadcast_dims));
+
+  auto reshape_type =
+      mlir::RankedTensorType::get(operand_type.getShape(), elem_type);
+  Value reshaped =
+      mlir::stablehlo::ReshapeOp::create(b, reshape_type, expanded);
+
+  return mlir::stablehlo::MulOp::create(b, operand, reshaped);
+}
+
 absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
+                                const HloScaledDotInstruction& scaled_dot,
                                 ScaledDotOperands& operands) {
   mlir::Type lhs_dot_elem_type = getElementTypeOrSelf(operands.lhs.getType());
   mlir::Type rhs_dot_elem_type = getElementTypeOrSelf(operands.rhs.getType());
+
+  if (lhs_dot_elem_type == b.getBF16Type() &&
+      rhs_dot_elem_type == b.getBF16Type()) {
+    Value lhs = DequantizeOperand(b, operands.lhs, operands.lhs_scale);
+    Value rhs = DequantizeOperand(b, operands.rhs, operands.rhs_scale);
+    const PrecisionConfig& pc = scaled_dot.precision_config();
+    PrecisionSpec prec{
+        pc.algorithm(),
+        XlaPrecisionToStableHloPrecision(pc.operand_precision(0)),
+        XlaPrecisionToStableHloPrecision(pc.operand_precision(1))};
+    return EmitStableHloDotAndAdd(b, lhs, rhs, operands.accumulator, prec,
+                                  operands.dot_dimension_numbers);
+  }
 
   Value lhs_scale;
   if (lhs_dot_elem_type != b.getBF16Type()) {
@@ -126,29 +213,6 @@ absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
           : mlir::arith::AddFOp::create(b, operands.accumulator, dot_scaled_op);
   return add_result->getResult(0);
 }
-
-namespace {
-
-Value EmitStableHloDotAndAdd(mlir::ImplicitLocOpBuilder& b, Value lhs,
-                             Value rhs, Value acc, PrecisionSpec precision_spec,
-                             mlir::stablehlo::DotDimensionNumbersAttr dims) {
-  auto precision_config = mlir::stablehlo::PrecisionConfigAttr::get(
-      b.getContext(), {precision_spec.lhs_operand_precision,
-                       precision_spec.rhs_operand_precision});
-  auto dot = mlir::stablehlo::DotGeneralOp::create(
-      b, acc.getType(), lhs, rhs, dims,
-      /*precision_config=*/precision_config,
-      /*algorithm=*/
-      stablehlo::ConvertDotAlgorithm(precision_spec.algorithm, &b));
-
-  auto add_result =
-      mlir::isa<mlir::IntegerType>(dot.getResult().getType().getElementType())
-          ? mlir::arith::AddIOp::create(b, acc, dot)
-          : mlir::arith::AddFOp::create(b, acc, dot);
-  return add_result->getResult(0);
-}
-
-}  // namespace
 
 absl::StatusOr<Type> GetAlgUnsetAccumulatorType(mlir::ImplicitLocOpBuilder& b,
                                                 const HloDotInstruction& dot) {
@@ -326,7 +390,7 @@ absl::StatusOr<Value> EmitSingleTileScaledDot(
   dot_operands.dot_dimension_numbers =
       ::xla::stablehlo::ConvertDotDimensionNumbers(
           scaled_dot.dot_dimension_numbers(), &b);
-  return ScaledDot(b, dot_operands);
+  return ScaledDot(b, scaled_dot, dot_operands);
 }
 
 }  // namespace xtile

--- a/xla/service/gpu/autotuning/autotuner_pass.cc
+++ b/xla/service/gpu/autotuning/autotuner_pass.cc
@@ -302,6 +302,7 @@ AutotunerPass::GetGpuAutotunerBackends(
     disabled_autotune_backends.push_back(autotuner::Backend::HIPBLASLT);
     disabled_autotune_backends.push_back(autotuner::Backend::MIOPEN);
     disabled_autotune_backends.push_back(autotuner::Backend::HIPBLASLT_FISSION);
+    disabled_autotune_backends.push_back(autotuner::Backend::CUBLASLT_FISSION);
   }
 
   if (debug_options.xla_gpu_autotune_level() == 0 ||


### PR DESCRIPTION
📝 Summary of Changes
This PR fixes `TritonEmitterTest.ScaledDotIsSupportedByReferencePlatform` subtest from `//xla/backends/gpu/codegen/triton/tests:fusion_emitter_device_test`.

It also adds `CUBLASLT_FISSION` to the list of disabled backends when `xla_gpu_experimental_disable_binary_libraries` is set.

XLA does not set scales for BF16 type https://github.com/openxla/xla/blob/111f921748b0643e70693b6b2a53a0d76b2af37a/xla/codegen/xtile/codegen/dot_algorithms.cc#L78-L120

and it also skips ScaledDotRewriter for Triton https://github.com/openxla/xla/blob/81ef88c292f808f640a7d73103a47e939e3250da/xla/service/gpu/gpu_compiler.cc#L700-L702

So it emits a `dot_scaled` with no scales, which explains the accuracy issues. This PR modifies `ScaledDot` function so that for bf16 it converts scale to operand type, broadcasts + reshapes it to operand shape, multiplies, then emits a plain `stablehlo.dot_general` via `EmitStableHloDotAndAdd`. This follows the logic from `ScaledDotRewriter::RewriteComputation` (https://github.com/openxla/xla/blob/9e1e4f3a8d7db8c626cd4079058353ce87d4f941/xla/backends/gpu/transforms/scaled_dot_rewriter.cc#L166-L192)


🎯 Justification
Test started falling on ROCm after https://github.com/openxla/xla/commit/80931bbe05b8e6e9dbb6dc8fbd8416f4131db0bd enforced Triton backend via:
```
debug_options.set_xla_gpu_experimental_disable_binary_libraries(true);
```

Until this point, the subtest was using hipblaslt instead of Triton.  The only reason it was still passing on CUDA side was that `CUBLASLT_FISSION` was not added to the list of disabled backends. After changing that subtest consistently failed with mismatch errors on both platforms.

Failing log:
```
Mismatch count 256 (100.0000%) in shape bf16[16,16] (256 elements), abs bound 0.001, rel bound 0.001
Top relative error mismatches:
  actual       0.2617, expected   -6.407e-07, index {7,10}, rel error 4.08e+05, abs error    0.262
  actual       0.3223, expected   -2.205e-06, index {10,8}, rel error 1.46e+05, abs error    0.322
  actual       0.4082, expected    6.407e-06, index {2,11}, rel error 6.37e+04, abs error    0.408
  actual       0.2139, expected   -4.262e-06, index {8,12}, rel error 5.02e+04, abs error    0.214
  actual       0.3574, expected   -7.749e-06, index {8,6}, rel error 4.61e+04, abs error    0.357
Absolute magnitude breakdown of actual values:
  0      <= x < 0.0001 :       0 (  0.0000%)
  0.0001 <= x < 0.001  :       0 (  0.0000%)
  0.001  <= x < 0.01   :       0 (  0.0000%)
  0.01   <= x < 0.1    :       8 (  3.1250%), mismatches 8
  0.1    <= x < 1      :     248 ( 96.8750%), mismatches 248
  1      <= x < inf    :       0 (  0.0000%)
Elements exceeding abs error bound 0.001: 256 (100.0000%)
Relative error breakdown of elements exceeding abs error bound:
  <  0.0001 :       0 (0.0000%)
  >= 0.0001 :     256 (100.0000%)
  >= 0.001  :     256 (100.0000%)
  >= 0.01   :     256 (100.0000%)
  >= 0.1    :     256 (100.0000%)
  >= 1      :     256 (100.0000%)
Elements exceeding rel error bound 0.001: 256 (100.0000%)
Absolute error breakdown of elements exceeding rel error bound:
  <  0.0001 :       0 (0.0000%)
  >= 0.0001 :     256 (100.0000%)
  >= 0.001  :     256 (100.0000%)
  >= 0.01   :     256 (100.0000%)
  >= 0.1    :     248 (96.8750%)
  >= 1      :       0 (0.0000%)
```


🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix,

📊 Benchmark (for Performance Improvements)
/

🧪 Unit Tests:
Confirmed in IR dump that test now produces a plain `stablehlo.dot_general`

```
      %21 = "stablehlo.broadcast_in_dim"(%17) <{broadcast_dimensions = array<i64: 0, 2>}> : (tensor<1x4xbf16>) -> tensor<1x256x4x32xbf16> "dot.1"
      %22 = "stablehlo.reshape"(%21) : (tensor<1x256x4x32xbf16>) -> tensor<256x128xbf16> "dot.1"
      %23 = "stablehlo.multiply"(%11, %22) : (tensor<256x128xbf16>, tensor<256x128xbf16>) -> tensor<256x128xbf16> "dot.1"
      %24 = "stablehlo.broadcast_in_dim"(%20) <{broadcast_dimensions = array<i64: 0, 2>}> : (tensor<4x1xbf16>) -> tensor<4x32x1x16xbf16> "dot.1"
      %25 = "stablehlo.reshape"(%24) : (tensor<4x32x1x16xbf16>) -> tensor<128x16xbf16> "dot.1"
      %26 = "stablehlo.multiply"(%14, %25) : (tensor<128x16xbf16>, tensor<128x16xbf16>) -> tensor<128x16xbf16> "dot.1"
      %27 = "stablehlo.dot_general"(%23, %26) <{dot_dimension_numbers = #stablehlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]}> : (tensor<256x128xbf16>, tensor<128x16xbf16>) -> tensor<256x16xf32> "dot.1"
```

🧪 Execution Tests:
/