### PR TITLE
[ROCm] Enable passing subtests in fusion_emitter_device_test

### DIFF
--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -1569,7 +1569,8 @@ CHECK-COUNT-1: xtile.insert
 
 TEST_F(WarpSpecializationTritonEmitterTest,
        DotAccumulationLoopUsesWarpSpecialization) {
-  if (!GetCudaComputeCapability().IsAtLeastBlackwell()) {
+  if (auto cc = GpuComputeCapability().cuda_compute_capability();
+      cc && !cc->IsAtLeastBlackwell()) {
     GTEST_SKIP() << "Currently only supported on Blackwell and newer.";
   }
 
@@ -2271,7 +2272,8 @@ ENTRY e {
 
 TEST_P(TritonScaledDotGemmTest, FP8ScaledDotGetsFusedAndExecutesCorrectly) {
   const ScaleDotTestParams& params = GetParam();
-  if (!GetCudaComputeCapability().IsAtLeastBlackwell()) {
+  if (auto cc = GpuComputeCapability().cuda_compute_capability();
+      cc && !cc->IsAtLeastBlackwell()) {
     GTEST_SKIP() << "Skipping test for pre-Blackwell GPUs.";
   }
   constexpr absl::string_view kHloTextTemplate = R"hlo(
@@ -2337,7 +2339,8 @@ class TritonScaledDotTest : public TritonEmitterTest {
 
 TEST_F(TritonScaledDotTest,
        ScaledDotWithOmmittedLhsScaleGetFusedAndExecutedCorrectly) {
-  if (!GetCudaComputeCapability().IsAtLeastHopper()) {
+  if (auto cc = GpuComputeCapability().cuda_compute_capability();
+      cc && !cc->IsAtLeastHopper()) {
     GTEST_SKIP() << "Scaled dot isn't supported by Triton for pre-Hopper GPUs.";
   }
   constexpr absl::string_view kHloTextTemplate = R"hlo(
@@ -2433,7 +2436,8 @@ ENTRY e {
 }
 
 TEST_F(TritonScaledDotTest, ScaledDotWithBatchGetFusedAndExecutedCorrectly) {
-  if (!GetCudaComputeCapability().IsAtLeastHopper()) {
+  if (auto cc = GpuComputeCapability().cuda_compute_capability();
+      cc && !cc->IsAtLeastHopper()) {
     GTEST_SKIP() << "Scaled dot isn't supported by Triton for pre-Hopper GPUs.";
   }
   constexpr absl::string_view kHloTextTemplate = R"hlo(
@@ -2480,7 +2484,8 @@ ENTRY e {
 }
 
 TEST_F(TritonScaledDotTest, BroadcastAndReshapeGetFused) {
-  if (!GetCudaComputeCapability().IsAtLeastHopper()) {
+  if (auto cc = GpuComputeCapability().cuda_compute_capability();
+      cc && !cc->IsAtLeastHopper()) {
     GTEST_SKIP() << "Scaled dot isn't supported by Triton for pre-Hopper GPUs.";
   }
   constexpr absl::string_view kHloTextTemplate = R"hlo(


### PR DESCRIPTION
📝 Summary of Changes
This PR enables several subtests in `//xla/backends/gpu/codegen/triton/tests:fusion_emitter_device_test` on ROCm 

🎯 Justification
These (passing) subtests were implicitly disabled on ROCm when checking for CUDA cc.

🚀 Kind of Contribution
Please remove what does not apply: 🧪 Tests

📊 Benchmark (for Performance Improvements)
/

🧪 Unit Tests:
/

🧪 Execution Tests:
/