### PR TITLE
Fix segfault in ifrt::PjRtExecutable::CommonMetadata::Serialize

### DIFF
--- a/xla/python/pjrt_ifrt/pjrt_executable.cc
+++ b/xla/python/pjrt_ifrt/pjrt_executable.cc
@@ -515,6 +515,8 @@ absl::StatusOr<std::string> PjRtExecutable::CommonMetadata::Serialize(
   // Get parameter specs.
   const std::optional<std::vector<xla::OpSharding>> parameter_shardings =
       pjrt_executable->GetParameterShardings();
+  // TODO(skye): add API for getting number of parameters, so we don't need this
+  // convoluted logic that potentially results in setting num_parameters = 0.
   uint64_t num_parameters;
   std::vector<std::shared_ptr<const xla::PjRtLayout>> parameter_layouts;
   if (auto maybe_layouts = pjrt_executable->GetParameterLayouts();
@@ -556,10 +558,12 @@ absl::StatusOr<std::string> PjRtExecutable::CommonMetadata::Serialize(
   for (int i = 0; i < num_parameters; ++i) {
     SerializedXlaExecutableMetadata::ParameterSpec& parameter_spec =
         *metadata.add_parameter_specs();
-    // Layout
-    auto pjrt_layout = PjRtLayout::Create(parameter_layouts[i]);
-    ASSIGN_OR_RETURN(*parameter_spec.mutable_layout(),
-                     pjrt_layout->ToProto(serdes_version));
+    // Layout (nullptr means default layout)
+    if (parameter_layouts[i] != nullptr) {
+      auto pjrt_layout = PjRtLayout::Create(parameter_layouts[i]);
+      ASSIGN_OR_RETURN(*parameter_spec.mutable_layout(),
+                       pjrt_layout->ToProto(serdes_version));
+    }
 
     // Sharding
     if (parameter_shardings.has_value()) {

--- a/xla/python/pjrt_ifrt/xla_executable_impl_test_lib.cc
+++ b/xla/python/pjrt_ifrt/xla_executable_impl_test_lib.cc
@@ -919,6 +919,32 @@ module @add_sub {
   }
 }
 
+// Regression test for a segfault during executable serialization when both a
+// sharded parameter and a token parameter are present.
+TEST_P(LoadedExecutableImplTest, ShardingsAndTokens) {
+  static constexpr absl::string_view kModule = R"(
+module @f attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 1 : i32} {
+  func.func @main(
+    %arg0: !stablehlo.token,
+    %arg1: tensor<2x4xf32> {mhlo.sharding = "{devices=[2,1]<=[2]}"}
+  ) -> (
+    !stablehlo.token,
+    tensor<2x4xf32> {mhlo.sharding = "{devices=[2,1]<=[2]}"}
+  ) {
+    %0 = stablehlo.add %arg1, %arg1 : tensor<2x4xf32>
+    return %arg0, %0 : !stablehlo.token, tensor<2x4xf32>
+  }
+})";
+  ASSERT_OK_AND_ASSIGN(auto client, test_util::GetClient());
+  Compiler* compiler = client->GetDefaultCompiler();
+  absl::Span<Device* const> devices =
+      client->addressable_devices().subspan(0, 2);
+  ASSERT_OK_AND_ASSIGN(
+      const LoadedExecutableRef executable,
+      CompileOnDevices(client.get(), compiler, kModule, devices,
+                       /*replicated=*/false, /*serialize=*/GetParam()));
+}
+
 INSTANTIATE_TEST_SUITE_P(
     LoadedExecutableImplTest, LoadedExecutableImplTest,
     /*serialize=*/testing::Bool(),


### PR DESCRIPTION
When serializing the parameter layouts, the underlying xla::PjRtLayouts might be nullptr, indicating default layout. This change adds a check to avoid attempting to serialize and thus dereference a nullptr layout.

This is tested via an executable with both a token and sharded parameter. The token causes the layout getter to return unimplemented, triggering a fallback that sets all layouts to nullptr. The sharded parameter is also needed because if neither parameter layouts nor shardings are retrievable, the num_parameters is set to 0 and nothing is serialized. We should also fix this, I added a TODO.

There might be other ways to trigger nullptr / default layouts but I'm not sure, it would also be good to figure this out and document the PJRT layout getter (I didn't add a TODO for this).