### PR TITLE
[XLA:CPU] onednn_threadpool: cap num_workers at n in parallel_for

### DIFF
--- a/xla/backends/cpu/runtime/onednn/onednn_threadpool.h
+++ b/xla/backends/cpu/runtime/onednn/onednn_threadpool.h
@@ -83,8 +83,8 @@ class OneDnnThreadPool final
   void parallel_for(int n, const std::function<void(int, int)>& fn) final {
     // Cap num_workers at n to avoid Worker::Parallelize's partition-clamping
     // logic that reduces parallelism when num_workers > num_work_items.
-    const size_t num_workers = std::min<size_t>(
-        static_cast<size_t>(n), thread_pool_->NumThreads());
+    const size_t num_workers =
+        std::min<size_t>(static_cast<size_t>(n), thread_pool_->NumThreads());
 
     if (is_async_) {
       // If we are using oneDNN with async support, we need to schedule the

--- a/xla/backends/cpu/runtime/onednn/onednn_threadpool.h
+++ b/xla/backends/cpu/runtime/onednn/onednn_threadpool.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef XLA_BACKENDS_CPU_RUNTIME_ONEDNN_ONEDNN_THREADPOOL_H_
 #define XLA_BACKENDS_CPU_RUNTIME_ONEDNN_ONEDNN_THREADPOOL_H_
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -80,13 +81,18 @@ class OneDnnThreadPool final
 #endif  // ENABLE_ONEDNN_ASYNC
 
   void parallel_for(int n, const std::function<void(int, int)>& fn) final {
+    // Cap num_workers at n to avoid Worker::Parallelize's partition-clamping
+    // logic that reduces parallelism when num_workers > num_work_items.
+    const size_t num_workers = std::min<size_t>(
+        static_cast<size_t>(n), thread_pool_->NumThreads());
+
     if (is_async_) {
       // If we are using oneDNN with async support, we need to schedule the
       // parallel loop using the done_event_. This allows us to return
       // immediately and not block the caller thread.
-      auto parallelize = [this, n, fn](tsl::Chain) {
+      auto parallelize = [this, n, num_workers, fn](tsl::Chain) {
         return Worker::Parallelize(
-            thread_pool_, thread_pool_->NumThreads(), n,
+            thread_pool_, num_workers, n,
             [fn, n](size_t i) { fn(static_cast<int>(i), n); });
       };
 
@@ -98,8 +104,7 @@ class OneDnnThreadPool final
     // block here as Worker implements work stealing that guarantees forward
     // progress and deadlock freedom, even if we are running in the same thread
     // pool as the Eigen thread_pool.
-    tsl::BlockUntilReady(Worker::Parallelize(thread_pool_,
-                                             thread_pool_->NumThreads(), n,
+    tsl::BlockUntilReady(Worker::Parallelize(thread_pool_, num_workers, n,
                                              [fn, n](size_t i) { fn(i, n); }));
   }
 


### PR DESCRIPTION
📝 Summary of Changes
`OneDnnThreadPool::parallel_for` (xla/backends/cpu/runtime/onednn/onednn_threadpool.h)  was passing `thread_pool_- NumThreads()` as `num_workers` regardless of `n`. Before   #42581, `Worker::Parallelize` had an entry-point clamp (`num_workers = std::min(num_work_items, num_workers)`) that silently fixed this up. #42581 replaced that clamp with a branch that triggers when `num_workers > num_work_items`:

  ```cpp
  if (num_workers > num_work_items) {
    num_partitions = ceil(num_work_items / 8);
    num_workers   = std::min(num_workers, num_partitions);
  }
  ```

  For oneDNN's small-n dispatches (reorders, packing, eltwise/softmax tiles), this collapses parallelism to ceil(n/8) cores. 
  eg: On a 56-thread host, n = 20 drops from 20 active cores to 3; n <= 8 falls through to a fully serial fallback. Multiplied across the many small primitives, this causes significant regression across multiple models when built with `build_with_onednn_async=true` and `XLA_FLAGS=--xla_cpu_experimental_onednn_custom_call=true`

  Fix
  Cap num_workers at n at the caller, matching the pattern already used in xla/backends/cpu/runtime/kernel.cc and xla/backends/cpu/runtime/convolution_lib.h: 
  ```cpp
  const size_t num_workers = std::min<size_t>(static_cast<size_t>(n),
                                              thread_pool_->NumThreads());
  ```

  With num_workers <= num_work_items, the call takes the else branch (num_partitions = num_workers) and behaves like pre-#42581. For n >= NumThreads(), the cap is a no-op and the heap/cacheline win from #42581 is fully preserved.


🎯 Justification
It fixes the significant regression (25%-60%) across multiple models run on CPU with onednn 

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

