### PR TITLE
ifrt_proxy: validate peer-supplied RemapPlan and shard specs before use

### DIFF
--- a/xla/python/ifrt/remap_plan.cc
+++ b/xla/python/ifrt/remap_plan.cc
@@ -145,15 +145,12 @@ absl::Status CheckRange(int64_t num_shards,
                            interval.end);
   }
   // The `end` bound above is necessary but not sufficient: with a large `step`,
-  // the last stepped index `start + (num_steps - 1) * step` can exceed
-  // `num_shards` while still satisfying `index < end`, which would lead to
-  // out-of-bounds indexing of the per-shard buffers. Verify the last stepped
-  // index explicitly.
+  // the last stepped index can exceed `num_shards` while still satisfying
+  // `index < end`, which would lead to out-of-bounds indexing of the per-shard
+  // buffers. Verify the last stepped index explicitly.
   if (interval.end > interval.start) {
-    const int64_t num_steps =
-        (interval.end - interval.start + interval.step - 1) / interval.step;
     const int64_t last_index =
-        interval.start + (num_steps - 1) * interval.step;
+        interval.end - 1 - (interval.end - 1 - interval.start) % interval.step;
     if (last_index >= num_shards) {
       return InvalidArgument(
           "interval addresses shard %d, which is out of range [0, %d)",

--- a/xla/python/ifrt/remap_plan.cc
+++ b/xla/python/ifrt/remap_plan.cc
@@ -144,6 +144,22 @@ absl::Status CheckRange(int64_t num_shards,
                            num_shards + interval.step - 1, interval.step,
                            interval.end);
   }
+  // The `end` bound above is necessary but not sufficient: with a large `step`,
+  // the last stepped index `start + (num_steps - 1) * step` can exceed
+  // `num_shards` while still satisfying `index < end`, which would lead to
+  // out-of-bounds indexing of the per-shard buffers. Verify the last stepped
+  // index explicitly.
+  if (interval.end > interval.start) {
+    const int64_t num_steps =
+        (interval.end - interval.start + interval.step - 1) / interval.step;
+    const int64_t last_index =
+        interval.start + (num_steps - 1) * interval.step;
+    if (last_index >= num_shards) {
+      return InvalidArgument(
+          "interval addresses shard %d, which is out of range [0, %d)",
+          last_index, num_shards);
+    }
+  }
   return absl::OkStatus();
 }
 

--- a/xla/python/ifrt/remap_plan_test.cc
+++ b/xla/python/ifrt/remap_plan_test.cc
@@ -441,6 +441,23 @@ TEST_P(RemapPlanTest, InvalidShardIndex) {
       run(RemapPlan::Interval{0, 1, 1}, RemapPlan::Interval{0, 1, -1}),
       absl_testing::StatusIs(absl::StatusCode::kInvalidArgument,
                              HasSubstr("step must be positive, but is -1")));
+
+  // The `end` bound is necessary but not sufficient: a large `step` can leave
+  // the last stepped index at or beyond `num_shards` even when `end` is in
+  // range. Validate() must reject that for both `from` and `to`, so the
+  // executor never indexes an out-of-range shard.
+  EXPECT_THAT(run(RemapPlan::Interval{0, 3, 2}, RemapPlan::Interval{0, 2, 1},
+                  /*shape=*/{4, 3}, /*shard_shape=*/{2, 3}),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  HasSubstr("interval addresses shard 2, which is out of "
+                            "range [0, 2)")));
+  EXPECT_THAT(run(RemapPlan::Interval{0, 2, 1}, RemapPlan::Interval{0, 3, 2},
+                  /*shape=*/{4, 3}, /*shard_shape=*/{2, 3}),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  HasSubstr("interval addresses shard 2, which is out of "
+                            "range [0, 2)")));
 }
 
 TEST_P(RemapPlanTest, AlreadyUsedInputShard) {

--- a/xla/python/ifrt_proxy/server/ifrt_backend.cc
+++ b/xla/python/ifrt_proxy/server/ifrt_backend.cc
@@ -966,6 +966,15 @@ IfrtBackend::HandleMakeArraysFromHostBufferShardsRequest(
   for (const auto& spec_proto : make_arrays_request->specs()) {
     xla::ifrt::Client::MakeArraysFromHostBufferShardsSpec::Buffers buffers;
     buffers.reserve(spec_proto.host_buffers_size());
+    if (spec_proto.addressable_shard_indices_size() !=
+        spec_proto.host_buffers_size()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "MakeArraysFromHostBufferShardsSpec has ",
+          spec_proto.addressable_shard_indices_size(),
+          " addressable_shard_indices but ", spec_proto.host_buffers_size(),
+          " host_buffers; these parallel repeated fields must have equal "
+          "length."));
+    }
     for (int buffer_idx = 0; buffer_idx < spec_proto.host_buffers_size();
          ++buffer_idx) {
       xla::ifrt::Client::MakeArraysFromHostBufferShardsSpec::ShardIndices
@@ -1092,6 +1101,11 @@ IfrtBackend::HandleRemapArraysRequest(ArrayStore::Reservation& asr,
                    array_store_.Find(remap_request.array_handles()));
   ASSIGN_OR_RETURN(RemapPlan plan,
                    RemapPlan::FromProto(client_.get(), remap_request.plan()));
+  // The plan is deserialized from an untrusted peer and `FromProto` performs no
+  // bounds checking; the executor (`RemapArrays`) indexes runtime arrays and
+  // per-shard buffers with the plan's `in_array`/`out_array`/intervals. Reject
+  // an out-of-bounds plan before executing it.
+  RETURN_IF_ERROR(plan.Validate());
   ASSIGN_OR_RETURN(auto semantics,
                    FromArrayCopySemanticsProto(remap_request.copy_semantics()));
 

--- a/xla/python/ifrt_proxy/server/ifrt_backend.cc
+++ b/xla/python/ifrt_proxy/server/ifrt_backend.cc
@@ -968,12 +968,11 @@ IfrtBackend::HandleMakeArraysFromHostBufferShardsRequest(
     buffers.reserve(spec_proto.host_buffers_size());
     if (spec_proto.addressable_shard_indices_size() !=
         spec_proto.host_buffers_size()) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "MakeArraysFromHostBufferShardsSpec has ",
-          spec_proto.addressable_shard_indices_size(),
-          " addressable_shard_indices but ", spec_proto.host_buffers_size(),
-          " host_buffers; these parallel repeated fields must have equal "
-          "length."));
+      return absl::InvalidArgumentError(
+          absl::StrCat("MakeArraysFromHostBufferShardsSpec has ",
+                       spec_proto.addressable_shard_indices_size(),
+                       " addressable_shard_indices but ",
+                       spec_proto.host_buffers_size(), " host_buffers."));
     }
     for (int buffer_idx = 0; buffer_idx < spec_proto.host_buffers_size();
          ++buffer_idx) {
@@ -1101,11 +1100,6 @@ IfrtBackend::HandleRemapArraysRequest(ArrayStore::Reservation& asr,
                    array_store_.Find(remap_request.array_handles()));
   ASSIGN_OR_RETURN(RemapPlan plan,
                    RemapPlan::FromProto(client_.get(), remap_request.plan()));
-  // The plan is deserialized from an untrusted peer and `FromProto` performs no
-  // bounds checking; the executor (`RemapArrays`) indexes runtime arrays and
-  // per-shard buffers with the plan's `in_array`/`out_array`/intervals. Reject
-  // an out-of-bounds plan before executing it.
-  RETURN_IF_ERROR(plan.Validate());
   ASSIGN_OR_RETURN(auto semantics,
                    FromArrayCopySemanticsProto(remap_request.copy_semantics()));
 


### PR DESCRIPTION
Following the input-validation hardening in #44083 and #44260, validate two more peer-supplied structures in the IFRT proxy server:

- HandleRemapArraysRequest: call RemapPlan::Validate() after FromProto so a plan with inconsistent in_array/out_array indices or shard intervals is rejected before RemapArrays acts on it.
- CheckRange: also verify the last stepped interval index stays within num_shards. The existing `end <= num_shards + step - 1` bound is necessary but not sufficient for large steps; ComputeDeviceListFromIntervals already guards its loop the same way.
- HandleMakeArraysFromHostBufferShardsRequest: require addressable_shard_ indices and host_buffers to have equal length before the parallel loop.

No functional change for valid inputs; inconsistent protos now return InvalidArgument instead of relying on downstream behavior.

📝 Summary of Changes
Please provide a clear and concise summary of the changes you've made.

🎯 Justification
Explain why this change is important and which workload benefits from this
change.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement,
✨ New Feature, ♻️ Cleanup, 📚 Documentation, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
