### PR TITLE
[XLA:GPU] Extract GPU module globals helper

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -694,8 +694,14 @@ bool_flag(
 
 cc_library(
     name = "gpu_executable",
-    srcs = ["gpu_executable.cc"],
-    hdrs = ["gpu_executable.h"],
+    srcs = [
+        "gpu_executable.cc",
+        "gpu_module_globals.cc",
+    ],
+    hdrs = [
+        "gpu_executable.h",
+        "gpu_module_globals.h",
+    ],
     deps = [
         ":alias_info",
         ":backend_configs_cc",

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -76,7 +76,6 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_input_output_alias_config.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_opcode.h"
-#include "xla/literal.h"
 #include "xla/pjrt/proto/compile_options.pb.h"
 #include "xla/runtime/buffer_use.h"
 #include "xla/runtime/device_id.h"

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -77,7 +77,6 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/literal.h"
-#include "xla/map_util.h"
 #include "xla/pjrt/proto/compile_options.pb.h"
 #include "xla/runtime/buffer_use.h"
 #include "xla/runtime/device_id.h"
@@ -92,6 +91,7 @@ limitations under the License.
 #include "xla/service/gpu/gpu_constants.h"
 #include "xla/service/gpu/gpu_executable.pb.h"
 #include "xla/service/gpu/gpu_executable_run_options.h"
+#include "xla/service/gpu/gpu_module_globals.h"
 #include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/stream_executor_util.h"
 #include "xla/service/hlo.pb.h"
@@ -119,11 +119,9 @@ limitations under the License.
 #include "xla/stream_executor/kernel_stats.h"
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/memory_reservation.h"
-#include "xla/stream_executor/module_spec.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_id.h"
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
-#include "xla/stream_executor/scoped_module_handle.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/stream_executor/sycl/sycl_platform_id.h"
@@ -415,35 +413,6 @@ absl::StatusOr<std::unique_ptr<GpuExecutable>> GpuExecutable::Create(
       std::move(params.cpu_target_machine_options),
       std::move(params.buffer_assignment_proto)));
 }
-
-class GpuModuleGlobals {
- public:
-  using BufferAllocToDeviceMemoryMap =
-      GpuExecutable::BufferAllocToDeviceMemoryMap;
-
-  GpuModuleGlobals(const std::vector<uint8_t>& binary,
-                   const std::vector<GpuExecutable::ConstantInfo>& constants)
-      : binary_(binary), constants_(constants) {}
-
-  // Loads the executable module for `stream` and initializes constant globals.
-  // Loaded modules and resolved global addresses are cached per executor.
-  absl::StatusOr<const BufferAllocToDeviceMemoryMap*> Resolve(
-      se::Stream* stream);
-
- private:
-  const std::vector<uint8_t>& binary_;
-  const std::vector<GpuExecutable::ConstantInfo>& constants_;
-
-  absl::Mutex mutex_;
-  // Cache of module handles. Required to keep loaded modules alive until this
-  // helper is destroyed.
-  absl::flat_hash_map<se::StreamExecutor*, se::ScopedModuleHandle>
-      module_handles_ ABSL_GUARDED_BY(mutex_);
-  // Cache of constant buffer allocation maps used by `Resolve`.
-  absl::flat_hash_map<se::StreamExecutor*,
-                      std::unique_ptr<BufferAllocToDeviceMemoryMap>>
-      globals_ ABSL_GUARDED_BY(mutex_);
-};
 
 // Implementation note: HLO profiling is always enabled for GPU executables,
 // since we can use timers around thunks.
@@ -1045,75 +1014,6 @@ absl::Status BarrierAfterExecutable(
           debug_options
               ? debug_options->xla_gpu_executable_terminate_timeout_seconds()
               : 30));
-}
-
-absl::StatusOr<const GpuModuleGlobals::BufferAllocToDeviceMemoryMap*>
-GpuModuleGlobals::Resolve(se::Stream* stream) {
-  se::StreamExecutor* executor = stream->parent();
-
-  absl::MutexLock lock(mutex_);
-  auto it = globals_.find(executor);
-  if (it != globals_.end()) {
-    return it->second.get();
-  }
-
-  se::MultiModuleLoaderSpec module_spec;
-  if (!binary_.empty()) {
-    module_spec.AddCudaCubinInMemory(binary_);
-  }
-
-  auto globals = std::make_unique<BufferAllocToDeviceMemoryMap>();
-  se::ModuleHandle module_handle;
-  // The CUDA driver isn't able to load a PTX and a binary which are both empty.
-  // It's okay if we skip loading in this case; if the module isn't loaded, all
-  // symbol lookups will fail, just as they should for an empty module.
-  if (!(executor->GetPlatform()->id() == se::cuda::kCudaPlatformId &&
-        binary_.empty())) {
-    ASSIGN_OR_RETURN(module_handle, executor->LoadModule(module_spec));
-  }
-
-  // A flag signalling if constant initialization submitted memcpy operations
-  // to the `stream`.
-  int submitted_mem_copies = 0;
-
-  for (const GpuExecutable::ConstantInfo& info : constants_) {
-    absl::StatusOr<se::DeviceAddressBase> global_status;
-    if (static_cast<bool>(module_handle)) {
-      global_status = executor->GetSymbol(info.symbol_name, module_handle);
-    }
-
-    se::DeviceAddressBase global;
-
-    CHECK(static_cast<bool>(module_handle) && global_status.ok());
-    // The constant was defined in the PTX and has been allocated by the CUDA
-    // driver.
-    global = *global_status;
-    XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
-        "Resolved global %s to %p", info.symbol_name, global.opaque());
-
-    if (!info.content.span().empty()) {
-      // This means the constant did not have an initializer in the PTX and
-      // therefore must be initialized by XLA here.
-      RETURN_IF_ERROR(stream->Memcpy(&global, info.content.span().data(),
-                                     info.content.span().size()));
-      submitted_mem_copies = true;
-    }
-
-    if (info.allocation_index != -1) {
-      InsertOrDie(globals.get(), info.allocation_index, global);
-    }
-  }
-
-  // Wait for the completion of all host->device transfers, to guarantee that
-  // destructor will not race with any operations in flight (deallocate
-  // xla::Literal owned by the HLO module).
-  if (submitted_mem_copies) {
-    CHECK_OK(stream->BlockHostUntilDone());
-  }
-
-  module_handles_.emplace(executor,
-                          se::ScopedModuleHandle(executor, module_handle));
-  return globals_.emplace(executor, std::move(globals)).first->second.get();
 }
 
 absl::StatusOr<const GpuExecutable::BufferAllocToDeviceMemoryMap*>

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -1788,41 +1788,6 @@ absl::StatusOr<GpuExecutable::OutputInfo> GpuExecutable::OutputInfo::FromProto(
   return output_info;
 }
 
-GpuExecutableProto::ConstantInfoProto GpuExecutable::ConstantInfo::ToProto(
-    bool skip_content_serialization) const {
-  GpuExecutableProto::ConstantInfoProto proto;
-  proto.set_symbol_name(symbol_name);
-  if (!skip_content_serialization) {
-    *proto.mutable_content() = content.ToProto();
-  }
-  proto.set_allocation_index(allocation_index);
-  return proto;
-}
-
-absl::StatusOr<GpuExecutable::ConstantInfo>
-GpuExecutable::ConstantInfo::FromProto(
-    const GpuExecutableProto::ConstantInfoProto& proto,
-    const absl::flat_hash_map<std::string, const HloInstruction*>* absl_nullable
-        content_overrides) {
-  if (content_overrides) {
-    auto it = content_overrides->find(proto.symbol_name());
-    if (it == content_overrides->end()) {
-      return absl::FailedPreconditionError(absl::StrCat(
-          "Instruction for ", proto.symbol_name(), " constant missing."));
-    }
-    const HloInstruction* instr = it->second;
-    const Literal& literal = instr->literal();
-    auto base = static_cast<const uint8_t*>(literal.untyped_data());
-    return ConstantInfo{proto.symbol_name(),
-                        DenseDataIntermediate::Alias(
-                            absl::MakeSpan(base, base + literal.size_bytes())),
-                        static_cast<int>(proto.allocation_index())};
-  }
-  return ConstantInfo{proto.symbol_name(),
-                      DenseDataIntermediate::FromProto(proto.content()),
-                      static_cast<int>(proto.allocation_index())};
-}
-
 absl::StatusOr<GpuExecutableProto> GpuExecutable::ToProto() const {
   GpuExecutableProto proto;
   proto.set_binary(binary_.data(), binary_.size());

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -416,6 +416,35 @@ absl::StatusOr<std::unique_ptr<GpuExecutable>> GpuExecutable::Create(
       std::move(params.buffer_assignment_proto)));
 }
 
+class GpuModuleGlobals {
+ public:
+  using BufferAllocToDeviceMemoryMap =
+      GpuExecutable::BufferAllocToDeviceMemoryMap;
+
+  GpuModuleGlobals(const std::vector<uint8_t>& binary,
+                   const std::vector<GpuExecutable::ConstantInfo>& constants)
+      : binary_(binary), constants_(constants) {}
+
+  // Loads the executable module for `stream` and initializes constant globals.
+  // Loaded modules and resolved global addresses are cached per executor.
+  absl::StatusOr<const BufferAllocToDeviceMemoryMap*> Resolve(
+      se::Stream* stream);
+
+ private:
+  const std::vector<uint8_t>& binary_;
+  const std::vector<GpuExecutable::ConstantInfo>& constants_;
+
+  absl::Mutex mutex_;
+  // Cache of module handles. Required to keep loaded modules alive until this
+  // helper is destroyed.
+  absl::flat_hash_map<se::StreamExecutor*, se::ScopedModuleHandle>
+      module_handles_ ABSL_GUARDED_BY(mutex_);
+  // Cache of constant buffer allocation maps used by `Resolve`.
+  absl::flat_hash_map<se::StreamExecutor*,
+                      std::unique_ptr<BufferAllocToDeviceMemoryMap>>
+      globals_ ABSL_GUARDED_BY(mutex_);
+};
+
 // Implementation note: HLO profiling is always enabled for GPU executables,
 // since we can use timers around thunks.
 GpuExecutable::GpuExecutable(
@@ -453,6 +482,7 @@ GpuExecutable::GpuExecutable(
       debug_buffer_assignment_show_max_(
           debug_options.xla_debug_buffer_assignment_show_max()),
       constants_(std::move(constants)),
+      module_globals_(std::make_unique<GpuModuleGlobals>(binary_, constants_)),
       output_info_(std::move(output_info)),
       enable_debug_info_manager_(enable_debug_info_manager),
       thunk_sequence_proto_(std::move(thunk_sequence_proto)),
@@ -1017,19 +1047,19 @@ absl::Status BarrierAfterExecutable(
               : 30));
 }
 
-absl::StatusOr<const GpuExecutable::BufferAllocToDeviceMemoryMap*>
-GpuExecutable::ResolveConstantGlobals(se::Stream* stream) {
+absl::StatusOr<const GpuModuleGlobals::BufferAllocToDeviceMemoryMap*>
+GpuModuleGlobals::Resolve(se::Stream* stream) {
   se::StreamExecutor* executor = stream->parent();
 
-  absl::MutexLock lock(module_handle_mutex_);
-  auto it = module_globals_.find(executor);
-  if (it != module_globals_.end()) {
+  absl::MutexLock lock(mutex_);
+  auto it = globals_.find(executor);
+  if (it != globals_.end()) {
     return it->second.get();
   }
 
   se::MultiModuleLoaderSpec module_spec;
-  if (!binary().empty()) {
-    module_spec.AddCudaCubinInMemory(binary());
+  if (!binary_.empty()) {
+    module_spec.AddCudaCubinInMemory(binary_);
   }
 
   auto globals = std::make_unique<BufferAllocToDeviceMemoryMap>();
@@ -1038,7 +1068,7 @@ GpuExecutable::ResolveConstantGlobals(se::Stream* stream) {
   // It's okay if we skip loading in this case; if the module isn't loaded, all
   // symbol lookups will fail, just as they should for an empty module.
   if (!(executor->GetPlatform()->id() == se::cuda::kCudaPlatformId &&
-        binary().empty())) {
+        binary_.empty())) {
     ASSIGN_OR_RETURN(module_handle, executor->LoadModule(module_spec));
   }
 
@@ -1046,7 +1076,7 @@ GpuExecutable::ResolveConstantGlobals(se::Stream* stream) {
   // to the `stream`.
   int submitted_mem_copies = 0;
 
-  for (const ConstantInfo& info : constants_) {
+  for (const GpuExecutable::ConstantInfo& info : constants_) {
     absl::StatusOr<se::DeviceAddressBase> global_status;
     if (static_cast<bool>(module_handle)) {
       global_status = executor->GetSymbol(info.symbol_name, module_handle);
@@ -1083,8 +1113,12 @@ GpuExecutable::ResolveConstantGlobals(se::Stream* stream) {
 
   module_handles_.emplace(executor,
                           se::ScopedModuleHandle(executor, module_handle));
-  return module_globals_.emplace(executor, std::move(globals))
-      .first->second.get();
+  return globals_.emplace(executor, std::move(globals)).first->second.get();
+}
+
+absl::StatusOr<const GpuExecutable::BufferAllocToDeviceMemoryMap*>
+GpuExecutable::ResolveConstantGlobals(se::Stream* stream) {
+  return module_globals_->Resolve(stream);
 }
 
 absl::StatusOr<se::DeviceAddressBase> GpuExecutable::BufferForAllocation(
@@ -1667,7 +1701,7 @@ absl::Status GpuExecutable::ExecuteThunks(
     // Collect the set of allocations that changed between executions.
     std::vector<std::pair<int32_t, std::string>> changed_allocations;
 
-    absl::MutexLock lock(module_handle_mutex_);
+    absl::MutexLock lock(module_allocations_mutex_);
     if (module_allocations_.find(executor) == module_allocations_.end()) {
       std::vector<se::DeviceAddressBase> allocs_addr;
       allocs_addr.reserve(buffer_allocations.size());

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -70,13 +70,14 @@ limitations under the License.
 #include "xla/stream_executor/kernel_stats.h"
 #include "xla/stream_executor/memory_reservation.h"
 #include "xla/stream_executor/platform.h"
-#include "xla/stream_executor/scoped_module_handle.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/xla.pb.h"
 
 namespace xla {
 namespace gpu {
+
+class GpuModuleGlobals;
 
 // GPU-targeting implementation of the XLA Executable interface.
 //
@@ -459,22 +460,14 @@ class GpuExecutable : public Executable {
 
   int64_t debug_buffer_assignment_show_max_;
 
-  absl::Mutex module_handle_mutex_;
-  // Cache of module handles. Required to keep loaded modules alive until this
-  // executable is destroyed.
-  absl::flat_hash_map<se::StreamExecutor*, se::ScopedModuleHandle>
-      module_handles_ ABSL_GUARDED_BY(module_handle_mutex_);
-  // Cache of constant buffer allocation maps used by `ResolveConstantGlobals`.
-  absl::flat_hash_map<se::StreamExecutor*,
-                      std::unique_ptr<BufferAllocToDeviceMemoryMap>>
-      module_globals_ ABSL_GUARDED_BY(module_handle_mutex_);
-
   // Cache previous memory allocations for current module, this is used to help
   // identify if user's model have unstable pointers by turning on VLOG(5).
+  absl::Mutex module_allocations_mutex_;
   absl::flat_hash_map<se::StreamExecutor*, std::vector<se::DeviceAddressBase>>
-      module_allocations_ ABSL_GUARDED_BY(module_handle_mutex_);
+      module_allocations_ ABSL_GUARDED_BY(module_allocations_mutex_);
 
   std::vector<ConstantInfo> constants_;
+  std::unique_ptr<GpuModuleGlobals> module_globals_;
   const absl::flat_hash_map<ShapeIndex, OutputInfo> output_info_;
   bool enable_debug_info_manager_;
 
@@ -482,8 +475,9 @@ class GpuExecutable : public Executable {
   // btree_set for deterministic iteration order.
   absl::btree_set<BufferAllocation::Index> command_buffer_allocation_indexes_;
 
-  // Separate mutex for VA ranges to avoid contention with module_handle_mutex_
-  // during VA remapping operations which may involve GPU synchronization.
+  // Separate mutex for VA ranges to avoid contention with
+  // module_allocations_mutex_ during VA remapping operations which may involve
+  // GPU synchronization.
   absl::Mutex va_ranges_mutex_;
   absl::node_hash_map<std::pair<se::StreamExecutor*, int>, VaRanges>
       module_va_ranges_ ABSL_GUARDED_BY(va_ranges_mutex_);

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -52,8 +52,8 @@ limitations under the License.
 #include "xla/service/executable.h"
 #include "xla/service/gpu/alias_info.h"
 #include "xla/service/gpu/buffer_allocations.h"
-#include "xla/service/gpu/dense_data_intermediate.h"
 #include "xla/service/gpu/gpu_executable.pb.h"
+#include "xla/service/gpu/gpu_module_globals.h"
 #include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/hlo.pb.h"
 #include "xla/service/service_executable_run_options.h"
@@ -77,8 +77,6 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
-class GpuModuleGlobals;
-
 // GPU-targeting implementation of the XLA Executable interface.
 //
 // Launches the given GPU kernel via the StreamExecutor.
@@ -91,20 +89,7 @@ class GpuExecutable : public Executable {
     int communication = 0;
   };
 
-  struct ConstantInfo {
-    std::string symbol_name;
-    DenseDataIntermediate content;
-    int allocation_index = -1;
-
-    GpuExecutableProto::ConstantInfoProto ToProto(
-        bool skip_content_serialization = false) const;
-
-    static absl::StatusOr<ConstantInfo> FromProto(
-        const GpuExecutableProto::ConstantInfoProto& proto,
-        const absl::flat_hash_map<std::string,
-                                  const HloInstruction*>* absl_nullable
-            content_overrides = nullptr);
-  };
+  using ConstantInfo = GpuModuleGlobals::ConstantInfo;
 
   struct OutputInfo {
     // Corresponding allocation index.
@@ -241,7 +226,7 @@ class GpuExecutable : public Executable {
                              const ServiceExecutableRunOptions* run_options);
 
   using BufferAllocToDeviceMemoryMap =
-      absl::flat_hash_map<BufferAllocation::Index, se::DeviceAddressBase>;
+      GpuModuleGlobals::BufferAllocToDeviceMemoryMap;
 
   // Loads the PTX or CUBIN for this executable and initializes all
   // constants that haven't already been initialized by the CUDA driver. Loaded

--- a/xla/service/gpu/gpu_module_globals.cc
+++ b/xla/service/gpu/gpu_module_globals.cc
@@ -1,0 +1,107 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/gpu_module_globals.h"
+
+#include <memory>
+
+#include "absl/log/check.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/map_util.h"
+#include "xla/stream_executor/cuda/cuda_platform_id.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/module_spec.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/scoped_module_handle.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/logging.h"
+#include "xla/util.h"
+
+namespace xla::gpu {
+
+absl::StatusOr<const GpuModuleGlobals::BufferAllocToDeviceMemoryMap*>
+GpuModuleGlobals::Resolve(se::Stream* stream) {
+  se::StreamExecutor* executor = stream->parent();
+
+  absl::MutexLock lock(mutex_);
+  auto it = globals_.find(executor);
+  if (it != globals_.end()) {
+    return it->second.get();
+  }
+
+  se::MultiModuleLoaderSpec module_spec;
+  if (!binary_.empty()) {
+    module_spec.AddCudaCubinInMemory(binary_);
+  }
+
+  auto globals = std::make_unique<BufferAllocToDeviceMemoryMap>();
+  se::ModuleHandle module_handle;
+  // The CUDA driver isn't able to load a PTX and a binary which are both empty.
+  // It's okay if we skip loading in this case; if the module isn't loaded, all
+  // symbol lookups will fail, just as they should for an empty module.
+  if (!(executor->GetPlatform()->id() == se::cuda::kCudaPlatformId &&
+        binary_.empty())) {
+    ASSIGN_OR_RETURN(module_handle, executor->LoadModule(module_spec));
+  }
+
+  // A flag signalling if constant initialization submitted memcpy operations
+  // to the `stream`.
+  int submitted_mem_copies = 0;
+
+  for (const GpuExecutable::ConstantInfo& info : constants_) {
+    absl::StatusOr<se::DeviceAddressBase> global_status;
+    if (static_cast<bool>(module_handle)) {
+      global_status = executor->GetSymbol(info.symbol_name, module_handle);
+    }
+
+    se::DeviceAddressBase global;
+
+    CHECK(static_cast<bool>(module_handle) && global_status.ok());
+    // The constant was defined in the PTX and has been allocated by the CUDA
+    // driver.
+    global = *global_status;
+    XLA_VLOG_DEVICE(3, executor->device_ordinal()) << absl::StreamFormat(
+        "Resolved global %s to %p", info.symbol_name, global.opaque());
+
+    if (!info.content.span().empty()) {
+      // This means the constant did not have an initializer in the PTX and
+      // therefore must be initialized by XLA here.
+      RETURN_IF_ERROR(stream->Memcpy(&global, info.content.span().data(),
+                                     info.content.span().size()));
+      submitted_mem_copies = true;
+    }
+
+    if (info.allocation_index != -1) {
+      InsertOrDie(globals.get(), info.allocation_index, global);
+    }
+  }
+
+  // Wait for the completion of all host->device transfers, to guarantee that
+  // destructor will not race with any operations in flight (deallocate
+  // xla::Literal owned by the HLO module).
+  if (submitted_mem_copies) {
+    CHECK_OK(stream->BlockHostUntilDone());
+  }
+
+  module_handles_.emplace(executor,
+                          se::ScopedModuleHandle(executor, module_handle));
+  return globals_.emplace(executor, std::move(globals)).first->second.get();
+}
+
+}  // namespace xla::gpu

--- a/xla/service/gpu/gpu_module_globals.cc
+++ b/xla/service/gpu/gpu_module_globals.cc
@@ -18,11 +18,16 @@ limitations under the License.
 #include <memory>
 
 #include "absl/log/check.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
-#include "xla/tsl/platform/status_macros.h"
+#include "absl/types/span.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/literal.h"
 #include "xla/map_util.h"
+#include "xla/service/gpu/dense_data_intermediate.h"
 #include "xla/stream_executor/cuda/cuda_platform_id.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/module_spec.h"
@@ -31,9 +36,45 @@ limitations under the License.
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 
 namespace xla::gpu {
+
+GpuExecutableProto::ConstantInfoProto GpuModuleGlobals::ConstantInfo::ToProto(
+    bool skip_content_serialization) const {
+  GpuExecutableProto::ConstantInfoProto proto;
+  proto.set_symbol_name(symbol_name);
+  if (!skip_content_serialization) {
+    *proto.mutable_content() = content.ToProto();
+  }
+  proto.set_allocation_index(allocation_index);
+  return proto;
+}
+
+absl::StatusOr<GpuModuleGlobals::ConstantInfo>
+GpuModuleGlobals::ConstantInfo::FromProto(
+    const GpuExecutableProto::ConstantInfoProto& proto,
+    const absl::flat_hash_map<std::string, const HloInstruction*>* absl_nullable
+        content_overrides) {
+  if (content_overrides) {
+    auto it = content_overrides->find(proto.symbol_name());
+    if (it == content_overrides->end()) {
+      return absl::FailedPreconditionError(absl::StrCat(
+          "Instruction for ", proto.symbol_name(), " constant missing."));
+    }
+    const HloInstruction* instr = it->second;
+    const Literal& literal = instr->literal();
+    auto base = static_cast<const uint8_t*>(literal.untyped_data());
+    return ConstantInfo{proto.symbol_name(),
+                        DenseDataIntermediate::Alias(
+                            absl::MakeSpan(base, base + literal.size_bytes())),
+                        static_cast<int>(proto.allocation_index())};
+  }
+  return ConstantInfo{proto.symbol_name(),
+                      DenseDataIntermediate::FromProto(proto.content()),
+                      static_cast<int>(proto.allocation_index())};
+}
 
 absl::StatusOr<const GpuModuleGlobals::BufferAllocToDeviceMemoryMap*>
 GpuModuleGlobals::Resolve(se::Stream* stream) {
@@ -64,7 +105,7 @@ GpuModuleGlobals::Resolve(se::Stream* stream) {
   // to the `stream`.
   int submitted_mem_copies = 0;
 
-  for (const GpuExecutable::ConstantInfo& info : constants_) {
+  for (const ConstantInfo& info : constants_) {
     absl::StatusOr<se::DeviceAddressBase> global_status;
     if (static_cast<bool>(module_handle)) {
       global_status = executor->GetSymbol(info.symbol_name, module_handle);

--- a/xla/service/gpu/gpu_module_globals.h
+++ b/xla/service/gpu/gpu_module_globals.h
@@ -1,0 +1,65 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_SERVICE_GPU_GPU_MODULE_GLOBALS_H_
+#define XLA_SERVICE_GPU_GPU_MODULE_GLOBALS_H_
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
+#include "xla/service/gpu/gpu_executable.h"
+#include "xla/stream_executor/scoped_module_handle.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace xla::gpu {
+
+class GpuModuleGlobals {
+ public:
+  using BufferAllocToDeviceMemoryMap =
+      GpuExecutable::BufferAllocToDeviceMemoryMap;
+
+  GpuModuleGlobals(const std::vector<uint8_t>& binary,
+                   const std::vector<GpuExecutable::ConstantInfo>& constants)
+      : binary_(binary), constants_(constants) {}
+
+  // Loads the executable module for `stream` and initializes constant globals.
+  // Loaded modules and resolved global addresses are cached per executor.
+  absl::StatusOr<const BufferAllocToDeviceMemoryMap*> Resolve(
+      se::Stream* stream);
+
+ private:
+  const std::vector<uint8_t>& binary_;
+  const std::vector<GpuExecutable::ConstantInfo>& constants_;
+
+  absl::Mutex mutex_;
+  // Cache of module handles. Required to keep loaded modules alive until this
+  // helper is destroyed.
+  absl::flat_hash_map<se::StreamExecutor*, se::ScopedModuleHandle>
+      module_handles_ ABSL_GUARDED_BY(mutex_);
+  // Cache of constant buffer allocation maps used by `Resolve`.
+  absl::flat_hash_map<se::StreamExecutor*,
+                      std::unique_ptr<BufferAllocToDeviceMemoryMap>>
+      globals_ ABSL_GUARDED_BY(mutex_);
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_SERVICE_GPU_GPU_MODULE_GLOBALS_H_

--- a/xla/service/gpu/gpu_module_globals.h
+++ b/xla/service/gpu/gpu_module_globals.h
@@ -18,26 +18,49 @@ limitations under the License.
 
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
+#include "absl/base/nullability.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/statusor.h"
 #include "absl/synchronization/mutex.h"
-#include "xla/service/gpu/gpu_executable.h"
+#include "xla/service/buffer_assignment.h"
+#include "xla/service/gpu/dense_data_intermediate.h"
+#include "xla/service/gpu/gpu_executable.pb.h"
+#include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/scoped_module_handle.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
 
-namespace xla::gpu {
+namespace xla {
+
+class HloInstruction;
+
+namespace gpu {
 
 class GpuModuleGlobals {
  public:
   using BufferAllocToDeviceMemoryMap =
-      GpuExecutable::BufferAllocToDeviceMemoryMap;
+      absl::flat_hash_map<BufferAllocation::Index, se::DeviceAddressBase>;
+
+  struct ConstantInfo {
+    std::string symbol_name;
+    DenseDataIntermediate content;
+    int allocation_index = -1;
+
+    GpuExecutableProto::ConstantInfoProto ToProto(
+        bool skip_content_serialization = false) const;
+
+    static absl::StatusOr<ConstantInfo> FromProto(
+        const GpuExecutableProto::ConstantInfoProto& proto,
+        const absl::flat_hash_map<std::string, const HloInstruction*>*
+            absl_nullable content_overrides = nullptr);
+  };
 
   GpuModuleGlobals(const std::vector<uint8_t>& binary,
-                   const std::vector<GpuExecutable::ConstantInfo>& constants)
+                   const std::vector<ConstantInfo>& constants)
       : binary_(binary), constants_(constants) {}
 
   // Loads the executable module for `stream` and initializes constant globals.
@@ -47,7 +70,7 @@ class GpuModuleGlobals {
 
  private:
   const std::vector<uint8_t>& binary_;
-  const std::vector<GpuExecutable::ConstantInfo>& constants_;
+  const std::vector<ConstantInfo>& constants_;
 
   absl::Mutex mutex_;
   // Cache of module handles. Required to keep loaded modules alive until this
@@ -60,6 +83,7 @@ class GpuModuleGlobals {
       globals_ ABSL_GUARDED_BY(mutex_);
 };
 
-}  // namespace xla::gpu
+}  // namespace gpu
+}  // namespace xla
 
 #endif  // XLA_SERVICE_GPU_GPU_MODULE_GLOBALS_H_


### PR DESCRIPTION
📝 Summary of Changes

This is a pure refactoring PR without any behavior change. 

Introduce `GpuModuleGlobals` as a helper owned by `GpuExecutable` to encapsulate module-global state used by constant resolution.


🎯 Justification

The gpu_executable.h/cc files are now too large, and hard to read. 

This cleans up `GpuExecutable` by separating module-global loading, symbol lookup, and constant initialization from the rest of executable execution bookkeeping. The change is intended to be behavior-preserving and should make future GPU executable buffer-allocation refactors easier to reason about.

🚀 Kind of Contribution
♻️ Cleanup

📊 Benchmark (for Performance Improvements)
N/A. This is a behavior-preserving refactor and does not target performance.

🧪 Unit Tests:
No new unit tests were added because this only moves existing logic behind an owned helper while preserving the public `GpuExecutable::ResolveConstantGlobals` entry point.

Validation performed:

- `git diff --check`

🧪 Execution Tests:
No new execution tests were added. `bazel build //xla/service/gpu:gpu_executable` was attempted locally, but Bazel failed during external LLVM repository analysis before compiling the target due to `repository_ctx` having no `repo_metadata` field.