### PR TITLE
Fix gpu test doc links

### DIFF
--- a/docs/persisted_autotuning.md
+++ b/docs/persisted_autotuning.md
@@ -90,7 +90,7 @@ For now let's assume that the test in question always uses the same GPU type.
     (It is OK to use sharding in tests that load autotune results.)
 
 Please also see the example tests in
-[xla/service/gpu/tests/BUILD](https://github.com/openxla/xla/blob/main/xla/service/gpu/tests/BUILD):
+[xla/backends/gpu/tests/BUILD](https://github.com/openxla/xla/blob/main/xla/backends/gpu/tests/BUILD):
 
 -   load_autotune_results_using_execpath_test
 -   load_autotune_results_from_test_workspace_test

--- a/docs/test_hlo_passes.md
+++ b/docs/test_hlo_passes.md
@@ -47,7 +47,7 @@ correspond to. Again, make sure to use `// CHECK` instead of `; CHECK` as the
 delimiter.
 
 For example, some
-[GPU tests](https://github.com/openxla/xla/tree/main/xla/service/gpu/tests) can
+[GPU tests](https://github.com/openxla/xla/tree/main/xla/backends/gpu/tests) can
 be written as follows:
 
 ```


### PR DESCRIPTION
I found two documentation links that still appear to be present on current `main` as of https://github.com/openxla/xla/commit/73a33cced4d2b473cf7bc215529486ec7b1303b8.

#### 1. Persisted autotuning docs link to the old GPU tests BUILD file

The persisted autotuning page links to `xla/service/gpu/tests/BUILD`:

https://github.com/openxla/xla/blob/73a33cced4d2b473cf7bc215529486ec7b1303b8/docs/persisted_autotuning.md#L93

But the BUILD file now lives at `xla/backends/gpu/tests/BUILD`, where the referenced autotune-result tests are defined:

Introduced by:
- https://github.com/openxla/xla/commit/cd88bae9b16396a0e42288fffa971c9fdbd8e4c9

#### 2. HLO pass testing docs link to the old GPU tests directory

The HLO pass testing page links to `xla/service/gpu/tests`:

https://github.com/openxla/xla/blob/73a33cced4d2b473cf7bc215529486ec7b1303b8/docs/test_hlo_passes.md#L50

But the GPU HLO tests now live under `xla/backends/gpu/tests`, for example:

Introduced by:
- https://github.com/openxla/xla/commit/cd88bae9b16396a0e42288fffa971c9fdbd8e4c9

This PR updates the stale documentation links:
- https://github.com/doehyunbaek/xla/commit/25a6db6d2fa0e7cf411ee9d5e6f46fd39ebf39bc
- https://github.com/doehyunbaek/xla/commit/f9e35e241936c927c2e50a417d43128cead5084a

Tests were not run because this is a documentation-only change.