### PR TITLE
[XLA:GPU][oneAPI][Bugfix] Fix barrier in legacy llvm emitter

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -323,6 +323,7 @@ cc_library(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:Support",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -323,7 +323,6 @@ cc_library(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:Support",

--- a/xla/service/gpu/target_util.cc
+++ b/xla/service/gpu/target_util.cc
@@ -75,9 +75,12 @@ struct TargetIntrinsics {
 
 // Emits IR to call a device function named "callee_name" on the given
 // operand. Returns the IR value that represents the return value.
+// `output_type` is std::nullopt for void-returning callees (e.g. SPIR-V
+// OpControlBarrier), since PrimitiveType cannot represent void.
 llvm::CallInst* EmitDeviceFunctionCall(
     const std::string& callee_name, absl::Span<llvm::Value* const> operands,
-    absl::Span<const PrimitiveType> input_types, PrimitiveType output_type,
+    absl::Span<const PrimitiveType> input_types,
+    std::optional<PrimitiveType> output_type,
     const llvm::AttrBuilder& attributes, llvm::IRBuilderBase* b,
     absl::string_view name = "") {
   std::vector<llvm::Type*> ir_input_types;
@@ -87,22 +90,21 @@ llvm::CallInst* EmitDeviceFunctionCall(
     ir_input_types.push_back(
         llvm_ir::PrimitiveTypeToIrType(input_type, b->getContext()));
   }
-  llvm::FunctionType* callee_type = llvm::FunctionType::get(
-      llvm_ir::PrimitiveTypeToIrType(output_type,
-                                     b->getContext()),  // Return type.
-      ir_input_types,                                   // Parameter types.
-      false);  // No variadic arguments.
+  llvm::Type* return_type =
+      output_type.has_value()
+          ? llvm_ir::PrimitiveTypeToIrType(*output_type, b->getContext())
+          : llvm::Type::getVoidTy(b->getContext());
+  llvm::FunctionType* callee_type =
+      llvm::FunctionType::get(return_type, ir_input_types, /*isVarArg=*/false);
 
   // Declares the callee if it is not declared already.
   llvm::Function* callee = llvm::dyn_cast<llvm::Function>(
-      b->GetInsertBlock()
-          ->getModule()
-          ->getOrInsertFunction(callee_name, callee_type)
-          .getCallee());
+      module->getOrInsertFunction(callee_name, callee_type).getCallee());
 
   callee->addFnAttrs(attributes);
-  if (target_triple.isSPIROrSPIRV())
+  if (target_triple.isSPIROrSPIRV()) {
     callee->setCallingConv(llvm::CallingConv::SPIR_FUNC);
+  }
 
   return b->CreateCall(callee, llvm_ir::AsArrayRef(operands), name.data());
 }
@@ -192,10 +194,10 @@ struct TargetIntrinsics GetIntrinsic(TargetIntrinsicID intrin) {
               },
               llvm::Intrinsic::amdgcn_s_barrier,
               [](llvm::IRBuilderBase* b_) -> llvm::CallInst* {
+                // OpenCL barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE);
+                // matches the MLIR emitter pipeline.
                 return EmitDeviceFunctionCall(
-                    "_Z22__spirv_ControlBarrierjjj",
-                    {b_->getInt32(2), b_->getInt32(2), b_->getInt32(272)},
-                    {U32, U32, U32}, U32,
+                    "_Z7barrierj", {b_->getInt32(3)}, {U32}, std::nullopt,
                     llvm::AttrBuilder(b_->getContext())
                         .addAttribute(llvm::Attribute::Convergent),
                     b_);
@@ -244,10 +246,10 @@ struct TargetIntrinsics GetIntrinsic(TargetIntrinsicID intrin) {
       return {llvm::Intrinsic::nvvm_bar_warp_sync,
               llvm::Intrinsic::amdgcn_wave_barrier,
               [](llvm::IRBuilderBase* b_) -> llvm::CallInst* {
+                // OpenCL barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE);
+                // matches the MLIR emitter pipeline.
                 return EmitDeviceFunctionCall(
-                    "_Z22__spirv_ControlBarrierjjj",
-                    {b_->getInt32(2), b_->getInt32(2), b_->getInt32(272)},
-                    {U32, U32, U32}, U32,
+                    "_Z7barrierj", {b_->getInt32(3)}, {U32}, std::nullopt,
                     llvm::AttrBuilder(b_->getContext())
                         .addAttribute(llvm::Attribute::Convergent),
                     b_);


### PR DESCRIPTION
This PR fixes incorrect barrier emission in the legacy LLVM emitter for SPIR-V and aligns it with the MLIR emitter path. Currently, the GPU code for sort is generated by the legacy LLVM emitter.