### PR TITLE
[ROCm] Use rocblas wrapper instead of calling directly

### DIFF
--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -436,7 +436,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":hipblas_lt_header",
-        ":rocblas_if_static",  # buildcleaner: keep
         ":rocblas_wrapper",
         ":rocm_complex_converters",
         ":rocm_executor",
@@ -454,12 +453,14 @@ cc_library(
         "//xla/stream_executor/gpu:gpu_blas_lt",
         "//xla/stream_executor/gpu:gpu_helpers_header",
         "//xla/stream_executor/platform:initialize",
+        "//xla/tsl/platform:env",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:logging",
         "//xla/tsl/platform:macros",
         "//xla/tsl/platform:status_macros",
         "//xla/tsl/platform:statusor",
         "//xla/tsl/util:determinism",
+        "@tsl//tsl/platform:dso_loader",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -437,6 +437,7 @@ cc_library(
     deps = [
         ":hipblas_lt_header",
         ":rocblas_if_static",  # buildcleaner: keep
+        ":rocblas_wrapper",
         ":rocm_complex_converters",
         ":rocm_executor",
         ":rocm_helpers",

--- a/xla/stream_executor/rocm/rocblas_wrapper.h
+++ b/xla/stream_executor/rocm/rocblas_wrapper.h
@@ -22,10 +22,27 @@ limitations under the License.
 #include "rocm/include/rocblas/rocblas.h"
 #include "rocm/rocm_config.h"
 
+// Undefine function-like macros to allow wrapping the actual functions
+#undef rocblas_gemm_ex
+#undef rocblas_gemm_strided_batched_ex
+#undef rocblas_gemm_ex_get_solutions
+#undef rocblas_gemm_ex_get_solutions_by_type
+#undef rocblas_gemm_batched_ex_get_solutions
+#undef rocblas_gemm_batched_ex_get_solutions_by_type
+#undef rocblas_gemm_strided_batched_ex_get_solutions
+
 namespace stream_executor {
 namespace wrap {
 
-#define ROCBLAS_API_WRAPPER(__name) using ::__name;
+#define ROCBLAS_API_WRAPPER(__name)               \
+  struct WrapperShim__##__name {                  \
+    constexpr static const char* kName = #__name; \
+    template <typename... Args>                   \
+    auto operator()(Args... args) const {         \
+      return ::__name(args...);                   \
+    }                                             \
+  };                                              \
+  inline constexpr WrapperShim__##__name __name{};
 
 // clang-format off
 #define FOREACH_ROCBLAS_API(__macro)            \

--- a/xla/stream_executor/rocm/rocblas_wrapper.h
+++ b/xla/stream_executor/rocm/rocblas_wrapper.h
@@ -21,28 +21,53 @@ limitations under the License.
 
 #include "rocm/include/rocblas/rocblas.h"
 #include "rocm/rocm_config.h"
-
-// Undefine function-like macros to allow wrapping the actual functions
-#undef rocblas_gemm_ex
-#undef rocblas_gemm_strided_batched_ex
-#undef rocblas_gemm_ex_get_solutions
-#undef rocblas_gemm_ex_get_solutions_by_type
-#undef rocblas_gemm_batched_ex_get_solutions
-#undef rocblas_gemm_batched_ex_get_solutions_by_type
-#undef rocblas_gemm_strided_batched_ex_get_solutions
+#include "xla/tsl/platform/env.h"
+#include "tsl/platform/dso_loader.h"
+#include "tsl/platform/platform.h"
 
 namespace stream_executor {
 namespace wrap {
 
+#ifdef PLATFORM_GOOGLE
 #define ROCBLAS_API_WRAPPER(__name)               \
   struct WrapperShim__##__name {                  \
     constexpr static const char* kName = #__name; \
     template <typename... Args>                   \
-    auto operator()(Args... args) const {         \
-      return ::__name(args...);                   \
+    rocblas_status operator()(Args... args) {     \
+      return (::__name)(args...);                 \
     }                                             \
-  };                                              \
-  inline constexpr WrapperShim__##__name __name{};
+  } __name;
+
+#else
+using tsl::internal::CachedDsoLoader::GetRocblasDsoHandle;
+
+#define ROCBLAS_API_WRAPPER(__name)                                      \
+  static struct DynLoadShim__##__name {                                  \
+    constexpr static const char* kName = #__name;                        \
+    using FuncPtrT = std::add_pointer<decltype(::__name)>::type;         \
+    static void* GetDsoHandle() {                                        \
+      auto s = GetRocblasDsoHandle();                                    \
+      return s.value();                                                  \
+    }                                                                    \
+    static FuncPtrT LoadOrDie() {                                        \
+      void* f;                                                           \
+      auto s = tsl::Env::Default()->GetSymbolFromLibrary(GetDsoHandle(), \
+                                                         kName, &f);     \
+      CHECK(s.ok()) << "could not find " << kName                        \
+                    << " in rocblas DSO; dlerror: " << s.message();      \
+      return reinterpret_cast<FuncPtrT>(f);                              \
+    }                                                                    \
+    static FuncPtrT DynLoad() {                                          \
+      static FuncPtrT f = LoadOrDie();                                   \
+      return f;                                                          \
+    }                                                                    \
+    template <typename... Args>                                          \
+    auto operator()(Args... args) {                                      \
+      return DynLoad()(args...);                                         \
+    }                                                                    \
+  } __name;
+
+#endif
 
 // clang-format off
 #define FOREACH_ROCBLAS_API(__macro)            \

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -33,12 +33,12 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
-#include "Eigen/Core"
-#include "unsupported/Eigen/CXX11/Tensor"
 #include "xla/tsl/platform/status_macros.h"
+#include "Eigen/Core"
 #include "rocm/include/hip/amd_detail/hip_fp16_gcc.h"
 #include "rocm/include/hipblas/hipblas.h"
 #include "rocm/rocm_config.h"
+#include "unsupported/Eigen/CXX11/Tensor"
 #include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/device_address.h"
@@ -73,17 +73,17 @@ extern void rocm_Broadcast_fp32(void *stream, float *dst, int dst_stride,
                                 int size);
 
 template <class T>
-const RocBlasType_t<T>* const* complex_cast(const DeviceAddress<T*>& a) {
+const RocBlasType_t<T> *const *complex_cast(const DeviceAddress<T *> &a) {
   return reinterpret_cast<const RocBlasType_t<T> *const *>(GpuMemory(a));
 }
 
 template <class T>
-RocBlasType_t<T>* const* complex_cast(DeviceAddress<T*>& a) {
+RocBlasType_t<T> *const *complex_cast(DeviceAddress<T *> &a) {
   return reinterpret_cast<RocBlasType_t<T> *const *>(GpuMemory(a));
 }
 
 template <class T>
-const RocBlasType_t<T>* complex_cast(const DeviceAddress<T>& a) {
+const RocBlasType_t<T> *complex_cast(const DeviceAddress<T> &a) {
   return reinterpret_cast<const RocBlasType_t<T> *>(GpuMemory(a));
 }
 
@@ -92,7 +92,7 @@ const RocBlasType_t<T> *complex_cast(const T &a) {
   return reinterpret_cast<const RocBlasType_t<T> *>(&a);
 }
 template <class T>
-RocBlasType_t<T>* complex_cast(DeviceAddress<T>* a) {
+RocBlasType_t<T> *complex_cast(DeviceAddress<T> *a) {
   return reinterpret_cast<RocBlasType_t<T> *>(GpuMemoryMutable(a));
 }
 
@@ -149,7 +149,7 @@ bool ROCMBlas::Init() {
   return true;
 }
 
-ROCMBlas::ROCMBlas(StreamExecutor* parent)
+ROCMBlas::ROCMBlas(StreamExecutor *parent)
     : parent_(CHECK_NOTNULL(parent)), blas_(nullptr), blas_lt_(parent) {}
 
 ROCMBlas::~ROCMBlas() {
@@ -405,8 +405,8 @@ absl::Status ROCMBlas::DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
 }
 
 #define Impl_DoBlasScal(Fun, T, Ta)                                         \
-  bool ROCMBlas::DoBlasScal(Stream* stream, uint64_t elem_count, Ta alpha,  \
-                            DeviceAddress<T>* x, int incx) {                \
+  bool ROCMBlas::DoBlasScal(Stream *stream, uint64_t elem_count, Ta alpha,  \
+                            DeviceAddress<T> *x, int incx) {                \
     return DoBlasInternal(Fun, stream, /* pointer_mode_host = */ true,      \
                           elem_count, complex_cast(alpha), complex_cast(x), \
                           incx);                                            \
@@ -421,10 +421,10 @@ Impl_DoBlasScal(wrap::rocblas_sscal, float, float)
                     Impl_DoBlasScal(wrap::rocblas_zscal, std::complex<double>,
                                     std::complex<double>)
 #define Impl_DoBlasGemv(fun, T)                                                \
-  bool ROCMBlas::DoBlasGemv(Stream* stream, blas::Transpose trans, uint64_t m, \
-                            uint64_t n, T alpha, const DeviceAddress<T>& a,    \
-                            int lda, const DeviceAddress<T>& x, int incx,      \
-                            T beta, DeviceAddress<T>* y, int incy) {           \
+  bool ROCMBlas::DoBlasGemv(Stream *stream, blas::Transpose trans, uint64_t m, \
+                            uint64_t n, T alpha, const DeviceAddress<T> &a,    \
+                            int lda, const DeviceAddress<T> &x, int incx,      \
+                            T beta, DeviceAddress<T> *y, int incy) {           \
     return DoBlasInternal(fun, stream, /* pointer_mode_host = */ true,         \
                           ROCMBlasTranspose(trans), m, n, complex_cast(alpha), \
                           complex_cast(a), lda, complex_cast(x), incx,         \
@@ -462,13 +462,13 @@ void ROCMBlas::MaybeLogGemmOp(GemmCallTrace::GemmType op,
       parent_->RecordApiTrace(GemmCallTrace{op, (int)context, size1, size2});
 }
 
-absl::Status ROCMBlas::DoBlasGemm(Stream* stream, blas::Transpose transa,
+absl::Status ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
                                   blas::Transpose transb, uint64_t m,
                                   uint64_t n, uint64_t k, blas::DataType dtype,
-                                  const void* alpha, const DeviceAddressBase& a,
-                                  int lda, const DeviceAddressBase& b, int ldb,
-                                  const void* beta, DeviceAddressBase* c,
-                                  int ldc, const EngineOptions& engine_options,
+                                  const void *alpha, const DeviceAddressBase &a,
+                                  int lda, const DeviceAddressBase &b, int ldb,
+                                  const void *beta, DeviceAddressBase *c,
+                                  int ldc, const EngineOptions &engine_options,
                                   blas::CallContext context) {
   MaybeLogGemmOp(GemmCallTrace::GemmType::kPlain, context,
                  m * k * DtypeSize(dtype), n * k * DtypeSize(dtype));
@@ -550,13 +550,13 @@ absl::Status ROCMBlas::DoBlasGemm(Stream* stream, blas::Transpose transa,
 }
 
 absl::Status ROCMBlas::DoBlasGemmWithAlgorithm(
-    Stream* stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64_t k, const void* alpha, const DeviceAddressBase& a,
-    blas::DataType type_a, int lda, const DeviceAddressBase& b,
-    blas::DataType type_b, int ldb, const void* beta, DeviceAddressBase* c,
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    uint64_t n, uint64_t k, const void *alpha, const DeviceAddressBase &a,
+    blas::DataType type_a, int lda, const DeviceAddressBase &b,
+    blas::DataType type_b, int ldb, const void *beta, DeviceAddressBase *c,
     blas::DataType type_c, int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, const EngineOptions& engine_options,
-    blas::ProfileResult* profile_result, blas::CallContext context) {
+    blas::AlgorithmType algorithm, const EngineOptions &engine_options,
+    blas::ProfileResult *profile_result, blas::CallContext context) {
   if (type_a != type_b) {
     return absl::InternalError(absl::StrFormat(
         "DoBlasGemmWithAlgorithm: different "
@@ -610,14 +610,14 @@ absl::Status ROCMBlas::DoBlasGemmWithAlgorithm(
 }
 
 absl::Status ROCMBlas::DoBlasGemmStridedBatchedWithAlgorithm(
-    Stream* stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
-    uint64_t n, uint64_t k, const void* alpha, const DeviceAddressBase& a,
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    uint64_t n, uint64_t k, const void *alpha, const DeviceAddressBase &a,
     blas::DataType type_a, int lda, int64_t stride_a,
-    const DeviceAddressBase& b, blas::DataType type_b, int ldb,
-    int64_t stride_b, const void* beta, DeviceAddressBase* c,
+    const DeviceAddressBase &b, blas::DataType type_b, int ldb,
+    int64_t stride_b, const void *beta, DeviceAddressBase *c,
     blas::DataType type_c, int ldc, int64_t stride_c, int batch_count,
     blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-    const EngineOptions& engine_options, blas::ProfileResult* profile_result,
+    const EngineOptions &engine_options, blas::ProfileResult *profile_result,
     blas::CallContext context) {
   if (type_a != type_b) {
     return absl::InternalError(absl::StrFormat(
@@ -811,9 +811,9 @@ bool MemCopyOpsFold(MemoryCopyOp &y, const MemoryCopyOp &x) {
 // The below algorithm tries to minimize the number of memcpy by consolidating
 // neighboring memcpy into a single request.
 template <typename MAPPED_T>
-absl::Status ReorganizeMemory(Stream* stream,
-                              DeviceAddress<MAPPED_T>* device_memory,
-                              const std::vector<MAPPED_T*>& raw_ptrs,
+absl::Status ReorganizeMemory(Stream *stream,
+                              DeviceAddress<MAPPED_T> *device_memory,
+                              const std::vector<MAPPED_T *> &raw_ptrs,
                               int batch_count, uint64_t batch_stride,
                               bool gather) {
   if (gather == false) {
@@ -924,12 +924,12 @@ absl::StatusOr<AllocateStridedResult<T>> AllocateStridedBuffer(
 
 template <typename T, typename FuncT>
 absl::Status ROCMBlas::DoBlasGemmBatchedInternal(
-    FuncT rocblas_func, Stream* stream, blas::Transpose transa,
+    FuncT rocblas_func, Stream *stream, blas::Transpose transa,
     blas::Transpose transb, uint64_t m, uint64_t n, uint64_t k, T alpha,
     DeviceAddressSlice<T> a_ptrs_to_wrappers, int lda,
     DeviceAddressSlice<T> b_ptrs_to_wrappers, int ldb, T beta,
     DeviceAddressSlice<T> c_ptrs_to_wrappers, int ldc, int batch_count,
-    ScratchAllocator* scratch_allocator) {
+    ScratchAllocator *scratch_allocator) {
   using MAPPED_T = RocBlasType_t<T>;
 
   // Sanity checks before making any further progress
@@ -1063,11 +1063,11 @@ class rocblas_gemm_strided_batched_bf16 {
 const char *rocblas_gemm_strided_batched_bf16::kName =
     "rocblas_gemm_strided_batched_bf16";
 bool ROCMBlas::DoBlasGemmBatched(
-    Stream* stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
     uint64_t n, uint64_t k, float alpha, DeviceAddressSlice<Eigen::half> a,
     int lda, DeviceAddressSlice<Eigen::half> b, int ldb, float beta,
     DeviceAddressSlice<Eigen::half> c, int ldc, int batch_count,
-    const EngineOptions& engine_options, ScratchAllocator* scratch_allocator,
+    const EngineOptions &engine_options, ScratchAllocator *scratch_allocator,
     blas::CallContext context) {
   MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a.size(),
                  b.size());
@@ -1098,12 +1098,12 @@ bool ROCMBlas::DoBlasGemmBatched(
 }
 
 bool ROCMBlas::DoBlasGemmBatched(
-    Stream* stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
+    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64_t m,
     uint64_t n, uint64_t k, float alpha,
     DeviceAddressSlice<Eigen::bfloat16> a_array, int lda,
     DeviceAddressSlice<Eigen::bfloat16> b_array, int ldb, float beta,
     DeviceAddressSlice<Eigen::bfloat16> c_array, int ldc, int batch_count,
-    const EngineOptions& engine_options, ScratchAllocator* scratch_allocator,
+    const EngineOptions &engine_options, ScratchAllocator *scratch_allocator,
     blas::CallContext context) {
   MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a_array.size(),
                  b_array.size());
@@ -1122,12 +1122,12 @@ bool ROCMBlas::DoBlasGemmBatched(
 
 #define IMPL_DoBlasGemmBatched(T, Fun)                                         \
   bool ROCMBlas::DoBlasGemmBatched(                                            \
-      Stream* stream, blas::Transpose transa, blas::Transpose transb,          \
+      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64_t m, uint64_t n, uint64_t k, T alpha,                             \
       DeviceAddressSlice<T> a_array, int lda, DeviceAddressSlice<T> b_array,   \
       int ldb, T beta, DeviceAddressSlice<T> c_array, int ldc,                 \
-      int batch_count, const EngineOptions& engine_options,                    \
-      ScratchAllocator* scratch_allocator, blas::CallContext context) {        \
+      int batch_count, const EngineOptions &engine_options,                    \
+      ScratchAllocator *scratch_allocator, blas::CallContext context) {        \
     MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a_array.size(), \
                    b_array.size());                                            \
     absl::Status status = DoBlasGemmBatchedInternal(                           \
@@ -1145,29 +1145,29 @@ IMPL_DoBlasGemmBatched(float, wrap::rocblas_sgemm_strided_batched)
                                wrap::rocblas_cgemm_strided_batched)
             IMPL_DoBlasGemmBatched(std::complex<double>,
                                    wrap::rocblas_zgemm_strided_batched)
-#define IMPL_DoBlasTrsm(T, Fun, Fun2)                                        \
-  bool ROCMBlas::DoBlasTrsm(Stream* stream, blas::Side side,                 \
-                            blas::UpperLower uplo, blas::Transpose transa,   \
-                            blas::Diagonal diag, uint64_t m, uint64_t n,     \
-                            T alpha, const DeviceAddress<T>& a, int lda,     \
-                            DeviceAddress<T>* b, int ldb) {                  \
-    return DoBlasInternal(Fun, stream, /* pointer_mode_host = */ true,       \
-                          ROCMBlasSide(side), ROCMBlasUpperLower(uplo),      \
-                          ROCMBlasTranspose(transa), ROCMBlasDiagonal(diag), \
-                          m, n, complex_cast(alpha), complex_cast(a), lda,   \
-                          complex_cast(b), ldb);                             \
-  }                                                                          \
-                                                                             \
-  bool ROCMBlas::DoBlasTrsmBatched(                                          \
-      Stream* stream, blas::Side side, blas::UpperLower uplo,                \
-      blas::Transpose transa, blas::Diagonal diag, uint64_t m, uint64_t n,   \
-      T alpha, const DeviceAddress<T*>& as, int lda, DeviceAddress<T*>* bs,  \
-      int ldb, int batch_count) {                                            \
-    return DoBlasInternal(Fun2, stream, true /* = pointer_mode_host */,      \
-                          ROCMBlasSide(side), ROCMBlasUpperLower(uplo),      \
-                          ROCMBlasTranspose(transa), ROCMBlasDiagonal(diag), \
-                          m, n, complex_cast(alpha), complex_cast(as), lda,  \
-                          complex_cast(*bs), ldb, batch_count);              \
+#define IMPL_DoBlasTrsm(T, Fun, Fun2)                                         \
+  bool ROCMBlas::DoBlasTrsm(Stream *stream, blas::Side side,                  \
+                            blas::UpperLower uplo, blas::Transpose transa,    \
+                            blas::Diagonal diag, uint64_t m, uint64_t n,      \
+                            T alpha, const DeviceAddress<T> &a, int lda,      \
+                            DeviceAddress<T> *b, int ldb) {                   \
+    return DoBlasInternal(Fun, stream, /* pointer_mode_host = */ true,        \
+                          ROCMBlasSide(side), ROCMBlasUpperLower(uplo),       \
+                          ROCMBlasTranspose(transa), ROCMBlasDiagonal(diag),  \
+                          m, n, complex_cast(alpha), complex_cast(a), lda,    \
+                          complex_cast(b), ldb);                              \
+  }                                                                           \
+                                                                              \
+  bool ROCMBlas::DoBlasTrsmBatched(                                           \
+      Stream *stream, blas::Side side, blas::UpperLower uplo,                 \
+      blas::Transpose transa, blas::Diagonal diag, uint64_t m, uint64_t n,    \
+      T alpha, const DeviceAddress<T *> &as, int lda, DeviceAddress<T *> *bs, \
+      int ldb, int batch_count) {                                             \
+    return DoBlasInternal(Fun2, stream, true /* = pointer_mode_host */,       \
+                          ROCMBlasSide(side), ROCMBlasUpperLower(uplo),       \
+                          ROCMBlasTranspose(transa), ROCMBlasDiagonal(diag),  \
+                          m, n, complex_cast(alpha), complex_cast(as), lda,   \
+                          complex_cast(*bs), ldb, batch_count);               \
   }
 
                 IMPL_DoBlasTrsm(float, wrap::rocblas_strsm,
@@ -1183,12 +1183,12 @@ IMPL_DoBlasGemmBatched(float, wrap::rocblas_sgemm_strided_batched)
 
                                 absl::Status
     ROCMBlas::DoBlasGemmStridedBatched(
-        Stream* stream, blas::Transpose transa, blas::Transpose transb,
+        Stream *stream, blas::Transpose transa, blas::Transpose transb,
         uint64_t m, uint64_t n, uint64_t k, blas::DataType dtype,
-        const void* alpha, const DeviceAddressBase& a, int lda,
-        int64_t stride_a, const DeviceAddressBase& b, int ldb, int64_t stride_b,
-        const void* beta, DeviceAddressBase* c, int ldc, int64_t stride_c,
-        int batch_count, const EngineOptions& engine_options,
+        const void *alpha, const DeviceAddressBase &a, int lda,
+        int64_t stride_a, const DeviceAddressBase &b, int ldb, int64_t stride_b,
+        const void *beta, DeviceAddressBase *c, int ldc, int64_t stride_c,
+        int batch_count, const EngineOptions &engine_options,
         blas::CallContext context) {
   VLOG(1) << absl::StreamFormat(
       "doing rocBLAS GEMM Strided Batched: at=%d bt=%d m=%u n=%u "

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -49,6 +49,7 @@ limitations under the License.
 #include "xla/stream_executor/gpu/gpu_helpers.h"
 #include "xla/stream_executor/platform/initialize.h"
 #include "xla/stream_executor/plugin_registry.h"
+#include "xla/stream_executor/rocm/rocblas_wrapper.h"
 #include "xla/stream_executor/rocm/rocm_complex_converters.h"
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/stream_executor/scratch_allocator.h"
@@ -62,58 +63,6 @@ limitations under the License.
 using tsl::OpDeterminismRequired;
 
 namespace stream_executor {
-
-namespace wrap {
-
-namespace {
-
-#define ROCBLAS_API_WRAPPER(__name)               \
-  struct WrapperShim__##__name {                  \
-    constexpr static const char* kName = #__name; \
-    template <typename... Args>                   \
-    rocblas_status operator()(Args... args) {     \
-      return (::__name)(args...);                 \
-    }                                             \
-  } __name;
-
-// clang-format off
-#define FOREACH_ROCBLAS_API(__macro)            \
-  __macro(rocblas_sscal)                        \
-  __macro(rocblas_dscal)                        \
-  __macro(rocblas_cscal)                        \
-  __macro(rocblas_csscal)                       \
-  __macro(rocblas_zscal)                        \
-  __macro(rocblas_zdscal)                       \
-  __macro(rocblas_strsm)                        \
-  __macro(rocblas_dtrsm)                        \
-  __macro(rocblas_ctrsm)                        \
-  __macro(rocblas_ztrsm)                        \
-  __macro(rocblas_sgemv)                        \
-  __macro(rocblas_dgemv)                        \
-  __macro(rocblas_cgemv)                        \
-  __macro(rocblas_zgemv)                        \
-  __macro(rocblas_sgemm)                        \
-  __macro(rocblas_dgemm)                        \
-  __macro(rocblas_hgemm)                        \
-  __macro(rocblas_cgemm)                        \
-  __macro(rocblas_zgemm)                        \
-  __macro(rocblas_hgemm_strided_batched)        \
-  __macro(rocblas_sgemm_strided_batched)        \
-  __macro(rocblas_dgemm_strided_batched)        \
-  __macro(rocblas_cgemm_strided_batched)        \
-  __macro(rocblas_zgemm_strided_batched)        \
-  __macro(rocblas_gemm_ex)                      \
-  __macro(rocblas_gemm_strided_batched_ex)      \
-  __macro(rocblas_strsm_batched)                \
-  __macro(rocblas_dtrsm_batched)                \
-  __macro(rocblas_ctrsm_batched)                \
-  __macro(rocblas_ztrsm_batched)
-
-// clang-format on
-
-FOREACH_ROCBLAS_API(ROCBLAS_API_WRAPPER)
-}  // namespace
-}  // namespace wrap
 
 namespace gpu {
 
@@ -176,7 +125,7 @@ static std::string ToString(rocblas_status status) {
 
 bool ROCMBlas::Init() {
   std::unique_ptr<ActivateContext> activation = parent_->Activate();
-  rocblas_status ret = rocblas_create_handle(&blas_);
+  rocblas_status ret = wrap::rocblas_create_handle(&blas_);
   if (ret != rocblas_status_success) {
     LOG(ERROR) << "failed to create rocBLAS handle: " << ToString(ret);
     return false;
@@ -206,7 +155,7 @@ ROCMBlas::ROCMBlas(StreamExecutor* parent)
 ROCMBlas::~ROCMBlas() {
   if (blas_ != nullptr) {
     std::unique_ptr<ActivateContext> activation = parent_->Activate();
-    rocblas_destroy_handle(blas_);
+    wrap::rocblas_destroy_handle(blas_);
   }
 }
 

--- a/xla/tsl/platform/default/dso_loader.cc
+++ b/xla/tsl/platform/default/dso_loader.cc
@@ -14,8 +14,6 @@ limitations under the License.
 ==============================================================================*/
 #include "xla/tsl/platform/default/dso_loader.h"
 
-#include <stdlib.h>
-
 #include <string>
 
 #include "absl/status/status.h"
@@ -25,11 +23,12 @@ limitations under the License.
 #include "third_party/gpus/cuda/cuda_config.h"
 #include "third_party/nccl/nccl_config.h"
 #include "third_party/nvshmem/nvshmem_config.h"
+#include "third_party/tensorrt/tensorrt_config.h"
+#include <stdlib.h>
 #include "xla/tsl/platform/logging.h"
 #include "tsl/platform/load_library.h"
 #include "tsl/platform/path.h"
 #include "tsl/platform/platform.h"
-#include "third_party/tensorrt/tensorrt_config.h"
 
 #if TENSORFLOW_USE_ROCM
 #include "rocm/rocm_config.h"
@@ -50,6 +49,8 @@ absl::string_view GetCusparseVersion() { return TF_CUSPARSE_VERSION; }
 absl::string_view GetNcclVersion() { return TF_NCCL_VERSION; }
 absl::string_view GetTensorRTVersion() { return TF_TENSORRT_VERSION; }
 absl::string_view GetNvshmemVersion() { return XLA_NVSHMEM_VERSION; }
+
+absl::string_view GetRocblasVersion() { return ""; }
 
 absl::StatusOr<void*> GetDsoHandle(const std::string& name,
                                    absl::string_view version) {
@@ -158,6 +159,10 @@ absl::StatusOr<void*> GetNvInferPluginDsoHandle() {
 #endif
 }
 
+absl::StatusOr<void*> GetRocblasDsoHandle() {
+  return GetDsoHandle("rocblas", GetRocblasVersion());
+}
+
 }  // namespace DsoLoader
 
 namespace CachedDsoLoader {
@@ -203,6 +208,11 @@ absl::StatusOr<void*> GetCuptiDsoHandle() {
 
 absl::StatusOr<void*> GetCudnnDsoHandle() {
   static auto result = new auto(DsoLoader::GetCudnnDsoHandle());
+  return *result;
+}
+
+absl::StatusOr<void*> GetRocblasDsoHandle() {
+  static auto result = new auto(DsoLoader::GetRocblasDsoHandle());
   return *result;
 }
 

--- a/xla/tsl/platform/default/dso_loader.h
+++ b/xla/tsl/platform/default/dso_loader.h
@@ -43,6 +43,7 @@ absl::StatusOr<void*> GetNvInferDsoHandle();
 absl::StatusOr<void*> GetNvInferPluginDsoHandle();
 absl::StatusOr<void*> GetNvmlDsoHandle();
 absl::StatusOr<void*> GetNvrtcDsoHandle();
+absl::StatusOr<void*> GetRocblasDsoHandle();
 
 // The following method tries to dlopen all necessary GPU libraries for the GPU
 // platform TF is built with (CUDA or ROCm) only when these libraries should be
@@ -69,6 +70,7 @@ absl::StatusOr<void*> GetCusolverDsoHandle();
 absl::StatusOr<void*> GetCusparseDsoHandle();
 absl::StatusOr<void*> GetCuptiDsoHandle();
 absl::StatusOr<void*> GetCudnnDsoHandle();
+absl::StatusOr<void*> GetRocblasDsoHandle();
 }  // namespace CachedDsoLoader
 
 }  // namespace internal


### PR DESCRIPTION
📝 Summary of Changes
Use rocblas calls wrapper instead of calling directly

🎯 Justification
We need that way of calling through dso so emulators have a change to intercept the calls

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
