### PR TITLE
[ROCm] Fix collective-permute connected-components clique deadlock for singleton groups

### DIFF
--- a/xla/backends/gpu/runtime/collective_clique_requests.cc
+++ b/xla/backends/gpu/runtime/collective_clique_requests.cc
@@ -55,9 +55,13 @@ absl::Status CollectiveCliqueRequests::RequestClique(
   if (auto it = cliques_.find(clique_key); it != cliques_.end()) {
     CliqueRequest& req = it->second;
 
-    // It is illegal to request the same GPU clique with different device
-    // groups. This must never happen under SPMD programming model.
-    if (!absl::c_equal(req.device_groups, device_groups)) {
+    // It is illegal to request the same multi-device GPU clique with different
+    // device groups under SPMD. Single-device (singleton) cliques are exempt:
+    // they involve no communication and are never split, so connected-component
+    // collective-permute may legitimately request the same singleton key with
+    // different surrounding device groups.
+    if (clique_key.devices().size() > 1 &&
+        !absl::c_equal(req.device_groups, device_groups)) {
       return InvalidArgument(
           "GPU clique %v requested from different device groups: [%s] vs [%s]",
           clique_key, HumanReadableDeviceGroups(req.device_groups),

--- a/xla/backends/gpu/runtime/collective_clique_requests_test.cc
+++ b/xla/backends/gpu/runtime/collective_clique_requests_test.cc
@@ -109,6 +109,31 @@ TEST(CollectiveCliqueRequestsTest, DeviceGroupsMismatch) {
                              testing::HasSubstr("different device groups")));
 }
 
+TEST(CollectiveCliqueRequestsTest, SingletonDeviceGroupsMismatchAllowed) {
+  GlobalDeviceId d0 = GlobalDeviceId(0);
+  GlobalDeviceId d1 = GlobalDeviceId(1);
+  GlobalDeviceId d2 = GlobalDeviceId(2);
+  GlobalDeviceId d3 = GlobalDeviceId(3);
+
+  // Singleton clique key (single device, no cross-device communication).
+  GpuCliqueKey k_singleton({d0}, /*num_local_participants=*/1);
+
+  // Same singleton key requested with different surrounding device groups, as
+  // produced by connected-component collective-permute on different
+  // instructions. This must be tolerated (regression test for the clique
+  // acquisition deadlock).
+  std::vector<std::vector<GlobalDeviceId>> dg_a = {{d0}, {d1, d2, d3}};
+  std::vector<std::vector<GlobalDeviceId>> dg_b = {{d0}, {d1}, {d2, d3}};
+
+  CollectiveCliqueRequests requests;
+  ASSERT_OK(requests.RequestClique(k_singleton, dg_a));
+  EXPECT_OK(requests.RequestClique(k_singleton, dg_b));
+
+  auto ordered_requests = requests.OrderedRequestedCliques();
+  ASSERT_EQ(ordered_requests.size(), 1);
+  EXPECT_EQ(ordered_requests[0].key, k_singleton);
+}
+
 TEST(CollectiveCliqueRequestsTest, BarrierAfterModuleExecutionRequested) {
   GlobalDeviceId d0 = GlobalDeviceId(0);
   GlobalDeviceId d1 = GlobalDeviceId(1);


### PR DESCRIPTION
## 📝 Summary of Changes
Lets take this minimal HLO reproducer extracted from JAX unit test 

```
HloModule min_cp_cc, num_partitions=4
ENTRY main {
  p0  = f32[8]{0} parameter(0)
  cp0 = f32[8]{0} collective-permute(p0),  channel_id=1, source_target_pairs={{0,1}}
  cp1 = f32[8]{0} collective-permute(cp0), channel_id=2, source_target_pairs={{2,3}}
  cp2 = f32[8]{0} collective-permute(cp1), channel_id=3, source_target_pairs={{1,2}}
  ROOT add = f32[8]{0} add(cp0, cp2)
}
```
```
XLA_FLAGS="--xla_gpu_collective_permute_connected_components=true" \
hlo_runner_main --device_type=gpu --num_replicas=1 --num_partitions=4 \
  --hlo_argument_mode=uninitialized min_cp_cc.hlo
```

this is currently hanging in ROCm 8 gpu setup and it runs into deadlock waiting for `AcquireGpuClique`

why it happens and how to go about this fix is below :

- Restrict the "different device groups" check in
`CollectiveCliqueRequests::RequestClique` to multi-device cliques.

- With `xla_gpu_collective_permute_connected_components` enabled, a
collective-permute records a singleton clique `{d}` for each non-participating
device, tagged with that instruction's full component decomposition as its
`device_groups`. 
- Different collective-permutes decompose differently, so the same
singleton `{d}` is requested with different `device_groups`, the check rejected
this, failing `Thunk::Prepare` on those devices and hanging the rest in clique
acquisition.
- A singleton clique is a 1-rank communicator (no communication,
never split), so its `device_groups` are irrelevant.

- Also side note I tested the same test in H100 8 GPU config locally I'm hitting the same hang so I suspect this issue could affect team green too.

## 🎯 Justification

Regression from  https://github.com/openxla/xla/commit/1808d03c51382336c4635f605e84cc1531b2199f 
("Enable
`xla_gpu_collective_permute_connected_components` by default"). The JAX
multi-accelerator suite hangs at
`shard_map_test.py::CustomPartitionerTest::test_partially_sharded_dim_with_auto`
 host looks idle, all GPUs at 0%, stuck in `AcquireGpuClique`:
`Acquire clique: devices=4:[1,2,3,5] ... Expected 4 threads ... not all arrived`.

## 🚀 Kind of Contribution
🐛 Bug Fix

## 🧪 Unit Tests
`xla/backends/gpu/runtime/collective_clique_requests_test.cc`:
- `SingletonDeviceGroupsMismatchAllowed` , simple UT where single-device clique can be requested twice with different device_groups without erroring