### PR TITLE
[XLA:GPU][oneAPI][Bugfix] Fix mxfp4 compare on SPIR-V backend

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -747,7 +747,15 @@ absl::Status RunOptimizationPasses(
                                    is_deviceless, is_early_exit_with_layouts);
   }
   // Comparison total order expander
-  pipeline.AddPass<ComparisonExpander>(std::array{std::make_pair(BF16, F32)});
+  std::vector<std::pair<PrimitiveType, PrimitiveType>>
+      comparison_expander_upcasts = {{BF16, F32}};
+  // On Intel GPUs, additionally upcast F4E2M1FN to F16 to avoid an fp4 compare
+  // that SPIR-V backend cannot lower.
+  // TODO(intel-tf): Remove this once SPIR-V backend can lower fp4 compares.
+  if (gpu_version.IsOneAPI()) {
+    comparison_expander_upcasts.push_back({F4E2M1FN, F16});
+  }
+  pipeline.AddPass<ComparisonExpander>(comparison_expander_upcasts);
 
   // Remove zero-sized HLO from the input so that other passes don't have to
   // handle it.


### PR DESCRIPTION
This PR fixes MXFP4 compare on Intel GPUs by upcasting `F4E2M1FN` to `F16` in the oneAPI path, avoiding SPIR-V lowering failures.
The following unit test is covered: `//xla/tests:array_elementwise_ops_test_intelgpu_any [sub-test: TotalOrderTest/10.Le, where TypeParam = ml_dtypes::mxfloat_internal::float4_e2m1fn]`