### PR TITLE
[ROCm][Triton] AllGather build info (PR1/4)

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -4095,6 +4095,32 @@ xla_test(
 )
 
 cc_library(
+    name = "all_gather",
+    srcs = ["all_gather.cc"],
+    hdrs = ["all_gather.h"],
+    deps = [
+        ":collective_params",
+        "//xla:shape_util",
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla/backends/gpu/transforms/collectives:collective_ops_utils",
+        "//xla/hlo/ir:hlo",
+        "//xla/service:collective_ops_utils",
+        "//xla/service:computation_placer_hdr",
+        "//xla/service:gpu_topology",
+        "//xla/service/gpu:gpu_constants",
+        "//xla/service/gpu:launch_dimensions",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/gpu:all_reduce_kernel",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@llvm-project//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "all_reduce",
     srcs = ["all_reduce.cc"],
     hdrs = ["all_reduce.h"],
@@ -4161,6 +4187,33 @@ xla_cc_test(
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+xla_cc_test(
+    name = "all_gather_build_info_test",
+    srcs = ["all_gather_build_info_test.cc"],
+    deps = [
+        ":all_gather",
+        "//xla:shape_util",
+        "//xla:xla_data_proto_cc",
+        "//xla/backends/gpu/target_config",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service:gpu_topology",
+        "//xla/service/gpu:gpu_device_info_for_tests",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor:device_description_proto_cc",
+        "//xla/tsl/lib/gtl:int_type",
+        "//xla/tsl/platform:status_macros",
+        "//xla/tsl/platform:test",
+        "//xla/tsl/platform:test_main",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest",

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -4113,9 +4113,11 @@ cc_library(
         "//xla/stream_executor:device_description",
         "//xla/stream_executor/gpu:all_reduce_kernel",
         "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/xla/backends/gpu/runtime/all_gather.cc
+++ b/xla/backends/gpu/runtime/all_gather.cc
@@ -1,0 +1,235 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/runtime/all_gather.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "llvm/ADT/bit.h"
+#include "xla/backends/gpu/runtime/collective_params.h"
+#include "xla/backends/gpu/transforms/collectives/collective_ops_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/primitive_util.h"
+#include "xla/service/collective_ops_utils.h"
+#include "xla/service/computation_placer.h"
+#include "xla/service/gpu/gpu_constants.h"
+#include "xla/service/gpu/launch_dimensions.h"
+#include "xla/service/gpu_topology.h"
+#include "xla/shape_util.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/gpu/all_reduce_kernel.h"
+#include "xla/util.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+
+absl::Status IsAllGatherKernelSupported(int64_t num_ranks, int64_t num_elements,
+                                        PrimitiveType element_type) {
+  // Triton does not have unsigned integer types — tt.store/tt.load only accept
+  // signless integers and floating-point types.
+  if (element_type == U8 || element_type == U16 || element_type == U32 ||
+      element_type == U64) {
+    return absl::UnimplementedError(absl::StrCat(
+        "Unsigned integer element type (",
+        primitive_util::LowercasePrimitiveTypeName(element_type),
+        ") is not supported for all-gather kernel (Triton has no unsigned "
+        "integer types). Use the signed equivalent or a floating-point type; "
+        "NCCL/RCCL handles unsigned types correctly."));
+  }
+
+  // The alignment requirement is on the total transfer size in bytes: the
+  // buffer must be a multiple of kNumElementsPerThread × 4 bytes (128 bits)
+  // so each thread processes a whole number of 32-bit words.
+  const int64_t element_bits = primitive_util::BitWidth(element_type);
+  const int64_t required_bits = se::gpu::kNumElementsPerThread * 32;  // 128 b
+  if ((num_elements * element_bits) % required_bits != 0) {
+    return absl::UnimplementedError(absl::StrCat(
+        "Number of elements (", num_elements, ") of type ",
+        primitive_util::LowercasePrimitiveTypeName(element_type), " (",
+        element_bits,
+        " bits each) is not aligned to the alignment requirement"
+        " (",
+        se::gpu::kNumElementsPerThread, " x 32-bit words per thread)."));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status IsAllGatherKernelSupported(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    int32_t num_operands, int64_t num_devices, int64_t num_elements,
+    PrimitiveType element_type, bool is_local,
+    const std::vector<ReplicaGroup>& replica_groups) {
+  if (!is_collective_kernel_enabled) {
+    return absl::UnimplementedError("Collective kernel is not enabled.");
+  }
+  // Check if the device supports Triton collective codegen:
+  // CUDA: Requires compute capability 9.0+ (Hopper or newer)
+  // ROCm: All versions with Triton support are enabled
+  if (!device_info.cuda_compute_capability().IsAtLeastHopper() &&
+      !device_info.gpu_compute_capability().IsRocm()) {
+    return absl::UnimplementedError(absl::StrCat(
+        "Triton collective codegen requires CUDA compute capability >= 9.0 "
+        "(Hopper or newer) or a ROCm device with Triton support. "
+        "Got: ",
+        device_info.gpu_compute_capability().ToString(), "."));
+  }
+  // TODO(b/383125489): Support variadic arguments.
+  if (num_operands != 1) {
+    return absl::UnimplementedError(
+        absl::StrCat("Collective kernel is not supported for number of "
+                     "operands not equal to 1. Got ",
+                     num_operands, "."));
+  }
+  if (replica_groups.empty()) {
+    return absl::UnimplementedError(
+        "Replica groups must be explicitly provided for collective kernels.");
+  }
+  if (!is_local) {
+    return absl::UnimplementedError(
+        "Cross-host symmetric memory collectives are not supported.");
+  }
+  if (!llvm::has_single_bit(static_cast<uint64_t>(num_devices))) {
+    return absl::UnimplementedError(
+        absl::StrCat("Collective kernels are only supported for power of 2 "
+                     "number of devices. Got ",
+                     num_devices, "."));
+  }
+  return IsAllGatherKernelSupported(num_devices, num_elements, element_type);
+}
+
+absl::StatusOr<AllGatherInfo> BuildAllGatherInfo(
+    bool is_collective_kernel_enabled, const GpuTopology& gpu_topology,
+    const HloAllGatherInstruction* all_gather,
+    const DeviceAssignment* device_assignment) {
+  if (!gpu_topology.has_gpu_target_config()) {
+    return absl::InvalidArgumentError(
+        "GpuTopology must have a target config to build AllGatherInfo.");
+  }
+  const se::DeviceDescription& device_info =
+      gpu_topology.gpu_target_config().device_description;
+  if (!all_gather->device_list()) {
+    return absl::UnimplementedError(
+        "Replica groups must be explicitly provided for collective kernels.");
+  }
+  const int64_t num_devices =
+      all_gather->device_list()->num_devices_per_group();
+  const int64_t num_elements =
+      ShapeUtil::ElementsIn(all_gather->operand(0)->shape());
+  const PrimitiveType element_type =
+      all_gather->operand(0)->shape().element_type();
+  const int32_t num_operands = all_gather->operand_count();
+  if (device_info.device_interconnect_info().active_links <= 0) {
+    return absl::UnimplementedError(
+        "Collective kernels are only supported on devices with NVLink/UALink "
+        "support.");
+  }
+  ASSIGN_OR_RETURN(const CollectiveOpGroupMode group_mode,
+                   GetCollectiveOpGroupMode(all_gather));
+  const bool is_local = IsAllReplicasLocal(
+      gpu_topology.num_devices_per_process(), all_gather->replica_groups(),
+      group_mode, device_assignment);
+  RETURN_IF_ERROR(IsAllGatherKernelSupported(
+      is_collective_kernel_enabled, device_info, num_operands, num_devices,
+      num_elements, element_type, is_local, all_gather->replica_groups()));
+  return AllGatherInfo{
+      /*.num_devices =*/num_devices,
+      /*.num_elements =*/num_elements,
+      /*.element_type =*/element_type,
+  };
+}
+
+namespace {
+// All-gather always uses a one-shot strategy: every rank reads its peers'
+// slices directly, so the work is proportional to the full element count
+// with no rank-based partitioning.
+static constexpr uint64_t kMaxThreadsPerBlock = 512;
+}  // namespace
+
+LaunchDimensions AllGatherLaunchDimensions(int64_t elements,
+                                           int64_t warp_size) {
+  // Maximum number of threads such that each thread has elements to process.
+  // Round up to a multiple of warp_size so every warp is fully occupied.
+  const int64_t total_threads = RoundUpTo(
+      CeilOfRatio(elements, se::gpu::kNumElementsPerThread), warp_size);
+  // Triton expects power of 2 for threads_per_block / threads_per_warp.
+  const int64_t threads_per_block =
+      std::min(kMaxThreadsPerBlock,
+               llvm::bit_ceil(static_cast<uint64_t>(total_threads)));
+  const int64_t blocks_per_grid =
+      std::min(kAllGatherMaxBlocksPerGrid,
+               CeilOfRatio(total_threads, threads_per_block));
+  return LaunchDimensions(blocks_per_grid, threads_per_block);
+}
+
+absl::StatusOr<CollectiveKernelSpec> CreateAllGatherKernelSpec(
+    const HloInstruction* instr, const LaunchDimensions& launch_dimensions) {
+  // instr may be the raw kAllGather instruction or a fusion wrapping it.
+  const HloInstruction* all_gather = instr;
+  if (instr->opcode() == HloOpcode::kFusion) {
+    all_gather = instr->fused_instructions_computation()->root_instruction();
+  }
+
+  int64_t group_size = instr->GetModule()->config().replica_count();
+  if (!all_gather->replica_groups().empty() &&
+      all_gather->replica_groups()[0].replica_ids_size() > 0) {
+    group_size = all_gather->replica_groups()[0].replica_ids_size();
+  }
+
+  // The symmetric scratch buffer holds one rank's slice (= input size).
+  // Double-buffering is handled by the should_double_buffer flag.
+  const int64_t input_size_bytes =
+      ShapeUtil::ByteSizeOf(all_gather->operand(0)->shape());
+  const int64_t num_signal_flags = group_size * launch_dimensions.num_blocks();
+  const int64_t signal_size = xla::RoundUpTo<uint64_t>(
+      num_signal_flags * sizeof(int32_t), kXlaAllocatedBufferAlignBytes);
+  // Each rank allocates its own input-sized symmetric buffer; pointers are
+  // exchanged via kXlaRendezvous so every rank can read from each peer.
+  const int64_t remote_size =
+      xla::RoundUpTo<uint64_t>(input_size_bytes, kXlaAllocatedBufferAlignBytes);
+
+  CollectiveKernelSpec kernel_spec = {
+      /* .input_buffer_specs= */ {
+          {/*requires_multimem=*/false, SymmetricMemoryType::kNone}},
+      /* .output_buffer_specs= */
+      {{/*requires_multimem=*/false, SymmetricMemoryType::kNone}},
+      /* .scratch_buffers= */
+      {{signal_size, /*requires_multimem=*/false,  // Signal flags
+        SymmetricMemoryType::kXlaRendezvous,
+        /*should_memzero=*/true,
+        /*should_double_buffer=*/true},
+       {remote_size, /*requires_multimem=*/false,  // Symmetric remote buffer
+        SymmetricMemoryType::kXlaRendezvous,
+        /*should_memzero=*/false,
+        /*should_double_buffer=*/true}},
+      /* .argument_descriptors= */
+      {{KernelArgType::kInputBuffer, /*index=*/0},   // buffers[0].source_buffer
+       {KernelArgType::kOutputBuffer, /*index=*/0},  // buffers[0].dst_buffer
+       {KernelArgType::kRuntimeRank},
+       {KernelArgType::kInvocationCount},
+       {KernelArgType::kScratchBuffer, /*index=*/0},   // signal buffers
+       {KernelArgType::kScratchBuffer, /*index=*/1}},  // remote buffers
+      /* .sync_count_increment= */ 1u};  // AllGather is always one-shot
+  return kernel_spec;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/all_gather.cc
+++ b/xla/backends/gpu/runtime/all_gather.cc
@@ -19,11 +19,13 @@ limitations under the License.
 #include <cstdint>
 #include <vector>
 
+#include "absl/algorithm/container.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "llvm/ADT/bit.h"
+#include "llvm/Support/Alignment.h"
 #include "xla/backends/gpu/runtime/collective_params.h"
 #include "xla/backends/gpu/transforms/collectives/collective_ops_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -43,33 +45,31 @@ limitations under the License.
 
 namespace xla::gpu {
 
-absl::Status IsAllGatherKernelSupported(int64_t num_ranks, int64_t num_elements,
+absl::Status IsAllGatherKernelSupported(int64_t num_elements,
                                         PrimitiveType element_type) {
-  // Triton does not have unsigned integer types — tt.store/tt.load only accept
-  // signless integers and floating-point types.
-  if (element_type == U8 || element_type == U16 || element_type == U32 ||
-      element_type == U64) {
-    return absl::UnimplementedError(absl::StrCat(
-        "Unsigned integer element type (",
-        primitive_util::LowercasePrimitiveTypeName(element_type),
-        ") is not supported for all-gather kernel (Triton has no unsigned "
-        "integer types). Use the signed equivalent or a floating-point type; "
-        "NCCL/RCCL handles unsigned types correctly."));
+  // Only types in kSupportedAllGatherTypes are allowed. Triton tt.load/tt.store
+  // support signless integers and floating-point types; unsigned integers,
+  // complex types, tokens, tuples, and exotic types (e.g. 4-bit, 8-bit floats)
+  // are not supported.
+  if (!absl::c_linear_search(kSupportedAllGatherTypes, element_type)) {
+    return absl::UnimplementedError(absl::StrFormat(
+        "Element type %s is not supported for the all-gather kernel. "
+        "Supported types are signed integers and standard floating-point "
+        "types; use NCCL/RCCL for other types.",
+        primitive_util::LowercasePrimitiveTypeName(element_type)));
   }
 
-  // The alignment requirement is on the total transfer size in bytes: the
-  // buffer must be a multiple of kNumElementsPerThread × 4 bytes (128 bits)
-  // so each thread processes a whole number of 32-bit words.
-  const int64_t element_bits = primitive_util::BitWidth(element_type);
-  const int64_t required_bits = se::gpu::kNumElementsPerThread * 32;  // 128 b
-  if ((num_elements * element_bits) % required_bits != 0) {
-    return absl::UnimplementedError(absl::StrCat(
-        "Number of elements (", num_elements, ") of type ",
-        primitive_util::LowercasePrimitiveTypeName(element_type), " (",
-        element_bits,
-        " bits each) is not aligned to the alignment requirement"
-        " (",
-        se::gpu::kNumElementsPerThread, " x 32-bit words per thread)."));
+  // The total transfer size in bits must be aligned to
+  // kBitsPerMemoryTransaction (128 bits = 16 bytes) so each thread can
+  // load/store a complete transaction.
+  const uint64_t element_bits = primitive_util::BitWidth(element_type);
+  if (!llvm::isAligned(llvm::Align(kBitsPerMemoryTransaction),
+                       static_cast<uint64_t>(num_elements) * element_bits)) {
+    return absl::UnimplementedError(absl::StrFormat(
+        "Number of elements (%d) of type %s (%d bits each) is not aligned to "
+        "the memory transaction alignment requirement (%d bits).",
+        num_elements, primitive_util::LowercasePrimitiveTypeName(element_type),
+        element_bits, kBitsPerMemoryTransaction));
   }
   return absl::OkStatus();
 }
@@ -87,18 +87,17 @@ absl::Status IsAllGatherKernelSupported(
   // ROCm: All versions with Triton support are enabled
   if (!device_info.cuda_compute_capability().IsAtLeastHopper() &&
       !device_info.gpu_compute_capability().IsRocm()) {
-    return absl::UnimplementedError(absl::StrCat(
+    return absl::UnimplementedError(absl::StrFormat(
         "Triton collective codegen requires CUDA compute capability >= 9.0 "
-        "(Hopper or newer) or a ROCm device with Triton support. "
-        "Got: ",
-        device_info.gpu_compute_capability().ToString(), "."));
+        "(Hopper or newer) or a ROCm device with Triton support. Got: %s.",
+        device_info.gpu_compute_capability().ToString()));
   }
   // TODO(b/383125489): Support variadic arguments.
   if (num_operands != 1) {
-    return absl::UnimplementedError(
-        absl::StrCat("Collective kernel is not supported for number of "
-                     "operands not equal to 1. Got ",
-                     num_operands, "."));
+    return absl::UnimplementedError(absl::StrFormat(
+        "Collective kernel is not supported for number of operands not equal "
+        "to 1. Got %d.",
+        num_operands));
   }
   if (replica_groups.empty()) {
     return absl::UnimplementedError(
@@ -109,12 +108,12 @@ absl::Status IsAllGatherKernelSupported(
         "Cross-host symmetric memory collectives are not supported.");
   }
   if (!llvm::has_single_bit(static_cast<uint64_t>(num_devices))) {
-    return absl::UnimplementedError(
-        absl::StrCat("Collective kernels are only supported for power of 2 "
-                     "number of devices. Got ",
-                     num_devices, "."));
+    return absl::UnimplementedError(absl::StrFormat(
+        "Collective kernels are only supported for power of 2 number of "
+        "devices. Got %d.",
+        num_devices));
   }
-  return IsAllGatherKernelSupported(num_devices, num_elements, element_type);
+  return IsAllGatherKernelSupported(num_elements, element_type);
 }
 
 absl::StatusOr<AllGatherInfo> BuildAllGatherInfo(

--- a/xla/backends/gpu/runtime/all_gather.h
+++ b/xla/backends/gpu/runtime/all_gather.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_
 #define XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_
 
+#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -31,6 +32,18 @@ limitations under the License.
 #include "xla/xla_data.pb.h"
 
 namespace xla::gpu {
+
+// Memory transaction width for the Triton all-gather kernel in bits (128 bits =
+// 16 bytes). The total buffer size in bits must be aligned to this value so
+// that each thread can load/store a complete 128-bit transaction.
+inline constexpr uint64_t kBitsPerMemoryTransaction = 128;
+
+// Element types supported by the Triton all-gather kernel.
+// Triton tt.load/tt.store support signless integers and floating-point types.
+// Unsigned integer types, complex types, tokens, tuples, and exotic types
+// (e.g. 4-bit integers, 8-bit floats) are not supported.
+inline constexpr auto kSupportedAllGatherTypes =
+    std::array{F16, BF16, F32, F64, S8, S16, S32, S64};
 
 // Maximum number of GPU thread-blocks launched per all-gather kernel.
 // This constant is shared between the kernel launcher (all_gather.cc) and the
@@ -49,7 +62,7 @@ struct AllGatherInfo {
 // Returns absl::OkStatus() if the all-gather kernel is supported for the given
 // element type and number of elements, or an error status detailing why it is
 // not supported.
-absl::Status IsAllGatherKernelSupported(int64_t num_ranks, int64_t num_elements,
+absl::Status IsAllGatherKernelSupported(int64_t num_elements,
                                         PrimitiveType element_type);
 
 // A broader check for all-gather kernel support that verifies device, operand

--- a/xla/backends/gpu/runtime/all_gather.h
+++ b/xla/backends/gpu/runtime/all_gather.h
@@ -1,0 +1,94 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_
+#define XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xla/backends/gpu/runtime/collective_params.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/service/computation_placer.h"
+#include "xla/service/gpu/launch_dimensions.h"
+#include "xla/service/gpu_topology.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+
+// Maximum number of GPU thread-blocks launched per all-gather kernel.
+// This constant is shared between the kernel launcher (all_gather.cc) and the
+// unmanaged-argument shaper (collective_emitter.cc) so that the signal buffer
+// is always sized to match the actual grid.
+inline constexpr int64_t kAllGatherMaxBlocksPerGrid = 32;
+
+// Encapsulates the information needed to perform an all-gather via the Triton
+// collective kernel backend.
+struct AllGatherInfo {
+  int64_t num_devices;
+  int64_t num_elements;
+  PrimitiveType element_type;
+};
+
+// Returns absl::OkStatus() if the all-gather kernel is supported for the given
+// element type and number of elements, or an error status detailing why it is
+// not supported.
+absl::Status IsAllGatherKernelSupported(int64_t num_ranks, int64_t num_elements,
+                                        PrimitiveType element_type);
+
+// A broader check for all-gather kernel support that verifies device, operand
+// count, replica group, and element-type constraints.
+// Returns absl::OkStatus() if supported, or an absl::UnimplementedError
+// explaining why not.
+absl::Status IsAllGatherKernelSupported(
+    bool is_collective_kernel_enabled, const se::DeviceDescription& device_info,
+    int32_t num_operands, int64_t num_devices, int64_t num_elements,
+    PrimitiveType element_type, bool is_local,
+    const std::vector<ReplicaGroup>& replica_groups);
+
+// Constructs an AllGatherInfo object for the given all-gather instruction.
+// Returns absl::UnimplementedError if the Triton all-gather kernel is not
+// supported for this instruction's configuration.
+absl::StatusOr<AllGatherInfo> BuildAllGatherInfo(
+    bool is_collective_kernel_enabled, const GpuTopology& gpu_topology,
+    const HloAllGatherInstruction* all_gather,
+    const DeviceAssignment* device_assignment);
+
+// Returns the launch dimensions for the all-gather kernel.
+// All-gather uses a one-shot strategy: each rank contributes its local slice
+// to the symmetric buffer and then reads each peer's slice.
+// warp_size should be device_description.threads_per_warp() (32 on NVIDIA,
+// 64 on AMD) so that the thread count is a multiple of the hardware warp.
+LaunchDimensions AllGatherLaunchDimensions(int64_t elements, int64_t warp_size);
+
+// Creates a CollectiveKernelSpec describing the resource requirements of a
+// Triton all-gather kernel.  The returned spec uses the same 6-argument layout
+// as the all-reduce kernel:
+//   [0] input buffer (per-rank source slice)
+//   [1] output buffer (full gathered destination)
+//   [2] runtime rank  (kRuntimeRank)
+//   [3] invocation count (kInvocationCount)
+//   [4] scratch index 0: signal flags (kScratchBuffer)
+//   [5] scratch index 1: symmetric remote buffer (kScratchBuffer)
+absl::StatusOr<CollectiveKernelSpec> CreateAllGatherKernelSpec(
+    const HloInstruction* instr, const LaunchDimensions& launch_dimensions);
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_RUNTIME_ALL_GATHER_H_

--- a/xla/backends/gpu/runtime/all_gather_build_info_test.cc
+++ b/xla/backends/gpu/runtime/all_gather_build_info_test.cc
@@ -174,7 +174,7 @@ TEST_F(BuildAllGatherInfoTest, FailsForUnsupportedUnsignedType) {
       BuildInfo(CollectiveKernelEnabled(true), U32, /*num_elements=*/512,
                 /*replica_groups=*/{0, 1}),
       StatusIs(absl::StatusCode::kUnimplemented,
-               HasSubstr("is not supported for all-gather kernel")));
+               HasSubstr("is not supported for the all-gather kernel")));
 }
 
 TEST_F(BuildAllGatherInfoTest, FailsForUnalignedElements) {
@@ -182,7 +182,8 @@ TEST_F(BuildAllGatherInfoTest, FailsForUnalignedElements) {
   EXPECT_THAT(BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/7,
                         /*replica_groups=*/{0, 1}),
               StatusIs(absl::StatusCode::kUnimplemented,
-                       HasSubstr("not aligned to the alignment requirement")));
+                       HasSubstr("not aligned to the memory transaction "
+                                 "alignment requirement")));
 }
 
 TEST_F(BuildAllGatherInfoTest, FailsIfReplicaGroupsEmpty) {

--- a/xla/backends/gpu/runtime/all_gather_build_info_test.cc
+++ b/xla/backends/gpu/runtime/all_gather_build_info_test.cc
@@ -1,0 +1,216 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/backends/gpu/runtime/all_gather.h"
+#include "xla/backends/gpu/target_config/target_config.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/primitive_util.h"
+#include "xla/service/gpu/gpu_device_info_for_tests.h"
+#include "xla/service/gpu_topology.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/device_description.pb.h"
+#include "xla/tsl/lib/gtl/int_type.h"
+#include "xla/tsl/platform/test.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+namespace {
+
+using ::absl_testing::IsOkAndHolds;
+using ::absl_testing::StatusIs;
+using ::testing::AllOf;
+using ::testing::Field;
+using ::testing::HasSubstr;
+
+TSL_LIB_GTL_DEFINE_INT_TYPE(CollectiveKernelEnabled, bool);
+
+class BuildAllGatherInfoTest : public HloHardwareIndependentTestBase {
+ protected:
+  // Builds an all-gather HLO module and invokes BuildAllGatherInfo.
+  //
+  // `num_elements` is the number of elements in the input operand (per
+  // replica). The all-gather is 1-D along dimension 0.
+  //
+  // `replica_groups` is a flat list of device IDs forming a single replica
+  // group. An empty list means replica_groups={} (empty) in the HLO, which
+  // will trigger the "replica groups must be provided" error path.
+  absl::StatusOr<AllGatherInfo> BuildInfo(
+      CollectiveKernelEnabled collective_kernel_enabled,
+      PrimitiveType element_type, int64_t num_elements,
+      std::vector<int32_t> replica_groups, int num_hosts = 1,
+      int active_links = 18) {
+    const int num_replicas =
+        replica_groups.empty() ? 1 : static_cast<int>(replica_groups.size());
+    const std::string element_type_str =
+        primitive_util::LowercasePrimitiveTypeName(element_type);
+    const std::string input_shape_str = absl::StrFormat("%d", num_elements);
+    const std::string output_shape_str =
+        absl::StrFormat("%d", num_elements * num_replicas);
+    const std::string replica_groups_str =
+        replica_groups.empty()
+            ? ""
+            : absl::StrFormat("{%s}", absl::StrJoin(replica_groups, ","));
+
+    // The all-gather gathers along dimension 0: output_dim0 = num_replicas *
+    // input_dim0.
+    constexpr absl::string_view kModuleStr = R"(
+    HloModule test
+    ENTRY test_computation {
+      param_0 = %1$s[%2$s] parameter(0)
+      ROOT all-gather = %1$s[%3$s] all-gather(param_0),
+          dimensions={0}, replica_groups={%4$s}
+    }
+    )";
+    const std::string module_str =
+        absl::StrFormat(kModuleStr, element_type_str, input_shape_str,
+                        output_shape_str, replica_groups_str);
+
+    SCOPED_TRACE(testing::Message() << "module_str: " << module_str);
+
+    se::DeviceDescription device_info = TestGpuDeviceInfo::H100SXMDeviceInfo();
+    stream_executor::GpuTargetConfigProto target_config_proto;
+    *target_config_proto.mutable_gpu_device_info() = device_info.ToProto();
+    target_config_proto.mutable_gpu_device_info()
+        ->mutable_device_interconnect_info()
+        ->set_active_links(active_links);
+    target_config_proto.set_platform_name("CUDA");
+    ASSIGN_OR_RETURN(gpu::GpuTargetConfig target_config,
+                     gpu::GpuTargetConfig::FromProto(target_config_proto));
+
+    // num_devices_per_host = num_replicas / num_hosts (for single group).
+    const int num_devices_per_host =
+        num_replicas > 0 ? num_replicas / num_hosts : 1;
+    GpuTopology gpu_topology("platform_version", /*num_partitions=*/1,
+                             /*num_hosts_per_partition=*/num_hosts,
+                             /*num_devices_per_host=*/num_devices_per_host,
+                             target_config);
+
+    ASSIGN_OR_RETURN(std::unique_ptr<HloModule> module,
+                     ParseAndReturnVerifiedModule(module_str, num_replicas));
+
+    const HloInstruction* hlo_instr =
+        HloHardwareIndependentTestBase::FindInstruction(module.get(),
+                                                        HloOpcode::kAllGather);
+    return BuildAllGatherInfo(collective_kernel_enabled.value(), gpu_topology,
+                              Cast<HloAllGatherInstruction>(hlo_instr),
+                              /*device_assignment=*/nullptr);
+  }
+};
+
+TEST_F(BuildAllGatherInfoTest, SucceedsForSupportedF32) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1}),
+      IsOkAndHolds(AllOf(Field(&AllGatherInfo::num_devices, 2),
+                         Field(&AllGatherInfo::num_elements, 512),
+                         Field(&AllGatherInfo::element_type, F32))));
+}
+
+TEST_F(BuildAllGatherInfoTest, SucceedsForSupportedBF16) {
+  EXPECT_THAT(BuildInfo(CollectiveKernelEnabled(true), BF16,
+                        /*num_elements=*/512, /*replica_groups=*/{0, 1}),
+              IsOkAndHolds(AllOf(Field(&AllGatherInfo::num_devices, 2),
+                                 Field(&AllGatherInfo::num_elements, 512),
+                                 Field(&AllGatherInfo::element_type, BF16))));
+}
+
+TEST_F(BuildAllGatherInfoTest, SucceedsForFourDevices) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1, 2, 3}),
+      IsOkAndHolds(AllOf(Field(&AllGatherInfo::num_devices, 4),
+                         Field(&AllGatherInfo::num_elements, 512),
+                         Field(&AllGatherInfo::element_type, F32))));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsIfCollectiveKernelDisabled) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(false), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1}),
+      StatusIs(absl::StatusCode::kUnimplemented, HasSubstr("not enabled")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForNonPowerOfTwoDevices) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1, 2}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("only supported for power of 2")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForUnsupportedUnsignedType) {
+  // U32 is not supported by the Triton all-gather kernel.
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), U32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("is not supported for all-gather kernel")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForUnalignedElements) {
+  // 7 is not divisible by kNumElementsPerThread (which is >= 2).
+  EXPECT_THAT(BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/7,
+                        /*replica_groups=*/{0, 1}),
+              StatusIs(absl::StatusCode::kUnimplemented,
+                       HasSubstr("not aligned to the alignment requirement")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsIfReplicaGroupsEmpty) {
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("Replica groups must be explicitly provided")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsForCrossHostCollective) {
+  // 2 replicas split across 2 hosts → not local → should be rejected.
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1}, /*num_hosts=*/2),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("Cross-host symmetric memory collectives")));
+}
+
+TEST_F(BuildAllGatherInfoTest, FailsWithoutNvlink) {
+  // Devices with no active NVLink/UALink connections cannot use symmetric
+  // memory collectives.
+  EXPECT_THAT(
+      BuildInfo(CollectiveKernelEnabled(true), F32, /*num_elements=*/512,
+                /*replica_groups=*/{0, 1}, /*num_hosts=*/1,
+                /*active_links=*/0),
+      StatusIs(absl::StatusCode::kUnimplemented, HasSubstr("NVLink/UALink")));
+}
+
+}  // namespace
+}  // namespace xla::gpu


### PR DESCRIPTION
📝 Summary of Changes
This PR is the first in a series of four.

PR 1/4: https://github.com/openxla/xla/pull/44559   <--- This PR
PR 2/4: https://github.com/openxla/xla/pull/44560
PR 3/4: https://github.com/openxla/xla/pull/44562
PR 4/4: https://github.com/openxla/xla/pull/44564

These PRs aim to enable the Triton backend for the All-Gather collective operation based on the experimental tiling strategy.

This PR adds a dedicated all_gather.cc/.h module with the metadata and tiling logic needed to decide whether and how to run an AllGather via the Triton backend (similar to all_reduce.cc/h).

🎯 Justification
Lowering All-Gather through the triton backend significantly improves performance of this operation for AMD/ROCm target (compared to RCCL backend), especially for small tensor, and could allow us to take greater advantage of kernel-level fusion.

Example of 5 Triton Performance Improvements — All-Gather 1D on MI355
 | DType | Shape | Replicas | Triton (µs) | RCCL (µs) | Speedup |
|--------|--------|----------|------------------:|---------------:|--------:|
| s8 | [16384] | 2 | 17.428 | 42.342 | **2.43×** |
| bf16 | [16384] | 2 | 17.708 | 41.733 | **2.36×** |
| f32 | [131072] | 2 | 27.924 | 52.497 | **1.88×** |
| s32 | [4096] | 2 | 24.435 | 44.287 | **1.81×** |
| s8 | [262144] | 4 | 40.459 | 71.119 | **1.76×** |

Example of 5 Triton Performance Improvements — All-Gather 2D on MI355
dtype | shape | replicas | RCCL (µs) | Triton (µs) | speedup
-- | -- | -- | -- | -- | --
bf16 | [32, 32] | 2 | 41.153 | 16.744 | **2.46×**
bf16 | [128, 64] | 4 | 68.079 | 35.498 | **1.92×**
bf16 | [256, 256] | 4 | 68.927 | 36.992 | **1.86×**
f32 | [128, 64] | 4 | 64.403 | 34.928 | **1.84×**
f8e4m3fn | [512, 512] | 4 | 68.342 | 41.506 | **1.65×**


🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement,✨ New Feature

🧪 Execution Tests:
Tests included in this PR.
