### PR TITLE
[ROCm][Triton] All gather thunk dispatch (PR2/4)

### DIFF
--- a/xla/BUILD
+++ b/xla/BUILD
@@ -1324,6 +1324,7 @@ xla_cc_test(
         ":xla_proto_cc",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:test_main",
+        "//xla/tsl/util:command_line_flags",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_googletest//:gtest",
         "@com_google_protobuf//:protobuf",

--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -744,6 +744,7 @@ cc_library(
         "//xla/stream_executor:device_description",
         "//xla/stream_executor/gpu:all_reduce_kernel",
         "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base:nullability",
         "@com_google_absl//absl/functional:any_invocable",
         "@com_google_absl//absl/log",

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -223,10 +223,12 @@ GetBlockLevelFusionConfigForAllReduce(
   }
 
   absl::StatusOr<AllReduceInfo> maybe_all_reduce_info = BuildAllReduceInfo(
-      /*is_collective_kernel_enabled=*/all_reduce->GetModule()
-          ->config()
-          .debug_options()
-          .xla_gpu_unsupported_use_all_reduce_one_shot_kernel(),
+      /*is_collective_kernel_enabled=*/absl::c_linear_search(
+          all_reduce->GetModule()
+              ->config()
+              .debug_options()
+              .xla_gpu_experimental_use_collective_kernels(),
+          static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE)),
       /*is_multimem_enabled=*/false, gpu_topology, all_reduce,
       device_assignment);
   if (absl::IsUnimplemented(maybe_all_reduce_info.status())) {

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "absl/algorithm/container.h"
 #include "absl/base/nullability.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -229,7 +229,7 @@ GetBlockLevelFusionConfigForAllReduce(
               ->config()
               .debug_options()
               .xla_gpu_experimental_use_collective_kernels(),
-          static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE)),
+          static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE)),
       /*is_multimem_enabled=*/false, gpu_topology, all_reduce,
       device_assignment);
   if (absl::IsUnimplemented(maybe_all_reduce_info.status())) {

--- a/xla/backends/gpu/tests/all_reduce_e2e_test.cc
+++ b/xla/backends/gpu/tests/all_reduce_e2e_test.cc
@@ -437,7 +437,7 @@ class AllReduceTest
     opts.clear_xla_gpu_experimental_use_collective_kernels();
     if (GetParam().use_all_reduce_one_shot_kernel) {
       opts.add_xla_gpu_experimental_use_collective_kernels(
-          DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE);
+          DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE);
     }
     return opts;
   }
@@ -456,7 +456,7 @@ class AllReduceTypesTest
     opts.clear_xla_gpu_experimental_use_collective_kernels();
     if (GetParam().use_all_reduce_one_shot_kernel) {
       opts.add_xla_gpu_experimental_use_collective_kernels(
-          DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE);
+          DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE);
     }
     return opts;
   }
@@ -503,7 +503,7 @@ class AllReduceLayoutAwareTest
     DebugOptions opts = CollectiveOpsWithFlagsBase::GetDebugOptionsForTest();
     opts.clear_xla_gpu_experimental_use_collective_kernels();
     opts.add_xla_gpu_experimental_use_collective_kernels(
-        DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE);
+        DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE);
     return opts;
   }
 };

--- a/xla/backends/gpu/tests/all_reduce_e2e_test.cc
+++ b/xla/backends/gpu/tests/all_reduce_e2e_test.cc
@@ -434,8 +434,11 @@ class AllReduceTest
  protected:
   DebugOptions GetDebugOptionsForTest() const override {
     DebugOptions opts = CollectiveOpsWithFlagsBase::GetDebugOptionsForTest();
-    opts.set_xla_gpu_unsupported_use_all_reduce_one_shot_kernel(
-        GetParam().use_all_reduce_one_shot_kernel);
+    opts.clear_xla_gpu_experimental_use_collective_kernels();
+    if (GetParam().use_all_reduce_one_shot_kernel) {
+      opts.add_xla_gpu_experimental_use_collective_kernels(
+          DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE);
+    }
     return opts;
   }
 };
@@ -450,8 +453,11 @@ class AllReduceTypesTest
  protected:
   DebugOptions GetDebugOptionsForTest() const override {
     DebugOptions opts = CollectiveOpsWithFlagsBase::GetDebugOptionsForTest();
-    opts.set_xla_gpu_unsupported_use_all_reduce_one_shot_kernel(
-        GetParam().use_all_reduce_one_shot_kernel);
+    opts.clear_xla_gpu_experimental_use_collective_kernels();
+    if (GetParam().use_all_reduce_one_shot_kernel) {
+      opts.add_xla_gpu_experimental_use_collective_kernels(
+          DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE);
+    }
     return opts;
   }
 };
@@ -495,7 +501,9 @@ class AllReduceLayoutAwareTest
  protected:
   DebugOptions GetDebugOptionsForTest() const override {
     DebugOptions opts = CollectiveOpsWithFlagsBase::GetDebugOptionsForTest();
-    opts.set_xla_gpu_unsupported_use_all_reduce_one_shot_kernel(true);
+    opts.clear_xla_gpu_experimental_use_collective_kernels();
+    opts.add_xla_gpu_experimental_use_collective_kernels(
+        DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE);
     return opts;
   }
 };

--- a/xla/backends/gpu/transforms/collectives/BUILD
+++ b/xla/backends/gpu/transforms/collectives/BUILD
@@ -743,6 +743,7 @@ cc_library(
     hdrs = ["collective_kernel_strategy_annotator.h"],
     deps = [
         "//xla:status_macros",
+        "//xla/backends/gpu/runtime:all_gather",
         "//xla/backends/gpu/runtime:all_reduce",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/pass:hlo_pass",

--- a/xla/backends/gpu/transforms/collectives/BUILD
+++ b/xla/backends/gpu/transforms/collectives/BUILD
@@ -743,6 +743,7 @@ cc_library(
     hdrs = ["collective_kernel_strategy_annotator.h"],
     deps = [
         "//xla:status_macros",
+        "//xla:xla_proto_cc",
         "//xla/backends/gpu/runtime:all_gather",
         "//xla/backends/gpu/runtime:all_reduce",
         "//xla/hlo/ir:hlo",
@@ -751,6 +752,7 @@ cc_library(
         "//xla/service/gpu:backend_configs_cc",
         "//xla/stream_executor/gpu:all_reduce_kernel",
         "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
@@ -765,6 +767,7 @@ xla_cc_test(
     srcs = ["collective_kernel_strategy_annotator_test.cc"],
     deps = [
         ":collective_kernel_strategy_annotator",
+        "//xla:xla_proto_cc",
         "//xla/backends/gpu/target_config",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",

--- a/xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator.cc
+++ b/xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "xla/tsl/platform/status_macros.h"
+#include "xla/backends/gpu/runtime/all_gather.h"
 #include "xla/backends/gpu/runtime/all_reduce.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_computation.h"
@@ -106,6 +107,44 @@ absl::StatusOr<bool> TryAnnotateAllReduce(HloInstruction* instr,
   return true;
 }
 
+// Tries to determine if the AllGather instruction should use the Triton
+// collective kernel and annotates it accordingly.
+// AllGather is always one-shot, so when eligible it is annotated with
+// KERNEL_STRATEGY_TRITON_ONE_SHOT.  Returns true if the annotation was written.
+absl::StatusOr<bool> TryAnnotateAllGather(HloInstruction* instr,
+                                          const GpuTopology& gpu_topology) {
+  const auto* all_gather = DynCast<HloAllGatherInstruction>(instr);
+  if (all_gather == nullptr) {
+    return false;
+  }
+
+  const DeviceAssignment* device_assignment = nullptr;
+  if (instr->GetModule()->config().has_static_device_assignment()) {
+    device_assignment =
+        &instr->GetModule()->config().static_device_assignment();
+  }
+
+  absl::StatusOr<AllGatherInfo> maybe_info = BuildAllGatherInfo(
+      /*is_collective_kernel_enabled=*/true, gpu_topology, all_gather,
+      device_assignment);
+  if (!maybe_info.ok()) {
+    VLOG(3) << "[CollectiveKernelStrategyAnnotator] Collective kernel not "
+               "supported for AllGather "
+            << instr->name() << ": " << maybe_info.status();
+    return false;
+  }
+
+  ASSIGN_OR_RETURN(GpuBackendConfig gpu_config,
+                   instr->backend_config<GpuBackendConfig>());
+  gpu_config.mutable_collective_backend_config()->set_kernel_strategy(
+      CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT);
+  RETURN_IF_ERROR(instr->set_backend_config(gpu_config));
+
+  VLOG(3) << "[CollectiveKernelStrategyAnnotator] Annotated AllGather "
+          << instr->name() << " with KERNEL_STRATEGY_TRITON_ONE_SHOT";
+  return true;
+}
+
 }  // namespace
 
 CollectiveKernelStrategyAnnotator::CollectiveKernelStrategyAnnotator(
@@ -121,13 +160,16 @@ absl::StatusOr<bool> CollectiveKernelStrategyAnnotator::RunImpl(
   for (HloComputation* computation :
        module->MakeNonfusionComputations(execution_threads)) {
     for (HloInstruction* instr : computation->instructions()) {
-      if (instr->opcode() != HloOpcode::kAllReduce) {
-        continue;
+      if (instr->opcode() == HloOpcode::kAllReduce) {
+        ASSIGN_OR_RETURN(
+            bool annotated,
+            TryAnnotateAllReduce(instr, gpu_topology_, is_multimem_enabled_));
+        changed |= annotated;
+      } else if (instr->opcode() == HloOpcode::kAllGather) {
+        ASSIGN_OR_RETURN(bool annotated,
+                         TryAnnotateAllGather(instr, gpu_topology_));
+        changed |= annotated;
       }
-      ASSIGN_OR_RETURN(
-          bool annotated,
-          TryAnnotateAllReduce(instr, gpu_topology_, is_multimem_enabled_));
-      changed |= annotated;
     }
   }
   return changed;

--- a/xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator.cc
+++ b/xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <utility>
 
+#include "absl/algorithm/container.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -36,6 +37,7 @@ limitations under the License.
 #include "xla/service/gpu_topology.h"
 #include "xla/status_macros.h"
 #include "xla/stream_executor/gpu/all_reduce_kernel.h"
+#include "xla/xla.pb.h"
 
 namespace xla {
 namespace gpu {
@@ -124,9 +126,16 @@ absl::StatusOr<bool> TryAnnotateAllGather(HloInstruction* instr,
         &instr->GetModule()->config().static_device_assignment();
   }
 
-  absl::StatusOr<AllGatherInfo> maybe_info = BuildAllGatherInfo(
-      /*is_collective_kernel_enabled=*/true, gpu_topology, all_gather,
-      device_assignment);
+  const bool is_collective_kernel_enabled = absl::c_linear_search(
+      instr->GetModule()
+          ->config()
+          .debug_options()
+          .xla_gpu_experimental_use_collective_kernels(),
+      static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER));
+
+  absl::StatusOr<AllGatherInfo> maybe_info =
+      BuildAllGatherInfo(is_collective_kernel_enabled, gpu_topology, all_gather,
+                         device_assignment);
   if (!maybe_info.ok()) {
     VLOG(3) << "[CollectiveKernelStrategyAnnotator] Collective kernel not "
                "supported for AllGather "

--- a/xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator.h
+++ b/xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator.h
@@ -26,17 +26,22 @@ namespace xla {
 class GpuTopology;
 namespace gpu {
 
-// Annotates AllReduce / AllReduceStart instructions with the kernel strategy
-// that will be used at runtime (Triton one-shot, Triton two-shot, or NCCL
-// default), writing the result into
-// CollectiveBackendConfig::kernel_strategy.
+// Annotates collective instructions with the kernel strategy that will be used
+// at runtime, writing the result into CollectiveBackendConfig::kernel_strategy.
+//
+// Currently annotated opcodes:
+//   - AllReduce / AllReduceStart : Triton one-shot, Triton two-shot, or NCCL
+//     default depending on the shape and device topology.
+//   - AllGather                  : Triton one-shot when eligible, NCCL
+//     default otherwise.
 //
 // This pass must run BEFORE the latency-hiding scheduler so that
 // SolLatencyEstimator can apply the correct cost model for each collective.
 //
-// Only called when COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE is present in
-// xla_gpu_experimental_use_collective_kernels; when absent all AllReduces
-// keep the default NCCL annotation.
+// The pass is a no-op for a collective type unless the corresponding entry is
+// present in xla_gpu_experimental_use_collective_kernels (e.g.
+// COLLECTIVE_KERNEL_ALL_REDUCE for AllReduce,
+// COLLECTIVE_KERNEL_ALL_GATHER for AllGather).
 class CollectiveKernelStrategyAnnotator : public HloModulePass {
  public:
   // `gpu_topology`        : GpuTopology instance for which the compilation is

--- a/xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator.h
+++ b/xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator.h
@@ -34,8 +34,9 @@ namespace gpu {
 // This pass must run BEFORE the latency-hiding scheduler so that
 // SolLatencyEstimator can apply the correct cost model for each collective.
 //
-// Only called when xla_gpu_unsupported_use_all_reduce_one_shot_kernel is true;
-// when the flag is off all AllReduces will keep the default NCCL annotation.
+// Only called when COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE is present in
+// xla_gpu_experimental_use_collective_kernels; when absent all AllReduces
+// keep the default NCCL annotation.
 class CollectiveKernelStrategyAnnotator : public HloModulePass {
  public:
   // `gpu_topology`        : GpuTopology instance for which the compilation is

--- a/xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator_test.cc
+++ b/xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator_test.cc
@@ -79,11 +79,30 @@ class CollectiveKernelStrategyAnnotatorTest
         /*num_devices_per_host=*/16, target_config);
   }
 
+  // Builds a GpuTopology suitable for AllGather tests with `num_replicas`
+  // devices all on a single host (making the collective local).
+  absl::StatusOr<std::unique_ptr<GpuTopology>> MakeLocalGpuTopology(
+      int num_replicas) {
+    se::DeviceDescription device_info = TestGpuDeviceInfo::H100SXMDeviceInfo();
+    stream_executor::GpuTargetConfigProto target_config_proto;
+    *target_config_proto.mutable_gpu_device_info() = device_info.ToProto();
+    target_config_proto.mutable_gpu_device_info()
+        ->mutable_device_interconnect_info()
+        ->set_active_links(1);
+    target_config_proto.set_platform_name("CUDA");
+    ASSIGN_OR_RETURN(gpu::GpuTargetConfig target_config,
+                     gpu::GpuTargetConfig::FromProto(target_config_proto));
+    return std::make_unique<GpuTopology>(
+        "platform_version", /*num_partitions=*/1,
+        /*num_hosts_per_partition=*/1,
+        /*num_devices_per_host=*/num_replicas, target_config);
+  }
+
   absl::StatusOr<CollectiveBackendConfig::CollectiveKernelStrategy>
-  GetKernelStrategy(HloModule* module) {
+  GetKernelStrategy(HloModule* module, HloOpcode opcode) {
     for (HloComputation* comp : module->computations()) {
       for (HloInstruction* instr : comp->instructions()) {
-        if (instr->opcode() == HloOpcode::kAllReduce) {
+        if (instr->opcode() == opcode) {
           ASSIGN_OR_RETURN(GpuBackendConfig cfg,
                            instr->backend_config<GpuBackendConfig>());
           return cfg.collective_backend_config().kernel_strategy();
@@ -91,6 +110,12 @@ class CollectiveKernelStrategyAnnotatorTest
       }
     }
     return CollectiveBackendConfig::KERNEL_STRATEGY_DEFAULT;
+  }
+
+  // Overload for backward compatibility with existing AllReduce tests.
+  absl::StatusOr<CollectiveBackendConfig::CollectiveKernelStrategy>
+  GetKernelStrategy(HloModule* module) {
+    return GetKernelStrategy(module, HloOpcode::kAllReduce);
   }
 
   se::DeviceDescription device_info_;
@@ -148,6 +173,118 @@ TEST_F(CollectiveKernelStrategyAnnotatorTest,
 
   ASSERT_OK_AND_ASSIGN(auto strategy_default, GetKernelStrategy(module.get()));
   EXPECT_EQ(strategy_default, CollectiveBackendConfig::KERNEL_STRATEGY_DEFAULT);
+}
+
+// ---- AllGather annotator tests -------------------------------------------
+
+// HLO template for AllGather: input is f32[num_elements], output is
+// f32[num_elements * num_replicas] gathered along dimension 0.
+constexpr absl::string_view kAllGatherHloTemplate = R"(
+  HloModule all_gather_test
+
+  ENTRY e {
+    p0 = f32[%1$d] parameter(0)
+    ROOT all-gather = f32[%2$d] all-gather(p0),
+        dimensions={0},
+        replica_groups={{%3$s}}
+  }
+)";
+
+// 4096 F32 elements per replica (16 KB) with 8 replicas → output 32768
+// elements. 4096 * 4 = 16384 bytes, aligned to 128 bits (16 bytes) → eligible →
+// KERNEL_STRATEGY_TRITON_ONE_SHOT.
+TEST_F(CollectiveKernelStrategyAnnotatorTest,
+       EligibleAllGatherIsAnnotatedOneShot) {
+  constexpr int kNumReplicas = 8;
+  constexpr int64_t kInputElements = 4096;
+  constexpr int64_t kOutputElements = kInputElements * kNumReplicas;
+  std::string replica_groups_str = "0,1,2,3,4,5,6,7";
+  std::string hlo = absl::StrFormat(kAllGatherHloTemplate, kInputElements,
+                                    kOutputElements, replica_groups_str);
+
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       ParseAndReturnVerifiedModule(hlo, kNumReplicas));
+  ASSERT_OK_AND_ASSIGN(auto local_topology, MakeLocalGpuTopology(kNumReplicas));
+
+  CollectiveKernelStrategyAnnotator annotator(*local_topology,
+                                              /*is_multimem_enabled=*/false);
+  ASSERT_OK(annotator.Run(module.get()).status());
+
+  ASSERT_OK_AND_ASSIGN(auto strategy,
+                       GetKernelStrategy(module.get(), HloOpcode::kAllGather));
+  EXPECT_EQ(strategy, CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT);
+}
+
+// 3 F32 elements per replica: 3 * 32 bits = 96 bits, not aligned to 128 bits
+// → ineligible → KERNEL_STRATEGY_DEFAULT (falls back to NCCL).
+TEST_F(CollectiveKernelStrategyAnnotatorTest,
+       IneligibleAllGatherKeepsDefaultStrategy) {
+  constexpr int kNumReplicas = 8;
+  // 3 F32 elements → 3 * 4 = 12 bytes, not aligned to 16 bytes → ineligible.
+  constexpr int64_t kInputElements = 3;
+  constexpr int64_t kOutputElements = kInputElements * kNumReplicas;
+  std::string replica_groups_str = "0,1,2,3,4,5,6,7";
+  std::string hlo = absl::StrFormat(kAllGatherHloTemplate, kInputElements,
+                                    kOutputElements, replica_groups_str);
+
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       ParseAndReturnVerifiedModule(hlo, kNumReplicas));
+  ASSERT_OK_AND_ASSIGN(auto local_topology, MakeLocalGpuTopology(kNumReplicas));
+
+  CollectiveKernelStrategyAnnotator annotator(*local_topology,
+                                              /*is_multimem_enabled=*/false);
+  ASSERT_OK(annotator.Run(module.get()).status());
+
+  ASSERT_OK_AND_ASSIGN(auto strategy,
+                       GetKernelStrategy(module.get(), HloOpcode::kAllGather));
+  EXPECT_EQ(strategy, CollectiveBackendConfig::KERNEL_STRATEGY_DEFAULT);
+}
+
+// Module with both AllReduce and AllGather: both should be annotated in a
+// single pass.
+TEST_F(CollectiveKernelStrategyAnnotatorTest,
+       BothAllReduceAndAllGatherAnnotatedInSameModule) {
+  constexpr int kNumReplicas = 8;
+  // Use 32768 elements for AllReduce (eligible one-shot), 4096 for AllGather.
+  constexpr absl::string_view kCombinedHlo = R"(
+    HloModule combined_test
+
+    add {
+      p0 = f32[] parameter(0)
+      p1 = f32[] parameter(1)
+      ROOT r = f32[] add(p0, p1)
+    }
+
+    ENTRY e {
+      p0 = f32[32768] parameter(0)
+      p1 = f32[4096] parameter(1)
+      all-reduce = f32[32768] all-reduce(p0),
+          replica_groups={{0,1,2,3,4,5,6,7}},
+          to_apply=add
+      all-gather = f32[32768] all-gather(p1),
+          dimensions={0},
+          replica_groups={{0,1,2,3,4,5,6,7}}
+      ROOT t = (f32[32768], f32[32768]) tuple(all-reduce, all-gather)
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kCombinedHlo, kNumReplicas));
+  ASSERT_OK_AND_ASSIGN(auto local_topology, MakeLocalGpuTopology(kNumReplicas));
+
+  CollectiveKernelStrategyAnnotator annotator(*local_topology,
+                                              /*is_multimem_enabled=*/false);
+  ASSERT_OK(annotator.Run(module.get()).status());
+
+  ASSERT_OK_AND_ASSIGN(auto ar_strategy,
+                       GetKernelStrategy(module.get(), HloOpcode::kAllReduce));
+  EXPECT_EQ(ar_strategy,
+            CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT);
+
+  ASSERT_OK_AND_ASSIGN(auto ag_strategy,
+                       GetKernelStrategy(module.get(), HloOpcode::kAllGather));
+  EXPECT_EQ(ag_strategy,
+            CollectiveBackendConfig::KERNEL_STRATEGY_TRITON_ONE_SHOT);
 }
 
 }  // namespace

--- a/xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator_test.cc
+++ b/xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator_test.cc
@@ -204,6 +204,10 @@ TEST_F(CollectiveKernelStrategyAnnotatorTest,
 
   ASSERT_OK_AND_ASSIGN(auto module,
                        ParseAndReturnVerifiedModule(hlo, kNumReplicas));
+  module->mutable_config()
+      .mutable_debug_options()
+      .add_xla_gpu_experimental_use_collective_kernels(
+          DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER);
   ASSERT_OK_AND_ASSIGN(auto local_topology, MakeLocalGpuTopology(kNumReplicas));
 
   CollectiveKernelStrategyAnnotator annotator(*local_topology,
@@ -229,6 +233,11 @@ TEST_F(CollectiveKernelStrategyAnnotatorTest,
 
   ASSERT_OK_AND_ASSIGN(auto module,
                        ParseAndReturnVerifiedModule(hlo, kNumReplicas));
+  // Flag is set so that the ineligibility comes from shape (not from the flag).
+  module->mutable_config()
+      .mutable_debug_options()
+      .add_xla_gpu_experimental_use_collective_kernels(
+          DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER);
   ASSERT_OK_AND_ASSIGN(auto local_topology, MakeLocalGpuTopology(kNumReplicas));
 
   CollectiveKernelStrategyAnnotator annotator(*local_topology,
@@ -270,6 +279,14 @@ TEST_F(CollectiveKernelStrategyAnnotatorTest,
 
   ASSERT_OK_AND_ASSIGN(
       auto module, ParseAndReturnVerifiedModule(kCombinedHlo, kNumReplicas));
+  module->mutable_config()
+      .mutable_debug_options()
+      .add_xla_gpu_experimental_use_collective_kernels(
+          DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE);
+  module->mutable_config()
+      .mutable_debug_options()
+      .add_xla_gpu_experimental_use_collective_kernels(
+          DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER);
   ASSERT_OK_AND_ASSIGN(auto local_topology, MakeLocalGpuTopology(kNumReplicas));
 
   CollectiveKernelStrategyAnnotator annotator(*local_topology,

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -471,7 +471,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_unsupported_enable_all_reduce_decomposer(false);
   opts.set_xla_gpu_unsupported_enable_ragged_all_to_all_decomposer(false);
   opts.add_xla_gpu_experimental_use_collective_kernels(
-      DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE);
+      DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE);
   opts.set_xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel(true);
   opts.set_xla_gpu_experimental_enable_fusion_autotuner(true);
   opts.set_xla_gpu_experimental_max_unroll_factor(32);
@@ -2978,91 +2978,22 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
                 debug_options->xla_gpu_experimental_stream_annotation(),
                 "Enable the experimental explicit stream annotation support. "
                 "If false, the annotations are ignored."));
-  // Custom parser for xla_gpu_experimental_use_collective_kernels.
-  // Accepts human-friendly names ("all-reduce", "all-gather") and
-  // proto enum names ("COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE", etc.) as well
-  // as the incremental +/- modifier syntax.
-  auto setter_for_xla_gpu_experimental_use_collective_kernels =
-      [debug_options](absl::string_view input) {
-        auto parse_one = [](absl::string_view value,
-                            DebugOptions::CollectiveKernelOpType* out) -> bool {
-          // Human-friendly aliases.
-          if (value == "all-reduce" || value == "all_reduce") {
-            *out = DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE;
-            return true;
-          }
-          if (value == "all-gather" || value == "all_gather") {
-            *out = DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER;
-            return true;
-          }
-          // Fall back to proto enum name (with or without prefix,
-          // case-insensitive).
-          std::string upper = absl::AsciiStrToUpper(value);
-          if (!absl::StartsWith(upper, "COLLECTIVE_KERNEL_OP_TYPE_")) {
-            upper = absl::StrCat("COLLECTIVE_KERNEL_OP_TYPE_", upper);
-          }
-          return DebugOptions::CollectiveKernelOpType_Parse(upper, out);
-        };
-
-        std::vector<absl::string_view> values =
-            absl::StrSplit(input, ',', absl::SkipEmpty());
-        // Check for incremental (+/-) syntax: delegate to SetterForRepeatedEnum
-        // by canonicalising the input so it only has full enum names.
-        bool has_modifier = false;
-        for (absl::string_view v : values) {
-          v = absl::StripAsciiWhitespace(v);
-          if (absl::StartsWith(v, "+") || absl::StartsWith(v, "-")) {
-            has_modifier = true;
-            break;
-          }
-        }
-        if (!has_modifier) {
-          // Full overwrite: clear and re-add.
-          debug_options->clear_xla_gpu_experimental_use_collective_kernels();
-        }
-        for (absl::string_view raw : values) {
-          raw = absl::StripAsciiWhitespace(raw);
-          if (raw.empty()) {
-            continue;
-          }
-          bool add = true;
-          if (absl::StartsWith(raw, "+")) {
-            raw = raw.substr(1);
-          } else if (absl::StartsWith(raw, "-")) {
-            add = false;
-            raw = raw.substr(1);
-          }
-          DebugOptions::CollectiveKernelOpType op_type;
-          if (!parse_one(raw, &op_type)) {
-            return false;
-          }
-          auto* ops =
-              debug_options
-                  ->mutable_xla_gpu_experimental_use_collective_kernels();
-          if (add) {
-            if (absl::c_find(*ops, static_cast<int>(op_type)) == ops->end()) {
-              ops->Add(op_type);
-            }
-          } else {
-            ops->erase(absl::c_find(*ops, static_cast<int>(op_type)));
-          }
-        }
-        return true;
-      };
-
   flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_use_collective_kernels",
-      setter_for_xla_gpu_experimental_use_collective_kernels,
+      SetterForRepeatedEnum<DebugOptions::CollectiveKernelType>(
+          "xla_gpu_experimental_use_collective_kernels",
+          /*enum_prefix=*/"COLLECTIVE_KERNEL_",
+          &DebugOptions::CollectiveKernelType_Parse,
+          debug_options->mutable_xla_gpu_experimental_use_collective_kernels()),
       collective_op_types_to_string(
           debug_options->xla_gpu_experimental_use_collective_kernels()),
       "Experimental: comma-separated filter of collective ops that should use "
       "custom kernels (e.g. Triton one-shot / two-shot) instead of NCCL. "
-      "Accepted values: all-reduce, all-gather (or all_reduce, all_gather, "
-      "or full enum names COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE / "
-      "COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER). Supports +/- incremental "
-      "modifiers. The deprecated "
+      "Accepted values: ALL_REDUCE, ALL_GATHER (case-insensitive; the "
+      "COLLECTIVE_KERNEL_ prefix may be omitted). Supports +/- "
+      "incremental modifiers (e.g. +ALL_REDUCE,-ALL_GATHER). The deprecated "
       "--xla_gpu_unsupported_use_all_reduce_one_shot_kernel flag also adds "
-      "'all-reduce' to this filter for legacy compatibility."));
+      "ALL_REDUCE to this filter for legacy compatibility."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_parallel_collective_overlap_limit",
       int32_setter_for(
@@ -3152,21 +3083,20 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
         const bool already_present =
             absl::c_find(
                 *ops,
-                static_cast<int>(
-                    DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE)) !=
+                static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE)) !=
             ops->end();
         if (value && !already_present) {
-          ops->Add(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE);
+          ops->Add(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE);
         } else if (!value) {
           ops->erase(absl::c_find(
-              *ops, static_cast<int>(
-                        DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE)));
+              *ops,
+              static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE)));
         }
         return true;
       },
       !debug_options->xla_gpu_experimental_use_collective_kernels().empty(),
       "DEPRECATED: Use "
-      "--xla_gpu_experimental_use_collective_kernels=all-reduce instead. "
+      "--xla_gpu_experimental_use_collective_kernels=ALL_REDUCE instead. "
       "Internal: Enable the one-shot kernel for single-host all-reduce "
       "operations."));
   flag_list->push_back(tsl::Flag(

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -470,7 +470,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_enable_scatter_determinism_expander(false);
   opts.set_xla_gpu_unsupported_enable_all_reduce_decomposer(false);
   opts.set_xla_gpu_unsupported_enable_ragged_all_to_all_decomposer(false);
-  opts.set_xla_gpu_unsupported_use_all_reduce_one_shot_kernel(true);
+  opts.add_xla_gpu_experimental_use_collective_kernels(
+      DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE);
   opts.set_xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel(true);
   opts.set_xla_gpu_experimental_enable_fusion_autotuner(true);
   opts.set_xla_gpu_experimental_max_unroll_factor(32);
@@ -2977,6 +2978,89 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
                 debug_options->xla_gpu_experimental_stream_annotation(),
                 "Enable the experimental explicit stream annotation support. "
                 "If false, the annotations are ignored."));
+  // Custom parser for xla_gpu_experimental_use_collective_kernels.
+  // Accepts human-friendly names ("all-reduce", "all-gather") and
+  // proto enum names ("COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE", etc.) as well
+  // as the incremental +/- modifier syntax.
+  auto setter_for_xla_gpu_experimental_use_collective_kernels =
+      [debug_options](absl::string_view input) {
+        auto parse_one = [](absl::string_view value,
+                            DebugOptions::CollectiveKernelOpType* out) -> bool {
+          // Human-friendly aliases.
+          if (value == "all-reduce" || value == "all_reduce") {
+            *out = DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE;
+            return true;
+          }
+          if (value == "all-gather" || value == "all_gather") {
+            *out = DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER;
+            return true;
+          }
+          // Fall back to proto enum name (with or without prefix,
+          // case-insensitive).
+          std::string upper = absl::AsciiStrToUpper(value);
+          if (!absl::StartsWith(upper, "COLLECTIVE_KERNEL_OP_TYPE_")) {
+            upper = absl::StrCat("COLLECTIVE_KERNEL_OP_TYPE_", upper);
+          }
+          return DebugOptions::CollectiveKernelOpType_Parse(upper, out);
+        };
+
+        std::vector<absl::string_view> values =
+            absl::StrSplit(input, ',', absl::SkipEmpty());
+        // Check for incremental (+/-) syntax: delegate to SetterForRepeatedEnum
+        // by canonicalising the input so it only has full enum names.
+        bool has_modifier = false;
+        for (absl::string_view v : values) {
+          v = absl::StripAsciiWhitespace(v);
+          if (absl::StartsWith(v, "+") || absl::StartsWith(v, "-")) {
+            has_modifier = true;
+            break;
+          }
+        }
+        if (!has_modifier) {
+          // Full overwrite: clear and re-add.
+          debug_options->clear_xla_gpu_experimental_use_collective_kernels();
+        }
+        for (absl::string_view raw : values) {
+          raw = absl::StripAsciiWhitespace(raw);
+          if (raw.empty()) continue;
+          bool add = true;
+          if (absl::StartsWith(raw, "+")) {
+            raw = raw.substr(1);
+          } else if (absl::StartsWith(raw, "-")) {
+            add = false;
+            raw = raw.substr(1);
+          }
+          DebugOptions::CollectiveKernelOpType op_type;
+          if (!parse_one(raw, &op_type)) {
+            return false;
+          }
+          auto* ops =
+              debug_options
+                  ->mutable_xla_gpu_experimental_use_collective_kernels();
+          if (add) {
+            if (absl::c_find(*ops, static_cast<int>(op_type)) == ops->end()) {
+              ops->Add(op_type);
+            }
+          } else {
+            ops->erase(absl::c_find(*ops, static_cast<int>(op_type)));
+          }
+        }
+        return true;
+      };
+
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_experimental_use_collective_kernels",
+      setter_for_xla_gpu_experimental_use_collective_kernels,
+      collective_op_types_to_string(
+          debug_options->xla_gpu_experimental_use_collective_kernels()),
+      "Experimental: comma-separated filter of collective ops that should use "
+      "custom kernels (e.g. Triton one-shot / two-shot) instead of NCCL. "
+      "Accepted values: all-reduce, all-gather (or all_reduce, all_gather, "
+      "or full enum names COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE / "
+      "COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER). Supports +/- incremental "
+      "modifiers. The deprecated "
+      "--xla_gpu_unsupported_use_all_reduce_one_shot_kernel flag also adds "
+      "'all-reduce' to this filter for legacy compatibility."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_parallel_collective_overlap_limit",
       int32_setter_for(
@@ -3059,19 +3143,30 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "overridden."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_unsupported_use_all_reduce_one_shot_kernel",
-      bool_setter_for(
-          &DebugOptions::
-              set_xla_gpu_unsupported_use_all_reduce_one_shot_kernel),
-      debug_options->xla_gpu_unsupported_use_all_reduce_one_shot_kernel(),
+      [debug_options](bool value) {
+        // Legacy: sync with xla_gpu_experimental_use_collective_kernels.
+        auto* ops = debug_options
+                        ->mutable_xla_gpu_experimental_use_collective_kernels();
+        const bool already_present =
+            absl::c_find(
+                *ops,
+                static_cast<int>(
+                    DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE)) !=
+            ops->end();
+        if (value && !already_present) {
+          ops->Add(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE);
+        } else if (!value) {
+          ops->erase(absl::c_find(
+              *ops, static_cast<int>(
+                        DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE)));
+        }
+        return true;
+      },
+      !debug_options->xla_gpu_experimental_use_collective_kernels().empty(),
+      "DEPRECATED: Use "
+      "--xla_gpu_experimental_use_collective_kernels=all-reduce instead. "
       "Internal: Enable the one-shot kernel for single-host all-reduce "
       "operations."));
-  flag_list->push_back(tsl::Flag(
-      "xla_gpu_unsupported_use_all_gather_triton_backend",
-      bool_setter_for(
-          &DebugOptions::set_xla_gpu_unsupported_use_all_gather_triton_backend),
-      debug_options->xla_gpu_unsupported_use_all_gather_triton_backend(),
-      "Internal: Enable Triton collective kernel backend for single-host "
-      "all-gather operations."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel",
       bool_setter_for(
@@ -3589,8 +3684,7 @@ FlagStatus GetFlagStatus(absl::string_view flag_name) {
           "xla_gpu_all_reduce_combine_threshold_bytes",
           "xla_gpu_autotune_level",
           "xla_gpu_collective_permute_decomposer_threshold",
-          "xla_gpu_cublas_fallback",
-          "xla_gpu_dot_merger_threshold_mb",
+          "xla_gpu_cublas_fallback", "xla_gpu_dot_merger_threshold_mb",
           "xla_gpu_enable_dynamic_slice_fusion",
           "xla_gpu_enable_latency_hiding_scheduler",
           "xla_gpu_enable_pipelined_all_gather",

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -108,7 +108,8 @@ absl::StatusOr<std::vector<RepeatedFlagModifier>> ParseRepeatedEnumModifiers(
 namespace {
 
 template <typename T>
-static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list, T value) {
+static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list,
+                                   T value) {
   for (auto it = list->begin(); it != list->end(); ++it) {
     if (*it == value) {
       return it;
@@ -3064,6 +3065,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_unsupported_use_all_reduce_one_shot_kernel(),
       "Internal: Enable the one-shot kernel for single-host all-reduce "
       "operations."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_unsupported_use_all_gather_triton_backend",
+      bool_setter_for(
+          &DebugOptions::set_xla_gpu_unsupported_use_all_gather_triton_backend),
+      debug_options->xla_gpu_unsupported_use_all_gather_triton_backend(),
+      "Internal: Enable Triton collective kernel backend for single-host "
+      "all-gather operations."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel",
       bool_setter_for(

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -3022,7 +3022,9 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
         }
         for (absl::string_view raw : values) {
           raw = absl::StripAsciiWhitespace(raw);
-          if (raw.empty()) continue;
+          if (raw.empty()) {
+            continue;
+          }
           bool add = true;
           if (absl::StartsWith(raw, "+")) {
             raw = raw.substr(1);

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -2983,8 +2983,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       SetterForRepeatedEnum<DebugOptions::CollectiveKernelType>(
           "xla_gpu_experimental_use_collective_kernels",
           /*enum_prefix=*/"COLLECTIVE_KERNEL_",
-          &DebugOptions::CollectiveKernelType_Parse,
-          debug_options->mutable_xla_gpu_experimental_use_collective_kernels()),
+          [](absl::string_view s, DebugOptions::CollectiveKernelType* v) {
+            return DebugOptions::CollectiveKernelType_Parse(s, v);
+          },
+          [debug_options]() {
+            return debug_options
+                ->mutable_xla_gpu_experimental_use_collective_kernels();
+          }),
       collective_op_types_to_string(
           debug_options->xla_gpu_experimental_use_collective_kernels()),
       "Experimental: comma-separated filter of collective ops that should use "

--- a/xla/debug_options_flags_test.cc
+++ b/xla/debug_options_flags_test.cc
@@ -22,10 +22,10 @@ limitations under the License.
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/container/flat_hash_set.h"
-#include "absl/strings/str_cat.h"
 #include "google/protobuf/descriptor.h"
 #include "xla/parse_flags_from_env.h"
 #include "xla/tsl/platform/env.h"
+#include "xla/tsl/util/command_line_flags.h"
 #include "xla/xla.pb.h"
 #include "xla/xla_data.pb.h"
 #include "tsl/platform/protobuf.h"
@@ -203,7 +203,7 @@ DebugOptions ParseCollectiveKernelsFlag(const std::string& value) {
   std::vector<tsl::Flag> flags;
   MakeDebugOptionsFlags(&flags, &opts);
   std::string flag_str =
-      absl::StrCat("--xla_gpu_experimental_use_collective_kernels=", value);
+      "--xla_gpu_experimental_use_collective_kernels=" + value;
   std::vector<char*> argv = {const_cast<char*>("test"),
                              const_cast<char*>(flag_str.c_str())};
   int argc = static_cast<int>(argv.size());

--- a/xla/debug_options_flags_test.cc
+++ b/xla/debug_options_flags_test.cc
@@ -214,47 +214,47 @@ DebugOptions ParseCollectiveKernelsFlag(const std::string& value) {
 // ---- xla_gpu_experimental_use_collective_kernels user-friendly name tests ---
 
 TEST(DebugOptions, CollectiveKernelsFlagHyphenatedAllReduce) {
-  DebugOptions opts = ParseCollectiveKernelsFlag("all-reduce");
+  DebugOptions opts = ParseCollectiveKernelsFlag("ALL_REDUCE");
   EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
-              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE));
 }
 
 TEST(DebugOptions, CollectiveKernelsFlagUnderscoreAllReduce) {
   DebugOptions opts = ParseCollectiveKernelsFlag("all_reduce");
   EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
-              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE));
 }
 
 TEST(DebugOptions, CollectiveKernelsFlagHyphenatedAllGather) {
-  DebugOptions opts = ParseCollectiveKernelsFlag("all-gather");
+  DebugOptions opts = ParseCollectiveKernelsFlag("ALL_GATHER");
   EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
-              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER));
 }
 
 TEST(DebugOptions, CollectiveKernelsFlagUnderscoreAllGather) {
   DebugOptions opts = ParseCollectiveKernelsFlag("all_gather");
   EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
-              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER));
 }
 
 TEST(DebugOptions, CollectiveKernelsFlagBothHyphenated) {
-  DebugOptions opts = ParseCollectiveKernelsFlag("all-reduce,all-gather");
+  DebugOptions opts = ParseCollectiveKernelsFlag("ALL_REDUCE,ALL_GATHER");
   EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
-              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE,
-                          DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE,
+                          DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER));
 }
 
 TEST(DebugOptions, CollectiveKernelsFlagFullEnumName) {
   DebugOptions opts =
-      ParseCollectiveKernelsFlag("COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE");
+      ParseCollectiveKernelsFlag("COLLECTIVE_KERNEL_ALL_REDUCE");
   EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
-              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE));
 }
 
 TEST(DebugOptions, CollectiveKernelsFlagShortEnumNameUppercase) {
   DebugOptions opts = ParseCollectiveKernelsFlag("ALL_REDUCE");
   EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
-              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE));
 }
 
 TEST(DebugOptions, CollectiveKernelsFlagEmptyDisablesAll) {
@@ -270,26 +270,26 @@ TEST(DebugOptions, CollectiveKernelsFlagIncrementalAdd) {
   // First parse: set to all-reduce only.
   {
     std::string flag_str =
-        "--xla_gpu_experimental_use_collective_kernels=all-reduce";
+        "--xla_gpu_experimental_use_collective_kernels=ALL_REDUCE";
     std::vector<char*> argv = {const_cast<char*>("test"),
                                const_cast<char*>(flag_str.c_str())};
     int argc = static_cast<int>(argv.size());
     EXPECT_TRUE(tsl::Flags::Parse(&argc, argv.data(), flags));
   }
   EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
-              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE));
   // Second parse: incrementally add all-gather.
   {
     std::string flag_str =
-        "--xla_gpu_experimental_use_collective_kernels=+all-gather";
+        "--xla_gpu_experimental_use_collective_kernels=+ALL_GATHER";
     std::vector<char*> argv = {const_cast<char*>("test"),
                                const_cast<char*>(flag_str.c_str())};
     int argc = static_cast<int>(argv.size());
     EXPECT_TRUE(tsl::Flags::Parse(&argc, argv.data(), flags));
   }
   EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
-              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE,
-                          DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE,
+                          DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER));
 }
 
 TEST(DebugOptions, CollectiveKernelsFlagIncrementalRemove) {
@@ -300,26 +300,26 @@ TEST(DebugOptions, CollectiveKernelsFlagIncrementalRemove) {
   // First parse: set to both.
   {
     std::string flag_str =
-        "--xla_gpu_experimental_use_collective_kernels=all-reduce,all-gather";
+        "--xla_gpu_experimental_use_collective_kernels=ALL_REDUCE,ALL_GATHER";
     std::vector<char*> argv = {const_cast<char*>("test"),
                                const_cast<char*>(flag_str.c_str())};
     int argc = static_cast<int>(argv.size());
     EXPECT_TRUE(tsl::Flags::Parse(&argc, argv.data(), flags));
   }
   EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
-              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE,
-                          DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE,
+                          DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER));
   // Second parse: incrementally remove all-reduce.
   {
     std::string flag_str =
-        "--xla_gpu_experimental_use_collective_kernels=-all-reduce";
+        "--xla_gpu_experimental_use_collective_kernels=-ALL_REDUCE";
     std::vector<char*> argv = {const_cast<char*>("test"),
                                const_cast<char*>(flag_str.c_str())};
     int argc = static_cast<int>(argv.size());
     EXPECT_TRUE(tsl::Flags::Parse(&argc, argv.data(), flags));
   }
   EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
-              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER));
 }
 
 TEST(DebugOptions, CollectiveKernelsFlagNoDuplicates) {
@@ -329,14 +329,14 @@ TEST(DebugOptions, CollectiveKernelsFlagNoDuplicates) {
   MakeDebugOptionsFlags(&flags, &opts);
   for (int i = 0; i < 2; ++i) {
     std::string flag_str =
-        "--xla_gpu_experimental_use_collective_kernels=+all-reduce";
+        "--xla_gpu_experimental_use_collective_kernels=+ALL_REDUCE";
     std::vector<char*> argv = {const_cast<char*>("test"),
                                const_cast<char*>(flag_str.c_str())};
     int argc = static_cast<int>(argv.size());
     EXPECT_TRUE(tsl::Flags::Parse(&argc, argv.data(), flags));
   }
   EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
-              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE));
 }
 
 }  // namespace

--- a/xla/debug_options_flags_test.cc
+++ b/xla/debug_options_flags_test.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/container/flat_hash_set.h"
+#include "absl/strings/str_cat.h"
 #include "google/protobuf/descriptor.h"
 #include "xla/parse_flags_from_env.h"
 #include "xla/tsl/platform/env.h"
@@ -193,6 +194,149 @@ TEST(DebugOptions, EnableNcclSymmetricBuffersForCollectives) {
     EXPECT_FALSE(filter.has_max_size_bytes());
     EXPECT_FALSE(filter.has_op_type());
   }
+}
+
+// Helper that parses a single flag value using MakeDebugOptionsFlags and
+// returns the resulting DebugOptions.  The flag is passed as "--name=value".
+DebugOptions ParseCollectiveKernelsFlag(const std::string& value) {
+  DebugOptions opts;
+  std::vector<tsl::Flag> flags;
+  MakeDebugOptionsFlags(&flags, &opts);
+  std::string flag_str =
+      absl::StrCat("--xla_gpu_experimental_use_collective_kernels=", value);
+  std::vector<char*> argv = {const_cast<char*>("test"),
+                             const_cast<char*>(flag_str.c_str())};
+  int argc = static_cast<int>(argv.size());
+  EXPECT_TRUE(tsl::Flags::Parse(&argc, argv.data(), flags));
+  return opts;
+}
+
+// ---- xla_gpu_experimental_use_collective_kernels user-friendly name tests ---
+
+TEST(DebugOptions, CollectiveKernelsFlagHyphenatedAllReduce) {
+  DebugOptions opts = ParseCollectiveKernelsFlag("all-reduce");
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
+}
+
+TEST(DebugOptions, CollectiveKernelsFlagUnderscoreAllReduce) {
+  DebugOptions opts = ParseCollectiveKernelsFlag("all_reduce");
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
+}
+
+TEST(DebugOptions, CollectiveKernelsFlagHyphenatedAllGather) {
+  DebugOptions opts = ParseCollectiveKernelsFlag("all-gather");
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
+}
+
+TEST(DebugOptions, CollectiveKernelsFlagUnderscoreAllGather) {
+  DebugOptions opts = ParseCollectiveKernelsFlag("all_gather");
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
+}
+
+TEST(DebugOptions, CollectiveKernelsFlagBothHyphenated) {
+  DebugOptions opts = ParseCollectiveKernelsFlag("all-reduce,all-gather");
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE,
+                          DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
+}
+
+TEST(DebugOptions, CollectiveKernelsFlagFullEnumName) {
+  DebugOptions opts =
+      ParseCollectiveKernelsFlag("COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE");
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
+}
+
+TEST(DebugOptions, CollectiveKernelsFlagShortEnumNameUppercase) {
+  DebugOptions opts = ParseCollectiveKernelsFlag("ALL_REDUCE");
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
+}
+
+TEST(DebugOptions, CollectiveKernelsFlagEmptyDisablesAll) {
+  DebugOptions opts = ParseCollectiveKernelsFlag("");
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(), IsEmpty());
+}
+
+TEST(DebugOptions, CollectiveKernelsFlagIncrementalAdd) {
+  // Start with all-reduce (from default), then add all-gather via +.
+  DebugOptions opts;
+  std::vector<tsl::Flag> flags;
+  MakeDebugOptionsFlags(&flags, &opts);
+  // First parse: set to all-reduce only.
+  {
+    std::string flag_str =
+        "--xla_gpu_experimental_use_collective_kernels=all-reduce";
+    std::vector<char*> argv = {const_cast<char*>("test"),
+                               const_cast<char*>(flag_str.c_str())};
+    int argc = static_cast<int>(argv.size());
+    EXPECT_TRUE(tsl::Flags::Parse(&argc, argv.data(), flags));
+  }
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
+  // Second parse: incrementally add all-gather.
+  {
+    std::string flag_str =
+        "--xla_gpu_experimental_use_collective_kernels=+all-gather";
+    std::vector<char*> argv = {const_cast<char*>("test"),
+                               const_cast<char*>(flag_str.c_str())};
+    int argc = static_cast<int>(argv.size());
+    EXPECT_TRUE(tsl::Flags::Parse(&argc, argv.data(), flags));
+  }
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE,
+                          DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
+}
+
+TEST(DebugOptions, CollectiveKernelsFlagIncrementalRemove) {
+  // Start with both, then remove all-reduce via -.
+  DebugOptions opts;
+  std::vector<tsl::Flag> flags;
+  MakeDebugOptionsFlags(&flags, &opts);
+  // First parse: set to both.
+  {
+    std::string flag_str =
+        "--xla_gpu_experimental_use_collective_kernels=all-reduce,all-gather";
+    std::vector<char*> argv = {const_cast<char*>("test"),
+                               const_cast<char*>(flag_str.c_str())};
+    int argc = static_cast<int>(argv.size());
+    EXPECT_TRUE(tsl::Flags::Parse(&argc, argv.data(), flags));
+  }
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE,
+                          DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
+  // Second parse: incrementally remove all-reduce.
+  {
+    std::string flag_str =
+        "--xla_gpu_experimental_use_collective_kernels=-all-reduce";
+    std::vector<char*> argv = {const_cast<char*>("test"),
+                               const_cast<char*>(flag_str.c_str())};
+    int argc = static_cast<int>(argv.size());
+    EXPECT_TRUE(tsl::Flags::Parse(&argc, argv.data(), flags));
+  }
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
+}
+
+TEST(DebugOptions, CollectiveKernelsFlagNoDuplicates) {
+  // Parsing the same value twice should not produce duplicates.
+  DebugOptions opts;
+  std::vector<tsl::Flag> flags;
+  MakeDebugOptionsFlags(&flags, &opts);
+  for (int i = 0; i < 2; ++i) {
+    std::string flag_str =
+        "--xla_gpu_experimental_use_collective_kernels=+all-reduce";
+    std::vector<char*> argv = {const_cast<char*>("test"),
+                               const_cast<char*>(flag_str.c_str())};
+    int argc = static_cast<int>(argv.size());
+    EXPECT_TRUE(tsl::Flags::Parse(&argc, argv.data(), flags));
+  }
+  EXPECT_THAT(opts.xla_gpu_experimental_use_collective_kernels(),
+              ElementsAre(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
 }
 
 }  // namespace

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -511,6 +511,7 @@ cc_library(
         "//xla/backends/gpu/codegen/triton:triton_kernel_source",
         "//xla/backends/gpu/codegen/triton:xtile_compiler",
         "//xla/backends/gpu/runtime:all_gather_thunk",
+        "//xla/backends/gpu/runtime:all_gather",
         "//xla/backends/gpu/runtime:all_reduce",
         "//xla/backends/gpu/runtime:all_reduce_thunk",
         "//xla/backends/gpu/runtime:all_to_all_thunk",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1443,10 +1443,18 @@ void AddCollectiveCombinerPasses(
   // of the NCCL ring model.  Only added when the Triton collective kernel flag
   // is enabled; when the flag is off all collectives keep
   // KERNEL_STRATEGY_DEFAULT.
+  // Run the annotator if any collective kernel type is enabled.
+  // It annotates AllReduce and AllGather instructions with the
+  // kernel strategy determined at compile time (before scheduling),
+  // so that SolLatencyEstimator and the thunk emitter can consume it.
   if (absl::c_linear_search(
           opts.xla_gpu_experimental_use_collective_kernels(),
           static_cast<int>(
-              DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE))) {
+              DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE)) ||
+      absl::c_linear_search(
+          opts.xla_gpu_experimental_use_collective_kernels(),
+          static_cast<int>(
+              DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER))) {
     pipeline.AddPass<CollectiveKernelStrategyAnnotator>(
         gpu_topology, /*is_multimem_enabled=*/false);
   }

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1443,7 +1443,10 @@ void AddCollectiveCombinerPasses(
   // of the NCCL ring model.  Only added when the Triton collective kernel flag
   // is enabled; when the flag is off all collectives keep
   // KERNEL_STRATEGY_DEFAULT.
-  if (opts.xla_gpu_unsupported_use_all_reduce_one_shot_kernel()) {
+  if (absl::c_linear_search(
+          opts.xla_gpu_experimental_use_collective_kernels(),
+          static_cast<int>(
+              DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE))) {
     pipeline.AddPass<CollectiveKernelStrategyAnnotator>(
         gpu_topology, /*is_multimem_enabled=*/false);
   }

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1449,12 +1449,10 @@ void AddCollectiveCombinerPasses(
   // so that SolLatencyEstimator and the thunk emitter can consume it.
   if (absl::c_linear_search(
           opts.xla_gpu_experimental_use_collective_kernels(),
-          static_cast<int>(
-              DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE)) ||
+          static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_ALL_REDUCE)) ||
       absl::c_linear_search(
           opts.xla_gpu_experimental_use_collective_kernels(),
-          static_cast<int>(
-              DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER))) {
+          static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER))) {
     pipeline.AddPass<CollectiveKernelStrategyAnnotator>(
         gpu_topology, /*is_multimem_enabled=*/false);
   }

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -255,13 +255,20 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveKernelThunk(
       NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
   HloFusionInstruction* fusion_instr = Cast<HloFusionInstruction>(
       fused_module->entry_computation()->root_instruction());
-  // Determine whether the collective kernel is enabled and whether flattening
-  // is needed, based on the opcode of the wrapped collective.
+  // For both AllReduce and AllGather the kernel strategy is determined by the
+  // annotation written by CollectiveKernelStrategyAnnotator before scheduling.
+  // Reading the annotation uniformly avoids direct flag checks in the emitter.
   const HloOpcode opcode = instr->opcode();
-  const auto& debug_options = instr->GetModule()->config().debug_options();
   bool should_flatten = false;
   bool is_collective_kernel_enabled = false;
-  if (opcode == HloOpcode::kAllReduce) {
+  if (auto gpu_config = instr->backend_config<GpuBackendConfig>();
+      gpu_config.ok()) {
+    is_collective_kernel_enabled = IsTritonCollectiveKernel(
+        gpu_config->collective_backend_config().kernel_strategy());
+  }
+  // For AllReduce two-shot, the fused module must be flattened to 1-D so
+  // Triton can assign contiguous subtiles to each rank.
+  if (opcode == HloOpcode::kAllReduce && is_collective_kernel_enabled) {
     static constexpr bool kMultimemDisabled = false;
     const int64_t size_bytes =
         ShapeUtil::ElementsIn(instr->shape()) *
@@ -271,14 +278,6 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveKernelThunk(
     should_flatten = has_rank_higher_than_1 &&
                      GetAllReduceStrategy(size_bytes, kMultimemDisabled) ==
                          se::gpu::AllReduceStrategy::kTwoShot;
-    is_collective_kernel_enabled = absl::c_linear_search(
-        debug_options.xla_gpu_experimental_use_collective_kernels(),
-        static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
-  } else if (opcode == HloOpcode::kAllGather) {
-    // AllGather is always one-shot; no flattening needed.
-    is_collective_kernel_enabled = absl::c_linear_search(
-        debug_options.xla_gpu_experimental_use_collective_kernels(),
-        static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
   }
   if (is_collective_kernel_enabled && should_flatten) {
     RETURN_IF_ERROR(FlattenCollectiveFusion(fusion_instr));
@@ -2077,41 +2076,10 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveThunk(
     use_triton = IsTritonCollectiveKernel(
         gpu_config_status->collective_backend_config().kernel_strategy());
   }
-  // For AllGather there is only one protocol (one-shot), so no strategy
-  // selection is needed. The Triton path is gated by the feature flag AND
-  // shape eligibility — not all shapes satisfy Triton's alignment/type
-  // requirements. When the flag is set but the shape is ineligible, we log
-  // and fall back to NCCL/RCCL.
-  if (!use_triton && kind == Thunk::Kind::kAllGather) {
-    if (absl::c_linear_search(
-            inst->GetModule()
-                ->config()
-                .debug_options()
-                .xla_gpu_experimental_use_collective_kernels(),
-            static_cast<int>(
-                DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER))) {
-      const DeviceAssignment* device_assignment = nullptr;
-      if (ir_emitter_context_->hlo_module()
-              .config()
-              .has_static_device_assignment()) {
-        device_assignment = &ir_emitter_context_->hlo_module()
-                                 .config()
-                                 .static_device_assignment();
-      }
-      absl::StatusOr<AllGatherInfo> info = BuildAllGatherInfo(
-          /*is_collective_kernel_enabled=*/true,
-          ir_emitter_context_->gpu_topology(),
-          Cast<HloAllGatherInstruction>(inst), device_assignment);
-      if (info.ok()) {
-        use_triton = true;
-      } else {
-        LOG(WARNING)
-            << "AllGather Triton backend requested but shape is ineligible "
-               "— falling back to NCCL/RCCL: "
-            << info.status().message();
-      }
-    }
-  }
+  // For AllGather the strategy is now determined by the annotation written
+  // by CollectiveKernelStrategyAnnotator.
+  // `use_triton` was already set above by reading the backend_config
+  // annotation.
   if (use_triton) {
     CollectiveConfig collective_config =
         GetCollectiveConfig(inst, use_global_device_ids);

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -65,7 +65,6 @@ limitations under the License.
 #include "xla/backends/gpu/codegen/triton/fusion.h"
 #include "xla/backends/gpu/codegen/triton/triton_kernel_source.h"
 #include "xla/backends/gpu/codegen/triton/xtile_compiler.h"
-#include "xla/backends/gpu/runtime/all_gather.h"
 #include "xla/backends/gpu/runtime/all_gather_thunk.h"
 #include "xla/backends/gpu/runtime/all_reduce.h"
 #include "xla/backends/gpu/runtime/all_reduce_thunk.h"

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -374,9 +374,10 @@ absl::StatusOr<std::string> CanonicalGemmHlo(
          BackendConfigWrapper(gpu_config).GetRawString();
 }
 
-ThunkEmitter::ThunkEmitter(IrEmitterContext* absl_nonnull ir_emitter_context,
-                           llvm_ir::LLVMCommandLineOptionsReleasableLock*
-                               absl_nonnull llvm_options_lock)
+ThunkEmitter::ThunkEmitter(
+    IrEmitterContext* absl_nonnull ir_emitter_context,
+    llvm_ir::LLVMCommandLineOptionsReleasableLock* absl_nonnull
+        llvm_options_lock)
     : ir_emitter_context_(ir_emitter_context),
       send_recv_events_(std::make_shared<HostSendRecvAsyncEvents>()),
       call_graph_(CallGraph::Build(&ir_emitter_context->hlo_module())),

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -65,6 +65,7 @@ limitations under the License.
 #include "xla/backends/gpu/codegen/triton/fusion.h"
 #include "xla/backends/gpu/codegen/triton/triton_kernel_source.h"
 #include "xla/backends/gpu/codegen/triton/xtile_compiler.h"
+#include "xla/backends/gpu/runtime/all_gather.h"
 #include "xla/backends/gpu/runtime/all_gather_thunk.h"
 #include "xla/backends/gpu/runtime/all_reduce.h"
 #include "xla/backends/gpu/runtime/all_reduce_thunk.h"
@@ -254,22 +255,29 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveKernelThunk(
       NewModuleWithFusion(instr, HloInstruction::FusionKind::kLoop);
   HloFusionInstruction* fusion_instr = Cast<HloFusionInstruction>(
       fused_module->entry_computation()->root_instruction());
-  static constexpr bool kMultimemDisabled = false;
-  const bool should_flatten = [&](const HloInstruction* instr) {
+  // Determine whether the collective kernel is enabled and whether flattening
+  // is needed, based on the opcode of the wrapped collective.
+  const HloOpcode opcode = instr->opcode();
+  const auto& debug_options = instr->GetModule()->config().debug_options();
+  bool should_flatten = false;
+  bool is_collective_kernel_enabled = false;
+  if (opcode == HloOpcode::kAllReduce) {
+    static constexpr bool kMultimemDisabled = false;
     const int64_t size_bytes =
         ShapeUtil::ElementsIn(instr->shape()) *
         primitive_util::ByteWidth(instr->shape().element_type());
     const bool has_rank_higher_than_1 =
         instr->shape().IsArray() && instr->shape().dimensions().size() > 1;
-    return has_rank_higher_than_1 &&
-           GetAllReduceStrategy(size_bytes, kMultimemDisabled) ==
-               se::gpu::AllReduceStrategy::kTwoShot;
-  }(instr);
-  bool is_collective_kernel_enabled =
-      instr->GetModule()
-          ->config()
-          .debug_options()
-          .xla_gpu_unsupported_use_all_reduce_one_shot_kernel();
+    should_flatten = has_rank_higher_than_1 &&
+                     GetAllReduceStrategy(size_bytes, kMultimemDisabled) ==
+                         se::gpu::AllReduceStrategy::kTwoShot;
+    is_collective_kernel_enabled =
+        debug_options.xla_gpu_unsupported_use_all_reduce_one_shot_kernel();
+  } else if (opcode == HloOpcode::kAllGather) {
+    // AllGather is always one-shot; no flattening needed.
+    is_collective_kernel_enabled =
+        debug_options.xla_gpu_unsupported_use_all_gather_triton_backend();
+  }
   if (is_collective_kernel_enabled && should_flatten) {
     RETURN_IF_ERROR(FlattenCollectiveFusion(fusion_instr));
   }
@@ -366,10 +374,9 @@ absl::StatusOr<std::string> CanonicalGemmHlo(
          BackendConfigWrapper(gpu_config).GetRawString();
 }
 
-ThunkEmitter::ThunkEmitter(
-    IrEmitterContext* absl_nonnull ir_emitter_context,
-    llvm_ir::LLVMCommandLineOptionsReleasableLock* absl_nonnull
-        llvm_options_lock)
+ThunkEmitter::ThunkEmitter(IrEmitterContext* absl_nonnull ir_emitter_context,
+                           llvm_ir::LLVMCommandLineOptionsReleasableLock*
+                               absl_nonnull llvm_options_lock)
     : ir_emitter_context_(ir_emitter_context),
       send_recv_events_(std::make_shared<HostSendRecvAsyncEvents>()),
       call_graph_(CallGraph::Build(&ir_emitter_context->hlo_module())),
@@ -2067,6 +2074,38 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveThunk(
       gpu_config_status.ok()) {
     use_triton = IsTritonCollectiveKernel(
         gpu_config_status->collective_backend_config().kernel_strategy());
+  }
+  // For AllGather there is only one protocol (one-shot), so no strategy
+  // selection is needed. The Triton path is gated by the feature flag AND
+  // shape eligibility — not all shapes satisfy Triton's alignment/type
+  // requirements. When the flag is set but the shape is ineligible, we log
+  // and fall back to NCCL/RCCL.
+  if (!use_triton && kind == Thunk::Kind::kAllGather) {
+    if (inst->GetModule()
+            ->config()
+            .debug_options()
+            .xla_gpu_unsupported_use_all_gather_triton_backend()) {
+      const DeviceAssignment* device_assignment = nullptr;
+      if (ir_emitter_context_->hlo_module()
+              .config()
+              .has_static_device_assignment()) {
+        device_assignment = &ir_emitter_context_->hlo_module()
+                                 .config()
+                                 .static_device_assignment();
+      }
+      absl::StatusOr<AllGatherInfo> info = BuildAllGatherInfo(
+          /*is_collective_kernel_enabled=*/true,
+          ir_emitter_context_->gpu_topology(),
+          Cast<HloAllGatherInstruction>(inst), device_assignment);
+      if (info.ok()) {
+        use_triton = true;
+      } else {
+        LOG(WARNING)
+            << "AllGather Triton backend requested but shape is ineligible "
+               "— falling back to NCCL/RCCL: "
+            << info.status().message();
+      }
+    }
   }
   if (use_triton) {
     CollectiveConfig collective_config =

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -271,12 +271,14 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveKernelThunk(
     should_flatten = has_rank_higher_than_1 &&
                      GetAllReduceStrategy(size_bytes, kMultimemDisabled) ==
                          se::gpu::AllReduceStrategy::kTwoShot;
-    is_collective_kernel_enabled =
-        debug_options.xla_gpu_unsupported_use_all_reduce_one_shot_kernel();
+    is_collective_kernel_enabled = absl::c_linear_search(
+        debug_options.xla_gpu_experimental_use_collective_kernels(),
+        static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE));
   } else if (opcode == HloOpcode::kAllGather) {
     // AllGather is always one-shot; no flattening needed.
-    is_collective_kernel_enabled =
-        debug_options.xla_gpu_unsupported_use_all_gather_triton_backend();
+    is_collective_kernel_enabled = absl::c_linear_search(
+        debug_options.xla_gpu_experimental_use_collective_kernels(),
+        static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER));
   }
   if (is_collective_kernel_enabled && should_flatten) {
     RETURN_IF_ERROR(FlattenCollectiveFusion(fusion_instr));
@@ -2081,10 +2083,13 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveThunk(
   // requirements. When the flag is set but the shape is ineligible, we log
   // and fall back to NCCL/RCCL.
   if (!use_triton && kind == Thunk::Kind::kAllGather) {
-    if (inst->GetModule()
-            ->config()
-            .debug_options()
-            .xla_gpu_unsupported_use_all_gather_triton_backend()) {
+    if (absl::c_linear_search(
+            inst->GetModule()
+                ->config()
+                .debug_options()
+                .xla_gpu_experimental_use_collective_kernels(),
+            static_cast<int>(
+                DebugOptions::COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER))) {
       const DeviceAssignment* device_assignment = nullptr;
       if (ir_emitter_context_->hlo_module()
               .config()

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -98,6 +98,15 @@ message DebugOptions {
     reserved 10;
   }
 
+  // Collective operation types for which a custom collective kernel
+  // (e.g. Triton one-shot / two-shot) should be used instead of NCCL.
+  // Used with xla_gpu_experimental_use_collective_kernels.
+  enum CollectiveKernelOpType {
+    COLLECTIVE_KERNEL_OP_TYPE_INVALID = 0;
+    COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE = 1;
+    COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER = 2;
+  }
+
   enum LibNvJitLinkMode {
     // LibNvJitLink is used if it is available and no buggy version has been
     // detected.
@@ -993,6 +1002,14 @@ message DebugOptions {
 
   optional bool xla_gpu_experimental_stream_annotation = 342;
 
+  // Experimental: filter specifying which collective operations should use
+  // custom kernels (e.g. Triton one-shot / two-shot) instead of NCCL.
+  // Accepted values: "all-reduce", "all-gather".
+  // For legacy support, the deprecated
+  // --xla_gpu_unsupported_use_all_reduce_one_shot_kernel flag also adds
+  // all-reduce to this filter.
+  repeated CollectiveKernelOpType xla_gpu_experimental_use_collective_kernels = 513;
+
   // If true, use the ragged dot fusion emitter rather than expanding to a
   // regular dot.
   optional bool xla_gpu_experimental_use_ragged_dot_fusion = 401;
@@ -1243,11 +1260,8 @@ message DebugOptions {
 
   // Internal testing flag to enable one-shot kernel for single-host
   // all-reduce operations.
-  optional bool xla_gpu_unsupported_use_all_reduce_one_shot_kernel = 387;
-
-  // Internal testing flag to enable Triton collective kernel backend for
-  // single-host all-gather operations.
-  optional bool xla_gpu_unsupported_use_all_gather_triton_backend = 515;
+  optional bool xla_gpu_unsupported_use_all_reduce_one_shot_kernel = 387
+      [deprecated = true];
 
   // Internal testing flag to enable one-shot kernel for single-host
   // ragged-all-to-all operations.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -362,12 +362,6 @@ message DebugOptions {
   //--------------------------------------------------------------------------//
   // XLA:GPU options.
   //--------------------------------------------------------------------------//
-<<<<<<< HEAD
-=======
-  // clang-format off
-  // go/keep-sorted start newline_separated=yes skip_lines=2 ignore_prefixes=["optional AutotuneCacheMode","optional bool","optional float","optional int32","optional int64","optional LibNvJitLinkMode","map<string, string>","optional PGLEStrictnessLevel","optional PipelineParallelismOptLevel","repeated CollectiveOpType","repeated CollectiveKernelType","repeated CommandBufferCmdType","repeated string","optional ShapeChecks","optional string","optional WhileLoopUnrolling","repeated GenericTritonEmitterFeature","optional CommandBufferSchedulingMode", "repeated AutotuneBackend", "optional CollectivesMode","optional CommandBufferUpdateMode"] // NOLINT
-  // clang-format on
->>>>>>> 6f4ec509f5 (Update CollectiveKernelType names + update comments + improve code quality)
 
   // Memory mode for XLA:GPU collective operations.
   //

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1014,7 +1014,7 @@ message DebugOptions {
   // For legacy support, the deprecated
   // --xla_gpu_unsupported_use_all_reduce_one_shot_kernel flag also adds
   // all-reduce to this filter.
-  repeated CollectiveKernelType xla_gpu_experimental_use_collective_kernels = 515;
+  repeated CollectiveKernelType xla_gpu_experimental_use_collective_kernels = 516;
 
   // If true, use the ragged dot fusion emitter rather than expanding to a
   // regular dot.
@@ -1689,7 +1689,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 516
+  // Next id: 517
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1008,7 +1008,7 @@ message DebugOptions {
   // For legacy support, the deprecated
   // --xla_gpu_unsupported_use_all_reduce_one_shot_kernel flag also adds
   // all-reduce to this filter.
-  repeated CollectiveKernelType xla_gpu_experimental_use_collective_kernels = 516;
+  repeated CollectiveKernelType xla_gpu_experimental_use_collective_kernels = 515;
 
   // If true, use the ragged dot fusion emitter rather than expanding to a
   // regular dot.
@@ -1683,7 +1683,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 517
+  // Next id: 516
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1008,7 +1008,7 @@ message DebugOptions {
   // For legacy support, the deprecated
   // --xla_gpu_unsupported_use_all_reduce_one_shot_kernel flag also adds
   // all-reduce to this filter.
-  repeated CollectiveKernelOpType xla_gpu_experimental_use_collective_kernels = 513;
+  repeated CollectiveKernelOpType xla_gpu_experimental_use_collective_kernels = 515;
 
   // If true, use the ragged dot fusion emitter rather than expanding to a
   // regular dot.
@@ -1683,7 +1683,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 515
+  // Next id: 516
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1245,6 +1245,10 @@ message DebugOptions {
   // all-reduce operations.
   optional bool xla_gpu_unsupported_use_all_reduce_one_shot_kernel = 387;
 
+  // Internal testing flag to enable Triton collective kernel backend for
+  // single-host all-gather operations.
+  optional bool xla_gpu_unsupported_use_all_gather_triton_backend = 515;
+
   // Internal testing flag to enable one-shot kernel for single-host
   // ragged-all-to-all operations.
   optional bool xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel = 375;

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -101,10 +101,10 @@ message DebugOptions {
   // Collective operation types for which a custom collective kernel
   // (e.g. Triton one-shot / two-shot) should be used instead of NCCL.
   // Used with xla_gpu_experimental_use_collective_kernels.
-  enum CollectiveKernelOpType {
-    COLLECTIVE_KERNEL_OP_TYPE_INVALID = 0;
-    COLLECTIVE_KERNEL_OP_TYPE_ALL_REDUCE = 1;
-    COLLECTIVE_KERNEL_OP_TYPE_ALL_GATHER = 2;
+  enum CollectiveKernelType {
+    COLLECTIVE_KERNEL_INVALID = 0;
+    COLLECTIVE_KERNEL_ALL_REDUCE = 1;
+    COLLECTIVE_KERNEL_ALL_GATHER = 2;
   }
 
   enum LibNvJitLinkMode {
@@ -362,6 +362,12 @@ message DebugOptions {
   //--------------------------------------------------------------------------//
   // XLA:GPU options.
   //--------------------------------------------------------------------------//
+<<<<<<< HEAD
+=======
+  // clang-format off
+  // go/keep-sorted start newline_separated=yes skip_lines=2 ignore_prefixes=["optional AutotuneCacheMode","optional bool","optional float","optional int32","optional int64","optional LibNvJitLinkMode","map<string, string>","optional PGLEStrictnessLevel","optional PipelineParallelismOptLevel","repeated CollectiveOpType","repeated CollectiveKernelType","repeated CommandBufferCmdType","repeated string","optional ShapeChecks","optional string","optional WhileLoopUnrolling","repeated GenericTritonEmitterFeature","optional CommandBufferSchedulingMode", "repeated AutotuneBackend", "optional CollectivesMode","optional CommandBufferUpdateMode"] // NOLINT
+  // clang-format on
+>>>>>>> 6f4ec509f5 (Update CollectiveKernelType names + update comments + improve code quality)
 
   // Memory mode for XLA:GPU collective operations.
   //
@@ -1008,7 +1014,7 @@ message DebugOptions {
   // For legacy support, the deprecated
   // --xla_gpu_unsupported_use_all_reduce_one_shot_kernel flag also adds
   // all-reduce to this filter.
-  repeated CollectiveKernelOpType xla_gpu_experimental_use_collective_kernels = 515;
+  repeated CollectiveKernelType xla_gpu_experimental_use_collective_kernels = 515;
 
   // If true, use the ragged dot fusion emitter rather than expanding to a
   // regular dot.


### PR DESCRIPTION
📝 Summary of Changes
This PR is the second in a series of four.

PR 1/4: https://github.com/openxla/xla/pull/44559   
PR 2/4: https://github.com/openxla/xla/pull/44560   <--- This PR
PR 3/4: https://github.com/openxla/xla/pull/44562
PR 4/4: https://github.com/openxla/xla/pull/44564

These PRs aim to enable the Triton backend for the All-Gather collective operation based on the experimental tiling strategy.

The PR wires AllGather through CollectiveKernelThunk/AllGatherThunk at runtime, and adds a dedicated flag.

🎯 Justification
Lowering All-Gather through the triton backend significantly improves performance of this operation for AMD/ROCm target (compared to RCCL backend), especially for small tensor, and could allow us to take greater advantage of kernel-level fusion.

Example of 5 Triton Performance Improvements — All-Gather 1D on MI355
 | DType | Shape | Replicas | Triton (µs) | RCCL (µs) | Speedup |
|--------|--------|----------|------------------:|---------------:|--------:|
| s8 | [16384] | 2 | 17.428 | 42.342 | **2.43×** |
| bf16 | [16384] | 2 | 17.708 | 41.733 | **2.36×** |
| f32 | [131072] | 2 | 27.924 | 52.497 | **1.88×** |
| s32 | [4096] | 2 | 24.435 | 44.287 | **1.81×** |
| s8 | [262144] | 4 | 40.459 | 71.119 | **1.76×** |

Example of 5 Triton Performance Improvements — All-Gather 2D on MI355
dtype | shape | replicas | RCCL (µs) | Triton (µs) | speedup
-- | -- | -- | -- | -- | --
bf16 | [32, 32] | 2 | 41.153 | 16.744 | **2.46×**
bf16 | [128, 64] | 4 | 68.079 | 35.498 | **1.92×**
bf16 | [256, 256] | 4 | 68.927 | 36.992 | **1.86×**
f32 | [128, 64] | 4 | 64.403 | 34.928 | **1.84×**
f8e4m3fn | [512, 512] | 4 | 68.342 | 41.506 | **1.65×**

🚀 Kind of Contribution
Please remove what does not apply:⚡️ Performance Improvement, ✨ New Feature