### PR TITLE
[ROCm][Triton] StableHLO lowering & end-to-end tests (PR 4/4)

### DIFF
--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -729,6 +729,7 @@ cc_library(
         "//xla:util",
         "//xla:xla_data_proto_cc",
         "//xla/backends/gpu/codegen/triton/ir:triton_xla",
+        "//xla/backends/gpu/runtime:all_gather",
         "//xla/backends/gpu/runtime:all_reduce",
         "//xla/backends/gpu/runtime:collective_params",
         "//xla/backends/gpu/transforms/collectives:collective_ops_utils",

--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -58,6 +58,7 @@ limitations under the License.
 #include "stablehlo/dialect/StablehloOps.h"
 #include "xla/backends/gpu/codegen/triton/ir/triton_xla_ops.h"
 #include "xla/backends/gpu/codegen/triton/lowering_util.h"
+#include "xla/backends/gpu/runtime/all_gather.h"
 #include "xla/backends/gpu/runtime/all_reduce.h"
 #include "xla/backends/gpu/runtime/collective_params.h"
 #include "xla/backends/gpu/transforms/collectives/collective_ops_utils.h"
@@ -933,6 +934,321 @@ class AllReduceEmitter {
   bool initialized_ = false;
 };
 
+// =========================================================================
+// AllGather emitter
+// =========================================================================
+
+// Context for AllGather emitter.
+struct AllGatherEmitterContext {
+  mlir::stablehlo::AllGatherOp op;
+  int32_t num_input_output_args{0};
+  int32_t num_scratch_buffers{0};
+  xtile::EntryFuncOp xtile_entry_fn;
+  xtile::TensorValue input_tile;
+  xtile::ExtractTileOp input_extract;
+  llvm::SmallVector<int64_t, 4> non_tiled_input_shape;
+  PrimitiveType element_type;
+  int64_t world_size{0};
+  int64_t num_elements{0};
+  int64_t all_gather_dimension{0};
+};
+
+absl::StatusOr<AllGatherEmitterContext> CreateAllGatherEmitterContext(
+    mlir::stablehlo::AllGatherOp op) {
+  AllGatherEmitterContext ctx;
+  if (op.getOperands().size() != 1) {
+    return absl::InvalidArgumentError(
+        "AllGather op must have exactly one operand in order to be lowered "
+        "to triton.");
+  }
+
+  mlir::Type element_type =
+      mlir::cast<mlir::ShapedType>(op.getOperand(0).getType()).getElementType();
+  ctx.element_type = xla::ConvertMlirTypeToPrimitiveType(element_type);
+  if (ctx.element_type == PrimitiveType::PRIMITIVE_TYPE_INVALID) {
+    std::string type_string;
+    llvm::raw_string_ostream stream(type_string);
+    op.getOperand(0).print(stream);
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Could not convert operand type to a valid PrimitiveType. "
+        "Operand Type: %s",
+        type_string));
+  }
+
+  ctx.xtile_entry_fn = op->getParentOfType<xtile::EntryFuncOp>();
+  if (!ctx.xtile_entry_fn) {
+    return absl::InvalidArgumentError(
+        "AllGather op must be in an XTile entry function in order to be "
+        "lowered to triton.");
+  }
+
+  // One input buffer + one output buffer per operand. For AllGather the output
+  // is larger than the input (world_size × input), but both are counted here
+  // as a single buffer slot each in the kernel argument list.
+  ctx.num_input_output_args = op->getNumOperands() * 2;
+  ctx.num_scratch_buffers = op->getNumOperands();
+  const int32_t expected_num_args =
+      ctx.num_input_output_args + ctx.num_scratch_buffers +
+      kNumCollectiveMetadataArgs + kNumTileIndexArgs;
+  if (ctx.xtile_entry_fn.getNumArguments() != expected_num_args) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("AllGather op must have ", expected_num_args,
+                     " arguments in order to "
+                     "be lowered to triton, but it has ",
+                     ctx.xtile_entry_fn.getNumArguments()));
+  }
+
+  ctx.input_tile = mlir::cast<xtile::TensorValue>(op->getOperand(0));
+  ctx.input_extract =
+      llvm::dyn_cast<xtile::ExtractTileOp>(ctx.input_tile.getDefiningOp());
+  if (!ctx.input_extract &&
+      ctx.input_tile.getDefiningOp()->getNumOperands() > 0) {
+    // Workaround for boolean types (stored as i8, cast to i1).
+    ctx.input_extract = llvm::dyn_cast<xtile::ExtractTileOp>(
+        ctx.input_tile.getDefiningOp()->getOperand(0).getDefiningOp());
+  }
+  if (!ctx.input_extract) {
+    return absl::InvalidArgumentError(
+        "AllGather op must have an extract tile op as operand in order to be "
+        "lowered to triton.");
+  }
+
+  ctx.non_tiled_input_shape = llvm::SmallVector<int64_t, 4>(
+      ctx.input_extract.getSource().getType().getShape());
+  ctx.num_elements = Product(ctx.non_tiled_input_shape);
+  // Get world_size from replica_groups dimension 1.
+  ctx.world_size = mlir::cast<mlir::DenseIntElementsAttr>(op.getReplicaGroups())
+                       .getType()
+                       .getDimSize(1);
+  ctx.all_gather_dimension = op.getAllGatherDim();
+  ctx.op = op;
+
+  return ctx;
+}
+
+class AllGatherEmitter {
+ public:
+  static mlir::LogicalResult Emit(AllGatherEmitterContext ctx,
+                                  mlir::PatternRewriter& rewriter) {
+    AllGatherEmitter emitter(std::move(ctx), rewriter);
+    if (auto result = emitter.Initialize(); !result.ok()) {
+      LOG(ERROR) << "Failed to initialize AllGatherEmitter: "
+                 << result.message();
+      return mlir::failure();
+    }
+    return emitter.EmitAllGather();
+  }
+
+ private:
+  AllGatherEmitter(AllGatherEmitterContext ctx, mlir::PatternRewriter& rewriter)
+      : ctx_(std::move(ctx)),
+        rewriter_(rewriter),
+        builder_(ctx_.op->getLoc(), rewriter) {}
+
+  absl::Status Initialize() {
+    CHECK(!initialized_);
+
+    // 1. Opaque arguments (start after input/output args).
+    const int32_t start_idx = ctx_.num_input_output_args;
+    device_rank_ = ctx_.xtile_entry_fn.getArgument(start_idx);
+    CHECK(device_rank_.getType().isInteger(32));
+    signal_value_ = ctx_.xtile_entry_fn.getArgument(start_idx + 1);
+    CHECK(signal_value_.getType().isInteger(32));
+    signal_buffers_ = ctx_.xtile_entry_fn.getArgument(start_idx + 2);
+    // remote_input_buffers: !tt.ptr<!tt.ptr<elem_type>>
+    remote_input_buffers_ = ctx_.xtile_entry_fn.getArgument(start_idx + 3);
+
+    // 2. Constants and types.
+    elem_type_ = mlir::getElementTypeOrSelf(ctx_.input_tile.getType());
+    elem_storage_type_ = xtile::StorageType(elem_type_);
+    ptr_to_i64_type_ =
+        ttir::PointerType::get(builder_.getI64Type(), kGlobalAddressSpace);
+    ptr_to_elem_type_ =
+        ttir::PointerType::get(elem_storage_type_, kGlobalAddressSpace);
+    ASSIGN_OR_RETURN(layout_, xtile::GetPermutationMinorToMajor(
+                                  ctx_.input_extract.getSource().getType()));
+
+    // 3. Emit double-buffer setup IR.
+    remote_input_buffers_i64_ = ttir::BitcastOp::create(
+        builder_, ptr_to_i64_type_, remote_input_buffers_);
+    const mlir::Type i64_type = builder_.getI64Type();
+
+    // buffer_index = signal_value & 1 (double buffering: 0 or 1)
+    mlir::Value buffer_index = arith::AndIOp::create(
+        builder_, i64_type,
+        arith::ExtSIOp::create(builder_, i64_type, signal_value_),
+        arith::ConstantOp::create(builder_, i64_type,
+                                  builder_.getI64IntegerAttr(1)));
+
+    const int64_t buffer_size = xla::RoundUpTo<uint64_t>(
+        ctx_.num_elements *
+            ShapeUtil::ByteSizeOfPrimitiveType(ctx_.element_type),
+        kXlaAllocatedBufferAlignBytes);
+    const int64_t elements_per_buffer =
+        buffer_size / ShapeUtil::ByteSizeOfPrimitiveType(ctx_.element_type);
+    buffer_offset_ = arith::MulIOp::create(
+        builder_, i64_type, buffer_index,
+        arith::ConstantOp::create(
+            builder_, i64_type,
+            builder_.getI64IntegerAttr(elements_per_buffer)));
+
+    initialized_ = true;
+    return absl::OkStatus();
+  }
+
+  // Returns a pointer into the symmetric buffer of the given rank.
+  mlir::Value GetRemoteBufferPtr(mlir::Value rank_idx) {
+    CHECK(initialized_);
+    mlir::Value remote_buf_ptr_addr = ttir::AddPtrOp::create(
+        builder_, ptr_to_i64_type_, remote_input_buffers_i64_, rank_idx);
+    mlir::Value remote_buf_i64 = ttir::LoadOp::create(
+        builder_, remote_buf_ptr_addr, ttir::CacheModifier::NONE,
+        ttir::EvictionPolicy::NORMAL, /*isVolatile=*/false);
+    mlir::Value remote_buf_ptr_base =
+        ttir::IntToPtrOp::create(builder_, ptr_to_elem_type_, remote_buf_i64,
+                                 llvm::ArrayRef<mlir::NamedAttribute>{
+                                     xtile::GetDivisibilityAttr(builder_)});
+    return ttir::AddPtrOp::create(builder_, ptr_to_elem_type_,
+                                  remote_buf_ptr_base, buffer_offset_);
+  }
+
+  // Loads a tile from the symmetric buffer of the given rank.
+  // The offsets are global offsets within the input buffer.
+  xtile::TensorValue LoadTileForRank(mlir::Value rank_idx,
+                                     mlir::ValueRange offsets,
+                                     llvm::ArrayRef<int64_t> shape) {
+    CHECK(initialized_);
+    mlir::Value remote_buf_ptr = GetRemoteBufferPtr(rank_idx);
+    auto [ptrs, mask] = triton::CreateTensorOfPointersAndMask(
+        builder_, remote_buf_ptr,
+        ctx_.non_tiled_input_shape,  // full global input shape
+        layout_,
+        offsets,  // global offsets within input
+        shape,    // tile shape (= input tile size)
+        ctx_.input_extract.getStrides(),
+        /*reduced_dims=*/{},  // AllGather does not reduce
+        shape);
+
+    auto next_tile = mlir::cast<xtile::TensorValue>(
+        ttir::LoadOp::create(builder_, ptrs, mask, /*other=*/mlir::Value(),
+                             ttir::CacheModifier::NONE,
+                             ttir::EvictionPolicy::NORMAL,
+                             /*isVolatile=*/false)
+            .getResult());
+
+    // Handle boolean storage type (i1 stored as i8).
+    if (elem_storage_type_ != elem_type_) {
+      next_tile = mlir::cast<xtile::TensorValue>(
+          xtile::Cast(builder_, next_tile, elem_type_));
+    }
+    return next_tile;
+  }
+
+  // Copies the local input tile into the symmetric buffer at device_rank_.
+  mlir::LogicalResult EmitCopyToSymmetric(mlir::Value tile_to_store,
+                                          mlir::ValueRange offsets,
+                                          llvm::ArrayRef<int64_t> shape) {
+    CHECK(initialized_);
+    mlir::Value remote_buf_ptr = GetRemoteBufferPtr(device_rank_);
+    mlir::Value storage_tile = tile_to_store;
+    if (elem_storage_type_ != elem_type_) {
+      storage_tile = mlir::cast<xtile::TensorValue>(
+          xtile::Cast(builder_, tile_to_store, elem_storage_type_));
+    }
+    auto [ptrs, mask] = triton::CreateTensorOfPointersAndMask(
+        builder_, remote_buf_ptr, ctx_.non_tiled_input_shape, layout_, offsets,
+        shape, ctx_.input_extract.getStrides(),
+        /*reduced_dims=*/{}, shape);
+    ttir::StoreOp::create(builder_, ptrs, storage_tile, mask,
+                          ttir::CacheModifier::NONE,
+                          ttir::EvictionPolicy::NORMAL);
+    return mlir::success();
+  }
+
+  // Barrier synchronization across all ranks using the signal buffer.
+  mlir::LogicalResult EmitSync(mlir::Value signal_value) {
+    CHECK(initialized_);
+    // Block-level barrier: all threads in the block complete their writes.
+    mlir::triton::gpu::BarrierOp::create(builder_,
+                                         mlir::triton::gpu::AddrSpace::Local);
+    // Cross-device barrier via signal buffer.
+    mtx::BlockBarrierOp::create(builder_, signal_buffers_, device_rank_,
+                                signal_value,
+                                builder_.getI32IntegerAttr(ctx_.world_size));
+    return mlir::success();
+  }
+
+  // Emits the three-phase AllGather protocol:
+  //   1. Each rank copies its input tile to its own symmetric buffer.
+  //   2. All ranks synchronize (barrier).
+  //   3. Each block reads the data from the source rank (tile_id /
+  //   tiles_per_rank)
+  //      and writes it to the output tile.
+  mlir::LogicalResult EmitAllGather() {
+    CHECK(initialized_);
+
+    llvm::ArrayRef<int64_t> shape = ctx_.input_tile.getType().getShape();
+
+    // source_rank: which rank this block gathers data from.
+    const int64_t local_size_in_gather_dim =
+        ctx_.non_tiled_input_shape[ctx_.all_gather_dimension];
+    const int64_t tile_size_in_gather_dim =
+        ctx_.input_tile.getType().getShape()[ctx_.all_gather_dimension];
+    CHECK_EQ(local_size_in_gather_dim % tile_size_in_gather_dim, 0)
+        << "local_size_in_gather_dim must be divisible by "
+           "tile_size_in_gather_dim";
+    const int64_t tiles_per_rank =
+        local_size_in_gather_dim / tile_size_in_gather_dim;
+
+    mlir::Value tile_id = ctx_.xtile_entry_fn.getProgramId();
+    mlir::Value tiles_per_rank_idx =
+        arith::ConstantIndexOp::create(builder_, tiles_per_rank);
+    mlir::Value source_rank_idx =
+        arith::DivUIOp::create(builder_, tile_id, tiles_per_rank_idx);
+    mlir::Value source_rank = arith::IndexCastOp::create(
+        builder_, builder_.getI64Type(), source_rank_idx);
+
+    // Phase 1: Copy local input tile to the symmetric buffer.
+    if (mlir::failed(EmitCopyToSymmetric(
+            ctx_.input_tile, ctx_.input_extract.getOffsets(),
+            ctx_.input_tile.getType().getShape()))) {
+      return rewriter_.notifyMatchFailure(ctx_.op,
+                                          "Failed to emit copy to symmetric");
+    }
+
+    // Phase 2: All-ranks barrier.
+    if (mlir::failed(EmitSync(signal_value_))) {
+      return rewriter_.notifyMatchFailure(ctx_.op,
+                                          "Failed to emit sync for all-gather");
+    }
+
+    // Phase 3: Load source rank's tile.
+    xtile::TensorValue result =
+        LoadTileForRank(source_rank, ctx_.input_extract.getOffsets(), shape);
+    rewriter_.replaceOp(ctx_.op, result);
+    return mlir::success();
+  }
+
+  AllGatherEmitterContext ctx_;
+  mlir::PatternRewriter& rewriter_;
+  mlir::ImplicitLocOpBuilder builder_;
+
+  mlir::Value device_rank_;
+  mlir::Value signal_value_;
+  mlir::Value signal_buffers_;
+  mlir::Value remote_input_buffers_;
+  mlir::Value remote_input_buffers_i64_;
+  mlir::Value buffer_offset_;
+
+  llvm::SmallVector<int64_t> layout_;
+  mlir::Type elem_type_;
+  mlir::Type elem_storage_type_;
+  ttir::PointerType ptr_to_i64_type_;
+  ttir::PointerType ptr_to_elem_type_;
+
+  bool initialized_ = false;
+};
+
 }  // namespace
 
 absl::Status FlattenCollectiveFusion(
@@ -1002,6 +1318,91 @@ llvm::SmallVector<int64_t> GreedyPowerOfTwoTiles(const Shape& output_shape,
   return tile_sizes;
 }
 
+// Returns the block level fusion config for all-gather if supported.
+// Tile sizes are computed over the INPUT shape of AllGather.
+// This makes the experimental tiling (TilingSpace) tile the output [N*W] with
+// size T_in, which gives W*num_input_blocks total kernel blocks — exactly one
+// block per rank per input tile.
+absl::StatusOr<std::optional<BlockLevelFusionConfig>>
+GetBlockLevelFusionConfigForAllGather(
+    const GpuTopology& gpu_topology, const HloAllGatherInstruction* all_gather,
+    const DeviceAssignment* device_assignment) {
+  // AllGather has a single one-shot protocol, so no strategy annotation is
+  // needed. Gate on the feature flag directly.
+  if (!absl::c_linear_search(
+          all_gather->GetModule()
+              ->config()
+              .debug_options()
+              .xla_gpu_experimental_use_collective_kernels(),
+          static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER))) {
+    VLOG(3) << "All-gather Triton backend is not enabled. Skipping.";
+    return std::nullopt;
+  }
+
+  absl::StatusOr<AllGatherInfo> maybe_all_gather_info = BuildAllGatherInfo(
+      /*is_collective_kernel_enabled=*/true, gpu_topology, all_gather,
+      device_assignment);
+  if (absl::IsUnimplemented(maybe_all_gather_info.status())) {
+    VLOG(3) << "Codegen for all-gather is not supported: "
+            << maybe_all_gather_info.status();
+    return std::nullopt;
+  }
+  ASSIGN_OR_RETURN(AllGatherInfo all_gather_info,
+                   std::move(maybe_all_gather_info));
+
+  // Compute tile sizes based on the INPUT shape.
+  const Shape& input_shape = all_gather->operand(0)->shape();
+  const se::DeviceDescription& device_info =
+      gpu_topology.gpu_target_config().device_description;
+  const LaunchDimensions launch_dims = AllGatherLaunchDimensions(
+      all_gather_info.num_elements, WarpSize(device_info));
+
+  BlockLevelFusionConfig block_level_config;
+  block_level_config.set_num_warps(xla::CeilOfRatio(
+      static_cast<int64_t>(launch_dims.num_threads_per_block()),
+      WarpSize(device_info)));
+  block_level_config.set_num_ctas(1);
+  block_level_config.set_num_stages(1);
+  Tile* output_tile = block_level_config.add_output_tiles();
+  // Tile over the INPUT shape; num_blocks = num_input_tiles * world_size.
+  const llvm::SmallVector<int64_t> tile_sizes =
+      GreedyPowerOfTwoTiles(input_shape, launch_dims.num_blocks());
+  output_tile->mutable_sizes()->Assign(tile_sizes.begin(), tile_sizes.end());
+  VLOG(3) << "Block level fusion config for all-gather " << all_gather->name()
+          << ": " << block_level_config;
+  return block_level_config;
+}
+
+absl::StatusOr<std::vector<Shape>> GetAllGatherUnmanagedKernelArguments(
+    const HloComputation* computation,
+    const HloAllGatherInstruction* all_gather) {
+  if (!all_gather->device_list()) {
+    return absl::InternalError(absl::StrCat("AllGather instruction ",
+                                            all_gather->name(),
+                                            " has null device_list."));
+  }
+  const int32_t num_devices =
+      all_gather->device_list()->num_devices_per_group();
+  std::vector<Shape> unmanaged_arguments;
+  unmanaged_arguments.reserve(computation->num_parameters() +
+                              kNumCollectiveMetadataArgs);
+  // rank and signal_value
+  unmanaged_arguments.push_back(ShapeUtil::MakeShape(S32, {}));
+  unmanaged_arguments.push_back(ShapeUtil::MakeShape(S32, {}));
+  // Signal buffers: one slot per (device × block)
+  unmanaged_arguments.push_back(
+      ShapeUtil::MakeShape(S32, {num_devices, kAllGatherMaxBlocksPerGrid}));
+  // Scratch buffers (one per parameter, each holding num_devices copies).
+  for (const HloInstruction* instr : computation->parameter_instructions()) {
+    Shape shape =
+        ShapeUtil::InsertDimensionAtIndex(instr->shape(), 0, num_devices);
+    unmanaged_arguments.push_back(shape);
+  }
+  TF_RET_CHECK(unmanaged_arguments.size() ==
+               computation->num_parameters() + kNumCollectiveMetadataArgs);
+  return unmanaged_arguments;
+}
+
 absl::StatusOr<std::optional<BlockLevelFusionConfig>>
 GetCollectiveBlockLevelFusionConfig(const GpuTopology& gpu_topology,
                                     const HloFusionInstruction* fusion_instr,
@@ -1011,6 +1412,9 @@ GetCollectiveBlockLevelFusionConfig(const GpuTopology& gpu_topology,
     case HloOpcode::kAllReduce:
       return GetBlockLevelFusionConfigForAllReduce(
           gpu_topology, Cast<HloAllReduceInstruction>(root), device_assignment);
+    case HloOpcode::kAllGather:
+      return GetBlockLevelFusionConfigForAllGather(
+          gpu_topology, Cast<HloAllGatherInstruction>(root), device_assignment);
     default:
       return std::nullopt;
   }
@@ -1047,6 +1451,9 @@ absl::StatusOr<std::vector<Shape>> GetCollectiveUnmanagedKernelArguments(
     case HloOpcode::kAllReduce:
       return GetAllReduceUnmanagedKernelArguments(
           computation, Cast<HloAllReduceInstruction>(root));
+    case HloOpcode::kAllGather:
+      return GetAllGatherUnmanagedKernelArguments(
+          computation, Cast<HloAllGatherInstruction>(root));
     default:
       return std::vector<Shape>();
   }
@@ -1101,6 +1508,21 @@ mlir::LogicalResult RewriteAllReduce(mlir::stablehlo::AllReduceOp op,
   return AllReduceEmitter::Emit(maybe_context.value(), rewriter);
 }
 
+mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
+                                     mlir::PatternRewriter& rewriter) {
+  const mlir::Location loc = op->getLoc();
+  absl::StatusOr<AllGatherEmitterContext> maybe_context =
+      CreateAllGatherEmitterContext(op);
+  if (!maybe_context.ok()) {
+    VLOG(3) << "Failed to create AllGatherEmitterContext: "
+            << maybe_context.status().message();
+    return rewriter.notifyMatchFailure(
+        loc, absl::StrCat("Failed to create AllGatherEmitterContext: ",
+                          maybe_context.status().message()));
+  }
+  return AllGatherEmitter::Emit(maybe_context.value(), rewriter);
+}
+
 absl::StatusOr<CollectiveKernelSpec> CreateCollectiveKernelSpec(
     const HloInstruction* instr, const LaunchDimensions& launch_dimensions) {
   const HloInstruction* collective = instr;
@@ -1110,6 +1532,8 @@ absl::StatusOr<CollectiveKernelSpec> CreateCollectiveKernelSpec(
   switch (collective->opcode()) {
     case HloOpcode::kAllReduce:
       return CreateAllReduceKernelSpec(collective, launch_dimensions);
+    case HloOpcode::kAllGather:
+      return CreateAllGatherKernelSpec(collective, launch_dimensions);
     default:
       return absl::UnimplementedError(
           absl::StrFormat("CollectiveKernelSpec creation not implemented for "

--- a/xla/backends/gpu/codegen/triton/collective_emitter.h
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.h
@@ -36,7 +36,6 @@ limitations under the License.
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/launch_dimensions.h"
 #include "xla/shape.h"
-#include "xla/stream_executor/device_description.h"
 #include "xla/types.h"  // IWYU pragma: keep
 
 namespace xla {

--- a/xla/backends/gpu/codegen/triton/collective_emitter.h
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.h
@@ -36,6 +36,7 @@ limitations under the License.
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/launch_dimensions.h"
 #include "xla/shape.h"
+#include "xla/stream_executor/device_description.h"
 #include "xla/types.h"  // IWYU pragma: keep
 
 namespace xla {
@@ -101,6 +102,22 @@ absl::StatusOr<std::vector<Shape>> GetCollectiveUnmanagedKernelArguments(
 
 // Rewrites stablehlo all-reduce op to a triton implementation.
 mlir::LogicalResult RewriteAllReduce(mlir::stablehlo::AllReduceOp op,
+                                     mlir::PatternRewriter& rewriter);
+
+// Returns the block level fusion config for an all-gather instruction if
+// the Triton backend is enabled for it.
+absl::StatusOr<std::optional<BlockLevelFusionConfig>>
+GetBlockLevelFusionConfigForAllGather(
+    const GpuTopology& gpu_topology, const HloAllGatherInstruction* all_gather,
+    const DeviceAssignment* device_assignment);
+
+// Returns the unmanaged kernel argument shapes for an all-gather fusion.
+absl::StatusOr<std::vector<Shape>> GetAllGatherUnmanagedKernelArguments(
+    const HloComputation* computation,
+    const HloAllGatherInstruction* all_gather);
+
+// MLIR pattern rewrite for stablehlo::AllGatherOp → Triton IR.
+mlir::LogicalResult RewriteAllGather(mlir::stablehlo::AllGatherOp op,
                                      mlir::PatternRewriter& rewriter);
 
 // Creates a CollectiveKernelSpec for a given collective or fusion instruction.

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -377,6 +377,31 @@ CodegenDecision IsTritonSupportedAllReduce(
   return CodegenDecision::Allow();
 }
 
+CodegenDecision IsTritonSupportedAllGather(
+    const HloAllGatherInstruction& all_gather,
+    const se::GpuComputeCapability& gpu_version) {
+  if (!absl::c_linear_search(
+          all_gather.GetModule()
+              ->config()
+              .debug_options()
+              .xla_gpu_experimental_use_collective_kernels(),
+          static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER))) {
+    return CodegenDecision::Forbid(
+        "Triton backend for all-gather is disabled. Enable with "
+        "--xla_gpu_experimental_use_collective_kernels=ALL_GATHER");
+  }
+  if (all_gather.operand_count() == 1) {
+    PrimitiveType element_type = all_gather.operand(0)->shape().element_type();
+    if (element_type == PrimitiveType::F8E4M3FN ||
+        element_type == PrimitiveType::F8E5M2 ||
+        element_type == PrimitiveType::S4) {
+      return CodegenDecision::Forbid(
+          "S4, F8E4M3FN and F8E5M2 are not supported for all-gathers.");
+    }
+  }
+  return CodegenDecision::Allow();
+}
+
 bool IsInTritonNestedGemmFusion(const HloInstruction& hlo) {
   if (!hlo.parent()->IsFusionComputation()) {
     return false;
@@ -809,6 +834,17 @@ CodegenDecision IsTritonSupportedInstructionImpl(
       return IsTritonSupportedAllReduce(*Cast<HloAllReduceInstruction>(&instr),
                                         gpu_version);
     case HloOpcode::kAllGather:
+      // If the Triton AllGather backend is enabled, use the dedicated checker.
+      if (absl::c_linear_search(
+              instr.GetModule()
+                  ->config()
+                  .debug_options()
+                  .xla_gpu_experimental_use_collective_kernels(),
+              static_cast<int>(DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER))) {
+        return IsTritonSupportedAllGather(
+            *Cast<HloAllGatherInstruction>(&instr), gpu_version);
+      }
+      // Legacy tiling-propagation path.
       if (instr.shape().element_type() == S4) {
         return CodegenDecision::Forbid("S4 is not supported.");
       }

--- a/xla/backends/gpu/codegen/triton/tests/collectives/all_gather.hlo
+++ b/xla/backends/gpu/codegen/triton/tests/collectives/all_gather.hlo
@@ -24,25 +24,37 @@ ENTRY entry {
     }
 }
 
-// CHECK-DAG: #[[MAP0:.*]] = #xla.indexing_map<"(pid) -> (((pid / 8) mod 8) * 16), domain: pid in [0, 127]">
-// CHECK-DAG: #[[MAP1:.*]] = #xla.indexing_map<"(pid) -> ((pid mod 8) * 16), domain: pid in [0, 127]">
-// CHECK-DAG: #[[MAP2:.*]] = #xla.indexing_map<"(pid) -> (pid / 64), domain: pid in [0, 127]">
-// CHECK-DAG: #[[MAP3:.*]] = #xla.indexing_map<"(pid) -> ((pid / 8) * 16), domain: pid in [0, 127]">
+// The AllGather is lowered by the Triton collective emitter
+// (collective_emitter.cc). Mirroring all-reduce, the parameter stays a flat
+// memref (NOT a nested-pointer buffer table): the source rank is recomputed
+// arithmetically inside the kernel and cross-rank data is moved through the
+// remote-buffer metadata argument plus a block barrier. There must be no
+// xtile.select_buffer and no memref<...xi64> buffer-table argument.
 
-// CHECK:      xtile.entry_func @triton_fn(
-// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<2xi64>,
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: memref<256x128xf32>,
-// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: i32,
-// CHECK-SAME:   %[[ARG3:[a-zA-Z0-9_]+]]: i32,
-// CHECK-SAME:   %[[ARG4:[a-zA-Z0-9_]+]]: !tt.ptr<!tt.ptr<i32>>,
-// CHECK-SAME:   %[[ARG5:[a-zA-Z0-9_]+]]: !tt.ptr<!tt.ptr<f32>>,
-// CHECK-SAME:   %[[PID:[a-zA-Z0-9_]+]]: index)
+// CHECK-LABEL: xtile.entry_func @triton_fn(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]: memref<128x128xf32>,
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]: memref<256x128xf32>,
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]+]]: i32,
+// CHECK-SAME:    %[[ARG3:[a-zA-Z0-9_]+]]: i32,
+// CHECK-SAME:    %[[ARG4:[a-zA-Z0-9_]+]]: !tt.ptr<!tt.ptr<i32>>,
+// CHECK-SAME:    %[[ARG5:[a-zA-Z0-9_]+]]: !tt.ptr<!tt.ptr<f32>>,
+// CHECK-SAME:    %[[PID:[a-zA-Z0-9_]+]]: index)
+// CHECK-SAME:    attributes {num_opaque_args = 4 : i32} {
 
-// CHECK:        %[[IDX0:.*]] = xla.apply_indexing #[[MAP0]](%[[PID]])
-// CHECK:        %[[IDX1:.*]] = xla.apply_indexing #[[MAP1]](%[[PID]])
-// CHECK:        %[[IDX2:.*]] = xla.apply_indexing #[[MAP2]](%[[PID]])
-// CHECK:        %[[BUF:.*]] = xtile.select_buffer %[[ARG0]][%[[IDX2]]] : memref<2xi64> -> memref<128x128xf32>
-// CHECK:        %[[EXT:.*]] = xtile.extract %[[BUF]][%[[IDX0]], %[[IDX1]]] [16, 16] [1, 1] : memref<128x128xf32> -> tensor<16x16xf32>
-// CHECK:        %[[IDX3:.*]] = xla.apply_indexing #[[MAP3]](%[[PID]])
-// CHECK:        xtile.insert %[[EXT]] into %[[ARG1]][%[[IDX3]], %[[IDX1]]] [16, 16] [1, 1] : tensor<16x16xf32> -> memref<256x128xf32>
-// CHECK:        xtile.return
+// CHECK-NOT:   xtile.select_buffer
+
+// Local input tile is extracted from the flat input memref.
+// CHECK:       %[[EXTRACT:.*]] = xtile.extract
+// CHECK-SAME:    : memref<128x128xf32> -> tensor<16x16xf32>
+
+// Copy-to-symmetric of the local tile.
+// CHECK:       tt.store %{{[a-zA-Z0-9_]+}}, %{{[a-zA-Z0-9_]+}}
+
+// Cross-rank synchronization.
+// CHECK:       ttg.barrier local
+// CHECK:       triton_xla.block_barrier
+// CHECK-SAME:    {world_size = 2 : i32} : (!tt.ptr<!tt.ptr<i32>>, i32, i32)
+
+// Gathered tile written to the output memref.
+// CHECK:       xtile.insert
+// CHECK-SAME:    : tensor<16x16xf32> -> memref<256x128xf32>

--- a/xla/backends/gpu/codegen/triton/transforms/stablehlo_lower_to_triton.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/stablehlo_lower_to_triton.cc
@@ -803,6 +803,18 @@ class LowerAllReduce : public mlir::OpRewritePattern<stablehlo::AllReduceOp> {
   }
 };
 
+class LowerAllGather : public mlir::OpRewritePattern<stablehlo::AllGatherOp> {
+ public:
+  using OpRewritePattern::OpRewritePattern;
+
+ private:
+  mlir::LogicalResult matchAndRewrite(
+      stablehlo::AllGatherOp op,
+      mlir::PatternRewriter& rewriter) const override {
+    return ::xla::gpu::RewriteAllGather(op, rewriter);
+  }
+};
+
 class StableHLOLowerToTritonPass
     : public impl::StableHLOLowerToTritonPassBase<StableHLOLowerToTritonPass> {
  public:
@@ -815,7 +827,8 @@ class StableHLOLowerToTritonPass
     {
       mlir::RewritePatternSet patterns(mlir_context);
       patterns.add<LowerTranspose, LowerIotaToMakeRange, LowerBroadcastInDim,
-                   LowerReduce, LowerReshape, LowerAllReduce>(mlir_context);
+                   LowerReduce, LowerReshape, LowerAllReduce, LowerAllGather>(
+          mlir_context);
       patterns.add<CanonicalizeDotGeneral>(mlir_context);
       patterns.add<LowerDotGeneral>(mlir_context, warp_specialization_allowed_);
       if (mlir::failed(mlir::applyPatternsGreedily(getOperation(),

--- a/xla/backends/gpu/tests/BUILD
+++ b/xla/backends/gpu/tests/BUILD
@@ -1337,6 +1337,47 @@ xla_test(
     ],
 )
 
+xla_test(
+    name = "all_gather_e2e_test",
+    srcs = ["all_gather_e2e_test.cc"],
+    backend_tags = {
+        "gpu": [
+            "multi_gpu",
+        ],
+    },
+    backends = [
+        "gpu",
+    ],
+    shard_count = 3,
+    deps = [
+        ":collective_ops_e2e_test_base",
+        "//xla:array",
+        "//xla:error_spec",
+        "//xla:literal",
+        "//xla:literal_util",
+        "//xla:shape_util",
+        "//xla:types",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service:collective_ops_utils",
+        "//xla/tests:literal_test_util",
+        "//xla/tests:xla_internal_test_main",
+        "//xla/tsl/platform:statusor",
+        "//xla/tsl/platform:test",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/log:scoped_mock_log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "collective_ops_ffi_kernels",
     testonly = True,

--- a/xla/backends/gpu/tests/all_gather_e2e_test.cc
+++ b/xla/backends/gpu/tests/all_gather_e2e_test.cc
@@ -1,0 +1,952 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// End-to-end tests for AllGather with the Triton collective kernel backend.
+//
+// Architecture note (xla/ vs xla_ref/):
+//   In xla_ref, allgather was wrapped in kAllGatherStart/kAllGatherDone.
+//   In xla/ (new upstream arch), ALL collectives use the generic
+//   kAsyncStart/kAsyncDone wrapper.  The inner wrapped instruction is
+//   kAllGather.  Tests that check for kAllGatherStart must use kAllGather
+//   instead, and runtime-fallback detection (ScopedMockLog warnings) is
+//   replaced by compile-time eligibility checks.
+
+#include <cstddef>
+#include <cstdint>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/log/scoped_mock_log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "xla/array.h"
+#include "xla/backends/gpu/tests/collective_ops_e2e_test_base.h"
+#include "xla/error_spec.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/literal.h"
+#include "xla/literal_util.h"
+#include "xla/primitive_util.h"
+#include "xla/service/collective_ops_utils.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+#include "xla/tests/literal_test_util.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/test.h"
+#include "xla/types.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla {
+namespace {
+
+std::string GetAsyncTestName(bool is_async) {
+  return is_async ? "async" : "sync";
+}
+
+// In the new architecture, kAllGather is the wrapped instruction inside
+// kAsyncStart.  We search for kAllGather (not the legacy kAllGatherStart).
+void VerifyAllGatherType(const HloModule* module, PrimitiveType expected_type) {
+  bool found = false;
+  for (auto* comp : module->computations()) {
+    for (auto* instr : comp->instructions()) {
+      if (instr->opcode() == HloOpcode::kAllGather) {
+        PrimitiveType actual_type = instr->operand(0)->shape().element_type();
+        ASSERT_EQ(actual_type, expected_type)
+            << "Expected AllGather type " << PrimitiveType_Name(expected_type)
+            << " but got " << PrimitiveType_Name(actual_type);
+        found = true;
+      }
+    }
+  }
+  ASSERT_TRUE(found) << "No AllGather found in module";
+}
+
+class AllGatherTestNoParams : public CollectiveOpsWithFlagsBase {
+ public:
+  explicit AllGatherTestNoParams(bool is_async = false)
+      : CollectiveOpsWithFlagsBase(/*enable_async=*/is_async,
+                                   /*enable_p2p_memcpy=*/false,
+                                   /*enable_symmetric_buffer=*/false,
+                                   /*memory_size=*/32 * kMB,
+                                   /*collectives_memory_size=*/0) {}
+
+  void SetUp() override {
+    CollectiveOpsE2ETestBase::SetUp();
+    // Check for Triton support: Ampere+ for CUDA, any supported GPU for ROCm
+    if (Capability().IsCuda() && !IsAmpereAndHigher()) {
+      GTEST_SKIP() << "Test requires Ampere or newer architecture for CUDA "
+                      "since it's using triton.";
+    }
+  }
+
+  // Returns true if the current device supports Triton collective kernels
+  // (Hopper+ for CUDA, or any supported ROCm device).
+  bool IsTritonCapable() {
+    return IsHopperAndHigher() || Capability().IsRocm();
+  }
+
+  bool CheckDeviceCount(int32_t required_device_count) {
+    [&]() -> void {
+      const int32_t current_device_count = device_count();
+      if (current_device_count < required_device_count) {
+        ASSERT_GE(current_device_count, 2)
+            << "Test requires at least 2 devices but only "
+            << current_device_count << " available";
+        if (current_device_count < required_device_count) {
+          GTEST_SKIP() << "Test requires at least " << required_device_count
+                       << " devices but only " << current_device_count
+                       << " available.";
+        }
+      }
+    }();
+    return !IsSkipped() && !HasFatalFailure();
+  }
+
+  // Installs a log interceptor that fails the test if the AllGather Triton
+  // backend silently falls back to NCCL/RCCL due to an ineligible shape.
+  // The interceptor stays active (via the member variable) until the test
+  // destructor runs, covering the `ExecuteReplicated` call that follows.
+  void CheckNoTritonFallback() {
+    triton_fallback_checker_ = std::make_unique<absl::ScopedMockLog>(
+        absl::MockLogDefault::kIgnoreUnexpected);
+    // Expect ZERO occurrences of the fallback warning. If it fires, the test
+    // fails because Triton was requested but the shape was not eligible.
+    EXPECT_CALL(*triton_fallback_checker_,
+                Log(absl::LogSeverity::kWarning, ::testing::_,
+                    ::testing::HasSubstr("falling back to NCCL/RCCL")))
+        .Times(0);
+    triton_fallback_checker_->StartCapturingLogs();
+  }
+
+ private:
+  // Holds the log interceptor set up by CheckNoTritonFallback().
+  // Destroyed at the end of the test, triggering expectation verification.
+  std::unique_ptr<absl::ScopedMockLog> triton_fallback_checker_;
+};
+
+struct AllGatherTestParams {
+  bool is_async;
+  bool use_all_gather_triton_backend;
+  bool use_experimental_tiling = false;
+
+  std::vector<int64_t> GetShape(PrimitiveType element_type,
+                                int32_t rank = 1) const {
+    int64_t total = 1024;
+    if (rank <= 1) {
+      return {total};
+    }
+    std::vector<int64_t> dims;
+    for (int32_t i = 0; i < rank - 1; ++i) {
+      dims.push_back(rank);
+      total /= rank;
+    }
+    dims.push_back(total);
+    return dims;
+  }
+
+  static std::vector<AllGatherTestParams> Generate() {
+    std::vector<AllGatherTestParams> params;
+    for (bool is_async : {true, false}) {
+      for (bool use_all_gather_triton_backend : {true, false}) {
+        params.push_back({is_async, use_all_gather_triton_backend,
+                          /*use_experimental_tiling=*/true});
+      }
+    }
+    return params;
+  }
+
+  [[maybe_unused]] friend void PrintTo(const AllGatherTestParams& params,
+                                       std::ostream* os) {
+    *os << "{ .is_async=" << params.is_async
+        << ", .use_all_gather_triton_backend="
+        << params.use_all_gather_triton_backend
+        << ", .use_experimental_tiling=" << params.use_experimental_tiling
+        << " }";
+  }
+};
+
+struct AllGatherTypesTestParams : public AllGatherTestParams {
+  PrimitiveType element_type;
+
+  static std::vector<AllGatherTypesTestParams> Generate() {
+    std::vector<AllGatherTypesTestParams> params;
+    for (auto& all_gather_test_params : AllGatherTestParams::Generate()) {
+      for (const PrimitiveType element_type :
+           {F32, F16, BF16, S32, S8, PRED, S16, F8E4M3FN, F8E5M2}) {
+        params.push_back({all_gather_test_params, element_type});
+      }
+    }
+    return params;
+  }
+};
+
+struct InputsOutputs {
+  std::vector<Literal> inputs;
+  std::vector<Literal> expected_outputs;
+
+  [[nodiscard]] std::vector<std::vector<Literal*>> InputLiteralPtrs() {
+    std::vector<std::vector<Literal*>> result;
+    for (auto& input : inputs) {
+      result.push_back(std::vector<Literal*>{&input});
+    }
+    return result;
+  }
+};
+
+template <typename T>
+static void FillRandom(Array<T>& array, int64_t seed) {
+  constexpr PrimitiveType primitive_type =
+      primitive_util::NativeToPrimitiveType<T>();
+  if constexpr (primitive_util::IsFloatingPointType(primitive_type)) {
+    array.FillRandom(T{1.0f}, T{10.0}, seed);
+  } else if constexpr (primitive_type == PRED) {
+    array.FillRandomBool(seed);
+  } else if constexpr (primitive_util::IsIntegralType(primitive_type)) {
+    array.FillRandomUniform(T{0}, T{100}, seed);
+  } else {
+    GTEST_FAIL() << "Unsupported element type: "
+                 << absl::StrFormat("%v",
+                                    primitive_util::NativeToPrimitiveType<T>());
+  }
+}
+
+template <PrimitiveType kElementType>
+static absl::StatusOr<InputsOutputs> BuildTestInputsOutputs(
+    const HloModule& module, int64_t num_replicas,
+    int64_t all_gather_dimension) {
+  using ElementType = primitive_util::NativeTypeOf<kElementType>;
+
+  std::vector<Array<ElementType>> inputs;
+  std::vector<Literal> input_literals;
+  const HloInstruction* const hlo_instr =
+      HloHardwareIndependentTestBase::FindInstruction(&module,
+                                                      HloOpcode::kAllGather);
+  if (hlo_instr == nullptr) {
+    return absl::InvalidArgumentError(
+        "Instruction 'all-gather' not found in module.");
+  }
+  const HloAllGatherInstruction* instr =
+      Cast<HloAllGatherInstruction>(hlo_instr);
+  const Shape& input_shape = instr->operand(0)->shape();
+
+  for (int i = 0; i < num_replicas; ++i) {
+    auto& input =
+        inputs.emplace_back(Array<ElementType>(input_shape.dimensions()));
+    FillRandom<ElementType>(input, i);
+    input_literals.push_back(LiteralUtil::CreateFromArray(input));
+  }
+
+  std::vector<Literal> expected_output_literals;
+  const std::vector<ReplicaGroup>& replica_groups =
+      instr->device_list()->replica_groups();
+
+  std::vector<std::vector<int64_t>> device_to_groups(num_replicas);
+  for (const auto& replica_group : replica_groups) {
+    const auto& replica_ids = replica_group.replica_ids();
+    for (int64_t replica : replica_group.replica_ids()) {
+      CHECK_EQ(device_to_groups[replica].size(), 0);
+      device_to_groups[replica].assign(replica_ids.begin(), replica_ids.end());
+    }
+  }
+
+  const Shape& output_shape = instr->shape();
+  for (int i = 0; i < num_replicas; ++i) {
+    const std::vector<int64_t>& group = device_to_groups[i];
+    Literal output(output_shape);
+    int64_t offset = 0;
+    for (int64_t replica : group) {
+      const Literal& input = input_literals[replica];
+      const int64_t slice_size = input_shape.dimensions(all_gather_dimension);
+      std::vector<int64_t> src_base(input_shape.dimensions_size(), 0);
+      std::vector<int64_t> dest_base(output_shape.dimensions_size(), 0);
+      dest_base[all_gather_dimension] = offset;
+      TF_RETURN_IF_ERROR(output.CopySliceFrom(input, src_base, dest_base,
+                                              input_shape.dimensions()));
+      offset += slice_size;
+    }
+    expected_output_literals.push_back(std::move(output));
+  }
+
+  return InputsOutputs{std::move(input_literals),
+                       std::move(expected_output_literals)};
+}
+
+absl::StatusOr<InputsOutputs> BuildTestInputsOutputs(
+    PrimitiveType element_type, const HloModule& module, int64_t num_replicas,
+    int64_t all_gather_dimension) {
+  const auto dispatch = [&](auto type) {
+    return BuildTestInputsOutputs<type>(module, num_replicas,
+                                        all_gather_dimension);
+  };
+  return primitive_util::ArrayTypeSwitch(dispatch, element_type);
+}
+
+class AllGatherTest
+    : public AllGatherTestNoParams,
+      public ::testing::WithParamInterface<AllGatherTestParams> {
+ public:
+  AllGatherTest() : AllGatherTestNoParams(/*is_async=*/GetParam().is_async) {}
+
+ protected:
+  DebugOptions GetDebugOptionsForTest() const override {
+    DebugOptions opts = CollectiveOpsWithFlagsBase::GetDebugOptionsForTest();
+    opts.clear_xla_gpu_experimental_use_collective_kernels();
+    if (GetParam().use_all_gather_triton_backend) {
+      opts.add_xla_gpu_experimental_use_collective_kernels(
+          DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER);
+      opts.set_xla_gpu_experimental_enable_tiling_propagation(true);
+    }
+    return opts;
+  }
+};
+
+class AllGatherTypesTest
+    : public AllGatherTestNoParams,
+      public ::testing::WithParamInterface<AllGatherTypesTestParams> {
+ public:
+  AllGatherTypesTest()
+      : AllGatherTestNoParams(/*is_async=*/GetParam().is_async) {}
+
+ protected:
+  DebugOptions GetDebugOptionsForTest() const override {
+    DebugOptions opts = CollectiveOpsWithFlagsBase::GetDebugOptionsForTest();
+    opts.clear_xla_gpu_experimental_use_collective_kernels();
+    if (GetParam().use_all_gather_triton_backend) {
+      opts.add_xla_gpu_experimental_use_collective_kernels(
+          DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER);
+      opts.set_xla_gpu_experimental_enable_tiling_propagation(true);
+    }
+    return opts;
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    AllGatherTest, AllGatherTest,
+    ::testing::ValuesIn(AllGatherTestParams::Generate()),
+    [](const ::testing::TestParamInfo<AllGatherTestParams>& info) {
+      return absl::StrCat(
+          GetAsyncTestName(info.param.is_async), "_",
+          info.param.use_all_gather_triton_backend ? "triton" : "nccl");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    AllGatherTypesTest, AllGatherTypesTest,
+    ::testing::ValuesIn(AllGatherTypesTestParams::Generate()),
+    [](const ::testing::TestParamInfo<AllGatherTypesTestParams>& info) {
+      return absl::StrCat(
+          GetAsyncTestName(info.param.is_async), "_",
+          primitive_util::LowercasePrimitiveTypeName(info.param.element_type),
+          "_", info.param.use_all_gather_triton_backend ? "triton" : "nccl");
+    });
+
+TEST_P(AllGatherTypesTest, SupportedTypes2GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = %1$s[%2$s] parameter(0)
+    ROOT all-gather = %1$s[%3$s] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  const PrimitiveType element_type = GetParam().element_type;
+  const std::vector<int64_t> input_shape = GetParam().GetShape(element_type);
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  const std::string module_str = absl::StrFormat(
+      kModuleStr, primitive_util::LowercasePrimitiveTypeName(element_type),
+      absl::StrJoin(input_shape, ","), absl::StrJoin(output_shape, ","));
+  SCOPED_TRACE(::testing::Message() << "module_str: " << module_str);
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(module_str, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs(element_type, *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Equal(test_io.expected_outputs[i], results[i]))
+        << "ExpectedOutput != Result at rank " << i;
+  }
+}
+
+TEST_P(AllGatherTest, F32_8GPUs_AllReplicasOneGroup) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,1,2,3,4,5,6,7}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 8;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  const std::vector<int64_t> input_shape =
+      GetParam().GetShape(PrimitiveType::F32);
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      ParseAndReturnVerifiedModule(
+          absl::StrFormat(kModuleStr, absl::StrJoin(input_shape, ","),
+                          absl::StrJoin(output_shape, ",")),
+          kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+TEST_P(AllGatherTest, F32_8GPUs_2ReplicasPerGroup) {
+  const std::vector<int64_t> input_shape =
+      GetParam().GetShape(PrimitiveType::F32);
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= 2;
+
+  const auto kModuleStr = absl::StrFormat(
+      R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,4},{1,5},{2,6},{3,7}}, dimensions={0}
+  }
+  )",
+      absl::StrJoin(input_shape, ","), absl::StrJoin(output_shape, ","));
+
+  constexpr int64_t kNumReplicas = 8;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Equal(test_io.expected_outputs[i], results[i]))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+TEST_P(AllGatherTest, F32TwoD4GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,1,2,3}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 4;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  const std::vector<int64_t> input_shape =
+      GetParam().GetShape(PrimitiveType::F32, /*rank=*/2);
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      ParseAndReturnVerifiedModule(
+          absl::StrFormat(kModuleStr, absl::StrJoin(input_shape, ","),
+                          absl::StrJoin(output_shape, ",")),
+          kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// Non-power-of-2 shape: NCCL should handle it.
+TEST_P(AllGatherTest, F32_3D_2GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+  // Use a Triton-eligible 3D shape: 4*4*64 = 1024 elements, F32 (32 bits).
+  // 1024 * 32 = 32768 bits ≡ 0 (mod 128) → aligned for Triton.
+  const std::vector<int64_t> input_shape = {4, 4, 64};
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      ParseAndReturnVerifiedModule(
+          absl::StrFormat(kModuleStr, absl::StrJoin(input_shape, ","),
+                          absl::StrJoin(output_shape, ",")),
+          kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// Power-of-2 shape: Triton should handle it.
+TEST_P(AllGatherTest, F32_3D_2GPUs_PowerOf2) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[%1$s] parameter(0)
+    ROOT all-gather = f32[%2$s] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+  const std::vector<int64_t> input_shape = {8, 8, 16};
+  std::vector<int64_t> output_shape = input_shape;
+  output_shape[0] *= kNumReplicas;
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      ParseAndReturnVerifiedModule(
+          absl::StrFormat(kModuleStr, absl::StrJoin(input_shape, ","),
+                          absl::StrJoin(output_shape, ",")),
+          kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+TEST_P(AllGatherTest, F32TwoD4GPUs_Dim1) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[32,32] parameter(0)
+    ROOT all-gather = f32[32,128] all-gather(param_0),
+      replica_groups={{0,1,2,3}}, dimensions={1}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 4;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/1)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+TEST_P(AllGatherTest, F32_3D_2GPUs_Dim1) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[8,8,16] parameter(0)
+    ROOT all-gather = f32[8,16,16] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={1}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/1)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+TEST_P(AllGatherTest, F32_3D_2GPUs_Dim2) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = f32[8,8,16] parameter(0)
+    ROOT all-gather = f32[8,8,32] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={2}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/2)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+TEST_P(AllGatherTest, BF16_1024Elements_2GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = bf16[1024] parameter(0)
+    ROOT all-gather = bf16[2048] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(InputsOutputs test_io,
+                          (BuildTestInputsOutputs<PrimitiveType::BF16>(
+                              *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-3}))
+        << "ExpectedOutput != Result at replica " << i;
+  }
+}
+
+TEST_P(AllGatherTest, BF16_1024Elements_4GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = bf16[1024] parameter(0)
+    ROOT all-gather = bf16[4096] all-gather(param_0),
+      replica_groups={{0,1,2,3}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 4;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(InputsOutputs test_io,
+                          (BuildTestInputsOutputs<PrimitiveType::BF16>(
+                              *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-3}))
+        << "ExpectedOutput != Result at replica " << i;
+  }
+}
+
+TEST_P(AllGatherTest, BF16_1024Elements_8GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+
+  ENTRY test_computation {
+    param_0 = bf16[1024] parameter(0)
+    ROOT all-gather = bf16[8192] all-gather(param_0),
+      replica_groups={{0,1,2,3,4,5,6,7}}, dimensions={0}
+  }
+  )";
+
+  constexpr int64_t kNumReplicas = 8;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(InputsOutputs test_io,
+                          (BuildTestInputsOutputs<PrimitiveType::BF16>(
+                              *module, kNumReplicas,
+                              /*all_gather_dimension=*/0)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-3}))
+        << "ExpectedOutput != Result at replica " << i;
+  }
+}
+
+// Tests AllGather with 4096 f32 elements per replica — exercises
+// multi-tile-per-rank execution (tiles_per_rank = 2, total_blocks = 4).
+TEST_P(AllGatherTest, F32_MultiTilePerRank_2GPUs) {
+  constexpr absl::string_view kModuleStr = R"(
+  HloModule test
+  ENTRY test_computation {
+    param_0 = f32[4096] parameter(0)
+    ROOT all-gather = f32[8192] all-gather(param_0),
+      replica_groups={{0,1}}, dimensions={0}
+  }
+  )";
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(
+      InputsOutputs test_io,
+      (BuildTestInputsOutputs<PrimitiveType::F32>(*module, kNumReplicas,
+                                                  /*all_gather_dimension=*/0)));
+  CheckNoTritonFallback();
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/test_io.InputLiteralPtrs()));
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (int i = 0; i < kNumReplicas; ++i) {
+    ASSERT_TRUE(LiteralTestUtil::Near(test_io.expected_outputs[i], results[i],
+                                      ErrorSpec{1e-5}))
+        << "ExpectedOutput != Result at index " << i;
+  }
+}
+
+// FP8 vs FP16 all-gather comparison.
+TEST_F(AllGatherTestNoParams, AsyncAllGather_F8E4M3FN_2GPUs) {
+  bool has_fp8_support = false;
+  if (Capability().IsCuda()) {
+    has_fp8_support = Capability().cuda_compute_capability()->IsAtLeast(9, 0);
+  } else if (Capability().IsRocm()) {
+    has_fp8_support =
+        Capability().rocm_compute_capability()->has_ocp_fp8_support();
+  }
+
+  if (!has_fp8_support) {
+    GTEST_SKIP() << "FP8 requires GPU with OCP FP8 support.";
+  }
+
+  constexpr absl::string_view kF16ModuleStr = R"(
+  HloModule f16_allgather
+  ENTRY test {
+    param = f16[32,64] parameter(0)
+    ROOT all-gather = f16[64,64] all-gather(param), replica_groups={{0,1}}, dimensions={0}
+  })";
+
+  constexpr absl::string_view kF8ModuleStr = R"(
+  HloModule fp8_allgather
+  ENTRY test {
+    param = f16[32,64] parameter(0)
+    param_f8 = f8e4m3fn[32,64] convert(param)
+    all-gather_f8 = f8e4m3fn[64,64] all-gather(param_f8), replica_groups={{0,1}}, dimensions={0}
+    ROOT result = f16[64,64] convert(all-gather_f8)
+  })";
+
+  constexpr int64_t kNumReplicas = 2;
+  if (!CheckDeviceCount(kNumReplicas)) {
+    return;
+  }
+
+  Array<Eigen::half> input1({32, 64}), input2({32, 64});
+  input1.FillRandom(Eigen::half(0.1f), 0.5f, /*seed=*/0);
+  input2.FillRandom(Eigen::half(0.1f), 0.5f, /*seed=*/1);
+
+  Literal input_lit1 = LiteralUtil::CreateFromArray(input1);
+  Literal input_lit2 = LiteralUtil::CreateFromArray(input2);
+
+  TF_ASSERT_OK_AND_ASSIGN(auto f16_module, ParseAndReturnVerifiedModule(
+                                               kF16ModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult f16_result,
+                          ExecuteReplicated(std::move(f16_module),
+                                            std::vector<std::vector<Literal*>>{
+                                                {&input_lit1}, {&input_lit2}}));
+  VerifyAllGatherType(f16_result.optimized_module, F16);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto f8_module, ParseAndReturnVerifiedModule(kF8ModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult f8_result,
+                          ExecuteReplicated(std::move(f8_module),
+                                            std::vector<std::vector<Literal*>>{
+                                                {&input_lit1}, {&input_lit2}}));
+  VerifyAllGatherType(f8_result.optimized_module, F8E4M3FN);
+
+  ASSERT_EQ(f16_result.results.size(), kNumReplicas);
+  ASSERT_EQ(f8_result.results.size(), kNumReplicas);
+
+  // FP8 vs FP16 comparison: close but not identical due to precision.
+  EXPECT_TRUE(LiteralTestUtil::Near(f16_result.results[0], f8_result.results[0],
+                                    ErrorSpec{6e-2, 6e-2}));
+}
+
+}  // namespace
+}  // namespace xla

--- a/xla/backends/gpu/tests/collective_ops_e2e_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_e2e_test.cc
@@ -3411,5 +3411,140 @@ ENTRY main {
   }
 }
 
+// =========================================================================
+// AllGather Triton custom kernel tests
+// =========================================================================
+
+// Test fixture for AllGather via the Triton custom kernel backend.
+// Mirrors the AllReduceKernelOps / CollectivesModeOps structure.
+// Parameterised by whether the async stream is used.
+class AllGatherKernelOps : public CollectiveOpsE2ETestBase,
+                           public ::testing::WithParamInterface<bool> {
+ public:
+  AllGatherKernelOps()
+      : CollectiveOpsE2ETestBase(/*memory_size=*/32 * kMB,
+                                 /*collectives_memory_size=*/0),
+        enable_async_(GetParam()) {}
+
+  void SetUp() override {
+    CollectiveOpsE2ETestBase::SetUp();
+    if (Capability().IsCuda() && !IsAmpereAndHigher()) {
+      GTEST_SKIP() << "Test requires Ampere or newer architecture for CUDA "
+                      "since it uses Triton.";
+    }
+  }
+
+ protected:
+  DebugOptions GetDebugOptionsForTest() const override {
+    DebugOptions debug_options =
+        CollectiveOpsE2ETestBase::GetDebugOptionsForTest();
+    if (!enable_async_) {
+      debug_options.add_xla_gpu_disable_async_collectives(
+          DebugOptions::ALLGATHER);
+    }
+    debug_options.add_xla_disable_hlo_passes(
+        "gpu-convert-async-collectives-to-sync");
+    // Always private memory: the Triton kernel is only emitted in this mode.
+    debug_options.set_xla_gpu_all_gather_mode(
+        DebugOptions::COLLECTIVES_PRIVATE_MEMORY);
+    // Enable the Triton AllGather backend.
+    debug_options.clear_xla_gpu_experimental_use_collective_kernels();
+    debug_options.add_xla_gpu_experimental_use_collective_kernels(
+        DebugOptions::COLLECTIVE_KERNEL_ALL_GATHER);
+    // Experimental tiling is the only supported path.
+    debug_options.set_xla_gpu_experimental_enable_tiling_propagation(true);
+    return debug_options;
+  }
+
+  bool enable_async() const { return enable_async_; }
+
+ private:
+  bool enable_async_;
+};
+
+INSTANTIATE_TEST_SUITE_P(AllGatherKernelOps, AllGatherKernelOps,
+                         ::testing::Bool(),
+                         [](const ::testing::TestParamInfo<bool>& info) {
+                           return GetAsyncTestName(info.param);
+                         });
+
+// Tests AllGather via the Triton custom kernel backend with a 2D input shape.
+TEST_P(AllGatherKernelOps, AllGather) {
+  const absl::string_view kModuleStr = R"(
+  HloModule test
+  ENTRY test_computation {
+    id = u32[] replica-id()
+    id_f32 = f32[] convert(id)
+    id2 = f32[1, 4] broadcast(id_f32), dimensions={}
+    a0 = f32[1, 4] constant({{10, 15, 20, 25}})
+    a1 = f32[1, 4] add(id2, a0)
+    allgather = f32[2, 4] all-gather(a1), replica_groups={{0,1}}, dimensions={0}
+    ROOT out = f32[8] reshape(allgather)
+  }
+  )";
+  const int64_t kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "Test requires at least " << kNumReplicas << " devices ("
+      << device_count() << " available)";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
+                          ExecuteReplicated(std::move(module)));
+
+  const HloModule* hlo_module = execution_result.optimized_module;
+  // In the new async-start wrapping, the collective is visible as kAllGather
+  // inside the async computation; FindCollectiveStart finds the kAsyncStart
+  // wrapper that contains it.
+  EXPECT_THAT(FindCollectiveStart(hlo_module, HloOpcode::kAllGather),
+              NotNull());
+  EXPECT_THAT(FindCollectiveDone(hlo_module, HloOpcode::kAllGather), NotNull());
+
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  for (const Literal& result : results) {
+    // Rank 0: a1=[10,15,20,25]; Rank 1: a1=[11,16,21,26].
+    // After gather on dim 0 and reshape to 1D:
+    LiteralTestUtil::ExpectR1Equal<float>(
+        {10.0f, 15.0f, 20.0f, 25.0f, 11.0f, 16.0f, 21.0f, 26.0f}, result);
+  }
+}
+
+// Tests AllGather via the Triton kernel with a 3D input shape.
+TEST_P(AllGatherKernelOps, AllGather3D) {
+  const absl::string_view kModuleStr = R"(
+  HloModule test
+  ENTRY test_computation {
+    id = u32[] replica-id()
+    id_f32 = f32[] convert(id)
+    id2 = f32[1, 2, 4] broadcast(id_f32), dimensions={}
+    a0 = f32[1, 2, 4] constant({{{1, 2, 3, 4}, {5, 6, 7, 8}}})
+    a1 = f32[1, 2, 4] add(id2, a0)
+    allgather = f32[2, 2, 4] all-gather(a1), replica_groups={{0,1}}, dimensions={0}
+    ROOT out = f32[16] reshape(allgather)
+  }
+  )";
+  const int64_t kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "Test requires at least " << kNumReplicas << " devices ("
+      << device_count() << " available)";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kModuleStr, kNumReplicas));
+  TF_ASSERT_OK_AND_ASSIGN(ExecutionResult execution_result,
+                          ExecuteReplicated(std::move(module)));
+
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  // Rank 0: a1={{{1,2,3,4},{5,6,7,8}}}; Rank 1: a1={{{2,3,4,5},{6,7,8,9}}}.
+  // After gather on dim 0 and reshape to [16]:
+  for (const Literal& result : results) {
+    LiteralTestUtil::ExpectR1Equal<float>(
+        {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 2.0f, 3.0f, 4.0f, 5.0f,
+         6.0f, 7.0f, 8.0f, 9.0f},
+        result);
+  }
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/codegen/tiling/experimental/tile_propagation.cc
+++ b/xla/codegen/tiling/experimental/tile_propagation.cc
@@ -1251,11 +1251,9 @@ Tiles PropagateTileToInputForAllGatherOp(const TilingSpace& tiling_space,
       << "Multi-operand AllGather is not yet supported.";
   const Shape& input_shape = hlo.operand(0)->shape();
   int64_t local_size = input_shape.dimensions(gather_dim);
-  int64_t num_replicas = hlo.shape().dimensions(gather_dim) / local_size;
 
   const DimTile& output_dim_tile = output_tile.dim_tiles()[gather_dim];
 
-  SymbolicExpr replica_id = output_dim_tile.offset / local_size;
   SymbolicExpr input_offset = output_dim_tile.offset % local_size;
 
   llvm::SmallVector<DimTile> input_dim_tiles;
@@ -1271,16 +1269,15 @@ Tiles PropagateTileToInputForAllGatherOp(const TilingSpace& tiling_space,
     }
   }
 
-  mlir::MLIRContext* ctx = output_tile.mlir_context();
+  // The input tile does NOT add a new replica_id dimension beyond what the
+  // output tile already carries. The AllGather emitter derives source_rank
+  // from the XTile tile_id function argument:
+  //   tiles_per_rank = local_size_in_gather_dim / tile_size_in_gather_dim
+  //   source_rank    = tile_id / tiles_per_rank
+  // This is computed directly in AllGatherEmitter::EmitAllGather() without
+  // needing a symbolic replica_id expression in the input tile.
   llvm::SmallVector<DimTile> replica_id_dim_tiles =
       llvm::to_vector(output_tile.replica_ids());
-  replica_id_dim_tiles.push_back(DimTile{
-      /*offset=*/replica_id,
-      /*size=*/CreateSymbolicConstant(1, ctx),
-      /*stride=*/CreateSymbolicConstant(1, ctx),
-      /*upper_bound=*/
-      CreateSymbolicConstant(num_replicas, ctx),
-  });
 
   Tile input_tile(output_tile.tiling_space(), std::move(input_dim_tiles),
                   std::move(replica_id_dim_tiles));

--- a/xla/codegen/xtile/codegen/experimental_fusion_emitter.cc
+++ b/xla/codegen/xtile/codegen/experimental_fusion_emitter.cc
@@ -166,6 +166,52 @@ absl::StatusOr<TensorValue> EmitAllReduce(
   return mlir::cast<TensorValue>(all_reduce_op.getResult(0));
 }
 
+absl::StatusOr<TensorValue> EmitAllGather(
+    EmitterContext& emitter_ctx, const HloAllGatherInstruction* all_gather,
+    const ge::TiledHloInstruction& tiled_all_gather, ValueRange operands) {
+  if (!all_gather->device_list() ||
+      all_gather->device_list()->replica_groups().empty()) {
+    return Internal(
+        "Triton emitting AllGather without replica groups is not supported.");
+  }
+
+  llvm::SmallVector<int64_t> flattened_replica_group_ids;
+  for (const auto& replica_group : all_gather->replica_groups()) {
+    for (const auto& replica_id : replica_group.replica_ids()) {
+      flattened_replica_group_ids.push_back(replica_id);
+    }
+  }
+
+  std::optional<int64_t> channel_handle = all_gather->channel_id();
+  bool use_global_device_ids = all_gather->use_global_device_ids();
+
+  ImplicitLocOpBuilder& b = emitter_ctx.b();
+  ASSIGN_OR_RETURN(
+      auto output_element_type,
+      xtile::PrimitiveTypeToMlirType(b, all_gather->shape().element_type()));
+  ASSIGN_OR_RETURN(SmallVector<int64_t> tile_sizes,
+                   tiled_all_gather.tile().GetStaticTileSizes());
+  auto output_type =
+      mlir::RankedTensorType::get(tile_sizes, output_element_type);
+
+  auto replica_groups_type = mlir::RankedTensorType::get(
+      {static_cast<int64_t>(all_gather->replica_groups().size()),
+       static_cast<int64_t>(
+           all_gather->replica_groups()[0].replica_ids_size())},
+      b.getI64Type());
+  auto replica_groups_attr = mlir::DenseIntElementsAttr::get(
+      replica_groups_type, flattened_replica_group_ids);
+  auto channel_handle_attr =
+      channel_handle ? mlir::stablehlo::ChannelHandleAttr::get(b.getContext(),
+                                                               *channel_handle,
+                                                               /*type=*/0)
+                     : nullptr;
+  auto all_gather_op = mlir::stablehlo::AllGatherOp::create(
+      b, b.getLoc(), output_type, operands, all_gather->all_gather_dimension(),
+      replica_groups_attr, channel_handle_attr, use_global_device_ids);
+  return mlir::cast<TensorValue>(all_gather_op.getResult(0));
+}
+
 absl::StatusOr<TensorValue> EmitBroadcast(
     mlir::ImplicitLocOpBuilder& b,
     const ge::TiledHloInstruction& tiled_broadcast, TensorValue input) {
@@ -1058,8 +1104,8 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
   // Please keep the cases in alphabetical order.
   switch (hlo->opcode()) {
     case HloOpcode::kAllGather: {
-      // AllGather is a no-op. Tile extraction handles the data movement.
-      return emitter_ctx.TiledHloToTensorValue(*tiled_hlo.operand(0));
+      return EmitAllGather(emitter_ctx, xla::Cast<HloAllGatherInstruction>(hlo),
+                           tiled_hlo, operands);
     }
     case HloOpcode::kAllReduce: {
       const HloComputation* computation =

--- a/xla/codegen/xtile/ir/transforms/verify_legal_xtile_ops.cc
+++ b/xla/codegen/xtile/ir/transforms/verify_legal_xtile_ops.cc
@@ -84,18 +84,18 @@ std::optional<absl::string_view> IsLegalStablehloOp(mlir::Operation* op) {
   if (mlir::isa<
           // go/keep-sorted start
           mlir::stablehlo::AbsOp, mlir::stablehlo::AddOp,
-          mlir::stablehlo::AllReduceOp, mlir::stablehlo::AndOp,
-          mlir::stablehlo::BroadcastInDimOp, mlir::stablehlo::CompareOp,
-          mlir::stablehlo::ComplexOp, mlir::stablehlo::ConstantOp,
-          mlir::stablehlo::ConvertOp, mlir::stablehlo::DivOp,
-          mlir::stablehlo::DotGeneralOp, mlir::stablehlo::ImagOp,
-          mlir::stablehlo::MaxOp, mlir::stablehlo::MinOp,
-          mlir::stablehlo::MulOp, mlir::stablehlo::NegOp, mlir::stablehlo::OrOp,
-          mlir::stablehlo::PowOp, mlir::stablehlo::RealOp,
-          mlir::stablehlo::ReduceOp, mlir::stablehlo::RemOp,
-          mlir::stablehlo::ReshapeOp, mlir::stablehlo::ReturnOp,
-          mlir::stablehlo::SubtractOp, mlir::stablehlo::TransposeOp,
-          mlir::stablehlo::XorOp
+          mlir::stablehlo::AllGatherOp, mlir::stablehlo::AllReduceOp,
+          mlir::stablehlo::AndOp, mlir::stablehlo::BroadcastInDimOp,
+          mlir::stablehlo::CompareOp, mlir::stablehlo::ComplexOp,
+          mlir::stablehlo::ConstantOp, mlir::stablehlo::ConvertOp,
+          mlir::stablehlo::DivOp, mlir::stablehlo::DotGeneralOp,
+          mlir::stablehlo::ImagOp, mlir::stablehlo::MaxOp,
+          mlir::stablehlo::MinOp, mlir::stablehlo::MulOp,
+          mlir::stablehlo::NegOp, mlir::stablehlo::OrOp, mlir::stablehlo::PowOp,
+          mlir::stablehlo::RealOp, mlir::stablehlo::ReduceOp,
+          mlir::stablehlo::RemOp, mlir::stablehlo::ReshapeOp,
+          mlir::stablehlo::ReturnOp, mlir::stablehlo::SubtractOp,
+          mlir::stablehlo::TransposeOp, mlir::stablehlo::XorOp
           // go/keep-sorted end
           >(op)) {
     return std::nullopt;


### PR DESCRIPTION
📝 Summary of Changes
This PR is the last in a series of four.

PR 1/4: https://github.com/openxla/xla/pull/44559   
PR 2/4: https://github.com/openxla/xla/pull/44560   
PR 3/4: https://github.com/openxla/xla/pull/44562  
PR 4/4: https://github.com/openxla/xla/pull/44564   <--- This PR

These PRs aim to enable the Triton backend for the All-Gather collective operation based on the experimental tiling strategy.

This PR adds the full suite of e2e correctness and regression tests.

🎯 Justification
Lowering All-Gather through the triton backend significantly improves performance of this operation for AMD/ROCm target (compared to RCCL backend), especially for small tensor, and could allow us to take greater advantage of kernel-level fusion.

Example of 5 Triton Performance Improvements — All-Gather 1D on MI355
 | DType | Shape | Replicas | Triton (µs) | RCCL (µs) | Speedup |
|--------|--------|----------|------------------:|---------------:|--------:|
| s8 | [16384] | 2 | 17.428 | 42.342 | **2.43×** |
| bf16 | [16384] | 2 | 17.708 | 41.733 | **2.36×** |
| f32 | [131072] | 2 | 27.924 | 52.497 | **1.88×** |
| s32 | [4096] | 2 | 24.435 | 44.287 | **1.81×** |
| s8 | [262144] | 4 | 40.459 | 71.119 | **1.76×** |

Example of 5 Triton Performance Improvements — All-Gather 2D on MI355
dtype | shape | replicas | RCCL (µs) | Triton (µs) | speedup
-- | -- | -- | -- | -- | --
bf16 | [32, 32] | 2 | 41.153 | 16.744 | **2.46×**
bf16 | [128, 64] | 4 | 68.079 | 35.498 | **1.92×**
bf16 | [256, 256] | 4 | 68.927 | 36.992 | **1.86×**
f32 | [128, 64] | 4 | 64.403 | 34.928 | **1.84×**
f8e4m3fn | [512, 512] | 4 | 68.342 | 41.506 | **1.65×**


🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement,✨ New Feature

🧪 Execution Tests:
Tests included in this PR.