### PR TITLE
[ROCm] Fix missing tensile libs in rocm sandbox

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -443,7 +443,12 @@ rocm_lib_import(
             "%{rocm_root}/lib/hipblaslt/library/*" + arch + "*",
             "%{rocm_root}/lib/hipblaslt/library/" + arch + "/**/*",
         ]
-    ]),
+    ]) + glob(
+        ["%{rocm_root}/lib/hipblaslt/library/*"],
+        exclude = [
+            "%{rocm_root}/lib/hipblaslt/library/*gfx*",
+        ],
+    ),
     interface_library = "%{rocm_root}/lib/libhipblaslt.so",
     deps = [
         ":hip_runtime_libs",


### PR DESCRIPTION
📝 Summary of Changes
Fix missing tensile libs in rocm sandbox

🎯 Justification
Remove skip for supported by mi3xx series GPUs algorithms.
Got this error when running tests:
No library mapping found in external/local_config_rocm/rocm/rocm_dist/lib/hipblaslt/library

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI