### PR TITLE
[GPU:XLA] Fix native emitter unroll test

### DIFF
--- a/xla/backends/gpu/autotuner/BUILD
+++ b/xla/backends/gpu/autotuner/BUILD
@@ -487,6 +487,8 @@ xla_test(
         "//xla/service:hlo_cost_analysis",
         "//xla/service:platform_util",
         "//xla/service/gpu:backend_configs_cc",
+        "//xla/service/gpu:gpu_fusible",
+        "//xla/service/gpu:hlo_fusion_analysis",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:stream_executor_h",
         "//xla/tsl/platform:statusor",

--- a/xla/backends/gpu/autotuner/native_emitter_test.cc
+++ b/xla/backends/gpu/autotuner/native_emitter_test.cc
@@ -31,6 +31,8 @@ limitations under the License.
 #include "xla/service/compiler.h"
 #include "xla/service/executable.h"
 #include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/gpu_fusible.h"
+#include "xla/service/gpu/hlo_fusion_analysis.h"
 #include "xla/service/hlo_cost_analysis.h"
 #include "xla/service/platform_util.h"
 #include "xla/stream_executor/platform.h"
@@ -185,12 +187,19 @@ TEST_F(NativeEmitterBackendTest, GetSupportedConfigsForLoopFusion) {
 
     native_configs.push_back(config->native_emitter());
   }
+  HloFusionAnalysis analysis =
+      HloFusionAnalysis::Create(*fusion, target_config_.device_description);
+  int64_t max_unroll_factor = MaxUnrollFactor(&analysis);
+  ASSERT_GT(max_unroll_factor, 1);
   EXPECT_THAT(
       native_configs,
-      UnorderedElementsAre(EqualsProto(R"pb(type: NATIVE_EMITTER_TYPE_LOOP
-                                            unroll_factor: 2)pb"),
-                           EqualsProto(R"pb(type: NATIVE_EMITTER_TYPE_LOOP
-                                            unroll_factor: 4)pb")));
+      UnorderedElementsAre(
+          EqualsProto(absl::Substitute(R"pb(type: NATIVE_EMITTER_TYPE_LOOP
+                                            unroll_factor: $0)pb",
+                                       max_unroll_factor / 2)),
+          EqualsProto(absl::Substitute(R"pb(type: NATIVE_EMITTER_TYPE_LOOP
+                                            unroll_factor: $0)pb",
+                                       max_unroll_factor))));
 }
 
 TEST_F(NativeEmitterBackendTest,


### PR DESCRIPTION
📝 Summary of Changes
Updates `NativeEmitterBackendTest.GetSupportedConfigsForLoopFusion` to derive the expected loop unroll factors from `MaxUnrollFactor()` for the target device instead of hard-coding fixed values. The test now builds `HloFusionAnalysis` for the fusion and expects `{max_unroll_factor / 2, max_unroll_factor}`.

🎯 Justification
This fixes `NativeEmitterBackendTest` failures seen on B200. On B200, `MaxUnrollFactor()` can be `8`, while the test assumed a lower fixed value `4`, causing the expected configs to disagree with the values produced by the backend.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
//xla/backends/gpu/autotuner:native_emitter_test NativeEmitterBackendTest.GetSupportedConfigsForLoopFusion
