### PR TITLE
[XLA:GPU] Check cuDNN fused conv metadata directly

### DIFF
--- a/xla/backends/gpu/transforms/cudnn_fused_conv_rewriter_test.cc
+++ b/xla/backends/gpu/transforms/cudnn_fused_conv_rewriter_test.cc
@@ -47,6 +47,7 @@ limitations under the License.
 #include "xla/hlo/transforms/simplifiers/convert_mover.h"
 #include "xla/hlo/transforms/simplifiers/hlo_constant_folding.h"
 #include "xla/hlo/transforms/simplifiers/reshape_mover.h"
+#include "xla/hlo/utils/hlo_query.h"
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/cublas_cudnn.h"
 #include "xla/service/gpu/stream_executor_util.h"
@@ -73,6 +74,7 @@ namespace m = match;
 
 using ::testing::HasSubstr;
 using ::testing::Not;
+using ::testing::NotNull;
 
 static const std::initializer_list<absl::string_view> kf16f32f64{"f16", "f32",
                                                                  "f64"};
@@ -843,10 +845,11 @@ TEST_F(CudnnFusedConvRewriterTest, PreservesMetadata) {
   ASSERT_OK_AND_ASSIGN(
       auto optimized_module,
       GetOptimizedModule(kHloString, GetModuleConfigForTest()));
-  const std::string optimized_hlo_string = optimized_module->ToString();
-  EXPECT_THAT(optimized_hlo_string,
-              ::testing::ContainsRegex(
-                  R"(custom-call.*metadata=\{op_type="foo" op_name="bar"\})"));
+  const HloInstruction* custom_call = hlo_query::GetFirstInstructionWithOpcode(
+      *optimized_module->entry_computation(), HloOpcode::kCustomCall);
+  ASSERT_THAT(custom_call, NotNull()) << optimized_module->ToString();
+  EXPECT_EQ(custom_call->metadata().op_type(), "foo");
+  EXPECT_EQ(custom_call->metadata().op_name(), "bar");
 }
 
 TEST_F(CudnnFusedConvRewriterTest, TestPreservesFeatureGroupCount) {


### PR DESCRIPTION
📝 Summary of Changes
Updates `CudnnFusedConvRewriterTest.PreservesMetadata` to check the preserved metadata fields directly on the rewritten custom-call instruction instead of matching the full serialized HLO text. The test now verifies that `op_type` and `op_name` are preserved while allowing other metadata fields, such as scheduling metadata added by later passes, to also be present.

🎯 Justification
The previous test was too strict because it expected the custom-call metadata serialization to contain only `op_type="foo"` and `op_name="bar"`. The rewritten custom call may also contain additional metadata such as `scheduling_name`, while still correctly preserving the original metadata fields.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
//xla/backends/gpu/transforms:cudnn_fused_conv_rewriter_test CudnnFusedConvRewriterTest.PreservesMetadata
