### PR TITLE
Validate buffer slices during deserialization

### DIFF
--- a/xla/backends/gpu/runtime/dynamic_slice_thunk_test.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_thunk_test.cc
@@ -104,10 +104,40 @@ se::StreamExecutor* GpuExecutor() {
 }
 void CheckProtoRoundTrip(const DynamicSliceThunk& thunk,
                          const DynamicSliceThunkProto& proto) {
+  // Size allocations to cover every slice referenced by the thunk. Hardcoding
+  // 1024 used to work when FromProto only checked the allocation index; with
+  // offset/size bounds checks it must also fit workspace slices (e.g. 1MiB).
+  std::vector<int64_t> allocation_sizes(10, 1024);
+  auto ensure_fits = [&](const BufferAllocation::Slice& slice) {
+    const int index = slice.index();
+    if (index >= static_cast<int>(allocation_sizes.size())) {
+      allocation_sizes.resize(index + 1, 1024);
+    }
+    allocation_sizes[index] =
+        std::max(allocation_sizes[index], slice.offset() + slice.size());
+  };
+  for (const std::optional<BufferAllocation::Slice>& arg :
+       thunk.get_arguments()) {
+    if (arg.has_value()) {
+      ensure_fits(*arg);
+    }
+  }
+  for (const std::optional<std::vector<DynamicSliceThunk::Offset>>& offsets :
+       thunk.get_offsets()) {
+    if (!offsets.has_value()) {
+      continue;
+    }
+    for (const DynamicSliceThunk::Offset& offset : *offsets) {
+      if (std::holds_alternative<BufferAllocation::Slice>(offset)) {
+        ensure_fits(std::get<BufferAllocation::Slice>(offset));
+      }
+    }
+  }
   std::vector<BufferAllocation> buffer_allocations;
-  for (int i = 0; i < 10; ++i) {
-    buffer_allocations.push_back(BufferAllocation(
-        /*index=*/i, /*size=*/1024, /*color=*/0));
+  buffer_allocations.reserve(allocation_sizes.size());
+  for (int i = 0; i < static_cast<int>(allocation_sizes.size()); ++i) {
+    buffer_allocations.push_back(
+        BufferAllocation(/*index=*/i, allocation_sizes[i], /*color=*/0));
   }
 
   std::vector<BufferAllocation> fake_allocations_span;

--- a/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk_test.cc
+++ b/xla/backends/gpu/runtime/gpublas_lt_matmul_thunk_test.cc
@@ -626,12 +626,14 @@ TEST_F(GpuBlasLtMatmulThunkTest, ThunkProtoSerializationGroupedMatmul) {
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       kCublasLtGroupedMatmulThunkProtoText, &proto));
 
+  // Allocation #4 must cover the grouped-matmul B operand (size 1302400),
+  // matching slice { size: 1302400 buffer_allocation_index: 4 } above.
   std::vector<BufferAllocation> allocations = {
       BufferAllocation(/*index=*/0, /*size=*/4, /*color=*/0),  // UNUSED
       BufferAllocation(/*index=*/1, /*size=*/4, /*color=*/0),  // UNUSED
       BufferAllocation(/*index=*/2, /*size=*/4, /*color=*/0),  // UNUSED
       BufferAllocation(/*index=*/3, /*size=*/164428, /*color=*/0),
-      BufferAllocation(/*index=*/4, /*size=*/651200, /*color=*/0),
+      BufferAllocation(/*index=*/4, /*size=*/1302400, /*color=*/0),
       BufferAllocation(/*index=*/5, /*size=*/161600, /*color=*/0),
       BufferAllocation(/*index=*/6, /*size=*/8, /*color=*/0),
   };

--- a/xla/backends/gpu/runtime/thunk_proto_deserialization_test.cc
+++ b/xla/backends/gpu/runtime/thunk_proto_deserialization_test.cc
@@ -952,12 +952,14 @@ TEST(ThunkProtoDeserializationTest, CublasLtGroupedMatmulThunk) {
         }
       )pb");
 
+  // Allocation #4 must cover the grouped-matmul B operand f32[2,407,400]
+  // (2 * 407 * 400 * sizeof(float) = 1302400), not the non-grouped 651200 size.
   std::vector<BufferAllocation> allocations = {
       BufferAllocation(/*index=*/0, /*size=*/4, /*color=*/0),  // UNUSED
       BufferAllocation(/*index=*/1, /*size=*/4, /*color=*/0),  // UNUSED
       BufferAllocation(/*index=*/2, /*size=*/4, /*color=*/0),  // UNUSED
       BufferAllocation(/*index=*/3, /*size=*/164428, /*color=*/0),
-      BufferAllocation(/*index=*/4, /*size=*/651200, /*color=*/0),
+      BufferAllocation(/*index=*/4, /*size=*/1302400, /*color=*/0),
       BufferAllocation(/*index=*/5, /*size=*/161600, /*color=*/0),
       BufferAllocation(/*index=*/6, /*size=*/8, /*color=*/0),
   };

--- a/xla/service/buffer_assignment.cc
+++ b/xla/service/buffer_assignment.cc
@@ -379,6 +379,18 @@ absl::StatusOr<BufferAllocation::Slice> BufferAllocation::Slice::FromProto(
   }
   const BufferAllocation& allocation =
       buffer_allocations[proto.buffer_allocation_index()];
+  if (proto.offset() < 0 || proto.size() < 0) {
+    return absl::OutOfRangeError(
+        absl::StrCat("Buffer slice has negative offset/size: offset=",
+                     proto.offset(), " size=", proto.size()));
+  }
+  if (proto.size() > allocation.size() ||
+      proto.offset() > allocation.size() - proto.size()) {
+    return absl::OutOfRangeError(absl::StrCat(
+        "Buffer slice [offset=", proto.offset(), ", size=", proto.size(),
+        "] is out of range for allocation #", proto.buffer_allocation_index(),
+        " of size ", allocation.size()));
+  }
   return BufferAllocation::Slice(&allocation, proto.offset(), proto.size(),
                                  proto.element_type());
 }

--- a/xla/service/buffer_assignment_test.cc
+++ b/xla/service/buffer_assignment_test.cc
@@ -3952,6 +3952,45 @@ TEST(BufferAllocationSliceProtoTest, FromProtoErrorAllocationNotFound) {
                   HasSubstr("Buffer allocation index 2 is out of range.")));
 }
 
+TEST(BufferAllocationSliceProtoTest, FromProtoErrorNegativeOffsetOrSize) {
+  std::vector<BufferAllocation> allocations;
+  allocations.push_back(
+      BufferAllocation(/*index=*/0, /*size=*/200, /*color=*/0));
+
+  xla::buffer_assignment::BufferAllocationSliceProto proto;
+  proto.set_buffer_allocation_index(0);
+  proto.set_offset(-1);
+  proto.set_size(60);
+  EXPECT_THAT(BufferAllocation::Slice::FromProto(proto, allocations),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kOutOfRange,
+                  HasSubstr("Buffer slice has negative offset/size")));
+
+  proto.set_offset(50);
+  proto.set_size(-1);
+  EXPECT_THAT(BufferAllocation::Slice::FromProto(proto, allocations),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kOutOfRange,
+                  HasSubstr("Buffer slice has negative offset/size")));
+}
+
+TEST(BufferAllocationSliceProtoTest, FromProtoErrorSliceOutOfRange) {
+  std::vector<BufferAllocation> allocations;
+  allocations.push_back(
+      BufferAllocation(/*index=*/0, /*size=*/200, /*color=*/0));
+
+  xla::buffer_assignment::BufferAllocationSliceProto proto;
+  proto.set_buffer_allocation_index(0);
+  proto.set_offset(150);
+  proto.set_size(60);
+
+  EXPECT_THAT(BufferAllocation::Slice::FromProto(proto, allocations),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kOutOfRange,
+                  HasSubstr("Buffer slice [offset=150, size=60] is out of "
+                            "range for allocation #0 of size 200")));
+}
+
 TEST(BufferAllocationTest, ToProto) {
   BufferAllocation alloc{42, 64, 3};
   alloc.set_constant(true);


### PR DESCRIPTION
## Summary

- validate `BufferAllocation::Slice::FromProto` rejects negative offsets and sizes
- reject serialized slices whose `[offset, offset + size)` range exceeds the referenced allocation
- add regression coverage for malformed `BufferAllocationSliceProto` values

## Why

`BufferAllocation::Slice::FromProto` reconstructs runtime buffer slices from serialized executable data. It previously validated only `buffer_allocation_index`, while the compile-time assignment path guarantees that `offset >= 0`, `size >= 0`, and `offset + size <= allocation.size()`. This change enforces that same invariant before constructing the slice.

## Testing

- `git diff --check`
- `clang++ -std=c++17 -fsanitize=address -g -DNDEBUG -DAPPLY_FIX poc_primitive_asan.cc -o /tmp/openxla_poc_fixed && /tmp/openxla_poc_fixed` from the local reproduction bundle; the fixed logic rejects the malformed slice
- attempted `bazel test //xla/service:buffer_assignment_test`; local sparse-checkout setup initially missed top-level `third_party` and `tools`, and after adding them the invocation stayed in Bazel repository mapping until interrupted. Retrying with `--noexperimental_repo_remote_exec` fails during repository initialization because `rules_ml_toolchain` requires that experimental flag.
