### PR TITLE
[XLA:GPU] Run PJRT buffer teardown after thunk execution

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -2177,14 +2177,16 @@ StreamExecutorGpuClient::RunAsync(
     RETURN_IF_ERROR(set_result({}, 0));
   }
 
-  RETURN_IF_ERROR(allocation_scope.ExecuteWithBufferAllocations(
+  absl::Status execute_status = allocation_scope.ExecuteWithBufferAllocations(
       buffer_allocations, device_ordinal,
       [&](const gpu::BufferAllocations& execution_buffers) {
         return gpu_exec->ExecuteThunks(execution_buffers, run_options);
-      }));
+      });
+  absl::Status teardown_status = buffer_allocations.TearDown(
+      buffers_in_result, gpu_exec->GetAllocations());
 
-  RETURN_IF_ERROR(buffer_allocations.TearDown(buffers_in_result,
-                                              gpu_exec->GetAllocations()));
+  RETURN_IF_ERROR(execute_status);
+  RETURN_IF_ERROR(teardown_status);
 
   std::vector<tsl::AsyncValueRef<RawSEDeviceMemory>> to_be_released;
 


### PR DESCRIPTION
📝 Summary of Changes
Split the PJRT GPU RunAsync execution status handling so buffer teardown still runs after ExecuteWithBufferAllocations returns an error.

🎯 Justification
This ensures delayed/owning buffer cleanup is attempted even when thunk execution fails, matching GpuExecutable behavior and preventing cleanup from being skipped on execution errors.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
No new unit tests. Compile validation only.

🧪 Execution Tests:
Not run.

Validation:
- bazel build //xla/pjrt/gpu:se_gpu_pjrt_client