### PR TITLE
[ROCm] Switch to do based gha runners for rocm CI

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -22,8 +22,9 @@ self-hosted-runner:
     - "linux-arm64-c4a-16" # Linux ARM64 CPU Runner using the 16 vcpu c4a-standard-16 machine.
     - "linux-arm64-t2a-48" # Linux ARM64 CPU Runner using the 48 vcpu t2a-standard-48 machine.
     - "windows-x86-n2-16" # Windows X86 runner using n2-standard-16 machine.
-    - "linux-x86-64-1gpu-amd" # AMD runner with 1 GPU.
-    - "linux-x86-64-4gpu-amd" # AMD runner with 4 GPUs.
+    - "amd-do-linux-xla-gpu-gfx950-1" # AMD runner 1 GPU.
+    - "amd-do-linux-xla-gpu-gfx950-4" # AMD runner 4 GPU.
+    - "amd-do-linux-xla-gpu-gfx950-8" # AMD runner 8 GPUs.
     - "linux-x86-a4-224-b200-1gpu" # Linux X86 GPU runner using 1 B200 GPU and 1/8 the resources of a a4-highgpu-8g machine
     - "linux-x86-a3-8g-h100-8gpu" # Linux X86 GPU runner using a3-highgpu-8g machine with 8 NVIDIA H100 GPUs attached.
     - "linux-x64-battlemage-256-1gpu-intel" # Linux X86 GPU runner using an EMR4148 machine with 2 Intel BMG GPUs attached.

--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -40,7 +40,7 @@ jobs:
     needs: rocm-config
     if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
     name: JAX Linux x86 AMD Instinct GPU
-    runs-on: linux-x86-64-1gpu-amd
+    runs-on: amd-do-linux-xla-gpu-gfx950-1
     timeout-minutes: 80
     env:
       DOCKER_IMAGE: ${{ needs.rocm-config.outputs.docker-image }}
@@ -104,7 +104,7 @@ jobs:
   xla:
     needs: rocm-config
     name: XLA Linux x86 AMD Instinct GPU
-    runs-on: linux-x86-64-1gpu-amd
+    runs-on: amd-do-linux-xla-gpu-gfx950-1
     timeout-minutes: 220
     env:
       DOCKER_IMAGE: ${{ needs.rocm-config.outputs.docker-image }}


### PR DESCRIPTION
📝 Summary of Changes
Switch to DO hosted gha runners for rocm upstream xla PR checks

🎯 Justification
Old runners are gonna to retire

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
