### PR TITLE
increase default value for kMaxEvents

### DIFF
--- a/xla/tsl/profiler/convert/xplane_to_trace_events.cc
+++ b/xla/tsl/profiler/convert/xplane_to_trace_events.cc
@@ -107,7 +107,7 @@ void ConvertXPlaneToTraceEvents(uint32_t device_id, const XPlaneVisitor& xplane,
 }  // namespace
 
 uint64_t GetTraceViewerMaxEvents() {
-  constexpr uint64_t kMaxEvents = 1000000;
+  constexpr uint64_t kMaxEvents = 5000000;
   // Testing only env variable, not recommended for use
   char* max_events = getenv("TF_PROFILER_TRACE_VIEWER_MAX_EVENTS");
   if (max_events != nullptr) {


### PR DESCRIPTION
Increase the default trace-viewer event cap from 1M to 5M so large XPlane profiles are not prematurely truncated when converted to Chrome trace JSON for large-scale models. With this default value, both trace json generation and TraceLens can work for at least 3 steps profiling for 8-node 405B model.