### PR TITLE
[XLA:GPU] ROCm VMM enablement: wire DeviceAddressVmmAllocator into PJRT GPU client

### DIFF
--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -361,6 +361,8 @@ xla_test(
     ] + if_cuda([
         "//xla/stream_executor/cuda:cuda_compute_capability",
         "//xla/stream_executor/cuda:cuda_device_address_vmm_allocator",
+    ]) + if_rocm([
+        "//xla/stream_executor/rocm:rocm_device_address_vmm_allocator",
     ]) + if_google([
         # In OSS this dependency is added automatically for xla_test targets. See
         # third_party/tensorflow/compiler/xla/xla.default.bzl.

--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -212,6 +212,7 @@ cc_library(
         "@local_config_cuda//cuda:cuda_headers",
     ]) + if_rocm([
         # keep sorted
+        "//xla/stream_executor/rocm:rocm_device_address_vmm_allocator",
         "@local_config_rocm//rocm:rocm_headers",
     ]) + if_sycl([
         # keep sorted

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -155,6 +155,7 @@ limitations under the License.
 #include "xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h"
 #elif TENSORFLOW_USE_ROCM
 #include "rocm/rocm_config.h"
+#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
 #endif
 
 #include "xla/service/gpu/gpu_executable_run_options.h"
@@ -1425,9 +1426,19 @@ GetStreamExecutorGpuDeviceAllocator(
       return se::gpu::CudaDeviceAddressVmmAllocator::Create(
           platform, allocator_config.memory_fraction,
           allocator_config.gpu_system_memory_size, executor_streams);
+#elif TENSORFLOW_USE_ROCM
+      std::vector<std::pair<se::StreamExecutor*, se::Stream*>> executor_streams;
+      executor_streams.reserve(addressable_devices.size());
+      for (const auto& [ordinal, device] : addressable_devices) {
+        executor_streams.push_back(
+            {device->executor(), device->compute_stream()});
+      }
+      return se::gpu::RocmDeviceAddressVmmAllocator::Create(
+          platform, allocator_config.memory_fraction,
+          allocator_config.gpu_system_memory_size, executor_streams);
 #else
       return absl::UnimplementedError(
-          "VMM allocator is only supported with CUDA.");
+          "VMM allocator is only supported with CUDA or ROCm.");
 #endif  // GOOGLE_CUDA
     }
 

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -89,6 +89,8 @@ limitations under the License.
 #if GOOGLE_CUDA
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h"
+#elif TENSORFLOW_USE_ROCM
+#include "xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h"
 #endif  // GOOGLE_CUDA
 #include "xla/pjrt/gpu/se_gpu_pjrt_client_test_helper.h"
 #include "xla/stream_executor/integrations/tf_allocator_adapter.h"
@@ -2321,12 +2323,13 @@ TEST(StreamExecutorGpuClientTest, AddressAllocatorIsSynchronousPassthrough) {
             nullptr);
 }
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 class VmmTest : public ::testing::Test {
  protected:
   void SetUp() override {
     ::testing::Test::SetUp();
 
+#if GOOGLE_CUDA
     auto platform_or = xla::PlatformUtil::GetPlatform("CUDA");
     if (!platform_or.ok()) {
       GTEST_SKIP() << "CUDA platform not available.";
@@ -2343,6 +2346,18 @@ class VmmTest : public ::testing::Test {
     if (!dev_desc.cuda_compute_capability().IsAtLeastHopper()) {
       GTEST_SKIP() << "This test requires at least a Hopper GPU (SM 9.0).";
     }
+#elif TENSORFLOW_USE_ROCM
+    auto platform_or = xla::PlatformUtil::GetPlatform("ROCM");
+    if (!platform_or.ok()) {
+      GTEST_SKIP() << "ROCM platform not available.";
+    }
+    auto* platform = platform_or.value();
+
+    auto executor_or = platform->ExecutorForDevice(0);
+    if (!executor_or.ok()) {
+      GTEST_SKIP() << "No ROCm device available.";
+    }
+#endif
   }
 };
 
@@ -2355,9 +2370,15 @@ TEST_F(VmmTest, VmmAllocatorCanBeSet) {
 
   auto* pjrt_se_client =
       absl::down_cast<PjRtStreamExecutorClient*>(client.get());
+#if GOOGLE_CUDA
   EXPECT_NE(dynamic_cast<se::gpu::CudaDeviceAddressVmmAllocator*>(
                 pjrt_se_client->allocator()),
             nullptr);
+#elif TENSORFLOW_USE_ROCM
+  EXPECT_NE(dynamic_cast<se::gpu::RocmDeviceAddressVmmAllocator*>(
+                pjrt_se_client->allocator()),
+            nullptr);
+#endif
 }
 
 TEST_F(VmmTest, VmmAllocatorE2ETest) {
@@ -2963,7 +2984,7 @@ TEST_F(VmmTest, CommandBufferVaRemappingTwoExecutables) {
   absl::SetVLogLevel("command_buffer_thunk", old_vlog_cbt);
 }
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
## Summary
Final integration step for the ROCm VMM allocator stack (the allocator layers + factory + tests landed via #43947). This wires the allocator into the runtime so it is actually selectable end-to-end:

- `se_gpu_pjrt_client.cc`: add a ROCm branch to the `kVmm` allocator selection so `XLA_PYTHON_CLIENT_ALLOCATOR=vmm` constructs `RocmDeviceAddressVmmAllocator` on ROCm. The `GOOGLE_CUDA` path is left byte-for-byte unchanged; ROCm support is added purely under `TENSORFLOW_USE_ROCM` / `if_rocm`, so the CUDA build is unaffected.
- `xla/pjrt/gpu/BUILD`: add the `rocm_device_address_vmm_allocator` dependency under `if_rocm`.
- `se_gpu_pjrt_client_test.cc`: extend the existing CUDA `VmmTest` (`VmmAllocatorCanBeSet`) to also run on ROCm, asserting the client's allocator is a `RocmDeviceAddressVmmAllocator`.

Small, self-contained change (~38 lines) on top of `main` now that the allocator stack has merged.

## Test plan
- [ ] `se_gpu_pjrt_client_test` `VmmTest.VmmAllocatorCanBeSet` passes on a ROCm (gfx942/gfx950) device.
- [ ] Build `//xla/pjrt/gpu:se_gpu_pjrt_client` under `--config=rocm`.
- [ ] Manual: `XLA_PYTHON_CLIENT_ALLOCATOR=vmm` selects the ROCm VMM allocator.