### PR TITLE
Avoid splitting softmax scaled logits across CPU fusions

### DIFF
--- a/xla/service/cpu/BUILD
+++ b/xla/service/cpu/BUILD
@@ -1083,6 +1083,7 @@ cc_library(
         "//xla:shape_util",
         "//xla:xla_data_proto_cc",
         "//xla/codegen/emitters:elemental_hlo_to_mlir",
+        "//xla/hlo/analysis:hlo_reachability",
         "//xla/hlo/ir:hlo",
         "//xla/service:fusion_node_indexing_evaluation",
         "//xla/service:hlo_module_config",
@@ -1094,6 +1095,7 @@ cc_library(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/xla/service/cpu/BUILD
+++ b/xla/service/cpu/BUILD
@@ -1067,6 +1067,7 @@ xla_cc_test(
         "//xla/tests:xla_internal_test_main",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",

--- a/xla/service/cpu/cpu_instruction_fusion.cc
+++ b/xla/service/cpu/cpu_instruction_fusion.cc
@@ -19,7 +19,9 @@ limitations under the License.
 
 #include "absl/algorithm/container.h"
 #include "absl/log/log.h"
+#include "absl/types/span.h"
 #include "xla/codegen/emitters/elemental_hlo_to_mlir.h"
+#include "xla/hlo/analysis/hlo_reachability.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"

--- a/xla/service/cpu/cpu_instruction_fusion.cc
+++ b/xla/service/cpu/cpu_instruction_fusion.cc
@@ -103,6 +103,79 @@ bool BlockSubcomputationFusion(const HloInstruction* instruction,
   return false;
 }
 
+bool FusionInstructionContainsOpcode(const HloInstruction& fusion,
+                                     HloOpcode opcode) {
+  if (!fusion.IsFusion()) {
+    return fusion.opcode() == opcode;
+  }
+  return absl::c_any_of(
+      fusion.fused_instructions(),
+      [opcode](const HloInstruction* instr) { return instr->opcode() == opcode; });
+}
+
+bool MultiplyFeedsReduceAndSubtract(const HloInstruction& multiply) {
+  bool feeds_reduce = false;
+  bool feeds_subtract = false;
+  auto note_user = [&](const HloInstruction& user) {
+    if (user.opcode() == HloOpcode::kReduce) {
+      feeds_reduce = true;
+    }
+    if (user.opcode() == HloOpcode::kSubtract) {
+      feeds_subtract = true;
+    }
+    if (user.IsFusion()) {
+      if (FusionInstructionContainsOpcode(user, HloOpcode::kReduce)) {
+        feeds_reduce = true;
+      }
+      if (FusionInstructionContainsOpcode(user, HloOpcode::kSubtract)) {
+        feeds_subtract = true;
+      }
+    }
+  };
+  for (const HloInstruction* user : multiply.users()) {
+    note_user(*user);
+  }
+  return feeds_reduce && feeds_subtract;
+}
+
+bool WouldSplitSoftmaxScaledMultiply(const HloInstruction* producer,
+                                     const HloInstruction* consumer) {
+  if (producer->opcode() != HloOpcode::kMultiply) {
+    return false;
+  }
+  if (!MultiplyFeedsReduceAndSubtract(*producer)) {
+    return false;
+  }
+  if (consumer->opcode() == HloOpcode::kReduce ||
+      consumer->opcode() == HloOpcode::kSubtract) {
+    return true;
+  }
+  if (consumer->IsFusion() &&
+      (FusionInstructionContainsOpcode(*consumer, HloOpcode::kReduce) ||
+       FusionInstructionContainsOpcode(*consumer, HloOpcode::kSubtract))) {
+    return true;
+  }
+  return false;
+}
+
+bool WouldFuseDotIntoSplitSoftmaxFusion(const HloInstruction* producer,
+                                        const HloInstruction* consumer) {
+  if (producer->opcode() != HloOpcode::kDot || !consumer->IsFusion()) {
+    return false;
+  }
+  if (!FusionInstructionContainsOpcode(*consumer, HloOpcode::kSubtract) ||
+      !FusionInstructionContainsOpcode(*consumer, HloOpcode::kExp)) {
+    return false;
+  }
+  for (const HloInstruction* user : producer->users()) {
+    if (user->opcode() == HloOpcode::kMultiply &&
+        MultiplyFeedsReduceAndSubtract(*user)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 }  // namespace
 
 bool CpuInstructionFusion::IsExpensive(const HloInstruction& instruction) {
@@ -382,6 +455,20 @@ FusionDecision CpuInstructionFusion::ShouldFuse(HloInstruction* consumer,
   if (producer->opcode() != HloOpcode::kFusion && is_expensive(*producer) &&
       ReusesOperandElements(consumer, operand_index)) {
     return FusionDecision::Forbid("Fusion is not profitable.");
+  }
+
+  // Stable softmax lowers as: dot -> multiply(scale) -> reduce(max) and
+  // subtract(multiply, broadcast(max)) -> exponential. Fusing multiply only into
+  // reduce, then fusing dot into subtract+exponential separately, recomputes
+  // scaled logits in a second kernel and can miscompile for large values.
+  if (WouldSplitSoftmaxScaledMultiply(producer, consumer)) {
+    return FusionDecision::Forbid(
+        "Don't split softmax scaled logits across separate fusions.");
+  }
+  if (WouldFuseDotIntoSplitSoftmaxFusion(producer, consumer)) {
+    return FusionDecision::Forbid(
+        "Don't fuse dot into softmax subtract-exponential fusion separately "
+        "from its scaled-logits reduce.");
   }
 
   RETURN_IF_NOT_FUSIBLE(InstructionFusion::ShouldFuse(consumer, operand_index));

--- a/xla/service/cpu/cpu_instruction_fusion.cc
+++ b/xla/service/cpu/cpu_instruction_fusion.cc
@@ -90,7 +90,8 @@ bool IsMaxReduction(const HloInstruction* reduce) {
   return root->opcode() == HloOpcode::kMaximum;
 }
 
-// Matches subtract(shift_value, broadcast(reduce)) used by exponential, i.e.
+// Matches subtract(shift_value, broadcast(reduce)) or the reversed operand
+// order subtract(broadcast(reduce), shift_value), used by exponential, i.e.
 // the numerically sensitive stable-softmax shift pattern.
 bool IsExpShiftCoupledSubtract(const HloInstruction& subtract,
                                const HloInstruction& shift_value,
@@ -349,6 +350,12 @@ CpuInstructionFusion::ComputeGloballyUnfusible(
       InstructionFusion::ComputeGloballyUnfusible(post_order, reachability);
   for (HloInstruction* producer : post_order) {
     if (IsCoupledReductionShiftExpProducer(producer)) {
+      // The base implementation treats effectively-unary elementwise ops as
+      // free to duplicate. For producers feeding both a max-reduce and its
+      // exp-shift subtract, duplication is unsound: FMA contraction can make
+      // the recomputed copy differ from the copy the max was taken over by up
+      // to one ulp, which exp() turns into inf/nan. Force such producers to be
+      // materialized once.
       do_not_duplicate.insert(producer);
     }
   }

--- a/xla/service/cpu/cpu_instruction_fusion.cc
+++ b/xla/service/cpu/cpu_instruction_fusion.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "xla/service/cpu/cpu_instruction_fusion.h"
 
 #include <cstdint>
+#include <functional>
 
 #include "absl/algorithm/container.h"
 #include "absl/log/log.h"
@@ -82,6 +83,141 @@ bool CanBeOutputFusedIntoSomeOperand(const HloInstruction* consumer) {
           CanBeOutputFused(consumer->operand(1), consumer));
 }
 
+bool IsMaxReduction(const HloInstruction* reduce) {
+  if (reduce->opcode() != HloOpcode::kReduce) {
+    return false;
+  }
+  const HloInstruction* root = reduce->to_apply()->root_instruction();
+  return root->opcode() == HloOpcode::kMaximum;
+}
+
+bool IsDotLikeOpcode(HloOpcode opcode) {
+  return opcode == HloOpcode::kDot;
+}
+
+// Matches subtract(shift_value, broadcast(reduce)) used by exponential, i.e.
+// the numerically sensitive stable-softmax shift pattern.
+bool IsExpShiftCoupledSubtract(const HloInstruction& subtract,
+                               const HloInstruction& shift_value,
+                               const HloInstruction& reduce) {
+  if (subtract.opcode() != HloOpcode::kSubtract) {
+    return false;
+  }
+  const HloInstruction* op0 = subtract.operand(0);
+  const HloInstruction* op1 = subtract.operand(1);
+  const bool uses_shift_value =
+      op0 == &shift_value || op1 == &shift_value ||
+      (op0->opcode() == HloOpcode::kBroadcast &&
+       op0->operand(0) == &shift_value) ||
+      (op1->opcode() == HloOpcode::kBroadcast &&
+       op1->operand(0) == &shift_value);
+  const bool uses_reduce_broadcast =
+      (op0->opcode() == HloOpcode::kBroadcast &&
+       op0->operand(0) == &reduce) ||
+      (op1->opcode() == HloOpcode::kBroadcast &&
+       op1->operand(0) == &reduce);
+  if (!uses_shift_value || !uses_reduce_broadcast) {
+    return false;
+  }
+  return absl::c_any_of(subtract.users(), [](const HloInstruction* user) {
+    return user->opcode() == HloOpcode::kExp;
+  });
+}
+
+const HloInstruction* FindMaxReduceForShiftValue(
+    const HloInstruction& shift_value) {
+  for (const HloInstruction* user : shift_value.users()) {
+    if (user->opcode() == HloOpcode::kReduce && user->operand(0) == &shift_value &&
+        IsMaxReduction(user)) {
+      return user;
+    }
+  }
+  return nullptr;
+}
+
+// A multiply that feeds both row-max reduction and exp-shift subtraction.
+bool IsCoupledReductionShiftExpProducer(const HloInstruction* instr) {
+  if (instr->opcode() != HloOpcode::kMultiply) {
+    return false;
+  }
+  const HloInstruction* reduce = FindMaxReduceForShiftValue(*instr);
+  if (reduce == nullptr) {
+    return false;
+  }
+  return absl::c_any_of(instr->users(), [&](const HloInstruction* user) {
+    return IsExpShiftCoupledSubtract(*user, *instr, *reduce);
+  });
+}
+
+bool InstructionOrFusionContains(
+    const HloInstruction* instr,
+    const std::function<bool(const HloInstruction*)>& pred) {
+  if (instr->opcode() != HloOpcode::kFusion) {
+    return pred(instr);
+  }
+  return absl::c_any_of(instr->fused_instructions(), pred);
+}
+
+bool IsReduceSideConsumer(const HloInstruction* consumer,
+                            const HloInstruction* shift_value) {
+  return InstructionOrFusionContains(consumer, [&](const HloInstruction* instr) {
+    return instr->opcode() == HloOpcode::kReduce &&
+           instr->operand(0) == shift_value && IsMaxReduction(instr);
+  });
+}
+
+bool IsShiftExpSideConsumer(const HloInstruction* consumer,
+                            const HloInstruction* shift_value,
+                            const HloInstruction* reduce) {
+  return InstructionOrFusionContains(consumer, [&](const HloInstruction* instr) {
+    return IsExpShiftCoupledSubtract(*instr, *shift_value, *reduce);
+  });
+}
+
+bool FusionLooksLikeShiftExpPath(const HloInstruction* consumer) {
+  if (consumer->opcode() != HloOpcode::kFusion) {
+    return false;
+  }
+  return absl::c_any_of(consumer->fused_instructions(),
+                        [](const HloInstruction* instr) {
+                          return instr->opcode() == HloOpcode::kExp ||
+                                 instr->opcode() == HloOpcode::kSubtract;
+                        });
+}
+
+// Returns true if fusing producer into consumer targets one side of a coupled
+// reduce-max / exp-shift producer that must stay numerically consistent.
+bool HasCoupledReductionShiftExpSplitRisk(const HloInstruction* producer,
+                                          const HloInstruction* consumer) {
+  const HloInstruction* shift_value = nullptr;
+  if (IsCoupledReductionShiftExpProducer(producer)) {
+    shift_value = producer;
+  } else if (IsDotLikeOpcode(producer->opcode())) {
+    for (const HloInstruction* user : producer->users()) {
+      if (IsCoupledReductionShiftExpProducer(user)) {
+        shift_value = user;
+        break;
+      }
+    }
+  }
+  if (shift_value == nullptr) {
+    return false;
+  }
+
+  const HloInstruction* reduce = FindMaxReduceForShiftValue(*shift_value);
+  if (reduce == nullptr) {
+    return false;
+  }
+
+  if (producer != shift_value) {
+    return IsShiftExpSideConsumer(consumer, shift_value, reduce) ||
+           FusionLooksLikeShiftExpPath(consumer);
+  }
+
+  return IsReduceSideConsumer(consumer, shift_value) ||
+         IsShiftExpSideConsumer(consumer, shift_value, reduce);
+}
+
 // Should we block the fusion of the subcomputation of the passed instruction?
 bool BlockSubcomputationFusion(const HloInstruction* instruction,
                                const HloModuleConfig& config) {
@@ -100,79 +236,6 @@ bool BlockSubcomputationFusion(const HloInstruction* instruction,
     return true;
   }
 
-  return false;
-}
-
-bool FusionInstructionContainsOpcode(const HloInstruction& fusion,
-                                     HloOpcode opcode) {
-  if (!fusion.IsFusion()) {
-    return fusion.opcode() == opcode;
-  }
-  return absl::c_any_of(
-      fusion.fused_instructions(),
-      [opcode](const HloInstruction* instr) { return instr->opcode() == opcode; });
-}
-
-bool MultiplyFeedsReduceAndSubtract(const HloInstruction& multiply) {
-  bool feeds_reduce = false;
-  bool feeds_subtract = false;
-  auto note_user = [&](const HloInstruction& user) {
-    if (user.opcode() == HloOpcode::kReduce) {
-      feeds_reduce = true;
-    }
-    if (user.opcode() == HloOpcode::kSubtract) {
-      feeds_subtract = true;
-    }
-    if (user.IsFusion()) {
-      if (FusionInstructionContainsOpcode(user, HloOpcode::kReduce)) {
-        feeds_reduce = true;
-      }
-      if (FusionInstructionContainsOpcode(user, HloOpcode::kSubtract)) {
-        feeds_subtract = true;
-      }
-    }
-  };
-  for (const HloInstruction* user : multiply.users()) {
-    note_user(*user);
-  }
-  return feeds_reduce && feeds_subtract;
-}
-
-bool WouldSplitSoftmaxScaledMultiply(const HloInstruction* producer,
-                                     const HloInstruction* consumer) {
-  if (producer->opcode() != HloOpcode::kMultiply) {
-    return false;
-  }
-  if (!MultiplyFeedsReduceAndSubtract(*producer)) {
-    return false;
-  }
-  if (consumer->opcode() == HloOpcode::kReduce ||
-      consumer->opcode() == HloOpcode::kSubtract) {
-    return true;
-  }
-  if (consumer->IsFusion() &&
-      (FusionInstructionContainsOpcode(*consumer, HloOpcode::kReduce) ||
-       FusionInstructionContainsOpcode(*consumer, HloOpcode::kSubtract))) {
-    return true;
-  }
-  return false;
-}
-
-bool WouldFuseDotIntoSplitSoftmaxFusion(const HloInstruction* producer,
-                                        const HloInstruction* consumer) {
-  if (producer->opcode() != HloOpcode::kDot || !consumer->IsFusion()) {
-    return false;
-  }
-  if (!FusionInstructionContainsOpcode(*consumer, HloOpcode::kSubtract) ||
-      !FusionInstructionContainsOpcode(*consumer, HloOpcode::kExp)) {
-    return false;
-  }
-  for (const HloInstruction* user : producer->users()) {
-    if (user->opcode() == HloOpcode::kMultiply &&
-        MultiplyFeedsReduceAndSubtract(*user)) {
-      return true;
-    }
-  }
   return false;
 }
 
@@ -352,6 +415,20 @@ bool CpuInstructionFusion::IsExpensive(const HloInstruction& instruction) {
   return false;
 }
 
+InstructionFusion::HloInstructionSet
+CpuInstructionFusion::ComputeGloballyUnfusible(
+    absl::Span<HloInstruction* const> post_order,
+    const HloReachabilityMap& reachability) {
+  HloInstructionSet do_not_duplicate =
+      InstructionFusion::ComputeGloballyUnfusible(post_order, reachability);
+  for (HloInstruction* producer : post_order) {
+    if (IsCoupledReductionShiftExpProducer(producer)) {
+      do_not_duplicate.insert(producer);
+    }
+  }
+  return do_not_duplicate;
+}
+
 void CpuInstructionFusion::ComputeInstructionsToSkip(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
@@ -457,21 +534,16 @@ FusionDecision CpuInstructionFusion::ShouldFuse(HloInstruction* consumer,
     return FusionDecision::Forbid("Fusion is not profitable.");
   }
 
-  // Stable softmax lowers as: dot -> multiply(scale) -> reduce(max) and
-  // subtract(multiply, broadcast(max)) -> exponential. Fusing multiply only into
-  // reduce, then fusing dot into subtract+exponential separately, recomputes
-  // scaled logits in a second kernel and can miscompile for large values.
-  if (WouldSplitSoftmaxScaledMultiply(producer, consumer)) {
-    return FusionDecision::Forbid(
-        "Don't split softmax scaled logits across separate fusions.");
-  }
-  if (WouldFuseDotIntoSplitSoftmaxFusion(producer, consumer)) {
-    return FusionDecision::Forbid(
-        "Don't fuse dot into softmax subtract-exponential fusion separately "
-        "from its scaled-logits reduce.");
-  }
-
   RETURN_IF_NOT_FUSIBLE(InstructionFusion::ShouldFuse(consumer, operand_index));
+
+  // Fusing one side of a reduce-max / exp-shift coupled producer into a
+  // separate kernel can recompute the shift value with different numerics.
+  if (HasCoupledReductionShiftExpSplitRisk(producer, consumer) &&
+      FusionWouldDuplicate(*producer, *consumer)) {
+    return FusionDecision::Forbid(
+        "Fusion would split a numerically coupled reduce-max / exp-shift "
+        "producer across kernels.");
+  }
 
   // Fusing too many reductions together can lead to a giant LLVM modules after
   // loop unrolling. We prefer to split such fusions into multiple kernels to

--- a/xla/service/cpu/cpu_instruction_fusion.cc
+++ b/xla/service/cpu/cpu_instruction_fusion.cc
@@ -16,7 +16,6 @@ limitations under the License.
 #include "xla/service/cpu/cpu_instruction_fusion.h"
 
 #include <cstdint>
-#include <functional>
 
 #include "absl/algorithm/container.h"
 #include "absl/log/log.h"
@@ -91,10 +90,6 @@ bool IsMaxReduction(const HloInstruction* reduce) {
   return root->opcode() == HloOpcode::kMaximum;
 }
 
-bool IsDotLikeOpcode(HloOpcode opcode) {
-  return opcode == HloOpcode::kDot;
-}
-
 // Matches subtract(shift_value, broadcast(reduce)) used by exponential, i.e.
 // the numerically sensitive stable-softmax shift pattern.
 bool IsExpShiftCoupledSubtract(const HloInstruction& subtract,
@@ -105,17 +100,14 @@ bool IsExpShiftCoupledSubtract(const HloInstruction& subtract,
   }
   const HloInstruction* op0 = subtract.operand(0);
   const HloInstruction* op1 = subtract.operand(1);
-  const bool uses_shift_value =
-      op0 == &shift_value || op1 == &shift_value ||
-      (op0->opcode() == HloOpcode::kBroadcast &&
-       op0->operand(0) == &shift_value) ||
-      (op1->opcode() == HloOpcode::kBroadcast &&
-       op1->operand(0) == &shift_value);
+  const bool uses_shift_value = op0 == &shift_value || op1 == &shift_value ||
+                                (op0->opcode() == HloOpcode::kBroadcast &&
+                                 op0->operand(0) == &shift_value) ||
+                                (op1->opcode() == HloOpcode::kBroadcast &&
+                                 op1->operand(0) == &shift_value);
   const bool uses_reduce_broadcast =
-      (op0->opcode() == HloOpcode::kBroadcast &&
-       op0->operand(0) == &reduce) ||
-      (op1->opcode() == HloOpcode::kBroadcast &&
-       op1->operand(0) == &reduce);
+      (op0->opcode() == HloOpcode::kBroadcast && op0->operand(0) == &reduce) ||
+      (op1->opcode() == HloOpcode::kBroadcast && op1->operand(0) == &reduce);
   if (!uses_shift_value || !uses_reduce_broadcast) {
     return false;
   }
@@ -127,17 +119,20 @@ bool IsExpShiftCoupledSubtract(const HloInstruction& subtract,
 const HloInstruction* FindMaxReduceForShiftValue(
     const HloInstruction& shift_value) {
   for (const HloInstruction* user : shift_value.users()) {
-    if (user->opcode() == HloOpcode::kReduce && user->operand(0) == &shift_value &&
-        IsMaxReduction(user)) {
+    if (user->opcode() == HloOpcode::kReduce &&
+        user->operand(0) == &shift_value && IsMaxReduction(user)) {
       return user;
     }
   }
   return nullptr;
 }
 
-// A multiply that feeds both row-max reduction and exp-shift subtraction.
+// An elementwise op that feeds both row-max reduction and exp-shift
+// subtraction. Matching any elementwise producer (not just multiply) covers
+// numerically coupled shapes like add(dot, bias) as well as multiply(dot,
+// scale), while staying within the reduce-max / exp-shift coupled structure.
 bool IsCoupledReductionShiftExpProducer(const HloInstruction* instr) {
-  if (instr->opcode() != HloOpcode::kMultiply) {
+  if (instr->opcode() == HloOpcode::kFusion || !instr->IsElementwise()) {
     return false;
   }
   const HloInstruction* reduce = FindMaxReduceForShiftValue(*instr);
@@ -147,75 +142,6 @@ bool IsCoupledReductionShiftExpProducer(const HloInstruction* instr) {
   return absl::c_any_of(instr->users(), [&](const HloInstruction* user) {
     return IsExpShiftCoupledSubtract(*user, *instr, *reduce);
   });
-}
-
-bool InstructionOrFusionContains(
-    const HloInstruction* instr,
-    const std::function<bool(const HloInstruction*)>& pred) {
-  if (instr->opcode() != HloOpcode::kFusion) {
-    return pred(instr);
-  }
-  return absl::c_any_of(instr->fused_instructions(), pred);
-}
-
-bool IsReduceSideConsumer(const HloInstruction* consumer,
-                            const HloInstruction* shift_value) {
-  return InstructionOrFusionContains(consumer, [&](const HloInstruction* instr) {
-    return instr->opcode() == HloOpcode::kReduce &&
-           instr->operand(0) == shift_value && IsMaxReduction(instr);
-  });
-}
-
-bool IsShiftExpSideConsumer(const HloInstruction* consumer,
-                            const HloInstruction* shift_value,
-                            const HloInstruction* reduce) {
-  return InstructionOrFusionContains(consumer, [&](const HloInstruction* instr) {
-    return IsExpShiftCoupledSubtract(*instr, *shift_value, *reduce);
-  });
-}
-
-bool FusionLooksLikeShiftExpPath(const HloInstruction* consumer) {
-  if (consumer->opcode() != HloOpcode::kFusion) {
-    return false;
-  }
-  return absl::c_any_of(consumer->fused_instructions(),
-                        [](const HloInstruction* instr) {
-                          return instr->opcode() == HloOpcode::kExp ||
-                                 instr->opcode() == HloOpcode::kSubtract;
-                        });
-}
-
-// Returns true if fusing producer into consumer targets one side of a coupled
-// reduce-max / exp-shift producer that must stay numerically consistent.
-bool HasCoupledReductionShiftExpSplitRisk(const HloInstruction* producer,
-                                          const HloInstruction* consumer) {
-  const HloInstruction* shift_value = nullptr;
-  if (IsCoupledReductionShiftExpProducer(producer)) {
-    shift_value = producer;
-  } else if (IsDotLikeOpcode(producer->opcode())) {
-    for (const HloInstruction* user : producer->users()) {
-      if (IsCoupledReductionShiftExpProducer(user)) {
-        shift_value = user;
-        break;
-      }
-    }
-  }
-  if (shift_value == nullptr) {
-    return false;
-  }
-
-  const HloInstruction* reduce = FindMaxReduceForShiftValue(*shift_value);
-  if (reduce == nullptr) {
-    return false;
-  }
-
-  if (producer != shift_value) {
-    return IsShiftExpSideConsumer(consumer, shift_value, reduce) ||
-           FusionLooksLikeShiftExpPath(consumer);
-  }
-
-  return IsReduceSideConsumer(consumer, shift_value) ||
-         IsShiftExpSideConsumer(consumer, shift_value, reduce);
 }
 
 // Should we block the fusion of the subcomputation of the passed instruction?
@@ -535,15 +461,6 @@ FusionDecision CpuInstructionFusion::ShouldFuse(HloInstruction* consumer,
   }
 
   RETURN_IF_NOT_FUSIBLE(InstructionFusion::ShouldFuse(consumer, operand_index));
-
-  // Fusing one side of a reduce-max / exp-shift coupled producer into a
-  // separate kernel can recompute the shift value with different numerics.
-  if (HasCoupledReductionShiftExpSplitRisk(producer, consumer) &&
-      FusionWouldDuplicate(*producer, *consumer)) {
-    return FusionDecision::Forbid(
-        "Fusion would split a numerically coupled reduce-max / exp-shift "
-        "producer across kernels.");
-  }
 
   // Fusing too many reductions together can lead to a giant LLVM modules after
   // loop unrolling. We prefer to split such fusions into multiple kernels to

--- a/xla/service/cpu/cpu_instruction_fusion.h
+++ b/xla/service/cpu/cpu_instruction_fusion.h
@@ -22,6 +22,8 @@ limitations under the License.
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "xla/hlo/analysis/hlo_reachability.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/service/fusion_node_indexing_evaluation.h"
 #include "xla/service/instruction_fusion.h"
@@ -46,6 +48,9 @@ class CpuInstructionFusion : public InstructionFusion {
  protected:
   FusionDecision ShouldFuse(HloInstruction* consumer,
                             int64_t operand_index) override;
+  HloInstructionSet ComputeGloballyUnfusible(
+      absl::Span<HloInstruction* const> post_order,
+      const HloReachabilityMap& reachability) override;
   HloInstruction::FusionKind ChooseKind(
       const HloInstruction* producer, const HloInstruction* consumer) override;
 

--- a/xla/service/cpu/cpu_instruction_fusion_test.cc
+++ b/xla/service/cpu/cpu_instruction_fusion_test.cc
@@ -1133,5 +1133,81 @@ TEST_F(InstructionFusionTest, SkipReduceComputationsIfFusionEmitters) {
   EXPECT_FALSE(changed);
 }
 
+namespace {
+
+bool HasSplitSoftmaxSubtractExponentialFusion(const HloModule& module) {
+  for (const HloComputation* computation : module.computations()) {
+    for (const HloInstruction* instruction : computation->instructions()) {
+      if (!instruction->IsFusion()) {
+        continue;
+      }
+      bool has_exp = false;
+      for (const HloInstruction* fused : instruction->fused_instructions()) {
+        if (fused->opcode() == HloOpcode::kExp) {
+          has_exp = true;
+          break;
+        }
+      }
+      if (!has_exp || instruction->operand_count() != 2) {
+        continue;
+      }
+      if (instruction->operand(0)->opcode() == HloOpcode::kFusion &&
+          instruction->operand(1)->opcode() == HloOpcode::kDot) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+static constexpr absl::string_view kSoftmaxFusionModuleString = R"(
+  HloModule module
+
+  %region_0.1 (param0: f32[], param1: f32[]) -> f32[] {
+    %param0 = f32[] parameter(0)
+    %param1 = f32[] parameter(1)
+    ROOT %maximum = f32[] maximum(%param0, %param1)
+  }
+
+  %region_1.2 (param0: f32[], param1: f32[]) -> f32[] {
+    %param0 = f32[] parameter(0)
+    %param1 = f32[] parameter(1)
+    ROOT %add = f32[] add(%param0, %param1)
+  }
+
+  ENTRY %main (Q: f32[5,5], K: f32[5,5]) -> f32[5,5] {
+    %Q = f32[5,5] parameter(0)
+    %K = f32[5,5] parameter(1)
+    %transpose = f32[5,5] transpose(%K), dimensions={1,0}
+    %dot = f32[5,5] dot(%Q, %transpose),
+        lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    %scale = f32[] constant(0.44721359)
+    %broadcast_scale = f32[5,5] broadcast(%scale), dimensions={}
+    %mul = f32[5,5] multiply(%dot, %broadcast_scale)
+    %neg_inf = f32[] constant(-inf)
+    %reduce_max = f32[5] reduce(%mul, %neg_inf),
+        dimensions={1}, to_apply=%region_0.1
+    %broadcast_max = f32[5,5] broadcast(%reduce_max), dimensions={0}
+    %sub = f32[5,5] subtract(%mul, %broadcast_max)
+    %exp = f32[5,5] exponential(%sub)
+    %zero = f32[] constant(0)
+    %reduce_sum = f32[5] reduce(%exp, %zero),
+        dimensions={1}, to_apply=%region_1.2
+    %broadcast_sum = f32[5,5] broadcast(%reduce_sum), dimensions={0}
+    ROOT %div = f32[5,5] divide(%exp, %broadcast_sum)
+  }
+)";
+
+TEST_F(InstructionFusionTest, AvoidSplitSoftmaxScaledLogitsFusions) {
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(kSoftmaxFusionModuleString));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          CpuInstructionFusion(&alias_info_).Run(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_FALSE(HasSplitSoftmaxSubtractExponentialFusion(*module));
+}
+
 }  // namespace
 }  // namespace xla::cpu

--- a/xla/service/cpu/cpu_instruction_fusion_test.cc
+++ b/xla/service/cpu/cpu_instruction_fusion_test.cc
@@ -1133,80 +1133,143 @@ TEST_F(InstructionFusionTest, SkipReduceComputationsIfFusionEmitters) {
   EXPECT_FALSE(changed);
 }
 
-namespace {
+bool FusionComputesShiftValueForReduce(const HloInstruction* fusion) {
+  if (fusion->opcode() != HloOpcode::kFusion) {
+    return false;
+  }
+  const HloInstruction* multiply = nullptr;
+  const HloInstruction* reduce = nullptr;
+  for (const HloInstruction* instr : fusion->fused_instructions()) {
+    if (instr->opcode() == HloOpcode::kMultiply) {
+      multiply = instr;
+    }
+    if (instr->opcode() == HloOpcode::kReduce) {
+      reduce = instr;
+    }
+  }
+  return multiply != nullptr && reduce != nullptr &&
+         reduce->operand(0) == multiply;
+}
 
-bool HasSplitSoftmaxSubtractExponentialFusion(const HloModule& module) {
-  for (const HloComputation* computation : module.computations()) {
-    for (const HloInstruction* instruction : computation->instructions()) {
-      if (!instruction->IsFusion()) {
-        continue;
-      }
-      bool has_exp = false;
-      for (const HloInstruction* fused : instruction->fused_instructions()) {
-        if (fused->opcode() == HloOpcode::kExp) {
-          has_exp = true;
-          break;
-        }
-      }
-      if (!has_exp || instruction->operand_count() != 2) {
-        continue;
-      }
-      if (instruction->operand(0)->opcode() == HloOpcode::kFusion &&
-          instruction->operand(1)->opcode() == HloOpcode::kDot) {
-        return true;
+bool FusionRecomputesShiftValueForExpShift(
+    const HloInstruction* fusion, const HloInstruction* dot) {
+  if (fusion->opcode() != HloOpcode::kFusion) {
+    return false;
+  }
+  const HloInstruction* multiply = nullptr;
+  const HloInstruction* subtract = nullptr;
+  for (const HloInstruction* instr : fusion->fused_instructions()) {
+    if (instr->opcode() == HloOpcode::kMultiply) {
+      multiply = instr;
+    }
+    if (instr->opcode() == HloOpcode::kSubtract) {
+      subtract = instr;
+    }
+  }
+  if (multiply == nullptr || subtract == nullptr) {
+    return false;
+  }
+  const HloComputation* fused_computation = fusion->fused_instructions_computation();
+  const HloInstruction* fusion_instr = fused_computation->FusionInstruction();
+  bool uses_dot = false;
+  for (int64_t i = 0; i < fusion_instr->operand_count(); ++i) {
+    if (fusion_instr->operand(i) == dot) {
+      const HloInstruction* param = fusion->fused_parameter(i);
+      if (multiply->operand(0) == param || multiply->operand(1) == param) {
+        uses_dot = true;
+        break;
       }
     }
   }
-  return false;
+  return uses_dot && subtract->operand(0) == multiply;
 }
 
-}  // namespace
-
-static constexpr absl::string_view kSoftmaxFusionModuleString = R"(
-  HloModule module
-
-  %region_0.1 (param0: f32[], param1: f32[]) -> f32[] {
-    %param0 = f32[] parameter(0)
-    %param1 = f32[] parameter(1)
-    ROOT %maximum = f32[] maximum(%param0, %param1)
+bool HasSplitCoupledReductionShiftExpFusion(const HloModule& module) {
+  const HloComputation* entry = module.entry_computation();
+  const HloInstruction* dot = nullptr;
+  for (const HloInstruction* instr : entry->instructions()) {
+    if (instr->opcode() == HloOpcode::kDot) {
+      dot = instr;
+      break;
+    }
+  }
+  if (dot == nullptr) {
+    return false;
   }
 
-  %region_1.2 (param0: f32[], param1: f32[]) -> f32[] {
-    %param0 = f32[] parameter(0)
-    %param1 = f32[] parameter(1)
-    ROOT %add = f32[] add(%param0, %param1)
+  const HloInstruction* reduce_fusion = nullptr;
+  const HloInstruction* shift_fusion = nullptr;
+  for (const HloInstruction* instr : entry->instructions()) {
+    if (!instr->IsLoopFusion()) {
+      continue;
+    }
+    if (FusionComputesShiftValueForReduce(instr)) {
+      reduce_fusion = instr;
+    }
+    if (FusionRecomputesShiftValueForExpShift(instr, dot)) {
+      shift_fusion = instr;
+    }
   }
+  return reduce_fusion != nullptr && shift_fusion != nullptr;
+}
 
-  ENTRY %main (Q: f32[5,5], K: f32[5,5]) -> f32[5,5] {
-    %Q = f32[5,5] parameter(0)
-    %K = f32[5,5] parameter(1)
-    %transpose = f32[5,5] transpose(%K), dimensions={1,0}
-    %dot = f32[5,5] dot(%Q, %transpose),
-        lhs_contracting_dims={1}, rhs_contracting_dims={0}
-    %scale = f32[] constant(0.44721359)
-    %broadcast_scale = f32[5,5] broadcast(%scale), dimensions={}
-    %mul = f32[5,5] multiply(%dot, %broadcast_scale)
-    %neg_inf = f32[] constant(-inf)
-    %reduce_max = f32[5] reduce(%mul, %neg_inf),
-        dimensions={1}, to_apply=%region_0.1
-    %broadcast_max = f32[5,5] broadcast(%reduce_max), dimensions={0}
-    %sub = f32[5,5] subtract(%mul, %broadcast_max)
-    %exp = f32[5,5] exponential(%sub)
-    %zero = f32[] constant(0)
-    %reduce_sum = f32[5] reduce(%exp, %zero),
-        dimensions={1}, to_apply=%region_1.2
-    %broadcast_sum = f32[5,5] broadcast(%reduce_sum), dimensions={0}
-    ROOT %div = f32[5,5] divide(%exp, %broadcast_sum)
-  }
+TEST_F(InstructionFusionTest, AvoidSplitCoupledReductionShiftExpFusions) {
+  absl::string_view module_string = R"(
+HloModule module
+
+%max (p0: f32[], p1: f32[]) -> f32[] {
+  %p0 = f32[] parameter(0)
+  %p1 = f32[] parameter(1)
+  ROOT %m = f32[] maximum(%p0, %p1)
+}
+
+ENTRY main {
+  %lhs = f32[5,5] parameter(0)
+  %rhs = f32[5,5] parameter(1)
+  %dot = f32[5,5] dot(%lhs, %rhs), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  %scale = f32[] constant(0.44721359)
+  %broadcast_scale = f32[5,5] broadcast(%scale), dimensions={}
+  %multiply = f32[5,5] multiply(%dot, %broadcast_scale)
+  %neg_inf = f32[] constant(-inf)
+  %reduce_max = f32[5] reduce(%multiply, %neg_inf), dimensions={1}, to_apply=%max
+  %broadcast_max = f32[5,5] broadcast(%reduce_max), dimensions={0}
+  %subtract = f32[5,5] subtract(%multiply, %broadcast_max)
+  ROOT %exp = f32[5,5] exponential(%subtract)
+}
 )";
 
-TEST_F(InstructionFusionTest, AvoidSplitSoftmaxScaledLogitsFusions) {
-  TF_ASSERT_OK_AND_ASSIGN(
-      auto module, ParseAndReturnVerifiedModule(kSoftmaxFusionModuleString));
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(module_string));
   TF_ASSERT_OK_AND_ASSIGN(bool changed,
                           CpuInstructionFusion(&alias_info_).Run(module.get()));
   EXPECT_TRUE(changed);
-  EXPECT_FALSE(HasSplitSoftmaxSubtractExponentialFusion(*module));
+  EXPECT_FALSE(HasSplitCoupledReductionShiftExpFusion(*module));
+}
+
+TEST_F(InstructionFusionTest, StillFusesUncoupledReduceAndSubtract) {
+  absl::string_view module_string = R"(
+HloModule module
+
+%add (p0: f32[], p1: f32[]) -> f32[] {
+  %p0 = f32[] parameter(0)
+  %p1 = f32[] parameter(1)
+  ROOT %a = f32[] add(%p0, %p1)
+}
+
+ENTRY main {
+  %arg = f32[8,16] parameter(0)
+  %init = f32[] constant(0)
+  %reduce = f32[8] reduce(%arg, %init), dimensions={1}, to_apply=%add
+  %broadcast = f32[8,16] broadcast(%reduce), dimensions={0}
+  ROOT %subtract = f32[8,16] subtract(%arg, %broadcast)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(module_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          CpuInstructionFusion(&alias_info_).Run(module.get()));
+  EXPECT_TRUE(changed);
 }
 
 }  // namespace

--- a/xla/service/cpu/cpu_instruction_fusion_test.cc
+++ b/xla/service/cpu/cpu_instruction_fusion_test.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/algorithm/container.h"
+#include "absl/status/status_matchers.h"  // IWYU pragma: keep
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"

--- a/xla/service/cpu/cpu_instruction_fusion_test.cc
+++ b/xla/service/cpu/cpu_instruction_fusion_test.cc
@@ -1258,9 +1258,9 @@ ENTRY main {
   EXPECT_FALSE(HasSplitCoupledReductionShiftExpFusion(*module));
 }
 
-// The coupling is not specific to multiply: add(dot, bias) feeding the same
-// max-reduce / exp-shift pair has the identical recompute-divergence risk, so
-// the elementwise shift value must not be split across kernels either.
+// Conservatively treat any elementwise shift value as coupled. Multiply is
+// the case with a known divergence mechanism (FMA contraction); other
+// elementwise ops are included defensively.
 TEST_F(InstructionFusionTest,
        AvoidSplitCoupledReductionShiftExpFusionsAddBias) {
   absl::string_view module_string = R"(

--- a/xla/service/cpu/cpu_instruction_fusion_test.cc
+++ b/xla/service/cpu/cpu_instruction_fusion_test.cc
@@ -1137,51 +1137,54 @@ bool FusionComputesShiftValueForReduce(const HloInstruction* fusion) {
   if (fusion->opcode() != HloOpcode::kFusion) {
     return false;
   }
-  const HloInstruction* multiply = nullptr;
-  const HloInstruction* reduce = nullptr;
   for (const HloInstruction* instr : fusion->fused_instructions()) {
-    if (instr->opcode() == HloOpcode::kMultiply) {
-      multiply = instr;
+    if (instr->opcode() != HloOpcode::kReduce) {
+      continue;
     }
-    if (instr->opcode() == HloOpcode::kReduce) {
-      reduce = instr;
+    // A split fusion recomputes the elementwise shift value inside the
+    // reduce kernel, so the reduce's operand is the elementwise producer
+    // (multiply, add, ...) rather than a fused parameter.
+    if (instr->operand(0)->IsElementwise()) {
+      return true;
     }
   }
-  return multiply != nullptr && reduce != nullptr &&
-         reduce->operand(0) == multiply;
+  return false;
 }
 
-bool FusionRecomputesShiftValueForExpShift(
-    const HloInstruction* fusion, const HloInstruction* dot) {
+bool FusionRecomputesShiftValueForExpShift(const HloInstruction* fusion,
+                                           const HloInstruction* dot) {
   if (fusion->opcode() != HloOpcode::kFusion) {
     return false;
   }
-  const HloInstruction* multiply = nullptr;
   const HloInstruction* subtract = nullptr;
   for (const HloInstruction* instr : fusion->fused_instructions()) {
-    if (instr->opcode() == HloOpcode::kMultiply) {
-      multiply = instr;
-    }
     if (instr->opcode() == HloOpcode::kSubtract) {
       subtract = instr;
+      break;
     }
   }
-  if (multiply == nullptr || subtract == nullptr) {
+  if (subtract == nullptr) {
     return false;
   }
-  const HloComputation* fused_computation = fusion->fused_instructions_computation();
+  // The shift value is the elementwise producer (multiply, add, ...) feeding
+  // the exp-shift subtract.
+  const HloInstruction* shift_value = subtract->operand(0);
+  if (!shift_value->IsElementwise()) {
+    return false;
+  }
+  const HloComputation* fused_computation =
+      fusion->fused_instructions_computation();
   const HloInstruction* fusion_instr = fused_computation->FusionInstruction();
-  bool uses_dot = false;
   for (int64_t i = 0; i < fusion_instr->operand_count(); ++i) {
-    if (fusion_instr->operand(i) == dot) {
-      const HloInstruction* param = fusion->fused_parameter(i);
-      if (multiply->operand(0) == param || multiply->operand(1) == param) {
-        uses_dot = true;
-        break;
-      }
+    if (fusion_instr->operand(i) != dot) {
+      continue;
+    }
+    const HloInstruction* param = fusion->fused_parameter(i);
+    if (absl::c_linear_search(shift_value->operands(), param)) {
+      return true;
     }
   }
-  return uses_dot && subtract->operand(0) == multiply;
+  return false;
 }
 
 bool HasSplitCoupledReductionShiftExpFusion(const HloModule& module) {
@@ -1211,6 +1214,15 @@ bool HasSplitCoupledReductionShiftExpFusion(const HloModule& module) {
     }
   }
   return reduce_fusion != nullptr && shift_fusion != nullptr;
+}
+
+// Returns true if a bare instruction with the given opcode is still present in
+// the entry computation (i.e. it was not fused/duplicated into consumers).
+bool EntryHasStandaloneOp(const HloModule& module, HloOpcode opcode) {
+  return absl::c_any_of(module.entry_computation()->instructions(),
+                        [opcode](const HloInstruction* instr) {
+                          return instr->opcode() == opcode;
+                        });
 }
 
 TEST_F(InstructionFusionTest, AvoidSplitCoupledReductionShiftExpFusions) {
@@ -1246,7 +1258,47 @@ ENTRY main {
   EXPECT_FALSE(HasSplitCoupledReductionShiftExpFusion(*module));
 }
 
-TEST_F(InstructionFusionTest, StillFusesUncoupledReduceAndSubtract) {
+// The coupling is not specific to multiply: add(dot, bias) feeding the same
+// max-reduce / exp-shift pair has the identical recompute-divergence risk, so
+// the elementwise shift value must not be split across kernels either.
+TEST_F(InstructionFusionTest,
+       AvoidSplitCoupledReductionShiftExpFusionsAddBias) {
+  absl::string_view module_string = R"(
+HloModule module
+
+%max (p0: f32[], p1: f32[]) -> f32[] {
+  %p0 = f32[] parameter(0)
+  %p1 = f32[] parameter(1)
+  ROOT %m = f32[] maximum(%p0, %p1)
+}
+
+ENTRY main {
+  %lhs = f32[5,5] parameter(0)
+  %rhs = f32[5,5] parameter(1)
+  %bias = f32[5,5] parameter(2)
+  %dot = f32[5,5] dot(%lhs, %rhs), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  %add = f32[5,5] add(%dot, %bias)
+  %neg_inf = f32[] constant(-inf)
+  %reduce_max = f32[5] reduce(%add, %neg_inf), dimensions={1}, to_apply=%max
+  %broadcast_max = f32[5,5] broadcast(%reduce_max), dimensions={0}
+  %subtract = f32[5,5] subtract(%add, %broadcast_max)
+  ROOT %exp = f32[5,5] exponential(%subtract)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(module_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          CpuInstructionFusion(&alias_info_).Run(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_FALSE(HasSplitCoupledReductionShiftExpFusion(*module));
+}
+
+// Discrimination check: the shift value multiply feeds a *sum* reduce (not a
+// max reduce), so it is not the numerically coupled stable-softmax pattern and
+// the multiply should still be fused/duplicated normally, leaving no
+// standalone multiply in the entry computation.
+TEST_F(InstructionFusionTest, StillFusesMultiplyWithSumReduce) {
   absl::string_view module_string = R"(
 HloModule module
 
@@ -1257,11 +1309,17 @@ HloModule module
 }
 
 ENTRY main {
-  %arg = f32[8,16] parameter(0)
-  %init = f32[] constant(0)
-  %reduce = f32[8] reduce(%arg, %init), dimensions={1}, to_apply=%add
-  %broadcast = f32[8,16] broadcast(%reduce), dimensions={0}
-  ROOT %subtract = f32[8,16] subtract(%arg, %broadcast)
+  %lhs = f32[5,5] parameter(0)
+  %rhs = f32[5,5] parameter(1)
+  %dot = f32[5,5] dot(%lhs, %rhs), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  %scale = f32[] constant(0.44721359)
+  %broadcast_scale = f32[5,5] broadcast(%scale), dimensions={}
+  %multiply = f32[5,5] multiply(%dot, %broadcast_scale)
+  %zero = f32[] constant(0)
+  %reduce_sum = f32[5] reduce(%multiply, %zero), dimensions={1}, to_apply=%add
+  %broadcast_sum = f32[5,5] broadcast(%reduce_sum), dimensions={0}
+  %subtract = f32[5,5] subtract(%multiply, %broadcast_sum)
+  ROOT %exp = f32[5,5] exponential(%subtract)
 }
 )";
 
@@ -1270,6 +1328,44 @@ ENTRY main {
   TF_ASSERT_OK_AND_ASSIGN(bool changed,
                           CpuInstructionFusion(&alias_info_).Run(module.get()));
   EXPECT_TRUE(changed);
+  EXPECT_FALSE(EntryHasStandaloneOp(*module, HloOpcode::kMultiply));
+}
+
+// Discrimination check: the multiply feeds a max reduce, but the subtract does
+// not feed an exponential, so it is not the coupled stable-softmax pattern and
+// the multiply should still be fused/duplicated normally, leaving no
+// standalone multiply in the entry computation.
+TEST_F(InstructionFusionTest, StillFusesMultiplyWhenSubtractDoesNotFeedExp) {
+  absl::string_view module_string = R"(
+HloModule module
+
+%max (p0: f32[], p1: f32[]) -> f32[] {
+  %p0 = f32[] parameter(0)
+  %p1 = f32[] parameter(1)
+  ROOT %m = f32[] maximum(%p0, %p1)
+}
+
+ENTRY main {
+  %lhs = f32[5,5] parameter(0)
+  %rhs = f32[5,5] parameter(1)
+  %dot = f32[5,5] dot(%lhs, %rhs), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  %scale = f32[] constant(0.44721359)
+  %broadcast_scale = f32[5,5] broadcast(%scale), dimensions={}
+  %multiply = f32[5,5] multiply(%dot, %broadcast_scale)
+  %neg_inf = f32[] constant(-inf)
+  %reduce_max = f32[5] reduce(%multiply, %neg_inf), dimensions={1}, to_apply=%max
+  %broadcast_max = f32[5,5] broadcast(%reduce_max), dimensions={0}
+  %subtract = f32[5,5] subtract(%multiply, %broadcast_max)
+  ROOT %negate = f32[5,5] negate(%subtract)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(module_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          CpuInstructionFusion(&alias_info_).Run(module.get()));
+  EXPECT_TRUE(changed);
+  EXPECT_FALSE(EntryHasStandaloneOp(*module, HloOpcode::kMultiply));
 }
 
 }  // namespace

--- a/xla/service/cpu/cpu_instruction_fusion_test.cc
+++ b/xla/service/cpu/cpu_instruction_fusion_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "xla/service/cpu/cpu_instruction_fusion.h"
 
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <string>
@@ -1251,10 +1252,10 @@ ENTRY main {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto module,
-                          ParseAndReturnVerifiedModule(module_string));
-  TF_ASSERT_OK_AND_ASSIGN(bool changed,
-                          CpuInstructionFusion(&alias_info_).Run(module.get()));
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       ParseAndReturnVerifiedModule(module_string));
+  ASSERT_OK_AND_ASSIGN(bool changed,
+                       CpuInstructionFusion(&alias_info_).Run(module.get()));
   EXPECT_TRUE(changed);
   EXPECT_FALSE(HasSplitCoupledReductionShiftExpFusion(*module));
 }
@@ -1287,10 +1288,10 @@ ENTRY main {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto module,
-                          ParseAndReturnVerifiedModule(module_string));
-  TF_ASSERT_OK_AND_ASSIGN(bool changed,
-                          CpuInstructionFusion(&alias_info_).Run(module.get()));
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       ParseAndReturnVerifiedModule(module_string));
+  ASSERT_OK_AND_ASSIGN(bool changed,
+                       CpuInstructionFusion(&alias_info_).Run(module.get()));
   EXPECT_TRUE(changed);
   EXPECT_FALSE(HasSplitCoupledReductionShiftExpFusion(*module));
 }
@@ -1324,10 +1325,10 @@ ENTRY main {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto module,
-                          ParseAndReturnVerifiedModule(module_string));
-  TF_ASSERT_OK_AND_ASSIGN(bool changed,
-                          CpuInstructionFusion(&alias_info_).Run(module.get()));
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       ParseAndReturnVerifiedModule(module_string));
+  ASSERT_OK_AND_ASSIGN(bool changed,
+                       CpuInstructionFusion(&alias_info_).Run(module.get()));
   EXPECT_TRUE(changed);
   EXPECT_FALSE(EntryHasStandaloneOp(*module, HloOpcode::kMultiply));
 }
@@ -1361,10 +1362,10 @@ ENTRY main {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto module,
-                          ParseAndReturnVerifiedModule(module_string));
-  TF_ASSERT_OK_AND_ASSIGN(bool changed,
-                          CpuInstructionFusion(&alias_info_).Run(module.get()));
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       ParseAndReturnVerifiedModule(module_string));
+  ASSERT_OK_AND_ASSIGN(bool changed,
+                       CpuInstructionFusion(&alias_info_).Run(module.get()));
   EXPECT_TRUE(changed);
   EXPECT_FALSE(EntryHasStandaloneOp(*module, HloOpcode::kMultiply));
 }


### PR DESCRIPTION
📝 Summary of Changes
Prevent the CPU instruction fusion pass from splitting scaled softmax logits across separate fusions.
CpuInstructionFusion::ShouldFuse now rejects fusion patterns that separate the dot × scale computation used by the row-max reduction from the corresponding subtract/exp path, avoiding incorrect numerics caused by inconsistent softmax logits computations.

🎯 Justification
This change is an attempt to address the issue reported in jax-ml/jax#38609.
While investigating the report, I observed that eager execution and JIT matched through the exp computation. The NaNs appeared later in the softmax path under jax.jit on CPU. 

**expm(Q) and scaled logits match between eager and JIT**
Q:          match=True  max_abs_diff=0
logits:     match=True  max_abs_diff=0
logits_max: match=True  max_abs_diff=0

**First eager/JIT divergence occurs in the softmax path**
shifted:      match=False  (eager max=0, JIT max=2557.42)
exp_shifted:  match=False  (JIT: inf ×4)
denom:        match=False  (JIT: inf ×4)
weights:      match=False  (JIT: nan ×9)
out:          JIT   = [nan nan nan nan nan]
              eager = [2.108 0.701 -0.218 0.090 0.078]

I then tested with the CPU fusion pass disabled and found that the NaNs disappeared. 

**Disabling the fusion pass eliminates the issue**

XLA_FLAGS=--xla_disable_hlo_passes=fusion

eager[0]: [ 2.108  0.701 -0.218  0.090  0.078]
jit[0]:   [ 2.108  0.701 -0.218  0.090  0.078]
eager/jit match: True

From the generated HLO, it appeared that the scaled softmax logits computation was being split across separate fusion kernels across the reduction boundary. This could cause the row-max reduction path and the subtract/exp path to use different fused computations of the logits, leading to numerical inconsistencies and, in some cases, NaNs.

**HLO split observed across two fusion kernels**

%multiply_reduce_fusion
  - computes dot * scale for reduce_max

%subtract_exponential_fusion
  - recomputes dot * scale for subtract/exp

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
Added AvoidSplitSoftmaxScaledLogitsFusions in xla/service/cpu/cpu_instruction_fusion_test.cc.
The test builds a minimal softmax HLO, runs CpuInstructionFusion, and verifies that the problematic split-fusion pattern is not introduced.

I intended to validate the change end-to-end by rebuilding jaxlib and confirming that the NaNs disappear when this fusion pattern is prevented. However, I was unable to complete that verification in my environment due to build and resource constraints.
