### PR TITLE
[PJRT C API] Add PJRT_DeviceEvent typedef

### DIFF
--- a/xla/pjrt/c/pjrt_c_api_device_event.h
+++ b/xla/pjrt/c/pjrt_c_api_device_event.h
@@ -64,10 +64,10 @@ PJRT_DEFINE_STRUCT_TRAITS(PJRT_DeviceEvent_FunctionTable,
 
 // A PJRT_DeviceEvent is a pair of pointers containing both type information
 // and the actual opaque device event object. See: xla::PjRtDeviceEventRef.
-struct PJRT_DeviceEvent {
+typedef struct PJRT_DeviceEvent {
   const struct PJRT_DeviceEvent_FunctionTable* vtable;
   void* device_event;
-};
+} PJRT_DeviceEvent;
 
 // A std::vector<PJRT_DeviceEvent> optimized for quickly passing over the c-api.
 typedef struct PJRT_DeviceEventVector {


### PR DESCRIPTION
PJRT_DeviceEvent is declared as a struct but used as a typedef name later in the C API headers.

This matches the C compliance cleanup from #22815 and makes the header valid for C compilers.