### PR TITLE
[XLA:GPU][ROCm] Fix rocm_clang_local host toolchain under Bazel 8

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -273,7 +273,7 @@ common:rocm_base --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950,
 
 common:rocm_clang_local --config=rocm_base
 common:rocm_clang_local --config=clang_local
-common:rocm_clang_local --crosstool_top=@local_config_rocm//crosstool:toolchain
+common:rocm_clang_local --extra_toolchains=@local_config_rocm//crosstool:toolchain-linux-x86_64
 common:rocm_clang_local --config=rocm_base
 common:rocm_clang_local --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
 


### PR DESCRIPTION
Under Bazel 8, rocm_clang_local's host and target C++ compiles fall back to the autodetected gcc, which rejects the Clang-only warning flags from --config=warnings (-Wself-assign, -Wthread-safety-analysis, etc.).

Register the ROCm crosstool via --extra_toolchains so toolchain resolution routes C++ compiles through the ROCm wrapper (clang via CLANG_COMPILER_PATH) while -x rocm still goes to hipcc. Drop the --crosstool_top, which is a no-op now.