### PR TITLE
docs: fix broken PJRT links and typo in determinism.md

### DIFF
--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -18,4 +18,4 @@ Programs compiled by XLA can be non-deterministic on operations like scatter,
 select-and-scatter, GEMMs, convolutions, multi-headed attention. The flag
 `--xla_gpu_exclude_nondeterministic_ops` switches these operations to
 deterministic and potentially slower implementations and makes compilation fail
-on select-and-scatter which does not have a deterministic implementaiton.
+on select-and-scatter which does not have a deterministic implementation.

--- a/docs/pjrt/index.md
+++ b/docs/pjrt/index.md
@@ -26,7 +26,7 @@ opaque to the frameworks.
 *   [PJRT Plugin Mechanism design doc](https://docs.google.com/document/d/1Qdptisz1tUPGn1qFAVgCV2omnfjN01zoQPwKLdlizas/edit)
 *   [OpenXLA 2024 Fall DevLab PJRT plugin tutorial slides](https://drive.google.com/file/d/1epUJkMONG2t06WOeMHz4Oi3F_-8cTuz-/view)
     ([recording](https://www.youtube.com/watch?v=2GlMqaNxP_w&list=PLlFotmaRrOzv2OIEpijqiHGmY7rpscFcj))
-*   [OpenXLA/IREE PJRT plugin implementation](https://github.com/openxla/openxla-pjrt-plugin)
+*   [IREE PJRT plugin implementation](https://github.com/iree-org/iree/tree/main/integrations/pjrt)
 
 
 [discord]: https://discord.gg/ZKXq7b3V8A "Join on Discord"

--- a/xla/pjrt/c/README.md
+++ b/xla/pjrt/c/README.md
@@ -6,9 +6,10 @@ which has device-specific implementations that are opaque to the frameworks; (2)
 each device focuses on implementing PJRT APIs as PJRT plugins, which can be
 opaque to the frameworks.
 
-## Communication channel
+## Communication channels
 
 *   Please file issues in the [OpenXla/xla repo](https://github.com/openxla/xla).
+*   Questions regarding PJRT can be asked on the [OpenXLA Discord](https://discord.gg/ZKXq7b3V8A).
 *   Join the [pjrt-announcement maillist](https://groups.google.com/g/pjrt-announce/).
 
 ## Resources
@@ -17,7 +18,8 @@ opaque to the frameworks.
 *   [PJRT C API changelog](https://github.com/openxla/xla/blob/main/xla/pjrt/c/CHANGELOG.md)
 *   [PJRT C++ API Overview](https://github.com/openxla/xla/blob/main/docs/pjrt/cpp_api_overview.md)
 *   [PJRT integration guide](https://github.com/openxla/xla/blob/main/docs/pjrt/pjrt_integration.md)
+*   [PJRT examples](https://github.com/openxla/xla/blob/main/docs/pjrt/examples.md)
 *   [PJRT design docs](https://drive.google.com/drive/folders/18M944-QQPk1E34qRyIjkqDRDnpMa3miN)
 *   [PJRT API ABI versioning and compatibility](https://docs.google.com/document/d/1TKB5NyGtdzrpgw5mpyFjVAhJjpSNdF31T6pjPl_UT2o/edit)
 *   [PJRT Plugin Mechanism design doc](https://docs.google.com/document/d/1Qdptisz1tUPGn1qFAVgCV2omnfjN01zoQPwKLdlizas/edit)
-*   [OpenXLA/IREE PJRT plugin implementation](https://github.com/openxla/openxla-pjrt-plugin)
+*   [IREE PJRT plugin implementation](https://github.com/iree-org/iree/tree/main/integrations/pjrt)


### PR DESCRIPTION
## Summary

Fix broken links and a typo across 3 documentation files.

## Changes

### 1. Fix broken PJRT plugin link (addresses #22840)

The `openxla/openxla-pjrt-plugin` repository no longer exists (returns 404). Updated the link in both:
- `xla/pjrt/c/README.md`
- `docs/pjrt/index.md`

to point to the current IREE PJRT plugin location at `iree-org/iree/tree/main/integrations/pjrt`.

### 2. Improve `xla/pjrt/c/README.md`

- Added Discord communication channel (matching `docs/pjrt/index.md`)
- Added link to PJRT examples page
- Pluralized "Communication channel" heading for consistency with `docs/pjrt/index.md`

### 3. Fix typo in `docs/determinism.md`

`implementaiton` -> `implementation` (line 21)

## Files Changed

- `xla/pjrt/c/README.md` — Fix broken link, add Discord + examples links
- `docs/pjrt/index.md` — Fix broken link
- `docs/determinism.md` — Fix typo

Partially addresses #22840.
