### PR TITLE
[codex] Lower dynamic-slice to collective-broadcast

### DIFF
--- a/xla/service/spmd/spmd_partitioner.cc
+++ b/xla/service/spmd/spmd_partitioner.cc
@@ -3840,8 +3840,7 @@ absl::Status SpmdPartitioningVisitor::HandleConstant(HloInstruction* hlo) {
 absl::StatusOr<bool>
 SpmdPartitioningVisitor::TryDynamicSliceWithCollectiveBroadcast(
     HloInstruction* hlo) {
-  if (!options_.enable_dynamic_slice_collective_broadcast ||
-      !hlo->sharding().IsReplicated() || hlo->shape().IsTuple()) {
+  if (!hlo->sharding().IsReplicated() || hlo->shape().IsTuple()) {
     return false;
   }
 

--- a/xla/service/spmd/spmd_partitioner.cc
+++ b/xla/service/spmd/spmd_partitioner.cc
@@ -3837,7 +3837,171 @@ absl::Status SpmdPartitioningVisitor::HandleConstant(HloInstruction* hlo) {
   return absl::OkStatus();
 }
 
+absl::StatusOr<bool>
+SpmdPartitioningVisitor::TryDynamicSliceWithCollectiveBroadcast(
+    HloInstruction* hlo) {
+  if (!options_.enable_dynamic_slice_collective_broadcast ||
+      !hlo->sharding().IsReplicated() || hlo->shape().IsTuple()) {
+    return false;
+  }
+
+  HloInstruction* input = hlo->mutable_operand(0);
+  if (input->shape().IsTuple()) {
+    return false;
+  }
+
+  const int64_t rank = input->shape().dimensions().size();
+  std::optional<int64_t> sliced_dim;
+  for (int64_t dim = 0; dim < rank; ++dim) {
+    if (hlo->dynamic_slice_sizes()[dim] != input->shape().dimensions(dim)) {
+      if (sliced_dim.has_value()) {
+        return false;
+      }
+      sliced_dim = dim;
+    }
+  }
+  if (!sliced_dim.has_value() || hlo->dynamic_slice_sizes()[*sliced_dim] != 1) {
+    return false;
+  }
+
+  const Shape& index_shape = hlo->operand(*sliced_dim + 1)->shape();
+  if (!ShapeUtil::IsScalar(index_shape) || index_shape.element_type() != S32) {
+    return false;
+  }
+
+  PartitionedHlo input_partitioned = GetPartitionedHlo(input);
+  const HloSharding& input_sharding = input_partitioned.sharding();
+  if (!input_sharding.IsTiled() || input_sharding.HasPartialReplication() ||
+      input_sharding.num_devices() != num_partitions_) {
+    return false;
+  }
+
+  const int64_t input_dim_size = input->shape().dimensions(*sliced_dim);
+  if (input_dim_size > std::numeric_limits<int32_t>::max()) {
+    return false;
+  }
+
+  const int64_t num_slice_partitions = input_sharding.dimension(*sliced_dim);
+  if (num_slice_partitions <= 1 || input_dim_size % num_slice_partitions != 0) {
+    return false;
+  }
+  for (int64_t dim = 0; dim < rank; ++dim) {
+    if (dim == *sliced_dim) {
+      continue;
+    }
+    if (input_sharding.dimension(dim) != 1) {
+      return false;
+    }
+  }
+
+  std::vector<int64_t> owner_partition(num_slice_partitions, -1);
+  bool valid_tile_assignment = true;
+  input_sharding.EachTile(
+      [&](absl::Span<const int64_t> indices, int64_t device) {
+        if (indices.size() <= *sliced_dim || device < 0 ||
+            device >= num_partitions_) {
+          valid_tile_assignment = false;
+          return;
+        }
+        for (int64_t dim = 0; dim < rank; ++dim) {
+          if (dim != *sliced_dim && indices[dim] != 0) {
+            valid_tile_assignment = false;
+            return;
+          }
+        }
+        const int64_t owner = indices[*sliced_dim];
+        if (owner < 0 || owner >= num_slice_partitions ||
+            owner_partition[owner] != -1) {
+          valid_tile_assignment = false;
+          return;
+        }
+        owner_partition[owner] = device;
+      });
+  if (!valid_tile_assignment ||
+      absl::c_any_of(owner_partition,
+                     [](int64_t device) { return device < 0; })) {
+    return false;
+  }
+
+  HloInstruction* index =
+      GetPartitionedHlo(hlo->operand(*sliced_dim + 1)).Replicate().hlo();
+  auto constant_s32 = [&](int32_t value) {
+    return b_.AddInstruction(
+        HloInstruction::CreateConstant(LiteralUtil::CreateR0<int32_t>(value)));
+  };
+  HloInstruction* zero = constant_s32(0);
+  HloInstruction* max_index =
+      constant_s32(static_cast<int32_t>(input_dim_size - 1));
+  HloInstruction* clamped_index =
+      b_.AddInstruction(HloInstruction::CreateTernary(
+          index_shape, HloOpcode::kClamp, zero, index, max_index));
+
+  const int64_t shard_size = input_dim_size / num_slice_partitions;
+  if (shard_size > std::numeric_limits<int32_t>::max()) {
+    return false;
+  }
+  HloInstruction* shard_size_hlo =
+      constant_s32(static_cast<int32_t>(shard_size));
+  HloInstruction* owner = b_.AddInstruction(HloInstruction::CreateBinary(
+      index_shape, HloOpcode::kDivide, clamped_index, shard_size_hlo));
+  HloInstruction* owner_offset = b_.AddInstruction(HloInstruction::CreateBinary(
+      index_shape, HloOpcode::kMultiply, owner, shard_size_hlo));
+  HloInstruction* local_index = b_.AddInstruction(HloInstruction::CreateBinary(
+      index_shape, HloOpcode::kSubtract, clamped_index, owner_offset));
+
+  std::vector<HloInstruction*> local_indices(rank, zero);
+  local_indices[*sliced_dim] = local_index;
+  HloInstruction* local_slice =
+      b_.AddInstruction(HloInstruction::CreateDynamicSlice(
+          hlo->shape(), input_partitioned.hlo(), local_indices,
+          hlo->dynamic_slice_sizes()));
+
+  std::vector<HloComputation*> branch_computations;
+  branch_computations.reserve(num_slice_partitions);
+  std::vector<HloInstruction*> branch_args(num_slice_partitions, local_slice);
+  for (int64_t branch_owner = 0; branch_owner < num_slice_partitions;
+       ++branch_owner) {
+    std::vector<ReplicaGroup> replica_groups(1);
+    replica_groups[0].add_replica_ids(owner_partition[branch_owner]);
+    for (int64_t i = 0; i < num_slice_partitions; ++i) {
+      if (i != branch_owner) {
+        replica_groups[0].add_replica_ids(owner_partition[i]);
+      }
+    }
+
+    SpmdBuilder branch_builder(
+        absl::StrCat("dynamic_slice_collective_broadcast_owner_", branch_owner),
+        hlo);
+    HloInstruction* branch_param =
+        branch_builder.AddInstruction(HloInstruction::CreateParameter(
+            /*parameter_number=*/0, local_slice->shape(), "operand"));
+    HloInstruction* broadcast =
+        branch_builder.AddInstruction(HloInstruction::CreateCollectiveBroadcast(
+            local_slice->shape(), {branch_param}, replica_groups,
+            /*constrain_layout=*/false, NewChannel()));
+    broadcast->set_metadata(hlo->metadata());
+    broadcast->set_frontend_attributes(hlo->frontend_attributes());
+    broadcast->set_frontend_attribute(kSpmdGeneratedAttr, "true");
+    branch_computations.push_back(
+        module_->AddEmbeddedComputation(branch_builder.Build(broadcast)));
+  }
+
+  HloInstruction* conditional =
+      b_.AddInstruction(HloInstruction::CreateConditional(
+          hlo->shape(), owner, branch_computations, branch_args));
+  conditional->set_metadata(hlo->metadata());
+  conditional->set_frontend_attributes(hlo->frontend_attributes());
+  SetPartitionedHlo(hlo, conditional);
+  return true;
+}
+
 absl::Status SpmdPartitioningVisitor::HandleDynamicSlice(HloInstruction* hlo) {
+  TF_ASSIGN_OR_RETURN(bool handled,
+                      TryDynamicSliceWithCollectiveBroadcast(hlo));
+  if (handled) {
+    return absl::OkStatus();
+  }
+
   if (hlo->sharding().IsReplicatedOrSingleDevice()) {
     return DefaultAction(hlo);
   }

--- a/xla/service/spmd/spmd_partitioner.h
+++ b/xla/service/spmd/spmd_partitioner.h
@@ -107,10 +107,6 @@ struct SpmdPartitionerOptions {
   // Enables windowed einsum for result reduce-scatter.
   bool enable_windowed_einsum_for_reduce_scatter = true;
 
-  // Enables a narrow dynamic-slice lowering that broadcasts a single slice from
-  // its sharded owner instead of all-gathering the full operand first.
-  bool enable_dynamic_slice_collective_broadcast = false;
-
   // Whether disable rewrite for dots that share the same
   // operand as an already rewritten windowed einsum loop.
   bool disable_ag_rewrite_for_multiple_consumers = false;

--- a/xla/service/spmd/spmd_partitioner.h
+++ b/xla/service/spmd/spmd_partitioner.h
@@ -107,6 +107,10 @@ struct SpmdPartitionerOptions {
   // Enables windowed einsum for result reduce-scatter.
   bool enable_windowed_einsum_for_reduce_scatter = true;
 
+  // Enables a narrow dynamic-slice lowering that broadcasts a single slice from
+  // its sharded owner instead of all-gathering the full operand first.
+  bool enable_dynamic_slice_collective_broadcast = false;
+
   // Whether disable rewrite for dots that share the same
   // operand as an already rewritten windowed einsum loop.
   bool disable_ag_rewrite_for_multiple_consumers = false;
@@ -883,6 +887,9 @@ class SpmdPartitioningVisitor : public DfsHloVisitorWithDefault {
   HloInstruction* partition_id_;
 
  private:
+  absl::StatusOr<bool> TryDynamicSliceWithCollectiveBroadcast(
+      HloInstruction* hlo);
+
   PartitionedHlo::ReshardCache reshard_cache_;
 
   // Mapping from the instruction in the original computation to the new SPMD

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -90,10 +90,10 @@ void VerifyNoShardingOnCollectives(HloModule* module) {
   for (const HloComputation* c : module->computations()) {
     for (const HloInstruction* inst : c->instructions()) {
       bool is_collective = absl::c_linear_search(
-          std::vector<HloOpcode>{HloOpcode::kAllToAll, HloOpcode::kAllReduce,
-                                 HloOpcode::kAllGather,
-                                 HloOpcode::kCollectivePermute,
-                                 HloOpcode::kReduceScatter},
+          std::vector<HloOpcode>{
+              HloOpcode::kAllToAll, HloOpcode::kAllReduce,
+              HloOpcode::kAllGather, HloOpcode::kCollectiveBroadcast,
+              HloOpcode::kCollectivePermute, HloOpcode::kReduceScatter},
           inst->opcode());
       if (is_collective) {
         EXPECT_FALSE(inst->has_sharding());
@@ -2635,6 +2635,56 @@ ENTRY entry {
   EXPECT_THAT(
       module->entry_computation()->root_instruction(),
       AllOf(op::DynamicSlice(root_replicated, _), op::Shape("f32[64]")));
+}
+
+TEST_P(SpmdPartitioningTest,
+       DynamicSliceReplicatedResultUsesCollectiveBroadcast) {
+  const char* const hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  %param = f32[4,8,16] parameter(0), sharding={devices=[4,1,1]<=[4]}
+  %index = s32[] parameter(1), sharding={replicated}
+  %zero.0 = s32[] constant(0)
+  %zero.1 = s32[] constant(0)
+  ROOT %dynamic-slice = f32[1,8,16] dynamic-slice(%param, %index, %zero.0, %zero.1),
+    dynamic_slice_sizes={1,8,16}, sharding={replicated}
+})";
+
+  SpmdPartitionerOptions options;
+  options.enable_dynamic_slice_collective_broadcast = true;
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      PartitionComputation(hlo_string, /*num_devices=*/4, options));
+
+  auto count_opcode = [&](HloOpcode opcode) {
+    int64_t count = 0;
+    for (const HloComputation* computation : module->computations()) {
+      count += NumOfInstructions(computation, opcode);
+    }
+    return count;
+  };
+
+  EXPECT_EQ(count_opcode(HloOpcode::kAllGather), 0);
+  EXPECT_EQ(count_opcode(HloOpcode::kCollectiveBroadcast), 4);
+
+  const HloInstruction* root = module->entry_computation()->root_instruction();
+  ASSERT_EQ(root->opcode(), HloOpcode::kConditional);
+  ASSERT_EQ(root->branch_count(), 4);
+
+  std::vector<int64_t> broadcast_roots;
+  for (int64_t branch = 0; branch < root->branch_count(); ++branch) {
+    const HloInstruction* broadcast =
+        root->branch_computation(branch)->root_instruction();
+    ASSERT_EQ(broadcast->opcode(), HloOpcode::kCollectiveBroadcast);
+    const std::vector<std::vector<int64_t>> replica_groups =
+        ReplicaGroupsToVecOfVec(broadcast->replica_groups());
+    ASSERT_EQ(replica_groups.size(), 1);
+    ASSERT_EQ(replica_groups[0].size(), 4);
+    broadcast_roots.push_back(replica_groups[0][0]);
+    EXPECT_THAT(replica_groups[0], UnorderedElementsAre(0, 1, 2, 3));
+  }
+  EXPECT_THAT(broadcast_roots, UnorderedElementsAre(0, 1, 2, 3));
 }
 
 TEST_P(SpmdPartitioningTest, PadAlongNonPartitionedDimension) {

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -2651,11 +2651,8 @@ ENTRY entry {
     dynamic_slice_sizes={1,8,16}, sharding={replicated}
 })";
 
-  SpmdPartitionerOptions options;
-  options.enable_dynamic_slice_collective_broadcast = true;
-  TF_ASSERT_OK_AND_ASSIGN(
-      auto module,
-      PartitionComputation(hlo_string, /*num_devices=*/4, options));
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       PartitionComputation(hlo_string, /*num_devices=*/4));
 
   auto count_opcode = [&](HloOpcode opcode) {
     int64_t count = 0;


### PR DESCRIPTION
📝 Summary of Changes
Adds an SPMD dynamic-slice lowering for the case where a replicated result slices a single element from an operand sharded along that sliced dimension. The lowering selects the owning partition with a conditional and broadcasts only the local slice with collective-broadcast instead of all-gathering the full operand.

The lowering is enabled by default; the temporary enable_dynamic_slice_collective_broadcast option was removed.

🎯 Justification
This avoids the all-gather generated in the JAX layer-FSDP forward path when selecting one layer's weights from an LP-sharded layer stack. The workload benefits by replacing full-operand all-gather traffic with a single-slice collective broadcast from the owner partition.

🚀 Kind of Contribution
🐛 Bug Fix, ⚡️ Performance Improvement, 🧪 Tests

📊 Benchmark (for Performance Improvements)
No public HLO benchmark result is included. The validation target was the layer-FSDP forward HLO from the muon_jax repro. With a fresh JAX compile, the LP forward HLO has 0 all-gather-start/all-gather-done ops and contains the expected conditional collective-broadcast lowering.

🧪 Unit Tests:
- bazel test --test_output=errors --test_filter="*DynamicSliceReplicatedResultUsesCollectiveBroadcast*" //xla/service/spmd:spmd_partitioner_test

🧪 Execution Tests:
- Rebuilt JAX/JAXLIB CUDA artifacts against this XLA checkout.
- Ran lp_fsdp_muon_test.py --mode lp --no-run --dump-hlo with JAX_ENABLE_COMPILATION_CACHE=false.
- Confirmed HLO counts: collective-broadcast-start=32, collective-broadcast-done=32, conditional=4, dynamic_slice_collective_broadcast_owner=16, all-gather-start=0, all-gather-done=0.