### PR TITLE
Lower dynamic-slice to collective-broadcast

### DIFF
--- a/xla/service/spmd/spmd_partitioner.cc
+++ b/xla/service/spmd/spmd_partitioner.cc
@@ -4007,7 +4007,8 @@ SpmdPartitioningVisitor::TryDynamicSliceWithCollectiveBroadcast(
             /*parameter_number=*/0, local_slice->shape(), "operand"));
     HloInstruction* broadcast =
         branch_builder.AddInstruction(HloInstruction::CreateCollectiveBroadcast(
-            local_slice->shape(), {branch_param}, replica_groups,
+            local_slice->shape(), {branch_param},
+            std::make_shared<CollectiveDeviceList>(replica_groups),
             /*constrain_layout=*/false, NewChannel()));
     broadcast->set_metadata(hlo->metadata());
     broadcast->set_frontend_attributes(hlo->frontend_attributes());
@@ -4026,8 +4027,7 @@ SpmdPartitioningVisitor::TryDynamicSliceWithCollectiveBroadcast(
 }
 
 absl::Status SpmdPartitioningVisitor::HandleDynamicSlice(HloInstruction* hlo) {
-  TF_ASSIGN_OR_RETURN(bool handled,
-                      TryDynamicSliceWithCollectiveBroadcast(hlo));
+  ASSIGN_OR_RETURN(bool handled, TryDynamicSliceWithCollectiveBroadcast(hlo));
   if (handled) {
     return absl::OkStatus();
   }

--- a/xla/service/spmd/spmd_partitioner.cc
+++ b/xla/service/spmd/spmd_partitioner.cc
@@ -3837,6 +3837,37 @@ absl::Status SpmdPartitioningVisitor::HandleConstant(HloInstruction* hlo) {
   return absl::OkStatus();
 }
 
+// Rewrites a replicated dynamic-slice from an operand that is tiled only along
+// the sliced dimension into a single-slice collective broadcast.
+//
+// The targeted pattern is intentionally narrow:
+//
+//   operand: T[N, ...] sharded as {devices=[P,1,...]<=[P]}
+//   index:   s32[] replicated
+//   result = dynamic-slice(operand, index, 0, ...),
+//            dynamic_slice_sizes={1, ..., ...}, sharding={replicated}
+//
+// Without this rewrite, producing the replicated result generally reshares the
+// whole operand first, which becomes an all-gather of T[N, ...]. Instead, this
+// helper computes the clamped global index, derives the owning tile as
+// `owner = clamped_index / shard_size`, slices the local shard at
+// `local_index = clamped_index % shard_size`, and then builds:
+//
+//   conditional(owner,
+//     branch 0: collective-broadcast(local_slice),  // source is tile 0
+//     branch 1: collective-broadcast(local_slice),  // source is tile 1
+//     ...)
+//
+// Each branch's replica group lists the owning partition first. Collective
+// broadcast therefore forwards only that partition's local one-element slice to
+// every partition, yielding the same replicated result without all-gathering
+// the full operand.
+//
+// Keep the guard conditions conservative. The rewrite relies on one-to-one
+// ownership between tiles of the sliced dimension and partitions: no tuple
+// shapes, one sliced dimension of size 1, scalar S32 index, no partial
+// replication, no sharding on non-sliced dimensions, and an evenly divisible
+// shard size.
 absl::StatusOr<bool>
 SpmdPartitioningVisitor::TryDynamicSliceWithCollectiveBroadcast(
     HloInstruction* hlo) {

--- a/xla/service/spmd/spmd_partitioner.cc
+++ b/xla/service/spmd/spmd_partitioner.cc
@@ -3840,8 +3840,7 @@ absl::Status SpmdPartitioningVisitor::HandleConstant(HloInstruction* hlo) {
 absl::StatusOr<bool>
 SpmdPartitioningVisitor::TryDynamicSliceWithCollectiveBroadcast(
     HloInstruction* hlo) {
-  if (!options_.enable_dynamic_slice_collective_broadcast ||
-      !hlo->sharding().IsReplicated() || hlo->shape().IsTuple()) {
+  if (!hlo->sharding().IsReplicated() || hlo->shape().IsTuple()) {
     return false;
   }
 

--- a/xla/service/spmd/spmd_partitioner.cc
+++ b/xla/service/spmd/spmd_partitioner.cc
@@ -3837,7 +3837,171 @@ absl::Status SpmdPartitioningVisitor::HandleConstant(HloInstruction* hlo) {
   return absl::OkStatus();
 }
 
+absl::StatusOr<bool>
+SpmdPartitioningVisitor::TryDynamicSliceWithCollectiveBroadcast(
+    HloInstruction* hlo) {
+  if (!options_.enable_dynamic_slice_collective_broadcast ||
+      !hlo->sharding().IsReplicated() || hlo->shape().IsTuple()) {
+    return false;
+  }
+
+  HloInstruction* input = hlo->mutable_operand(0);
+  if (input->shape().IsTuple()) {
+    return false;
+  }
+
+  const int64_t rank = input->shape().dimensions().size();
+  std::optional<int64_t> sliced_dim;
+  for (int64_t dim = 0; dim < rank; ++dim) {
+    if (hlo->dynamic_slice_sizes()[dim] != input->shape().dimensions(dim)) {
+      if (sliced_dim.has_value()) {
+        return false;
+      }
+      sliced_dim = dim;
+    }
+  }
+  if (!sliced_dim.has_value() || hlo->dynamic_slice_sizes()[*sliced_dim] != 1) {
+    return false;
+  }
+
+  const Shape& index_shape = hlo->operand(*sliced_dim + 1)->shape();
+  if (!ShapeUtil::IsScalar(index_shape) || index_shape.element_type() != S32) {
+    return false;
+  }
+
+  PartitionedHlo input_partitioned = GetPartitionedHlo(input);
+  const HloSharding& input_sharding = input_partitioned.sharding();
+  if (!input_sharding.IsTiled() || input_sharding.HasPartialReplication() ||
+      input_sharding.num_devices() != num_partitions_) {
+    return false;
+  }
+
+  const int64_t input_dim_size = input->shape().dimensions(*sliced_dim);
+  if (input_dim_size > std::numeric_limits<int32_t>::max()) {
+    return false;
+  }
+
+  const int64_t num_slice_partitions = input_sharding.dimension(*sliced_dim);
+  if (num_slice_partitions <= 1 || input_dim_size % num_slice_partitions != 0) {
+    return false;
+  }
+  for (int64_t dim = 0; dim < rank; ++dim) {
+    if (dim == *sliced_dim) {
+      continue;
+    }
+    if (input_sharding.dimension(dim) != 1) {
+      return false;
+    }
+  }
+
+  std::vector<int64_t> owner_partition(num_slice_partitions, -1);
+  bool valid_tile_assignment = true;
+  input_sharding.EachTile(
+      [&](absl::Span<const int64_t> indices, int64_t device) {
+        if (indices.size() <= *sliced_dim || device < 0 ||
+            device >= num_partitions_) {
+          valid_tile_assignment = false;
+          return;
+        }
+        for (int64_t dim = 0; dim < rank; ++dim) {
+          if (dim != *sliced_dim && indices[dim] != 0) {
+            valid_tile_assignment = false;
+            return;
+          }
+        }
+        const int64_t owner = indices[*sliced_dim];
+        if (owner < 0 || owner >= num_slice_partitions ||
+            owner_partition[owner] != -1) {
+          valid_tile_assignment = false;
+          return;
+        }
+        owner_partition[owner] = device;
+      });
+  if (!valid_tile_assignment ||
+      absl::c_any_of(owner_partition,
+                     [](int64_t device) { return device < 0; })) {
+    return false;
+  }
+
+  HloInstruction* index =
+      GetPartitionedHlo(hlo->operand(*sliced_dim + 1)).Replicate().hlo();
+  auto constant_s32 = [&](int32_t value) {
+    return b_.AddInstruction(
+        HloInstruction::CreateConstant(LiteralUtil::CreateR0<int32_t>(value)));
+  };
+  HloInstruction* zero = constant_s32(0);
+  HloInstruction* max_index =
+      constant_s32(static_cast<int32_t>(input_dim_size - 1));
+  HloInstruction* clamped_index =
+      b_.AddInstruction(HloInstruction::CreateTernary(
+          index_shape, HloOpcode::kClamp, zero, index, max_index));
+
+  const int64_t shard_size = input_dim_size / num_slice_partitions;
+  if (shard_size > std::numeric_limits<int32_t>::max()) {
+    return false;
+  }
+  HloInstruction* shard_size_hlo =
+      constant_s32(static_cast<int32_t>(shard_size));
+  HloInstruction* owner = b_.AddInstruction(HloInstruction::CreateBinary(
+      index_shape, HloOpcode::kDivide, clamped_index, shard_size_hlo));
+  HloInstruction* owner_offset = b_.AddInstruction(HloInstruction::CreateBinary(
+      index_shape, HloOpcode::kMultiply, owner, shard_size_hlo));
+  HloInstruction* local_index = b_.AddInstruction(HloInstruction::CreateBinary(
+      index_shape, HloOpcode::kSubtract, clamped_index, owner_offset));
+
+  std::vector<HloInstruction*> local_indices(rank, zero);
+  local_indices[*sliced_dim] = local_index;
+  HloInstruction* local_slice =
+      b_.AddInstruction(HloInstruction::CreateDynamicSlice(
+          hlo->shape(), input_partitioned.hlo(), local_indices,
+          hlo->dynamic_slice_sizes()));
+
+  std::vector<HloComputation*> branch_computations;
+  branch_computations.reserve(num_slice_partitions);
+  std::vector<HloInstruction*> branch_args(num_slice_partitions, local_slice);
+  for (int64_t branch_owner = 0; branch_owner < num_slice_partitions;
+       ++branch_owner) {
+    std::vector<ReplicaGroup> replica_groups(1);
+    replica_groups[0].add_replica_ids(owner_partition[branch_owner]);
+    for (int64_t i = 0; i < num_slice_partitions; ++i) {
+      if (i != branch_owner) {
+        replica_groups[0].add_replica_ids(owner_partition[i]);
+      }
+    }
+
+    SpmdBuilder branch_builder(
+        absl::StrCat("dynamic_slice_collective_broadcast_owner_", branch_owner),
+        hlo);
+    HloInstruction* branch_param =
+        branch_builder.AddInstruction(HloInstruction::CreateParameter(
+            /*parameter_number=*/0, local_slice->shape(), "operand"));
+    HloInstruction* broadcast =
+        branch_builder.AddInstruction(HloInstruction::CreateCollectiveBroadcast(
+            local_slice->shape(), {branch_param}, replica_groups,
+            /*constrain_layout=*/false, NewChannel()));
+    broadcast->set_metadata(hlo->metadata());
+    broadcast->set_frontend_attributes(hlo->frontend_attributes());
+    broadcast->set_frontend_attribute(kSpmdGeneratedAttr, "true");
+    branch_computations.push_back(
+        module_->AddEmbeddedComputation(branch_builder.Build(broadcast)));
+  }
+
+  HloInstruction* conditional =
+      b_.AddInstruction(HloInstruction::CreateConditional(
+          hlo->shape(), owner, branch_computations, branch_args));
+  conditional->set_metadata(hlo->metadata());
+  conditional->set_frontend_attributes(hlo->frontend_attributes());
+  SetPartitionedHlo(hlo, conditional);
+  return true;
+}
+
 absl::Status SpmdPartitioningVisitor::HandleDynamicSlice(HloInstruction* hlo) {
+  TF_ASSIGN_OR_RETURN(bool handled,
+                      TryDynamicSliceWithCollectiveBroadcast(hlo));
+  if (handled) {
+    return absl::OkStatus();
+  }
+
   if (hlo->sharding().IsReplicatedOrSingleDevice()) {
     return DefaultAction(hlo);
   }

--- a/xla/service/spmd/spmd_partitioner.h
+++ b/xla/service/spmd/spmd_partitioner.h
@@ -107,10 +107,6 @@ struct SpmdPartitionerOptions {
   // Enables windowed einsum for result reduce-scatter.
   bool enable_windowed_einsum_for_reduce_scatter = true;
 
-  // Enables a narrow dynamic-slice lowering that broadcasts a single slice from
-  // its sharded owner instead of all-gathering the full operand first.
-  bool enable_dynamic_slice_collective_broadcast = false;
-
   // Whether disable rewrite for dots that share the same
   // operand as an already rewritten windowed einsum loop.
   bool disable_ag_rewrite_for_multiple_consumers = false;

--- a/xla/service/spmd/spmd_partitioner.h
+++ b/xla/service/spmd/spmd_partitioner.h
@@ -107,6 +107,10 @@ struct SpmdPartitionerOptions {
   // Enables windowed einsum for result reduce-scatter.
   bool enable_windowed_einsum_for_reduce_scatter = true;
 
+  // Enables a narrow dynamic-slice lowering that broadcasts a single slice from
+  // its sharded owner instead of all-gathering the full operand first.
+  bool enable_dynamic_slice_collective_broadcast = false;
+
   // Whether disable rewrite for dots that share the same
   // operand as an already rewritten windowed einsum loop.
   bool disable_ag_rewrite_for_multiple_consumers = false;
@@ -883,6 +887,9 @@ class SpmdPartitioningVisitor : public DfsHloVisitorWithDefault {
   HloInstruction* partition_id_;
 
  private:
+  absl::StatusOr<bool> TryDynamicSliceWithCollectiveBroadcast(
+      HloInstruction* hlo);
+
   PartitionedHlo::ReshardCache reshard_cache_;
 
   // Mapping from the instruction in the original computation to the new SPMD

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -90,10 +90,10 @@ void VerifyNoShardingOnCollectives(HloModule* module) {
   for (const HloComputation* c : module->computations()) {
     for (const HloInstruction* inst : c->instructions()) {
       bool is_collective = absl::c_linear_search(
-          std::vector<HloOpcode>{HloOpcode::kAllToAll, HloOpcode::kAllReduce,
-                                 HloOpcode::kAllGather,
-                                 HloOpcode::kCollectivePermute,
-                                 HloOpcode::kReduceScatter},
+          std::vector<HloOpcode>{
+              HloOpcode::kAllToAll, HloOpcode::kAllReduce,
+              HloOpcode::kAllGather, HloOpcode::kCollectiveBroadcast,
+              HloOpcode::kCollectivePermute, HloOpcode::kReduceScatter},
           inst->opcode());
       if (is_collective) {
         EXPECT_FALSE(inst->has_sharding());
@@ -2635,6 +2635,56 @@ ENTRY entry {
   EXPECT_THAT(
       module->entry_computation()->root_instruction(),
       AllOf(op::DynamicSlice(root_replicated, _), op::Shape("f32[64]")));
+}
+
+TEST_P(SpmdPartitioningTest,
+       DynamicSliceReplicatedResultUsesCollectiveBroadcast) {
+  const char* const hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  %param = f32[4,8,16] parameter(0), sharding={devices=[4,1,1]<=[4]}
+  %index = s32[] parameter(1), sharding={replicated}
+  %zero.0 = s32[] constant(0)
+  %zero.1 = s32[] constant(0)
+  ROOT %dynamic-slice = f32[1,8,16] dynamic-slice(%param, %index, %zero.0, %zero.1),
+    dynamic_slice_sizes={1,8,16}, sharding={replicated}
+})";
+
+  SpmdPartitionerOptions options;
+  options.enable_dynamic_slice_collective_broadcast = true;
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module,
+      PartitionComputation(hlo_string, /*num_devices=*/4, options));
+
+  auto count_opcode = [&](HloOpcode opcode) {
+    int64_t count = 0;
+    for (const HloComputation* computation : module->computations()) {
+      count += NumOfInstructions(computation, opcode);
+    }
+    return count;
+  };
+
+  EXPECT_EQ(count_opcode(HloOpcode::kAllGather), 0);
+  EXPECT_EQ(count_opcode(HloOpcode::kCollectiveBroadcast), 4);
+
+  const HloInstruction* root = module->entry_computation()->root_instruction();
+  ASSERT_EQ(root->opcode(), HloOpcode::kConditional);
+  ASSERT_EQ(root->branch_count(), 4);
+
+  std::vector<int64_t> broadcast_roots;
+  for (int64_t branch = 0; branch < root->branch_count(); ++branch) {
+    const HloInstruction* broadcast =
+        root->branch_computation(branch)->root_instruction();
+    ASSERT_EQ(broadcast->opcode(), HloOpcode::kCollectiveBroadcast);
+    const std::vector<std::vector<int64_t>> replica_groups =
+        ReplicaGroupsToVecOfVec(broadcast->replica_groups());
+    ASSERT_EQ(replica_groups.size(), 1);
+    ASSERT_EQ(replica_groups[0].size(), 4);
+    broadcast_roots.push_back(replica_groups[0][0]);
+    EXPECT_THAT(replica_groups[0], UnorderedElementsAre(0, 1, 2, 3));
+  }
+  EXPECT_THAT(broadcast_roots, UnorderedElementsAre(0, 1, 2, 3));
 }
 
 TEST_P(SpmdPartitioningTest, PadAlongNonPartitionedDimension) {

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -2651,11 +2651,8 @@ ENTRY entry {
     dynamic_slice_sizes={1,8,16}, sharding={replicated}
 })";
 
-  SpmdPartitionerOptions options;
-  options.enable_dynamic_slice_collective_broadcast = true;
-  TF_ASSERT_OK_AND_ASSIGN(
-      auto module,
-      PartitionComputation(hlo_string, /*num_devices=*/4, options));
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       PartitionComputation(hlo_string, /*num_devices=*/4));
 
   auto count_opcode = [&](HloOpcode opcode) {
     int64_t count = 0;


### PR DESCRIPTION
## Summary

This PR adds an SPMD lowering for a dynamic-slice pattern that appears in the Layered-FSDP forward pass for Muon workloads.

When a replicated result dynamically slices a single layer from an operand sharded along the layer dimension, XLA previously materialized the full operand with an all-gather and then sliced out the requested layer. This PR lowers that pattern to a per-owner `collective-broadcast`: each partition slices its local candidate, a conditional selects the partition that owns the requested layer, and that owner broadcasts only the selected slice.

## Workload

The motivating workload is Layered-FSDP for Muon.

Muon's Newton-Schulz update needs the full weight/gradient matrix for each layer. To preserve full matrices locally, Layered-FSDP shards scanned layer stacks along the layer dimension instead of sharding the matrix row/column dimensions.

A representative weight layout is:

```text
logical shape: [L, K, N]
sharding:      P("lp", None, None)
```

where `L` is the scanned layer dimension and `lp` is the layer-parallel mesh axis.

During the forward pass, the scan body selects the current layer:

```text
W_i = dynamic-slice(W, i, 0, 0), dynamic_slice_sizes={1, K, N}
```

The selected `W_i` is needed replicated across the LP partitions for the layer computation. If `L == LP`, layer `i` is owned by LP partition `i`.

The ideal communication pattern for scan iteration `i` is therefore:

```text
owner = partition that owns layer i
broadcast W_i from owner to all LP partitions
```

## Original Issue

Before this PR, XLA SPMD did not have a specialized lowering for this case:

```text
replicated result = dynamic-slice(tiled operand, dynamic layer index)
```

Because the operand is sharded on the sliced dimension but the dynamic-slice result is replicated, the existing path falls back to replicating the operand first. In practice this produces:

```text
all-gather full W across LP
dynamic-slice W_i from the gathered W
```

That is correct, but inefficient for this workload.

For example, if the scan only needs one layer's weight `[1, K, N]`, the old lowering gathers the full layer stack `[L, K, N]` and then slices out one layer. This defeats the purpose of Layered-FSDP's layerwise ownership for the forward pass, because every scan iteration communicates all layer shards instead of the one layer needed by that iteration.

## Solution In This PR

This PR adds `SpmdPartitioningVisitor::TryDynamicSliceWithCollectiveBroadcast` and calls it from `HandleDynamicSlice` before the generic replicated-output fallback.

The new lowering matches a conservative pattern:

```text
- dynamic-slice output is replicated
- operand is tiled
- exactly one dimension is dynamically sliced
- sliced size is 1
- operand is sharded only along the sliced dimension
- no partial replication
- partitioning is even
- slice index is an S32 scalar
- operand sharding uses the same number of devices as the SPMD partition count
```

For the matched case, XLA lowers:

```text
dynamic-slice(tiled_operand, i) -> replicated result
```

to:

```text
clamped_i   = clamp(i, 0, dim_size - 1)
owner       = clamped_i / shard_size
local_i     = clamped_i - owner * shard_size
local_slice = dynamic-slice(local_operand, local_i)

result = conditional(owner)
  branch 0: collective-broadcast(local_slice), root=partition owning shard 0
  branch 1: collective-broadcast(local_slice), root=partition owning shard 1
  ...
```

Each conditional branch contains a `collective-broadcast` with a static root. The dynamic part is only the branch selection, which is derived from the replicated layer index. This lets the HLO represent the desired "changing owner per scan iteration" pattern without requiring a dynamic-root collective.

The generated communication now moves only the selected layer slice instead of all layer shards.

## Before / After

Before:

```text
all-gather W_local -> W_full
dynamic-slice W_full[i]
```

After:

```text
local dynamic-slice W_local[local_i]
conditional(owner)
  collective-broadcast from owner partition
```

So the forward pass communication changes from:

```text
communicate [L, K, N] per scan iteration
```

to:

```text
communicate [1, K, N] per scan iteration
```

for the matched Layered-FSDP pattern.

## Testing

Added a focused SPMD partitioner test:

```text
DynamicSliceReplicatedResultUsesCollectiveBroadcast
```

The test verifies that a replicated dynamic-slice result from a layer-sharded operand produces:

```text
- no all-gather
- one conditional with one branch per owner partition
- collective-broadcast in each branch
- replica groups whose first member is the branch's broadcast root
```

Validation performed for the motivating workload:

```text
bazel test --test_output=errors \
  --test_filter="DynamicSliceReplicatedResultUsesCollectiveBroadcast" \
  //xla/service/spmd:spmd_partitioner_test
```

Additional workload validation:

```text
- Rebuilt JAX/JAXLIB CUDA artifacts against this XLA checkout.
- Ran lp_fsdp_muon_test.py --mode lp --no-run --dump-hlo with
  JAX_ENABLE_COMPILATION_CACHE=false.
- Confirmed the LP forward HLO contains the expected conditional
  collective-broadcast lowering.
```

Observed HLO counts for the workload:

```text
collective-broadcast-start = 32
collective-broadcast-done  = 32
conditional                = 4
dynamic_slice_collective_broadcast_owner = 16
all-gather-start           = 0
all-gather-done            = 0
```


🚀 Kind of Contribution
🐛 Bug Fix, ⚡️ Performance Improvement, 🧪 Tests

📊 Benchmark (for Performance Improvements)
No public HLO benchmark result is included. The validation target was the layer-FSDP forward HLO from the muon_jax repro. With a fresh JAX compile, the LP forward HLO has 0 all-gather-start/all-gather-done ops and contains the expected conditional collective-broadcast lowering.

🧪 Unit Tests:
- bazel test --test_output=errors --test_filter="*DynamicSliceReplicatedResultUsesCollectiveBroadcast*" //xla/service/spmd:spmd_partitioner_test

🧪 Execution Tests:
- Rebuilt JAX/JAXLIB CUDA artifacts against this XLA checkout.
- Ran lp_fsdp_muon_test.py --mode lp --no-run --dump-hlo with JAX_ENABLE_COMPILATION_CACHE=false.
- Confirmed HLO counts: collective-broadcast-start=32, collective-broadcast-done=32, conditional=4, dynamic_slice_collective_broadcast_owner=16, all-gather-start=0, all-gather-done=0.