### PR TITLE
Fix PJRT plugin README and E0102 error docs

### DIFF
--- a/docs/errors/error_0102.md
+++ b/docs/errors/error_0102.md
@@ -1,10 +1,10 @@
 # Error code: E0102
 
-**Category:** Runtime: Program Input Buffer Mismatch
+**Category:** Runtime: Program Input Mismatch
 
-This error occurs when the XLA runtime detects a mismatch between the size of a
-memory buffer expected by a compiled program and the size of the buffer that is
-actually provided at execution time.
+This error occurs when the XLA runtime detects that an input buffer provided at
+execution time does not match the metadata expected by a compiled program, such
+as the buffer size or PJRT memory space kind.
 
 **Sample error message:**
 
@@ -16,11 +16,12 @@ XlaRuntimeError: INVALID_ARGUMENT: Executable(jit_embedding_pipeline_step_fn) ex
 
 ## Overview
 
-The error message indicates both the expected and actual sizes, as well as the
-tensor shapes and layouts. Note that these errors might occur even if two
-tensors have the same shape but their size in memory can be different if their
-physical layout (how the data is tiled and arranged on the hardware) is
-different.
+For buffer-size mismatches, the error message indicates both the expected and
+actual sizes, as well as the tensor shapes and layouts. Note that these errors
+might occur even if two tensors have the same shape but their size in memory can
+be different if their physical layout (how the data is tiled and arranged on the
+hardware) is different. For memory-space mismatches, the error message reports
+that the parameter buffer is in an unexpected memory space.
 
 These errors are predominantly caused by:
 

--- a/xla/pjrt/plugin/README.md
+++ b/xla/pjrt/plugin/README.md
@@ -44,7 +44,7 @@ There are two primary ways to integrate a PJRT plugin into your application:
     *   **Example (Conceptual):**
 
         ```c++
-        const char* plugin_name = PJRT_PLUGIN_NAME_CPU;
+        absl::string_view plugin_name = kCpuPjrtName;
         // Or another name from plugin_names.h
 
         absl::StatusOr<std::unique_ptr<PjrtClient>> client =


### PR DESCRIPTION
I found two documentation issues that still appear to be present on current `main` as of https://github.com/openxla/xla/commit/3800f12fd9a711543c16896333903d447f7f13ee.

#### 1. PJRT plugin README uses a CPU plugin name that is not defined in `plugin_names.h`

The PJRT plugin README example uses `PJRT_PLUGIN_NAME_CPU`:

https://github.com/openxla/xla/blob/3800f12fd9a711543c16896333903d447f7f13ee/xla/pjrt/plugin/README.md#L47

But `plugin_names.h` defines the CPU plugin name as `kCpuPjrtName`

Introduced by:
- https://github.com/openxla/xla/commit/c014708ef28713050a5d35a1467ca7aa001f6810

#### 2. E0102 docs describe only buffer size mismatches

The E0102 documentation describes `RuntimeProgramInputMismatch` as a buffer size mismatch only:

https://github.com/openxla/xla/blob/3800f12fd9a711543c16896333903d447f7f13ee/docs/errors/error_0102.md#L3-L7

But `RuntimeProgramInputMismatch` is also used when a PJRT parameter buffer is in an unexpected memory space:

Introduced by:
- https://github.com/openxla/xla/commit/4651da4da5b43312966a9734c9cea1f12d444e21

This PR updates the documentation:
- https://github.com/doehyunbaek/xla/commit/7595892496dd7f42f9870007770c514d6e08cb7d
- https://github.com/doehyunbaek/xla/commit/0c30bf46afb006c696aece2d7026eef0d5999d34

Tests were not run because this is a documentation-only change.
