### PR TITLE
[xla:gpu] Do not sink constants that are not part of offset expr

### DIFF
--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
@@ -508,17 +508,48 @@ std::optional<DynamicSliceFusionPlan> BuildFusionPlan(
     }
   }
 
-  // Sink constants into the fusion body instead of capturing them as
-  // parameters. Constants have no operands so they go at the front.
-  std::vector<HloInstruction*> constants;
+  // Sink constants that are part of offset expressions into the fusion body
+  // instead of capturing them as parameters. Other constants must remain fusion
+  // parameters because the dynamic-slice fusion emitter expects hero operands
+  // and DUS targets to be backed by fusion parameters.
+  auto is_offset_use = [&](HloInstruction* instr, int64_t operand_index) {
+    if (offset_instruction_set.contains(instr)) {
+      return true;
+    }
+    return (instr->opcode() == HloOpcode::kDynamicSlice &&
+            operand_index >= 1) ||
+           (instr->opcode() == HloOpcode::kDynamicUpdateSlice &&
+            operand_index >= 2);
+  };
+
+  std::vector<HloInstruction*> offset_constants;
+  absl::flat_hash_set<HloInstruction*> offset_constant_set;
+  absl::flat_hash_set<HloInstruction*> non_offset_constant_set;
+
   for (HloInstruction* instr : clone_instructions) {
-    for (HloInstruction* operand : instr->operands()) {
-      if (HloPredicateIsOp<HloOpcode::kConstant>(operand) &&
-          clone_instruction_set.insert(operand).second) {
-        constants.push_back(operand);
+    for (int64_t i = 0; i < instr->operand_count(); ++i) {
+      HloInstruction* operand = instr->mutable_operand(i);
+      if (!HloPredicateIsOp<HloOpcode::kConstant>(operand)) {
+        continue;
+      }
+      if (is_offset_use(instr, i)) {
+        if (offset_constant_set.insert(operand).second) {
+          offset_constants.push_back(operand);
+        }
+      } else {
+        non_offset_constant_set.insert(operand);
       }
     }
   }
+
+  std::vector<HloInstruction*> constants;
+  for (HloInstruction* constant : offset_constants) {
+    if (!non_offset_constant_set.contains(constant) &&
+        clone_instruction_set.insert(constant).second) {
+      constants.push_back(constant);
+    }
+  }
+
   clone_instructions.insert(clone_instructions.begin(), constants.begin(),
                             constants.end());
 
@@ -531,10 +562,6 @@ std::optional<DynamicSliceFusionPlan> BuildFusionPlan(
   absl::flat_hash_set<HloInstruction*> visited_offset_instruction_set;
 
   auto collect_external_operand = [&](auto& self, HloInstruction* operand) {
-    // Constants have already been sunk into the fusion body.
-    if (HloPredicateIsOp<HloOpcode::kConstant>(operand)) {
-      return;
-    }
     // Any non-cloned operand is external to the fusion body and must become a
     // fusion parameter.
     if (!clone_instruction_set.contains(operand)) {

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
@@ -694,6 +694,68 @@ TEST_F(DynamicSliceFusionRewriterV2Test, DUSWithConstantOffset) {
   RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
 }
 
+TEST_F(DynamicSliceFusionRewriterV2Test, DUSWithConstantHeroOperand) {
+  const char* hlo = R"(
+    HloModule test
+
+    ENTRY main {
+      %p0 = f32[4,8,8]{2,1,0} parameter(0)
+      %input = f32[8,8]{1,0} constant({
+        {1, 1, 1, 1, 1, 1, 1, 1},
+        {1, 1, 1, 1, 1, 1, 1, 1},
+        {1, 1, 1, 1, 1, 1, 1, 1},
+        {1, 1, 1, 1, 1, 1, 1, 1},
+        {1, 1, 1, 1, 1, 1, 1, 1},
+        {1, 1, 1, 1, 1, 1, 1, 1},
+        {1, 1, 1, 1, 1, 1, 1, 1},
+        {1, 1, 1, 1, 1, 1, 1, 1}})
+      %hero = f32[8,8]{1,0} custom-call(%input),
+        custom_call_target="fake_target"
+      %bitcast = f32[1,8,8]{2,1,0} bitcast(%hero)
+      %c0 = s32[] constant(0)
+      ROOT %dus = f32[4,8,8]{2,1,0} dynamic-update-slice(
+        %p0, %bitcast, %c0, %c0, %c0)
+    }
+  )";
+
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:       {{.*}} bitcast(
+    ; CHECK:       ROOT {{.*}} dynamic-update-slice(
+    ; CHECK:     }
+    ; CHECK:     ENTRY %main{{.*}} {
+    ; CHECK:       ROOT {{.*}} fusion(%input, %p0),
+    ; CHECK:              kind=kCustom
+    ; CHECK:              "name":"dynamic_slice_fusion"
+    ; CHECK:     }
+  )";
+
+  auto f32_488 = ShapeUtil::MakeShape(F32, {4, 8, 8});
+  auto f32_188 = ShapeUtil::MakeShape(F32, {1, 8, 8});
+  auto f32_88 = ShapeUtil::MakeShape(F32, {8, 8});
+
+  auto fusion_checks = [&](HloModule* module) {
+    auto* hero = DynamicSliceFusion::FindHero(FindDsfBody(module));
+
+    ASSERT_OK_AND_ASSIGN(auto params,
+                         DynamicSliceFusion::ResolveParameters(hero));
+    EXPECT_THAT(params, ElementsAre(Param{0, f32_88, f32_88, std::nullopt,
+                                          std::nullopt}));
+
+    ASSERT_OK_AND_ASSIGN(auto results,
+                         DynamicSliceFusion::ResolveResults(hero));
+    std::vector<Offset> offsets = {{0, Offset::Constant(0)},
+                                   {1, Offset::Constant(0)},
+                                   {2, Offset::Constant(0)}};
+    EXPECT_THAT(results, ElementsAre(Result{1, 0, f32_488, f32_188,
+                                            MakeStaticConfig(0), offsets}));
+  };
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
+}
+
 TEST_F(DynamicSliceFusionRewriterV2Test, DUSNotRootNotFused) {
   const char* hlo = R"(
     HloModule test


### PR DESCRIPTION
Do not sink arbitrary constants into DUS fusions as they must be handled by `ThunkEmitter`, sink only scalar constants that are part of offset expression and captured by the expression itself and do not need a buffer at run time.