### PR TITLE
[xla] Forward frontend attributes in AllReduceFolder

### DIFF
--- a/xla/hlo/transforms/simplifiers/BUILD
+++ b/xla/hlo/transforms/simplifiers/BUILD
@@ -69,6 +69,7 @@ cc_library(
         "//xla/hlo/pass:hlo_pass",
         "//xla/hlo/utils:hlo_query",
         "//xla/service:all_reduce_key",
+        "//xla/service:collective_combiner_utils",
         "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_map",
@@ -77,7 +78,6 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
-        "@tsl//tsl/platform:errors",
     ],
 )
 
@@ -90,11 +90,9 @@ xla_cc_test(
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "//xla/hlo/testlib:test",
         "//xla/hlo/utils:hlo_matchers",
-        "//xla/tsl/lib/core:status_test_util",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings:string_view",
-        "@com_google_googletest//:gtest_main",
-        "@tsl//tsl/platform:statusor",
+        "@com_google_googletest//:gtest_main",  # build_cleaner: keep
     ],
 )
 

--- a/xla/hlo/transforms/simplifiers/all_reduce_folder.cc
+++ b/xla/hlo/transforms/simplifiers/all_reduce_folder.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -36,8 +37,8 @@ limitations under the License.
 #include "xla/hlo/ir/replica_group.h"
 #include "xla/hlo/utils/hlo_query.h"
 #include "xla/service/all_reduce_key.h"
+#include "xla/service/collective_combiner_utils.h"
 #include "xla/xla_data.pb.h"
-#include "tsl/platform/errors.h"
 
 namespace xla {
 namespace {
@@ -49,7 +50,7 @@ std::optional<std::vector<ReplicaGroup>> FoldReplicaGroups(
   // For a valid all-reduce with non-empty replica groups, the groups should
   // list each replica exactly once.
   int64_t num_replicas = 0;
-  for (const ReplicaGroup &rg : replica_groups0) {
+  for (const ReplicaGroup& rg : replica_groups0) {
     for (int64_t id : rg.replica_ids()) {
       num_replicas = std::max(num_replicas, id);
     }
@@ -82,7 +83,7 @@ std::optional<std::vector<ReplicaGroup>> FoldReplicaGroups(
   std::vector<int64_t> contributing_replicas_set_id(num_replicas, 0);
 
   int64_t next_id = 1;
-  for (const ReplicaGroup &rg : replica_groups1) {
+  for (const ReplicaGroup& rg : replica_groups1) {
     std::vector<bool> contributors(num_replicas, false);
     for (int64_t id : rg.replica_ids()) {
       int64_t group_no = replica_group_no[id];
@@ -122,11 +123,11 @@ std::optional<std::vector<ReplicaGroup>> FoldReplicaGroups(
   std::vector<ReplicaGroup> new_replica_groups;
   new_replica_groups.reserve(contributor_set_id.size());
 
-  for (const auto &it : contributor_set_id) {
-    const std::vector<bool> &contributors = it.first;
+  for (const auto& it : contributor_set_id) {
+    const std::vector<bool>& contributors = it.first;
     const int64_t set_id = it.second;
     new_replica_groups.emplace_back();
-    ReplicaGroup &group = new_replica_groups.back();
+    ReplicaGroup& group = new_replica_groups.back();
     for (int64_t replica = 0; replica < num_replicas; ++replica) {
       if (contributors[replica]) {
         if (contributing_replicas_set_id[replica] != set_id) {
@@ -141,7 +142,7 @@ std::optional<std::vector<ReplicaGroup>> FoldReplicaGroups(
   // groups are formed according to the order in the contributor_set_id map,
   // which is not stable.
   absl::c_sort(new_replica_groups,
-               [](const ReplicaGroup &a, const ReplicaGroup &b) {
+               [](const ReplicaGroup& a, const ReplicaGroup& b) {
                  return a.replica_ids(0) < b.replica_ids(0);
                });
   return new_replica_groups;
@@ -162,14 +163,14 @@ absl::StatusOr<bool> AllReduceFolder::RunImpl(
 
   bool changed = false;
   for (auto computation : module->computations(execution_threads)) {
-    for (HloInstruction *inst : computation->MakeInstructionPostOrder()) {
+    for (HloInstruction* inst : computation->MakeInstructionPostOrder()) {
       if (inst->opcode() != HloOpcode::kAllReduce ||
           inst->operand(0)->opcode() != HloOpcode::kAllReduce) {
         continue;
       }
 
-      auto *ar0 = Cast<HloAllReduceInstruction>(inst->mutable_operand(0));
-      auto *ar1 = Cast<HloAllReduceInstruction>(inst);
+      auto* ar0 = Cast<HloAllReduceInstruction>(inst->mutable_operand(0));
+      auto* ar1 = Cast<HloAllReduceInstruction>(inst);
 
       if (ar0->user_count() != 1) {
         continue;
@@ -216,6 +217,12 @@ absl::StatusOr<bool> AllReduceFolder::RunImpl(
               std::make_shared<CollectiveDeviceList>(*new_replica_groups),
               /*constrain_layout=*/false, channel_id,
               ar0->use_global_device_ids()));
+
+      // Forward frontend attributes from folded instructions.
+      std::vector<HloInstruction*> folded_all_reduces = {ar0, ar1};
+      new_ar->set_frontend_attributes(
+          MergeFrontendAttributes(folded_all_reduces));
+
       RETURN_IF_ERROR(ar1->ReplaceAllUsesWith(new_ar));
       RETURN_IF_ERROR(computation->RemoveInstruction(ar1));
       RETURN_IF_ERROR(computation->RemoveInstruction(ar0));

--- a/xla/hlo/transforms/simplifiers/all_reduce_folder_test.cc
+++ b/xla/hlo/transforms/simplifiers/all_reduce_folder_test.cc
@@ -27,8 +27,6 @@ limitations under the License.
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/hlo/testlib/test.h"
 #include "xla/hlo/utils/hlo_matchers.h"
-#include "xla/tsl/lib/core/status_test_util.h"
-#include "tsl/platform/statusor.h"
 
 namespace xla {
 namespace {
@@ -38,7 +36,7 @@ using ::testing::HasSubstr;
 
 class AllReduceFolderTest : public HloHardwareIndependentTestBase {};
 
-const char *k2AllReduce = R"(
+constexpr absl::string_view k2AllReduce = R"(
     HloModule m
 
     sum {
@@ -54,21 +52,21 @@ const char *k2AllReduce = R"(
     }
   )";
 
-size_t AllReduceCount(HloModule *module) {
+size_t AllReduceCount(HloModule* module) {
   return absl::c_count_if(module->entry_computation()->instructions(),
                           HloPredicateIsOp<HloOpcode::kAllReduce>);
 }
 
-void ExpectOneAllReduce(HloModule *module,
+void ExpectOneAllReduce(HloModule* module,
                         absl::string_view target_replica_groups) {
   EXPECT_EQ(AllReduceCount(module), 1);
-  HloInstruction *root = module->entry_computation()->root_instruction();
+  HloInstruction* root = module->entry_computation()->root_instruction();
   EXPECT_THAT(root, matcher::AllReduce(matcher::Parameter(0)));
   EXPECT_THAT(root->ToString(), HasSubstr(target_replica_groups));
 }
 
 TEST_F(AllReduceFolderTest, Simple) {
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       auto module, RunAndCheckHloRewrite(k2AllReduce, AllReduceFolder(), true,
                                          {{"$group_0", "{{0,1},{2,3}}"},
                                           {"$group_1", "{{0,2},{1,3}}"}}));
@@ -77,20 +75,48 @@ TEST_F(AllReduceFolderTest, Simple) {
 
 // Same as Simple, but groups for the 2 all-reduce's are swapped.
 TEST_F(AllReduceFolderTest, SimpleSwap) {
-  TF_ASSERT_OK_AND_ASSIGN(
+  ASSERT_OK_AND_ASSIGN(
       auto module, RunAndCheckHloRewrite(k2AllReduce, AllReduceFolder(), true,
                                          {{"$group_1", "{{0,1},{2,3}}"},
                                           {"$group_0", "{{0,2},{1,3}}"}}));
   ExpectOneAllReduce(module.get(), "replica_groups={{0,1,2,3}}");
 }
 
+TEST_F(AllReduceFolderTest, PreservesFrontendAttributes) {
+  absl::string_view hlo_string = R"(
+    HloModule m
+
+    sum {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT add.2 = f32[] add(a, b)
+    }
+
+    ENTRY main {
+      p0 = f32[8] parameter(0)
+      ar0 = f32[8] all-reduce(p0), replica_groups={{0,1},{2,3}},
+        to_apply=sum, frontend_attributes={pipeline="stage0", shared="value"}
+      ROOT ar1 = f32[8] all-reduce(ar0), replica_groups={{0,2},{1,3}},
+        to_apply=sum, frontend_attributes={pipeline="stage1", shared="value"}
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(
+      auto module, RunAndCheckHloRewrite(hlo_string, AllReduceFolder(), true));
+  ExpectOneAllReduce(module.get(), "replica_groups={{0,1,2,3}}");
+  const auto& attributes =
+      module->entry_computation()->root_instruction()->frontend_attributes();
+  EXPECT_EQ(attributes.map().at("pipeline"), "stage0,stage1");
+  EXPECT_EQ(attributes.map().at("shared"), "value");
+}
+
 TEST_F(AllReduceFolderTest, BothEmptyReplicaGroups_NotTransformed) {
-  TF_ASSERT_OK(RunAndCheckHloRewrite(k2AllReduce, AllReduceFolder(), false,
-                                     {{"$group_0", "{}"}, {"$group_1", "{}"}}));
+  ASSERT_OK(RunAndCheckHloRewrite(k2AllReduce, AllReduceFolder(), false,
+                                  {{"$group_0", "{}"}, {"$group_1", "{}"}}));
 }
 
 TEST_F(AllReduceFolderTest, EmptyReplicaGroups_NotTransformed) {
-  TF_ASSERT_OK(RunAndCheckHloRewrite(
+  ASSERT_OK(RunAndCheckHloRewrite(
       k2AllReduce, AllReduceFolder(), false,
       {{"$group_0", "{}"}, {"$group_1", "{{0,2},{1,3}}"}}));
 }
@@ -111,7 +137,7 @@ TEST_F(AllReduceFolderTest, MismatchOtherProperties0_NotTransformed) {
       ROOT ar1 = f32[8] all-reduce(ar0), replica_groups={{0,2},{1,3}}, to_apply=sum
     }
     )";
-  TF_ASSERT_OK(RunAndCheckHloRewrite(hlo_string, AllReduceFolder(), false));
+  ASSERT_OK(RunAndCheckHloRewrite(hlo_string, AllReduceFolder(), false));
 }
 
 TEST_F(AllReduceFolderTest, MismatchOtherProperties1_NotTransformed) {
@@ -136,7 +162,7 @@ TEST_F(AllReduceFolderTest, MismatchOtherProperties1_NotTransformed) {
       ROOT ar1 = f32[8] all-reduce(ar0), replica_groups={{0,2},{1,3}}, to_apply=mul
     }
     )";
-  TF_ASSERT_OK(RunAndCheckHloRewrite(hlo_string, AllReduceFolder(), false));
+  ASSERT_OK(RunAndCheckHloRewrite(hlo_string, AllReduceFolder(), false));
 }
 
 TEST_F(AllReduceFolderTest, NotFoldable_NotTransformed) {
@@ -155,7 +181,7 @@ TEST_F(AllReduceFolderTest, NotFoldable_NotTransformed) {
       ROOT ar1 = f32[8] all-reduce(ar0), replica_groups={{0,1},{2,3}}, to_apply=sum
     }
     )";
-  TF_ASSERT_OK(RunAndCheckHloRewrite(hlo_string, AllReduceFolder(), false));
+  ASSERT_OK(RunAndCheckHloRewrite(hlo_string, AllReduceFolder(), false));
 }
 
 TEST_F(AllReduceFolderTest, Foldable0) {
@@ -174,8 +200,8 @@ TEST_F(AllReduceFolderTest, Foldable0) {
       ROOT ar1 = f32[8] all-reduce(ar0), replica_groups={{0,5},{4,1},{2,7},{3,6}}, to_apply=sum
     }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(auto module,
-                          RunAndCheckHloRewrite(hlo_string, AllReduceFolder()));
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       RunAndCheckHloRewrite(hlo_string, AllReduceFolder()));
   ExpectOneAllReduce(module.get(), "replica_groups={{0,1,4,5},{2,3,6,7}}");
 }
 
@@ -198,8 +224,8 @@ TEST_F(AllReduceFolderTest, FoldableChain) {
       ROOT ar2 = f32[8] all-reduce(ar1), replica_groups={{0,4},{1,5},{2,6},{3,7}}, to_apply=sum
     }
     )";
-  TF_ASSERT_OK_AND_ASSIGN(auto module,
-                          RunAndCheckHloRewrite(hlo_string, AllReduceFolder()));
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       RunAndCheckHloRewrite(hlo_string, AllReduceFolder()));
   ExpectOneAllReduce(module.get(), "replica_groups={{0,1,2,3,4,5,6,7}}");
 }
 


### PR DESCRIPTION
Don't drop frontend attributes when folding all-reduce instructions