### PR TITLE
Disable CUPTI V2 path and unit tests

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -209,7 +209,6 @@ xla_test(
         ":cupti_wrapper",
         ":mock_cupti",
         "//xla/tsl/profiler/utils:time_utils",
-        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@local_config_cuda//cuda:cupti_headers",
     ],
@@ -415,6 +414,7 @@ cc_library(
             ":cupti_utils",
             "//xla/stream_executor/cuda:cuda_status",
             "//xla/tsl/platform:errors",
+            "//xla/tsl/platform:status_macros",
             "@com_google_absl//absl/base",
             "@com_google_absl//absl/base:core_headers",
             "@com_google_absl//absl/cleanup",
@@ -428,7 +428,7 @@ cc_library(
             "@local_config_cuda//cuda:cupti_headers",
             "@tsl//tsl/platform:errors",
         ],
-    ) + ["//xla/tsl/platform:status_macros"],
+    ),
 )
 
 cc_library(

--- a/xla/backends/profiler/gpu/cupti_error_manager_test.cc
+++ b/xla/backends/profiler/gpu/cupti_error_manager_test.cc
@@ -22,7 +22,6 @@ limitations under the License.
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
-#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_driver_cbid.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
 #include "xla/backends/profiler/gpu/cuda_test.h"
@@ -118,28 +117,27 @@ TEST_F(CuptiErrorManagerTest, GpuTraceActivityEnableTest) {
   // Enforces the order of execution below.
   Sequence s1;
   // CuptiBase::EnableProfiling()
-  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
+  EXPECT_CALL(*mock_, Subscribe(_, _, _))
       .InSequence(s1)
-      .WillOnce([](CUpti_SubscriberHandle* subscriber,
-                   CUpti_CallbackFunc /*callback*/, void* /*userdata*/) {
-        *subscriber = reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
-        return CUPTI_SUCCESS;
-      });
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::Subscribe));
   const int cb_enable_times = IsCudaNewEnoughForGraphTraceTest() ? 6 : 1;
   EXPECT_CALL(*mock_, EnableCallback(1, _, _, _))
       .Times(cb_enable_times)
       .InSequence(s1)
-      .WillRepeatedly(Return(CUPTI_SUCCESS));
-  EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(_))
+      .WillRepeatedly(
+          Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableCallback));
+  EXPECT_CALL(*mock_, SetThreadIdType(_))
       .InSequence(s1)
-      .WillOnce(Return(CUPTI_SUCCESS));
-  EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::SetThreadIdType));
+  EXPECT_CALL(*mock_, ActivityUsePerThreadBuffer())
       .InSequence(s1)
-      .WillOnce(Return(CUPTI_SUCCESS));
-  EXPECT_CALL(*mock_, ActivityRegisterCallbacksV2(_, _, _))
+      .WillOnce(Invoke(cupti_wrapper_.get(),
+                       &CuptiWrapper::ActivityUsePerThreadBuffer));
+  EXPECT_CALL(*mock_, ActivityRegisterCallbacks(_, _))
       .InSequence(s1)
-      .WillOnce(Return(CUPTI_SUCCESS));
-  EXPECT_CALL(*mock_, ActivityEnableV2(_, CUPTI_ACTIVITY_KIND_KERNEL, _))
+      .WillOnce(Invoke(cupti_wrapper_.get(),
+                       &CuptiWrapper::ActivityRegisterCallbacks));
+  EXPECT_CALL(*mock_, ActivityEnable(CUPTI_ACTIVITY_KIND_KERNEL))
       .InSequence(s1)
       .WillOnce(Return(CUPTI_ERROR_UNKNOWN));  // injected error
   // CuptiErrorManager::ResultString()
@@ -150,10 +148,11 @@ TEST_F(CuptiErrorManagerTest, GpuTraceActivityEnableTest) {
   EXPECT_CALL(*mock_, EnableCallback(0, _, _, _))
       .Times(cb_enable_times)
       .InSequence(s1)
-      .WillRepeatedly(Return(CUPTI_SUCCESS));
+      .WillRepeatedly(
+          Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableCallback));
   EXPECT_CALL(*mock_, Unsubscribe(_))
       .InSequence(s1)
-      .WillOnce(Return(CUPTI_SUCCESS));
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::Unsubscribe));
 
   EXPECT_FALSE(CuptiDisabled());
   CuptiTracerOptions options;
@@ -174,36 +173,35 @@ TEST_F(CuptiErrorManagerTest, GpuTraceAutoEnableTest) {
   EXPECT_FALSE(CuptiDisabled());
   // Enforces the order of execution below.
   Sequence s1;
-  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
+  EXPECT_CALL(*mock_, Subscribe(_, _, _))
       .InSequence(s1)
-      .WillOnce([](CUpti_SubscriberHandle* subscriber,
-                   CUpti_CallbackFunc /*callback*/, void* /*userdata*/) {
-        *subscriber = reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
-        return CUPTI_SUCCESS;
-      });
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::Subscribe));
   const int cb_enable_times = IsCudaNewEnoughForGraphTraceTest() ? 5 : 0;
   if (cb_enable_times > 0) {
     EXPECT_CALL(*mock_, EnableCallback(1, _, _, _))
         .Times(cb_enable_times)
         .InSequence(s1)
-        .WillRepeatedly(Return(CUPTI_SUCCESS));
+        .WillRepeatedly(
+            Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableCallback));
   }
   EXPECT_CALL(*mock_, EnableDomain(1, _, _))
       .InSequence(s1)
-      .WillOnce(Return(CUPTI_SUCCESS));
-  EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(_))
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableDomain));
+  EXPECT_CALL(*mock_, SetThreadIdType(_))
       .InSequence(s1)
-      .WillOnce(Return(CUPTI_SUCCESS));
-  EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::SetThreadIdType));
+  EXPECT_CALL(*mock_, ActivityUsePerThreadBuffer())
       .InSequence(s1)
-      .WillOnce(Return(CUPTI_SUCCESS));
-  EXPECT_CALL(*mock_, ActivityRegisterCallbacksV2(_, _, _))
+      .WillOnce(Invoke(cupti_wrapper_.get(),
+                       &CuptiWrapper::ActivityUsePerThreadBuffer));
+  EXPECT_CALL(*mock_, ActivityRegisterCallbacks(_, _))
       .InSequence(s1)
-      .WillOnce(Return(CUPTI_SUCCESS));
-  EXPECT_CALL(*mock_, ActivityEnableV2(_, CUPTI_ACTIVITY_KIND_MEMCPY, _))
+      .WillOnce(Invoke(cupti_wrapper_.get(),
+                       &CuptiWrapper::ActivityRegisterCallbacks));
+  EXPECT_CALL(*mock_, ActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY))
       .InSequence(s1)
-      .WillOnce(Return(CUPTI_SUCCESS));
-  EXPECT_CALL(*mock_, ActivityEnableV2(_, CUPTI_ACTIVITY_KIND_MEMCPY2, _))
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::ActivityEnable));
+  EXPECT_CALL(*mock_, ActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY2))
       .InSequence(s1)
       .WillOnce(Return(CUPTI_ERROR_UNKNOWN));  // injected error
   // CuptiErrorManager::ResultString()
@@ -211,21 +209,22 @@ TEST_F(CuptiErrorManagerTest, GpuTraceAutoEnableTest) {
       .InSequence(s1)
       .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::GetResultString));
   // CuptiErrorManager::UndoAndDisable()
-  EXPECT_CALL(*mock_, ActivityDisableV2(_, CUPTI_ACTIVITY_KIND_MEMCPY, _))
+  EXPECT_CALL(*mock_, ActivityDisable(CUPTI_ACTIVITY_KIND_MEMCPY))
       .InSequence(s1)
-      .WillOnce(Return(CUPTI_SUCCESS));
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::ActivityDisable));
   EXPECT_CALL(*mock_, EnableDomain(0, _, _))
       .InSequence(s1)
-      .WillOnce(Return(CUPTI_SUCCESS));
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableDomain));
   if (cb_enable_times > 0) {
     EXPECT_CALL(*mock_, EnableCallback(0, _, _, _))
         .Times(cb_enable_times)
         .InSequence(s1)
-        .WillRepeatedly(Return(CUPTI_SUCCESS));
+        .WillRepeatedly(
+            Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableCallback));
   }
   EXPECT_CALL(*mock_, Unsubscribe(_))
       .InSequence(s1)
-      .WillOnce(Return(CUPTI_SUCCESS));
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::Unsubscribe));
 
   EXPECT_FALSE(CuptiDisabled());
   CuptiTracerOptions options;

--- a/xla/backends/profiler/gpu/cupti_tracer.h
+++ b/xla/backends/profiler/gpu/cupti_tracer.h
@@ -53,7 +53,7 @@ struct CuptiTracerOptions {
   // Whether to call cuptiFinalize.
   bool cupti_finalize = false;
   // Whether to prefer CUPTI V2 multi-subscriber APIs when available.
-  bool prefer_cupti_v2 = true;
+  bool prefer_cupti_v2 = false;
   // Whether to call cuCtxSynchronize for each device before Stop().
   bool sync_devices_before_stop = false;
   // Whether to enable NVTX tracking, we need this for TensorRT tracking.


### PR DESCRIPTION
📝 Summary of Changes
Disable the CUDA 13.2+ CUPTI V2 multi-subscriber profiling path by default.

🎯 Justification
On CUDA 13.3, the default CUPTI V2 multi-subscriber path fails during profiling with `CUPTI_ERROR_NOT_COMPATIBLE` from `cuptiGetTimestamp`.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N/A.

🧪 Unit Tests:
Disable the two CUPTI V2-specific mock tests in `xla/backends/profiler/gpu/cupti_error_manager_test.cc`

🧪 Execution Tests:
Verified the user-facing JAX PGLE test //tests:pgle_test_gpu could pass under CUDA 13.3.
