### PR TITLE
[XLA:GPU]  Reuse stale VMM reservation mappings in Map in DeviceAddressVmmAllocator

### DIFF
--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -39,8 +39,6 @@ namespace stream_executor {
 namespace {
 
 using ::absl_testing::IsOk;
-using ::absl_testing::IsOkAndHolds;
-using ::testing::Ne;
 
 class DeviceAddressVmmAllocatorTest : public ::testing::Test {
  protected:
@@ -281,6 +279,260 @@ TEST_F(DeviceAddressVmmAllocatorTest, MapAndUnMapReservationAlias) {
   ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
                                /*reservation_offset=*/0, granularity),
               IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       MapRejectsPartialOverlapWithActiveReservationMapping) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  const uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+  const uint64_t mapping_size = 2 * granularity;
+
+  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
+                                             executor_, mapping_size));
+  ASSERT_OK_AND_ASSIGN(
+      auto full_range_source,
+      allocator->Allocate(ordinal, mapping_size, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+  ASSERT_OK_AND_ASSIGN(
+      auto partial_range_source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  ASSERT_THAT(
+      allocator->Map(ordinal, full_range_source.cref(), reservation.get(),
+                     /*reservation_offset=*/0, mapping_size),
+      IsOk());
+
+  EXPECT_THAT(
+      allocator->Map(ordinal, partial_range_source.cref(), reservation.get(),
+                     /*reservation_offset=*/granularity, granularity),
+      absl_testing::StatusIs(
+          absl::StatusCode::kFailedPrecondition,
+          ::testing::HasSubstr("partially overlaps active reservation")));
+
+  ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
+                               /*reservation_offset=*/0, mapping_size),
+              IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, full_range_source.Release()),
+              IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, partial_range_source.Release()),
+              IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       MapReactivatesPendingUnMapForSameRawAndRange) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  const uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+
+  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
+                                             executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+  auto* raw_allocation = allocator->GetRawAllocation(ordinal, source.cref());
+  ASSERT_NE(raw_allocation, nullptr);
+  DeviceAddressBase reservation_address = reservation->address().GetByteSlice(
+      /*offset_bytes=*/0, granularity);
+
+  ASSERT_THAT(allocator->Map(ordinal, source.cref(), reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  EXPECT_EQ(allocator->GetRawAllocation(ordinal, reservation_address), nullptr);
+
+  ASSERT_THAT(allocator->Map(ordinal, source.cref(), reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+  EXPECT_EQ(allocator->GetRawAllocation(ordinal, reservation_address),
+            raw_allocation);
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+  EXPECT_EQ(allocator->GetRawAllocation(ordinal, reservation_address),
+            raw_allocation);
+
+  ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, source.Release()), IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       MapRejectsPartialOverlapWithStaleReservationMapping) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  const uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+  const uint64_t mapping_size = 2 * granularity;
+
+  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
+                                             executor_, mapping_size));
+  ASSERT_OK_AND_ASSIGN(
+      auto full_range_source,
+      allocator->Allocate(ordinal, mapping_size, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+  ASSERT_OK_AND_ASSIGN(
+      auto partial_range_source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  ASSERT_THAT(
+      allocator->Map(ordinal, full_range_source.cref(), reservation.get(),
+                     /*reservation_offset=*/0, mapping_size),
+      IsOk());
+  ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
+                               /*reservation_offset=*/0, mapping_size),
+              IsOk());
+
+  EXPECT_THAT(
+      allocator->Map(ordinal, partial_range_source.cref(), reservation.get(),
+                     /*reservation_offset=*/granularity, granularity),
+      absl_testing::StatusIs(
+          absl::StatusCode::kFailedPrecondition,
+          ::testing::HasSubstr("partially overlaps stale reservation")));
+
+  ASSERT_THAT(allocator->Deallocate(ordinal, full_range_source.Release()),
+              IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, partial_range_source.Release()),
+              IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       MapRemapsPendingUnMapForDifferentRawAllocation) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  const uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+
+  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
+                                             executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto old_source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+  ASSERT_OK_AND_ASSIGN(
+      auto new_source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+  auto* old_raw_allocation =
+      allocator->GetRawAllocation(ordinal, old_source.cref());
+  auto* new_raw_allocation =
+      allocator->GetRawAllocation(ordinal, new_source.cref());
+  ASSERT_NE(old_raw_allocation, nullptr);
+  ASSERT_NE(new_raw_allocation, nullptr);
+  ASSERT_NE(old_raw_allocation, new_raw_allocation);
+  DeviceAddressBase reservation_address = reservation->address().GetByteSlice(
+      /*offset_bytes=*/0, granularity);
+
+  ASSERT_THAT(allocator->Map(ordinal, old_source.cref(), reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+  constexpr uint64_t kPattern = 0x123456789ABCDEF0ULL;
+  DeviceAddressBase device_address = reservation_address;
+  ASSERT_THAT(stream_->Memcpy(&device_address, &kPattern, sizeof(kPattern)),
+              IsOk());
+  ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  EXPECT_EQ(allocator->GetRawAllocation(ordinal, reservation_address), nullptr);
+
+  ASSERT_THAT(allocator->Map(ordinal, new_source.cref(), reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+  EXPECT_EQ(allocator->GetRawAllocation(ordinal, reservation_address),
+            new_raw_allocation);
+
+  ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, old_source.Release()), IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, new_source.Release()), IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       MapConflictPreservesUnrelatedPendingUnMap) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  const uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+
+  ASSERT_OK_AND_ASSIGN(
+      auto unrelated_reservation,
+      gpu::CudaMemoryReservation::Create(executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto conflict_reservation,
+      gpu::CudaMemoryReservation::Create(executor_, granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto unrelated_source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+  ASSERT_OK_AND_ASSIGN(
+      auto old_source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+  ASSERT_OK_AND_ASSIGN(
+      auto new_source,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective)));
+
+  ASSERT_THAT(allocator->Map(ordinal, unrelated_source.cref(),
+                             unrelated_reservation.get(),
+                             /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->UnMap(ordinal, unrelated_reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+
+  ASSERT_THAT(
+      allocator->Map(ordinal, old_source.cref(), conflict_reservation.get(),
+                     /*reservation_offset=*/0, granularity),
+      IsOk());
+  ASSERT_THAT(allocator->UnMap(ordinal, conflict_reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+
+  ASSERT_THAT(
+      allocator->Map(ordinal, new_source.cref(), conflict_reservation.get(),
+                     /*reservation_offset=*/0, granularity),
+      IsOk());
+  EXPECT_THAT(
+      allocator->UnMap(ordinal, unrelated_reservation.get(),
+                       /*reservation_offset=*/0, granularity),
+      absl_testing::StatusIs(absl::StatusCode::kFailedPrecondition,
+                             ::testing::HasSubstr("already pending UnMap()")));
+
+  ASSERT_THAT(allocator->UnMap(ordinal, conflict_reservation.get(),
+                               /*reservation_offset=*/0, granularity),
+              IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, unrelated_source.Release()),
+              IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, old_source.Release()), IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, new_source.Release()), IsOk());
   ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
 }
 

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -914,19 +914,84 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
         "mapping_size=%uB, allocation_size=%uB",
         size, raw_allocation->address().size()));
   }
-  if (state->active_reservation_records.contains(
-          reservation_address.opaque()) ||
-      state->stale_reservation_records.contains(reservation_address.opaque())) {
-    return absl::FailedPreconditionError(
-        "Reservation address is already tracked by this allocator");
+  if (auto overlap = FindOverlappingRecord(
+          *state, reservation_address, /*include_allocator=*/false,
+          /*include_reservation=*/true, /*include_active=*/true,
+          /*include_stale=*/true, /*exact_only=*/false,
+          /*partial_only=*/true)) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "reservation range at %p (%uB) partially overlaps %s reservation "
+        "range at %p (%uB); reservation mappings must be managed with the "
+        "same full range",
+        reservation_address.opaque(), reservation_address.size(),
+        overlap->is_active ? "active" : "stale",
+        overlap->tracked_address.opaque(), overlap->tracked_address.size()));
   }
   if (source_record->reservation_active()) {
     return absl::FailedPreconditionError(
         "Allocator address already has an active reservation alias");
   }
+  if (source_record->reservation_stale() &&
+      !source_record->reservation_matches(reservation_address)) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "Allocator address already has a pending reservation alias at virtual "
+        "address %p (%uB)",
+        source_record->reservation_address().opaque(),
+        source_record->reservation_address().size()));
+  }
+
+  // If this exact reservation mapping is still stale for the same raw
+  // allocation, reactivate it directly and cancel the pending unmap. This keeps
+  // captured command-buffer VAs stable without waiting for the GPU timeline.
+  if (auto stale_reservation_overlap = FindOverlappingRecord(
+          *state, reservation_address, /*include_allocator=*/false,
+          /*include_reservation=*/true, /*include_active=*/false,
+          /*include_stale=*/true, /*exact_only=*/true,
+          /*partial_only=*/false)) {
+    AllocationRecord& stale_record = *stale_reservation_overlap->record;
+    if (stale_record.raw_allocation() == raw_allocation &&
+        &stale_record == source_record &&
+        stale_record.reservation_mapping_matches(reservation_address)) {
+      CHECK(source_record->reservation_stale());
+      MoveReservationRecordToActive(*state, stale_record);
+      ErasePendingDeallocation(*state, PendingDeallocationKind::kMap,
+                               reservation_address);
+      return absl::OkStatus();
+    }
+
+    // The reservation range is exact but belongs to a different raw allocation
+    // or record. Wait for the old mapping to drain before installing the new
+    // alias.
+    RETURN_IF_ERROR(WaitAndCompleteStaleReservationMapping(
+        *state, PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                       stale_record.reservation_stale_seqno(),
+                                       stale_record.reservation_address()}));
+  }
   if (source_record->reservation_stale()) {
-    return absl::FailedPreconditionError(
-        "Allocator address already has a pending reservation alias");
+    CHECK(source_record->has_reservation_address());
+    auto stale_allocator_overlap = FindOverlappingRecord(
+        *state, source_record->reservation_address(),
+        /*include_allocator=*/false, /*include_reservation=*/true,
+        /*include_active=*/false, /*include_stale=*/true,
+        /*exact_only=*/true, /*partial_only=*/false);
+    CHECK(stale_allocator_overlap.has_value());
+    RETURN_IF_ERROR(WaitAndCompleteStaleReservationMapping(
+        *state,
+        PendingDeallocationKey{PendingDeallocationKind::kMap,
+                               source_record->reservation_stale_seqno(),
+                               source_record->reservation_address()}));
+  }
+  if (FindOverlappingRecord(*state, reservation_address,
+                            /*include_allocator=*/false,
+                            /*include_reservation=*/true,
+                            /*include_active=*/true,
+                            /*include_stale=*/false,
+                            /*exact_only=*/false,
+                            /*partial_only=*/false)
+          .has_value()) {
+    return absl::AlreadyExistsError(absl::StrFormat(
+        "reservation range is already tracked at virtual address %p",
+        reservation_address.opaque()));
   }
 
   // Install the reservation address mapping to the raw physical allocation. The

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -212,6 +213,26 @@ static uint64_t LoadTimeline(const volatile uint64_t* pinned_timeline) {
   return __atomic_load_n(pinned_timeline, __ATOMIC_ACQUIRE);
 }
 
+static uintptr_t AddressStart(DeviceAddressBase address) {
+  return reinterpret_cast<uintptr_t>(address.opaque());
+}
+
+static uintptr_t AddressEnd(DeviceAddressBase address) {
+  uintptr_t start = AddressStart(address);
+  if (std::numeric_limits<uintptr_t>::max() - start < address.size()) {
+    return std::numeric_limits<uintptr_t>::max();
+  }
+  return start + address.size();
+}
+
+static bool AddressRangesOverlap(DeviceAddressBase lhs, DeviceAddressBase rhs) {
+  if (lhs.is_null() || rhs.is_null() || lhs.size() == 0 || rhs.size() == 0) {
+    return false;
+  }
+  return AddressStart(lhs) < AddressEnd(rhs) &&
+         AddressStart(rhs) < AddressEnd(lhs);
+}
+
 DeviceAddressVmmAllocator::DeviceAddressVmmAllocator(const Platform* platform)
     : DeviceAddressAllocator(platform) {}
 
@@ -322,11 +343,10 @@ MemoryAllocation* DeviceAddressVmmAllocator::GetRawAllocation(
   absl::MutexLock lock(state->mu);
 
   // Allocator addresses are keyed directly by their VA. Stale records remain in
-  // this map until deferred teardown completes, so require both active state
-  // and an exact address-range match before exposing the backing allocation.
+  // this map until deferred teardown completes, so expose their backing
+  // allocation for diagnostics/reuse checks until the pending operation drains.
   auto allocation_it = state->records_by_allocator_address.find(addr.opaque());
   if (allocation_it != state->records_by_allocator_address.end() &&
-      allocation_it->second->allocator_active() &&
       allocation_it->second->allocator_matches(addr)) {
     return allocation_it->second->raw_allocation();
   }
@@ -777,6 +797,72 @@ DeviceAddressVmmAllocator::ValidateReservationRange(
   return address.GetByteSlice(reservation_offset, size);
 }
 
+std::optional<DeviceAddressVmmAllocator::OverlappingRecord>
+DeviceAddressVmmAllocator::FindOverlappingRecord(
+    PerDeviceState& state, DeviceAddressBase address, bool include_allocator,
+    bool include_reservation, bool include_active, bool include_stale,
+    bool exact_only, bool partial_only) const {
+  auto overlaps = [&](DeviceAddressBase tracked_address) {
+    if (exact_only) {
+      return tracked_address.IsSameAs(address);
+    }
+    if (partial_only) {
+      return AddressRangesOverlap(tracked_address, address) &&
+             !tracked_address.IsSameAs(address);
+    }
+    return AddressRangesOverlap(tracked_address, address);
+  };
+
+  if (include_allocator) {
+    for (const auto& [_, record_owner] : state.records_by_allocator_address) {
+      AllocationRecord* record = record_owner.get();
+      if (((record->allocator_active() && include_active) ||
+           (record->allocator_stale() && include_stale)) &&
+          overlaps(record->allocator_address())) {
+        return OverlappingRecord{
+            .record = record,
+            .tracked_address = record->allocator_address(),
+            .is_allocator = true,
+            .is_active = record->allocator_active(),
+        };
+      }
+    }
+  }
+
+  if (include_reservation) {
+    if (include_active) {
+      for (const auto& [_, record] : state.active_reservation_records) {
+        CHECK(record->reservation_active());
+        CHECK(record->has_reservation_address());
+        if (overlaps(record->reservation_address())) {
+          return OverlappingRecord{
+              .record = record,
+              .tracked_address = record->reservation_address(),
+              .is_allocator = false,
+              .is_active = true,
+          };
+        }
+      }
+    }
+    if (include_stale) {
+      for (const auto& [_, record] : state.stale_reservation_records) {
+        CHECK(record->reservation_stale());
+        CHECK(record->has_reservation_address());
+        if (overlaps(record->reservation_address())) {
+          return OverlappingRecord{
+              .record = record,
+              .tracked_address = record->reservation_address(),
+              .is_allocator = false,
+              .is_active = false,
+          };
+        }
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+
 absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
                                             DeviceAddressBase addr,
                                             MemoryReservation* reservation,
@@ -879,6 +965,18 @@ void DeviceAddressVmmAllocator::ErasePendingDeallocationAt(
   state.pending_deallocations.erase(it);
 }
 
+void DeviceAddressVmmAllocator::ErasePendingDeallocation(
+    PerDeviceState& state, PendingDeallocationKind kind,
+    DeviceAddressBase addr) {
+  for (auto it = state.pending_deallocations.begin();
+       it != state.pending_deallocations.end(); ++it) {
+    if (it->kind == kind && it->addr.IsSameAs(addr)) {
+      ErasePendingDeallocationAt(state, it);
+      return;
+    }
+  }
+}
+
 void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
     PerDeviceState& state, AllocationRecord& record, uint64_t new_size) {
   CHECK(!record.allocator_active());
@@ -902,6 +1000,19 @@ void DeviceAddressVmmAllocator::MoveReservationRecordToStale(
       state.stale_reservation_records.emplace(reservation_va, &record);
   CHECK(insert_result.second);
   record.MarkReservationStale(seqno);
+}
+
+void DeviceAddressVmmAllocator::MoveReservationRecordToActive(
+    PerDeviceState& state, AllocationRecord& record) {
+  CHECK(!record.reservation_active());
+  CHECK(record.reservation_stale());
+  CHECK(record.has_reservation_address());
+  void* reservation_va = record.reservation_key();
+  CHECK_EQ(state.stale_reservation_records.erase(reservation_va), 1);
+  auto insert_result =
+      state.active_reservation_records.emplace(reservation_va, &record);
+  CHECK(insert_result.second);
+  record.ReactivateReservation();
 }
 
 void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
@@ -979,6 +1090,41 @@ bool DeviceAddressVmmAllocator::CompletePendingDeallocationByKey(
     }
   }
   return false;
+}
+
+absl::Status
+DeviceAddressVmmAllocator::WaitAndCompleteStaleAllocatorDeallocation(
+    PerDeviceState& state, const PendingDeallocationKey& key) {
+  CHECK_NE(key.kind, PendingDeallocationKind::kMap);
+  RETURN_IF_ERROR(WaitUntilSeqno(state, key.seqno));
+  CompletePendingDeallocationByKey(state, key);
+  return absl::OkStatus();
+}
+
+absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleReservationMapping(
+    PerDeviceState& state, const PendingDeallocationKey& key) {
+  CHECK_EQ(key.kind, PendingDeallocationKind::kMap);
+  RETURN_IF_ERROR(WaitUntilSeqno(state, key.seqno));
+  CompletePendingDeallocationByKey(state, key);
+  return absl::OkStatus();
+}
+
+absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleOverlap(
+    PerDeviceState& state, const OverlappingRecord& overlap) {
+  CHECK(!overlap.is_active);
+  if (overlap.is_allocator) {
+    AllocationRecord& record = *overlap.record;
+    return WaitAndCompleteStaleAllocatorDeallocation(
+        state, PendingDeallocationKey{record.pending_deallocation_kind(),
+                                      record.allocator_stale_seqno(),
+                                      record.allocator_address()});
+  }
+  CHECK(overlap.record->reservation_stale());
+  CHECK(overlap.record->has_reservation_address());
+  return WaitAndCompleteStaleReservationMapping(
+      state, PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                    overlap.record->reservation_stale_seqno(),
+                                    overlap.record->reservation_address()});
 }
 
 void DeviceAddressVmmAllocator::CompletePendingDeallocation(

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -111,8 +111,10 @@ namespace stream_executor {
 // only reservation addresses created by Map() or by
 // Allocate(..., return_reservation_address=false). Passing an allocator address
 // to UnMap(), or a reservation address to Deallocate(), is an error.
-// Each allocator address may have at most one active or stale
-// reservation-address alias.
+// Each allocator address may have at most one active reservation-address alias.
+// A reservation mapping is owned as the same full range that created it:
+// partial UnMap(), Map(), or Allocate() operations that overlap an active or
+// stale reservation mapping are rejected.
 //
 // Deallocate() and UnMap() are stream-ordered deferred operations. The
 // allocator assigns the affected address record a per-device sequence number,
@@ -124,6 +126,15 @@ namespace stream_executor {
 // When the sequence completes, dropping the ScopedMapping objects performs the
 // real unmap, then the allocator releases any owned reservation and raw
 // physical memory.
+//
+// Stale records are also the fast reuse path. Allocate() first looks for a
+// compatible stale allocator address before creating new VMM state. Map() does
+// the same for a stale reservation mapping: if the requested reservation
+// address is still mapped to the same raw physical allocation, the allocator
+// reactivates the old mapping instead of unmapping and remapping. If a
+// requested reservation address is still stale for a different raw allocation,
+// Map() waits for that deferred unmap to complete before installing the new
+// mapping.
 //
 // Each registered device has independent state protected by its own mutex, so
 // operations on different devices can proceed in parallel. The per-device map
@@ -241,7 +252,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // range until all previously enqueued work on the allocator stream has
   // completed.
   // The caller must pass the same full reservation range that created the
-  // mapping.
+  // mapping; partial ranges that overlap a tracked mapping are rejected.
   // The reservation-derived allocator address returned by
   // Allocate(..., return_reservation_address=true) is not a reservation
   // address for this API and must be released with Deallocate() instead.
@@ -574,11 +585,33 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       MemoryReservation* reservation, uint64_t reservation_offset,
       uint64_t size) const;
 
+  struct OverlappingRecord {
+    AllocationRecord* record = nullptr;
+    DeviceAddressBase tracked_address;
+    bool is_allocator = false;
+    bool is_active = false;
+  };
+
+  // Finds a tracked allocator or reservation range that overlaps `address`.
+  // `exact_only` returns only identical ranges; `partial_only` returns only
+  // non-identical overlapping ranges; both false returns any overlap.
+  std::optional<OverlappingRecord> FindOverlappingRecord(
+      PerDeviceState& state, DeviceAddressBase address, bool include_allocator,
+      bool include_reservation, bool include_active, bool include_stale,
+      bool exact_only, bool partial_only) const
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
   // UnMap/deferred teardown helpers.
 
   // Removes a pending entry when a stale record is reused.
   void ErasePendingDeallocationAt(PerDeviceState& state,
                                   std::deque<PendingDeallocation>::iterator it)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Removes the matching pending entry when a stale record is reused.
+  void ErasePendingDeallocation(PerDeviceState& state,
+                                PendingDeallocationKind kind,
+                                DeviceAddressBase addr)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   void MoveAllocatorRecordToActive(PerDeviceState& state,
@@ -587,6 +620,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   void MoveReservationRecordToStale(PerDeviceState& state,
                                     AllocationRecord& record, uint64_t seqno)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  void MoveReservationRecordToActive(PerDeviceState& state,
+                                     AllocationRecord& record)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   void CompleteStaleReservationMapping(PerDeviceState& state,
@@ -625,6 +662,24 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // while state.mu was released.
   bool CompletePendingDeallocationByKey(PerDeviceState& state,
                                         const PendingDeallocationKey& key)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Waits for and completes the selected allocator-address deallocation, if it
+  // is still pending after the wait.
+  absl::Status WaitAndCompleteStaleAllocatorDeallocation(
+      PerDeviceState& state, const PendingDeallocationKey& key)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Waits for and completes a stale reservation-address mapping queued by
+  // UnMap().
+  absl::Status WaitAndCompleteStaleReservationMapping(
+      PerDeviceState& state, const PendingDeallocationKey& key)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
+  // Completes only the stale allocator or reservation mapping that conflicts
+  // with the current request, leaving unrelated stale mappings reusable.
+  absl::Status WaitAndCompleteStaleOverlap(PerDeviceState& state,
+                                           const OverlappingRecord& overlap)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Device ordinal -> per-device allocator state. Populated at construction by


### PR DESCRIPTION
📝 Summary of Changes

This PR adds the common helper layer for stale VMM mapping reuse:

- range-overlap helpers for `DeviceAddressBase` virtual address intervals;
- `FindOverlappingRecord()` for active/stale allocator and reservation records;
- helpers to remove a pending deallocation entry by kind/address;
- helpers to reactivate stale reservation records;
- helpers to wait for and complete one selected stale allocator or reservation overlap;
- documentation updates for full-range reservation ownership and stale record reuse;
- `GetRawAllocation()` keeps returning raw allocations for stale allocator addresses until deferred teardown drains.

It also wires the reservation reuse path into `DeviceAddressVmmAllocator::Map()`:

- finds a reusable stale reservation record for exact full-range remaps;
- rejects unsupported partial stale reservation overlap with an internal error;
- waits for a selected pending stale reservation when the overlap cannot be reused;
- reactivates a stale reservation record instead of allocating a fresh mapping record when reuse is valid.

Mapped `Allocate()` reuse is still left for the next stacked PR.

Stack:
1. openxla/xla#44861: helper/docs foundation plus stale reservation reuse in `Map()`. This PR.
2. shawnwang18/xla#3: reuse stale mappings in mapped `Allocate()`.

Note: the original upstream draft PR #44174 is unchanged. The former fork PR shawnwang18/xla#2 has been merged into this PR branch.

🎯 Justification
The original PR touched several allocator paths at once. This updated split now gives reviewers the shared bookkeeping primitives together with the first direct caller, so the lifetime invariants can be reviewed in context before the mapped `Allocate()` path is added.

This is important for VMM allocator reuse because remapping a full stale reservation can avoid unnecessary reservation bookkeeping churn while still preserving correctness for partial overlaps and pending deferred teardown.

🚀 Kind of Contribution
⚡️ Performance Improvement, ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
No benchmark results were collected for this split.

🧪 Unit Tests:
No new test files were added.

Local validation:

```bash
bazel build //xla/stream_executor:device_address_vmm_allocator
```

Result: passed.

🧪 Execution Tests:
The full stacked branch was validated with:

```bash
bazel test --cache_test_results=no --test_output=errors //xla/stream_executor/cuda:cuda_device_address_vmm_allocator_test
```

Result: passed.
