### PR TITLE
[XLA:GPU] zero initialize the output buffers of cuDNN SDPA to avoid unexpected garbage values

### DIFF
--- a/xla/backends/gpu/runtime/cudnn_thunk.cc
+++ b/xla/backends/gpu/runtime/cudnn_thunk.cc
@@ -50,13 +50,14 @@ namespace gpu {
 
 CuDnnThunk::CuDnnThunk(std::string fingerprint, ThunkInfo thunk_info,
                        std::vector<ShapedSlice> args,
-                       std::vector<bool> output_args,
+                       std::vector<bool> output_args, bool should_memzero,
                        std::optional<int64_t> sdpa_dropout_seed)
     : TracedCommand(Kind::kCuDnn, std::move(thunk_info)),
       fingerprint_(std::move(fingerprint)),
       graph_(std::make_shared<se::dnn::LazyDnnGraph>(nullptr)),
       args_(std::move(args)),
       output_args_(std::move(output_args)),
+      should_memzero_(should_memzero),
       sdpa_dropout_seed_(sdpa_dropout_seed) {}
 
 absl::Status CuDnnThunk::Initialize(const InitializeParams& params) {
@@ -102,6 +103,9 @@ absl::Status CuDnnThunk::ExecuteOnStream(const ExecuteParams& params) {
   for (const ShapedSlice& arg : args_) {
     auto addr = params.buffer_allocations->GetDeviceAddress(arg.slice);
     if (output_args_[buffer_args.size()]) {
+      if (should_memzero_) {
+        RETURN_IF_ERROR(params.stream->MemZero(&addr, addr.size()));
+      }
       tsl::profiler::MarkMemoryInitialized(
           addr.opaque(), addr.size(),
           static_cast<tsl::profiler::StreamHandle>(
@@ -164,6 +168,7 @@ absl::StatusOr<ThunkProto> CuDnnThunk::ToProto() const {
   for (const bool is_output : output_args_) {
     proto.mutable_cudnn_thunk()->add_output_args(is_output);
   }
+  proto.mutable_cudnn_thunk()->set_should_memzero(should_memzero_);
   if (sdpa_dropout_seed_.has_value()) {
     proto.mutable_cudnn_thunk()->set_sdpa_dropout_seed(
         static_cast<int64_t>(*sdpa_dropout_seed_));
@@ -191,7 +196,7 @@ absl::StatusOr<std::unique_ptr<CuDnnThunk>> CuDnnThunk::FromProto(
   }
   return std::make_unique<CuDnnThunk>(
       proto.fingerprint(), std::move(thunk_info), std::move(args),
-      std::move(output_args), sdpa_dropout_seed);
+      std::move(output_args), proto.should_memzero(), sdpa_dropout_seed);
 }
 
 }  // namespace gpu

--- a/xla/backends/gpu/runtime/cudnn_thunk.h
+++ b/xla/backends/gpu/runtime/cudnn_thunk.h
@@ -48,7 +48,7 @@ namespace gpu {
 class CuDnnThunk : public TracedCommand {
  public:
   CuDnnThunk(std::string fingerprint, ThunkInfo, std::vector<ShapedSlice> args,
-             std::vector<bool> output_args,
+             std::vector<bool> output_args, bool should_memzero = false,
              std::optional<int64_t> sdpa_dropout_seed = std::nullopt);
   CuDnnThunk(const CuDnnThunk&) = delete;
   CuDnnThunk& operator=(const CuDnnThunk&) = delete;
@@ -91,6 +91,7 @@ class CuDnnThunk : public TracedCommand {
   std::shared_ptr<se::dnn::LazyDnnGraph> graph_;
   std::vector<ShapedSlice> args_;
   std::vector<bool> output_args_;
+  bool should_memzero_;
   // Sdpa dropout seed
   std::optional<int64_t> sdpa_dropout_seed_;
 };

--- a/xla/backends/gpu/runtime/thunk.proto
+++ b/xla/backends/gpu/runtime/thunk.proto
@@ -134,6 +134,7 @@ message CudnnThunkProto {
   repeated ShapedSliceProto args = 2;
   repeated bool output_args = 4;
   optional int64 sdpa_dropout_seed = 3;
+  bool should_memzero = 5;
 }
 
 message HostSendThunkProto {

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -944,7 +944,8 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCuDnnThunk(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
       kernel_arguments.GetArgumentShapedSlices(),
-      kernel_arguments.GetArgumentOutputFlags(), dropout_seed));
+      kernel_arguments.GetArgumentOutputFlags(),
+      /*should_memzero=*/IsCustomCallTofMHA(*instr), dropout_seed));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitPtxCustomCall(


### PR DESCRIPTION
📝 Summary of Changes
Zero initialize the output buffers of cuDNN SDPA so users don't get random values for regions that cuDNN doesn't touch.  This could happen when user specify the padded region of the inputs. cuDNN skips computing output for these regions and keep the initial values for padded regions of the output buffers.

🎯 Justification
It is expected that the SDPA gradient output should be 0 if its corresponding input is in the padded regions. Zero initialize the output buffers so this constraints hold.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix
