### PR TITLE
[ROCm] Fix dangling reference to cubin span in RocmExecutor::LoadKernel

### DIFF
--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -659,8 +659,8 @@ absl::StatusOr<std::unique_ptr<Kernel>> RocmExecutor::LoadKernel(
   const std::string& kernel_name = spec.kernel_name();
 
   if (spec.has_cuda_cubin_in_memory()) {
-    const auto& cubin = spec.cuda_cubin_in_memory()->cubin_bytes;
-    const char* hsaco = reinterpret_cast<const char*>(cubin.data());
+    const char* hsaco = reinterpret_cast<const char*>(
+        spec.cuda_cubin_in_memory()->cubin_bytes.data());
     absl::MutexLock lock{in_memory_modules_mu_};
     ASSIGN_OR_RETURN(ModuleHandle module_handle, LoadModuleFromHsaco(hsaco));
     hipModule_t module = gpu_binary_to_module_.at(module_handle).first;


### PR DESCRIPTION
cuda_cubin_in_memory() returns a std::optional<CudaCubinInMemory> by value. Splitting the cubin access across two statements bound a reference into the temporary optional, which is destroyed at the end of the statement, leaving the span dangling before cubin.data() reads it. ASan reported this as a stack-use-after-scope in p2p_ops_e2e_test.

Inline the access back into a single full-expression so the optional stays alive while data() runs. Introduced by PR #40419.