### PR TITLE
[ROCm] Use proper sysroot version, fixing abi clashes with therock

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -295,6 +295,7 @@ common:rocm_ci_hermetic --dynamic_mode=off
 common:rocm_ci_hermetic --config=rocm_clang_hermetic
 common:rocm_ci_hermetic --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a"
 common:rocm_ci_hermetic --repo_env=ROCM_DISTRO_VERSION="rocm_7.12.0_gfx90a"
+common:rocm_ci_hermetic --repo_env=SYSROOT_DIST=linux_glibc_2_31
 common:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 # This config option is used for SYCL as GPU backend.


### PR DESCRIPTION
📝 Summary of Changes
Use proper sysroot version, fixing abi clashes with therock.

🎯 Justification
We have abi clash with therock due to the built in stdcpp symbols when building
using heremetic toolchain. We use a newer sysroot version to avoid that clash

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
