### PR TITLE
[XLA:GPU] Track XTile scaled-dot element types

### DIFF
--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_shared_dialect_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_shared_dialect_test.cc
@@ -403,7 +403,7 @@ ENTRY e {
   EXPECT_OK(CreateXTileIrAndFileCheck(
       *module->GetComputationWithName("triton_dot"), block_level_parameters,
       R"(
-      CHECK: %[[DOT:.*]] = xtile.dot_scaled %[[LHS:.*]] scale %[[LHS_SCALE:.*]], %[[RHS:.*]] scale %[[RHS_SCALE:.*]] {dot_dimension_numbers = #stablehlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>, fastMath = true} : tensor<128x128xf8E5M2>, tensor<128x4xi8> * tensor<128x256xf8E5M2>, tensor<256x4xi8> -> tensor<128x256xf32>
+      CHECK: %[[DOT:.*]] = xtile.dot_scaled %[[LHS:.*]] scale %[[LHS_SCALE:.*]], %[[RHS:.*]] scale %[[RHS_SCALE:.*]] {dot_dimension_numbers = #stablehlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>, fastMath = true, lhs_elem_type = f8E5M2, rhs_elem_type = f8E5M2} : tensor<128x128xf8E5M2>, tensor<128x4xi8> * tensor<128x256xf8E5M2>, tensor<256x4xi8> -> tensor<128x256xf32>
       CHECK: %[[RES:.*]] = arith.addf %{{.*}}, %[[DOT]] : tensor<128x256xf32>
       )"));
 }

--- a/xla/backends/gpu/codegen/triton/transforms/tests/xtile_to_triton_lowering.mlir
+++ b/xla/backends/gpu/codegen/triton/transforms/tests/xtile_to_triton_lowering.mlir
@@ -13,11 +13,29 @@ func.func @lower_dot_scaled_add_to_triton(
   // CHECK-NOT: arith.addf
   %0 = xtile.dot_scaled %lhs scale %lhs_scale, %rhs scale %rhs_scale
     {dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [], rhs_batching_dimensions = [], lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>,
-     fastMath = true} : tensor<128x128xf8E5M2>,
+     fastMath = true, lhs_elem_type = f8E5M2, rhs_elem_type = f8E5M2} : tensor<128x128xf8E5M2>,
     tensor<128x4xi8> * tensor<128x256xf8E5M2>, tensor<256x4xi8> -> tensor<128x256xf32>
   %1 = arith.addf %acc, %0 : tensor<128x256xf32>
   // CHECK: return %[[RES]] : tensor<128x256xf32>
   return %1 : tensor<128x256xf32>
+}
+
+// -----
+
+// CHECK: func @lower_packed_dot_scaled_add_to_triton(%[[LHS:.*]]: tensor<128x32xi8>, %[[LHS_SCALE:.*]]: tensor<128x2xi8>, %[[RHS:.*]]: tensor<32x128xi8>, %[[RHS_SCALE:.*]]: tensor<128x2xi8>, %[[ACC:.*]]: tensor<128x128xf32>) -> tensor<128x128xf32> {
+func.func @lower_packed_dot_scaled_add_to_triton(
+  %lhs: tensor<128x32xi8>, %lhs_scale: tensor<128x2xi8>,
+  %rhs: tensor<32x128xi8>, %rhs_scale: tensor<128x2xi8>,
+  %acc: tensor<128x128xf32>) -> tensor<128x128xf32> {
+  // CHECK: %[[RES:.*]] = tt.dot_scaled %[[LHS]] scale %[[LHS_SCALE]], %[[RHS]] scale %[[RHS_SCALE]], %[[ACC]] lhs = e2m1 rhs = e2m1 {fastMath = true} : tensor<128x32xi8>, tensor<128x2xi8> * tensor<32x128xi8>, tensor<128x2xi8> -> tensor<128x128xf32>
+  // CHECK-NOT: arith.addf
+  %0 = xtile.dot_scaled %lhs scale %lhs_scale, %rhs scale %rhs_scale
+    {dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [], rhs_batching_dimensions = [], lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>,
+     fastMath = true, lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN} : tensor<128x32xi8>,
+    tensor<128x2xi8> * tensor<32x128xi8>, tensor<128x2xi8> -> tensor<128x128xf32>
+  %1 = arith.addf %acc, %0 : tensor<128x128xf32>
+  // CHECK: return %[[RES]] : tensor<128x128xf32>
+  return %1 : tensor<128x128xf32>
 }
 
 // CHECK-LABEL: func @lower_dot_scaled_in_loop_non_canonical
@@ -36,7 +54,7 @@ func.func @lower_dot_scaled_in_loop_non_canonical(
     // CHECK: scf.yield %[[DOT]] : tensor<128x256xf32>
     %0 = xtile.dot_scaled %lhs scale %lhs_scale, %rhs scale %rhs_scale
       {dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
-       fastMath = true} : tensor<1x128x128xf8E5M2>, tensor<1x128x4xi8> * tensor<1x128x256xf8E5M2>, tensor<1x256x4xi8> -> tensor<1x128x256xf32>
+       fastMath = true, lhs_elem_type = f8E5M2, rhs_elem_type = f8E5M2} : tensor<1x128x128xf8E5M2>, tensor<1x128x4xi8> * tensor<1x128x256xf8E5M2>, tensor<1x256x4xi8> -> tensor<1x128x256xf32>
     %1 = arith.addf %accum, %0 : tensor<1x128x256xf32>
     scf.yield %1 : tensor<1x128x256xf32>
   }
@@ -53,7 +71,7 @@ func.func @lower_dot_scaled_without_add_falls_back_to_xtile(
   // CHECK: %[[RES:.*]] = xtile.dot_scaled %[[LHS]] scale %[[LHS_SCALE]], %[[RHS]] scale %[[RHS_SCALE]] {{.*}}fastMath = true{{.*}} : tensor<128x128xf8E5M2>, tensor<128x4xi8> * tensor<128x256xf8E5M2>, tensor<256x4xi8> -> tensor<128x256xf32>
   %0 = xtile.dot_scaled %lhs scale %lhs_scale, %rhs scale %rhs_scale
     {dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [], rhs_batching_dimensions = [], lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>,
-     fastMath = true} : tensor<128x128xf8E5M2>,
+     fastMath = true, lhs_elem_type = f8E5M2, rhs_elem_type = f8E5M2} : tensor<128x128xf8E5M2>,
     tensor<128x4xi8> * tensor<128x256xf8E5M2>, tensor<256x4xi8> -> tensor<128x256xf32>
   // CHECK: return %[[RES]] : tensor<128x256xf32>
   return %0 : tensor<128x256xf32>

--- a/xla/backends/gpu/codegen/triton/transforms/xtile_lower_to_triton.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/xtile_lower_to_triton.cc
@@ -48,18 +48,18 @@ namespace ttir = ::mlir::triton;
 
 namespace {
 
-absl::StatusOr<ttir::ScaleDotElemType> GetScaleDotElemType(Type value) {
-  Type type = getElementTypeOrSelf(value);
-  if (type == mlir::Float8E4M3FNType::get(value.getContext())) {
+absl::StatusOr<ttir::ScaleDotElemType> GetScaleDotElemType(Type type) {
+  MLIRContext* context = type.getContext();
+  if (type == mlir::Float8E4M3FNType::get(context)) {
     return ttir::ScaleDotElemType::E4M3;
   }
-  if (type == mlir::Float8E5M2Type::get(value.getContext())) {
+  if (type == mlir::Float8E5M2Type::get(context)) {
     return ttir::ScaleDotElemType::E5M2;
   }
-  if (type == mlir::Float4E2M1FNType::get(value.getContext())) {
+  if (type == mlir::Float4E2M1FNType::get(context)) {
     return ttir::ScaleDotElemType::E2M1;
   }
-  if (type == mlir::BFloat16Type::get(value.getContext())) {
+  if (type == mlir::BFloat16Type::get(context)) {
     return ttir::ScaleDotElemType::BF16;
   }
   return absl::InvalidArgumentError(
@@ -144,7 +144,9 @@ LogicalResult CanonicalDotScaled(::xla::xtile::DotScaledOp op,
 
   canonical_dot = ::xla::xtile::DotScaledOp::create(
       builder, new_result_type, lhs, rhs, lhs_scale, rhs_scale,
-      op.getFastMath(), op.getLhsKPack(), op.getRhsKPack(), canonical_dims);
+      op.getFastMath(), op.getLhsKPack(), op.getRhsKPack(),
+      op.getLhsElemTypeAttr().getValue(), op.getRhsElemTypeAttr().getValue(),
+      canonical_dims);
   return mlir::success();
 }
 
@@ -193,7 +195,7 @@ class LowerDotScaled
     }
 
     absl::StatusOr<ttir::ScaleDotElemType> lhs_dot_elem_type =
-        GetScaleDotElemType(op.getLhs().getType());
+        GetScaleDotElemType(op.getLhsElemTypeAttr().getValue());
     if (!lhs_dot_elem_type.ok()) {
       return rewriter.notifyMatchFailure(
           op_loc, absl::StrCat("Failed to get dot element type for LHS: ",
@@ -201,7 +203,7 @@ class LowerDotScaled
     }
 
     absl::StatusOr<ttir::ScaleDotElemType> rhs_dot_elem_type =
-        GetScaleDotElemType(op.getRhs().getType());
+        GetScaleDotElemType(op.getRhsElemTypeAttr().getValue());
     if (!rhs_dot_elem_type.ok()) {
       return rewriter.notifyMatchFailure(
           op_loc, absl::StrCat("Failed to get dot element type for RHS: ",

--- a/xla/codegen/xtile/codegen/dot_algorithms.cc
+++ b/xla/codegen/xtile/codegen/dot_algorithms.cc
@@ -116,8 +116,8 @@ absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
 
   auto dot_scaled_op = xtile::DotScaledOp::create(
       b, operands.accumulator.getType(), operands.lhs, operands.rhs, lhs_scale,
-      rhs_scale, /*fastMath=*/true, lhs_k_pack, rhs_k_pack,
-      operands.dot_dimension_numbers);
+      rhs_scale, /*fastMath=*/true, lhs_k_pack, rhs_k_pack, lhs_dot_elem_type,
+      rhs_dot_elem_type, operands.dot_dimension_numbers);
 
   auto add_result =
       mlir::isa<mlir::IntegerType>(

--- a/xla/codegen/xtile/ir/tests/ops.mlir
+++ b/xla/codegen/xtile/ir/tests/ops.mlir
@@ -120,7 +120,7 @@ func.func @type_mismatch_insert(%src: tensor<24xf64>, %dst: memref<1024xf32>) {
 // -----
 
 func.func @dot_scaled(%lhs: tensor<128x128xf32>, %lhs_scale: tensor<128x4xi8>, %rhs: tensor<128x256xf32>, %rhs_scale: tensor<256x4xi8>, %acc: tensor<128x256xf32>) -> tensor<128x256xf32> {
-  %0 = xtile.dot_scaled %lhs scale %lhs_scale, %rhs scale %rhs_scale {fastMath = true} : tensor<128x128xf32>, tensor<128x4xi8> * tensor<128x256xf32>, tensor<256x4xi8> -> tensor<128x256xf32>
+  %0 = xtile.dot_scaled %lhs scale %lhs_scale, %rhs scale %rhs_scale {fastMath = true, lhs_elem_type = f32, rhs_elem_type = f32} : tensor<128x128xf32>, tensor<128x4xi8> * tensor<128x256xf32>, tensor<256x4xi8> -> tensor<128x256xf32>
   return %0 : tensor<128x256xf32>
 }
 

--- a/xla/codegen/xtile/ir/xtile_ops.td
+++ b/xla/codegen/xtile/ir/xtile_ops.td
@@ -325,8 +325,8 @@ def DotScaledOp : XTile_Op<"dot_scaled", [Pure, AttrSizedOperandSegments]> {
 
     let arguments = (
       ins
-      // inputs are floats if we have a type for them, otherwise (fp4),
-      // they are packed in pairs in an I8Tensor
+      // Data operands carry logical element types separately from their tensor
+      // element types because packed operands use i8 storage.
       RankedTensorOf<[AnyFloat,I8]>:$lhs,
       RankedTensorOf<[AnyFloat,I8]>:$rhs,
       Optional<RankedTensorOf<[AnyFloat,I8]>>:$lhs_scale,
@@ -334,6 +334,8 @@ def DotScaledOp : XTile_Op<"dot_scaled", [Pure, AttrSizedOperandSegments]> {
       BoolAttr:$fastMath,
       DefaultValuedAttr<BoolAttr, "true">:$lhs_k_pack,
       DefaultValuedAttr<BoolAttr, "true">:$rhs_k_pack,
+      TypeAttr:$lhs_elem_type,
+      TypeAttr:$rhs_elem_type,
       OptionalAttr<AnyAttr>:$dot_dimension_numbers
     );
 


### PR DESCRIPTION
📝 Summary of Changes
Make xtile.dot_scaled carry logical LHS/RHS element types explicitly, instead of deriving them from operand tensor element types during Triton lowering. This lets XTile represent packed FP4 scaled-dot operands correctly: the operand tensor can use physical i8 storage, while the dot semantics remain f4E2M1FN. This is the first PR in the decomposition of larger scaled-dot fixes https://github.com/openxla/xla/pull/44223.

🎯 Justification
XTile cannot defer FP4 packing until Triton lowering because packing changes the storage value, not just the final `tt.dot_scaled` attributes. For `f4E2M1FN`, two logical elements are stored in one byte, so the packed dimension (minor vs major), tile offsets, and load/result value type all need to be computed in the tiled XTile emission path before `xtile.dot_scaled` is lowered. A logical `tensor<128x64xf4E2M1FN>` tile and a physical `tensor<128x32xi8>` tile are different IR values with different indexing contracts. Converting only at Triton lowering would require rewriting producers (i.e. transpose in front of scaled dot after canonicalization), shapes, offsets, and layout decisions after the fact.

This matches Triton boundary: XTile models the actual packed storage tile, and Triton lowering still has the semantic type information needed to emit `tt.dot_scaled lhs = e2m1 rhs = e2m1`.

🚀 Kind of Contribution
♻️ Cleanup, 🧪 Tests

🧪 Unit Tests:
`lower_packed_dot_scaled_add_to_triton` in `xla/backends/gpu/codegen/triton/transforms/tests/xtile_to_triton_lowering.mlir`
