### PR TITLE
[XLA:GPU] Rename two Command API names

### DIFF
--- a/xla/backends/gpu/runtime/collective_thunk.h
+++ b/xla/backends/gpu/runtime/collective_thunk.h
@@ -126,7 +126,7 @@ class CollectiveThunk : public Command {
   }
 
   bool IsTracedCommand() const override { return true; }
-  bool requires_initialization() const override { return true; }
+  bool requires_update_on_initialize() const override { return true; }
   bool requires_warmup() const override { return true; }
 
   absl::Status Prepare(const PrepareParams& params) override;

--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -150,8 +150,8 @@ class Command : public Thunk {
     return absl::UnimplementedError("Record is not implemented");
   }
 
-  // Returns true if command requires initialization (has to be recorded at
-  // command buffer thunk initialization).
+  // Returns true if command requires a command buffer update during command
+  // buffer thunk initialization.
   //
   // Today this is only true for collective commands that might use NCCL for
   // communication. With NCCL, all participating ranks must record collective
@@ -159,7 +159,7 @@ class Command : public Thunk {
   // they got lucky and got the same buffer allocations), it will lead to
   // deadlocks. By forcing the command update at thunk initialization time, we
   // ensure that all ranks execute NCCL command update.
-  virtual bool requires_initialization() const { return false; }
+  virtual bool requires_update_on_initialize() const { return false; }
 
   // Returns true if command requires a one-time fallback execution before it is
   // recorded into a command buffer.
@@ -167,7 +167,7 @@ class Command : public Thunk {
 
   // Returns true if command buffer command parameters can change even when
   // buffer allocation base addresses are unchanged.
-  virtual bool requires_update() const { return false; }
+  virtual bool requires_update_on_execute() const { return false; }
 
   // Returns true if this command is implemented via CUDA stream activity
   // tracing (i.e. a subclass of TracedCommand).

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -210,14 +210,14 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
   // memory on device and this might lead to deadlocks when we have concurrent
   // NCCL operations in flight.
 
-  // If commands require initialization (and VA remapping is not enabled), we
-  // also record them into the command buffer before execution. This is required
-  // to guarantee that collective commands are recorded on all participating
-  // ranks to avoid deadlocks.
+  // If commands require an update during initialization (and VA remapping is
+  // not enabled), we also record them into the command buffer before execution.
+  // This is required to guarantee that collective commands are recorded on all
+  // participating ranks to avoid deadlocks.
   if (cmd_buffer->command_buffer->state() ==
           se::CommandBuffer::State::kCreate ||
       (command_buffer_update_mode_ != DebugOptions::NEVER_UPDATE &&
-       commands_.requires_initialization())) {
+       commands_.requires_update_on_initialize())) {
     VLOG(3) << "Initialize command buffer on device #"
             << params.executor->device_ordinal()
             << " by recoding command buffer cmd sequence"
@@ -294,7 +294,7 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
       cmd_buffer->command_buffer->state() == se::CommandBuffer::State::kCreate;
   bool has_commands_requiring_update =
       command_buffer_update_mode_ != DebugOptions::NEVER_UPDATE &&
-      commands_.requires_update();
+      commands_.requires_update_on_execute();
   bool needs_update =
       (command_buffer_update_mode_ == DebugOptions::ALWAYS_UPDATE ||
        command_buffer_update_mode_ == DebugOptions::CAPTURE_CMD_NEVER_UPDATE) &&

--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -568,7 +568,7 @@ absl::Status CommandExecutor::RecordUpdate(
 
     Command* command = commands_[id];
 
-    if (command->requires_update()) {
+    if (command->requires_update_on_execute()) {
       return false;
     }
 
@@ -579,10 +579,10 @@ absl::Status CommandExecutor::RecordUpdate(
     // executions and no update is needed.
     //
     // Note: CollectiveThunk satisfies both IsTracedCommand() and
-    // requires_initialization(), but the requires_initialization() check below
-    // is intentionally unreachable for traced commands in this mode. Because
-    // their buffer addresses are stable (VA-mapped), re-initialization is
-    // unnecessary.
+    // requires_update_on_initialize(), but the
+    // requires_update_on_initialize() check below is intentionally unreachable
+    // for traced commands in this mode. Because their buffer addresses are
+    // stable (VA-mapped), re-initialization is unnecessary.
     if (record_params.command_buffer_update_mode ==
             DebugOptions::CAPTURE_CMD_NEVER_UPDATE &&
         command->IsTracedCommand()) {
@@ -591,9 +591,10 @@ absl::Status CommandExecutor::RecordUpdate(
       return true;
     }
 
-    // We always update commands that require initialization, even if buffer
-    // allocations didn't change.
-    if (command->requires_initialization() && record_params.is_initialization) {
+    // We always update commands that require updates on initialization, even if
+    // buffer allocations didn't change.
+    if (command->requires_update_on_initialize() &&
+        record_params.is_initialization) {
       return false;
     }
 

--- a/xla/backends/gpu/runtime/command_executor.h
+++ b/xla/backends/gpu/runtime/command_executor.h
@@ -154,12 +154,12 @@ class CommandExecutor {
   bool empty() const { return commands_.empty(); }
   size_t size() const { return commands_.size(); }
 
-  bool requires_initialization() const {
-    bool requires_initialization = false;
+  bool requires_update_on_initialize() const {
+    bool requires_update_on_initialize = false;
     commands_.Walk([&](const Command* command) {
-      requires_initialization |= command->requires_initialization();
+      requires_update_on_initialize |= command->requires_update_on_initialize();
     });
-    return requires_initialization;
+    return requires_update_on_initialize;
   }
 
   bool requires_warmup() const {
@@ -170,12 +170,12 @@ class CommandExecutor {
     return requires_warmup;
   }
 
-  bool requires_update() const {
-    bool requires_update = false;
+  bool requires_update_on_execute() const {
+    bool requires_update_on_execute = false;
     commands_.Walk([&](const Command* command) {
-      requires_update |= command->requires_update();
+      requires_update_on_execute |= command->requires_update_on_execute();
     });
-    return requires_update;
+    return requires_update_on_execute;
   }
 
   bool support_loop_unroll() const {

--- a/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.cc
@@ -408,14 +408,15 @@ DynamicSliceFusionV2Thunk::Record(const Thunk::ExecuteParams& execute_params,
   return Internal("Invalid record action");
 }
 
-bool DynamicSliceFusionV2Thunk::requires_initialization() const {
+bool DynamicSliceFusionV2Thunk::requires_update_on_initialize() const {
   return command_executor_.has_value() &&
-         command_executor_->requires_initialization();
+         command_executor_->requires_update_on_initialize();
 }
 
-bool DynamicSliceFusionV2Thunk::requires_update() const {
-  return HasLoopDependentOffsets() || (command_executor_.has_value() &&
-                                       command_executor_->requires_update());
+bool DynamicSliceFusionV2Thunk::requires_update_on_execute() const {
+  return HasLoopDependentOffsets() ||
+         (command_executor_.has_value() &&
+          command_executor_->requires_update_on_execute());
 }
 
 bool DynamicSliceFusionV2Thunk::support_loop_unroll() const {

--- a/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.h
+++ b/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.h
@@ -89,8 +89,8 @@ class DynamicSliceFusionV2Thunk : public Command {
       const Thunk::ExecuteParams& execute_params,
       const RecordParams& record_params, RecordAction record_action,
       se::CommandBuffer* command_buffer) override;
-  bool requires_initialization() const override;
-  bool requires_update() const override;
+  bool requires_update_on_initialize() const override;
+  bool requires_update_on_execute() const override;
   bool support_loop_unroll() const override;
 
   BufferUses buffer_uses() const override;


### PR DESCRIPTION
📝 Summary of Changes
Renamed `Command::requires_initialization()` to `Command::requires_update_on_initialize()` and `Command::requires_update()` to `Command::requires_update_on_execute()`.

Updated the `CommandExecutor` aggregate helpers and GPU runtime overrides/call sites to use the new lifecycle-specific names.

🎯 Justification
The original method names were confusing because they did not make it clear when the command buffer update is required. The new names distinguish initialization-time updates from execution-time updates, which makes the command-buffer lifecycle behavior easier to understand.

🚀 Kind of Contribution
♻️ Cleanup

📊 Benchmark (for Performance Improvements)
N/A. This is a pure API rename with no intended behavior or performance change.

🧪 Unit Tests:
No new tests. Existing coverage:

- `bazel test //xla/backends/gpu/runtime:command_executor_test`

🧪 Execution Tests:
No new execution tests. Build validation:

- `bazel build //xla/backends/gpu/runtime:command_buffer_thunk //xla/backends/gpu/runtime:dynamic_slice_fusion_v2_thunk //xla/backends/gpu/runtime:collective_thunk`
