### PR TITLE
[ROCm] Fix dot_algorithms_test

### DIFF
--- a/xla/backends/gpu/codegen/triton/dot_algorithms_test.cc
+++ b/xla/backends/gpu/codegen/triton/dot_algorithms_test.cc
@@ -1587,22 +1587,10 @@ TEST_P(TritonAndBlasSupportForDifferentTensorSizes,
       break;
     case PC::ALG_DOT_BF16_BF16_F32_X6:
     case PC::ALG_DOT_BF16_BF16_F32_X9:
-      if (GpuComputeComp().IsRocm()) {
-        if (result_or_status.status().ok()) {
-          // X6 and X9 algorithms on ROCm marked as not supported
-          // because they often require too much shared memory.
-          EXPECT_FALSE(result_or_status.value())
-              << "algorithms not supported on ROCm";
-        } else if (GpuComputeComp().rocm_compute_capability()->gfx9_mi200()) {
-          EXPECT_EQ(result_or_status.status().code(),
-                    absl::StatusCode::kInternal);
-        }
-      } else {
         ASSERT_TRUE(result_or_status.status().ok())
             << "failed to compile " << algorithm_;
         EXPECT_TRUE(result_or_status.value())
             << "wrong result for " << algorithm_;
-      }
       break;
     case PC::ALG_DOT_F64_F64_F64:
       EXPECT_EQ(result_or_status.status().code(),


### PR DESCRIPTION
📝 Summary of Changes
This PR fixes `TritonAndBlasSupportForDifferentTensorSizes.IsDotAlgorithmSupportedByTriton` for ROCm by removing ROCm-specific branch for `ALG_DOT_BF16_BF16_F32_X6` and `ALG_DOT_BF16_BF16_F32_X9`. Before this change, the test expected failure on the ROCm side, and execution was actually successful.

🎯 Justification
These were disabled a long time ago in legacy emitters due to the excessive shared memory usage, and these tests were also modified to expect failure -> https://github.com/openxla/xla/pull/38759.
This is not an issue anymore.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix
