### PR TITLE
Algebraic simplifier: do not fold transposes into scatters with batch dims.

### DIFF
--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -9612,6 +9612,12 @@ absl::StatusOr<bool> AlgebraicSimplifierVisitor::TryFoldTransposeIntoScatter(
       !xla::ScatterSimplifier::IsSimplifiedScatter(scatter)) {
     return false;
   }
+  const ScatterDimensionNumbers& old_dnums =
+      scatter->scatter_dimension_numbers();
+  if (!old_dnums.input_batching_dims().empty() ||
+      !old_dnums.scatter_indices_batching_dims().empty()) {
+    return false;
+  }
 
   absl::Span<const int64_t> permutation = transpose->dimensions();
   std::vector<int64_t> inverse_permutation = InversePermutation(permutation);
@@ -9637,8 +9643,6 @@ absl::StatusOr<bool> AlgebraicSimplifierVisitor::TryFoldTransposeIntoScatter(
       transpose->AddInstruction(HloInstruction::CreateTranspose(
           new_update_shape, scatter_update, update_permutation));
 
-  const ScatterDimensionNumbers& old_dnums =
-      scatter->scatter_dimension_numbers();
   ScatterDimensionNumbers new_dnums = old_dnums;
   new_dnums.clear_scatter_dims_to_operand_dims();
   for (int64_t dim : old_dnums.scatter_dims_to_operand_dims()) {

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -14323,6 +14323,33 @@ CHECK-SAME: index_vector_dim=1
   EXPECT_TRUE(matched);
 }
 
+TEST_F(AlgebraicSimplifierTest,
+       DoNotFoldTransposeIntoScatterWithInputBatchingDim) {
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(R"(
+    update_computation {
+      a_val = bf16[] parameter(0)
+      b_val = bf16[] parameter(1)
+      add = bf16[] add(a_val, b_val)
+    }
+
+    test {
+      operand = bf16[1,16,8208,128] parameter(0)
+      indices = s32[1,3] parameter(1)
+      updates = bf16[1,16,8192,128] parameter(2)
+      scatter = bf16[1,16,8208,128] scatter(operand, indices, updates),
+        update_window_dims={1,2,3}, inserted_window_dims={},
+        scatter_dims_to_operand_dims={1,2,3}, index_vector_dim=1,
+        input_batching_dims={0}, scatter_indices_batching_dims={0},
+        to_apply=update_computation
+      transpose = bf16[1,8208,16,128] transpose(scatter), dimensions={0,2,1,3}
+    }
+  )"));
+  AlgebraicSimplifierOptions options = default_options_;
+  options.set_enable_fold_transpose_into_scatter(true);
+  EXPECT_THAT(AlgebraicSimplifier(options).Run(module.get()),
+              absl_testing::IsOkAndHolds(false));
+}
+
 TEST_F(AlgebraicSimplifierTest, DoNotFoldTransposeIntoScatterWhenDisabled) {
   const std::string& hlo_string = R"(
     HloModule m


### PR DESCRIPTION
📝 Summary of Changes
Avoid folding cases which are not correctly handled. The case added in the test fails with "INVALID_ARGUMENT: during context [Unknown]: Bounds of the window dimensions of updates must not exceed the bounds of the corresponding dimensions of operand. For dimension 2, updates bound is 128, operand bound is 16." without this fix.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
yes