### PR TITLE
[XLA:GPU][oneAPI] Fix segfault when running JAX programs with oneCCL

### DIFF
--- a/third_party/oneccl/load_plugin.patch
+++ b/third_party/oneccl/load_plugin.patch
@@ -1,0 +1,76 @@
+diff --git a/src/api.cpp b/src/api.cpp
+index d6430ae..e709c5c 100644
+--- a/src/api.cpp
++++ b/src/api.cpp
+@@ -142,55 +142,17 @@ std::string to_string(onecclPluginType_t type) {
+     }
+ }
+ 
+-onecclResult_t load_plugin(onecclPlugin_t *plugin, const std::string &path) {
+-    if (plugin == nullptr) {
+-        return onecclInvalidArgument;
+-    }
++extern "C" void* onecclPluginCall(onecclPluginCall_t call_type);
+ 
+-    dl_handle handle = nullptr;
+-    {
+-        // Attempt to read from the library cache using the path as the key
+-        std::shared_lock<std::shared_mutex> const lock(plugin_lock);
+-        auto cached_library = library_cache.find(path);
+-        if (cached_library != library_cache.end()) {
+-            handle = cached_library->second;
+-        }
+-    }
+-
+-    if (handle == nullptr) {
+-        {
+-            std::scoped_lock const lock(plugin_lock);
+-            handle = dlopen(path.c_str(), RTLD_LAZY);
+-            if (handle == nullptr) {
+-                ONECCL_INFO("Cannot open plugin library: %s", dlerror());
+-                return onecclError;
+-            }
+-            // Cache the loaded library
+-            library_cache[path] = handle;
+-        }
+-    }
+-
+-    dlerror(); // Clear any existing error
+-
+-    // Get pointer the plugin entrypoint
+-    const char *symbol = "onecclPluginCall";
++onecclResult_t load_plugin(onecclPlugin_t *plugin, const std::string &path) {
+     auto plugin_call =
+-        reinterpret_cast<onecclPluginEntrypoint_t>(dlsym(handle, symbol));
+-    const char *dlsym_error = dlerror();
+-    if (dlsym_error != nullptr) {
+-        ONECCL_ERROR("Cannot load plugin entrypoint: '%s': %s", symbol,
+-                     dlsym_error);
+-        return onecclError;
+-    }
+-
++        reinterpret_cast<onecclPluginEntrypoint_t>(onecclPluginCall);
+     plugin->call = plugin_call;
+-
+     auto plugin_init_fn = reinterpret_cast<onecclPluginCallInit_t>(
+         plugin->call(ONECCL_PLUGIN_INIT));
+     if (plugin_init_fn != nullptr) {
+         return plugin_init_fn();
+     }
+-
+     return onecclSuccess;
+ }
+ 
+diff --git a/src/internal/api/plugin.h b/src/internal/api/plugin.h
+index 59e664a..0eb8f42 100644
+--- a/src/internal/api/plugin.h
++++ b/src/internal/api/plugin.h
+@@ -26,7 +26,7 @@
+ extern "C" {
+ #endif
+ 
+-typedef enum onecclPluginCall {
++typedef enum onecclPluginCall_ {
+     ONECCL_PLUGIN_INIT = 1,
+     ONECCL_PLUGIN_INIT_ID,
+     ONECCL_PLUGIN_INIT_COMM,

--- a/third_party/oneccl/oneccl_v1.BUILD
+++ b/third_party/oneccl/oneccl_v1.BUILD
@@ -176,4 +176,5 @@ sycl_library(
         ":umf",
         "@hwloc",
     ],
+    alwayslink = True,
 )

--- a/third_party/oneccl/oneccl_v2.BUILD
+++ b/third_party/oneccl/oneccl_v2.BUILD
@@ -19,6 +19,7 @@ sycl_library(
     deps = [
         "@oneccl_v1",
     ],
+    alwayslink = True,
 )
 
 sycl_library(
@@ -38,6 +39,7 @@ sycl_library(
         "@oneccl_v1",
         "@oneccl_v1//:mpi",
     ],
+    alwayslink = True,
 )
 
 sycl_library(
@@ -47,4 +49,5 @@ sycl_library(
         ":ccl_legacy",
         ":oneccl",
     ],
+    alwayslink = True,
 )

--- a/third_party/oneccl/workspace.bzl
+++ b/third_party/oneccl/workspace.bzl
@@ -18,6 +18,9 @@ def repo_v2():
     tf_http_archive(
         name = "oneccl",
         build_file = "//third_party/oneccl:oneccl_v2.BUILD",
+        patch_file = [
+            "//third_party/oneccl:load_plugin.patch",
+        ],
         sha256 = "f57ea65a4477003bce367cbed57c06195868d8a3993633a499b38cd0ea165350",
         strip_prefix = "oneCCL-master-v2",
         urls = tf_mirror_urls("https://github.com/uxlfoundation/oneCCL/archive/refs/heads/master-v2.tar.gz"),


### PR DESCRIPTION
JAX build statically links the oneccl lib into the oneapi pjrt plugin. This PR fixes missing symbol errors in the current oneCCL build.
1)  Set alwayslink=True for oneccl libs to make sure all objects files are linked.
2)  A patch is applied to oneCCL so the onecclPluginCall is correctly linked from the static library instead of looking up the symbol inside an .so file.

🚀 Kind of Contribution
🐛 Bug Fix