### PR TITLE
[XLA:GPU][codegen] Extend SPIR-V math op lowering to support 16-bit floating point precisions

### DIFF
--- a/xla/backends/gpu/codegen/emitters/transforms/tests/lower_math_oneapi.mlir
+++ b/xla/backends/gpu/codegen/emitters/transforms/tests/lower_math_oneapi.mlir
@@ -18,6 +18,21 @@ module {
 // -----
 
 module {
+  // CHECK-LABEL: func @test_exp
+  func.func @test_exp(%arg0: f16) -> f16 {
+    // CHECK-NOT: llvm.intr.exp
+    // CHECK: %[[EXT:.*]] = llvm.fpext %arg0
+    // CHECK: llvm.call spir_funccc @_Z{{.*}}__spirv_ocl_expf(%[[EXT]])
+    // CHECK: %{{.*}} = llvm.fptrunc %{{.*}}
+    // CHECK: return %{{.*}} : f16
+    %0 = math.exp %arg0 : f16
+    return %0 : f16
+  }
+}
+
+// -----
+
+module {
   func.func @test_tan(%arg0: complex<f32>) -> complex<f32> {
     %0 = complex.tan %arg0 : complex<f32>
     func.return %0 : complex<f32>

--- a/xla/codegen/emitters/transforms/BUILD
+++ b/xla/codegen/emitters/transforms/BUILD
@@ -36,11 +36,11 @@ cc_library(
     deps = [
         "//xla/tsl/platform:logging",
         "@com_google_absl//absl/strings:str_format",
-        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LLVMCommonConversion",
         "@llvm-project//mlir:LLVMDialect",
         "@llvm-project//mlir:MathDialect",
+        "@llvm-project//mlir:Support",
     ],
 )
 

--- a/xla/codegen/emitters/transforms/BUILD
+++ b/xla/codegen/emitters/transforms/BUILD
@@ -36,6 +36,7 @@ cc_library(
     deps = [
         "//xla/tsl/platform:logging",
         "@com_google_absl//absl/strings:str_format",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LLVMCommonConversion",
         "@llvm-project//mlir:LLVMDialect",

--- a/xla/codegen/emitters/transforms/lowering_utils.h
+++ b/xla/codegen/emitters/transforms/lowering_utils.h
@@ -17,11 +17,15 @@ limitations under the License.
 #define XLA_CODEGEN_EMITTERS_TRANSFORMS_LOWERING_UTILS_H_
 
 #include "absl/strings/str_format.h"
+#include "llvm/ADT/SmallVector.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
 
 namespace xla {
 namespace emitters {

--- a/xla/codegen/emitters/transforms/lowering_utils.h
+++ b/xla/codegen/emitters/transforms/lowering_utils.h
@@ -17,7 +17,6 @@ limitations under the License.
 #define XLA_CODEGEN_EMITTERS_TRANSFORMS_LOWERING_UTILS_H_
 
 #include "absl/strings/str_format.h"
-#include "llvm/ADT/SmallVector.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -26,6 +25,7 @@ limitations under the License.
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
 
 namespace xla {
 namespace emitters {

--- a/xla/codegen/emitters/transforms/lowering_utils.h
+++ b/xla/codegen/emitters/transforms/lowering_utils.h
@@ -54,21 +54,30 @@ struct OpToSPVFuncCallLowering : public mlir::ConvertOpToLLVMPattern<Op> {
       Op op, typename Op::Adaptor adaptor,
       mlir::ConversionPatternRewriter& rewriter) const override {
     mlir::Type result_type = op->getResultTypes().front();
-    mlir::SmallVector<mlir::Type> arg_types(adaptor.getOperands().getTypes());
+    mlir::SmallVector<mlir::Value> operands;
 
     bool can_lower =
-        mlir::isa<mlir::Float32Type, mlir::Float64Type>(result_type);
-    for (mlir::Type type : arg_types) {
-      can_lower = can_lower && (type == result_type);
+        mlir::isa<mlir::BFloat16Type, mlir::Float16Type, mlir::Float32Type,
+                  mlir::Float64Type>(result_type);
+
+    for (mlir::Value value : adaptor.getOperands()) {
+      can_lower = can_lower && (value.getType() == result_type);
+      if (value.getType().getIntOrFloatBitWidth() < 32) {
+        value = mlir::LLVM::FPExtOp::create(
+            rewriter, value.getLoc(),
+            mlir::Float32Type::get(rewriter.getContext()), value);
+      }
+      operands.push_back(value);
     }
 
     if (!can_lower) {
       return rewriter.notifyMatchFailure(
-          op, " expected F32 or F64 result and operand types");
+          op, " expected BF16, F16, F32 or F64 result and operand types");
     }
 
+    mlir::Type new_result_type = operands.front().getType();
     std::string name =
-        base + (mlir::isa<mlir::Float32Type>(result_type) ? "f" : "d");
+        base + (mlir::isa<mlir::Float32Type>(new_result_type) ? "f" : "d");
 
     auto symbol_table =
         op->template getParentWithTrait<mlir::OpTrait::SymbolTable>();
@@ -78,14 +87,21 @@ struct OpToSPVFuncCallLowering : public mlir::ConvertOpToLLVMPattern<Op> {
       mlir::OpBuilder b(symbol_table->getRegion(0));
       func = ml::LLVMFuncOp::create(
           b, symbol_table->getLoc(), name,
-          ml::LLVMFunctionType::get(result_type, arg_types));
+          ml::LLVMFunctionType::get(
+              new_result_type,
+              llvm::to_vector(llvm::map_range(
+                  operands, [](mlir::Value v) { return v.getType(); }))));
       func.setCConv(ml::cconv::CConv::SPIR_FUNC);
     }
-    auto call =
-        ml::CallOp::create(rewriter, op->getLoc(), func, adaptor.getOperands());
+    auto call = ml::CallOp::create(rewriter, op->getLoc(), func, operands);
     call.setCConv(func.getCConv());
 
-    rewriter.replaceOp(op, {call.getResult()});
+    mlir::Value result = call.getResult();
+    if (result_type != new_result_type) {
+      result = mlir::LLVM::FPTruncOp::create(rewriter, op->getLoc(),
+                                             result_type, result);
+    }
+    rewriter.replaceOp(op, result);
     return mlir::success();
   }
 


### PR DESCRIPTION
This PR adds 16-bit floating point support to SPIR-V math op lowerings via builtin intrinsics. It fixes the legalization failure errors that many tests like `xla/hlo/builder/lib/math_test.cc` throw for F16 precisions.