### PR TITLE
[XLA:GPU] Fix device association for reordered GPU communicator splits

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -245,6 +245,7 @@ xla_cc_test(
         ":gpu_clique_key",
         ":gpu_cliques",
         ":gpu_collectives",
+        ":gpu_communicator",
         ":loopback_collectives",
         ":nccl_or_rccl_collectives",  # fixdeps: keep
         "//xla:executable_run_options",

--- a/xla/backends/gpu/collectives/gpu_cliques.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques.cc
@@ -623,11 +623,29 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
       absl::StrAppend(str, mapping.first.value(), "->", mapping.second.value());
     };
 
-    // Collect parent communicators we'll be splitting from and keys for
-    // creating new communicators.
+    // SplitCommunicators treats parent_comms, keys, and ranks as parallel
+    // arrays. Keep all three in child-rank order so that each parent
+    // communicator stays paired with the device and rank of the same physical
+    // participant. Ordering parent_comms by parent rank while independently
+    // ordering ranks by child rank can bind a split communicator to the wrong
+    // StreamExecutor when the child clique permutes ranks.
+    std::vector<const RankPair*> sorted_rank_pairs(rank_pairs.begin(),
+                                                   rank_pairs.end());
+    absl::c_sort(sorted_rank_pairs, [](const RankPair* a, const RankPair* b) {
+      return a->second.rank < b->second.rank;
+    });
+
+    // Collect parent communicators we'll be splitting from, keys for creating
+    // new communicators, and device ranks in their common child-rank order.
     std::vector<Communicator*> parent_comms;
     std::vector<RankId> keys;
-    for (auto& [parent_rank, split_rank] : rank_mapping) {
+    std::vector<DeviceRank> ranks;
+    parent_comms.reserve(sorted_rank_pairs.size());
+    keys.reserve(sorted_rank_pairs.size());
+    ranks.reserve(sorted_rank_pairs.size());
+    for (const RankPair* rank_pair : sorted_rank_pairs) {
+      RankId parent_rank = rank_pair->first;
+      const DeviceRank& device_rank = rank_pair->second;
       auto parent_comm = (*parent_clique)->comm(parent_rank);
       if (!parent_comm.has_value()) {
         return InvalidArgument(
@@ -636,17 +654,9 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
       }
 
       parent_comms.push_back(*parent_comm);
-      keys.push_back(split_rank);
+      keys.push_back(device_rank.rank);
+      ranks.push_back(device_rank);
     }
-
-    std::vector<DeviceRank> ranks;
-    ranks.reserve(rank_pairs.size());
-    for (auto& rank_pair : rank_pairs) {
-      ranks.emplace_back(rank_pair->second);
-    }
-
-    // Sort device ranks, mainly to get more readable logs below.
-    absl::c_sort(ranks, [](auto& a, auto& b) { return a.rank < b.rank; });
 
     // Get a globally consistent color value for newly created clique.
     int32_t color = GetCommSplitColor(clique_key);

--- a/xla/backends/gpu/collectives/gpu_cliques_test.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques_test.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/gpu_clique.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
+#include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/core/collectives/clique_id.h"
 #include "xla/core/collectives/collectives.h"
 #include "xla/core/collectives/collectives_registry.h"
@@ -244,6 +245,65 @@ TEST(GpuCliquesTest, SplitCliques) {
 
     ASSERT_OK_AND_ASSIGN(auto cliques1, WaitCliques(std::move(futures0)));
     ASSERT_OK_AND_ASSIGN(auto cliques2, WaitCliques(std::move(futures1)));
+  }
+}
+
+TEST(GpuCliquesTest, SplitCliquesKeepsReorderedRanksOnCorrectExecutors) {
+  auto cleanup = absl::MakeCleanup([] { internal::DestroyAcquiredCliques(); });
+
+  ASSERT_OK_AND_ASSIGN(se::Platform * platform,
+                       se::PlatformManager::PlatformWithName("CUDA"));
+
+  if (platform->VisibleDeviceCount() < 2) {
+    GTEST_SKIP() << "Test requires at least 2 GPUs";
+  }
+
+  tsl::thread::ThreadPool pool(tsl::Env::Default(), "collectives", 2);
+  tsl::Executor& exec = *pool.AsExecutor();
+
+  ASSERT_OK_AND_ASSIGN(std::vector<se::StreamExecutor*> executors,
+                       CreateExecutors(platform, 2));
+  ASSERT_OK_AND_ASSIGN(Collectives * loopback_base,
+                       CollectivesRegistry::Get("GPU", "loopback"));
+  auto* loopback = tsl::down_cast<GpuCollectives*>(loopback_base);
+
+  GpuCliqueKey parent_key({kD0, kD1}, 2);
+  DeviceGroups parent_group = {{kD0, kD1}};
+  std::vector<AcquiredCliquesMap> acquired_cliques(2);
+
+  // Create a parent whose communicator ranks match physical device order.
+  auto parent_futures = AcquireCliquesWithCollectives(
+      loopback, exec, executors, parent_key, parent_group, acquired_cliques);
+  ASSERT_OK_AND_ASSIGN(auto parent_cliques,
+                       WaitCliques(std::move(parent_futures)));
+  for (size_t i = 0; i < 2; ++i) {
+    acquired_cliques[i].emplace(parent_key, parent_cliques[i]);
+  }
+
+  // Split a child that reverses the ranks: device 1 becomes rank 0 and device
+  // 0 becomes rank 1. Reorder both per-device inputs to match the child ranks.
+  GpuCliqueKey child_key({kD1, kD0}, 2);
+  DeviceGroups child_group = {{kD1, kD0}};
+  std::vector<se::StreamExecutor*> child_executors = {executors[1],
+                                                      executors[0]};
+  std::vector<AcquiredCliquesMap> child_acquired_cliques = {
+      acquired_cliques[1], acquired_cliques[0]};
+
+  auto child_futures =
+      AcquireCliquesWithCollectives(loopback, exec, child_executors, child_key,
+                                    child_group, child_acquired_cliques);
+  ASSERT_OK_AND_ASSIGN(auto child_cliques,
+                       WaitCliques(std::move(child_futures)));
+
+  ASSERT_NE((*child_cliques.front())->parent(), nullptr);
+  EXPECT_EQ((*child_cliques.front())->parent()->key(), parent_key);
+  for (size_t rank = 0; rank < 2; ++rank) {
+    auto comm = (*child_cliques[rank])->comm(RankId(rank));
+    ASSERT_TRUE(comm.has_value());
+    auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(*comm);
+    EXPECT_EQ(gpu_comm->stream_executor(), child_executors[rank]);
+    ASSERT_OK_AND_ASSIGN(size_t current_rank, gpu_comm->CurrentRank());
+    EXPECT_EQ(current_rank, rank);
   }
 }
 
@@ -509,7 +569,7 @@ TEST(GpuCliquesTest, DifferentCollectivesProduceDifferentCliques) {
   // Acquire clique with loopback collectives for the same key.
   ASSERT_OK_AND_ASSIGN(Collectives * loopback_base,
                        CollectivesRegistry::Get("GPU", "loopback"));
-  auto* loopback = absl::down_cast<GpuCollectives*>(loopback_base);
+  auto* loopback = tsl::down_cast<GpuCollectives*>(loopback_base);
 
   std::vector<std::shared_ptr<LockableGpuClique::Lock>> loopback_cliques;
   {


### PR DESCRIPTION
📝 Summary of Changes

Keep the parent communicator, split key, and device rank for each GPU in one
child-rank-ordered sequence when splitting a GPU clique.

Add a two-GPU regression that splits parent clique `[D0, D1]` into reordered
child clique `[D1, D0]`. The test verifies that the split path was used and
that each child communicator reports both the expected rank and the expected
physical `StreamExecutor`.

### Root cause

`SplitCommunicatorsWithCancel` consumes `parent_comms`, `keys`, and `ranks` as
parallel arrays. Before this change, XLA constructed them using two independent
orders:

- `parent_comms` and `keys` were emitted from a map sorted by parent rank.
- `ranks`, which determines the `StreamExecutor`, was sorted by child rank.

For a parent `[D0, D1]` and child `[D1, D0]`, the old inputs were:

| Index | Parent communicator | Split key | Device rank / executor | Result                       |
|------:|---------------------|----------:|------------------------|------------------------------|
|     0 | parent rank 0 / D0  |         1 | child rank 0 / D1      | D0 communicator paired to D1 |
|     1 | parent rank 1 / D1  |         0 | child rank 1 / D0      | D1 communicator paired to D0 |

`ncclCommSplit` still received each valid parent communicator and split key, so
the underlying NCCL child ranks were correct. XLA also stored each returned
communicator under its split key. This made communicator creation appear
successful.

The wrapper was nevertheless constructed with `ranks[i]`'s executor. For a
rank permutation, the resulting `NcclCommunicator` therefore held the NCCL
communicator for one physical GPU and the `StreamExecutor` for another.

Automatic BFC memory registration uses that wrapper executor to find the GPU's
allocator range. It consequently registered D0's arena with D1's communicator
and D1's arena with D0's communicator. In a larger reordered group, unaffected
ranks could use NCCL's registered-buffer path while affected ranks used the
ordinary path. NCCL requires registered-buffer participation to be consistent
across ranks; mixing the paths is undefined and manifested as a collective
hang followed by XLA's rendezvous timeout. See the
[NCCL user-buffer registration requirements](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html).

This change sorts the complete parent-rank/device-rank pairs by child rank and
populates all three arrays in one loop:

| Index | Parent communicator | Split key | Device rank / executor | Result                 |
|------:|---------------------|----------:|------------------------|------------------------|
|     0 | parent rank 1 / D1  |         0 | child rank 0 / D1      | D1 remains paired to D1 |
|     1 | parent rank 0 / D0  |         1 | child rank 1 / D0      | D0 remains paired to D0 |

Child-rank ordering also preserves Loopback's contract that returned
communicator index `i` represents child rank `i`. This does not change
`split_share`; its existing default and behavior remain intact.

🎯 Justification

Any workload that builds communicators over the same devices in different rank
orders can otherwise bind a communicator to the wrong GPU executor. The issue
became visible in the dynamic-slice collective-broadcast workload, where the
broadcast owner changes and reordered communicator groups are created inside a
loop.

Keeping each physical participant's communicator, key, rank, and executor
aligned prevents wrong-device memory registration and the resulting NCCL
deadlock.

🚀 Kind of Contribution

🐛 Bug Fix, 🧪 Tests

📊 Benchmark (for Performance Improvements)

Not applicable. This is a correctness fix and does not change collective
algorithms or data movement.

🧪 Unit Tests:

- PASS: `bazel test //xla/backends/gpu/collectives:gpu_cliques_test --test_filter=GpuCliquesTest.SplitCliquesKeepsReorderedRanksOnCorrectExecutors`
- PASS: `bazel test //xla/backends/gpu/collectives:gpu_cliques_test '--test_filter=GpuCliquesTest.Split*'`
- Negative control: with the old ordering temporarily restored, the new test
  failed on both ranks with swapped executors and `0 -> 1`, `1 -> 0` reported
  ranks. Restoring this fix made the same test pass.
- The unfiltered target was also attempted, but the unchanged
  `DifferentCollectivesProduceDifferentCliques` test blocked in its rendezvous
  after all participants arrived. All split-specific tests pass.

🧪 Execution Tests:

- The committed regression uses exactly two GPUs and executes parent-to-child
  clique splitting with reordered ranks through the Loopback GPU collectives
  implementation.
- As additional diagnostic validation, the original four-GPU Muon reproducer
  completed a training step with this ordering fix and source-built NCCL
  2.30.7 under `NCCL_CHECK_MODE=DEBUG_LOCAL`; no wrong-device registration
  diagnostics were reported. This diagnostic workload is not added as a test.
