### PR TITLE
[ROCm] Package Tensile fallback libs for rocblas

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -222,6 +222,7 @@ rocm_lib_import(
     name = "rocblas",
     data = glob([
         "%{rocm_root}/lib/librocblas.so*",
+        "%{rocm_root}/lib/rocblas/library/*fallback.dat",
     ]) + glob([
         pattern
         for arch in rocm_gpu_architectures()


### PR DESCRIPTION
The per-arch rocblas glob added in PR #43603 (`<arch>`) misses the arch-independent *_fallback.dat Tensile solution libraries, causing a null-deref SEGV in loadPlaceholderLibrary() when a problem falls back (e.g. bf16 grouped conv on gfx90a). Add "*fallback.dat" to the glob.