### PR TITLE
[XLA:GPU] Fix device association for reordered GPU communicator splits

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -180,6 +180,7 @@ cc_library(
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:logging",
         "//xla/tsl/platform:status_macros",
+        "//xla/tsl/util:sorted_range",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
@@ -264,12 +265,12 @@ xla_cc_test(
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:status_macros",
         "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",  # fixdeps: keep
-        "@tsl//tsl/platform:casts",
     ],
 )
 

--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -245,6 +245,7 @@ xla_cc_test(
         ":gpu_clique_key",
         ":gpu_cliques",
         ":gpu_collectives",
+        ":gpu_communicator",
         ":loopback_collectives",
         ":nccl_or_rccl_collectives",  # fixdeps: keep
         "//xla:executable_run_options",

--- a/xla/backends/gpu/collectives/gpu_cliques.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques.cc
@@ -63,6 +63,7 @@ limitations under the License.
 #include "xla/stream_executor/stream_executor.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/logging.h"
+#include "xla/tsl/util/sorted_range.h"
 #include "xla/util.h"
 #include "tsl/platform/casts.h"
 #include "tsl/platform/hash.h"
@@ -624,28 +625,21 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
     };
 
     // SplitCommunicators treats parent_comms, keys, and ranks as parallel
-    // arrays. Keep all three in child-rank order so that each parent
+    // arrays. Collect all three in child-rank order so that each parent
     // communicator stays paired with the device and rank of the same physical
-    // participant. Ordering parent_comms by parent rank while independently
-    // ordering ranks by child rank can bind a split communicator to the wrong
-    // StreamExecutor when the child clique permutes ranks.
-    std::vector<const RankPair*> sorted_rank_pairs(rank_pairs.begin(),
-                                                   rank_pairs.end());
-    absl::c_sort(sorted_rank_pairs, [](const RankPair* a, const RankPair* b) {
-      return a->second.rank < b->second.rank;
-    });
-
-    // Collect parent communicators we'll be splitting from, keys for creating
-    // new communicators, and device ranks in their common child-rank order.
+    // participant. Ordering parent_comms by parent rank while ordering ranks by
+    // child rank can bind a split communicator to the wrong StreamExecutor.
     std::vector<Communicator*> parent_comms;
     std::vector<RankId> keys;
     std::vector<DeviceRank> ranks;
-    parent_comms.reserve(sorted_rank_pairs.size());
-    keys.reserve(sorted_rank_pairs.size());
-    ranks.reserve(sorted_rank_pairs.size());
-    for (const RankPair* rank_pair : sorted_rank_pairs) {
-      RankId parent_rank = rank_pair->first;
-      const DeviceRank& device_rank = rank_pair->second;
+    parent_comms.reserve(rank_pairs.size());
+    keys.reserve(rank_pairs.size());
+    ranks.reserve(rank_pairs.size());
+    for (const RankPair* rank_pair :
+         tsl::SortedRange(rank_pairs, [](const RankPair* a, const RankPair* b) {
+           return a->second.rank < b->second.rank;
+         })) {
+      const auto& [parent_rank, device_rank] = *rank_pair;
       auto parent_comm = (*parent_clique)->comm(parent_rank);
       if (!parent_comm.has_value()) {
         return InvalidArgument(

--- a/xla/backends/gpu/collectives/gpu_cliques.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques.cc
@@ -623,11 +623,29 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
       absl::StrAppend(str, mapping.first.value(), "->", mapping.second.value());
     };
 
-    // Collect parent communicators we'll be splitting from and keys for
-    // creating new communicators.
+    // SplitCommunicators treats parent_comms, keys, and ranks as parallel
+    // arrays. Keep all three in child-rank order so that each parent
+    // communicator stays paired with the device and rank of the same physical
+    // participant. Ordering parent_comms by parent rank while independently
+    // ordering ranks by child rank can bind a split communicator to the wrong
+    // StreamExecutor when the child clique permutes ranks.
+    std::vector<const RankPair*> sorted_rank_pairs(rank_pairs.begin(),
+                                                   rank_pairs.end());
+    absl::c_sort(sorted_rank_pairs, [](const RankPair* a, const RankPair* b) {
+      return a->second.rank < b->second.rank;
+    });
+
+    // Collect parent communicators we'll be splitting from, keys for creating
+    // new communicators, and device ranks in their common child-rank order.
     std::vector<Communicator*> parent_comms;
     std::vector<RankId> keys;
-    for (auto& [parent_rank, split_rank] : rank_mapping) {
+    std::vector<DeviceRank> ranks;
+    parent_comms.reserve(sorted_rank_pairs.size());
+    keys.reserve(sorted_rank_pairs.size());
+    ranks.reserve(sorted_rank_pairs.size());
+    for (const RankPair* rank_pair : sorted_rank_pairs) {
+      RankId parent_rank = rank_pair->first;
+      const DeviceRank& device_rank = rank_pair->second;
       auto parent_comm = (*parent_clique)->comm(parent_rank);
       if (!parent_comm.has_value()) {
         return InvalidArgument(
@@ -636,17 +654,9 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
       }
 
       parent_comms.push_back(*parent_comm);
-      keys.push_back(split_rank);
+      keys.push_back(device_rank.rank);
+      ranks.push_back(device_rank);
     }
-
-    std::vector<DeviceRank> ranks;
-    ranks.reserve(rank_pairs.size());
-    for (auto& rank_pair : rank_pairs) {
-      ranks.emplace_back(rank_pair->second);
-    }
-
-    // Sort device ranks, mainly to get more readable logs below.
-    absl::c_sort(ranks, [](auto& a, auto& b) { return a.rank < b.rank; });
 
     // Get a globally consistent color value for newly created clique.
     int32_t color = GetCommSplitColor(clique_key);

--- a/xla/backends/gpu/collectives/gpu_cliques.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques.cc
@@ -559,6 +559,13 @@ static int32_t GetCommSplitColor(const GpuCliqueKey& clique_key) {
                   sizeof(int64_t) * global_device_ids.size(), 0)));
 }
 
+using RankPair = std::pair<RankId, DeviceRank>;
+
+static bool CompareRankPairsByDeviceRank(const RankPair* lhs,
+                                         const RankPair* rhs) {
+  return lhs->second.rank < rhs->second.rank;
+}
+
 // Joins a GpuClique initialization rendezvous for a `clique_key` and returns
 // a lock that gives an access to clique created by splitting already acquired
 // `parent_clique` clique (access is shared between all participating ranks that
@@ -580,7 +587,6 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
       device->device_ordinal(), rank, clique_key, parent_rank,
       parent_clique_key, num_local_participants);
 
-  using RankPair = std::pair<RankId, DeviceRank>;
   Device gpu_device(device);
   DeviceRank device_rank = {&gpu_device, rank};
   RankPair rank_pair = {parent_rank, device_rank};
@@ -635,10 +641,9 @@ InitializeGpuClique(GpuCollectives* collectives, se::StreamExecutor* device,
     parent_comms.reserve(rank_pairs.size());
     keys.reserve(rank_pairs.size());
     ranks.reserve(rank_pairs.size());
-    for (const RankPair* rank_pair :
-         tsl::SortedRange(rank_pairs, [](const RankPair* a, const RankPair* b) {
-           return a->second.rank < b->second.rank;
-         })) {
+    auto sorted_rank_pairs =
+        tsl::SortedRange(rank_pairs, CompareRankPairsByDeviceRank);
+    for (const RankPair* rank_pair : sorted_rank_pairs) {
       const auto& [parent_rank, device_rank] = *rank_pair;
       auto parent_comm = (*parent_clique)->comm(parent_rank);
       if (!parent_comm.has_value()) {

--- a/xla/backends/gpu/collectives/gpu_cliques_test.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques_test.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/gpu_clique.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
+#include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/core/collectives/clique_id.h"
 #include "xla/core/collectives/collectives.h"
 #include "xla/core/collectives/collectives_registry.h"
@@ -244,6 +245,65 @@ TEST(GpuCliquesTest, SplitCliques) {
 
     ASSERT_OK_AND_ASSIGN(auto cliques1, WaitCliques(std::move(futures0)));
     ASSERT_OK_AND_ASSIGN(auto cliques2, WaitCliques(std::move(futures1)));
+  }
+}
+
+TEST(GpuCliquesTest, SplitCliquesKeepsReorderedRanksOnCorrectExecutors) {
+  auto cleanup = absl::MakeCleanup([] { internal::DestroyAcquiredCliques(); });
+
+  ASSERT_OK_AND_ASSIGN(se::Platform * platform,
+                       se::PlatformManager::PlatformWithName("CUDA"));
+
+  if (platform->VisibleDeviceCount() < 2) {
+    GTEST_SKIP() << "Test requires at least 2 GPUs";
+  }
+
+  tsl::thread::ThreadPool pool(tsl::Env::Default(), "collectives", 2);
+  tsl::Executor& exec = *pool.AsExecutor();
+
+  ASSERT_OK_AND_ASSIGN(std::vector<se::StreamExecutor*> executors,
+                       CreateExecutors(platform, 2));
+  ASSERT_OK_AND_ASSIGN(Collectives * loopback_base,
+                       CollectivesRegistry::Get("GPU", "loopback"));
+  auto* loopback = tsl::down_cast<GpuCollectives*>(loopback_base);
+
+  GpuCliqueKey parent_key({kD0, kD1}, 2);
+  DeviceGroups parent_group = {{kD0, kD1}};
+  std::vector<AcquiredCliquesMap> acquired_cliques(2);
+
+  // Create a parent whose communicator ranks match physical device order.
+  auto parent_futures = AcquireCliquesWithCollectives(
+      loopback, exec, executors, parent_key, parent_group, acquired_cliques);
+  ASSERT_OK_AND_ASSIGN(auto parent_cliques,
+                       WaitCliques(std::move(parent_futures)));
+  for (size_t i = 0; i < 2; ++i) {
+    acquired_cliques[i].emplace(parent_key, parent_cliques[i]);
+  }
+
+  // Split a child that reverses the ranks: device 1 becomes rank 0 and device
+  // 0 becomes rank 1. Reorder both per-device inputs to match the child ranks.
+  GpuCliqueKey child_key({kD1, kD0}, 2);
+  DeviceGroups child_group = {{kD1, kD0}};
+  std::vector<se::StreamExecutor*> child_executors = {executors[1],
+                                                      executors[0]};
+  std::vector<AcquiredCliquesMap> child_acquired_cliques = {
+      acquired_cliques[1], acquired_cliques[0]};
+
+  auto child_futures =
+      AcquireCliquesWithCollectives(loopback, exec, child_executors, child_key,
+                                    child_group, child_acquired_cliques);
+  ASSERT_OK_AND_ASSIGN(auto child_cliques,
+                       WaitCliques(std::move(child_futures)));
+
+  ASSERT_NE((*child_cliques.front())->parent(), nullptr);
+  EXPECT_EQ((*child_cliques.front())->parent()->key(), parent_key);
+  for (size_t rank = 0; rank < 2; ++rank) {
+    auto comm = (*child_cliques[rank])->comm(RankId(rank));
+    ASSERT_TRUE(comm.has_value());
+    auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(*comm);
+    EXPECT_EQ(gpu_comm->stream_executor(), child_executors[rank]);
+    ASSERT_OK_AND_ASSIGN(size_t current_rank, gpu_comm->CurrentRank());
+    EXPECT_EQ(current_rank, rank);
   }
 }
 
@@ -509,7 +569,7 @@ TEST(GpuCliquesTest, DifferentCollectivesProduceDifferentCliques) {
   // Acquire clique with loopback collectives for the same key.
   ASSERT_OK_AND_ASSIGN(Collectives * loopback_base,
                        CollectivesRegistry::Get("GPU", "loopback"));
-  auto* loopback = absl::down_cast<GpuCollectives*>(loopback_base);
+  auto* loopback = tsl::down_cast<GpuCollectives*>(loopback_base);
 
   std::vector<std::shared_ptr<LockableGpuClique::Lock>> loopback_cliques;
   {

--- a/xla/backends/gpu/collectives/gpu_cliques_test.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques_test.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/algorithm/container.h"
+#include "absl/base/casts.h"
 #include "absl/cleanup/cleanup.h"
 #include "absl/log/check.h"
 #include "absl/status/statusor.h"
@@ -46,7 +47,6 @@ limitations under the License.
 #include "xla/tsl/concurrency/executor.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/threadpool.h"
-#include "tsl/platform/casts.h"
 
 namespace xla::gpu {
 
@@ -265,7 +265,7 @@ TEST(GpuCliquesTest, SplitCliquesKeepsReorderedRanksOnCorrectExecutors) {
                        CreateExecutors(platform, 2));
   ASSERT_OK_AND_ASSIGN(Collectives * loopback_base,
                        CollectivesRegistry::Get("GPU", "loopback"));
-  auto* loopback = tsl::down_cast<GpuCollectives*>(loopback_base);
+  auto* loopback = absl::down_cast<GpuCollectives*>(loopback_base);
 
   GpuCliqueKey parent_key({kD0, kD1}, 2);
   DeviceGroups parent_group = {{kD0, kD1}};
@@ -300,7 +300,7 @@ TEST(GpuCliquesTest, SplitCliquesKeepsReorderedRanksOnCorrectExecutors) {
   for (size_t rank = 0; rank < 2; ++rank) {
     auto comm = (*child_cliques[rank])->comm(RankId(rank));
     ASSERT_TRUE(comm.has_value());
-    auto* gpu_comm = tsl::down_cast<GpuCommunicator*>(*comm);
+    auto* gpu_comm = absl::down_cast<GpuCommunicator*>(*comm);
     EXPECT_EQ(gpu_comm->stream_executor(), child_executors[rank]);
     ASSERT_OK_AND_ASSIGN(size_t current_rank, gpu_comm->CurrentRank());
     EXPECT_EQ(current_rank, rank);
@@ -569,7 +569,7 @@ TEST(GpuCliquesTest, DifferentCollectivesProduceDifferentCliques) {
   // Acquire clique with loopback collectives for the same key.
   ASSERT_OK_AND_ASSIGN(Collectives * loopback_base,
                        CollectivesRegistry::Get("GPU", "loopback"));
-  auto* loopback = tsl::down_cast<GpuCollectives*>(loopback_base);
+  auto* loopback = absl::down_cast<GpuCollectives*>(loopback_base);
 
   std::vector<std::shared_ptr<LockableGpuClique::Lock>> loopback_cliques;
   {


### PR DESCRIPTION
📝 Summary of Changes

Fix GPU clique splitting when a child clique reorders the parent ranks. XLA now emits each parent communicator, split key, and device/executor together in child-rank order. Add a two-GPU regression for `[D0, D1] → [D1, D0]`.

🎯 Justification

The old code built parallel arrays in different orders, which could pair an NCCL communicator with the wrong GPU `StreamExecutor`. Wrong-device memory registration could make ranks use inconsistent NCCL paths and hang collectives. This fix preserves the communicator/device association.

### Example

For parent clique `[D0, D1]` and reordered child clique `[D1, D0]`, the old code built:

```text
parent communicator: [D0, D1]
split key:           [ 1,  0]
executor:            [D1, D0]
```

The arrays are consumed by index, so the D0 communicator was paired with the D1 executor, and the D1 communicator with the D0 executor. The communicator split could succeed, but later buffer registration used the wrong physical GPU.

The fix builds all fields in child-rank order:

```text
parent communicator: [D1, D0]
split key:           [ 0,  1]
executor:            [D1, D0]
```

Each communicator now remains paired with its matching device and executor.

🚀 Kind of Contribution

🐛 Bug Fix, 🧪 Tests

📊 Benchmark (for Performance Improvements)

Not applicable; this is a correctness fix.

🧪 Unit Tests:

- PASS: `bazel test //xla/backends/gpu/collectives:gpu_cliques_test --test_filter=GpuCliquesTest.SplitCliquesKeepsReorderedRanksOnCorrectExecutors`
- PASS: `bazel test //xla/backends/gpu/collectives:gpu_cliques_test --test_filter=GpuCliquesTest.Split*`

🧪 Execution Tests:

The two-GPU Loopback regression exercises reordered clique splitting. The original four-GPU Muon reproducer also completed one training step with source-built NCCL 2.30.7.