### PR TITLE
[ROCm] Add suppoprt for exp bf16 on gfx1250

### DIFF
--- a/xla/codegen/emitters/transforms/BUILD
+++ b/xla/codegen/emitters/transforms/BUILD
@@ -140,6 +140,7 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LLVMCommonConversion",
         "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:MathToLLVM",
         "@llvm-project//mlir:MemRefToLLVM",
         "@llvm-project//mlir:NVVMDialect",

--- a/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "mlir/Conversion/GPUToNVVM/GPUToNVVMPass.h"
 #include "mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h"
 #include "mlir/Conversion/GPUToROCDL/Runtimes.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
@@ -43,6 +44,7 @@ limitations under the License.
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"  // IWYU pragma: keep
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"  // IWYU pragma: keep
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"  // IWYU pragma: keep
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/Location.h"
@@ -68,6 +70,60 @@ namespace emitters {
 namespace {
 
 namespace se = ::stream_executor;
+
+// log2(e), used to express exp(x) = exp2(x * log2(e)).
+constexpr double kLog2E = 1.4426950408889634;
+
+// Lowers a scalar bf16 `math.exp2` to the native gfx1250 `v_exp_bf16`
+// instruction via the `llvm.amdgcn.exp2` intrinsic. Without this, the default
+// MathToROCDL lowering upcasts bf16 to f32 and calls `__ocml_exp2_f32`, never
+// using the hardware bf16 transcendental unit. Vector ops are scalarized first
+// by MathToROCDL's ScalarizeVectorOpLowering (lower benefit), so this pattern
+// only needs to handle the scalar case.
+struct Exp2BF16ToAMDGPU
+    : public mlir::ConvertOpToLLVMPattern<mlir::math::Exp2Op> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  mlir::LogicalResult matchAndRewrite(
+      mlir::math::Exp2Op op, OpAdaptor adaptor,
+      mlir::ConversionPatternRewriter& rewriter) const override {
+    if (!op.getType().isBF16()) {
+      return rewriter.notifyMatchFailure(op, "not a scalar bf16 exp2");
+    }
+    mlir::Value operand = adaptor.getOperands().front();
+    rewriter.replaceOpWithNewOp<mlir::LLVM::CallIntrinsicOp>(
+        op, /*resultType=*/operand.getType(),
+        rewriter.getStringAttr("llvm.amdgcn.exp2"), mlir::ValueRange{operand});
+    return mlir::success();
+  }
+};
+
+// Lowers a scalar bf16 `math.exp` to the native gfx1250 `v_exp_bf16`
+// instruction by rewriting exp(x) = exp2(x * log2(e)) and emitting the
+// `llvm.amdgcn.exp2` intrinsic. See Exp2BF16ToAMDGPU for the rationale.
+struct ExpBF16ToAMDGPU
+    : public mlir::ConvertOpToLLVMPattern<mlir::math::ExpOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  mlir::LogicalResult matchAndRewrite(
+      mlir::math::ExpOp op, OpAdaptor adaptor,
+      mlir::ConversionPatternRewriter& rewriter) const override {
+    if (!op.getType().isBF16()) {
+      return rewriter.notifyMatchFailure(op, "not a scalar bf16 exp");
+    }
+    mlir::Location loc = op.getLoc();
+    mlir::Value operand = adaptor.getOperands().front();
+    mlir::Type bf16 = operand.getType();
+    mlir::Value log2e = rewriter.create<mlir::LLVM::ConstantOp>(
+        loc, bf16, rewriter.getFloatAttr(bf16, kLog2E));
+    mlir::Value scaled =
+        rewriter.create<mlir::LLVM::FMulOp>(loc, operand, log2e);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::CallIntrinsicOp>(
+        op, /*resultType=*/bf16, rewriter.getStringAttr("llvm.amdgcn.exp2"),
+        mlir::ValueRange{scaled});
+    return mlir::success();
+  }
+};
 
 class LowerToLLVMGPUPass
     : public impl::LowerToLLVMGPUPassBase<LowerToLLVMGPUPass> {
@@ -111,6 +167,15 @@ class LowerToLLVMGPUPass
         mlir::configureGpuToROCDLConversionLegality(target);
         mlir::populateAMDGPUToROCDLConversionPatterns(converter, patterns,
                                                       *maybeChipset);
+        // On gfx1250 emit native bf16 exp via v_exp_bf16 instead of upcasting
+        // to f32 and calling __ocml_exp(2)_f32. Higher benefit than the default
+        // MathToROCDL patterns so it wins for scalar bf16 ops.
+        if (device_spec_.gpu()
+                .rocm_compute_capability()
+                .has_bf16_transcendental_support()) {
+          patterns.add<ExpBF16ToAMDGPU, Exp2BF16ToAMDGPU>(
+              converter, /*benefit=*/mlir::PatternBenefit(2));
+        }
         target.addIllegalDialect<mlir::amdgpu::AMDGPUDialect>();
       } else if (device_spec_.IsIntelGpu()) {
         // Add sub-group-size attribute to functions.

--- a/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
+++ b/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
@@ -1,0 +1,32 @@
+// RUN: emitters_opt %s -split-input-file \
+// RUN:   -xla-lower-to-llvm-gpu="gpu_device_info='rocm_compute_capability {gcn_arch_name: \"gfx1250\"}'" \
+// RUN:   | FileCheck %s
+
+// gfx1250 has a native bf16 exp2 instruction (v_exp_bf16), reached via the
+// llvm.amdgcn.exp2 intrinsic, instead of upcasting to f32 and calling
+// __ocml_exp2_f32.
+module {
+  func.func @exp2_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.exp2 %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @exp2_bf16
+// CHECK: llvm.call_intrinsic "llvm.amdgcn.exp2"({{.*}}) : (bf16) -> bf16
+// CHECK-NOT: __ocml_exp2_f32
+
+// -----
+
+// A plain bf16 exp is rewritten to exp2(x * log2(e)) on gfx1250 so it also uses
+// the native instruction.
+module {
+  func.func @exp_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.exp %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @exp_bf16
+// CHECK: llvm.fmul
+// CHECK: llvm.call_intrinsic "llvm.amdgcn.exp2"({{.*}}) : (bf16) -> bf16

--- a/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu_fallback.mlir
+++ b/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu_fallback.mlir
@@ -1,0 +1,17 @@
+// RUN: emitters_opt %s -split-input-file \
+// RUN:   -xla-lower-to-llvm-gpu="gpu_device_info='rocm_compute_capability {gcn_arch_name: \"gfx942\"}'" \
+// RUN:   | FileCheck %s
+
+// On architectures without native bf16 transcendentals (e.g. gfx942), bf16
+// exp2 is upcast to f32 and lowered to __ocml_exp2_f32 rather than the gfx1250
+// v_exp_bf16 / llvm.amdgcn.exp2 path.
+module {
+  func.func @exp2_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.exp2 %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @exp2_bf16
+// CHECK: llvm.call @__ocml_exp2_f32
+// CHECK-NOT: llvm.amdgcn.exp2

--- a/xla/service/gpu/gpu_float_support.cc
+++ b/xla/service/gpu/gpu_float_support.cc
@@ -139,6 +139,17 @@ bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
       return true;
     // Elementwise ops.
     case HloOpcode::kExp:
+      if (LowPrecisionType() == BF16) {
+        if (compute_capability_.IsCuda()) {
+          return true;
+        }
+        // gfx1250 has a native bf16 exponential instruction, so there is no
+        // need to upcast bf16 exp to f32.
+        if (auto* rocm_cc = compute_capability_.rocm_compute_capability()) {
+          return rocm_cc->has_bf16_transcendental_support();
+        }
+      }
+      return false;
     case HloOpcode::kLog:
       if (LowPrecisionType() == BF16) {
         return compute_capability_.IsCuda();

--- a/xla/service/gpu/gpu_float_support_test.cc
+++ b/xla/service/gpu/gpu_float_support_test.cc
@@ -655,6 +655,32 @@ ENTRY main {
       Normalize(module_exp.get(), se::GpuComputeCapability{cc}, BF16, F32));
 }
 
+TEST_F(FloatSupportTest, BF16ExpOnGfx1250IsNotNormalized) {
+  // gfx1250 has a native bf16 exponential instruction, so bf16 exp should be
+  // kept as bf16 instead of being upcast to f32.
+  auto cc = se::RocmComputeCapability("gfx1250");
+  constexpr absl::string_view kHloModule = R"(
+HloModule module
+
+ENTRY main {
+      p0 = bf16[4] parameter(0)
+      ROOT r = bf16[4] $0(p0)
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module_exp,
+                          ParseAndReturnVerifiedModule(
+                              absl::Substitute(kHloModule, "exponential")));
+  EXPECT_FALSE(
+      Normalize(module_exp.get(), se::GpuComputeCapability{cc}, BF16, F32));
+
+  // log has no native bf16 instruction wired up, so it is still normalized.
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module_log,
+      ParseAndReturnVerifiedModule(absl::Substitute(kHloModule, "log")));
+  EXPECT_TRUE(
+      Normalize(module_log.get(), se::GpuComputeCapability{cc}, BF16, F32));
+}
+
 TEST_F(FloatSupportTest, ScaledDotIsIgnored) {
   auto cc = se::CudaComputeCapability::Hopper();
   constexpr absl::string_view kHloModule = R"(

--- a/xla/stream_executor/rocm/rocm_compute_capability.h
+++ b/xla/stream_executor/rocm/rocm_compute_capability.h
@@ -199,6 +199,11 @@ class RocmComputeCapability {
 
   bool has_mx_type_support() const { return gfx9_mi350() || gfx1250(); }
 
+  // Native bf16 transcendental instructions (v_exp_bf16, v_log_bf16, etc.),
+  // backed by the LLVM FeatureBF16TransInsts subtarget feature. Lets us compute
+  // these bf16 ops without upcasting to f32 (currently only used for exp).
+  bool has_bf16_transcendental_support() const { return gfx1250(); }
+
   bool has_tdm_support() const { return gfx1250(); }
 
   int threads_per_warp() const { return gfx9_mi100_or_later() ? 64 : 32; }


### PR DESCRIPTION
📝 Summary of Changes
Enable native bf16 exp on AMD gfx1250: added RocmComputeCapability::has_bf16_transcendental_support() and stopped normalizing bf16 exp to f32 on that target. Added two higher-benefit lowering patterns in the existing xla-lower-to-llvm-gpu pass that route scalar bf16 math.exp/math.exp2 to llvm.amdgcn.exp2 (native v_exp_bf16), with the default f32/OCML path kept as fallback elsewhere.

🎯 Justification
Remove the up/down casts and the call for exp and bf16, use native v_exp_bf16 instruction on gfx1250

🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement,
✨ New Feature,🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
xla/xla/service/gpu/gpu_float_support_test.cc (BF16ExpOnGfx1250IsNotNormalized)
xla/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
xla/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu_fallback.mlir

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
