### PR TITLE
[GPU] Relay control dependencies when inlining fissioned GEMMs.

### DIFF
--- a/xla/backends/gpu/autotuner/BUILD
+++ b/xla/backends/gpu/autotuner/BUILD
@@ -766,6 +766,7 @@ cc_library(
         "//xla/hlo/pass:hlo_pass_pipeline",
         "//xla/service:compiler",
         "//xla/service:hlo_cost_analysis",
+        "//xla:status_macros",
         "//xla/stream_executor:stream_executor_h",
         "//xla/tools:hlo_decomposer_lib",
         "//xla/tsl/platform:errors",

--- a/xla/backends/gpu/autotuner/fission_backend.cc
+++ b/xla/backends/gpu/autotuner/fission_backend.cc
@@ -38,6 +38,7 @@ limitations under the License.
 #include "xla/service/compiler.h"
 #include "xla/service/hlo_cost_analysis.h"
 #include "xla/shape_util.h"
+#include "xla/status_macros.h"
 #include "xla/tools/hlo_decomposer.h"
 #include "xla/tsl/platform/errors.h"
 #include "xla/tsl/platform/statusor.h"
@@ -80,7 +81,13 @@ absl::Status InlineFissionedComputation(HloInstruction* fusion_instr,
   }
   HloInstruction* new_root =
       cloned_instructions.at(fissioned_computation->root_instruction());
-  return parent_computation->ReplaceInstruction(fusion_instr, new_root);
+  ASSIGN_OR_RETURN(bool replaced,
+                   parent_computation->ReplaceInstruction(
+                       fusion_instr, new_root, /*preserve_sharding=*/false,
+                       /*relay_control_dependency=*/true));
+  TF_RET_CHECK(replaced) << "Failed to inline fissioned computation for "
+                         << fusion_instr->name();
+  return absl::OkStatus();
 }
 
 }  // namespace

--- a/xla/backends/gpu/autotuner/fission_backend_test.cc
+++ b/xla/backends/gpu/autotuner/fission_backend_test.cc
@@ -387,6 +387,31 @@ class CublasFissionBackendTest : public HloHardwareIndependentTestBase {
             &mlir_context_, stream_executor_)) {}
 };
 
+TEST_F(CublasFissionBackendTest, ApplyConfigReplacesFusionWithControlDeps) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(R"(
+  c {
+    p0 = bf16[1024,1024] parameter(0)
+    p1 = bf16[1024,1024] parameter(1)
+    dot = bf16[1024,1024] dot(p0, p1),
+        lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  }
+
+  main {
+    p0 = bf16[1024,1024] parameter(0)
+    p1 = bf16[1024,1024] parameter(1)
+    a = bf16[1024,1024] add(p0, p0)
+    f = bf16[1024,1024] fusion(p0, p1),
+      kind=kCustom, calls=c, control-predecessors={a},
+      backend_config={"fusion_backend_config":{"kind":"__triton_gemm"}}
+  })"));
+  HloInstruction& fusion = *module->entry_computation()->root_instruction();
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<BackendConfig> config,
+                       fission_backend_->GetDefaultConfig(fusion));
+  EXPECT_OK(fission_backend_->ApplyConfig(fusion, *config));
+  EXPECT_THAT(module->ToString(), testing::Not(HasSubstr("__triton_gemm")));
+}
+
 TEST_F(CublasFissionBackendTest, ApplyConfigRemovesComputation) {
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                        ParseAndReturnVerifiedModule(kTritonFusionHlo));


### PR DESCRIPTION
📝 Summary of Changes
GEMM fusions carrying control dependencies were left unconfigured with "__triton_gemm" even though the autotuner selected cuBLAS for them and failed later in codegen with "Block level fusion config is required for Triton fusions".

🎯 Justification
Fixes execution of xla/tools/benchmarks/hlo/hlo_llama3_8b_bf16_activation_offloading_1x8.hlo and other programs.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
no

🧪 Unit Tests:
yes

🧪 Execution Tests:
no