### PR TITLE
[XLA:GPU][oneAPI] Add ULP budgets for double precision trigonometric functions

### DIFF
--- a/xla/codegen/intrinsic/accuracy/accuracy_budget.h
+++ b/xla/codegen/intrinsic/accuracy/accuracy_budget.h
@@ -176,6 +176,10 @@ constexpr AccuracyBudget kSinF64Budget = {
     /*gpu=*/
     {/*regular=*/1,
      /*subnormal=*/0},
+    /*rocm_gpu=*/std::nullopt,
+    /*intel_gpu=*/
+    UlpBudget{/*regular=*/2,
+              /*subnormal=*/0},
 };
 
 // Cos
@@ -193,6 +197,10 @@ constexpr AccuracyBudget kCosF64Budget = {
     /*gpu=*/
     {/*regular=*/1,
      /*subnormal=*/0},
+    /*rocm_gpu=*/std::nullopt,
+    /*intel_gpu=*/
+    UlpBudget{/*regular=*/2,
+              /*subnormal=*/0},
 };
 
 // Erf


### PR DESCRIPTION
This PR adds Intel-GPU specific ULP budgets for double precision sin and cos. The OCL implementation shows up to 2 ULP deviation from the double precision mpmath baseline, so Intel GPU-specific tolerances are needed to avoid test failures.