### PR TITLE
[XLA:GPU] Use packed storage shapes for FP4 XTile operands

### DIFF
--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -698,8 +698,8 @@ ENTRY e {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
-                          ParseAndReturnVerifiedModule(kHloText));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                       ParseAndReturnVerifiedModule(kHloText));
   EXPECT_THAT(
       CreateXTileIrAndFileCheck(std::move(module), "triton_dot", ""),
       absl_testing::StatusIs(
@@ -737,8 +737,8 @@ ENTRY e {
 }
 )";
 
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
-                          ParseAndReturnVerifiedModule(kHloText));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                       ParseAndReturnVerifiedModule(kHloText));
   EXPECT_THAT(CreateXTileIrAndFileCheck(std::move(module), "triton_dot", R"(
 CHECK: #[[$LHS_OFFSET_MAP:.*]] = #xla.indexing_map<"(pid_0) -> (pid_0 * 128 + 2), domain: pid_0 in [0, 1]">
 CHECK: xtile.entry_func @xtile_dialect_fn(%[[LHS_ARG:[A-Za-z0-9_]*]]: memref<128x130xi8>

--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -669,6 +669,92 @@ ENTRY entry {
                          "(compute capability 8.0) and up, but got")));
 }
 
+TEST_F(TritonDevicelessTest, RejectsPackedFp4OddMinorOffset) {
+  constexpr absl::string_view kHloText = R"(
+HloModule m
+
+triton_dot {
+  lhs_param = f4e2m1fn[128,258]{1,0:E(4)} parameter(0)
+  lhs = f4e2m1fn[128,256]{1,0:E(4)} slice(lhs_param), slice={[0:128], [1:257]}
+  rhs = f4e2m1fn[256,128]{1,0:E(4)} parameter(1)
+  lhs_scale = f8e8m0fnu[128,8]{1,0} parameter(2)
+  rhs_scale = f8e8m0fnu[8,128]{1,0} parameter(3)
+  ROOT _ = bf16[128,128]{1,0} scaled-dot(lhs, rhs, lhs_scale, rhs_scale),
+    lhs_contracting_dims={1}, rhs_contracting_dims={0},
+    backend_config={sizes:[128]}
+}
+
+ENTRY e {
+  lhs = f4e2m1fn[128,258]{1,0:E(4)} parameter(0)
+  rhs = f4e2m1fn[256,128]{1,0:E(4)} parameter(1)
+  lhs_scale = f8e8m0fnu[128,8]{1,0} parameter(2)
+  rhs_scale = f8e8m0fnu[8,128]{1,0} parameter(3)
+  ROOT fusion = bf16[128,128]{1,0} fusion(lhs, rhs, lhs_scale, rhs_scale),
+    kind=kCustom, calls=triton_dot,
+    backend_config={"fusion_backend_config":{"kind":"__triton_nested_gemm_fusion",
+      "block_level_fusion_config":{
+        "output_tiles":[{"sizes":["128","128"]}],
+        "num_warps":"4","num_ctas":"1","num_stages":"1"}}}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                          ParseAndReturnVerifiedModule(kHloText));
+  EXPECT_THAT(
+      CreateXTileIrAndFileCheck(std::move(module), "triton_dot", ""),
+      absl_testing::StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          ::testing::HasSubstr("Packed storage requires offset in dimension 1 "
+                               "to be divisible by 2")));
+}
+
+TEST_F(TritonDevicelessTest, EmitsPackedFp4StorageForEvenMinorOffset) {
+  constexpr absl::string_view kHloText = R"(
+HloModule m
+
+triton_dot {
+  lhs_param = f4e2m1fn[128,260]{1,0:E(4)} parameter(0)
+  lhs = f4e2m1fn[128,256]{1,0:E(4)} slice(lhs_param), slice={[0:128], [2:258]}
+  rhs = f4e2m1fn[256,128]{1,0:E(4)} parameter(1)
+  lhs_scale = f8e8m0fnu[128,8]{1,0} parameter(2)
+  rhs_scale = f8e8m0fnu[8,128]{1,0} parameter(3)
+  ROOT _ = bf16[128,128]{1,0} scaled-dot(lhs, rhs, lhs_scale, rhs_scale),
+    lhs_contracting_dims={1}, rhs_contracting_dims={0},
+    backend_config={sizes:[128]}
+}
+
+ENTRY e {
+  lhs = f4e2m1fn[128,260]{1,0:E(4)} parameter(0)
+  rhs = f4e2m1fn[256,128]{1,0:E(4)} parameter(1)
+  lhs_scale = f8e8m0fnu[128,8]{1,0} parameter(2)
+  rhs_scale = f8e8m0fnu[8,128]{1,0} parameter(3)
+  ROOT fusion = bf16[128,128]{1,0} fusion(lhs, rhs, lhs_scale, rhs_scale),
+    kind=kCustom, calls=triton_dot,
+    backend_config={"fusion_backend_config":{"kind":"__triton_nested_gemm_fusion",
+      "block_level_fusion_config":{
+        "output_tiles":[{"sizes":["128","128"]}],
+        "num_warps":"4","num_ctas":"1","num_stages":"1"}}}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                          ParseAndReturnVerifiedModule(kHloText));
+  EXPECT_THAT(CreateXTileIrAndFileCheck(std::move(module), "triton_dot", R"(
+CHECK: #[[$LHS_OFFSET_MAP:.*]] = #xla.indexing_map<"(pid_0) -> (pid_0 * 128 + 2), domain: pid_0 in [0, 1]">
+CHECK: xtile.entry_func @xtile_dialect_fn(%[[LHS_ARG:[A-Za-z0-9_]*]]: memref<128x130xi8>
+CHECK-SAME: %[[RHS_ARG:[A-Za-z0-9_]*]]: memref<256x64xi8>
+CHECK: %[[LHS_LOGICAL_OFFSET:.*]] = xla.apply_indexing #[[$LHS_OFFSET_MAP]](%{{.*}})
+CHECK: %[[C2:.*]] = arith.constant 2 : index
+CHECK: %[[LHS_STORAGE_OFFSET:.*]] = arith.divsi %[[LHS_LOGICAL_OFFSET]], %[[C2]] : index
+CHECK: %[[LHS:.*]] = xtile.extract %[[LHS_ARG]][%{{.*}}, %[[LHS_STORAGE_OFFSET]]] [128, 64] [1, 1] : memref<128x130xi8> -> tensor<128x64xi8>
+CHECK: %[[RHS:.*]] = xtile.extract %[[RHS_ARG]][%{{.*}}, %{{.*}}] [128, 64] [1, 1] : memref<256x64xi8> -> tensor<128x64xi8>
+CHECK: xtile.dot_scaled %[[LHS]]
+CHECK-SAME: %[[RHS]]
+CHECK-SAME: lhs_elem_type = i8, rhs_elem_type = i8
+)"),
+              absl_testing::IsOk());
+}
+
 // TODO(b/353484968): Tests that don't run RunAndCompareNoHloPasses should be
 // moved to deviceless test file.
 TEST_P(TritonDevicelessTest,

--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -669,7 +669,7 @@ ENTRY entry {
                          "(compute capability 8.0) and up, but got")));
 }
 
-TEST_F(TritonDevicelessTest, RejectsPackedFp4OddMinorOffset) {
+TEST_P(TritonDevicelessTest, RejectsPackedFp4OddMinorOffset) {
   constexpr absl::string_view kHloText = R"(
 HloModule m
 
@@ -708,7 +708,7 @@ ENTRY e {
                                "to be divisible by 2")));
 }
 
-TEST_F(TritonDevicelessTest, EmitsPackedFp4StorageForEvenMinorOffset) {
+TEST_P(TritonDevicelessTest, EmitsPackedFp4StorageForEvenMinorOffset) {
   constexpr absl::string_view kHloText = R"(
 HloModule m
 
@@ -740,7 +740,7 @@ ENTRY e {
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
                        ParseAndReturnVerifiedModule(kHloText));
   EXPECT_THAT(CreateXTileIrAndFileCheck(std::move(module), "triton_dot", R"(
-CHECK: #[[$LHS_OFFSET_MAP:.*]] = #xla.indexing_map<"(pid_0) -> (pid_0 * 128 + 2), domain: pid_0 in [0, 1]">
+CHECK: #[[$LHS_OFFSET_MAP:.*]] = #xla.indexing_map<{{.*[+] 2.*}}>
 CHECK: xtile.entry_func @xtile_dialect_fn(%[[LHS_ARG:[A-Za-z0-9_]*]]: memref<128x130xi8>
 CHECK-SAME: %[[RHS_ARG:[A-Za-z0-9_]*]]: memref<256x64xi8>
 CHECK: %[[LHS_LOGICAL_OFFSET:.*]] = xla.apply_indexing #[[$LHS_OFFSET_MAP]](%{{.*}})

--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -750,7 +750,7 @@ CHECK: %[[LHS:.*]] = xtile.extract %[[LHS_ARG]][%{{.*}}, %[[LHS_STORAGE_OFFSET]]
 CHECK: %[[RHS:.*]] = xtile.extract %[[RHS_ARG]][%{{.*}}, %{{.*}}] [128, 64] [1, 1] : memref<256x64xi8> -> tensor<128x64xi8>
 CHECK: xtile.dot_scaled %[[LHS]]
 CHECK-SAME: %[[RHS]]
-CHECK-SAME: lhs_elem_type = i8, rhs_elem_type = i8
+CHECK-SAME: lhs_elem_type = f4E2M1FN, rhs_elem_type = f4E2M1FN
 )"),
               absl_testing::IsOk());
 }

--- a/xla/backends/gpu/codegen/triton/transforms/triton_xla_convert_unsupported_types.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/triton_xla_convert_unsupported_types.cc
@@ -89,29 +89,6 @@ struct ConstantOpConversionPattern final
   }
 };
 
-template <>
-LogicalResult
-GenericOpConversionPattern<::xla::xtile::ExtractTileOp>::matchAndRewrite(
-    ::xla::xtile::ExtractTileOp op,
-    ::xla::xtile::ExtractTileOp::Adaptor adaptor,
-    ConversionPatternRewriter& rewriter) const {
-  auto* ctx = op.getContext();
-  ::xla::xtile::ExtractTileOp replacement =
-      mlir::cast<::xla::xtile::ExtractTileOp>(rewriter.clone(*op));
-  if (op.getResult().getType().getElementType() == Float4E2M1FNType::get(ctx)) {
-    auto full_tile_shape = op.getFullTileShape().vec();
-    full_tile_shape[full_tile_shape.size() - 1] = full_tile_shape.back() / 2;
-    replacement.setFullTileShape(full_tile_shape);
-  }
-  replacement->setOperands(adaptor.getOperands());
-  const TypeConverter* converter = this->getTypeConverter();
-  for (auto result : replacement->getResults()) {
-    result.setType(converter->convertType(result.getType()));
-  }
-  rewriter.replaceOp(op, replacement);
-  return success();
-}
-
 class TritonXLAConvertUnsupportedTypesPass
     : public impl::TritonXLAConvertUnsupportedTypesPassBase<
           TritonXLAConvertUnsupportedTypesPass> {
@@ -129,11 +106,6 @@ class TritonXLAConvertUnsupportedTypesPass
       return IntegerType::get(type.getContext(), 8);
     });
     converter.addConversion([&](ShapedType type) {
-      if (llvm::isa<Float4E2M1FNType>(type.getElementType())) {
-        auto shape = type.getShape().vec();
-        shape.back() /= 2;
-        return type.clone(shape, IntegerType::get(type.getContext(), 8));
-      }
       return type.clone(converter.convertType(type.getElementType()));
     });
 

--- a/xla/codegen/xtile/codegen/dot_algorithms.cc
+++ b/xla/codegen/xtile/codegen/dot_algorithms.cc
@@ -57,6 +57,17 @@ using ::mlir::Value;
 
 Type ElementType(Value v) { return mlir::getElementTypeOrSelf(v); }
 
+// tt.dot_scaled accepts scale tensors as floating point values or i8. UE8M0
+// has no MLIR FloatType representation that Triton recognizes, so XLA carries
+// it as i8.
+Value ReinterpretScaleIfNeeded(mlir::ImplicitLocOpBuilder& b, Value scale) {
+  if (mlir::isa<mlir::Float8E8M0FNUType>(
+          getElementTypeOrSelf(scale.getType()))) {
+    return Bitcast(b, scale, b.getI8Type());
+  }
+  return scale;
+}
+
 mlir::stablehlo::Precision XlaPrecisionToStableHloPrecision(
     PrecisionConfig::Precision precision) {
   switch (precision) {
@@ -76,26 +87,19 @@ mlir::stablehlo::Precision XlaPrecisionToStableHloPrecision(
 namespace {
 
 absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
+                                const HloScaledDotInstruction& dot,
                                 ScaledDotOperands& operands) {
-  mlir::Type lhs_dot_elem_type = getElementTypeOrSelf(operands.lhs.getType());
-  mlir::Type rhs_dot_elem_type = getElementTypeOrSelf(operands.rhs.getType());
+  PrimitiveType lhs_primitive_type = dot.operand(0)->shape().element_type();
+  PrimitiveType rhs_primitive_type = dot.operand(1)->shape().element_type();
 
   Value lhs_scale;
-  if (lhs_dot_elem_type != b.getBF16Type() && operands.lhs_scale) {
-    lhs_scale = operands.lhs_scale;
-    if (mlir::isa<mlir::Float8E8M0FNUType>(
-            getElementTypeOrSelf(lhs_scale.getType()))) {
-      lhs_scale = Bitcast(b, lhs_scale, b.getI8Type());
-    }
+  if (IsTritonDotScaledOperandType(lhs_primitive_type) && operands.lhs_scale) {
+    lhs_scale = ReinterpretScaleIfNeeded(b, operands.lhs_scale);
   }
 
   Value rhs_scale;
-  if (rhs_dot_elem_type != b.getBF16Type() && operands.rhs_scale) {
-    rhs_scale = operands.rhs_scale;
-    if (mlir::isa<mlir::Float8E8M0FNUType>(
-            getElementTypeOrSelf(rhs_scale.getType()))) {
-      rhs_scale = Bitcast(b, rhs_scale, b.getI8Type());
-    }
+  if (IsTritonDotScaledOperandType(rhs_primitive_type) && operands.rhs_scale) {
+    rhs_scale = ReinterpretScaleIfNeeded(b, operands.rhs_scale);
     auto rhs_scale_type = mlir::cast<mlir::ShapedType>(rhs_scale.getType());
     int64_t rank = rhs_scale_type.getRank();
     CHECK_GE(rank, 2) << "RHS scale must be at least rank 2 for scaled dot.";
@@ -109,24 +113,29 @@ absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
         b, rhs_scale, b.getDenseI64ArrayAttr(permutation));
   }
 
-  int64_t lhs_rank = mlir::cast<ShapedType>(operands.lhs.getType()).getRank();
-  int64_t lhs_contracting_dim =
-      operands.dot_dimension_numbers.getLhsContractingDimensions()[0];
-  const bool lhs_k_pack =
-      (lhs_dot_elem_type != mlir::Float4E2M1FNType::get(b.getContext())) ||
-      (lhs_contracting_dim == lhs_rank - 1);
+  // Non-sub-byte operands are represented as K-packed.
+  bool lhs_k_pack = true;
+  bool rhs_k_pack = true;
+  if (IsPackedTritonDotScaledOperandType(lhs_primitive_type)) {
+    const int64_t lhs_c =
+        dot.dot_dimension_numbers().lhs_contracting_dimensions(0);
+    lhs_k_pack = dot.operand(0)->shape().layout().minor_to_major(0) == lhs_c;
+  }
+  if (IsPackedTritonDotScaledOperandType(rhs_primitive_type)) {
+    const int64_t rhs_c =
+        dot.dot_dimension_numbers().rhs_contracting_dimensions(0);
+    rhs_k_pack = dot.operand(1)->shape().layout().minor_to_major(0) == rhs_c;
+  }
 
-  int64_t rhs_rank = mlir::cast<ShapedType>(operands.rhs.getType()).getRank();
-  int64_t rhs_contracting_dim =
-      operands.dot_dimension_numbers.getRhsContractingDimensions()[0];
-  const bool rhs_k_pack =
-      (rhs_dot_elem_type != mlir::Float4E2M1FNType::get(b.getContext())) ||
-      (rhs_contracting_dim == rhs_rank - 1);
+  ASSIGN_OR_RETURN(Type lhs_elem_type,
+                   PrimitiveTypeToMlirType(b, lhs_primitive_type));
+  ASSIGN_OR_RETURN(Type rhs_elem_type,
+                   PrimitiveTypeToMlirType(b, rhs_primitive_type));
 
   auto dot_scaled_op = xtile::DotScaledOp::create(
       b, operands.accumulator.getType(), operands.lhs, operands.rhs, lhs_scale,
-      rhs_scale, /*fastMath=*/true, lhs_k_pack, rhs_k_pack, lhs_dot_elem_type,
-      rhs_dot_elem_type, operands.dot_dimension_numbers);
+      rhs_scale, /*fastMath=*/true, lhs_k_pack, rhs_k_pack, lhs_elem_type,
+      rhs_elem_type, operands.dot_dimension_numbers);
 
   auto add_result =
       mlir::isa<mlir::IntegerType>(
@@ -335,7 +344,7 @@ absl::StatusOr<Value> EmitSingleTileScaledDot(
   dot_operands.dot_dimension_numbers =
       ::xla::stablehlo::ConvertDotDimensionNumbers(
           scaled_dot.dot_dimension_numbers(), &b);
-  return ScaledDot(b, dot_operands);
+  return ScaledDot(b, scaled_dot, dot_operands);
 }
 
 }  // namespace xtile

--- a/xla/codegen/xtile/codegen/emitter_helpers.cc
+++ b/xla/codegen/xtile/codegen/emitter_helpers.cc
@@ -278,8 +278,8 @@ absl::StatusOr<SmallVector<int64_t>> GetStorageShape(
         absl::StrCat("Packed storage dimension is out of bounds for shape ",
                      shape.ToString()));
   }
-  TF_ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
-                      PackedElementsPerByte(shape.element_type()));
+  ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
+                   PackedElementsPerByte(shape.element_type()));
   if (storage_shape[packed_dim] % packed_elements_per_byte != 0) {
     return absl::InvalidArgumentError(absl::StrCat(
         "Packed storage dimension must be divisible by ",
@@ -310,8 +310,8 @@ absl::Status CheckPackedStorageTile(const Shape& shape,
         absl::StrCat("Packed storage requires unit stride in dimension ",
                      packed_dim, " for shape ", shape.ToString()));
   }
-  TF_ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
-                      PackedElementsPerByte(shape.element_type()));
+  ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
+                   PackedElementsPerByte(shape.element_type()));
   if (!tile_offsets[packed_dim].IsMultipleOf(packed_elements_per_byte)) {
     return absl::InvalidArgumentError(absl::StrCat(
         "Packed storage requires offset in dimension ", packed_dim,
@@ -760,10 +760,10 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
     const TiledHloInstruction& tiled_hlo) {
   const Shape& shape = tiled_hlo.hlo()->shape();
   auto tile_strides = tiled_hlo.tile_strides();
-  TF_ASSIGN_OR_RETURN(IndexingMap tile_offsets_indexing,
-                      tiled_hlo.tile_offsets_indexing());
+  ASSIGN_OR_RETURN(IndexingMap tile_offsets_indexing,
+                   tiled_hlo.tile_offsets_indexing());
   auto tile_offsets = tile_offsets_indexing.GetSymbolicMap().GetResults();
-  TF_RETURN_IF_ERROR(CheckPackedStorageTile(shape, tile_strides, tile_offsets));
+  RETURN_IF_ERROR(CheckPackedStorageTile(shape, tile_strides, tile_offsets));
   ASSIGN_OR_RETURN(SmallVector<Value> offsets,
                    ComputeOffsetsForTile(b, pid, runtime_values, tiled_hlo));
 
@@ -771,9 +771,9 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
   auto padded_tile_sizes = GetPaddedTileSizes(tiled_hlo.tile_sizes());
   SmallVector<int64_t> original_shape;
   original_shape.assign(shape.dimensions().begin(), shape.dimensions().end());
-  TF_ASSIGN_OR_RETURN(original_shape, GetStorageShape(original_shape, shape));
-  TF_ASSIGN_OR_RETURN(padded_tile_sizes,
-                      GetStorageShape(padded_tile_sizes, shape));
+  ASSIGN_OR_RETURN(original_shape, GetStorageShape(original_shape, shape));
+  ASSIGN_OR_RETURN(padded_tile_sizes,
+                   GetStorageShape(padded_tile_sizes, shape));
 
   ASSIGN_OR_RETURN(Type expected_element_type,
                    PrimitiveTypeToMlirType(b, shape.element_type()));
@@ -783,8 +783,8 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
   if (IsPackedTritonDotScaledOperandType(shape.element_type()) &&
       !minor_to_major_layout.empty()) {
     int64_t packed_dim = minor_to_major_layout.front();
-    TF_ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
-                        PackedElementsPerByte(shape.element_type()));
+    ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
+                     PackedElementsPerByte(shape.element_type()));
     offsets[packed_dim] = DivideIndexByPackedElementsPerByte(
         b, offsets[packed_dim], packed_elements_per_byte);
   }
@@ -800,7 +800,7 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
   const Shape& shape = tiled_hlo.hlo()->shape();
   ASSIGN_OR_RETURN(SmallVector<int64_t> tile_strides,
                    tiled_hlo.tile().GetStaticTileStrides());
-  TF_RETURN_IF_ERROR(
+  RETURN_IF_ERROR(
       CheckPackedStorageTile(shape, tile_strides, tiled_hlo.tile().offsets()));
   ASSIGN_OR_RETURN(
       SmallVector<Value> offsets,
@@ -813,8 +813,8 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
 
   SmallVector<int64_t> original_shape;
   original_shape.assign(shape.dimensions().begin(), shape.dimensions().end());
-  TF_ASSIGN_OR_RETURN(original_shape, GetStorageShape(original_shape, shape));
-  TF_ASSIGN_OR_RETURN(tile_sizes, GetStorageShape(tile_sizes, shape));
+  ASSIGN_OR_RETURN(original_shape, GetStorageShape(original_shape, shape));
+  ASSIGN_OR_RETURN(tile_sizes, GetStorageShape(tile_sizes, shape));
 
   ASSIGN_OR_RETURN(
       Type expected_element_type,
@@ -843,8 +843,8 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
   if (IsPackedTritonDotScaledOperandType(shape.element_type()) &&
       !minor_to_major_layout.empty()) {
     int64_t packed_dim = minor_to_major_layout.front();
-    TF_ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
-                        PackedElementsPerByte(shape.element_type()));
+    ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
+                     PackedElementsPerByte(shape.element_type()));
     offsets[packed_dim] = DivideIndexByPackedElementsPerByte(
         emitter_ctx.b(), offsets[packed_dim], packed_elements_per_byte);
   }
@@ -1052,8 +1052,8 @@ absl::StatusOr<mlir::MemRefType> GetMemRefType(const Shape& shape,
   mlir::Type storage_type = StorageType(element_type);
   SmallVector<int64_t> logical_shape(shape.dimensions().begin(),
                                      shape.dimensions().end());
-  TF_ASSIGN_OR_RETURN(SmallVector<int64_t> storage_shape,
-                      GetStorageShape(logical_shape, shape));
+  ASSIGN_OR_RETURN(SmallVector<int64_t> storage_shape,
+                   GetStorageShape(logical_shape, shape));
 
   // Don't add any attribute for default layouts as it adds a lot of noise to
   // the printed IR.

--- a/xla/codegen/xtile/codegen/emitter_helpers.cc
+++ b/xla/codegen/xtile/codegen/emitter_helpers.cc
@@ -215,6 +215,32 @@ Value ReducePrecision(mlir::ImplicitLocOpBuilder& b, const HloInstruction& hlo,
       b.getLoc(), value, hlo.exponent_bits(), hlo.mantissa_bits(), &b);
 }
 
+absl::StatusOr<int64_t> PackedElementsPerByte(PrimitiveType type) {
+  if (!primitive_util::IsSubByteNonPredType(type)) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Packed storage requires a sub-byte non-predicate type, got ",
+        primitive_util::LowercasePrimitiveTypeName(type), "."));
+  }
+
+  const int64_t storage_bit_width = primitive_util::BitWidth(U8);
+  const int64_t element_bit_width = primitive_util::BitWidth(type);
+  if (storage_bit_width % element_bit_width != 0) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Packed storage bit width ", storage_bit_width,
+                     " must be divisible by element bit width ",
+                     element_bit_width, " for primitive type ",
+                     primitive_util::LowercasePrimitiveTypeName(type), "."));
+  }
+  return storage_bit_width / element_bit_width;
+}
+
+Value DivideIndexByPackedElementsPerByte(mlir::ImplicitLocOpBuilder& b,
+                                         Value value,
+                                         int64_t packed_elements_per_byte) {
+  return ma::DivSIOp::create(
+      b, value, CreateConst(b, value.getType(), packed_elements_per_byte));
+}
+
 }  // namespace
 
 SmallVector<int64_t> GetPaddedTileSizes(ArrayRef<int64_t> tile_sizes) {
@@ -225,6 +251,74 @@ SmallVector<int64_t> GetPaddedTileSizes(ArrayRef<int64_t> tile_sizes) {
     result.push_back(value == 0 ? 1 : llvm::PowerOf2Ceil(value));
   }
   return result;
+}
+
+bool IsTritonDotScaledOperandType(PrimitiveType type) {
+  return type == F4E2M1FN || type == F8E4M3FN || type == F8E5M2;
+}
+
+bool IsPackedTritonDotScaledOperandType(PrimitiveType type) {
+  return IsTritonDotScaledOperandType(type) &&
+         primitive_util::IsSubByteNonPredType(type);
+}
+
+absl::StatusOr<SmallVector<int64_t>> GetStorageShape(
+    ArrayRef<int64_t> logical_shape, const Shape& shape) {
+  SmallVector<int64_t> storage_shape(logical_shape.begin(),
+                                     logical_shape.end());
+  if (!IsPackedTritonDotScaledOperandType(shape.element_type()) ||
+      storage_shape.empty()) {
+    return storage_shape;
+  }
+
+  int64_t packed_dim = LayoutUtil::MinorToMajor(shape).front();
+  if (packed_dim < 0 ||
+      packed_dim >= static_cast<int64_t>(storage_shape.size())) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Packed storage dimension is out of bounds for shape ",
+                     shape.ToString()));
+  }
+  TF_ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
+                      PackedElementsPerByte(shape.element_type()));
+  if (storage_shape[packed_dim] % packed_elements_per_byte != 0) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Packed storage dimension must be divisible by ",
+        packed_elements_per_byte, ", got ", storage_shape[packed_dim],
+        " for shape ", shape.ToString()));
+  }
+  storage_shape[packed_dim] /= packed_elements_per_byte;
+  return storage_shape;
+}
+
+absl::Status CheckPackedStorageTile(const Shape& shape,
+                                    ArrayRef<int64_t> tile_strides,
+                                    ArrayRef<SymbolicExpr> tile_offsets) {
+  if (!IsPackedTritonDotScaledOperandType(shape.element_type()) ||
+      LayoutUtil::MinorToMajor(shape).empty()) {
+    return absl::OkStatus();
+  }
+  int64_t packed_dim = LayoutUtil::MinorToMajor(shape).front();
+  if (packed_dim < 0 ||
+      packed_dim >= static_cast<int64_t>(tile_strides.size()) ||
+      packed_dim >= static_cast<int64_t>(tile_offsets.size())) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Packed storage dimension is out of bounds for shape ",
+                     shape.ToString()));
+  }
+  if (tile_strides[packed_dim] != 1) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Packed storage requires unit stride in dimension ",
+                     packed_dim, " for shape ", shape.ToString()));
+  }
+  TF_ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
+                      PackedElementsPerByte(shape.element_type()));
+  if (!tile_offsets[packed_dim].IsMultipleOf(packed_elements_per_byte)) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Packed storage requires offset in dimension ", packed_dim,
+        " to be divisible by ", packed_elements_per_byte, " for shape ",
+        shape.ToString(), ", got ", tile_offsets[packed_dim].ToString()));
+  }
+  return absl::OkStatus();
 }
 
 Value EmitClampedRTVar(mlir::ImplicitLocOpBuilder& b,
@@ -428,6 +522,9 @@ absl::StatusOr<PrimitiveType> GetPrimitiveType(Type t) {
 Type StorageType(Type t) {
   if (auto i = mlir::dyn_cast<mlir::IntegerType>(t); i && i.getWidth() == 1) {
     return i.get(i.getContext(), 8, i.getSignedness());
+  }
+  if (mlir::isa<mlir::Float4E2M1FNType>(t)) {
+    return mlir::IntegerType::get(t.getContext(), 8);
   }
   return t;
 }
@@ -661,21 +758,36 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
 /*static */ absl::StatusOr<TileInfo> TileInfo::Construct(
     mlir::ImplicitLocOpBuilder& b, Value pid, ValueRange runtime_values,
     const TiledHloInstruction& tiled_hlo) {
+  const Shape& shape = tiled_hlo.hlo()->shape();
+  auto tile_strides = tiled_hlo.tile_strides();
+  TF_ASSIGN_OR_RETURN(IndexingMap tile_offsets_indexing,
+                      tiled_hlo.tile_offsets_indexing());
+  auto tile_offsets = tile_offsets_indexing.GetSymbolicMap().GetResults();
+  TF_RETURN_IF_ERROR(CheckPackedStorageTile(shape, tile_strides, tile_offsets));
   ASSIGN_OR_RETURN(SmallVector<Value> offsets,
                    ComputeOffsetsForTile(b, pid, runtime_values, tiled_hlo));
 
   // Triton requires that all block dimensions are a power of 2.
   auto padded_tile_sizes = GetPaddedTileSizes(tiled_hlo.tile_sizes());
-  const Shape& shape = tiled_hlo.hlo()->shape();
   SmallVector<int64_t> original_shape;
   original_shape.assign(shape.dimensions().begin(), shape.dimensions().end());
+  TF_ASSIGN_OR_RETURN(original_shape, GetStorageShape(original_shape, shape));
+  TF_ASSIGN_OR_RETURN(padded_tile_sizes,
+                      GetStorageShape(padded_tile_sizes, shape));
 
   ASSIGN_OR_RETURN(Type expected_element_type,
                    PrimitiveTypeToMlirType(b, shape.element_type()));
   auto storage_type = StorageType(expected_element_type);
 
-  auto tile_strides = tiled_hlo.tile_strides();
   auto minor_to_major_layout = llvm::to_vector(LayoutUtil::MinorToMajor(shape));
+  if (IsPackedTritonDotScaledOperandType(shape.element_type()) &&
+      !minor_to_major_layout.empty()) {
+    int64_t packed_dim = minor_to_major_layout.front();
+    TF_ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
+                        PackedElementsPerByte(shape.element_type()));
+    offsets[packed_dim] = DivideIndexByPackedElementsPerByte(
+        b, offsets[packed_dim], packed_elements_per_byte);
+  }
 
   // Replica id is only supported for ge::TiledHloInstruction.
   return TileInfo(offsets, tile_strides, original_shape, padded_tile_sizes,
@@ -685,6 +797,11 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
 
 /*static */ absl::StatusOr<TileInfo> TileInfo::Construct(
     EmitterContext& emitter_ctx, const ge::TiledHloInstruction& tiled_hlo) {
+  const Shape& shape = tiled_hlo.hlo()->shape();
+  ASSIGN_OR_RETURN(SmallVector<int64_t> tile_strides,
+                   tiled_hlo.tile().GetStaticTileStrides());
+  TF_RETURN_IF_ERROR(
+      CheckPackedStorageTile(shape, tile_strides, tiled_hlo.tile().offsets()));
   ASSIGN_OR_RETURN(
       SmallVector<Value> offsets,
       emitter_ctx.EvaluateTilingParameters(tiled_hlo.tile().offsets()));
@@ -692,13 +809,12 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
   // Triton requires that all block dimensions are a power of 2.
   ASSIGN_OR_RETURN(SmallVector<int64_t> tile_sizes,
                    tiled_hlo.tile().GetStaticTileSizes());
-  ASSIGN_OR_RETURN(SmallVector<int64_t> tile_strides,
-                   tiled_hlo.tile().GetStaticTileStrides());
   DCHECK(ArePowersOfTwo(tile_sizes)) << "Tile sizes must be a power of 2.";
 
-  const Shape& shape = tiled_hlo.hlo()->shape();
   SmallVector<int64_t> original_shape;
   original_shape.assign(shape.dimensions().begin(), shape.dimensions().end());
+  TF_ASSIGN_OR_RETURN(original_shape, GetStorageShape(original_shape, shape));
+  TF_ASSIGN_OR_RETURN(tile_sizes, GetStorageShape(tile_sizes, shape));
 
   ASSIGN_OR_RETURN(
       Type expected_element_type,
@@ -723,6 +839,14 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
                      emitter_ctx.EvaluateTilingParameters(bound_exprs));
     replica_id_offsets = std::move(evaluated_offsets);
     replica_id_bounds = std::move(evaluated_bounds);
+  }
+  if (IsPackedTritonDotScaledOperandType(shape.element_type()) &&
+      !minor_to_major_layout.empty()) {
+    int64_t packed_dim = minor_to_major_layout.front();
+    TF_ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
+                        PackedElementsPerByte(shape.element_type()));
+    offsets[packed_dim] = DivideIndexByPackedElementsPerByte(
+        emitter_ctx.b(), offsets[packed_dim], packed_elements_per_byte);
   }
 
   return TileInfo(std::move(offsets), std::move(tile_strides),
@@ -768,8 +892,8 @@ absl::StatusOr<TensorValue> EmitParameterExtract(mlir::ImplicitLocOpBuilder& b,
     xla::Shape spatial_shape = xla::ShapeUtil::MakeShapeWithDenseLayout(
         element_type, tile_info.original_shape(),
         tile_info.minor_to_major_layout());
-    mlir::Type spatial_memref_type =
-        GetMemRefType(spatial_shape, tile_info.storage_type());
+    ASSIGN_OR_RETURN(mlir::MemRefType spatial_memref_type,
+                     GetMemRefType(spatial_shape, tile_info.storage_type()));
     source_buffer = b.create<xtile::SelectBufferOp>(spatial_memref_type,
                                                     source_buffer, replica_id);
   }
@@ -922,21 +1046,26 @@ absl::StatusOr<llvm::SmallVector<int64_t>> GetPermutationMinorToMajor(
   return permutation;
 }
 
-mlir::MemRefType GetMemRefType(const Shape& shape, mlir::Type element_type) {
+absl::StatusOr<mlir::MemRefType> GetMemRefType(const Shape& shape,
+                                               mlir::Type element_type) {
   mlir::MLIRContext* context = element_type.getContext();
   mlir::Type storage_type = StorageType(element_type);
+  SmallVector<int64_t> logical_shape(shape.dimensions().begin(),
+                                     shape.dimensions().end());
+  TF_ASSIGN_OR_RETURN(SmallVector<int64_t> storage_shape,
+                      GetStorageShape(logical_shape, shape));
 
   // Don't add any attribute for default layouts as it adds a lot of noise to
   // the printed IR.
   if (LayoutUtil::IsMonotonicWithDim0Major(shape.layout())) {
-    return mlir::MemRefType::get(shape.dimensions(), storage_type);
+    return mlir::MemRefType::get(storage_shape, storage_type);
   }
 
   auto minor_to_major_attr =
       mlir::DenseI64ArrayAttr::get(context, shape.layout().minor_to_major());
   auto layout = xtile::LayoutAttr::get(context, minor_to_major_attr);
 
-  return mlir::MemRefType::get(shape.dimensions(), storage_type, layout);
+  return mlir::MemRefType::get(storage_shape, storage_type, layout);
 }
 
 absl::StatusOr<Type> GetMlirType(
@@ -970,7 +1099,9 @@ absl::StatusOr<SmallVector<Type>> GetFnArgTypes(
       fn_arg_types.push_back(
           mlir::MemRefType::get({replica_id_bounds.front()}, b.getI64Type()));
     } else {
-      fn_arg_types.push_back(GetMemRefType(p->shape(), ir_type));
+      ASSIGN_OR_RETURN(mlir::MemRefType memref_type,
+                       GetMemRefType(p->shape(), ir_type));
+      fn_arg_types.push_back(memref_type);
     }
   }
 
@@ -978,7 +1109,9 @@ absl::StatusOr<SmallVector<Type>> GetFnArgTypes(
   for (const auto& [index, shape] : ShapeUtil::GetLeafShapes(fusion.shape())) {
     ASSIGN_OR_RETURN(Type ir_type,
                      PrimitiveTypeToMlirType(b, shape.element_type(), gpu_cc));
-    fn_arg_types.push_back(GetMemRefType(shape, ir_type));
+    ASSIGN_OR_RETURN(mlir::MemRefType memref_type,
+                     GetMemRefType(shape, ir_type));
+    fn_arg_types.push_back(memref_type);
   }
 
   // Add opaque arguments.

--- a/xla/codegen/xtile/codegen/emitter_helpers.cc
+++ b/xla/codegen/xtile/codegen/emitter_helpers.cc
@@ -263,62 +263,85 @@ bool IsPackedTritonDotScaledOperandType(PrimitiveType type) {
 }
 
 absl::StatusOr<SmallVector<int64_t>> GetStorageShape(
-    ArrayRef<int64_t> logical_shape, const Shape& shape) {
-  SmallVector<int64_t> storage_shape(logical_shape.begin(),
-                                     logical_shape.end());
-  if (!IsPackedTritonDotScaledOperandType(shape.element_type()) ||
+    ArrayRef<int64_t> logical_shape_dims, const Shape& logical_shape) {
+  SmallVector<int64_t> storage_shape(logical_shape_dims.begin(),
+                                     logical_shape_dims.end());
+  if (!IsPackedTritonDotScaledOperandType(logical_shape.element_type()) ||
       storage_shape.empty()) {
     return storage_shape;
   }
 
-  int64_t packed_dim = LayoutUtil::MinorToMajor(shape).front();
+  int64_t packed_dim = LayoutUtil::MinorToMajor(logical_shape).front();
   if (packed_dim < 0 ||
       packed_dim >= static_cast<int64_t>(storage_shape.size())) {
     return absl::InvalidArgumentError(
         absl::StrCat("Packed storage dimension is out of bounds for shape ",
-                     shape.ToString()));
+                     logical_shape.ToString()));
   }
   ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
-                   PackedElementsPerByte(shape.element_type()));
+                   PackedElementsPerByte(logical_shape.element_type()));
   if (storage_shape[packed_dim] % packed_elements_per_byte != 0) {
     return absl::InvalidArgumentError(absl::StrCat(
         "Packed storage dimension must be divisible by ",
         packed_elements_per_byte, ", got ", storage_shape[packed_dim],
-        " for shape ", shape.ToString()));
+        " for shape ", logical_shape.ToString()));
   }
   storage_shape[packed_dim] /= packed_elements_per_byte;
   return storage_shape;
 }
 
-absl::Status CheckPackedStorageTile(const Shape& shape,
-                                    ArrayRef<int64_t> tile_strides,
-                                    ArrayRef<SymbolicExpr> tile_offsets) {
-  if (!IsPackedTritonDotScaledOperandType(shape.element_type()) ||
-      LayoutUtil::MinorToMajor(shape).empty()) {
-    return absl::OkStatus();
+absl::StatusOr<SmallVector<Value>> GetStorageOffsets(
+    mlir::ImplicitLocOpBuilder& b, const Shape& logical_shape,
+    ArrayRef<SymbolicExpr> logical_tile_offsets,
+    SmallVector<Value> logical_offsets) {
+  SmallVector<Value> storage_offsets = std::move(logical_offsets);
+  if (!IsPackedTritonDotScaledOperandType(logical_shape.element_type()) ||
+      LayoutUtil::MinorToMajor(logical_shape).empty()) {
+    return storage_offsets;
   }
-  int64_t packed_dim = LayoutUtil::MinorToMajor(shape).front();
+  int64_t packed_dim = LayoutUtil::MinorToMajor(logical_shape).front();
   if (packed_dim < 0 ||
-      packed_dim >= static_cast<int64_t>(tile_strides.size()) ||
-      packed_dim >= static_cast<int64_t>(tile_offsets.size())) {
+      packed_dim >= static_cast<int64_t>(logical_tile_offsets.size())) {
     return absl::InvalidArgumentError(
         absl::StrCat("Packed storage dimension is out of bounds for shape ",
-                     shape.ToString()));
-  }
-  if (tile_strides[packed_dim] != 1) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("Packed storage requires unit stride in dimension ",
-                     packed_dim, " for shape ", shape.ToString()));
+                     logical_shape.ToString()));
   }
   ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
-                   PackedElementsPerByte(shape.element_type()));
-  if (!tile_offsets[packed_dim].IsMultipleOf(packed_elements_per_byte)) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "Packed storage requires offset in dimension ", packed_dim,
-        " to be divisible by ", packed_elements_per_byte, " for shape ",
-        shape.ToString(), ", got ", tile_offsets[packed_dim].ToString()));
+                   PackedElementsPerByte(logical_shape.element_type()));
+  // Packed storage is byte-addressed along the layout-minor dimension, so the
+  // logical offset must be aligned before converting it to a byte offset.
+  if (!logical_tile_offsets[packed_dim].IsMultipleOf(
+          packed_elements_per_byte)) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Packed storage requires offset in dimension ", packed_dim,
+                     " to be divisible by ", packed_elements_per_byte,
+                     " for shape ", logical_shape.ToString(), ", got ",
+                     logical_tile_offsets[packed_dim].ToString()));
   }
-  return absl::OkStatus();
+  storage_offsets[packed_dim] = DivideIndexByPackedElementsPerByte(
+      b, storage_offsets[packed_dim], packed_elements_per_byte);
+  return storage_offsets;
+}
+
+absl::StatusOr<SmallVector<int64_t>> GetStorageTileStrides(
+    ArrayRef<int64_t> logical_tile_strides, const Shape& logical_shape) {
+  if (IsPackedTritonDotScaledOperandType(logical_shape.element_type()) &&
+      !LayoutUtil::MinorToMajor(logical_shape).empty()) {
+    int64_t packed_dim = LayoutUtil::MinorToMajor(logical_shape).front();
+    if (packed_dim < 0 ||
+        packed_dim >= static_cast<int64_t>(logical_tile_strides.size())) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("Packed storage dimension is out of bounds for shape ",
+                       logical_shape.ToString()));
+    }
+    if (logical_tile_strides[packed_dim] != 1) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("Packed storage requires unit stride in dimension ",
+                       packed_dim, " for shape ", logical_shape.ToString()));
+    }
+  }
+  return SmallVector<int64_t>(logical_tile_strides.begin(),
+                              logical_tile_strides.end());
 }
 
 Value EmitClampedRTVar(mlir::ImplicitLocOpBuilder& b,
@@ -758,70 +781,78 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
 /*static */ absl::StatusOr<TileInfo> TileInfo::Construct(
     mlir::ImplicitLocOpBuilder& b, Value pid, ValueRange runtime_values,
     const TiledHloInstruction& tiled_hlo) {
-  const Shape& shape = tiled_hlo.hlo()->shape();
-  auto tile_strides = tiled_hlo.tile_strides();
-  ASSIGN_OR_RETURN(IndexingMap tile_offsets_indexing,
+  const Shape& logical_shape = tiled_hlo.hlo()->shape();
+  auto logical_tile_strides = tiled_hlo.tile_strides();
+  ASSIGN_OR_RETURN(SmallVector<int64_t> storage_tile_strides,
+                   GetStorageTileStrides(logical_tile_strides, logical_shape));
+  ASSIGN_OR_RETURN(IndexingMap logical_tile_offsets_indexing,
                    tiled_hlo.tile_offsets_indexing());
-  auto tile_offsets = tile_offsets_indexing.GetSymbolicMap().GetResults();
-  RETURN_IF_ERROR(CheckPackedStorageTile(shape, tile_strides, tile_offsets));
-  ASSIGN_OR_RETURN(SmallVector<Value> offsets,
+  auto logical_tile_offsets =
+      logical_tile_offsets_indexing.GetSymbolicMap().GetResults();
+  ASSIGN_OR_RETURN(SmallVector<Value> logical_offsets,
                    ComputeOffsetsForTile(b, pid, runtime_values, tiled_hlo));
+  ASSIGN_OR_RETURN(SmallVector<Value> storage_offsets,
+                   GetStorageOffsets(b, logical_shape, logical_tile_offsets,
+                                     std::move(logical_offsets)));
 
   // Triton requires that all block dimensions are a power of 2.
-  auto padded_tile_sizes = GetPaddedTileSizes(tiled_hlo.tile_sizes());
-  SmallVector<int64_t> original_shape;
-  original_shape.assign(shape.dimensions().begin(), shape.dimensions().end());
-  ASSIGN_OR_RETURN(original_shape, GetStorageShape(original_shape, shape));
-  ASSIGN_OR_RETURN(padded_tile_sizes,
-                   GetStorageShape(padded_tile_sizes, shape));
+  SmallVector<int64_t> padded_logical_tile_sizes =
+      GetPaddedTileSizes(tiled_hlo.tile_sizes());
+  SmallVector<int64_t> logical_shape_dims(logical_shape.dimensions().begin(),
+                                          logical_shape.dimensions().end());
+  ASSIGN_OR_RETURN(SmallVector<int64_t> storage_shape,
+                   GetStorageShape(logical_shape_dims, logical_shape));
+  ASSIGN_OR_RETURN(SmallVector<int64_t> padded_storage_tile_sizes,
+                   GetStorageShape(padded_logical_tile_sizes, logical_shape));
 
   ASSIGN_OR_RETURN(Type expected_element_type,
-                   PrimitiveTypeToMlirType(b, shape.element_type()));
+                   PrimitiveTypeToMlirType(b, logical_shape.element_type()));
   auto storage_type = StorageType(expected_element_type);
 
-  auto minor_to_major_layout = llvm::to_vector(LayoutUtil::MinorToMajor(shape));
-  if (IsPackedTritonDotScaledOperandType(shape.element_type()) &&
-      !minor_to_major_layout.empty()) {
-    int64_t packed_dim = minor_to_major_layout.front();
-    ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
-                     PackedElementsPerByte(shape.element_type()));
-    offsets[packed_dim] = DivideIndexByPackedElementsPerByte(
-        b, offsets[packed_dim], packed_elements_per_byte);
-  }
-
+  auto minor_to_major_layout =
+      llvm::to_vector(LayoutUtil::MinorToMajor(logical_shape));
   // Replica id is only supported for ge::TiledHloInstruction.
-  return TileInfo(offsets, tile_strides, original_shape, padded_tile_sizes,
-                  minor_to_major_layout, storage_type,
+  return TileInfo(storage_offsets, storage_tile_strides, storage_shape,
+                  padded_storage_tile_sizes, minor_to_major_layout,
+                  storage_type,
                   /*replica_id_offsets=*/{}, /*replica_id_bounds=*/{});
 }
 
 /*static */ absl::StatusOr<TileInfo> TileInfo::Construct(
     EmitterContext& emitter_ctx, const ge::TiledHloInstruction& tiled_hlo) {
-  const Shape& shape = tiled_hlo.hlo()->shape();
-  ASSIGN_OR_RETURN(SmallVector<int64_t> tile_strides,
+  const Shape& logical_shape = tiled_hlo.hlo()->shape();
+  ASSIGN_OR_RETURN(SmallVector<int64_t> logical_tile_strides,
                    tiled_hlo.tile().GetStaticTileStrides());
-  RETURN_IF_ERROR(
-      CheckPackedStorageTile(shape, tile_strides, tiled_hlo.tile().offsets()));
+  ASSIGN_OR_RETURN(SmallVector<int64_t> storage_tile_strides,
+                   GetStorageTileStrides(logical_tile_strides, logical_shape));
   ASSIGN_OR_RETURN(
-      SmallVector<Value> offsets,
+      SmallVector<Value> logical_offsets,
       emitter_ctx.EvaluateTilingParameters(tiled_hlo.tile().offsets()));
+  ASSIGN_OR_RETURN(SmallVector<Value> storage_offsets,
+                   GetStorageOffsets(emitter_ctx.b(), logical_shape,
+                                     tiled_hlo.tile().offsets(),
+                                     std::move(logical_offsets)));
 
   // Triton requires that all block dimensions are a power of 2.
-  ASSIGN_OR_RETURN(SmallVector<int64_t> tile_sizes,
+  ASSIGN_OR_RETURN(SmallVector<int64_t> logical_tile_sizes,
                    tiled_hlo.tile().GetStaticTileSizes());
-  DCHECK(ArePowersOfTwo(tile_sizes)) << "Tile sizes must be a power of 2.";
+  DCHECK(ArePowersOfTwo(logical_tile_sizes))
+      << "Tile sizes must be a power of 2.";
 
-  SmallVector<int64_t> original_shape;
-  original_shape.assign(shape.dimensions().begin(), shape.dimensions().end());
-  ASSIGN_OR_RETURN(original_shape, GetStorageShape(original_shape, shape));
-  ASSIGN_OR_RETURN(tile_sizes, GetStorageShape(tile_sizes, shape));
+  SmallVector<int64_t> logical_shape_dims(logical_shape.dimensions().begin(),
+                                          logical_shape.dimensions().end());
+  ASSIGN_OR_RETURN(SmallVector<int64_t> storage_shape,
+                   GetStorageShape(logical_shape_dims, logical_shape));
+  ASSIGN_OR_RETURN(SmallVector<int64_t> storage_tile_sizes,
+                   GetStorageShape(logical_tile_sizes, logical_shape));
 
   ASSIGN_OR_RETURN(
       Type expected_element_type,
-      PrimitiveTypeToMlirType(emitter_ctx.b(), shape.element_type()));
+      PrimitiveTypeToMlirType(emitter_ctx.b(), logical_shape.element_type()));
   auto storage_type = StorageType(expected_element_type);
 
-  auto minor_to_major_layout = llvm::to_vector(LayoutUtil::MinorToMajor(shape));
+  auto minor_to_major_layout =
+      llvm::to_vector(LayoutUtil::MinorToMajor(logical_shape));
   SmallVector<Value> replica_id_offsets;
   SmallVector<Value> replica_id_bounds;
   if (!tiled_hlo.tile().replica_ids().empty()) {
@@ -840,17 +871,8 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
     replica_id_offsets = std::move(evaluated_offsets);
     replica_id_bounds = std::move(evaluated_bounds);
   }
-  if (IsPackedTritonDotScaledOperandType(shape.element_type()) &&
-      !minor_to_major_layout.empty()) {
-    int64_t packed_dim = minor_to_major_layout.front();
-    ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
-                     PackedElementsPerByte(shape.element_type()));
-    offsets[packed_dim] = DivideIndexByPackedElementsPerByte(
-        emitter_ctx.b(), offsets[packed_dim], packed_elements_per_byte);
-  }
-
-  return TileInfo(std::move(offsets), std::move(tile_strides),
-                  std::move(original_shape), std::move(tile_sizes),
+  return TileInfo(std::move(storage_offsets), std::move(storage_tile_strides),
+                  std::move(storage_shape), std::move(storage_tile_sizes),
                   std::move(minor_to_major_layout), storage_type,
                   std::move(replica_id_offsets), std::move(replica_id_bounds));
 }
@@ -890,7 +912,7 @@ absl::StatusOr<TensorValue> EmitParameterExtract(mlir::ImplicitLocOpBuilder& b,
     ASSIGN_OR_RETURN(PrimitiveType element_type,
                      GetPrimitiveType(tile_info.storage_type()));
     xla::Shape spatial_shape = xla::ShapeUtil::MakeShapeWithDenseLayout(
-        element_type, tile_info.original_shape(),
+        element_type, tile_info.storage_shape(),
         tile_info.minor_to_major_layout());
     ASSIGN_OR_RETURN(mlir::MemRefType spatial_memref_type,
                      GetMemRefType(spatial_shape, tile_info.storage_type()));

--- a/xla/codegen/xtile/codegen/emitter_helpers.cc
+++ b/xla/codegen/xtile/codegen/emitter_helpers.cc
@@ -234,11 +234,10 @@ absl::StatusOr<int64_t> PackedElementsPerByte(PrimitiveType type) {
   return storage_bit_width / element_bit_width;
 }
 
-Value DivideIndexByPackedElementsPerByte(mlir::ImplicitLocOpBuilder& b,
-                                         Value value,
-                                         int64_t packed_elements_per_byte) {
+Value DivideBy(mlir::ImplicitLocOpBuilder& b, Value value,
+               int64_t elements_per_byte) {
   return ma::DivSIOp::create(
-      b, value, CreateConst(b, value.getType(), packed_elements_per_byte));
+      b, value, CreateConst(b, value.getType(), elements_per_byte));
 }
 
 }  // namespace
@@ -278,15 +277,15 @@ absl::StatusOr<SmallVector<int64_t>> GetStorageShape(
         absl::StrCat("Packed storage dimension is out of bounds for shape ",
                      logical_shape.ToString()));
   }
-  ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
+  ASSIGN_OR_RETURN(int64_t elements_per_byte,
                    PackedElementsPerByte(logical_shape.element_type()));
-  if (storage_shape[packed_dim] % packed_elements_per_byte != 0) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "Packed storage dimension must be divisible by ",
-        packed_elements_per_byte, ", got ", storage_shape[packed_dim],
-        " for shape ", logical_shape.ToString()));
+  if (storage_shape[packed_dim] % elements_per_byte != 0) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Packed storage dimension must be divisible by ",
+                     elements_per_byte, ", got ", storage_shape[packed_dim],
+                     " for shape ", logical_shape.ToString()));
   }
-  storage_shape[packed_dim] /= packed_elements_per_byte;
+  storage_shape[packed_dim] /= elements_per_byte;
   return storage_shape;
 }
 
@@ -306,20 +305,19 @@ absl::StatusOr<SmallVector<Value>> GetStorageOffsets(
         absl::StrCat("Packed storage dimension is out of bounds for shape ",
                      logical_shape.ToString()));
   }
-  ASSIGN_OR_RETURN(int64_t packed_elements_per_byte,
+  ASSIGN_OR_RETURN(int64_t elements_per_byte,
                    PackedElementsPerByte(logical_shape.element_type()));
   // Packed storage is byte-addressed along the layout-minor dimension, so the
   // logical offset must be aligned before converting it to a byte offset.
-  if (!logical_tile_offsets[packed_dim].IsMultipleOf(
-          packed_elements_per_byte)) {
+  if (!logical_tile_offsets[packed_dim].IsMultipleOf(elements_per_byte)) {
     return absl::InvalidArgumentError(
         absl::StrCat("Packed storage requires offset in dimension ", packed_dim,
-                     " to be divisible by ", packed_elements_per_byte,
-                     " for shape ", logical_shape.ToString(), ", got ",
+                     " to be divisible by ", elements_per_byte, " for shape ",
+                     logical_shape.ToString(), ", got ",
                      logical_tile_offsets[packed_dim].ToString()));
   }
-  storage_offsets[packed_dim] = DivideIndexByPackedElementsPerByte(
-      b, storage_offsets[packed_dim], packed_elements_per_byte);
+  storage_offsets[packed_dim] =
+      DivideBy(b, storage_offsets[packed_dim], elements_per_byte);
   return storage_offsets;
 }
 

--- a/xla/codegen/xtile/codegen/emitter_helpers.h
+++ b/xla/codegen/xtile/codegen/emitter_helpers.h
@@ -145,16 +145,18 @@ class TileInfo {
       EmitterContext& ctx,
       const gpu::experimental::TiledHloInstruction& tiled_hlo);
 
-  // Tile offsets. Its size is equal to the rank of the output shape.
+  // Tile offsets in storage coordinates. Its size is equal to the rank of the
+  // output shape.
   mlir::ValueRange offsets() const { return offsets_; }
 
-  // Tile strides. Its size is equal to the rank of the output shape.
+  // Tile strides in storage coordinates. Its size is equal to the rank of the
+  // output shape.
   mlir::ArrayRef<int64_t> tile_strides() const { return tile_strides_; }
 
-  // The original shape of the tensor.
-  mlir::ArrayRef<int64_t> original_shape() const { return original_shape_; }
+  // The full tensor shape in storage coordinates.
+  mlir::ArrayRef<int64_t> storage_shape() const { return storage_shape_; }
 
-  // Tile sizes after padding to a power of 2 (Triton requirement).
+  // Tile sizes in storage coordinates after padding to a power of 2.
   mlir::ArrayRef<int64_t> padded_tile_sizes() const {
     return padded_tile_sizes_;
   }
@@ -181,7 +183,7 @@ class TileInfo {
  private:
   llvm::SmallVector<mlir::Value> offsets_;
   llvm::SmallVector<int64_t> tile_strides_;
-  llvm::SmallVector<int64_t> original_shape_;
+  llvm::SmallVector<int64_t> storage_shape_;
   llvm::SmallVector<int64_t> padded_tile_sizes_;
   llvm::SmallVector<int64_t> minor_to_major_layout_;
   mlir::Type storage_type_;
@@ -190,7 +192,7 @@ class TileInfo {
 
   TileInfo(llvm::SmallVector<mlir::Value> offsets,             //
            llvm::SmallVector<int64_t> tile_strides,            //
-           llvm::SmallVector<int64_t> original_shape,          //
+           llvm::SmallVector<int64_t> storage_shape,           //
            llvm::SmallVector<int64_t> padded_tile_sizes,       //
            llvm::SmallVector<int64_t> minor_to_major_layout,   //
            mlir::Type storage_type,                            //
@@ -199,7 +201,7 @@ class TileInfo {
            )
       : offsets_(std::move(offsets)),
         tile_strides_(std::move(tile_strides)),
-        original_shape_(std::move(original_shape)),
+        storage_shape_(std::move(storage_shape)),
         padded_tile_sizes_(std::move(padded_tile_sizes)),
         minor_to_major_layout_(std::move(minor_to_major_layout)),
         storage_type_(std::move(storage_type)),
@@ -238,7 +240,7 @@ bool IsTritonDotScaledOperandType(PrimitiveType type);
 bool IsPackedTritonDotScaledOperandType(PrimitiveType type);
 
 absl::StatusOr<llvm::SmallVector<int64_t>> GetStorageShape(
-    llvm::ArrayRef<int64_t> logical_shape, const Shape& shape);
+    llvm::ArrayRef<int64_t> logical_shape_dims, const Shape& logical_shape);
 
 // Get the value of the scalar constant's literal in a C++ type.
 template <typename T>

--- a/xla/codegen/xtile/codegen/emitter_helpers.h
+++ b/xla/codegen/xtile/codegen/emitter_helpers.h
@@ -225,6 +225,21 @@ absl::StatusOr<PrimitiveType> GetPrimitiveType(mlir::Type t);
 mlir::Type StorageType(mlir::Type t);
 mlir::Type GetSignlessType(mlir::Type t);
 
+// Triton tt.dot_scaled takes scale operands only for low-precision lhs/rhs
+// value dtypes that it interprets through a dot-scaled element-type attribute.
+// Other HLO scaled-dot operand dtypes are emitted without attaching a scale
+// operand to tt.dot_scaled.
+bool IsTritonDotScaledOperandType(PrimitiveType type);
+
+// Some Triton dot-scaled value dtypes are smaller than one byte. XTile stores
+// those logical elements inside byte-sized carrier elements, so storage shapes
+// and offsets are expressed in carrier elements rather than logical elements.
+// For these operands, Triton's k_pack attribute is derived from the HLO layout.
+bool IsPackedTritonDotScaledOperandType(PrimitiveType type);
+
+absl::StatusOr<llvm::SmallVector<int64_t>> GetStorageShape(
+    llvm::ArrayRef<int64_t> logical_shape, const Shape& shape);
+
 // Get the value of the scalar constant's literal in a C++ type.
 template <typename T>
 T ScalarConstantValue(const HloInstruction& instr, PrimitiveType dst_type) {
@@ -378,7 +393,8 @@ absl::StatusOr<llvm::SmallVector<int64_t>> GetPermutationMinorToMajor(
     mlir::MemRefType memref);
 
 // Function to get a MemRefType from a Shape.
-mlir::MemRefType GetMemRefType(const Shape& shape, mlir::Type element_type);
+absl::StatusOr<mlir::MemRefType> GetMemRefType(const Shape& shape,
+                                               mlir::Type element_type);
 
 // Function to get the MLIR type from a PrimitiveType.
 absl::StatusOr<mlir::Type> GetMlirType(

--- a/xla/codegen/xtile/codegen/experimental_fusion_emitter.cc
+++ b/xla/codegen/xtile/codegen/experimental_fusion_emitter.cc
@@ -710,14 +710,14 @@ absl::StatusOr<TensorValue> EmitBitcast(
   auto& b = emitter_ctx.b();
   ASSIGN_OR_RETURN(Type output_element_type,
                    PrimitiveTypeToMlirType(b, output_primitive_type));
-  ASSIGN_OR_RETURN(SmallVector<int64_t> operand_tile_sizes,
+  ASSIGN_OR_RETURN(SmallVector<int64_t> operand_logical_tile_sizes,
                    tiled_bitcast.operand(0)->tile().GetStaticTileSizes());
-  ASSIGN_OR_RETURN(SmallVector<int64_t> output_tile_sizes,
+  ASSIGN_OR_RETURN(SmallVector<int64_t> output_logical_tile_sizes,
                    tiled_bitcast.tile().GetStaticTileSizes());
-  ASSIGN_OR_RETURN(operand_tile_sizes,
-                   GetStorageShape(operand_tile_sizes, input_shape));
-  ASSIGN_OR_RETURN(output_tile_sizes,
-                   GetStorageShape(output_tile_sizes, output_shape));
+  ASSIGN_OR_RETURN(SmallVector<int64_t> operand_storage_tile_sizes,
+                   GetStorageShape(operand_logical_tile_sizes, input_shape));
+  ASSIGN_OR_RETURN(SmallVector<int64_t> output_storage_tile_sizes,
+                   GetStorageShape(output_logical_tile_sizes, output_shape));
 
   // If the bitcast changes the element type to an element type of the same
   // bitwidth, we need to emit a ttir::BitcastOp.
@@ -728,8 +728,8 @@ absl::StatusOr<TensorValue> EmitBitcast(
           "Bitcast with different bitwidth for operand and output shape "
           "element type is not yet supported.");
     }
-    auto output_type =
-        mlir::RankedTensorType::get(operand_tile_sizes, output_element_type);
+    auto output_type = mlir::RankedTensorType::get(operand_storage_tile_sizes,
+                                                   output_element_type);
     input = mlir::cast<TensorValue>(
         mlir::tensor::BitcastOp::create(b, output_type, input).getResult());
     input_shape.set_element_type(output_shape.element_type());
@@ -740,7 +740,7 @@ absl::StatusOr<TensorValue> EmitBitcast(
     if (std::optional<std::vector<int64_t>> transpose_dims =
             ShapeUtil::DeduceTransposeDimensionsForBitcast(input_shape,
                                                            output_shape)) {
-      return EmitTiledTranspose(b, output_tile_sizes,
+      return EmitTiledTranspose(b, output_storage_tile_sizes,
                                 llvm::to_vector(*transpose_dims), input);
     }
   }
@@ -748,8 +748,8 @@ absl::StatusOr<TensorValue> EmitBitcast(
   // Bitcast is reshape.
   if (ShapeUtil::ReshapeIsBitcast(input_shape, output_shape,
                                   /*ignore_element_type=*/true)) {
-    return EmitTiledBroadcastedReshape(b, output_shape, output_tile_sizes,
-                                       input);
+    return EmitTiledBroadcastedReshape(b, output_shape,
+                                       output_storage_tile_sizes, input);
   }
 
   // Bitcast is decomposable to a transpose+reshape+transpose.
@@ -770,7 +770,7 @@ absl::StatusOr<TensorValue> EmitBitcast(
   // different, even in rank, compared to the tile sizes of the final shape of
   // the bitcast, so it's not possible to easily propagate them from the output.
   std::vector<int64_t> transpose1_tile_sizes =
-      Permute(operand_tile_sizes, trt->transpose1_dims);
+      Permute(operand_storage_tile_sizes, trt->transpose1_dims);
   TensorValue normalized_input =
       trt->IsTranspose1Identity()
           ? input
@@ -783,7 +783,7 @@ absl::StatusOr<TensorValue> EmitBitcast(
   // the tile sizes of the reshape, we compute the tile sizes backwards, taking
   // the inverse permutation.
   std::vector<int64_t> reshape_tile_sizes =
-      PermuteInverse(output_tile_sizes, trt->transpose2_dims);
+      PermuteInverse(output_storage_tile_sizes, trt->transpose2_dims);
   TensorValue normalized_reshape;
   if (ShapeUtil::Equal(trt->transpose1_shape, trt->reshape_shape)) {
     normalized_reshape = normalized_input;
@@ -798,7 +798,7 @@ absl::StatusOr<TensorValue> EmitBitcast(
   // bitcast by the tiling analysis.
   return trt->IsTranspose2Identity()
              ? normalized_reshape
-             : EmitTiledTranspose(b, output_tile_sizes,
+             : EmitTiledTranspose(b, output_storage_tile_sizes,
                                   llvm::to_vector(trt->transpose2_dims),
                                   normalized_reshape);
 }
@@ -1095,19 +1095,23 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
       return EmitPad(emitter_ctx, tiled_hlo);
     }
     case HloOpcode::kReshape: {
-      ASSIGN_OR_RETURN(auto tile_sizes, tiled_hlo.tile().GetStaticTileSizes());
-      ASSIGN_OR_RETURN(tile_sizes, GetStorageShape(tile_sizes, hlo->shape()));
+      ASSIGN_OR_RETURN(auto logical_tile_sizes,
+                       tiled_hlo.tile().GetStaticTileSizes());
+      ASSIGN_OR_RETURN(auto storage_tile_sizes,
+                       GetStorageShape(logical_tile_sizes, hlo->shape()));
       return EmitTiledReshape(
-          emitter_ctx.b(), tile_sizes,
+          emitter_ctx.b(), storage_tile_sizes,
           emitter_ctx.TiledHloToTensorValue(*tiled_hlo.operand(0)));
     }
     case HloOpcode::kSlice: {
       return emitter_ctx.TiledHloToTensorValue(*tiled_hlo.operand(0));
     }
     case HloOpcode::kTranspose: {
-      ASSIGN_OR_RETURN(auto tile_sizes, tiled_hlo.tile().GetStaticTileSizes());
-      ASSIGN_OR_RETURN(tile_sizes, GetStorageShape(tile_sizes, hlo->shape()));
-      return EmitTranspose(b, tile_sizes, hlo->dimensions(),
+      ASSIGN_OR_RETURN(auto logical_tile_sizes,
+                       tiled_hlo.tile().GetStaticTileSizes());
+      ASSIGN_OR_RETURN(auto storage_tile_sizes,
+                       GetStorageShape(logical_tile_sizes, hlo->shape()));
+      return EmitTranspose(b, storage_tile_sizes, hlo->dimensions(),
                            mlir::cast<TensorValue>(operands[0]));
     }
     case HloOpcode::kReduce: {

--- a/xla/codegen/xtile/codegen/experimental_fusion_emitter.cc
+++ b/xla/codegen/xtile/codegen/experimental_fusion_emitter.cc
@@ -714,6 +714,10 @@ absl::StatusOr<TensorValue> EmitBitcast(
                    tiled_bitcast.operand(0)->tile().GetStaticTileSizes());
   ASSIGN_OR_RETURN(SmallVector<int64_t> output_tile_sizes,
                    tiled_bitcast.tile().GetStaticTileSizes());
+  ASSIGN_OR_RETURN(operand_tile_sizes,
+                   GetStorageShape(operand_tile_sizes, input_shape));
+  ASSIGN_OR_RETURN(output_tile_sizes,
+                   GetStorageShape(output_tile_sizes, output_shape));
 
   // If the bitcast changes the element type to an element type of the same
   // bitwidth, we need to emit a ttir::BitcastOp.
@@ -1022,8 +1026,10 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
             "while lowering ",
             fusion.called_computation()->ToString()));
       }
-      parameter =
-          mlir::cast<TensorValue>(Cast(b, parameter, expected_element_type));
+      if (!IsPackedTritonDotScaledOperandType(hlo->shape().element_type())) {
+        parameter =
+            mlir::cast<TensorValue>(Cast(b, parameter, expected_element_type));
+      }
     }
     return parameter;
   }
@@ -1090,6 +1096,7 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
     }
     case HloOpcode::kReshape: {
       ASSIGN_OR_RETURN(auto tile_sizes, tiled_hlo.tile().GetStaticTileSizes());
+      ASSIGN_OR_RETURN(tile_sizes, GetStorageShape(tile_sizes, hlo->shape()));
       return EmitTiledReshape(
           emitter_ctx.b(), tile_sizes,
           emitter_ctx.TiledHloToTensorValue(*tiled_hlo.operand(0)));
@@ -1099,6 +1106,7 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
     }
     case HloOpcode::kTranspose: {
       ASSIGN_OR_RETURN(auto tile_sizes, tiled_hlo.tile().GetStaticTileSizes());
+      ASSIGN_OR_RETURN(tile_sizes, GetStorageShape(tile_sizes, hlo->shape()));
       return EmitTranspose(b, tile_sizes, hlo->dimensions(),
                            mlir::cast<TensorValue>(operands[0]));
     }

--- a/xla/codegen/xtile/codegen/fusion_emitter.cc
+++ b/xla/codegen/xtile/codegen/fusion_emitter.cc
@@ -272,6 +272,12 @@ absl::StatusOr<TensorValue> EmitTiledBitcast(
     TensorValue input) {
   Shape input_shape = tiled_bitcast.hlo()->operand(0)->shape();
   const Shape& output_shape = tiled_bitcast.hlo()->shape();
+  TF_ASSIGN_OR_RETURN(
+      SmallVector<int64_t> input_tile_sizes,
+      GetStorageShape(tiled_bitcast.operand(0)->tile_sizes(), input_shape));
+  TF_ASSIGN_OR_RETURN(
+      SmallVector<int64_t> output_tile_sizes,
+      GetStorageShape(tiled_bitcast.tile_sizes(), output_shape));
   // If the bitcast changes the element type to an element type of the same
   // bitwidth, we need to emit a ttir::BitcastOp.
   if (input_shape.element_type() != output_shape.element_type()) {
@@ -284,8 +290,7 @@ absl::StatusOr<TensorValue> EmitTiledBitcast(
     ASSIGN_OR_RETURN(Type output_element_type,
                      PrimitiveTypeToMlirType(b, output_shape.element_type()));
     auto output_type = mlir::RankedTensorType::get(
-        GetPaddedTileSizes(tiled_bitcast.operand(0)->tile_sizes()),
-        output_element_type);
+        GetPaddedTileSizes(input_tile_sizes), output_element_type);
     input = mlir::cast<TensorValue>(
         mlir::tensor::BitcastOp::create(b, output_type, input).getResult());
     input_shape.set_element_type(output_shape.element_type());
@@ -309,7 +314,7 @@ absl::StatusOr<TensorValue> EmitTiledBitcast(
   // different, even in rank, compared to the tile sizes of the final shape of
   // the bitcast, so it's not possible to easily propagate them from the output.
   std::vector<int64_t> transpose1_tile_sizes =
-      Permute(tiled_bitcast.operand(0)->tile_sizes(), trt->transpose1_dims);
+      Permute(input_tile_sizes, trt->transpose1_dims);
   TensorValue normalized_input =
       trt->IsTranspose1Identity()
           ? input
@@ -322,7 +327,7 @@ absl::StatusOr<TensorValue> EmitTiledBitcast(
   // the tile sizes of the reshape, we compute the tile sizes backwards, taking
   // the inverse permutation.
   std::vector<int64_t> reshape_tile_sizes =
-      PermuteInverse(tiled_bitcast.tile_sizes(), trt->transpose2_dims);
+      PermuteInverse(output_tile_sizes, trt->transpose2_dims);
   TensorValue normalized_reshape;
   if (ShapeUtil::Equal(trt->transpose1_shape, trt->reshape_shape)) {
     normalized_reshape = normalized_input;
@@ -335,7 +340,7 @@ absl::StatusOr<TensorValue> EmitTiledBitcast(
   // bitcast by the tiling analysis.
   return trt->IsTranspose2Identity()
              ? normalized_reshape
-             : EmitTiledTranspose(b, tiled_bitcast.tile_sizes(),
+             : EmitTiledTranspose(b, output_tile_sizes,
                                   llvm::to_vector(trt->transpose2_dims),
                                   normalized_reshape);
 }
@@ -990,8 +995,10 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
             "while lowering ",
             fusion.called_computation()->ToString()));
       }
-      parameter =
-          mlir::cast<TensorValue>(Cast(b, parameter, expected_element_type));
+      if (!IsPackedTritonDotScaledOperandType(hlo->shape().element_type())) {
+        parameter =
+            mlir::cast<TensorValue>(Cast(b, parameter, expected_element_type));
+      }
     }
 
     return parameter;
@@ -1056,7 +1063,9 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
   }
 
   if (hlo->opcode() == HloOpcode::kReshape) {
-    return EmitTiledReshape(b, tiled_hlo.tile_sizes(),
+    TF_ASSIGN_OR_RETURN(SmallVector<int64_t> storage_tile_sizes,
+                        GetStorageShape(tiled_hlo.tile_sizes(), hlo->shape()));
+    return EmitTiledReshape(b, storage_tile_sizes,
                             values[tiled_hlo.operand(0)]);
   }
 
@@ -1067,7 +1076,9 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
   if (hlo->opcode() == HloOpcode::kTranspose) {
     auto transpose =
         ::xla::Cast<const HloTransposeInstruction>(tiled_hlo.hlo());
-    return EmitTiledTranspose(b, tiled_hlo.tile_sizes(),
+    TF_ASSIGN_OR_RETURN(SmallVector<int64_t> storage_tile_sizes,
+                        GetStorageShape(tiled_hlo.tile_sizes(), hlo->shape()));
+    return EmitTiledTranspose(b, storage_tile_sizes,
                               llvm::to_vector(transpose->dimensions()),
                               values[tiled_hlo.operand(0)]);
   }

--- a/xla/codegen/xtile/codegen/fusion_emitter.cc
+++ b/xla/codegen/xtile/codegen/fusion_emitter.cc
@@ -272,12 +272,11 @@ absl::StatusOr<TensorValue> EmitTiledBitcast(
     TensorValue input) {
   Shape input_shape = tiled_bitcast.hlo()->operand(0)->shape();
   const Shape& output_shape = tiled_bitcast.hlo()->shape();
-  TF_ASSIGN_OR_RETURN(
+  ASSIGN_OR_RETURN(
       SmallVector<int64_t> input_tile_sizes,
       GetStorageShape(tiled_bitcast.operand(0)->tile_sizes(), input_shape));
-  TF_ASSIGN_OR_RETURN(
-      SmallVector<int64_t> output_tile_sizes,
-      GetStorageShape(tiled_bitcast.tile_sizes(), output_shape));
+  ASSIGN_OR_RETURN(SmallVector<int64_t> output_tile_sizes,
+                   GetStorageShape(tiled_bitcast.tile_sizes(), output_shape));
   // If the bitcast changes the element type to an element type of the same
   // bitwidth, we need to emit a ttir::BitcastOp.
   if (input_shape.element_type() != output_shape.element_type()) {
@@ -1063,8 +1062,8 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
   }
 
   if (hlo->opcode() == HloOpcode::kReshape) {
-    TF_ASSIGN_OR_RETURN(SmallVector<int64_t> storage_tile_sizes,
-                        GetStorageShape(tiled_hlo.tile_sizes(), hlo->shape()));
+    ASSIGN_OR_RETURN(SmallVector<int64_t> storage_tile_sizes,
+                     GetStorageShape(tiled_hlo.tile_sizes(), hlo->shape()));
     return EmitTiledReshape(b, storage_tile_sizes,
                             values[tiled_hlo.operand(0)]);
   }
@@ -1076,8 +1075,8 @@ absl::StatusOr<TensorValue> EmitTiledHloInstruction(
   if (hlo->opcode() == HloOpcode::kTranspose) {
     auto transpose =
         ::xla::Cast<const HloTransposeInstruction>(tiled_hlo.hlo());
-    TF_ASSIGN_OR_RETURN(SmallVector<int64_t> storage_tile_sizes,
-                        GetStorageShape(tiled_hlo.tile_sizes(), hlo->shape()));
+    ASSIGN_OR_RETURN(SmallVector<int64_t> storage_tile_sizes,
+                     GetStorageShape(tiled_hlo.tile_sizes(), hlo->shape()));
     return EmitTiledTranspose(b, storage_tile_sizes,
                               llvm::to_vector(transpose->dimensions()),
                               values[tiled_hlo.operand(0)]);

--- a/xla/codegen/xtile/codegen/fusion_emitter.cc
+++ b/xla/codegen/xtile/codegen/fusion_emitter.cc
@@ -273,9 +273,9 @@ absl::StatusOr<TensorValue> EmitTiledBitcast(
   Shape input_shape = tiled_bitcast.hlo()->operand(0)->shape();
   const Shape& output_shape = tiled_bitcast.hlo()->shape();
   ASSIGN_OR_RETURN(
-      SmallVector<int64_t> input_tile_sizes,
+      SmallVector<int64_t> input_storage_tile_sizes,
       GetStorageShape(tiled_bitcast.operand(0)->tile_sizes(), input_shape));
-  ASSIGN_OR_RETURN(SmallVector<int64_t> output_tile_sizes,
+  ASSIGN_OR_RETURN(SmallVector<int64_t> output_storage_tile_sizes,
                    GetStorageShape(tiled_bitcast.tile_sizes(), output_shape));
   // If the bitcast changes the element type to an element type of the same
   // bitwidth, we need to emit a ttir::BitcastOp.
@@ -289,7 +289,7 @@ absl::StatusOr<TensorValue> EmitTiledBitcast(
     ASSIGN_OR_RETURN(Type output_element_type,
                      PrimitiveTypeToMlirType(b, output_shape.element_type()));
     auto output_type = mlir::RankedTensorType::get(
-        GetPaddedTileSizes(input_tile_sizes), output_element_type);
+        GetPaddedTileSizes(input_storage_tile_sizes), output_element_type);
     input = mlir::cast<TensorValue>(
         mlir::tensor::BitcastOp::create(b, output_type, input).getResult());
     input_shape.set_element_type(output_shape.element_type());
@@ -313,7 +313,7 @@ absl::StatusOr<TensorValue> EmitTiledBitcast(
   // different, even in rank, compared to the tile sizes of the final shape of
   // the bitcast, so it's not possible to easily propagate them from the output.
   std::vector<int64_t> transpose1_tile_sizes =
-      Permute(input_tile_sizes, trt->transpose1_dims);
+      Permute(input_storage_tile_sizes, trt->transpose1_dims);
   TensorValue normalized_input =
       trt->IsTranspose1Identity()
           ? input
@@ -326,7 +326,7 @@ absl::StatusOr<TensorValue> EmitTiledBitcast(
   // the tile sizes of the reshape, we compute the tile sizes backwards, taking
   // the inverse permutation.
   std::vector<int64_t> reshape_tile_sizes =
-      PermuteInverse(output_tile_sizes, trt->transpose2_dims);
+      PermuteInverse(output_storage_tile_sizes, trt->transpose2_dims);
   TensorValue normalized_reshape;
   if (ShapeUtil::Equal(trt->transpose1_shape, trt->reshape_shape)) {
     normalized_reshape = normalized_input;
@@ -339,7 +339,7 @@ absl::StatusOr<TensorValue> EmitTiledBitcast(
   // bitcast by the tiling analysis.
   return trt->IsTranspose2Identity()
              ? normalized_reshape
-             : EmitTiledTranspose(b, output_tile_sizes,
+             : EmitTiledTranspose(b, output_storage_tile_sizes,
                                   llvm::to_vector(trt->transpose2_dims),
                                   normalized_reshape);
 }


### PR DESCRIPTION
📝 Summary of Changes
Update XTile codegen to model packed FP4 scaled-dot operands using their physical storage shape and storage element type. For packed f4E2M1FN operands, XTile now uses i8 storage, divides the packed layout-minor dimension by the number of FP4 elements per byte, adjusts tile offsets for the packed storage coordinate system, and validates that packed tiles use unit stride and byte-aligned offsets. This is the second PR in the decomposition of the larger scaled-dot fix series: https://github.com/openxla/xla/pull/44223.

🎯 Justification
FP4 scaled-dot operands are stored packed: two logical f4E2M1FN values live in one byte. After https://github.com/openxla/xla/pull/44885, XTile can carry the logical dot element type separately from the tensor storage type. This PR makes the tile and memref storage side consistent with that contract.

This cannot be delayed until Triton lowering because XTile already materializes memref types, tile shapes, slice offsets, and extract geometry before Triton sees the operation. If XTile keeps using logical FP4 shapes at that layer, it can describe incorrect byte storage shapes, tile sizes, and offsets for packed FP4 data. This matters for NVFP4/MXFP4 scaled-dot workloads lowered through Triton, where Triton expects e2m1 operands to be carried as packed i8 storage.

🚀 Kind of Contribution
🐛 Bug Fix, 🧪 Tests

🧪 Unit Tests:
TritonDevicelessTest.RejectsPackedFp4OddMinorOffset verifies that packed FP4 tiles reject byte-unaligned minor offsets.
TritonDevicelessTest.EmitsPackedFp4StorageForEvenMinorOffset verifies that byte-aligned packed FP4 operands use packed i8 memrefs/tensors, storage-coordinate offsets, and dot_scaled i8 storage element types.