### PR TITLE
[ROCm] Make rocm_ci.yml callable from withing rocm-dev-infra prs

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -26,6 +26,11 @@ on:
         required: false
         default: 'rocm-dev-infra'
         type: string
+      runner_label:
+        description: 'Runner label for GPU jobs'
+        required: false
+        default: 'amd-do-linux-xla-gpu-gfx950-1'
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -47,7 +52,7 @@ jobs:
     needs: rocm-config
     if: ${{ github.event_name != 'pull_request' || github.base_ref == 'main' }}
     name: JAX Linux x86 AMD Instinct GPU
-    runs-on: amd-do-linux-xla-gpu-gfx950-1
+    runs-on: ${{ inputs.runner_label || 'amd-do-linux-xla-gpu-gfx950-1' }}
     timeout-minutes: 80
     env:
       DOCKER_IMAGE: ${{ needs.rocm-config.outputs.docker-image }}
@@ -111,7 +116,7 @@ jobs:
   xla:
     needs: rocm-config
     name: XLA Linux x86 AMD Instinct GPU
-    runs-on: amd-do-linux-xla-gpu-gfx950-1
+    runs-on: ${{ inputs.runner_label || 'amd-do-linux-xla-gpu-gfx950-1' }}
     timeout-minutes: 220
     env:
       DOCKER_IMAGE: ${{ needs.rocm-config.outputs.docker-image }}

--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -19,6 +19,13 @@ permissions:
 on:
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      rocm_xla_branch:
+        description: 'Branch name to fetch ROCm XLA scripts from'
+        required: false
+        default: 'rocm-dev-infra'
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -108,7 +115,7 @@ jobs:
     timeout-minutes: 220
     env:
       DOCKER_IMAGE: ${{ needs.rocm-config.outputs.docker-image }}
-      EXECUTE_CI_BUILD_URL: https://raw.githubusercontent.com/ROCm/xla/refs/heads/rocm-dev-infra/build_tools/rocm/execute_ci_build_upstream.sh
+      EXECUTE_CI_BUILD_URL: https://raw.githubusercontent.com/ROCm/xla/refs/heads/${{ inputs.rocm_xla_branch || 'rocm-dev-infra' }}/build_tools/rocm/execute_ci_build_upstream.sh
     container: *rocm_container
     defaults:
       run:

--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Checking out openxla/xla
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          repository: openxla/xla
           persist-credentials: false
 
       - name: Checkout JAX
@@ -129,6 +130,7 @@ jobs:
       - name: Checking out openxla/xla
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          repository: openxla/xla
           persist-credentials: false
 
       - name: Fetch ROCm XLA Upstream Script from ROCm/xla


### PR DESCRIPTION
📝 Summary of Changes
Make rocm-ci.yml be callable from within

🎯 Justification
We do maintain a shim script that is called on each pr check.
We use it to maintain our infrastructure and build flags for rocm config.
We would like to test shim adaptions against the exact upstream ci workflow we use in xla.

🚀 Kind of Contribution
Please remove what does not apply:  🧪 Tests

📊 Benchmark (for Performance Improvements)
Not relevant, CI

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
