### PR TITLE
[XLA:GPU][ROCm] Fix absl::bit_cast in device code for GCC 13 compatibility

### DIFF
--- a/xla/stream_executor/rocm/buffer_debug_float_check_kernel_rocm.cu.cc
+++ b/xla/stream_executor/rocm/buffer_debug_float_check_kernel_rocm.cu.cc
@@ -38,12 +38,11 @@ namespace stream_executor::gpu {
 
 template <>
 __device__ constexpr hip_bfloat16 kInfinity<hip_bfloat16> =
-    absl::bit_cast<hip_bfloat16>(static_cast<uint16_t>(
-        absl::bit_cast<uint32_t>(kInfinity<float>) >> 16));
+    __builtin_bit_cast(hip_bfloat16, uint16_t{0x7F80});
 
 template <>
 __device__ constexpr _Float16 kInfinity<_Float16> =
-    absl::bit_cast<_Float16>(uint16_t{0x7C00});
+    __builtin_bit_cast(_Float16, uint16_t{0x7C00});
 
 template <>
 __device__ inline bool IsNan(hip_bfloat16 v) {
@@ -72,8 +71,9 @@ __device__ inline bool IsZero(_Float16 v) {
 
 template <>
 __device__ _Float16 WarpShuffleDown(_Float16 value, unsigned int offset) {
-  return absl::bit_cast<_Float16>(static_cast<uint16_t>(
-      __shfl_down(absl::bit_cast<uint16_t>(value), offset)));
+  return __builtin_bit_cast(
+      _Float16, static_cast<uint16_t>(
+                    __shfl_down(__builtin_bit_cast(uint16_t, value), offset)));
 }
 
 template <typename T>


### PR DESCRIPTION
PR #44389 introduced `buffer_debug_float_check_kernel_rocm.cu.cc`, which uses `absl::bit_cast` in `__device__ constexpr` initializers. This breaks the rocm_clang_local build on Ubuntu 24.04 where GCC 13 is the default.

GCC 13 reimplemented `std::__or_<>` using __or_fn helper functions that are not annotated `__host__ __device__`. This causes clang/HIP to reject instantiation of `std::is_trivially_copyable` (via `__is_complete_or_unbounded`) from device context during overload resolution, even when the type is complete and the slow overload is never actually called.

absl::bit_cast triggers this via its static_assert on is_trivially_copyable. Replace `absl::bit_cast` with `__builtin_bit_cast` in `__device__ code`, which is a compiler intrinsic and bypasses standard library type trait machinery entirely. Also substitute the bfloat16 infinity bit pattern (0x7F80) directly.