### PR TITLE
[tsl] Fix FileSystem::Extension for paths with a directory component

### DIFF
--- a/xla/tsl/platform/file_system.cc
+++ b/xla/tsl/platform/file_system.cc
@@ -376,7 +376,9 @@ absl::string_view FileSystem::Extension(absl::string_view path) const {
   if (pos == absl::string_view::npos) {
     return absl::string_view(path.data() + path.size(), 0);
   } else {
-    return absl::string_view(path.data() + pos + 1, path.size() - (pos + 1));
+    // pos indexes into basename, so slice basename rather than path.
+    return absl::string_view(basename.data() + pos + 1,
+                             basename.size() - (pos + 1));
   }
 }
 

--- a/xla/tsl/platform/ram_file_system_test.cc
+++ b/xla/tsl/platform/ram_file_system_test.cc
@@ -110,5 +110,13 @@ TEST(RamFileSystemTest, ReadAfterWrite) {
   }
 }
 
+TEST(RamFileSystemTest, ExtensionUsesBasenameForPathsWithDirectory) {
+  RamFileSystem fs;
+  EXPECT_EQ(fs.Extension("dir/file.txt"), "txt");
+  EXPECT_EQ(fs.Extension("a/b/c/name.tar.gz"), "gz");
+  EXPECT_EQ(fs.Extension("/tmp/foo.log"), "log");
+  EXPECT_EQ(fs.Extension("file.txt"), "txt");
+  EXPECT_EQ(fs.Extension("noext"), "");
+}
 }  // namespace
 }  // namespace tsl


### PR DESCRIPTION
### Problem

`FileSystem::Extension` (`xla/tsl/platform/file_system.cc`) is meant to return the characters after the final `.` in a path's basename. It computes `pos` as the offset of the last `.` **within `basename`**, but then constructs the returned `string_view` from the **full `path`**:

```cpp
absl::string_view basename = this->Basename(path);
size_t pos = basename.rfind('.');
...
return absl::string_view(path.data() + pos + 1, path.size() - (pos + 1));  // uses path, not basename
```

`basename` is a later substring of `path` whenever `path` has a directory component, so applying the basename-relative `pos` to `path` indexes into the wrong location:

```
Extension("dir/file.txt")      -> "ile.txt"    (expected "txt")
Extension("a/b/c/name.tar.gz") -> "e.tar.gz"   (expected "gz")
Extension("/tmp/foo.log")      -> "/foo.log"   (expected "log")
Extension("file.txt")          -> "txt"        (correct — no directory)
Extension("noext")             -> ""           (correct)
```

The result is correct only in the `basename == path` case (no directory component).

### Fix

Build the returned view from `basename`, which is where `pos` was computed:

```cpp
return absl::string_view(basename.data() + pos + 1,
                         basename.size() - (pos + 1));
```

### Tests

Added `RamFileSystemTest.ExtensionUsesBasenameForPathsWithDirectory` to `xla/tsl/platform/ram_file_system_test.cc` (using `RamFileSystem` to exercise the inherited `FileSystem::Extension`). It covers directory-prefixed paths, an absolute path, a no-directory path, and a no-extension path; it fails on the current code and passes with the fix. There was previously no test covering `FileSystem::Extension`, which is how this survived.
