### PR TITLE
[xla:gpu] Don't forget to lookup allocation override in ThunkEmitter::GetShapedSliceForHlo

### DIFF
--- a/xla/backends/gpu/tests/dynamic_slice_fusion_v2_test.cc
+++ b/xla/backends/gpu/tests/dynamic_slice_fusion_v2_test.cc
@@ -248,6 +248,79 @@ TEST_F(DynamicSliceFusionV2Test, SingleOutputOneDUSWithOffsetExpression) {
   EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
 }
 
+TEST_F(DynamicSliceFusionV2Test, CublasLtMatmulWithBitcastSlicedOperand) {
+  const char* hlo = R"(
+    HloModule test, is_scheduled=true
+
+    %dsf_computation {
+      %p0 = f32[4,4] parameter(0)
+      %p1 = f32[1,4] parameter(1)
+      %p2 = s32[] parameter(2)
+      %zero = s32[] constant(0)
+      %ds = f32[1,4] dynamic-slice(%p0, %p2, %zero),
+        dynamic_slice_sizes={1,4},
+        backend_config={"dynamic_slice_config":
+          {"loop_index":0,"byte_offset":0,"byte_stride":16}}
+      %lhs = f32[4,1] bitcast(%ds)
+      ROOT %gemm = f32[4,4] custom-call(%lhs, %p1),
+        custom_call_target="__cublas$lt$matmul",
+        backend_config={"gemm_backend_config":{"alpha_real":1,"alpha_imag":0,
+          "beta":0,"dot_dimension_numbers":{"lhs_contracting_dimensions":["1"],
+          "rhs_contracting_dimensions":["0"],"lhs_batch_dimensions":[],
+          "rhs_batch_dimensions":[]},"precision_config":{"operand_precision":["DEFAULT",
+          "DEFAULT"],"algorithm":"ALG_UNSET"},"epilogue":"DEFAULT","grad_x":false,
+          "grad_y":false,"damax_output":false}}
+    }
+
+    body {
+      param = (s32[], f32[4,4], f32[1,4], f32[4,4]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      input = f32[4,4] get-tuple-element(param), index=1
+      rhs = f32[1,4] get-tuple-element(param), index=2
+      output = f32[4,4] get-tuple-element(param), index=3
+      updated = f32[4,4] fusion(input, rhs, i),
+        kind=kCustom, calls=%dsf_computation,
+        backend_config={"fusion_backend_config":{
+          "kind":"__custom_fusion",
+          "custom_fusion_config":
+            {"name":"dynamic_slice_fusion"}}}
+      one = s32[] constant(1)
+      next_i = s32[] add(i, one)
+      ROOT tuple = (s32[], f32[4,4], f32[1,4], f32[4,4])
+        tuple(next_i, input, rhs, updated)
+    }
+
+    cond {
+      param = (s32[], f32[4,4], f32[1,4], f32[4,4]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      limit = s32[] constant(4)
+      ROOT cmp = pred[] compare(i, limit), direction=LT
+    }
+
+    ENTRY main {
+      zero = s32[] constant(0)
+      input = f32[4,4] broadcast(f32[] constant(1)), dimensions={}
+      rhs = f32[1,4] broadcast(f32[] constant(1)), dimensions={}
+      init_output = f32[4,4] broadcast(f32[] constant(0)), dimensions={}
+      init = (s32[], f32[4,4], f32[1,4], f32[4,4])
+        tuple(zero, input, rhs, init_output)
+      while = (s32[], f32[4,4], f32[1,4], f32[4,4])
+        while(init), condition=cond, body=body
+      ROOT result = f32[4,4] get-tuple-element(while), index=3
+    }
+  )";
+
+  Literal expected = LiteralUtil::CreateR2<float>({{1.0f, 1.0f, 1.0f, 1.0f},
+                                                   {1.0f, 1.0f, 1.0f, 1.0f},
+                                                   {1.0f, 1.0f, 1.0f, 1.0f},
+                                                   {1.0f, 1.0f, 1.0f, 1.0f}});
+
+  ASSERT_OK_AND_ASSIGN(
+      Literal result, Execute(std::move(*ParseAndReturnVerifiedModule(hlo)), {},
+                              /*run_hlo_passes=*/false));
+  EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
+}
+
 TEST_F(DynamicSliceFusionV2Test, TupleOutputTwoDUS) {
   const char* hlo = R"(
     HloModule test, is_scheduled=true

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -991,22 +991,38 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitPtxCustomCall(
   return GetThunkSequence(std::move(thunk));
 }
 
+std::optional<BufferAllocation::Slice> ThunkEmitter::GetAllocationOverride(
+    const HloInstruction* instr, const ShapeIndex& index) const {
+  auto it = allocation_overrides_.find(instr);
+  if (it == allocation_overrides_.end()) {
+    return std::nullopt;
+  }
+
+  int64_t flat_idx = index.empty() ? 0 : index[0];
+  if (flat_idx >= 0 && static_cast<size_t>(flat_idx) < it->second.size()) {
+    return it->second[static_cast<size_t>(flat_idx)];
+  }
+
+  return std::nullopt;
+}
+
 absl::StatusOr<BufferAllocation::Slice> ThunkEmitter::GetAllocationSliceForHlo(
     const HloInstruction* instr, const ShapeIndex& index) const {
-  if (!allocation_overrides_.empty()) {
-    auto it = allocation_overrides_.find(instr);
-    if (it != allocation_overrides_.end()) {
-      int64_t flat_idx = index.empty() ? 0 : index[0];
-      if (flat_idx < it->second.size()) {
-        return it->second[flat_idx];
-      }
-    }
+  if (std::optional<BufferAllocation::Slice> slice =
+          GetAllocationOverride(instr, index)) {
+    return *slice;
   }
+
   return ir_emitter_context_->buffer_assignment().GetUniqueSlice(instr, index);
 }
 
 absl::StatusOr<ShapedSlice> ThunkEmitter::GetShapedSliceForHlo(
     const HloInstruction* instr, const ShapeIndex& index) const {
+  if (std::optional<BufferAllocation::Slice> slice =
+          GetAllocationOverride(instr, index)) {
+    return ShapedSlice{*slice, ShapeUtil::GetSubshape(instr->shape(), index)};
+  }
+
   ASSIGN_OR_RETURN(BufferAllocation::Slice slice,
                    GetAllocationSliceForHlo(instr, index));
   ASSIGN_OR_RETURN(

--- a/xla/service/gpu/thunk_emitter.h
+++ b/xla/service/gpu/thunk_emitter.h
@@ -221,6 +221,8 @@ class ThunkEmitter {
   AsyncThunkSequence EmitDynamicSliceFusionV2(
       const HloFusionInstruction* instr);
 
+  std::optional<BufferAllocation::Slice> GetAllocationOverride(
+      const HloInstruction* instr, const ShapeIndex& index) const;
   absl::StatusOr<BufferAllocation::Slice> GetAllocationSliceForHlo(
       const HloInstruction* instr, const ShapeIndex& index = {}) const;
   absl::StatusOr<ShapedSlice> GetShapedSliceForHlo(


### PR DESCRIPTION
This should be a fix for test that failed with dynamic slice fusion (reverted in https://github.com/openxla/xla/commit/54cc9d947d21a00c937367300ed91a733a8b1f08)