### PR TITLE
[XLA:GPU] Cache CommandExecutor update requirements

### DIFF
--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -292,6 +292,7 @@ CommandExecutor::CommandExecutor(
   commands_.Walk([&](const Command* command) {
     Command::BufferUses buffer_uses = command->buffer_uses();
     buffer_uses_.insert(buffer_uses.begin(), buffer_uses.end());
+    requires_update_on_execute_ |= command->requires_update_on_execute();
   });
 
   // Buffer allocations referenced by all buffer uses.

--- a/xla/backends/gpu/runtime/command_executor.cc
+++ b/xla/backends/gpu/runtime/command_executor.cc
@@ -292,6 +292,7 @@ CommandExecutor::CommandExecutor(
   commands_.Walk([&](const Command* command) {
     Command::BufferUses buffer_uses = command->buffer_uses();
     buffer_uses_.insert(buffer_uses.begin(), buffer_uses.end());
+    requires_update_on_initialize_ |= command->requires_update_on_initialize();
     requires_update_on_execute_ |= command->requires_update_on_execute();
   });
 

--- a/xla/backends/gpu/runtime/command_executor.h
+++ b/xla/backends/gpu/runtime/command_executor.h
@@ -155,11 +155,7 @@ class CommandExecutor {
   size_t size() const { return commands_.size(); }
 
   bool requires_update_on_initialize() const {
-    bool requires_update_on_initialize = false;
-    commands_.Walk([&](const Command* command) {
-      requires_update_on_initialize |= command->requires_update_on_initialize();
-    });
-    return requires_update_on_initialize;
+    return requires_update_on_initialize_;
   }
 
   bool requires_warmup() const {
@@ -256,6 +252,10 @@ class CommandExecutor {
   // Unique buffer allocations indices referenced by all commands in this
   // sequence (sorted by the buffer allocation index).
   std::vector<BufferAllocation::Index> allocs_indices_;
+
+  // Whether any command in this sequence requires an update during
+  // initialization.
+  bool requires_update_on_initialize_ = false;
 
   // Whether any command in this sequence requires an update on every
   // execution.

--- a/xla/backends/gpu/runtime/command_executor.h
+++ b/xla/backends/gpu/runtime/command_executor.h
@@ -171,11 +171,7 @@ class CommandExecutor {
   }
 
   bool requires_update_on_execute() const {
-    bool requires_update_on_execute = false;
-    commands_.Walk([&](const Command* command) {
-      requires_update_on_execute |= command->requires_update_on_execute();
-    });
-    return requires_update_on_execute;
+    return requires_update_on_execute_;
   }
 
   bool support_loop_unroll() const {
@@ -260,6 +256,10 @@ class CommandExecutor {
   // Unique buffer allocations indices referenced by all commands in this
   // sequence (sorted by the buffer allocation index).
   std::vector<BufferAllocation::Index> allocs_indices_;
+
+  // Whether any command in this sequence requires an update on every
+  // execution.
+  bool requires_update_on_execute_ = false;
 
   // A mapping from command id to unique buffer allocations indices referenced
   // by the command (sorted by the buffer allocation index).

--- a/xla/backends/gpu/runtime/command_executor_test.cc
+++ b/xla/backends/gpu/runtime/command_executor_test.cc
@@ -59,17 +59,29 @@ class FakeCmd : public Command {
 
 class UpdateRequirementCmd : public FakeCmd {
  public:
-  UpdateRequirementCmd(bool requires_update, int* num_queries)
-      : requires_update_(requires_update), num_queries_(num_queries) {}
+  UpdateRequirementCmd(bool requires_update_on_initialize,
+                       bool requires_update_on_execute,
+                       int* num_initialize_queries, int* num_execute_queries)
+      : requires_update_on_initialize_(requires_update_on_initialize),
+        requires_update_on_execute_(requires_update_on_execute),
+        num_initialize_queries_(num_initialize_queries),
+        num_execute_queries_(num_execute_queries) {}
+
+  bool requires_update_on_initialize() const override {
+    ++*num_initialize_queries_;
+    return requires_update_on_initialize_;
+  }
 
   bool requires_update_on_execute() const override {
-    ++*num_queries_;
-    return requires_update_;
+    ++*num_execute_queries_;
+    return requires_update_on_execute_;
   }
 
  private:
-  bool requires_update_;
-  int* num_queries_;
+  bool requires_update_on_initialize_;
+  bool requires_update_on_execute_;
+  int* num_initialize_queries_;
+  int* num_execute_queries_;
 };
 
 // Convenience aliases for synchronization modes.
@@ -93,19 +105,26 @@ TEST(CommandExecutorTest, DuplicateAllocsCollapsedToOne) {
   EXPECT_EQ(executor.allocs_indices()[0], 0);
 }
 
-TEST(CommandExecutorTest, RequiresUpdateOnExecuteIsCached) {
-  int num_queries = 0;
+TEST(CommandExecutorTest, UpdateRequirementsAreCached) {
+  int num_initialize_queries = 0;
+  int num_execute_queries = 0;
   CommandSequence cmds;
-  cmds.Emplace<UpdateRequirementCmd>(false, &num_queries);
-  cmds.Emplace<UpdateRequirementCmd>(true, &num_queries);
+  cmds.Emplace<UpdateRequirementCmd>(false, true, &num_initialize_queries,
+                                     &num_execute_queries);
+  cmds.Emplace<UpdateRequirementCmd>(true, false, &num_initialize_queries,
+                                     &num_execute_queries);
 
   ASSERT_OK_AND_ASSIGN(auto executor,
                        CommandExecutor::Create(std::move(cmds), kSerialize));
-  EXPECT_EQ(num_queries, 2);
+  EXPECT_EQ(num_initialize_queries, 2);
+  EXPECT_EQ(num_execute_queries, 2);
 
+  EXPECT_TRUE(executor.requires_update_on_initialize());
+  EXPECT_TRUE(executor.requires_update_on_initialize());
   EXPECT_TRUE(executor.requires_update_on_execute());
   EXPECT_TRUE(executor.requires_update_on_execute());
-  EXPECT_EQ(num_queries, 2);
+  EXPECT_EQ(num_initialize_queries, 2);
+  EXPECT_EQ(num_execute_queries, 2);
 }
 
 //===----------------------------------------------------------------------===//

--- a/xla/backends/gpu/runtime/command_executor_test.cc
+++ b/xla/backends/gpu/runtime/command_executor_test.cc
@@ -57,33 +57,6 @@ class FakeCmd : public Command {
   BufferUses uses_;
 };
 
-class UpdateRequirementCmd : public FakeCmd {
- public:
-  UpdateRequirementCmd(bool requires_update_on_initialize,
-                       bool requires_update_on_execute,
-                       int* num_initialize_queries, int* num_execute_queries)
-      : requires_update_on_initialize_(requires_update_on_initialize),
-        requires_update_on_execute_(requires_update_on_execute),
-        num_initialize_queries_(num_initialize_queries),
-        num_execute_queries_(num_execute_queries) {}
-
-  bool requires_update_on_initialize() const override {
-    ++*num_initialize_queries_;
-    return requires_update_on_initialize_;
-  }
-
-  bool requires_update_on_execute() const override {
-    ++*num_execute_queries_;
-    return requires_update_on_execute_;
-  }
-
- private:
-  bool requires_update_on_initialize_;
-  bool requires_update_on_execute_;
-  int* num_initialize_queries_;
-  int* num_execute_queries_;
-};
-
 // Convenience aliases for synchronization modes.
 constexpr auto kSerialize = CommandExecutor::SynchronizationMode::kSerialize;
 constexpr auto kConcurrent = CommandExecutor::SynchronizationMode::kConcurrent;
@@ -103,28 +76,6 @@ TEST(CommandExecutorTest, DuplicateAllocsCollapsedToOne) {
   // Both commands reference the same allocation index — should appear once.
   EXPECT_EQ(executor.allocs_indices().size(), 1);
   EXPECT_EQ(executor.allocs_indices()[0], 0);
-}
-
-TEST(CommandExecutorTest, UpdateRequirementsAreCached) {
-  int num_initialize_queries = 0;
-  int num_execute_queries = 0;
-  CommandSequence cmds;
-  cmds.Emplace<UpdateRequirementCmd>(false, true, &num_initialize_queries,
-                                     &num_execute_queries);
-  cmds.Emplace<UpdateRequirementCmd>(true, false, &num_initialize_queries,
-                                     &num_execute_queries);
-
-  ASSERT_OK_AND_ASSIGN(auto executor,
-                       CommandExecutor::Create(std::move(cmds), kSerialize));
-  EXPECT_EQ(num_initialize_queries, 2);
-  EXPECT_EQ(num_execute_queries, 2);
-
-  EXPECT_TRUE(executor.requires_update_on_initialize());
-  EXPECT_TRUE(executor.requires_update_on_initialize());
-  EXPECT_TRUE(executor.requires_update_on_execute());
-  EXPECT_TRUE(executor.requires_update_on_execute());
-  EXPECT_EQ(num_initialize_queries, 2);
-  EXPECT_EQ(num_execute_queries, 2);
 }
 
 //===----------------------------------------------------------------------===//

--- a/xla/backends/gpu/runtime/command_executor_test.cc
+++ b/xla/backends/gpu/runtime/command_executor_test.cc
@@ -57,6 +57,21 @@ class FakeCmd : public Command {
   BufferUses uses_;
 };
 
+class UpdateRequirementCmd : public FakeCmd {
+ public:
+  UpdateRequirementCmd(bool requires_update, int* num_queries)
+      : requires_update_(requires_update), num_queries_(num_queries) {}
+
+  bool requires_update_on_execute() const override {
+    ++*num_queries_;
+    return requires_update_;
+  }
+
+ private:
+  bool requires_update_;
+  int* num_queries_;
+};
+
 // Convenience aliases for synchronization modes.
 constexpr auto kSerialize = CommandExecutor::SynchronizationMode::kSerialize;
 constexpr auto kConcurrent = CommandExecutor::SynchronizationMode::kConcurrent;
@@ -76,6 +91,21 @@ TEST(CommandExecutorTest, DuplicateAllocsCollapsedToOne) {
   // Both commands reference the same allocation index — should appear once.
   EXPECT_EQ(executor.allocs_indices().size(), 1);
   EXPECT_EQ(executor.allocs_indices()[0], 0);
+}
+
+TEST(CommandExecutorTest, RequiresUpdateOnExecuteIsCached) {
+  int num_queries = 0;
+  CommandSequence cmds;
+  cmds.Emplace<UpdateRequirementCmd>(false, &num_queries);
+  cmds.Emplace<UpdateRequirementCmd>(true, &num_queries);
+
+  ASSERT_OK_AND_ASSIGN(auto executor,
+                       CommandExecutor::Create(std::move(cmds), kSerialize));
+  EXPECT_EQ(num_queries, 2);
+
+  EXPECT_TRUE(executor.requires_update_on_execute());
+  EXPECT_TRUE(executor.requires_update_on_execute());
+  EXPECT_EQ(num_queries, 2);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
📝 Summary of Changes

Precompute `CommandExecutor::requires_update_on_initialize()` and
`CommandExecutor::requires_update_on_execute()` during the constructor's
existing recursive command walk. Subsequent queries return the cached values
instead of walking all top-level and nested commands again.

🎯 Justification

`CommandBufferThunk` queries these properties while initializing and executing
command buffers. Their results are invariant after command executor
construction, so recursively walking the command tree and making virtual calls
for every query is unnecessary. This cleanup reduces host overhead for command
buffers, particularly those with large nested while or conditional bodies.

🚀 Kind of Contribution

♻️ Cleanup

📊 Benchmark (for Performance Improvements)

N/A. This is a cleanup-grade removal of invariant host-side work and does not
claim an end-to-end performance improvement.

🧪 Unit Tests:

No new unit tests were added. Both update-requirement functions are already
covered through the existing command executor and command-buffer tests.

Validated the existing tests with:

`bazel test //xla/backends/gpu/runtime:command_executor_test --test_output=errors`

🧪 Execution Tests:

No new execution tests were added because command-buffer behavior is unchanged
and the affected paths are covered by existing command-buffer execution tests.
The affected integration target was compiled with:

`bazel build //xla/backends/gpu/runtime:command_buffer_thunk`
