### PR TITLE
[ROCm] Add suppoprt for  exp2, sqrt, rsq, tanh, log with bf16 on gfx1250

### DIFF
--- a/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
@@ -74,33 +74,42 @@ namespace se = ::stream_executor;
 // log2(e), used to express exp(x) = exp2(x * log2(e)).
 constexpr double kLog2E = 1.4426950408889634;
 
-// Lowers a scalar bf16 `math.exp2` to the native gfx1250 `v_exp_bf16`
-// instruction via the `llvm.amdgcn.exp2` intrinsic. Without this, the default
-// MathToROCDL lowering upcasts bf16 to f32 and calls `__ocml_exp2_f32`, never
-// using the hardware bf16 transcendental unit. Vector ops are scalarized first
-// by MathToROCDL's ScalarizeVectorOpLowering (lower benefit), so this pattern
-// only needs to handle the scalar case.
-struct Exp2BF16ToAMDGPU
-    : public mlir::ConvertOpToLLVMPattern<mlir::math::Exp2Op> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+// Lowers a scalar bf16 unary `math` op to the matching native gfx1250 bf16
+// transcendental instruction (v_exp_bf16, v_sqrt_bf16, v_rsq_bf16, v_tanh_bf16,
+// v_log_bf16, ...) via its `llvm.amdgcn.*` intrinsic, when the op maps 1:1 to
+// the instruction. Without this, the default MathToROCDL lowering upcasts bf16
+// to f32 and calls an `__ocml_*_f32` library function, never using the hardware
+// bf16 transcendental unit. Vector ops are scalarized first by MathToROCDL's
+// ScalarizeVectorOpLowering (lower benefit), so this pattern only needs to
+// handle the scalar case.
+template <typename OpTy>
+struct TranscendentalBF16ToAMDGPU : public mlir::ConvertOpToLLVMPattern<OpTy> {
+  TranscendentalBF16ToAMDGPU(const mlir::LLVMTypeConverter& converter,
+                             llvm::StringRef intrinsic,
+                             mlir::PatternBenefit benefit)
+      : mlir::ConvertOpToLLVMPattern<OpTy>(converter, benefit),
+        intrinsic(intrinsic) {}
 
   mlir::LogicalResult matchAndRewrite(
-      mlir::math::Exp2Op op, OpAdaptor adaptor,
+      OpTy op, typename OpTy::Adaptor adaptor,
       mlir::ConversionPatternRewriter& rewriter) const override {
     if (!op.getType().isBF16()) {
-      return rewriter.notifyMatchFailure(op, "not a scalar bf16 exp2");
+      return rewriter.notifyMatchFailure(op, "not a scalar bf16 op");
     }
     mlir::Value operand = adaptor.getOperands().front();
     rewriter.replaceOpWithNewOp<mlir::LLVM::CallIntrinsicOp>(
-        op, /*resultType=*/operand.getType(),
-        rewriter.getStringAttr("llvm.amdgcn.exp2"), mlir::ValueRange{operand});
+        op, /*resultType=*/operand.getType(), rewriter.getStringAttr(intrinsic),
+        mlir::ValueRange{operand});
     return mlir::success();
   }
+
+  llvm::StringRef intrinsic;
 };
 
 // Lowers a scalar bf16 `math.exp` to the native gfx1250 `v_exp_bf16`
 // instruction by rewriting exp(x) = exp2(x * log2(e)) and emitting the
-// `llvm.amdgcn.exp2` intrinsic. See Exp2BF16ToAMDGPU for the rationale.
+// `llvm.amdgcn.exp2` intrinsic. See TranscendentalBF16ToAMDGPU for the
+// rationale.
 struct ExpBF16ToAMDGPU
     : public mlir::ConvertOpToLLVMPattern<mlir::math::ExpOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
@@ -167,14 +176,25 @@ class LowerToLLVMGPUPass
         mlir::configureGpuToROCDLConversionLegality(target);
         mlir::populateAMDGPUToROCDLConversionPatterns(converter, patterns,
                                                       *maybeChipset);
-        // On gfx1250 emit native bf16 exp via v_exp_bf16 instead of upcasting
-        // to f32 and calling __ocml_exp(2)_f32. Higher benefit than the default
-        // MathToROCDL patterns so it wins for scalar bf16 ops.
+        // On gfx1250 emit native bf16 transcendentals (v_exp_bf16, v_sqrt_bf16,
+        // v_rsq_bf16, v_tanh_bf16, v_log_bf16, ...) instead of upcasting to f32
+        // and calling __ocml_*_f32. Higher benefit than the default MathToROCDL
+        // patterns so it wins for scalar bf16 ops.
         if (device_spec_.gpu()
                 .rocm_compute_capability()
                 .has_bf16_transcendental_support()) {
-          patterns.add<ExpBF16ToAMDGPU, Exp2BF16ToAMDGPU>(
-              converter, /*benefit=*/mlir::PatternBenefit(2));
+          mlir::PatternBenefit benefit(2);
+          patterns.add<ExpBF16ToAMDGPU>(converter, benefit);
+          patterns.add<TranscendentalBF16ToAMDGPU<mlir::math::Exp2Op>>(
+              converter, "llvm.amdgcn.exp2", benefit);
+          patterns.add<TranscendentalBF16ToAMDGPU<mlir::math::SqrtOp>>(
+              converter, "llvm.amdgcn.sqrt", benefit);
+          patterns.add<TranscendentalBF16ToAMDGPU<mlir::math::RsqrtOp>>(
+              converter, "llvm.amdgcn.rsq", benefit);
+          patterns.add<TranscendentalBF16ToAMDGPU<mlir::math::TanhOp>>(
+              converter, "llvm.amdgcn.tanh", benefit);
+          patterns.add<TranscendentalBF16ToAMDGPU<mlir::math::Log2Op>>(
+              converter, "llvm.amdgcn.log", benefit);
         }
         target.addIllegalDialect<mlir::amdgpu::AMDGPUDialect>();
       } else if (device_spec_.IsIntelGpu()) {

--- a/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
+++ b/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
@@ -30,3 +30,63 @@ module {
 // CHECK-LABEL: llvm.func @exp_bf16
 // CHECK: llvm.fmul
 // CHECK: llvm.call_intrinsic "llvm.amdgcn.exp2"({{.*}}) : (bf16) -> bf16
+
+// -----
+
+// gfx1250 has a native bf16 sqrt instruction (v_sqrt_bf16), reached via the
+// llvm.amdgcn.sqrt intrinsic.
+module {
+  func.func @sqrt_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.sqrt %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @sqrt_bf16
+// CHECK: llvm.call_intrinsic "llvm.amdgcn.sqrt"({{.*}}) : (bf16) -> bf16
+// CHECK-NOT: __ocml
+
+// -----
+
+// gfx1250 has a native bf16 rsqrt instruction (v_rsq_bf16), reached via the
+// llvm.amdgcn.rsq intrinsic.
+module {
+  func.func @rsqrt_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.rsqrt %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @rsqrt_bf16
+// CHECK: llvm.call_intrinsic "llvm.amdgcn.rsq"({{.*}}) : (bf16) -> bf16
+// CHECK-NOT: __ocml
+
+// -----
+
+// gfx1250 has a native bf16 tanh instruction (v_tanh_bf16), reached via the
+// llvm.amdgcn.tanh intrinsic.
+module {
+  func.func @tanh_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.tanh %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @tanh_bf16
+// CHECK: llvm.call_intrinsic "llvm.amdgcn.tanh"({{.*}}) : (bf16) -> bf16
+// CHECK-NOT: __ocml
+
+// -----
+
+// gfx1250 has a native bf16 log2 instruction (v_log_bf16), reached via the
+// llvm.amdgcn.log intrinsic.
+module {
+  func.func @log2_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.log2 %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @log2_bf16
+// CHECK: llvm.call_intrinsic "llvm.amdgcn.log"({{.*}}) : (bf16) -> bf16
+// CHECK-NOT: __ocml

--- a/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu_fallback.mlir
+++ b/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu_fallback.mlir
@@ -15,3 +15,60 @@ module {
 // CHECK-LABEL: llvm.func @exp2_bf16
 // CHECK: llvm.call @__ocml_exp2_f32
 // CHECK-NOT: llvm.amdgcn.exp2
+
+// -----
+
+// sqrt has a generic bf16 lowering (llvm.intr.sqrt) on gfx942, so it does not
+// use the native gfx1250 llvm.amdgcn.sqrt path.
+module {
+  func.func @sqrt_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.sqrt %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @sqrt_bf16
+// CHECK: llvm.intr.sqrt
+// CHECK-NOT: llvm.amdgcn.sqrt
+
+// -----
+
+// rsqrt is upcast to f32 and lowered to __ocml_rsqrt_f32 on gfx942.
+module {
+  func.func @rsqrt_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.rsqrt %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @rsqrt_bf16
+// CHECK: llvm.call @__ocml_rsqrt_f32
+// CHECK-NOT: llvm.amdgcn.rsq
+
+// -----
+
+// tanh is upcast to f32 and lowered to __ocml_tanh_f32 on gfx942.
+module {
+  func.func @tanh_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.tanh %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @tanh_bf16
+// CHECK: llvm.call @__ocml_tanh_f32
+// CHECK-NOT: llvm.amdgcn.tanh
+
+// -----
+
+// log2 is upcast to f32 and lowered to __ocml_log2_f32 on gfx942.
+module {
+  func.func @log2_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.log2 %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @log2_bf16
+// CHECK: llvm.call @__ocml_log2_f32
+// CHECK-NOT: llvm.amdgcn.log

--- a/xla/service/gpu/gpu_float_support.cc
+++ b/xla/service/gpu/gpu_float_support.cc
@@ -155,6 +155,18 @@ bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
         return compute_capability_.IsCuda();
       }
       return false;
+    case HloOpcode::kRsqrt:
+    case HloOpcode::kSqrt:
+    case HloOpcode::kTanh:
+      // gfx1250 has native bf16 transcendental instructions (v_sqrt_bf16,
+      // v_rsq_bf16, v_tanh_bf16), so there is no need to upcast these bf16 ops
+      // to f32.
+      if (LowPrecisionType() == BF16) {
+        if (auto* rocm_cc = compute_capability_.rocm_compute_capability()) {
+          return rocm_cc->has_bf16_transcendental_support();
+        }
+      }
+      return false;
     case HloOpcode::kAbs:
     case HloOpcode::kMaximum:
     case HloOpcode::kMinimum:

--- a/xla/service/gpu/gpu_float_support_test.cc
+++ b/xla/service/gpu/gpu_float_support_test.cc
@@ -655,9 +655,9 @@ ENTRY main {
       Normalize(module_exp.get(), se::GpuComputeCapability{cc}, BF16, F32));
 }
 
-TEST_F(FloatSupportTest, BF16ExpOnGfx1250IsNotNormalized) {
-  // gfx1250 has a native bf16 exponential instruction, so bf16 exp should be
-  // kept as bf16 instead of being upcast to f32.
+TEST_F(FloatSupportTest, BF16TranscendentalsOnGfx1250AreNotNormalized) {
+  // gfx1250 has native bf16 transcendental instructions, so these bf16 ops
+  // should be kept as bf16 instead of being upcast to f32.
   auto cc = se::RocmComputeCapability("gfx1250");
   constexpr absl::string_view kHloModule = R"(
 HloModule module
@@ -667,11 +667,13 @@ ENTRY main {
       ROOT r = bf16[4] $0(p0)
 })";
 
-  TF_ASSERT_OK_AND_ASSIGN(auto module_exp,
-                          ParseAndReturnVerifiedModule(
-                              absl::Substitute(kHloModule, "exponential")));
-  EXPECT_FALSE(
-      Normalize(module_exp.get(), se::GpuComputeCapability{cc}, BF16, F32));
+  for (absl::string_view op : {"exponential", "sqrt", "rsqrt", "tanh"}) {
+    TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(
+                                             absl::Substitute(kHloModule, op)));
+    EXPECT_FALSE(
+        Normalize(module.get(), se::GpuComputeCapability{cc}, BF16, F32))
+        << "bf16 " << op << " should not be normalized on gfx1250";
+  }
 
   // log has no native bf16 instruction wired up, so it is still normalized.
   TF_ASSERT_OK_AND_ASSIGN(

--- a/xla/stream_executor/rocm/rocm_compute_capability.h
+++ b/xla/stream_executor/rocm/rocm_compute_capability.h
@@ -199,9 +199,10 @@ class RocmComputeCapability {
 
   bool has_mx_type_support() const { return gfx9_mi350() || gfx1250(); }
 
-  // Native bf16 transcendental instructions (v_exp_bf16, v_log_bf16, etc.),
-  // backed by the LLVM FeatureBF16TransInsts subtarget feature. Lets us compute
-  // these bf16 ops without upcasting to f32 (currently only used for exp).
+  // Native bf16 transcendental instructions (v_exp_bf16, v_sqrt_bf16,
+  // v_rsq_bf16, v_tanh_bf16, v_log_bf16, etc.), backed by the LLVM
+  // FeatureBF16TransInsts subtarget feature. Lets us compute these bf16 ops
+  // without upcasting to f32 (currently used for exp, sqrt, rsqrt, tanh).
   bool has_bf16_transcendental_support() const { return gfx1250(); }
 
   bool has_tdm_support() const { return gfx1250(); }


### PR DESCRIPTION
📝 Summary of Changes
Enable native bf16 exp2, sqrt, rsq, tanh, log on AMD gfx1250 and stopped normalizing bf16 to f32 for those opperators.

🎯 Justification
Remove the up/down casts and the call for those operators and bf16, use native instructions on gfx1250

🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement,
✨ New Feature, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
xla/xla/service/gpu/gpu_float_support_test.cc (BF16ExpOnGfx1250IsNotNormalized)
xla/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
xla/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu_fallback.mlir

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
