### PR TITLE
[HLO] Keep self-pairs in AllGatherDynamicSlicePermutedOffsetSimplifier

### DIFF
--- a/xla/hlo/transforms/simplifiers/all_gather_permuted_ds_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/all_gather_permuted_ds_simplifier.cc
@@ -71,15 +71,15 @@ AllGatherDynamicSlicePermutedOffsetSimplifierVisitor::HandleDynamicSlice(
           /*allow_multiple_users=*/false);
 
   if (offset_spec.has_value() && !offset_spec->permutation_pairs.empty()) {
-    // Remove the duplicated pairs as no collective permute is needed.
-    offset_spec->permutation_pairs.erase(
-        std::remove_if(offset_spec->permutation_pairs.begin(),
-                       offset_spec->permutation_pairs.end(),
-                       [](const std::pair<int64_t, int64_t>& pair) {
-                         return pair.first == pair.second;
-                       }),
-        offset_spec->permutation_pairs.end());
     // Replace the pattern with a collective permute.
+    //
+    // Note: self-pairs (src == dst) must be kept. A pair (p, p) means partition
+    // p reads the all-gather offset holding its own shard, i.e. it keeps its
+    // own data. Removing such pairs would make those partitions non-targets of
+    // the collective-permute, and per its semantics a replica/partition that is
+    // not a target of any pair outputs zeros -- silently replacing the
+    // partition's data with zeros. Keeping the self-pair produces the correct
+    // identity copy.
     HloInstruction* cp =
         dynamic_slice->AddInstruction(HloInstruction::CreateCollectivePermute(
             dynamic_slice->shape(), all_gather->mutable_operand(0),

--- a/xla/hlo/transforms/simplifiers/all_gather_permuted_ds_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/all_gather_permuted_ds_simplifier_test.cc
@@ -126,9 +126,14 @@ TEST_F(AllGatherPermutedDsSimplifierTest,
 
   HloInstruction* root = module->entry_computation()->root_instruction();
   EXPECT_THAT(root, op::CollectivePermute(op::Parameter(0)));
+  // Self-pairs (e.g. {0, 0}) must be kept: a partition that reads its own
+  // all-gather offset keeps its own data. A collective-permute zeroes any
+  // partition that is not a target of some pair, so dropping the self-pairs
+  // would silently zero those partitions.
   EXPECT_THAT(root->source_target_pairs(),
               (UnorderedElementsAreArray<std::pair<int64_t, int64_t>>(
-                  {{1, 2}, {2, 1}})));
+                  {{0, 0}, {1, 2}, {2, 1}, {3, 3}, {4, 4}, {5, 5}, {6, 6},
+                   {7, 7}})));
 }
 
 TEST_F(AllGatherPermutedDsSimplifierTest,
@@ -158,9 +163,12 @@ TEST_F(AllGatherPermutedDsSimplifierTest,
 
   HloInstruction* root = module->entry_computation()->root_instruction();
   EXPECT_THAT(root, op::CollectivePermute(op::Parameter(0)));
+  // {5, 5} is a self-pair and must be kept so partition 5 (which reads its own
+  // shard) is not zeroed by the collective-permute.
   EXPECT_THAT(root->source_target_pairs(),
               (UnorderedElementsAreArray<std::pair<int64_t, int64_t>>(
-                  {{0, 3}, {1, 2}, {2, 1}, {3, 0}, {4, 7}, {6, 4}, {7, 6}})));
+                  {{0, 3}, {1, 2}, {2, 1}, {3, 0}, {4, 7}, {5, 5}, {6, 4},
+                   {7, 6}})));
 }
 
 TEST_F(AllGatherPermutedDsSimplifierTest,
@@ -196,6 +204,42 @@ TEST_F(AllGatherPermutedDsSimplifierTest,
       root->source_target_pairs(),
       (UnorderedElementsAreArray<std::pair<int64_t, int64_t>>(
           {{0, 3}, {1, 2}, {2, 1}, {3, 0}, {4, 7}, {5, 6}, {6, 5}, {7, 4}})));
+}
+
+TEST_F(AllGatherPermutedDsSimplifierTest, KeepsSelfPairsForIdentityPartitions) {
+  // Only partitions 0 and 1 swap shards; partitions 2-7 read their own shard.
+  // The resulting self-pairs {2,2}..{7,7} must be preserved in the
+  // collective-permute -- otherwise those partitions, being the target of no
+  // pair, would be zeroed instead of keeping their own data.
+  absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY entry {
+      p = f32[32,8,128] parameter(0)
+      ag = f32[256,8,128] all-gather(p), replica_groups={{0,1,2,3,4,5,6,7}},
+        dimensions={0}, channel_id=1, use_global_device_ids=true
+      pid = u32[] partition-id()
+      permuteed_idx_list = s32[8]{0} constant({32,0,64,96,128,160,192,224})
+      offset = s32[1] dynamic-slice(permuteed_idx_list, pid),
+        dynamic_slice_sizes={1}
+      offset_reshape = s32[] reshape(offset)
+      zero = s32[] constant(0)
+      ROOT ds = f32[32,8,128] dynamic-slice(ag, offset_reshape, zero, zero),
+        dynamic_slice_sizes={32,8,128}
+    }
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          RunPass(hlo_string,
+                                  /*num_replicas=*/1,
+                                  /*num_partitions=*/8,
+                                  /*expect_change=*/true));
+
+  HloInstruction* root = module->entry_computation()->root_instruction();
+  EXPECT_THAT(root, op::CollectivePermute(op::Parameter(0)));
+  EXPECT_THAT(root->source_target_pairs(),
+              (UnorderedElementsAreArray<std::pair<int64_t, int64_t>>(
+                  {{0, 1}, {1, 0}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6},
+                   {7, 7}})));
 }
 
 TEST_F(AllGatherPermutedDsSimplifierTest,


### PR DESCRIPTION
### Problem
`AllGatherDynamicSlicePermutedOffsetSimplifier` can miscompile: partitions whose permutation entry is a fixed point (they keep their own shard) end up receiving zeros.

### Root cause
`HandleDynamicSlice` (`all_gather_permuted_ds_simplifier.cc:73-80`) strips self-pairs (`src == dst`) from `permutation_pairs` before building the collective-permute. The pairs are `(src_partition_id, dest_partition_id)`; a fixed point `(p, p)` means partition `p` recovers its own all-gather shard. Per collective-permute semantics (`docs/operation_semantics.md`; `xla_builder.h`), a replica/partition that is **not** a target of any pair outputs a tensor of zeros. Removing the self-pair makes those partitions non-targets, so they get zeros instead of their own data. The transform is only correct for derangements.

This is exercised by the existing tests `AllPartitionsPermutedMultipleReplicaGroupsAlmostMatch` and `AllPartitionsPermutedMultipleReplicaGroups`, but they assert only `source_target_pairs` structure, not numeric output, so the miscompile is not caught.

### Fix
Keep all pairs — a self-pair `(p, p)` is a valid identity copy — so every partition remains a target.

### Verification
Static reasoning from the documented collective-permute contract; no bazel build available on my machine. Happy to extend a test to evaluate numeric output for a permutation containing a fixed point.
