### PR TITLE
[SPMD] Fix instruction-height recurrence in schedule-aware collective CSE

### DIFF
--- a/xla/service/spmd/schedule_aware_collective_ops_cse.cc
+++ b/xla/service/spmd/schedule_aware_collective_ops_cse.cc
@@ -110,7 +110,7 @@ absl::StatusOr<bool> RunOnComputation(HloComputation* comp, bool for_replicas,
     auto hlo = *it;
     int64_t h = 0;
     for (auto user : hlo->users()) {
-      h = std::max(h, height[user]) + 1;
+      h = std::max(h, height[user] + 1);
     }
     max_height = std::max(max_height, h);
     height[hlo] = h;


### PR DESCRIPTION
### Problem
`RunOnComputation` in `schedule_aware_collective_ops_cse.cc` computes instruction "height" (distance to root) incorrectly for any multi-user node, corrupting the heuristic that gates schedule-aware CSE.

### Root cause
```cpp
for (auto user : hlo->users()) {
  h = std::max(h, height[user]) + 1;   // +1 applied per user
}
```
The `+ 1` binds outside `std::max`, and `h` is reassigned each iteration, so a node with N users accumulates roughly `+N` instead of a single `+1` on top of the max child height (the result is also order-dependent). For example, two height-0 users yield height 2 where the true longest-path height is 1. This inflated height feeds `coll_height` and `lowest_user_height` into the CSE gate `lowest_user_height(earlier_coll) > coll_height + distance_threshold` (line 152).

### Fix
Move the `+1` inside the max (`std::max(h, height[user] + 1)`) — the canonical longest-path recurrence — matching the no-`+1` reads in `lowest_user_height`.

### Impact / verification
Scheduling/CSE quality heuristic (live-range / peak-memory), not a numerical miscompile. Static reasoning; trivially checkable (two zero-height users → 1, not 2).
