### PR TITLE
[HLO] Guard out-of-bounds dimension access in all-gather reshape match

### DIFF
--- a/xla/hlo/transforms/collectives/collective_transformation_reorderer.cc
+++ b/xla/hlo/transforms/collectives/collective_transformation_reorderer.cc
@@ -94,6 +94,15 @@ GetAllGatherTransformations(HloInstruction* all_gather) {
     if (reshaped_num_strides != all_gather_num_strides) {
       return std::nullopt;
     }
+    // The loop above can exit with reshaped_all_gather_dimension equal to the
+    // rank when all reshape dimensions are consumed to reach the stride count
+    // (e.g. a size-1 all-gather dimension). In that case there is no reshaped
+    // all-gather dimension; guard against the out-of-bounds dimensions() access
+    // below.
+    if (reshaped_all_gather_dimension >=
+        transformation_hlo->shape().dimensions().size()) {
+      return std::nullopt;
+    }
     // Additionally, we make sure the reshape does not change the size of the
     // all-gather dimension.
     // TODO(jlwei@): support merging dimensions following the all-gather

--- a/xla/hlo/transforms/collectives/collective_transformation_reorderer_test.cc
+++ b/xla/hlo/transforms/collectives/collective_transformation_reorderer_test.cc
@@ -125,6 +125,28 @@ TEST_F(CollectiveTransformationReordererTest, ReshapeAcrossShards) {
   EXPECT_FALSE(changed);
 }
 
+TEST_F(CollectiveTransformationReordererTest,
+       SizeOneAllGatherDimensionReshapeConsumesFullRank) {
+  // Regression test: when the all-gather dimension has size 1, the loop that
+  // maps strides onto the reshaped operand can consume the entire reshaped
+  // rank to reach the stride count, leaving the candidate reshaped all-gather
+  // dimension equal to the rank. The transformation must be rejected rather
+  // than performing an out-of-bounds dimensions() access on the reshape.
+  absl::string_view hlo_string = R"(
+  HloModule module
+  ENTRY entry {
+    param = bf16[4,2,1] parameter(0)
+    all-gather = bf16[4,2,1] all-gather(param), dimensions={2}, replica_groups={{0}}, channel_id=1
+    ROOT reshape = bf16[8] reshape(all-gather)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          RunCollectiveTransformationReorderer(module.get()));
+  EXPECT_FALSE(changed);
+}
+
 TEST_F(CollectiveTransformationReordererTest, MergeAllGatherDimensionWithNext) {
   absl::string_view hlo_string = R"(
   HloModule module


### PR DESCRIPTION
### Problem
The `get_reshaped_all_gather_dimension` lambda in `GetAllGatherTransformations` (`collective_transformation_reorderer.cc`) can read one past the end of the shape's `DimensionVector`.

### Root cause
The loop (lines 87-93) advances `reshaped_all_gather_dimension` while it is `< rank` **and** `reshaped_num_strides < all_gather_num_strides`. When it exits because the index reached the rank *at the same moment* the stride counts became equal — which happens when the all-gather dimension and any trailing dims are size 1, so `product(dims[all_gather_dim:]) == 1` — the guard at line 94 (`reshaped_num_strides != all_gather_num_strides`) passes, and line 101 then evaluates `shape().dimensions(reshaped_all_gather_dimension)` with the index equal to the rank. `Shape::dimensions(int)` indexes the `DimensionVector` with no bounds check (fires `ABSL_HARDENING_ASSERT` under hardened builds, reads OOB otherwise).

Concrete trigger: all-gather output `[6, 1]`, `all_gather_dimension = 1`, single-user reshape to `[6]`.

### Fix
Return `nullopt` when the index reaches the rank, mirroring the loop's own bound.

### Verification
Static reasoning (loop/index math). No bazel build available on my machine; happy to add a test with a size-1 all-gather dimension followed by a reshape.
