### PR TITLE
[SPMD] Read constant dynamic-update-slice start index via GetIntegralAsS64

### DIFF
--- a/xla/service/spmd/spmd_partitioner_util.cc
+++ b/xla/service/spmd/spmd_partitioner_util.cc
@@ -3524,11 +3524,8 @@ DynamicUpdateSliceAnalysis AnalyzeDynamicUpdateSlice(
     }
 
     if (hlo->operand(i + 2)->IsConstant()) {
-      const PrimitiveType elemType =
-          hlo->operand(i + 2)->shape().element_type();
       int64_t start_index =
-          elemType == S64 ? hlo->operand(i + 2)->literal().Get<int64_t>({})
-                          : hlo->operand(i + 2)->literal().Get<int>({});
+          hlo->operand(i + 2)->literal().GetIntegralAsS64({}).value();
       int64_t end_index = start_index + slice_size - 1;
 
       int64_t per_partition_size =


### PR DESCRIPTION
### Problem
`AnalyzeDynamicUpdateSlice` (`spmd_partitioner_util.cc`) reads a constant dynamic-update-slice start index with a type that is only correct for S32/S64, so a valid integral index of another type is mis-read.

### Root cause
```cpp
int64_t start_index =
    elemType == S64 ? hlo->operand(i + 2)->literal().Get<int64_t>({})
                    : hlo->operand(i + 2)->literal().Get<int>({});
```
`Get<int>` requires the literal's element type to be S32, so for a `U32`/`U64`/`S16`/... index it trips the literal's element-type check (and under `NDEBUG` silently reinterprets the underlying buffer). `ShapeInference::InferDynamicUpdateSliceShape` permits any integral index type, so such indices are valid HLO. The sibling constant-index read a few lines below (line ~3576) already uses the type-agnostic `GetIntegralAsS64`.

### Fix
Use `GetIntegralAsS64({})`, matching that sibling.

### Impact / verification
Latent robustness bug (mainline frontends emit S32/S64). Static reasoning. Happy to add a test with a `U32`-typed DUS index.
