### PR TITLE
[XLA:GPU] Keep VMM mappings alive across executions in command buffer va-remapping run.

### DIFF
--- a/xla/service/gpu/gpu_executable_buffer_allocator.cc
+++ b/xla/service/gpu/gpu_executable_buffer_allocator.cc
@@ -738,13 +738,12 @@ GpuExecutableBufferAllocator::CreateExecutionScope(
   }
   remapping->vmm_allocator = vmm_allocator;
 
-  if (remapping->va_reservation != nullptr) {
-    // With a single VA reservation range, the next execution must wait until
-    // deferred unmaps from the previous execution have retired before it can
-    // map the same reservation aliases again.
-    RETURN_IF_ERROR(
-        vmm_allocator->SynchronizePendingOperations(device_ordinal));
-  }
+  // Deferred deallocations and unmaps from the previous execution are left
+  // pending on purpose: Allocate() and Map() reactivate a compatible stale
+  // mapping at the same reservation VA, which keeps the same physical
+  // allocation across executions and avoids waiting for the previous execution
+  // to retire. Incompatible stale mappings are completed lazily and per-record
+  // by the fresh-mapping paths.
   return ExecutionScope(this, remapping, vmm_allocator, std::move(remap_lock),
                         /*address_policy_active=*/true);
 }

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -937,6 +937,7 @@ xla_cc_test(
         "//xla/service:computation_placer_hdr",
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:device_address_vmm_allocator",
+        "//xla/stream_executor:memory_allocation",
         "//xla/stream_executor:memory_space",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:platform_manager",

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h"
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -28,6 +29,7 @@ limitations under the License.
 #include "xla/stream_executor/cuda/cuda_memory_reservation.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/device_address_vmm_allocator.h"
+#include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/memory_space.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
@@ -884,6 +886,146 @@ TEST_F(DeviceAddressVmmAllocatorTest,
   ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
                                /*reservation_offset=*/0, granularity),
               IsOk());
+  ASSERT_THAT(allocator->Deallocate(ordinal, reused.Release()), IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
+// Simulates back-to-back executable runs over a shared reservation layout:
+// each step allocates the same reservation slices, runs stream work through
+// the reservation addresses, and defers deallocation at teardown. Later steps
+// allocate again immediately, with no synchronization in between and with the
+// previous step's work potentially still in flight. Every later step must
+// reactivate the previous step's stale mappings — same reservation VA backed
+// by the same physical allocation — and the stream-ordered data flow must
+// stay correct.
+TEST_F(DeviceAddressVmmAllocatorTest,
+       BackToBackMappedAllocationsReuseMappingsAcrossSteps) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  const uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+
+  // Two slices at fixed offsets emulate a module's deterministic reservation
+  // layout for two temp allocations.
+  constexpr int kSlices = 2;
+  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
+                                             executor_, kSlices * granularity));
+
+  constexpr int kSteps = 4;
+  uint64_t last_pattern = 0;
+  std::array<MemoryAllocation*, kSlices> first_step_raw = {nullptr, nullptr};
+  std::vector<ScopedDeviceAddress<uint8_t>> addresses;
+  for (int step = 0; step < kSteps; ++step) {
+    addresses.clear();
+    for (int slice = 0; slice < kSlices; ++slice) {
+      ASSERT_OK_AND_ASSIGN(
+          auto address,
+          allocator->Allocate(
+              ordinal, granularity, /*retry_on_failure=*/true,
+              static_cast<int64_t>(MemorySpace::kCollective), reservation.get(),
+              /*reservation_offset=*/slice * granularity, granularity,
+              /*return_reservation_address=*/true));
+      EXPECT_TRUE(address.cref().IsSameAs(reservation->address().GetByteSlice(
+          slice * granularity, granularity)));
+      auto* raw_allocation =
+          allocator->GetRawAllocation(ordinal, address.cref());
+      ASSERT_NE(raw_allocation, nullptr);
+      if (step == 0) {
+        first_step_raw[slice] = raw_allocation;
+      } else {
+        // Reuse must reactivate the previous step's mapping instead of
+        // creating a new physical allocation.
+        EXPECT_EQ(raw_allocation, first_step_raw[slice])
+            << "step=" << step << " slice=" << slice;
+      }
+      addresses.push_back(std::move(address));
+    }
+
+    // Stream work through the reservation addresses: write a per-step pattern
+    // into slice 0 and copy it into slice 1.
+    last_pattern = 0xC0FFEE00ULL + step;
+    DeviceAddressBase slice0 = addresses[0].cref();
+    DeviceAddressBase slice1 = addresses[1].cref();
+    ASSERT_THAT(stream_->Memcpy(&slice0, &last_pattern, sizeof(last_pattern)),
+                IsOk());
+    ASSERT_THAT(stream_->MemcpyD2D(&slice1, slice0, sizeof(last_pattern)),
+                IsOk());
+
+    if (step < kSteps - 1) {
+      // Teardown: defer deallocation while the copies may still be in flight.
+      for (auto& address : addresses) {
+        ASSERT_THAT(allocator->Deallocate(ordinal, address.Release()), IsOk());
+      }
+    }
+  }
+
+  // One sync at the very end: all steps' copies executed in stream order
+  // through mappings that were never torn down.
+  uint64_t read_value = 0;
+  ASSERT_THAT(
+      stream_->Memcpy(&read_value, addresses[1].cref(), sizeof(read_value)),
+      IsOk());
+  ASSERT_THAT(stream_->BlockHostUntilDone(), IsOk());
+  EXPECT_EQ(read_value, last_pattern);
+
+  for (auto& address : addresses) {
+    ASSERT_THAT(allocator->Deallocate(ordinal, address.Release()), IsOk());
+  }
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
+// A request with a different size at the same reservation offset does not
+// match the stale mapping: it must be rejected as a partial overlap instead
+// of remapping underneath the pending teardown, and the stale mapping must
+// stay reusable for a later matching request.
+TEST_F(DeviceAddressVmmAllocatorTest,
+       AllocateIntoReservationRejectsSizeChangeAtSameAddress) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+
+  const int ordinal = executor_->device_ordinal();
+  const uint64_t granularity = allocator->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+
+  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
+                                             executor_, 2 * granularity));
+  ASSERT_OK_AND_ASSIGN(
+      auto address,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective),
+                          reservation.get(), /*reservation_offset=*/0,
+                          granularity,
+                          /*return_reservation_address=*/true));
+  auto* raw_allocation = allocator->GetRawAllocation(ordinal, address.cref());
+  ASSERT_NE(raw_allocation, nullptr);
+  ASSERT_THAT(allocator->Deallocate(ordinal, address.Release()), IsOk());
+
+  // A larger mapping at the same offset partially overlaps the stale
+  // granularity-sized mapping and must be rejected.
+  EXPECT_FALSE(allocator
+                   ->Allocate(ordinal, 2 * granularity,
+                              /*retry_on_failure=*/true,
+                              static_cast<int64_t>(MemorySpace::kCollective),
+                              reservation.get(), /*reservation_offset=*/0,
+                              2 * granularity,
+                              /*return_reservation_address=*/true)
+                   .ok());
+
+  // The failed attempt must leave the stale mapping intact: a matching-size
+  // request still reuses it.
+  ASSERT_OK_AND_ASSIGN(
+      auto reused, allocator->Allocate(
+                       ordinal, granularity, /*retry_on_failure=*/true,
+                       static_cast<int64_t>(MemorySpace::kCollective),
+                       reservation.get(), /*reservation_offset=*/0, granularity,
+                       /*return_reservation_address=*/true));
+  EXPECT_EQ(allocator->GetRawAllocation(ordinal, reused.cref()),
+            raw_allocation);
+
   ASSERT_THAT(allocator->Deallocate(ordinal, reused.Release()), IsOk());
   ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
 }


### PR DESCRIPTION
## What

Removes the blanket `SynchronizePendingOperations()` drain from `GpuExecutableBufferAllocator::CreateExecutionScope`, so in the command buffer run with va-remapping, deferred deallocations and unmaps from the previous execution stay pending and the next execution reactivates the compatible stale mappings at the same reservation VAs.

## Why

The drain completed every deferred operation before each execution:

* the host spin-waited until the previous execution's teardown seqno retired on the GPU, blocking host run-ahead every step, and
* the reservation-VA mappings were torn down and their physical allocations released, so every step paid fresh physical allocations plus remapping work for each VA-remapped allocation, and the physical handle behind the stable VA changed on every step.

The allocator already handles the leftover state correctly, so the drain is unnecessary:

* `Allocate()` reactivates a compatible stale mapping at the same reservation VA (`TryReuseMappedAllocationAtReservationAddress`, `TryReuseMappedAllocationWithSeparateAddress`), and `Map()` reactivates a stale alias for the same raw allocation and range, keeping the same physical allocation across executions with no unmap/remap work,
* incompatible stale mappings are completed lazily and per-record by the fresh-mapping paths (`EnsureReservationAvailableForFreshMapping` and the `Map()` target preparation), and
* memory pressure is handled by the `ResourceExhausted` reclaim path.

The destructor still synchronizes pending operations so the module-owned VA reservation outlives any stale mappings into it.

With this change, in steady state the VA→physical mapping for VA-remapped allocations is never torn down between executions, which also keeps physical-handle-caching consumers (e.g. `CollectiveMemoryCache` registrations keyed by VA) consistent with the addresses command buffers capture.

## Tests

New tests in `cuda_device_address_vmm_allocator_test.cc`:

* `BackToBackMappedAllocationsReuseMappingsAcrossSteps` — simulates consecutive executable runs over a shared two-slice reservation layout: each step allocates the same slices, runs stream work through the reservation addresses, and defers deallocation at teardown with no synchronization between steps. Asserts later steps reactivate the same physical allocation and verifies stream-ordered data flow through mappings that are never torn down.
* `AllocateIntoReservationRejectsSizeChangeAtSameAddress` — pins that a different-size request at the same reservation offset is rejected as a partial overlap instead of remapping underneath the pending teardown, and that the stale mapping stays reusable for a matching request.

