### PR TITLE
Allow dynamic-update-slice into an unbounded-dynamic operand dimension

### DIFF
--- a/xla/service/shape_inference.cc
+++ b/xla/service/shape_inference.cc
@@ -3442,7 +3442,8 @@ ShapeInference::InferCollectivePermuteDoneShape(const Shape& operand_shape) {
           "Size index %d to dynamic update slice must be >= 0.",
           update_dim_size);
     }
-    if (update_dim_size > input_dim_size) {
+    if (!IsUnboundedDynamicSize(input_dim_size) &&
+        update_dim_size > input_dim_size) {
       return InvalidArgument(
           "Update dim size %d greater than dynamic slice dimension: %d.",
           update_dim_size, input_dim_size);


### PR DESCRIPTION
### Problem
`InferDynamicUpdateSliceShape` rejects a valid `dynamic-update-slice` into an **unbounded-dynamic** operand dimension.

### Root cause
```cpp
const int64_t input_dim_size = operand_shape.dimensions(dim);
...
if (update_dim_size > input_dim_size) {   // input_dim_size == kUnboundedSize (INT64_MIN) for an unbounded dim
  return InvalidArgument("Update dim size %d greater than dynamic slice dimension: %d.", ...);
}
```
For an unbounded-dynamic operand dimension, `operand_shape.dimensions(dim)` is `kUnboundedSize` (`INT64_MIN`). Any concrete static update size (e.g. `5`) then satisfies `5 > INT64_MIN` and the op is rejected with a nonsensical bound (`-9223372036854775808`). The sibling `InferDynamicSliceShape` guards the identical comparison with `!IsUnboundedDynamicSize(input_dim_size)`, and this function already handles unbounded *update* sizes just above — so unbounded operands are in scope, but the operand side is unguarded.

### Fix
Guard with `!IsUnboundedDynamicSize(input_dim_size)`, matching `InferDynamicSliceShape`.

### Verification
Static reasoning: e.g. `operand = f32[?, 10]`, `update = f32[3, 5]` is rejected today (`3 > INT64_MIN`) and accepted with the fix; operand-static-with-too-large-update still errors; both-unbounded and operand-static-with-unbounded-update are unchanged. (No local Bazel build set up — happy to add a shape-inference test.)
