### PR TITLE
[ROCm] Bump rocm_device_libs to 53996464fa8d94b182ac4aaa7dc3a109ab524f45

### DIFF
--- a/third_party/rocm_device_libs/build_defs.bzl
+++ b/third_party/rocm_device_libs/build_defs.bzl
@@ -19,10 +19,15 @@ def _bitcode_library_impl(ctx):
 
             extra_flags = ctx.attr.file_specific_flags.get(src.basename, [])
             include_flags = ["-I{}".format(dir) for dir in include_dirs]
-            include_flags += ["-I{}".format(ctx.files._clang_header[0].dirname)]
-            include_flags += ["-I{}".format(ctx.files._clang_includes[0].dirname)]
 
-            # https://github.com/ROCm/llvm-project/blob/679865ee84553d564ad0551d878196e58c9d03f3/amd/device-libs/cmake/OCL.cmake#L33
+            clang_header_dir = ctx.files._clang_header[0].dirname
+            clang_includes_dir = ctx.files._clang_includes[0].dirname
+            include_flags += ["-I{}".format(clang_header_dir)]
+            include_flags += ["-I{}".format(clang_includes_dir)]
+            include_flags += ["-isystem", clang_header_dir]
+            include_flags += ["-isystem", clang_includes_dir]
+
+            # https://github.com/ROCm/llvm-project/blob/c7235dceaf25c6ef9ad8bcae4b4a10a3ac691588/amd/device-libs/cmake/OCL.cmake#L33
             args = [
                 "-fcolor-diagnostics",
                 "-Werror",
@@ -36,6 +41,7 @@ def _bitcode_library_impl(ctx):
                 "-fomit-frame-pointer",
                 "-Xclang",
                 "-finclude-default-header",
+                "-nostdlibinc",
                 "-Xclang",
                 "-fexperimental-strict-floating-point",
                 "-Xclang",

--- a/third_party/rocm_device_libs/prepare_builtins.patch
+++ b/third_party/rocm_device_libs/prepare_builtins.patch
@@ -1,11 +1,11 @@
 diff --git a/utils/prepare-builtins/prepare-builtins.cpp b/utils/prepare-builtins/prepare-builtins.cpp
-index 3f60dcd..82c23a1 100644
+index e693e6d2e4e9..f3b941cce4e7 100644
 --- a/utils/prepare-builtins/prepare-builtins.cpp
 +++ b/utils/prepare-builtins/prepare-builtins.cpp
-@@ -73,6 +73,14 @@ int main(int argc, char **argv) {
-     return 1;
+@@ -96,6 +96,14 @@ int main(int argc, char **argv) {
+     }
    }
-
+ 
 +  // Strip the OpenCL version metadata. There are a lot of linked
 +  // modules in the library build, each spamming the same
 +  // version. This may also report a different version than the user

--- a/third_party/rocm_device_libs/rocm_device_libs.BUILD
+++ b/third_party/rocm_device_libs/rocm_device_libs.BUILD
@@ -59,19 +59,5 @@ bitcode_library(
     ]),
     file_specific_flags = {
         "gaaf.cl": ["-munsafe-fp-atomics"],
-        "media.cl": [
-            "-Xclang",
-            "-target-feature",
-            "-Xclang",
-            "+msad-insts",
-            "-Xclang",
-            "-target-feature",
-            "-Xclang",
-            "+mqsad-pk-insts",
-            "-Xclang",
-            "-target-feature",
-            "-Xclang",
-            "+mqsad-insts",
-        ],
     },
 )

--- a/third_party/rocm_device_libs/workspace.bzl
+++ b/third_party/rocm_device_libs/workspace.bzl
@@ -4,8 +4,8 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 
 def repo():
     """Imports Rocm-Device-Libs."""
-    LLVM_COMMIT = "04484e4c8fa747928c59c49fd063e6d7eea9fd87"
-    LLVM_SHA256 = "ac17b9cd3e4c30179ba08cad67c1767476644236a8cb55ddb2eeb9e4716ebd21"
+    LLVM_COMMIT = "53996464fa8d94b182ac4aaa7dc3a109ab524f45"
+    LLVM_SHA256 = "92f4ee3cb7de1f00e0f46f95558246ef18e5eb8ddb364fc98daad6622a08fac7"
 
     tf_http_archive(
         name = "rocm_device_libs",

--- a/xla/backends/gpu/tests/gpu_unrolling_test.cc
+++ b/xla/backends/gpu/tests/gpu_unrolling_test.cc
@@ -127,7 +127,7 @@ TEST_F(GpuUnrollingTest, UnrollUnfusedSine) {
       absl::Substitute(R"(
 ; CHECK: load <$0 x float>
 ; CHECK-NOT: load <$0 x float>
-; CHECK: store <$0 x float>
+; CHECK: store <$0 x {{(float|i32)}}>
       )",
                        GetExpectedUnrollFactor(device_description())),
       /*match_optimized_ir=*/true));


### PR DESCRIPTION
📝 Summary of Changes
Bump rocm_device_libs  and remove existing build workarounds

🎯 Justification
Make the build more in line to what standalone rocm_device_libs cmake build does

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N\A

🧪 Unit Tests:
N\A

🧪 Execution Tests:
N\A
