### PR TITLE
Switch clang-format GitHub workflow to uv.

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -40,8 +40,10 @@ jobs:
           persist-credentials: false
       - name: "Fetch HEAD of main branch"
         run: git fetch origin main --depth=1
+      - name: Install uv dependencies
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: "Install clang-format"
-        run: pipx install clang-format==17.0.6
+        run: uv tool install clang-format==17.0.6
       - name: "Run clang-format-diff"
         run: |
           # Run diff against origin/main.
@@ -50,7 +52,7 @@ jobs:
 
           REFERENCE="origin/${GITHUB_BASE_REF:-main}"
           MERGE_BASE="$(git merge-base "$REFERENCE" HEAD)" # Merge base is the commit on main this PR was branched from.
-          CLANG_FORMAT_BIN="$(pipx environment --value PIPX_BIN_DIR)/clang-format"
+          CLANG_FORMAT_BIN="$(command -v clang-format)"
           DIFF=$(git diff -U0 --no-color "$MERGE_BASE" -- '*.cc' '*.h' | clang-format-diff.py -binary "$CLANG_FORMAT_BIN" -p1 -style=file)
           if [ -n "$DIFF" ]; then
             echo "Clang-format failed on the following changes:"


### PR DESCRIPTION
📝 Summary of Changes
Unifies with .github/workflows/zizmor.yml.

🚀 Kind of Contribution
♻️ Cleanup
