### PR TITLE
[ROCm] Add suppoprt for  log with bf16 on gfx1250

### DIFF
--- a/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
@@ -74,6 +74,9 @@ namespace se = ::stream_executor;
 // log2(e), used to express exp(x) = exp2(x * log2(e)).
 constexpr double kLog2E = 1.4426950408889634;
 
+// ln(2), used to express log(x) = log2(x) * ln(2).
+constexpr double kLn2 = 0.6931471805599453;
+
 // Lowers a scalar bf16 unary `math` op to the matching native gfx1250 bf16
 // transcendental instruction (v_exp_bf16, v_sqrt_bf16, v_rsq_bf16, v_tanh_bf16,
 // v_log_bf16, ...) via its `llvm.amdgcn.*` intrinsic, when the op maps 1:1 to
@@ -134,6 +137,36 @@ struct ExpBF16ToAMDGPU
   }
 };
 
+// Lowers a scalar bf16 `math.log` to the native gfx1250 `v_log_bf16`
+// instruction by rewriting log(x) = log2(x) * ln(2) and emitting the
+// `llvm.amdgcn.log` intrinsic. See TranscendentalBF16ToAMDGPU for the
+// rationale.
+struct LogBF16ToAMDGPU
+    : public mlir::ConvertOpToLLVMPattern<mlir::math::LogOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  mlir::LogicalResult matchAndRewrite(
+      mlir::math::LogOp op, OpAdaptor adaptor,
+      mlir::ConversionPatternRewriter& rewriter) const override {
+    if (!op.getType().isBF16()) {
+      return rewriter.notifyMatchFailure(op, "not a scalar bf16 log");
+    }
+    mlir::Location loc = op.getLoc();
+    mlir::Value operand = adaptor.getOperands().front();
+    mlir::Type bf16 = operand.getType();
+    mlir::Value log2x = rewriter
+                            .create<mlir::LLVM::CallIntrinsicOp>(
+                                loc, /*resultType=*/bf16,
+                                rewriter.getStringAttr("llvm.amdgcn.log"),
+                                mlir::ValueRange{operand})
+                            .getResults();
+    mlir::Value ln2 = rewriter.create<mlir::LLVM::ConstantOp>(
+        loc, bf16, rewriter.getFloatAttr(bf16, kLn2));
+    rewriter.replaceOpWithNewOp<mlir::LLVM::FMulOp>(op, log2x, ln2);
+    return mlir::success();
+  }
+};
+
 class LowerToLLVMGPUPass
     : public impl::LowerToLLVMGPUPassBase<LowerToLLVMGPUPass> {
  public:
@@ -185,6 +218,7 @@ class LowerToLLVMGPUPass
                 .has_bf16_transcendental_support()) {
           mlir::PatternBenefit benefit(2);
           patterns.add<ExpBF16ToAMDGPU>(converter, benefit);
+          patterns.add<LogBF16ToAMDGPU>(converter, benefit);
           patterns.add<TranscendentalBF16ToAMDGPU<mlir::math::Exp2Op>>(
               converter, "llvm.amdgcn.exp2", benefit);
           patterns.add<TranscendentalBF16ToAMDGPU<mlir::math::SqrtOp>>(

--- a/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
+++ b/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
@@ -90,3 +90,19 @@ module {
 // CHECK-LABEL: llvm.func @log2_bf16
 // CHECK: llvm.call_intrinsic "llvm.amdgcn.log"({{.*}}) : (bf16) -> bf16
 // CHECK-NOT: __ocml
+
+// -----
+
+// A plain bf16 log is rewritten to log2(x) * ln(2) on gfx1250 so it also uses
+// the native instruction.
+module {
+  func.func @log_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.log %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @log_bf16
+// CHECK: llvm.call_intrinsic "llvm.amdgcn.log"({{.*}}) : (bf16) -> bf16
+// CHECK: llvm.fmul
+// CHECK-NOT: __ocml

--- a/xla/service/gpu/gpu_float_support.cc
+++ b/xla/service/gpu/gpu_float_support.cc
@@ -152,7 +152,14 @@ bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
       return false;
     case HloOpcode::kLog:
       if (LowPrecisionType() == BF16) {
-        return compute_capability_.IsCuda();
+        if (compute_capability_.IsCuda()) {
+          return true;
+        }
+        // gfx1250 has a native bf16 logarithm instruction, so there is no
+        // need to upcast bf16 log to f32.
+        if (auto* rocm_cc = compute_capability_.rocm_compute_capability()) {
+          return rocm_cc->has_bf16_transcendental_support();
+        }
       }
       return false;
     case HloOpcode::kRsqrt:

--- a/xla/service/gpu/gpu_float_support_test.cc
+++ b/xla/service/gpu/gpu_float_support_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <memory>
 #include <string>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/log/check.h"
 #include "absl/status/statusor.h"
@@ -667,20 +668,21 @@ ENTRY main {
       ROOT r = bf16[4] $0(p0)
 })";
 
-  for (absl::string_view op : {"exponential", "sqrt", "rsqrt", "tanh"}) {
-    TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(
-                                             absl::Substitute(kHloModule, op)));
+  for (absl::string_view op : {"exponential", "log", "sqrt", "rsqrt", "tanh"}) {
+    ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(
+                                          absl::Substitute(kHloModule, op)));
     EXPECT_FALSE(
         Normalize(module.get(), se::GpuComputeCapability{cc}, BF16, F32))
         << "bf16 " << op << " should not be normalized on gfx1250";
   }
 
-  // log has no native bf16 instruction wired up, so it is still normalized.
-  TF_ASSERT_OK_AND_ASSIGN(
-      auto module_log,
-      ParseAndReturnVerifiedModule(absl::Substitute(kHloModule, "log")));
+  // sine has a native bf16 hardware instruction (v_sin_bf16) but is not yet
+  // wired up in XLA (no lowering / gate), so it is still normalized to f32.
+  ASSERT_OK_AND_ASSIGN(
+      auto module_sin,
+      ParseAndReturnVerifiedModule(absl::Substitute(kHloModule, "sine")));
   EXPECT_TRUE(
-      Normalize(module_log.get(), se::GpuComputeCapability{cc}, BF16, F32));
+      Normalize(module_sin.get(), se::GpuComputeCapability{cc}, BF16, F32));
 }
 
 TEST_F(FloatSupportTest, ScaledDotIsIgnored) {

--- a/xla/stream_executor/rocm/rocm_compute_capability.h
+++ b/xla/stream_executor/rocm/rocm_compute_capability.h
@@ -202,7 +202,7 @@ class RocmComputeCapability {
   // Native bf16 transcendental instructions (v_exp_bf16, v_sqrt_bf16,
   // v_rsq_bf16, v_tanh_bf16, v_log_bf16, etc.), backed by the LLVM
   // FeatureBF16TransInsts subtarget feature. Lets us compute these bf16 ops
-  // without upcasting to f32 (currently used for exp, sqrt, rsqrt, tanh).
+  // without upcasting to f32 (currently used for exp, log, sqrt, rsqrt, tanh).
   bool has_bf16_transcendental_support() const { return gfx1250(); }
 
   bool has_tdm_support() const { return gfx1250(); }


### PR DESCRIPTION
  📝 Summary of Changes
Adds native bf16 log support on AMD gfx1250. bf16 log is no longer upcast to f32; it maps to the hardware v_log_bf16 instruction 
  
  🎯 Justification
gfx1250 has a native v_log_bf16 instruction
  
  🚀 Kind of Contribution
  Please remove what does not apply: ⚡️ Performance Improvement,
  ✨ New Feature,  🧪 Tests
  
  📊 Benchmark (for Performance Improvements)
  Please measure and include speedups for one of the public HLOs in
  `compiler/xla/tools/benchmarks/hlo/`.
  
  🧪 Unit Tests:
xla/xla/service/gpu/gpu_float_support_test.cc
xla/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
  
  🧪 Execution Tests:
  What execution tests were added? For example, a new optimization should be
  tested with an end-to-end execution test triggering the optimization and
  asserting correctness. Please provide test cases running with at most 2 GPUs.
