### PR TITLE
[XLA:CPU][oneDNN] Add GELU_ERF pattern matching for StableHLO legalized erfc

### DIFF
--- a/xla/service/cpu/onednn_contraction_rewriter.cc
+++ b/xla/service/cpu/onednn_contraction_rewriter.cc
@@ -222,6 +222,12 @@ bool IsScalar(const HloInstruction* instr) {
   return ShapeUtil::IsEffectiveScalar(instr->shape());
 }
 
+// Match pattern, optionally looking through a convert first.
+template <typename Pattern>
+auto OptionalConvertTo(Pattern pattern) {
+  return m::AnyOf<HloInstruction>(m::Convert(pattern), std::move(pattern));
+}
+
 std::optional<float> GetConstantValueAsFloat32(const HloInstruction* inst) {
   if (!IsScalar(inst)) {
     return std::nullopt;
@@ -285,6 +291,84 @@ inline auto MultiplyMultiplyAnyOrder(PatternA a, PatternB b, PatternC c) {
       m::MultiplyAnyOrder(c, m::MultiplyAnyOrder(a, b)));
 }
 
+// Broadcast of 1/sqrt(2) ≈ 0.7071. Multiple approximations are matched
+// because different precisions (F32, BF16, F16) and compiler optimizations
+// produce slightly different constant values:
+//   0.707106769 — F32 nearest representation of 1/√2
+//   0.70703125  — BF16 nearest representation
+//   0.707182348 — F16-derived approximation after convert to F32
+inline auto BcastInvSqrt2() {
+  return m::AnyOf<HloInstruction>(BcastConstScalarNear(0.707106769),
+                                  BcastConstScalarNear(0.70703125),
+                                  BcastConstScalarNear(0.707182348));
+}
+
+// Match x * (1/sqrt(2)) i.e., x * 0.707...
+inline auto ScaledByInvSqrt2(HloInstruction** src) {
+  return m::MultiplyAnyOrder(m::Op(src), BcastInvSqrt2());
+}
+
+// Match -x * (1/sqrt(2))
+inline auto NegScaledByInvSqrt2(HloInstruction* src) {
+  return m::MultiplyAnyOrder(m::Negate(m::Op().Is(src)), BcastInvSqrt2());
+}
+
+// Match 0.5 * x
+inline auto HalfX(HloInstruction** src) {
+  return m::MultiplyAnyOrder(BcastConstScalar(0.5), m::Op(src));
+}
+
+bool MatchLegalizedErfcLike(HloInstruction* instr, HloInstruction* src) {
+  // instr is expected to be the cdf-like term in:
+  //   0.5 * x * instr
+  //
+  // For current StableHLO f32 erfc legalization, the top-level form is:
+  //   select(abs(y) < 1, 1 - erf_approx(y), erfc_approx(y))
+  // where y = -x / sqrt(2)
+
+  // For FP16, the erfc polynomial runs in F32, so the pattern becomes:
+  //   convert(select(abs(convert(negate(x) * inv_sqrt2)) < 1, ...))
+  // OptionalConvertTo looks through converts at each dtype boundary.
+  HloInstruction* pred = nullptr;
+  HloInstruction* true_branch = nullptr;
+  HloInstruction* false_branch = nullptr;
+
+  if (!Match(instr,
+             OptionalConvertTo(
+                 m::Select(m::Op(&pred), m::Op(&true_branch),
+                           m::Op(&false_branch))
+                     .WithOneUser()))) {
+    return false;
+  }
+
+  // Predicate must be abs(y) < 1
+  HloInstruction* y = nullptr;
+  if (!Match(pred, m::Compare(m::Abs(m::Op(&y)), BcastConstScalar(1.0))
+                       .WithComparisonDirection(ComparisonDirection::kLt)
+                       .WithOneUser())) {
+    return false;
+  }
+
+  // y must be -x / sqrt(2), optionally wrapped in a convert (f16 -> f32 upcast
+  // before erfc polynomial). No WithOneUser() here because y is reused by
+  // multiple nodes within the pattern (abs(y) in the predicate, erf(y) in both
+  // branches). All users are fused together into the GELU post-op.
+  if (!Match(y, OptionalConvertTo(NegScaledByInvSqrt2(src)))) {
+    return false;
+  }
+
+  // True branch must be 1 - <something based on y>
+  if (!Match(true_branch,
+             m::Subtract(BcastConstScalar(1.0), m::Op()).WithOneUser())) {
+    return false;
+  }
+
+  // Checking the above two conditions (abs(y) < 1 and the true branch) is
+  // sufficient to confirm the pattern. We don't check for exact pattern on
+  // the false branch.
+  return true;
+}
+
 auto GELUActivation(HloInstruction* instr, HloInstruction** src) {
   // Attempt to match GELU_TANH activation or GELU_ERF activation
   // (https://arxiv.org/abs/1606.08415), where:
@@ -326,25 +410,21 @@ auto GELUActivation(HloInstruction* instr, HloInstruction** src) {
             BcastConstScalarNear(0.044715),
             m::Multiply(m::Op().Is(*src), m::Op().Is(*src)), m::Op().Is(*src)));
 
-    auto errf_apprx_pattern =
-        m::Tanh(m::MultiplyAnyOrder(
+    auto errf_apprx_pattern = OptionalConvertTo(
+        m::Tanh(OptionalConvertTo(m::MultiplyAnyOrder(
                     BcastConstScalarNear(sqrt(M_2_PI)),
-                    m::AddAnyOrder(m::Op().Is(*src), subexpr_pattern)
-                        .WithOneUser()))
-            .WithOneUser();
+                    m::AddAnyOrder(OptionalConvertTo(m::Op().Is(*src)),
+                                   subexpr_pattern)
+                        .WithOneUser())))
+            .WithOneUser());
 
     HloInstruction* erf;
-    auto errf_exact_pattern =
+    auto errf_exact_pattern = OptionalConvertTo(
         m::Op(&erf)
             .WithOpcode(HloOpcode::kErf)
-            .WithOperand(
-                0, m::MultiplyAnyOrder(m::Op(src),
-                                       m::AnyOf<HloInstruction>(
-                                           BcastConstScalarNear(0.707106769),
-                                           BcastConstScalarNear(0.70703125),
-                                           BcastConstScalarNear(0.707182348)))
-                       .WithOneUser())
-            .WithOneUser();
+            .WithOperand(0,
+                         OptionalConvertTo(ScaledByInvSqrt2(src)).WithOneUser())
+            .WithOneUser());
 
     if (Match(errf, errf_apprx_pattern)) {  // Gelu-approximate pattern.
       return OneDnnFusionConfig::GELU_TANH;
@@ -352,6 +432,23 @@ auto GELUActivation(HloInstruction* instr, HloInstruction** src) {
     if (Match(errf, errf_exact_pattern)) {  // Gelu-exact pattern.
       return OneDnnFusionConfig::GELU_ERF;
     }
+  }
+
+  // In mathematical terms, we are matching:
+  //   GELU_ERF(x) = x * cdf(x),
+  // where the CDF-like term cdf(x) is expressed via erfc as
+  //   cdf(x) = 0.5 * erfc(-x / sqrt(2)).
+  //
+  // The legalized StableHLO pattern we recognize is:
+  //   0.5 * x * select(|y| < 1,
+  //                    1 - erf_approx(y),
+  //                    erfc_approx(y)),
+  // with y = -x / sqrt(2), which numerically approximates cdf(x) above.
+  HloInstruction* cdf_like = nullptr;
+
+  if (Match(instr, m::MultiplyAnyOrder(HalfX(src), m::Op(&cdf_like))) &&
+      MatchLegalizedErfcLike(cdf_like, *src)) {
+    return OneDnnFusionConfig::GELU_ERF;
   }
   return OneDnnFusionConfig::UNDEFINED;
 }

--- a/xla/service/cpu/tests/restricted/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/restricted/onednn_matmul_test.cc
@@ -1906,6 +1906,131 @@ TEST_F(MatmulTest, MulTanhMul) {
   )");
 }
 
+TEST_F(MatmulTest, BiasAndLegalizedErfcGELUTestF32) {
+  // This test exercises the legalized StableHLO erfc-based GELU_ERF pattern:
+  //   0.5 * x * select(|y| < 1, 1 - erf_approx(y), erfc_approx(y))
+  // where y = -x / sqrt(2).
+  //
+  // We use a simplified erfc approximation for the test: the exact functional
+  // form doesn't matter as long as the top-level select structure matches.
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32
+  ENTRY matmul.test.f32 {
+    arg.0 = f32[6304,768] parameter(0), parameter_replication={false}
+    arg.1 = f32[768,3072] parameter(1), parameter_replication={false}
+    dot.0 = f32[6304,3072] dot(arg.0, arg.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    reshape.0 = f32[32,197,3072] reshape(dot.0)
+    constant.bias = f32[3072] constant(0.3)
+    broadcast.bias = f32[32,197,3072] broadcast(constant.bias), dimensions={2}
+    add.bias = f32[32,197,3072] add(reshape.0, broadcast.bias)
+
+    // Compute y = -x / sqrt(2) = negate(x) * (1/sqrt(2))
+    negate.0 = f32[32,197,3072] negate(add.bias)
+    constant.inv_sqrt2 = f32[] constant(0.707106769)
+    broadcast.inv_sqrt2 = f32[32,197,3072] broadcast(constant.inv_sqrt2), dimensions={}
+    y.0 = f32[32,197,3072] multiply(negate.0, broadcast.inv_sqrt2)
+
+    // Compute predicate: |y| < 1
+    abs.y = f32[32,197,3072] abs(y.0)
+    constant.one_pred = f32[] constant(1)
+    broadcast.one_pred = f32[32,197,3072] broadcast(constant.one_pred), dimensions={}
+    pred.0 = pred[32,197,3072] compare(abs.y, broadcast.one_pred), direction=LT
+
+    // True branch: 1 - erf_approx(y)
+    // Use erf(y) as a stand-in for the polynomial erf approximation
+    erf.y = f32[32,197,3072] erf(y.0)
+    constant.one_true = f32[] constant(1)
+    broadcast.one_true = f32[32,197,3072] broadcast(constant.one_true), dimensions={}
+    true_branch.0 = f32[32,197,3072] subtract(broadcast.one_true, erf.y)
+
+    // False branch: erfc_approx(y)
+    // Use (1 - erf(y)) as a stand-in for the erfc polynomial approximation
+    constant.one_false = f32[] constant(1)
+    broadcast.one_false = f32[32,197,3072] broadcast(constant.one_false), dimensions={}
+    erf.y2 = f32[32,197,3072] erf(y.0)
+    false_branch.0 = f32[32,197,3072] subtract(broadcast.one_false, erf.y2)
+
+    // select(|y| < 1, 1 - erf_approx(y), erfc_approx(y))
+    select.0 = f32[32,197,3072] select(pred.0, true_branch.0, false_branch.0)
+
+    // 0.5 * x
+    constant.half = f32[] constant(0.5)
+    broadcast.half = f32[32,197,3072] broadcast(constant.half), dimensions={}
+    half_x.0 = f32[32,197,3072] multiply(broadcast.half, add.bias)
+
+    // 0.5 * x * select(...)
+    ROOT out = f32[32,197,3072] multiply(half_x.0, select.0)
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+  MatchOptimizedHlo(matmul_module_str, fused_matmul_bias_gelu_erf_);
+}
+
+TEST_F(MatmulTest, BiasAndLegalizedErfcGELUTestF16) {
+  // FP16 uses erfc-legalized GELU because FP16's narrow exponent range (5 bits)
+  // causes underflow in erfc for moderate inputs. JAX/StableHLO legalizes erfc
+  // into a piecewise polynomial computed in F32, with f16<->f32 converts at the
+  // boundaries.
+  // Pattern: 0.5 * x * convert(select(|convert(y)| < 1, 1 - erf(y_f32),
+  // erfc_approx(y_f32))) where y = negate(x) * inv_sqrt2 in f16, and the select
+  // internals are in f32.
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f16
+  ENTRY matmul.test.f16 {
+    arg.0 = f16[6304,768] parameter(0), parameter_replication={false}
+    arg.1 = f16[768,3072] parameter(1), parameter_replication={false}
+    dot.0 = f16[6304,3072] dot(arg.0, arg.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    reshape.0 = f16[32,197,3072] reshape(dot.0)
+    constant.bias = f16[3072] constant(0.3)
+    broadcast.bias = f16[32,197,3072] broadcast(constant.bias), dimensions={2}
+    add.bias = f16[32,197,3072] add(reshape.0, broadcast.bias)
+
+    // Compute y = -x / sqrt(2) in f16
+    negate.0 = f16[32,197,3072] negate(add.bias)
+    constant.inv_sqrt2 = f16[] constant(0.707106769)
+    broadcast.inv_sqrt2 = f16[32,197,3072] broadcast(constant.inv_sqrt2), dimensions={}
+    y.0 = f16[32,197,3072] multiply(negate.0, broadcast.inv_sqrt2)
+
+    // Convert f16 -> f32 before erfc polynomial
+    y.f32 = f32[32,197,3072] convert(y.0)
+
+    // Compute predicate: |y| < 1 (in f32)
+    abs.y = f32[32,197,3072] abs(y.f32)
+    constant.one_pred = f32[] constant(1)
+    broadcast.one_pred = f32[32,197,3072] broadcast(constant.one_pred), dimensions={}
+    pred.0 = pred[32,197,3072] compare(abs.y, broadcast.one_pred), direction=LT
+
+    // True branch: 1 - erf_approx(y) (in f32)
+    erf.y = f32[32,197,3072] erf(y.f32)
+    constant.one_true = f32[] constant(1)
+    broadcast.one_true = f32[32,197,3072] broadcast(constant.one_true), dimensions={}
+    true_branch.0 = f32[32,197,3072] subtract(broadcast.one_true, erf.y)
+
+    // False branch: erfc_approx(y) (in f32, simplified stand-in)
+    constant.one_false = f32[] constant(1)
+    broadcast.one_false = f32[32,197,3072] broadcast(constant.one_false), dimensions={}
+    erf.y2 = f32[32,197,3072] erf(y.f32)
+    false_branch.0 = f32[32,197,3072] subtract(broadcast.one_false, erf.y2)
+
+    // select(|y| < 1, 1 - erf_approx(y), erfc_approx(y)) in f32
+    select.0 = f32[32,197,3072] select(pred.0, true_branch.0, false_branch.0)
+
+    // Convert f32 -> f16 after erfc polynomial
+    select.f16 = f16[32,197,3072] convert(select.0)
+
+    // 0.5 * x (in f16)
+    constant.half = f16[] constant(0.5)
+    broadcast.half = f16[32,197,3072] broadcast(constant.half), dimensions={}
+    half_x.0 = f16[32,197,3072] multiply(broadcast.half, add.bias)
+
+    // 0.5 * x * cdf(x)
+    ROOT out = f16[32,197,3072] multiply(half_x.0, select.f16)
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{0.1, 0.1}));
+  MatchOptimizedHlo(matmul_module_str, fused_matmul_bias_gelu_erf_);
+}
+
 TEST_F(MatmulTest, BiasAlongNonLastDimShouldNotFuseAsBias) {
   // When a 1D addend is broadcast along a non-last dimension
   // (e.g., M dimension instead of N), it should be fused as BINARY_ADD, not


### PR DESCRIPTION
Expand CPU oneDNN GELU pattern matching to recognize the exact-GELU form emitted by JAX/StableHLO after `erfc` legalization. This handles the piecewise `select(abs(y) < 1, 1 - ..., ...)` structure for `erfc(-x / sqrt(2))`, in addition to the existing `tanh` and `erf` forms. The decomposition happens because exact GELU lowers through `erfc`, and StableHLO legalizes `erfc` into portable primitive ops rather than preserving it as a first-class op. The matcher stays loose on approximation internals and instead matches the stable mathematical skeleton, improving fusion robustness for Keras/JAX workloads.