### PR TITLE
[ROCm] Allow asynchronous deallocation for StreamExecutorAddressAllocator

### DIFF
--- a/xla/stream_executor/stream_executor_address_allocator.cc
+++ b/xla/stream_executor/stream_executor_address_allocator.cc
@@ -96,13 +96,18 @@ StreamExecutorAddressAllocator::GetStreamExecutor(int device_ordinal) const {
 }
 
 bool StreamExecutorAddressAllocator::AllowsAsynchronousDeallocation() const {
-  return false;
+  // Only report asynchronous deallocation on ROCm. Deallocate() routes to
+  // hipFree, which synchronizes the whole device, so scratch can be freed
+  // inline instead of being deferred into a stream host callback (where hipFree
+  // deadlocks on ROCm). CUDA's cuMemFree is also device-synchronizing and would
+  // be safe, but SYCL's sycl::free only synchronizes the passed queue, so
+  // returning true there could free memory still in use on another queue.
+  // Scope the behavior to ROCm to keep the other platforms unchanged.
+  return platform()->Name() == "ROCM";
 }
 
 absl::StatusOr<Stream*> StreamExecutorAddressAllocator::GetStream(
     int device_ordinal) {
-  CHECK(!AllowsAsynchronousDeallocation())
-      << "The logic below only works for synchronous allocators";
   ASSIGN_OR_RETURN(StreamExecutor * executor,
                    GetStreamExecutor(device_ordinal));
   absl::MutexLock lock(mutex_);


### PR DESCRIPTION
### 📝 Summary of Changes
Report `AllowsAsynchronousDeallocation() == true` for
`StreamExecutorAddressAllocator` **on the ROCM platform only**, and drop the
now-obsolete synchronous-only `CHECK` in `GetStream()`. With this,
`OwningScratchAllocator` frees scratch inline instead of deferring it into a
`Stream::DoHostCallback`. CUDA and SYCL keep their prior behavior.

### 🎯 Justification
On ROCm the synchronous free calls `hipFree`, which deadlocks when invoked
from a HIP stream-callback thread. `OwningScratchAllocator` only defers the
free into a host callback for allocators reporting async-dealloc == false, so
any op allocating a work buffer hangs — notably real FFTs
(`rfft`/`irfft`/`hfft`/`ihfft`/`rfft2`) under the address allocator on gfx950,
which blocked the JAX ROCm test suite at the FFT stage. `Deallocate()` uses
`hipFree`, which already synchronizes the device, so deallocation is safe to
issue asynchronously; reporting `true` frees scratch inline (off the callback)
and keeps the path non-blocking, matching the VMM allocators.

This is scoped to the ROCM platform. CUDA's `cuMemFree` is also
device-synchronizing and would be safe, but SYCL's `sycl::free` synchronizes
only the passed queue (not all device queues), so returning `true` there could
free memory still in use on another queue. CUDA and SYCL therefore retain
their existing behavior.

`GetStream()` is also used by the autotuner/profiler regardless of dealloc
mode, so its `!AllowsAsynchronousDeallocation()` CHECK is removed.

### 🚀 Kind of Contribution
🐛 Bug Fix

### 🧪 Unit Tests:
None. The deadlock is ROCm-GPU-specific (`hipFree` in a HIP callback); on the
host/CPU platform `DoHostCallback` runs fine, so a CPU unit test cannot
reproduce it and would pass with or without the change.

### 🧪 Execution Tests:
Covered by existing JAX ROCm FFT tests (`fft_test.py`, `scipy_fft_test.py`)
run under `XLA_PYTHON_CLIENT_ALLOCATOR=address`: real-transform cases hang
without this fix and pass with it (verified on gfx950 / ROCm 7.2.0).