### PR TITLE
[oneAPI] Disable BF16 SPIR-V tests on Ubuntu 22.04 CI

### DIFF
--- a/build_tools/sycl/ci_test_xla.sh
+++ b/build_tools/sycl/ci_test_xla.sh
@@ -38,7 +38,12 @@ TEST_TARGETS="${TEST_TARGETS:-\
   //xla/backends/gpu/codegen/emitters/tests/... \
   //xla/codegen/emitters/tests/... \
   -//xla/backends/gpu/codegen/emitters/tests:transpose/packed_transpose_s4.hlo.test \
-  -//xla/codegen/emitters/tests:loop/s8_to_s2.hlo.test\
+  -//xla/codegen/emitters/tests:loop/s8_to_s2.hlo.test \
+  -//xla/backends/gpu/codegen/emitters/tests:transpose/multiple_roots_mixed_rank.hlo.test \
+  -//xla/backends/gpu/codegen/emitters/tests:transpose/multiple_roots_one_shmem_transpose.hlo.test \
+  -//xla/backends/gpu/codegen/emitters/tests:transpose/packed_transpose_bf16.hlo.test \
+  -//xla/backends/gpu/codegen/emitters/tests:transpose/packed_transpose_two_heroes.hlo.test \
+  -//xla/codegen/emitters/tests:loop/broadcast_constant.hlo.test\
 }"
 
 echo "TEST_TARGETS=${TEST_TARGETS}"


### PR DESCRIPTION
This PR excludes a small set of GPU emitter tests that currently fail in the oneAPI CI due to the Ubuntu 22.04-based Docker image using an older Intel GPU runtime that does not support the SPV_KHR_bfloat16 SPIR-V extension. The tests can be re-enabled once the CI image is upgraded to a newer Ubuntu/runtime stack with BF16 SPIR-V support.