### PR TITLE
[XLA:SE] Refactoring/cleaning DeviceAddressVmmAllocator, adding tests for DeviceAddressVmmAllocator 

### DIFF
--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -380,6 +380,27 @@ cc_library(
     ],
 )
 
+xla_cc_test(
+    name = "device_address_vmm_allocator_test",
+    srcs = ["device_address_vmm_allocator_test.cc"],
+    deps = [
+        ":device_address",
+        ":device_address_vmm_allocator",
+        ":memory_allocation",
+        ":memory_reservation",
+        ":mock_platform",
+        ":mock_stream",
+        ":mock_stream_executor",
+        ":platform",
+        ":stream_executor_h",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 # Factory backends. Each implementation is free of platform `#if` macros; the
 # right one is selected by the top-level `device_address_vmm_allocator_factory`
 # dispatcher below (Stub / CUDA / ROCm), mirroring the //xla/pjrt:triton idiom.

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -95,7 +95,7 @@ DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
       CHECK(allocator_address_reservation_ == nullptr);
       break;
   }
-  CHECK(allocator_address_mapping_.has_value());
+  CHECK(!allocator_address_mapping_.is_null());
 }
 
 DeviceAddressVmmAllocator::PendingDeallocationKind
@@ -114,85 +114,57 @@ DeviceAddressVmmAllocator::AllocationRecord::pending_deallocation_kind() const {
 
 DeviceAddressBase
 DeviceAddressVmmAllocator::AllocationRecord::reservation_address() const {
-  CHECK(reservation_address_.has_value());
-  return *reservation_address_;
+  CHECK(has_reservation_alias());
+  return reservation_alias_->mapping.mapped_address();
 }
 
-bool DeviceAddressVmmAllocator::AllocationRecord::reservation_mapping_matches(
-    DeviceAddressBase address) const {
-  return reservation_address_mapping_.has_value() &&
-         reservation_address_mapping_->mapped_address().IsSameAs(address);
+uint64_t DeviceAddressVmmAllocator::AllocationRecord::reservation_stale_seqno()
+    const {
+  CHECK(has_reservation_alias());
+  return reservation_alias_->stale_seqno;
 }
 
 void DeviceAddressVmmAllocator::AllocationRecord::MarkAllocatorStale(
     uint64_t seqno) {
   CHECK(allocator_active());
-  CHECK(!allocator_stale());
-  CHECK(has_allocator_address_mapping());
+  CHECK(!allocator_address_mapping_.is_null());
   CHECK_NE(seqno, 0);
-  allocator_state_ = AllocatorState::kStale;
   allocator_stale_seqno_ = seqno;
 }
 
 void DeviceAddressVmmAllocator::AllocationRecord::ReactivateAllocator(
     uint64_t new_size) {
-  CHECK(!allocator_active());
   CHECK(allocator_stale());
-  CHECK(has_allocator_address_mapping());
+  CHECK(!allocator_address_mapping_.is_null());
   allocator_address_ = DeviceAddressBase(allocator_address_.opaque(), new_size);
-  allocator_state_ = AllocatorState::kActive;
   allocator_stale_seqno_ = 0;
 }
 
-void DeviceAddressVmmAllocator::AllocationRecord::CompleteStaleAllocator() {
-  CHECK(!allocator_active());
-  CHECK(allocator_stale());
-  CHECK(!reservation_active());
-  allocator_address_mapping_.reset();
-  allocator_address_reservation_.reset();
-  raw_allocation_.reset();
-}
-
 void DeviceAddressVmmAllocator::AllocationRecord::AddActiveReservationAlias(
-    DeviceAddressBase reservation_address,
     MemoryReservation::ScopedMapping reservation_address_mapping) {
   CHECK(!has_reservation_alias());
-  CHECK(!reservation_address.is_null());
-  reservation_address_ = reservation_address;
-  reservation_address_mapping_.emplace(std::move(reservation_address_mapping));
-  reservation_state_ = ReservationState::kActive;
+  CHECK(!reservation_address_mapping.is_null());
+  reservation_alias_.emplace(
+      ReservationAlias{std::move(reservation_address_mapping)});
 }
 
 void DeviceAddressVmmAllocator::AllocationRecord::MarkReservationStale(
     uint64_t seqno) {
   CHECK(reservation_active());
-  CHECK(!reservation_stale());
-  CHECK(has_reservation_address());
-  CHECK(reservation_address_mapping_.has_value());
   CHECK_NE(seqno, 0);
-  reservation_state_ = ReservationState::kStale;
-  reservation_stale_seqno_ = seqno;
+  reservation_alias_->stale_seqno = seqno;
 }
 
 void DeviceAddressVmmAllocator::AllocationRecord::ReactivateReservation() {
-  CHECK(!reservation_active());
   CHECK(reservation_stale());
-  CHECK(has_reservation_address());
-  CHECK(reservation_address_mapping_.has_value());
-  reservation_state_ = ReservationState::kActive;
-  reservation_stale_seqno_ = 0;
+  reservation_alias_->stale_seqno = 0;
 }
 
 void DeviceAddressVmmAllocator::AllocationRecord::CompleteStaleReservation() {
   if (!reservation_stale()) {
     return;
   }
-  CHECK(!reservation_active());
-  CHECK(has_reservation_address());
-  reservation_address_mapping_.reset();
-  reservation_address_.reset();
-  reservation_state_ = ReservationState::kNone;
-  reservation_stale_seqno_ = 0;
+  reservation_alias_.reset();
 }
 
 // Interval between CPU polls of the GPU-written deallocation timeline while
@@ -525,7 +497,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationWithSeparateAddress(
     if (!record.reservation_stale()) {
       continue;
     }
-    CHECK(record.has_reservation_address());
+    CHECK(record.has_reservation_alias());
     // The allocator address can be reused for command-buffer update-free
     // execution only if the external reservation VA is also the same VA the
     // command buffer captured.
@@ -664,8 +636,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
       AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
       std::move(raw_alloc), std::move(allocator_address_reservation),
       std::move(allocator_address_mapping), request.multi_device);
-  record->AddActiveReservationAlias(request.reservation_address,
-                                    std::move(reservation_address_mapping));
+  record->AddActiveReservationAlias(std::move(reservation_address_mapping));
   AllocationRecord* record_ptr = record.get();
   auto record_insert = state.records_by_allocator_address.emplace(
       allocator_va, std::move(record));
@@ -984,7 +955,7 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   AllocationRecord& record = *record_it->second;
   CHECK(!state->active_reservation_records.contains(mem.opaque()));
   if (record.reservation_active()) {
-    CHECK(record.has_reservation_address());
+    CHECK(record.has_reservation_alias());
     return absl::FailedPreconditionError(absl::StrFormat(
         "Deallocate() requires the active reservation alias at virtual address "
         "%p (%uB) to be released with UnMap() first",
@@ -1009,7 +980,6 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   // mapping alive as stale state until the stream reaches `seqno`.
   CHECK(record.allocator_active());
   CHECK(!record.allocator_stale());
-  CHECK(record.has_allocator_address_mapping());
   void* allocator_va = record.allocator_key();
   auto allocator_record_it =
       state->records_by_allocator_address.find(allocator_va);
@@ -1094,7 +1064,7 @@ DeviceAddressVmmAllocator::FindOverlappingRecord(
   }
   if (include_reservation && include_active) {
     for (const auto& [_, record] : state.active_reservation_records) {
-      CHECK(record->has_reservation_address());
+      CHECK(record->has_reservation_alias());
       if (auto overlap = check_record(record, record->reservation_address(),
                                       /*is_allocator=*/false,
                                       /*is_active=*/true)) {
@@ -1104,7 +1074,7 @@ DeviceAddressVmmAllocator::FindOverlappingRecord(
   }
   if (include_reservation && include_stale) {
     for (const auto& [_, record] : state.stale_reservation_records) {
-      CHECK(record->has_reservation_address());
+      CHECK(record->has_reservation_alias());
       if (auto overlap = check_record(record, record->reservation_address(),
                                       /*is_allocator=*/false,
                                       /*is_active=*/false)) {
@@ -1196,7 +1166,7 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
       }
 
       if (source_record->reservation_stale()) {
-        CHECK(source_record->has_reservation_address());
+        CHECK(source_record->has_reservation_alias());
         if (!source_record->reservation_matches(request.reservation_address)) {
           pending_completion_key =
               PendingDeallocationKey{PendingDeallocationKind::kMap,
@@ -1215,7 +1185,7 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
           // A deferred UnMap() leaves the old mapping valid. Reuse it when it
           // aliases the requested physical allocation; otherwise wait before
           // overwriting it.
-          CHECK(stale_record.has_reservation_address());
+          CHECK(stale_record.has_reservation_alias());
           CHECK(stale_record.reservation_matches(request.reservation_address));
           if (stale_record.raw_allocation() ==
               source_record->raw_allocation()) {
@@ -1260,7 +1230,7 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
 
         CHECK(!source_record->reservation_active());
         CHECK(!source_record->reservation_stale());
-        source_record->AddActiveReservationAlias(mapped, std::move(mapping));
+        source_record->AddActiveReservationAlias(std::move(mapping));
         auto mapping_insert_result = state.active_reservation_records.emplace(
             mapped.opaque(), source_record);
         CHECK(mapping_insert_result.second);
@@ -1333,7 +1303,6 @@ void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
     PerDeviceState& state, AllocationRecord& record, uint64_t new_size) {
   CHECK(!record.allocator_active());
   CHECK(record.allocator_stale());
-  CHECK(record.has_allocator_address_mapping());
   void* allocator_va = record.allocator_key();
   auto record_it = state.records_by_allocator_address.find(allocator_va);
   CHECK(record_it != state.records_by_allocator_address.end());
@@ -1345,7 +1314,7 @@ void DeviceAddressVmmAllocator::MoveReservationRecordToStale(
     PerDeviceState& state, AllocationRecord& record, uint64_t seqno) {
   CHECK(record.reservation_active());
   CHECK(!record.reservation_stale());
-  CHECK(record.has_reservation_address());
+  CHECK(record.has_reservation_alias());
   void* reservation_va = record.reservation_key();
   CHECK_EQ(state.active_reservation_records.erase(reservation_va), 1);
   auto insert_result =
@@ -1358,7 +1327,7 @@ void DeviceAddressVmmAllocator::MoveReservationRecordToActive(
     PerDeviceState& state, AllocationRecord& record) {
   CHECK(!record.reservation_active());
   CHECK(record.reservation_stale());
-  CHECK(record.has_reservation_address());
+  CHECK(record.has_reservation_alias());
   void* reservation_va = record.reservation_key();
   CHECK_EQ(state.stale_reservation_records.erase(reservation_va), 1);
   auto insert_result =
@@ -1373,7 +1342,7 @@ void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
     return;
   }
   CHECK(!record.reservation_active());
-  CHECK(record.has_reservation_address());
+  CHECK(record.has_reservation_alias());
   void* reservation_va = record.reservation_key();
   auto stale_it = state.stale_reservation_records.find(reservation_va);
   if (stale_it != state.stale_reservation_records.end()) {
@@ -1472,7 +1441,7 @@ absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleOverlap(
                                       record.allocator_address()});
   }
   CHECK(overlap.record->reservation_stale());
-  CHECK(overlap.record->has_reservation_address());
+  CHECK(overlap.record->has_reservation_alias());
   return WaitAndCompleteStaleReservationMapping(
       state, PendingDeallocationKey{PendingDeallocationKind::kMap,
                                     overlap.record->reservation_stale_seqno(),
@@ -1504,7 +1473,7 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
   CHECK(!record.allocator_active());
   CHECK(!record.reservation_active());
   if (record.reservation_stale()) {
-    CHECK(record.has_reservation_address());
+    CHECK(record.has_reservation_alias());
     PendingDeallocationKey reservation_key{PendingDeallocationKind::kMap,
                                            record.reservation_stale_seqno(),
                                            record.reservation_address()};
@@ -1529,7 +1498,6 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
     DCHECK_GE(state.pa_allocated, released_size);
     state.pa_allocated -= released_size;
   }
-  record.CompleteStaleAllocator();
   CHECK_EQ(state.records_by_allocator_address.erase(allocator_va), 1);
 }
 
@@ -1559,7 +1527,7 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
     auto stale_it =
         state->stale_reservation_records.find(reservation_address.opaque());
     if (stale_it != state->stale_reservation_records.end()) {
-      CHECK(stale_it->second->has_reservation_address());
+      CHECK(stale_it->second->has_reservation_alias());
     }
     if (stale_it != state->stale_reservation_records.end() &&
         stale_it->second->reservation_matches(reservation_address)) {
@@ -1577,14 +1545,12 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
   AllocationRecord* record = active_it->second;
   CHECK(record->reservation_active());
   CHECK(!record->reservation_stale());
-  CHECK(record->has_reservation_address());
+  CHECK(record->has_reservation_alias());
   if (!record->reservation_matches(reservation_address)) {
     return absl::InvalidArgumentError(
         "DeviceAddressVmmAllocator::UnMap requires the same full reservation "
         "range passed to Map");
   }
-  CHECK(record->reservation_mapping_matches(reservation_address));
-
   uint64_t seqno = state->next_seqno++;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
   MoveReservationRecordToStale(*state, *record, seqno);

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -1118,43 +1118,26 @@ DeviceAddressVmmAllocator::FindOverlappingRecord(
 
 absl::StatusOr<DeviceAddressVmmAllocator::AllocationRecord*>
 DeviceAddressVmmAllocator::ResolveMapSourceRecord(
-    PerDeviceState& state, DeviceAddressBase source_address) const {
+    PerDeviceState& state, DeviceAddressBase source_address,
+    uint64_t size) const {
   auto allocation_it =
       state.records_by_allocator_address.find(source_address.opaque());
   if (allocation_it == state.records_by_allocator_address.end() ||
       !allocation_it->second->allocator_active() ||
       !allocation_it->second->allocator_matches(source_address)) {
     return absl::NotFoundError(absl::StrFormat(
-        "addr %p is not an active allocator address, when trying to "
-        "do map of VA reservation to existing physical allocation, we "
-        "requires the buffer being mapped to is being allocated through "
-        "DeviceAddressVmmAllocator, check the allocator type for the "
-        "buffer.",
+        "addr %p is not an active allocator address; Map() sources must be "
+        "allocated by this DeviceAddressVmmAllocator",
         source_address.opaque()));
   }
-  return allocation_it->second.get();
-}
-
-absl::Status DeviceAddressVmmAllocator::ValidateMapSourceSize(
-    PerDeviceState&, const AllocationRecord& source_record,
-    uint64_t size) const {
-  MemoryAllocation* raw_allocation = source_record.raw_allocation();
+  AllocationRecord* source_record = allocation_it->second.get();
+  MemoryAllocation* raw_allocation = source_record->raw_allocation();
   if (size > raw_allocation->address().size()) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "mapping size must not exceed physical allocation size: "
         "mapping_size=%uB, allocation_size=%uB",
         size, raw_allocation->address().size()));
   }
-  return absl::OkStatus();
-}
-
-absl::StatusOr<DeviceAddressVmmAllocator::AllocationRecord*>
-DeviceAddressVmmAllocator::ResolveAndValidateMapSource(
-    PerDeviceState& state, DeviceAddressBase source_address,
-    uint64_t size) const {
-  ASSIGN_OR_RETURN(AllocationRecord * source_record,
-                   ResolveMapSourceRecord(state, source_address));
-  RETURN_IF_ERROR(ValidateMapSourceSize(state, *source_record, size));
   return source_record;
 }
 
@@ -1252,29 +1235,17 @@ DeviceAddressVmmAllocator::PrepareMapTarget(PerDeviceState& state,
   // occupant. Without concurrent changes, at most two waits are needed before
   // a third attempt can install or reuse the requested mapping.
   constexpr int kMaxStaleMappingWaits = 2;
-  bool first_attempt = true;
   for (int wait_count = 0;; ++wait_count) {
     std::optional<PendingDeallocationKey> pending_completion_key;
     {
       // Keep record pointers inside this scope so none survives a wait that
       // releases state.mu.
       AllocationRecord* source_record;
-      if (first_attempt) {
-        ASSIGN_OR_RETURN(source_record,
-                         ResolveAndValidateMapSource(
-                             state, request.source_address, request.size));
-        RETURN_IF_ERROR(CheckNoPartialReservationOverlap(
-            state, request.reservation_address));
-      } else {
-        // Preserve Map()'s post-wait validation order: re-resolve the source,
-        // recheck target overlaps, then revalidate its current allocation size.
-        ASSIGN_OR_RETURN(source_record,
-                         ResolveMapSourceRecord(state, request.source_address));
-        RETURN_IF_ERROR(CheckNoPartialReservationOverlap(
-            state, request.reservation_address));
-        RETURN_IF_ERROR(
-            ValidateMapSourceSize(state, *source_record, request.size));
-      }
+      ASSIGN_OR_RETURN(
+          source_record,
+          ResolveMapSourceRecord(state, request.source_address, request.size));
+      RETURN_IF_ERROR(
+          CheckNoPartialReservationOverlap(state, request.reservation_address));
 
       ASSIGN_OR_RETURN(MapTargetEvaluation evaluation,
                        EvaluateMapTarget(state, request, *source_record));
@@ -1309,7 +1280,6 @@ DeviceAddressVmmAllocator::PrepareMapTarget(PerDeviceState& state,
       RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
           state, *pending_completion_key));
     }
-    first_attempt = false;
   }
 }
 

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -391,7 +391,8 @@ DeviceAddressVmmAllocator::AllocatePhysicalWithinBudget(
   return raw_alloc;
 }
 
-void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
+DeviceAddressVmmAllocator::AllocationRecord&
+DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
     PerDeviceState& state, AllocationRecord::Kind kind,
     DeviceAddressBase allocator_address,
     std::unique_ptr<MemoryAllocation> raw_allocation,
@@ -403,11 +404,12 @@ void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
   auto record = std::make_unique<AllocationRecord>(
       kind, allocator_address, std::move(raw_allocation),
       std::move(reservation), std::move(mapping), multi_device);
+  AllocationRecord* record_ptr = record.get();
   auto insert_result =
       state.records_by_allocator_address.emplace(va_ptr, std::move(record));
   CHECK(insert_result.second);
   state.pa_allocated += physical_size;
-  return va_ptr;
+  return *record_ptr;
 }
 
 std::optional<DeviceAddressBase>
@@ -521,82 +523,53 @@ DeviceAddressVmmAllocator::EnsureReservationAvailableForFreshMapping(
 }
 
 absl::StatusOr<DeviceAddressBase>
-DeviceAddressVmmAllocator::CreateMappedAllocationAtReservationAddress(
+DeviceAddressVmmAllocator::CreateMappedAllocation(
     PerDeviceState& state, const MappedAllocateRequest& request) {
-  // The returned allocator address is the caller-owned reservation VA. The
-  // record is keyed by that VA and owns only the raw allocation plus the scoped
-  // mapping into the external reservation.
   uint64_t physical_size = 0;
-  ASSIGN_OR_RETURN(auto raw_alloc,
-                   AllocatePhysicalWithinBudget(
-                       state, request.size, physical_size));
-  if (request.size > physical_size) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "physical allocation is smaller than requested mapping: "
-        "allocation_size=%uB, mapping_size=%uB",
-        physical_size, request.size));
+  ASSIGN_OR_RETURN(auto raw_alloc, AllocatePhysicalWithinBudget(
+                                       state, request.size, physical_size));
+
+  const bool separate_address =
+      request.mode == MappedAddressMode::kSeparateAllocatorAddress;
+  AllocationRecord::Kind kind =
+      AllocationRecord::Kind::kAllocateAndMapReturnMapAddr;
+  DeviceAddressBase allocator_address = request.reservation_address;
+  std::unique_ptr<MemoryReservation> allocator_address_reservation;
+  MemoryReservation::ScopedMapping allocator_address_mapping;
+
+  if (separate_address) {
+    kind = AllocationRecord::Kind::kAllocateAndMapReturnNewAddr;
+    ASSIGN_OR_RETURN(allocator_address_reservation,
+                     CreateReservation(state.executor, request.size));
+    allocator_address = DeviceAddressBase(
+        allocator_address_reservation->address().opaque(), request.size);
+    ASSIGN_OR_RETURN(allocator_address_mapping,
+                     allocator_address_reservation->MapTo(
+                         /*reservation_offset=*/0, /*allocation_offset=*/0,
+                         physical_size, *raw_alloc));
   }
 
-  ASSIGN_OR_RETURN(auto scoped_mapping, request.reservation->MapTo(
-                                            request.reservation_offset,
-                                            /*allocation_offset=*/0,
-                                            request.size, *raw_alloc));
-  TrackAllocatorAddressMappedAllocation(
-      state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
-      request.reservation_address, std::move(raw_alloc), nullptr,
-      std::move(scoped_mapping), request.multi_device);
+  ASSIGN_OR_RETURN(auto reservation_address_mapping,
+                   request.reservation->MapTo(request.reservation_offset,
+                                              /*allocation_offset=*/0,
+                                              request.size, *raw_alloc));
 
-  return request.reservation_address;
-}
-
-absl::StatusOr<DeviceAddressBase>
-DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
-    PerDeviceState& state, const MappedAllocateRequest& request) {
-  // This mode creates two VAs for the same raw allocation: an allocator-owned
-  // VA returned to the caller, and a non-owning alias in the caller reservation
-  // used by captured command buffers.
-  uint64_t physical_size = 0;
-  ASSIGN_OR_RETURN(auto raw_alloc,
-                   AllocatePhysicalWithinBudget(
-                       state, request.size, physical_size));
-  if (request.size > physical_size) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "mapping size must not exceed physical allocation size: "
-        "mapping_size=%uB, allocation_size=%uB",
-        request.size, physical_size));
+  if (!separate_address) {
+    allocator_address_mapping = std::move(reservation_address_mapping);
+    reservation_address_mapping = MemoryReservation::ScopedMapping();
   }
-
-  ASSIGN_OR_RETURN(auto allocator_address_reservation,
-                   CreateReservation(state.executor, request.size));
-  ASSIGN_OR_RETURN(auto allocator_address_mapping,
-                   allocator_address_reservation->MapTo(
-                       /*reservation_offset=*/0, /*allocation_offset=*/0,
-                       physical_size, *raw_alloc));
-  ASSIGN_OR_RETURN(
-      auto reservation_address_mapping,
-      request.reservation->MapTo(request.reservation_offset,
-                                 /*allocation_offset=*/0, request.size,
-                                 *raw_alloc));
-
-  // Record the paired allocation: the allocator-owned returned VA owns the raw
-  // allocation, and the caller reservation VA is a non-owning alias.
-  void* allocator_va = allocator_address_reservation->address().opaque();
-  DeviceAddressBase allocator_address(allocator_va, request.size);
-  auto record = std::make_unique<AllocationRecord>(
-      AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
-      std::move(raw_alloc), std::move(allocator_address_reservation),
+  AllocationRecord& record = TrackAllocatorAddressMappedAllocation(
+      state, kind, allocator_address, std::move(raw_alloc),
+      std::move(allocator_address_reservation),
       std::move(allocator_address_mapping), request.multi_device);
-  record->AddActiveReservationAlias(std::move(reservation_address_mapping));
-  AllocationRecord* record_ptr = record.get();
-  auto record_insert = state.records_by_allocator_address.emplace(
-      allocator_va, std::move(record));
-  CHECK(record_insert.second);
-  auto reservation_insert = state.reservation_records.emplace(
-      request.reservation_address.opaque(), record_ptr);
-  CHECK(reservation_insert.second);
-  state.pa_allocated += physical_size;
+  if (separate_address) {
+    record.AddActiveReservationAlias(std::move(reservation_address_mapping));
+    auto reservation_insert = state.reservation_records.emplace(
+        request.reservation_address.opaque(), &record);
+    CHECK(reservation_insert.second);
+  }
 
-  return DeviceAddressBase(allocator_va, request.size);
+  return allocator_address;
 }
 
 // Shared pending-reclaim retry flow:
@@ -785,26 +758,22 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
                            physical_size, *raw_alloc));
 
     DeviceAddressBase allocator_address(reservation->address().opaque(), size);
-    void* va_ptr = TrackAllocatorAddressMappedAllocation(
+    TrackAllocatorAddressMappedAllocation(
         *state, AllocationRecord::Kind::kAllocate, allocator_address,
         std::move(raw_alloc), std::move(reservation),
         std::move(scoped_mapping), multi_device);
     // Return the original requested size, not the padded size.
-    return absl::StatusOr<DeviceAddressBase>(DeviceAddressBase(va_ptr, size));
+    return absl::StatusOr<DeviceAddressBase>(allocator_address);
   };
 
-  absl::StatusOr<DeviceAddressBase> result =
-      TryWithPendingReclaim(*state, size, try_reuse, try_fresh);
-
-  if (!result.ok()) {
-    return result.status();
-  }
+  ASSIGN_OR_RETURN(DeviceAddressBase result,
+                   TryWithPendingReclaim(*state, size, try_reuse, try_fresh));
 
   VLOG(3) << absl::StreamFormat(
       "Allocated virtual address %p (%uB) on device ordinal %d",
-      result->opaque(), size, device_ordinal);
+      result.opaque(), size, device_ordinal);
 
-  return ScopedDeviceAddress<uint8_t>(*result, device_ordinal, this);
+  return ScopedDeviceAddress<uint8_t>(result, device_ordinal, this);
 }
 
 // Mapped Allocate() reuses matching pending mapped deallocations, otherwise
@@ -815,26 +784,15 @@ DeviceAddressVmmAllocator::Allocate(
     int64_t /*memory_space*/, MemoryReservation* reservation,
     uint64_t reservation_offset, uint64_t mapping_size,
     bool return_reservation_address) {
-  // Keep zero-sized mapped allocation consistent with regular Allocate(): no
-  // physical allocation or mapping is created, so the requested mapping size
-  // must also be zero.
-  if (allocation_size == 0) {
-    if (mapping_size != 0) {
-      return absl::InvalidArgumentError(
-          "mapping_size must be zero when allocation_size is zero");
-    }
-    return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
-                                        this);
-  }
-  // A mapped allocation with a nonzero physical allocation must establish a
-  // nonempty mapping into the caller-owned reservation.
-  if (mapping_size == 0) {
-    return absl::InvalidArgumentError(
-        "mapping_size must be nonzero for mapped Allocate");
-  }
   if (allocation_size != mapping_size) {
     return absl::InvalidArgumentError(
         "allocation_size must equal mapping_size for mapped Allocate");
+  }
+  // Keep zero-sized mapped allocation consistent with regular Allocate(): no
+  // physical allocation or mapping is created.
+  if (allocation_size == 0) {
+    return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
+                                        this);
   }
 
   ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
@@ -865,26 +823,20 @@ DeviceAddressVmmAllocator::Allocate(
   auto try_fresh = [&]() -> absl::StatusOr<DeviceAddressBase> {
     state->mu.AssertHeld();
     RETURN_IF_ERROR(EnsureReservationAvailableForFreshMapping(*state, request));
-    if (request.mode == MappedAddressMode::kReservationAddress) {
-      return CreateMappedAllocationAtReservationAddress(*state, request);
-    }
-    return CreateMappedAllocationWithSeparateAddress(*state, request);
+    return CreateMappedAllocation(*state, request);
   };
 
   // The shared retry helper handles PA-budget pressure: try reuse, try fresh,
   // complete already-finished pending work on ResourceExhausted, and finally
   // wait for enough pending deallocations only if necessary.
-  absl::StatusOr<DeviceAddressBase> result =
-      TryWithPendingReclaim(*state, allocation_size, try_reuse, try_fresh);
-
-  if (!result.ok()) {
-    return result.status();
-  }
+  ASSIGN_OR_RETURN(
+      DeviceAddressBase result,
+      TryWithPendingReclaim(*state, allocation_size, try_reuse, try_fresh));
 
   // For return_reservation_address=true this is `reservation_address`; for
   // return_reservation_address=false it is the allocator-owned address paired
   // with the reservation mapping.
-  return ScopedDeviceAddress<uint8_t>(*result, device_ordinal, this);
+  return ScopedDeviceAddress<uint8_t>(result, device_ordinal, this);
 }
 
 absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -324,10 +324,12 @@ MemoryAllocation* DeviceAddressVmmAllocator::GetRawAllocation(
   }
 
   // Reservation aliases created by Map() or by Allocate(...,
-  // return_reservation_address=false) are tracked in a separate active-only
-  // index. Stale or already-unmapped aliases intentionally return nullptr.
-  auto reservation_it = state->active_reservation_records.find(addr.opaque());
-  if (reservation_it != state->active_reservation_records.end()) {
+  // return_reservation_address=false) share one index. Only active aliases are
+  // exposed; stale or already-unmapped aliases intentionally return nullptr.
+  auto reservation_it = state->reservation_records.find(addr.opaque());
+  if (reservation_it != state->reservation_records.end() &&
+      reservation_it->second->reservation_active() &&
+      reservation_it->second->reservation_matches(addr)) {
     return reservation_it->second->raw_allocation();
   }
   return nullptr;
@@ -521,7 +523,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationWithSeparateAddress(
     // reservation VA. This cancels the pending allocator teardown and the
     // paired pending kMap unmap for the reservation mapping.
     MoveAllocatorRecordToActive(state, record, request.allocation_size);
-    MoveReservationRecordToActive(state, record);
+    record.ReactivateReservation();
     ErasePendingDeallocationAt(state, it);
     ErasePendingDeallocation(state, PendingDeallocationKind::kMap,
                              request.reservation_address);
@@ -641,7 +643,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
   auto record_insert = state.records_by_allocator_address.emplace(
       allocator_va, std::move(record));
   CHECK(record_insert.second);
-  auto reservation_insert = state.active_reservation_records.emplace(
+  auto reservation_insert = state.reservation_records.emplace(
       request.reservation_address.opaque(), record_ptr);
   CHECK(reservation_insert.second);
   state.pa_allocated += physical_size;
@@ -953,7 +955,9 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
         mem.opaque()));
   }
   AllocationRecord& record = *record_it->second;
-  CHECK(!state->active_reservation_records.contains(mem.opaque()));
+  auto reservation_it = state->reservation_records.find(mem.opaque());
+  CHECK(reservation_it == state->reservation_records.end() ||
+        !reservation_it->second->reservation_active());
   if (record.reservation_active()) {
     CHECK(record.has_reservation_alias());
     return absl::FailedPreconditionError(absl::StrFormat(
@@ -1062,22 +1066,17 @@ DeviceAddressVmmAllocator::FindOverlappingRecord(
       }
     }
   }
-  if (include_reservation && include_active) {
-    for (const auto& [_, record] : state.active_reservation_records) {
+  if (include_reservation) {
+    for (const auto& [_, record] : state.reservation_records) {
       CHECK(record->has_reservation_alias());
-      if (auto overlap = check_record(record, record->reservation_address(),
-                                      /*is_allocator=*/false,
-                                      /*is_active=*/true)) {
-        return overlap;
+      bool include_record = (include_active && record->reservation_active()) ||
+                            (include_stale && record->reservation_stale());
+      if (!include_record) {
+        continue;
       }
-    }
-  }
-  if (include_reservation && include_stale) {
-    for (const auto& [_, record] : state.stale_reservation_records) {
-      CHECK(record->has_reservation_alias());
-      if (auto overlap = check_record(record, record->reservation_address(),
-                                      /*is_allocator=*/false,
-                                      /*is_active=*/false)) {
+      if (auto overlap = check_record(
+              record, record->reservation_address(), /*is_allocator=*/false,
+              /*is_active=*/record->reservation_active())) {
         return overlap;
       }
     }
@@ -1189,7 +1188,7 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
           CHECK(stale_record.reservation_matches(request.reservation_address));
           if (stale_record.raw_allocation() ==
               source_record->raw_allocation()) {
-            MoveReservationRecordToActive(state, stale_record);
+            stale_record.ReactivateReservation();
             ErasePendingDeallocation(state, PendingDeallocationKind::kMap,
                                      request.reservation_address);
             return absl::OkStatus();
@@ -1231,8 +1230,8 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
         CHECK(!source_record->reservation_active());
         CHECK(!source_record->reservation_stale());
         source_record->AddActiveReservationAlias(std::move(mapping));
-        auto mapping_insert_result = state.active_reservation_records.emplace(
-            mapped.opaque(), source_record);
+        auto mapping_insert_result =
+            state.reservation_records.emplace(mapped.opaque(), source_record);
         CHECK(mapping_insert_result.second);
         return absl::OkStatus();
       }
@@ -1310,32 +1309,6 @@ void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
   record.ReactivateAllocator(new_size);
 }
 
-void DeviceAddressVmmAllocator::MoveReservationRecordToStale(
-    PerDeviceState& state, AllocationRecord& record, uint64_t seqno) {
-  CHECK(record.reservation_active());
-  CHECK(!record.reservation_stale());
-  CHECK(record.has_reservation_alias());
-  void* reservation_va = record.reservation_key();
-  CHECK_EQ(state.active_reservation_records.erase(reservation_va), 1);
-  auto insert_result =
-      state.stale_reservation_records.emplace(reservation_va, &record);
-  CHECK(insert_result.second);
-  record.MarkReservationStale(seqno);
-}
-
-void DeviceAddressVmmAllocator::MoveReservationRecordToActive(
-    PerDeviceState& state, AllocationRecord& record) {
-  CHECK(!record.reservation_active());
-  CHECK(record.reservation_stale());
-  CHECK(record.has_reservation_alias());
-  void* reservation_va = record.reservation_key();
-  CHECK_EQ(state.stale_reservation_records.erase(reservation_va), 1);
-  auto insert_result =
-      state.active_reservation_records.emplace(reservation_va, &record);
-  CHECK(insert_result.second);
-  record.ReactivateReservation();
-}
-
 void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
     PerDeviceState& state, AllocationRecord& record) {
   if (!record.reservation_stale()) {
@@ -1344,11 +1317,10 @@ void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
   CHECK(!record.reservation_active());
   CHECK(record.has_reservation_alias());
   void* reservation_va = record.reservation_key();
-  auto stale_it = state.stale_reservation_records.find(reservation_va);
-  if (stale_it != state.stale_reservation_records.end()) {
-    CHECK_EQ(stale_it->second, &record);
-    state.stale_reservation_records.erase(stale_it);
-  }
+  auto reservation_it = state.reservation_records.find(reservation_va);
+  CHECK(reservation_it != state.reservation_records.end());
+  CHECK_EQ(reservation_it->second, &record);
+  state.reservation_records.erase(reservation_it);
   record.CompleteStaleReservation();
 }
 
@@ -1451,9 +1423,9 @@ absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleOverlap(
 void DeviceAddressVmmAllocator::CompletePendingDeallocation(
     PerDeviceState& state, const PendingDeallocation& pending) {
   if (pending.kind == PendingDeallocationKind::kMap) {
-    auto record_it =
-        state.stale_reservation_records.find(pending.addr.opaque());
-    CHECK(record_it != state.stale_reservation_records.end());
+    auto record_it = state.reservation_records.find(pending.addr.opaque());
+    CHECK(record_it != state.reservation_records.end());
+    CHECK(record_it->second->reservation_stale());
     CHECK_EQ(record_it->second->reservation_stale_seqno(), pending.seqno);
     CompleteStaleReservationMapping(state, *record_it->second);
     return;
@@ -1521,16 +1493,19 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
   // UnMap() only accepts the exact active reservation range previously created
   // by Map() or Allocate(..., return_reservation_address=false). Allocator
   // addresses and subranges are not valid UnMap() inputs.
-  auto active_it =
-      state->active_reservation_records.find(reservation_address.opaque());
-  if (active_it == state->active_reservation_records.end()) {
-    auto stale_it =
-        state->stale_reservation_records.find(reservation_address.opaque());
-    if (stale_it != state->stale_reservation_records.end()) {
-      CHECK(stale_it->second->has_reservation_alias());
-    }
-    if (stale_it != state->stale_reservation_records.end() &&
-        stale_it->second->reservation_matches(reservation_address)) {
+  auto reservation_it =
+      state->reservation_records.find(reservation_address.opaque());
+  if (reservation_it == state->reservation_records.end()) {
+    return absl::NotFoundError(absl::StrFormat(
+        "UnMap() requires an exact active reservation range created by Map() "
+        "or Allocate(..., return_reservation_address=false): virtual address "
+        "%p (%uB)",
+        reservation_address.opaque(), reservation_address.size()));
+  }
+  AllocationRecord* record = reservation_it->second;
+  CHECK(record->has_reservation_alias());
+  if (record->reservation_stale()) {
+    if (record->reservation_matches(reservation_address)) {
       return absl::FailedPreconditionError(absl::StrFormat(
           "reservation range at virtual address %p (%uB) is already pending "
           "UnMap()",
@@ -1542,10 +1517,7 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
         "%p (%uB)",
         reservation_address.opaque(), reservation_address.size()));
   }
-  AllocationRecord* record = active_it->second;
   CHECK(record->reservation_active());
-  CHECK(!record->reservation_stale());
-  CHECK(record->has_reservation_alias());
   if (!record->reservation_matches(reservation_address)) {
     return absl::InvalidArgumentError(
         "DeviceAddressVmmAllocator::UnMap requires the same full reservation "
@@ -1553,7 +1525,7 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
   }
   uint64_t seqno = state->next_seqno++;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
-  MoveReservationRecordToStale(*state, *record, seqno);
+  record->MarkReservationStale(seqno);
   state->pending_deallocations.push_back(
       PendingDeallocation{PendingDeallocationKind::kMap, seqno,
                           reservation_address, /*reclaimable_bytes=*/0});

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -410,117 +410,63 @@ void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
   return va_ptr;
 }
 
-absl::StatusOr<std::optional<DeviceAddressBase>>
-DeviceAddressVmmAllocator::TryReuseMappedAllocationAtReservationAddress(
+std::optional<DeviceAddressBase>
+DeviceAddressVmmAllocator::TryReuseMappedAllocation(
     PerDeviceState& state, const MappedAllocateRequest& request) {
-  // Look for a pending deallocation that already owns the requested
-  // reservation VA as its returned allocator address. Reusing it keeps the
-  // same virtual address mapped and avoids waiting for the GPU timeline when
-  // the pending raw allocation is compatible with this request.
-  auto record_it = state.records_by_allocator_address.find(
-      request.reservation_address.opaque());
-  if (record_it == state.records_by_allocator_address.end()) {
-    return std::nullopt;
-  }
-  AllocationRecord& record = *record_it->second;
-  if (!record.allocator_stale()) {
-    return std::nullopt;
-  }
-  if (record.kind() != AllocationRecord::Kind::kAllocateAndMapReturnMapAddr) {
-    return std::nullopt;
-  }
-  if (record.multi_device() != request.multi_device) {
-    return std::nullopt;
-  }
-  if (!record.allocator_matches(request.reservation_address)) {
-    return std::nullopt;
+  const bool separate_address =
+      request.mode == MappedAddressMode::kSeparateAllocatorAddress;
+  AllocationRecord* record;
+  if (separate_address) {
+    auto record_it =
+        state.reservation_records.find(request.reservation_address.opaque());
+    if (record_it == state.reservation_records.end()) {
+      return std::nullopt;
+    }
+    record = record_it->second;
+  } else {
+    auto record_it = state.records_by_allocator_address.find(
+        request.reservation_address.opaque());
+    if (record_it == state.records_by_allocator_address.end()) {
+      return std::nullopt;
+    }
+    record = record_it->second.get();
   }
 
-  // Allocate(..., return_reservation_address=true) returns the reservation VA
-  // as an owning allocator address. If the pending raw allocation is too small
-  // for the new request, wait for the old mapping to drain so the fresh path
-  // can remap this reservation VA to a larger raw allocation.
-  if (record.raw_allocation()->address().size() < request.allocation_size) {
-    uint64_t seqno = record.allocator_stale_seqno();
-    WaitUntilSeqno(state, seqno);
-    CompletePendingDeallocationBySeqno(state, seqno);
+  AllocationRecord::Kind expected_kind =
+      separate_address ? AllocationRecord::Kind::kAllocateAndMapReturnNewAddr
+                       : AllocationRecord::Kind::kAllocateAndMapReturnMapAddr;
+  bool address_matches =
+      separate_address
+          ? record->reservation_matches(request.reservation_address)
+          : record->allocator_matches(request.reservation_address);
+  if (record->kind() != expected_kind || !record->allocator_stale() ||
+      record->multi_device() != request.multi_device || !address_matches ||
+      (separate_address && !record->reservation_stale())) {
     return std::nullopt;
   }
 
   auto pending_it = state.pending_deallocations.end();
-  // The record is indexed by allocator address, but the FIFO queue owns the
-  // stream-ordered allocator teardown. Find the queue entry so reuse can cancel
-  // it while leaving explicit pending kMap entries untouched.
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
     if (it->kind == PendingDeallocationKind::kAllocation &&
-        it->addr.IsSameAs(request.reservation_address)) {
+        it->addr.IsSameAs(record->allocator_address())) {
       pending_it = it;
       break;
     }
   }
   CHECK(pending_it != state.pending_deallocations.end());
-  MoveAllocatorRecordToActive(state, record, request.allocation_size);
+
+  DeviceAddressBase reused_mem(record->allocator_key(), request.size);
+  MoveAllocatorRecordToActive(state, *record, request.size);
+  if (separate_address) {
+    record->ReactivateReservation();
+  }
   ErasePendingDeallocationAt(state, pending_it);
-  return request.reservation_address;
-}
-
-absl::StatusOr<std::optional<DeviceAddressBase>>
-DeviceAddressVmmAllocator::TryReuseMappedAllocationWithSeparateAddress(
-    PerDeviceState& state, const MappedAllocateRequest& request) {
-  // This mode returns a distinct allocator-owned VA while also mapping that
-  // allocation into the caller-owned reservation. Reuse is possible only when
-  // a pending kAllocateAndMapReturnNewAddr record still has both sides stale
-  // and its reservation side exactly matches this request.
-  for (auto it = state.pending_deallocations.begin();
-       it != state.pending_deallocations.end(); ++it) {
-    if (it->kind != PendingDeallocationKind::kAllocation) {
-      continue;
-    }
-    auto record_it = state.records_by_allocator_address.find(it->addr.opaque());
-    CHECK(record_it != state.records_by_allocator_address.end());
-    AllocationRecord& record = *record_it->second;
-    CHECK(record.allocator_stale());
-    CHECK(record.allocator_matches(it->addr));
-    if (record.kind() != AllocationRecord::Kind::kAllocateAndMapReturnNewAddr) {
-      continue;
-    }
-    if (record.multi_device() != request.multi_device) {
-      continue;
-    }
-    if (!record.reservation_stale()) {
-      continue;
-    }
-    CHECK(record.has_reservation_alias());
-    // The allocator address can be reused for command-buffer update-free
-    // execution only if the external reservation VA is also the same VA the
-    // command buffer captured.
-    if (!record.reservation_matches(request.reservation_address)) {
-      continue;
-    }
-    if (record.raw_allocation()->address().size() < request.allocation_size) {
-      // The old mapping is the right VA but not enough physical memory. Wait
-      // for its deferred teardown to finish, then let the fresh path create a
-      // larger allocation and install a new mapping.
-      uint64_t seqno = record.allocator_stale_seqno();
-      WaitUntilSeqno(state, seqno);
-      CompletePendingDeallocationBySeqno(state, seqno);
-      return std::nullopt;
-    }
-
-    DeviceAddressBase reused_mem(record.allocator_key(),
-                                 request.allocation_size);
-    // Reactivate both aliases: the returned allocator VA and the external
-    // reservation VA. This cancels the pending allocator teardown and the
-    // paired pending kMap unmap for the reservation mapping.
-    MoveAllocatorRecordToActive(state, record, request.allocation_size);
-    record.ReactivateReservation();
-    ErasePendingDeallocationAt(state, it);
+  if (separate_address) {
     ErasePendingDeallocation(state, PendingDeallocationKind::kMap,
                              request.reservation_address);
-    return reused_mem;
   }
-  return std::nullopt;
+  return reused_mem;
 }
 
 absl::Status
@@ -583,18 +529,18 @@ DeviceAddressVmmAllocator::CreateMappedAllocationAtReservationAddress(
   uint64_t physical_size = 0;
   ASSIGN_OR_RETURN(auto raw_alloc,
                    AllocatePhysicalWithinBudget(
-                       state, request.allocation_size, physical_size));
-  if (request.mapping_size > physical_size) {
+                       state, request.size, physical_size));
+  if (request.size > physical_size) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "physical allocation is smaller than requested mapping: "
         "allocation_size=%uB, mapping_size=%uB",
-        physical_size, request.mapping_size));
+        physical_size, request.size));
   }
 
   ASSIGN_OR_RETURN(auto scoped_mapping, request.reservation->MapTo(
                                             request.reservation_offset,
                                             /*allocation_offset=*/0,
-                                            request.mapping_size, *raw_alloc));
+                                            request.size, *raw_alloc));
   TrackAllocatorAddressMappedAllocation(
       state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
       request.reservation_address, std::move(raw_alloc), nullptr,
@@ -612,16 +558,16 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
   uint64_t physical_size = 0;
   ASSIGN_OR_RETURN(auto raw_alloc,
                    AllocatePhysicalWithinBudget(
-                       state, request.allocation_size, physical_size));
-  if (request.mapping_size > physical_size) {
+                       state, request.size, physical_size));
+  if (request.size > physical_size) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "mapping size must not exceed physical allocation size: "
         "mapping_size=%uB, allocation_size=%uB",
-        request.mapping_size, physical_size));
+        request.size, physical_size));
   }
 
   ASSIGN_OR_RETURN(auto allocator_address_reservation,
-                   CreateReservation(state.executor, request.allocation_size));
+                   CreateReservation(state.executor, request.size));
   ASSIGN_OR_RETURN(auto allocator_address_mapping,
                    allocator_address_reservation->MapTo(
                        /*reservation_offset=*/0, /*allocation_offset=*/0,
@@ -629,13 +575,13 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
   ASSIGN_OR_RETURN(
       auto reservation_address_mapping,
       request.reservation->MapTo(request.reservation_offset,
-                                 /*allocation_offset=*/0, request.mapping_size,
+                                 /*allocation_offset=*/0, request.size,
                                  *raw_alloc));
 
   // Record the paired allocation: the allocator-owned returned VA owns the raw
   // allocation, and the caller reservation VA is a non-owning alias.
   void* allocator_va = allocator_address_reservation->address().opaque();
-  DeviceAddressBase allocator_address(allocator_va, request.allocation_size);
+  DeviceAddressBase allocator_address(allocator_va, request.size);
   auto record = std::make_unique<AllocationRecord>(
       AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
       std::move(raw_alloc), std::move(allocator_address_reservation),
@@ -650,7 +596,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
   CHECK(reservation_insert.second);
   state.pa_allocated += physical_size;
 
-  return DeviceAddressBase(allocator_va, request.allocation_size);
+  return DeviceAddressBase(allocator_va, request.size);
 }
 
 // Shared pending-reclaim retry flow:
@@ -700,7 +646,7 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
   // First try to reactivate a compatible pending deallocation without waiting.
   // Reuse is stream-order safe and avoids both a fresh VMM allocation and any
   // host-side wait for the GPU timeline.
-  ASSIGN_OR_RETURN(std::optional<DeviceAddressBase> reused, try_reuse());
+  std::optional<DeviceAddressBase> reused = try_reuse();
   if (reused.has_value()) {
     return *reused;
   }
@@ -789,7 +735,7 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
   // Clang cannot propagate TryWithPendingReclaim's state.mu lock requirement
   // into its callbacks. AssertHeld makes that invariant explicit within each
   // independently analyzed lambda.
-  auto try_reuse = [&]() -> absl::StatusOr<std::optional<DeviceAddressBase>> {
+  auto try_reuse = [&]() -> std::optional<DeviceAddressBase> {
     state->mu.AssertHeld();
     uint64_t rounded_size = RoundUpToGranularity(*state, size);
     for (auto it = state->pending_deallocations.begin();
@@ -818,10 +764,10 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
       MoveAllocatorRecordToActive(*state, record, size);
       ErasePendingDeallocationAt(*state, it);
 
-      return std::optional<DeviceAddressBase>(reused_mem);
+      return reused_mem;
     }
 
-    return std::optional<DeviceAddressBase>();
+    return std::nullopt;
   };
   auto try_fresh = [&]() -> absl::StatusOr<DeviceAddressBase> {
     state->mu.AssertHeld();
@@ -901,25 +847,25 @@ DeviceAddressVmmAllocator::Allocate(
       DeviceAddressBase reservation_address,
       ValidateReservationRange(reservation, reservation_offset, mapping_size));
 
+  const MappedAddressMode mode =
+      return_reservation_address ? MappedAddressMode::kReservationAddress
+                                 : MappedAddressMode::kSeparateAllocatorAddress;
   const MappedAllocateRequest request{reservation,     reservation_address,
                                       allocation_size, reservation_offset,
-                                      mapping_size,    multi_device};
+                                      multi_device,    mode};
 
   absl::MutexLock lock(state->mu);
   // Clang cannot propagate TryWithPendingReclaim's state.mu lock requirement
   // into its callbacks. AssertHeld makes that invariant explicit within each
   // independently analyzed lambda; stateful work stays in annotated helpers.
-  auto try_reuse = [&]() -> absl::StatusOr<std::optional<DeviceAddressBase>> {
+  auto try_reuse = [&]() -> std::optional<DeviceAddressBase> {
     state->mu.AssertHeld();
-    if (return_reservation_address) {
-      return TryReuseMappedAllocationAtReservationAddress(*state, request);
-    }
-    return TryReuseMappedAllocationWithSeparateAddress(*state, request);
+    return TryReuseMappedAllocation(*state, request);
   };
   auto try_fresh = [&]() -> absl::StatusOr<DeviceAddressBase> {
     state->mu.AssertHeld();
     RETURN_IF_ERROR(EnsureReservationAvailableForFreshMapping(*state, request));
-    if (return_reservation_address) {
+    if (request.mode == MappedAddressMode::kReservationAddress) {
       return CreateMappedAllocationAtReservationAddress(*state, request);
     }
     return CreateMappedAllocationWithSeparateAddress(*state, request);

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -1245,7 +1245,26 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
       }
 
       if (!pending_completion_key.has_value()) {
-        return InstallMapAlias(state, request, *source_record);
+        // Map() aliases the beginning of the source allocation into the
+        // caller's VA slice. No physical allocation or PA accounting is added.
+        ASSIGN_OR_RETURN(
+            auto mapping,
+            request.reservation->MapTo(request.reservation_offset,
+                                       /*allocation_offset=*/0, request.size,
+                                       *source_record->raw_allocation()));
+        DeviceAddressBase mapped = mapping.mapped_address();
+        DCHECK(mapped.IsSameAs(request.reservation_address))
+            << "Map() mapped unexpected virtual address: expected="
+            << request.reservation_address.opaque()
+            << ", actual=" << mapped.opaque();
+
+        CHECK(!source_record->reservation_active());
+        CHECK(!source_record->reservation_stale());
+        source_record->AddActiveReservationAlias(mapped, std::move(mapping));
+        auto mapping_insert_result = state.active_reservation_records.emplace(
+            mapped.opaque(), source_record);
+        CHECK(mapping_insert_result.second);
+        return absl::OkStatus();
       }
       if (wait_count == kMaxStaleMappingWaits) {
         return absl::AbortedError(
@@ -1263,31 +1282,6 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
           state, *pending_completion_key));
     }
   }
-}
-
-absl::Status DeviceAddressVmmAllocator::InstallMapAlias(
-    PerDeviceState& state, const MapRequest& request,
-    AllocationRecord& source_record) {
-  // Map() aliases the beginning of the source allocation into the caller's VA
-  // slice. No physical allocation or PA accounting is added.
-  ASSIGN_OR_RETURN(auto mapping, request.reservation->MapTo(
-                                     request.reservation_offset,
-                                     /*allocation_offset=*/0, request.size,
-                                     *source_record.raw_allocation()));
-  DeviceAddressBase mapped = mapping.mapped_address();
-  if (!mapped.IsSameAs(request.reservation_address)) {
-    return absl::InternalError(absl::StrFormat(
-        "Map() mapped unexpected virtual address: expected=%p, actual=%p",
-        request.reservation_address.opaque(), mapped.opaque()));
-  }
-
-  CHECK(!source_record.reservation_active());
-  CHECK(!source_record.reservation_stale());
-  source_record.AddActiveReservationAlias(mapped, std::move(mapping));
-  auto mapping_insert_result =
-      state.active_reservation_records.emplace(mapped.opaque(), &source_record);
-  CHECK(mapping_insert_result.second);
-  return absl::OkStatus();
 }
 
 absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -575,10 +575,8 @@ DeviceAddressVmmAllocator::EnsureReservationAvailableForFreshMapping(
     // stale record, then rescan because another thread may have changed the
     // allocator state while the lock was released.
     auto stale_overlap = FindOverlappingRecord(
-        state, request.reservation_address, /*include_allocator=*/true,
-        /*include_reservation=*/true, /*include_active=*/false,
-        /*include_stale=*/true, /*exact_only=*/true,
-        /*partial_only=*/false);
+        state, request.reservation_address, AddressRole::kBoth,
+        RecordState::kStale, OverlapKind::kExact);
     if (!stale_overlap.has_value()) {
       break;
     }
@@ -590,10 +588,8 @@ DeviceAddressVmmAllocator::EnsureReservationAvailableForFreshMapping(
   // reported as a duplicate mapping attempt instead of remapped underneath
   // existing users.
   if (FindOverlappingRecord(state, request.reservation_address,
-                            /*include_allocator=*/true,
-                            /*include_reservation=*/true,
-                            /*include_active=*/true, /*include_stale=*/false,
-                            /*exact_only=*/false, /*partial_only=*/false)
+                            AddressRole::kBoth, RecordState::kActive,
+                            OverlapKind::kExact)
           .has_value()) {
     return absl::AlreadyExistsError(absl::StrFormat(
         "reservation range is already tracked at virtual address %p",
@@ -1050,22 +1046,23 @@ DeviceAddressVmmAllocator::ValidateReservationRange(
 
 std::optional<DeviceAddressVmmAllocator::OverlappingRecord>
 DeviceAddressVmmAllocator::FindOverlappingRecord(
-    PerDeviceState& state, DeviceAddressBase address, bool include_allocator,
-    bool include_reservation, bool include_active, bool include_stale,
-    bool exact_only, bool partial_only) const {
-  CHECK(!(exact_only && partial_only));
+    PerDeviceState& state, DeviceAddressBase address, AddressRole role,
+    RecordState record_state, OverlapKind overlap_kind) const {
+  const bool include_allocator = role != AddressRole::kReservation;
+  const bool include_reservation = role != AddressRole::kAllocator;
+  const bool include_active = record_state != RecordState::kStale;
+  const bool include_stale = record_state != RecordState::kActive;
 
   auto matches = [&](DeviceAddressBase tracked_address) {
-    if (exact_only) {
-      return tracked_address.IsSameAs(address);
+    switch (overlap_kind) {
+      case OverlapKind::kExact:
+        return tracked_address.IsSameAs(address);
+      case OverlapKind::kPartial:
+        // Partial overlap means the ranges intersect but are not the same full
+        // ownership range.
+        return AddressRangesOverlap(tracked_address, address) &&
+               !tracked_address.IsSameAs(address);
     }
-    if (partial_only) {
-      // Partial overlap means the ranges intersect but are not the same full
-      // ownership range.
-      return AddressRangesOverlap(tracked_address, address) &&
-             !tracked_address.IsSameAs(address);
-    }
-    return AddressRangesOverlap(tracked_address, address);
   };
 
   auto check_record = [&](AllocationRecord* record,
@@ -1163,11 +1160,9 @@ DeviceAddressVmmAllocator::ResolveAndValidateMapSource(
 
 absl::Status DeviceAddressVmmAllocator::CheckNoPartialReservationOverlap(
     PerDeviceState& state, DeviceAddressBase reservation_address) const {
-  if (auto overlap = FindOverlappingRecord(
-          state, reservation_address, /*include_allocator=*/true,
-          /*include_reservation=*/true, /*include_active=*/true,
-          /*include_stale=*/true, /*exact_only=*/false,
-          /*partial_only=*/true)) {
+  if (auto overlap =
+          FindOverlappingRecord(state, reservation_address, AddressRole::kBoth,
+                                RecordState::kBoth, OverlapKind::kPartial)) {
     return absl::FailedPreconditionError(absl::StrFormat(
         "reservation range at %p (%uB) partially overlaps %s %s range at %p "
         "(%uB); reservation mappings must be managed with the same full "
@@ -1195,12 +1190,8 @@ DeviceAddressVmmAllocator::EvaluateMapTarget(
   // Reject an active destination before waiting for a stale source alias. A
   // failed Map() must not drain unrelated pending state.
   if (FindOverlappingRecord(state, request.reservation_address,
-                            /*include_allocator=*/true,
-                            /*include_reservation=*/true,
-                            /*include_active=*/true,
-                            /*include_stale=*/false,
-                            /*exact_only=*/false,
-                            /*partial_only=*/false)
+                            AddressRole::kBoth, RecordState::kActive,
+                            OverlapKind::kExact)
           .has_value()) {
     return absl::AlreadyExistsError(absl::StrFormat(
         "reservation range is already tracked at virtual address %p",
@@ -1219,10 +1210,8 @@ DeviceAddressVmmAllocator::EvaluateMapTarget(
   }
 
   auto stale_reservation_overlap = FindOverlappingRecord(
-      state, request.reservation_address, /*include_allocator=*/false,
-      /*include_reservation=*/true, /*include_active=*/false,
-      /*include_stale=*/true, /*exact_only=*/true,
-      /*partial_only=*/false);
+      state, request.reservation_address, AddressRole::kReservation,
+      RecordState::kStale, OverlapKind::kExact);
   if (stale_reservation_overlap.has_value()) {
     AllocationRecord& stale_record = *stale_reservation_overlap->record;
 
@@ -1242,10 +1231,8 @@ DeviceAddressVmmAllocator::EvaluateMapTarget(
   }
 
   auto stale_allocator_overlap = FindOverlappingRecord(
-      state, request.reservation_address, /*include_allocator=*/true,
-      /*include_reservation=*/false, /*include_active=*/false,
-      /*include_stale=*/true, /*exact_only=*/true,
-      /*partial_only=*/false);
+      state, request.reservation_address, AddressRole::kAllocator,
+      RecordState::kStale, OverlapKind::kExact);
   if (stale_allocator_overlap.has_value()) {
     AllocationRecord& stale_record = *stale_allocator_overlap->record;
     return MapTargetEvaluation{
@@ -1255,19 +1242,6 @@ DeviceAddressVmmAllocator::EvaluateMapTarget(
                                stale_record.allocator_address()}};
   }
 
-  // A fresh Map() must have exclusive ownership of the reservation address.
-  if (FindOverlappingRecord(state, request.reservation_address,
-                            /*include_allocator=*/true,
-                            /*include_reservation=*/true,
-                            /*include_active=*/true,
-                            /*include_stale=*/true,
-                            /*exact_only=*/false,
-                            /*partial_only=*/false)
-          .has_value()) {
-    return absl::AlreadyExistsError(absl::StrFormat(
-        "reservation range is already tracked at virtual address %p",
-        request.reservation_address.opaque()));
-  }
   return MapTargetEvaluation{MapTargetEvaluation::Action::kInstallFresh};
 }
 

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -16,7 +16,6 @@ limitations under the License.
 #include "xla/stream_executor/device_address_vmm_allocator.h"
 
 #include <algorithm>
-#include <cstddef>
 #include <cstdint>
 #include <deque>
 #include <limits>
@@ -25,7 +24,6 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -67,9 +65,8 @@ DeviceAddressVmmAllocator::DeviceAssignmentScope::~DeviceAssignmentScope() {
 bool DeviceAddressVmmAllocator::CurrentMultiDevice() {
   const xla::DeviceAssignment* device_assignment = current_device_assignment;
   return device_assignment != nullptr &&
-         device_assignment->replica_count() *
-                 device_assignment->computation_count() >
-             1;
+         (device_assignment->replica_count() > 1 ||
+          device_assignment->computation_count() > 1);
 }
 
 DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
@@ -86,6 +83,7 @@ DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
       allocator_address_mapping_(std::move(allocator_address_mapping)) {
   CHECK(raw_allocation_ != nullptr);
   CHECK(!allocator_address_.is_null());
+  CHECK_GT(raw_allocation_->address().size(), 0);
   switch (kind_) {
     case Kind::kAllocate:
     case Kind::kAllocateAndMapReturnNewAddr:
@@ -147,9 +145,7 @@ void DeviceAddressVmmAllocator::AllocationRecord::ReactivateReservation() {
 }
 
 void DeviceAddressVmmAllocator::AllocationRecord::CompleteStaleReservation() {
-  if (!reservation_stale()) {
-    return;
-  }
+  CHECK(reservation_stale());
   reservation_alias_.reset();
 }
 
@@ -201,9 +197,9 @@ absl::Status DeviceAddressVmmAllocator::PopulateDevices(
   for (const DeviceConfig& cfg : devices) {
     DCHECK_NE(cfg.executor, nullptr);
     DCHECK_NE(cfg.stream, nullptr);
+    DCHECK_EQ(cfg.stream->parent(), cfg.executor);
     int ordinal = cfg.executor->device_ordinal();
-    DCHECK(seen_ordinals.insert(ordinal).second)
-        << "Duplicate device ordinal: " << ordinal;
+    DCHECK(seen_ordinals.insert(ordinal).second);
   }
 
   for (const DeviceConfig& cfg : devices) {
@@ -218,7 +214,9 @@ absl::Status DeviceAddressVmmAllocator::PopulateDevices(
 
     VLOG(3) << "DeviceAddressVmmAllocator: registering device " << ordinal
             << " with pa_budget " << cfg.pa_budget;
-    allocator->per_device_.emplace(ordinal, std::move(state));
+    auto insert_result =
+        allocator->per_device_.emplace(ordinal, std::move(state));
+    CHECK(insert_result.second);
   }
 
   return absl::OkStatus();
@@ -495,9 +493,12 @@ DeviceAddressVmmAllocator::EnsureReservationAvailableForFreshMapping(
       if (stale_overlap.has_value()) {
         CHECK(!stale_overlap->is_active);
         AllocationRecord& record = *stale_overlap->record;
-        pending_completion_seqno =
-            stale_overlap->is_allocator ? record.allocator_stale_seqno()
-                                        : record.reservation_stale_seqno();
+        if (stale_overlap->is_allocator) {
+          pending_completion_seqno = record.allocator_stale_seqno();
+        } else {
+          CHECK(record.reservation_stale());
+          pending_completion_seqno = record.reservation_stale_seqno();
+        }
       }
     }
     if (pending_completion_seqno == 0) {
@@ -572,44 +573,9 @@ DeviceAddressVmmAllocator::CreateMappedAllocation(
   return allocator_address;
 }
 
-// Shared pending-reclaim retry flow:
-//
-// TryWithPendingReclaim(reclaim_size, try_reuse, try_fresh)
-//           │
-//           ▼
-// ┌─────────────────────────────────┐
-// │ try_reuse()                     │──found──► return reused address
-// └─────────────────────────────────┘
-//           │ not found
-//           ▼
-// ┌─────────────────────────────────┐
-// │ try_fresh()                     │──OK──► return fresh address
-// └─────────────────────────────────┘
-//           │ ResourceExhausted
-//           ▼
-// ┌─────────────────────────────────┐
-// │ Process completed pending       │
-// │ operations                      │
-// └─────────────────────────────────┘
-//           │
-//           ▼
-// ┌─────────────────────────────────┐
-// │ try_fresh()                     │──OK──► return fresh address
-// └─────────────────────────────────┘
-//           │ ResourceExhausted
-//           ▼
-// ┌─────────────────────────────────┐
-// │ Wait for pending operations     │
-// │ to reclaim enough memory        │
-// └─────────────────────────────────┘
-//           │
-//           ▼
-// ┌─────────────────────────────────┐
-// │ try_fresh()                     │──OK──► return fresh address
-// └─────────────────────────────────┘
-//           │ failed
-//           ▼
-//       return error
+// Reuses compatible pending state before trying a fresh allocation. On a
+// ResourceExhausted failure, first reclaim completed work, then wait for enough
+// queued allocator deallocations and try once more.
 template <typename TryReuseFn, typename TryFreshFn>
 absl::StatusOr<DeviceAddressBase>
 DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
@@ -628,7 +594,6 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
   // calls should finish here; the reclaim paths below are only for PA budget
   // pressure or allocator-level allocation failures.
   absl::StatusOr<DeviceAddressBase> result = try_fresh();
-
   if (absl::IsResourceExhausted(result.status())) {
     // A ResourceExhausted error may be stale: some pending deallocations can
     // already be past their stream timeline point. Complete ready allocator
@@ -647,41 +612,37 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
     // request, then wait for the selected tail seqno to become safe. Unrelated
     // kMap entries do not own physical memory, so leave them stale and
     // reusable.
-    if (!state.pending_deallocations.empty()) {
-      uint64_t accumulated_size = 0;
-      uint64_t rounded_size = RoundUpToGranularity(state, reclaim_size);
-      uint64_t target_seqno = 0;
-      std::vector<uint64_t> selected;
+    uint64_t accumulated_size = 0;
+    uint64_t rounded_size = RoundUpToGranularity(state, reclaim_size);
+    uint64_t target_seqno = 0;
+    std::vector<uint64_t> selected;
 
-      // Target 1.1x the requested size to provide some headroom.
-      uint64_t target_size = rounded_size + rounded_size / 10;
+    // Target 1.1x the requested size to provide some headroom.
+    uint64_t target_size = rounded_size + rounded_size / 10;
 
-      for (const PendingDeallocation& pending : state.pending_deallocations) {
-        if (pending.kind == PendingDeallocationKind::kMap) {
-          continue;
-        }
-        auto record_it =
-            state.records_by_allocator_address.find(pending.addr.opaque());
-        CHECK(record_it != state.records_by_allocator_address.end());
-        CHECK(record_it->second->allocator_stale());
-        CHECK(record_it->second->allocator_matches(pending.addr));
-        CHECK(record_it->second->raw_allocation() != nullptr);
-        uint64_t reclaimable_bytes =
-            record_it->second->raw_allocation()->address().size();
-        CHECK_GT(reclaimable_bytes, 0);
-        accumulated_size += reclaimable_bytes;
-        target_seqno = std::max(target_seqno, pending.seqno);
-        selected.push_back(pending.seqno);
-        if (accumulated_size >= target_size) {
-          break;
-        }
+    for (const PendingDeallocation& pending : state.pending_deallocations) {
+      if (pending.kind == PendingDeallocationKind::kMap) {
+        continue;
       }
+      auto record_it =
+          state.records_by_allocator_address.find(pending.addr.opaque());
+      CHECK(record_it != state.records_by_allocator_address.end());
+      CHECK(record_it->second->allocator_stale());
+      uint64_t reclaimable_bytes =
+          record_it->second->raw_allocation()->address().size();
+      CHECK_GT(reclaimable_bytes, 0);
+      accumulated_size += reclaimable_bytes;
+      target_seqno = std::max(target_seqno, pending.seqno);
+      selected.push_back(pending.seqno);
+      if (accumulated_size >= target_size) {
+        break;
+      }
+    }
 
-      if (!selected.empty()) {
-        WaitUntilSeqno(state, target_seqno);
-        for (uint64_t seqno : selected) {
-          CompletePendingDeallocationBySeqno(state, seqno);
-        }
+    if (!selected.empty()) {
+      WaitUntilSeqno(state, target_seqno);
+      for (uint64_t seqno : selected) {
+        CompletePendingDeallocationBySeqno(state, seqno);
       }
     }
     result = try_fresh();
@@ -745,9 +706,8 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
   auto try_fresh = [&]() -> absl::StatusOr<DeviceAddressBase> {
     state->mu.AssertHeld();
     uint64_t physical_size = 0;
-    ASSIGN_OR_RETURN(
-        auto raw_alloc,
-        AllocatePhysicalWithinBudget(*state, size, physical_size));
+    ASSIGN_OR_RETURN(auto raw_alloc,
+                     AllocatePhysicalWithinBudget(*state, size, physical_size));
 
     ASSIGN_OR_RETURN(auto reservation,
                      CreateReservation(state->executor, size));
@@ -760,8 +720,8 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
     DeviceAddressBase allocator_address(reservation->address().opaque(), size);
     TrackAllocatorAddressMappedAllocation(
         *state, AllocationRecord::Kind::kAllocate, allocator_address,
-        std::move(raw_alloc), std::move(reservation),
-        std::move(scoped_mapping), multi_device);
+        std::move(raw_alloc), std::move(reservation), std::move(scoped_mapping),
+        multi_device);
     // Return the original requested size, not the padded size.
     return absl::StatusOr<DeviceAddressBase>(allocator_address);
   };
@@ -883,13 +843,6 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
   // Move the returned allocator address out of active ownership and keep its
   // mapping alive as stale state until the stream reaches `seqno`.
-  CHECK(record.allocator_active());
-  CHECK(!record.allocator_stale());
-  void* allocator_va = record.allocator_key();
-  auto allocator_record_it =
-      state->records_by_allocator_address.find(allocator_va);
-  CHECK(allocator_record_it != state->records_by_allocator_address.end());
-  CHECK_EQ(allocator_record_it->second.get(), &record);
   record.MarkAllocatorStale(seqno);
   state->pending_deallocations.push_back(PendingDeallocation{
       PendingDeallocationKind::kAllocation, seqno, record.allocator_address()});
@@ -952,7 +905,6 @@ DeviceAddressVmmAllocator::FindOverlappingRecord(
   if (include_allocator) {
     for (const auto& [_, record_owner] : state.records_by_allocator_address) {
       AllocationRecord* record = record_owner.get();
-      CHECK_NE(record->allocator_active(), record->allocator_stale());
       bool include_record = (include_active && record->allocator_active()) ||
                             (include_stale && record->allocator_stale());
       if (!include_record) {
@@ -1067,8 +1019,7 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
       if (source_record->reservation_stale()) {
         CHECK(source_record->has_reservation_alias());
         if (!source_record->reservation_matches(request.reservation_address)) {
-          pending_completion_seqno =
-              source_record->reservation_stale_seqno();
+          pending_completion_seqno = source_record->reservation_stale_seqno();
         }
       }
 
@@ -1119,8 +1070,6 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
             << request.reservation_address.opaque()
             << ", actual=" << mapped.opaque();
 
-        CHECK(!source_record->reservation_active());
-        CHECK(!source_record->reservation_stale());
         source_record->AddActiveReservationAlias(std::move(mapping));
         auto mapping_insert_result =
             state.reservation_records.emplace(mapped.opaque(), source_record);
@@ -1187,8 +1136,6 @@ void DeviceAddressVmmAllocator::ErasePendingDeallocation(
 
 void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
     PerDeviceState& state, AllocationRecord& record, uint64_t new_size) {
-  CHECK(!record.allocator_active());
-  CHECK(record.allocator_stale());
   void* allocator_va = record.allocator_key();
   auto record_it = state.records_by_allocator_address.find(allocator_va);
   CHECK(record_it != state.records_by_allocator_address.end());
@@ -1266,24 +1213,17 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
   // explicitly unmapped stale reservation alias, drop that mapping first, then
   // release allocator VA state and physical allocation accounting.
   AllocationRecord& record = *record_it->second;
-  CHECK(!record.allocator_active());
   CHECK(!record.reservation_active());
   if (record.reservation_stale()) {
     CHECK(record.has_reservation_alias());
     CompletePendingDeallocationBySeqno(state, record.reservation_stale_seqno());
     CHECK(!record.has_reservation_alias());
   }
-  void* allocator_va = record.allocator_key();
-  auto owning_record_it = state.records_by_allocator_address.find(allocator_va);
-  CHECK(owning_record_it != state.records_by_allocator_address.end());
-  CHECK_EQ(owning_record_it->second.get(), &record);
-
-  if (record.raw_allocation() != nullptr) {
-    uint64_t released_size = record.raw_allocation()->address().size();
-    DCHECK_GE(state.pa_allocated, released_size);
-    state.pa_allocated -= released_size;
-  }
-  CHECK_EQ(state.records_by_allocator_address.erase(allocator_va), 1);
+  uint64_t physical_size = record.raw_allocation()->address().size();
+  CHECK_GT(physical_size, 0);
+  CHECK_GE(state.pa_allocated, physical_size);
+  state.pa_allocated -= physical_size;
+  state.records_by_allocator_address.erase(record_it);
 }
 
 absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
@@ -1336,6 +1276,7 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
         "DeviceAddressVmmAllocator::UnMap requires the same full reservation "
         "range passed to Map");
   }
+
   uint64_t seqno = state->next_seqno++;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
   record->MarkReservationStale(seqno);

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -1158,79 +1158,8 @@ absl::Status DeviceAddressVmmAllocator::CheckNoPartialReservationOverlap(
   return absl::OkStatus();
 }
 
-absl::StatusOr<DeviceAddressVmmAllocator::MapTargetEvaluation>
-DeviceAddressVmmAllocator::EvaluateMapTarget(
-    PerDeviceState& state, const MapRequest& request,
-    AllocationRecord& source_record) const {
-  if (source_record.reservation_active()) {
-    return absl::AlreadyExistsError(absl::StrFormat(
-        "allocator address %p already has an active reservation mapping at "
-        "%p",
-        request.source_address.opaque(),
-        source_record.reservation_address().opaque()));
-  }
-
-  // Reject an active destination before waiting for a stale source alias. A
-  // failed Map() must not drain unrelated pending state.
-  if (FindOverlappingRecord(state, request.reservation_address,
-                            AddressRole::kBoth, RecordState::kActive,
-                            OverlapKind::kExact)
-          .has_value()) {
-    return absl::AlreadyExistsError(absl::StrFormat(
-        "reservation range is already tracked at virtual address %p",
-        request.reservation_address.opaque()));
-  }
-
-  if (source_record.reservation_stale()) {
-    CHECK(source_record.has_reservation_address());
-    if (!source_record.reservation_matches(request.reservation_address)) {
-      return MapTargetEvaluation{
-          MapTargetEvaluation::Action::kWait, nullptr,
-          PendingDeallocationKey{PendingDeallocationKind::kMap,
-                                 source_record.reservation_stale_seqno(),
-                                 source_record.reservation_address()}};
-    }
-  }
-
-  auto stale_reservation_overlap = FindOverlappingRecord(
-      state, request.reservation_address, AddressRole::kReservation,
-      RecordState::kStale, OverlapKind::kExact);
-  if (stale_reservation_overlap.has_value()) {
-    AllocationRecord& stale_record = *stale_reservation_overlap->record;
-
-    // A deferred UnMap() leaves the old mapping valid. Reuse it when it aliases
-    // the requested physical allocation; otherwise wait before overwriting it.
-    CHECK(stale_record.has_reservation_address());
-    CHECK(stale_record.reservation_matches(request.reservation_address));
-    if (stale_record.raw_allocation() == source_record.raw_allocation()) {
-      return MapTargetEvaluation{MapTargetEvaluation::Action::kReactivateStale,
-                                 &stale_record};
-    }
-    return MapTargetEvaluation{
-        MapTargetEvaluation::Action::kWait, nullptr,
-        PendingDeallocationKey{PendingDeallocationKind::kMap,
-                               stale_record.reservation_stale_seqno(),
-                               stale_record.reservation_address()}};
-  }
-
-  auto stale_allocator_overlap = FindOverlappingRecord(
-      state, request.reservation_address, AddressRole::kAllocator,
-      RecordState::kStale, OverlapKind::kExact);
-  if (stale_allocator_overlap.has_value()) {
-    AllocationRecord& stale_record = *stale_allocator_overlap->record;
-    return MapTargetEvaluation{
-        MapTargetEvaluation::Action::kWait, nullptr,
-        PendingDeallocationKey{stale_record.pending_deallocation_kind(),
-                               stale_record.allocator_stale_seqno(),
-                               stale_record.allocator_address()}};
-  }
-
-  return MapTargetEvaluation{MapTargetEvaluation::Action::kInstallFresh};
-}
-
-absl::StatusOr<DeviceAddressVmmAllocator::PreparedMapTarget>
-DeviceAddressVmmAllocator::PrepareMapTarget(PerDeviceState& state,
-                                            const MapRequest& request) {
+absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
+    PerDeviceState& state, const MapRequest& request) {
   // One source can have one stale alias and the destination can have one stale
   // occupant. Without concurrent changes, at most two waits are needed before
   // a third attempt can install or reuse the requested mapping.
@@ -1247,28 +1176,81 @@ DeviceAddressVmmAllocator::PrepareMapTarget(PerDeviceState& state,
       RETURN_IF_ERROR(
           CheckNoPartialReservationOverlap(state, request.reservation_address));
 
-      ASSIGN_OR_RETURN(MapTargetEvaluation evaluation,
-                       EvaluateMapTarget(state, request, *source_record));
-      switch (evaluation.action) {
-        case MapTargetEvaluation::Action::kInstallFresh:
-          return PreparedMapTarget{PreparedMapTarget::Action::kInstallFresh,
-                                   source_record};
-        case MapTargetEvaluation::Action::kReactivateStale:
-          CHECK(evaluation.stale_record != nullptr);
-          MoveReservationRecordToActive(state, *evaluation.stale_record);
-          ErasePendingDeallocation(state, PendingDeallocationKind::kMap,
-                                   request.reservation_address);
-          return PreparedMapTarget{
-              PreparedMapTarget::Action::kReusedStaleMapping};
-        case MapTargetEvaluation::Action::kWait:
-          CHECK(evaluation.pending_completion_key.has_value());
-          if (wait_count == kMaxStaleMappingWaits) {
-            return absl::AbortedError(
-                "Map() allocator state changed repeatedly while waiting for "
-                "stale mappings; retry Map()");
+      if (source_record->reservation_active()) {
+        return absl::AlreadyExistsError(absl::StrFormat(
+            "allocator address %p already has an active reservation mapping "
+            "at %p",
+            request.source_address.opaque(),
+            source_record->reservation_address().opaque()));
+      }
+
+      // Reject an active destination before waiting for a stale source alias. A
+      // failed Map() must not drain unrelated pending state.
+      if (FindOverlappingRecord(state, request.reservation_address,
+                                AddressRole::kBoth, RecordState::kActive,
+                                OverlapKind::kExact)
+              .has_value()) {
+        return absl::AlreadyExistsError(absl::StrFormat(
+            "reservation range is already tracked at virtual address %p",
+            request.reservation_address.opaque()));
+      }
+
+      if (source_record->reservation_stale()) {
+        CHECK(source_record->has_reservation_address());
+        if (!source_record->reservation_matches(request.reservation_address)) {
+          pending_completion_key =
+              PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                     source_record->reservation_stale_seqno(),
+                                     source_record->reservation_address()};
+        }
+      }
+
+      if (!pending_completion_key.has_value()) {
+        auto stale_reservation_overlap = FindOverlappingRecord(
+            state, request.reservation_address, AddressRole::kReservation,
+            RecordState::kStale, OverlapKind::kExact);
+        if (stale_reservation_overlap.has_value()) {
+          AllocationRecord& stale_record = *stale_reservation_overlap->record;
+
+          // A deferred UnMap() leaves the old mapping valid. Reuse it when it
+          // aliases the requested physical allocation; otherwise wait before
+          // overwriting it.
+          CHECK(stale_record.has_reservation_address());
+          CHECK(stale_record.reservation_matches(request.reservation_address));
+          if (stale_record.raw_allocation() ==
+              source_record->raw_allocation()) {
+            MoveReservationRecordToActive(state, stale_record);
+            ErasePendingDeallocation(state, PendingDeallocationKind::kMap,
+                                     request.reservation_address);
+            return absl::OkStatus();
           }
-          pending_completion_key = evaluation.pending_completion_key;
-          break;
+          pending_completion_key =
+              PendingDeallocationKey{PendingDeallocationKind::kMap,
+                                     stale_record.reservation_stale_seqno(),
+                                     stale_record.reservation_address()};
+        }
+      }
+
+      if (!pending_completion_key.has_value()) {
+        auto stale_allocator_overlap = FindOverlappingRecord(
+            state, request.reservation_address, AddressRole::kAllocator,
+            RecordState::kStale, OverlapKind::kExact);
+        if (stale_allocator_overlap.has_value()) {
+          AllocationRecord& stale_record = *stale_allocator_overlap->record;
+          pending_completion_key =
+              PendingDeallocationKey{stale_record.pending_deallocation_kind(),
+                                     stale_record.allocator_stale_seqno(),
+                                     stale_record.allocator_address()};
+        }
+      }
+
+      if (!pending_completion_key.has_value()) {
+        return InstallMapAlias(state, request, *source_record);
+      }
+      if (wait_count == kMaxStaleMappingWaits) {
+        return absl::AbortedError(
+            "Map() allocator state changed repeatedly while waiting for stale "
+            "mappings; retry Map()");
       }
     }
 
@@ -1330,13 +1312,7 @@ absl::Status DeviceAddressVmmAllocator::Map(int device_ordinal,
                      reservation_address};
 
   absl::MutexLock lock(state->mu);
-  ASSIGN_OR_RETURN(PreparedMapTarget prepared,
-                   PrepareMapTarget(*state, request));
-  if (prepared.action == PreparedMapTarget::Action::kReusedStaleMapping) {
-    return absl::OkStatus();
-  }
-  CHECK(prepared.source_record != nullptr);
-  return InstallMapAlias(*state, request, *prepared.source_record);
+  return ResolveAndMapAlias(*state, request);
 }
 
 // UnMap/deferred teardown helpers.

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -98,20 +98,6 @@ DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
   CHECK(!allocator_address_mapping_.is_null());
 }
 
-DeviceAddressVmmAllocator::PendingDeallocationKind
-DeviceAddressVmmAllocator::AllocationRecord::pending_deallocation_kind() const {
-  switch (kind_) {
-    case Kind::kAllocate:
-      return PendingDeallocationKind::kAllocate;
-    case Kind::kAllocateAndMapReturnMapAddr:
-      return PendingDeallocationKind::kAllocateAndMapReturnMapAddr;
-    case Kind::kAllocateAndMapReturnNewAddr:
-      return PendingDeallocationKind::kAllocateAndMapReturnNewAddr;
-  }
-  LOG(FATAL) << "Unknown AllocationRecord kind";
-  return PendingDeallocationKind::kAllocate;
-}
-
 DeviceAddressBase
 DeviceAddressVmmAllocator::AllocationRecord::reservation_address() const {
   CHECK(has_reservation_alias());
@@ -295,8 +281,15 @@ absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
   if (state->pending_deallocations.empty()) {
     return absl::OkStatus();
   }
-  return WaitAndDrainPendingDeallocationsUntilSeqno(
-      *state, state->pending_deallocations.back().seqno);
+  uint64_t target_seqno = state->pending_deallocations.back().seqno;
+  WaitUntilSeqno(*state, target_seqno);
+  while (!state->pending_deallocations.empty() &&
+         state->pending_deallocations.front().seqno <= target_seqno) {
+    PendingDeallocation pending = state->pending_deallocations.front();
+    state->pending_deallocations.pop_front();
+    CompletePendingDeallocation(*state, pending);
+  }
+  return absl::OkStatus();
 }
 
 absl::StatusOr<StreamExecutor*> DeviceAddressVmmAllocator::GetStreamExecutor(
@@ -433,8 +426,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationAtReservationAddress(
   if (!record.allocator_stale()) {
     return std::nullopt;
   }
-  if (record.pending_deallocation_kind() !=
-      PendingDeallocationKind::kAllocateAndMapReturnMapAddr) {
+  if (record.kind() != AllocationRecord::Kind::kAllocateAndMapReturnMapAddr) {
     return std::nullopt;
   }
   if (record.multi_device() != request.multi_device) {
@@ -449,10 +441,9 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationAtReservationAddress(
   // for the new request, wait for the old mapping to drain so the fresh path
   // can remap this reservation VA to a larger raw allocation.
   if (record.raw_allocation()->address().size() < request.allocation_size) {
-    RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
-        state, PendingDeallocationKey{record.pending_deallocation_kind(),
-                                      record.allocator_stale_seqno(),
-                                      record.allocator_address()}));
+    uint64_t seqno = record.allocator_stale_seqno();
+    WaitUntilSeqno(state, seqno);
+    CompletePendingDeallocationBySeqno(state, seqno);
     return std::nullopt;
   }
 
@@ -462,7 +453,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationAtReservationAddress(
   // it while leaving explicit pending kMap entries untouched.
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
-    if (it->kind == PendingDeallocationKind::kAllocateAndMapReturnMapAddr &&
+    if (it->kind == PendingDeallocationKind::kAllocation &&
         it->addr.IsSameAs(request.reservation_address)) {
       pending_it = it;
       break;
@@ -483,7 +474,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationWithSeparateAddress(
   // and its reservation side exactly matches this request.
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
-    if (it->kind != PendingDeallocationKind::kAllocateAndMapReturnNewAddr) {
+    if (it->kind != PendingDeallocationKind::kAllocation) {
       continue;
     }
     auto record_it = state.records_by_allocator_address.find(it->addr.opaque());
@@ -491,8 +482,9 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationWithSeparateAddress(
     AllocationRecord& record = *record_it->second;
     CHECK(record.allocator_stale());
     CHECK(record.allocator_matches(it->addr));
-    CHECK_EQ(record.pending_deallocation_kind(),
-             PendingDeallocationKind::kAllocateAndMapReturnNewAddr);
+    if (record.kind() != AllocationRecord::Kind::kAllocateAndMapReturnNewAddr) {
+      continue;
+    }
     if (record.multi_device() != request.multi_device) {
       continue;
     }
@@ -510,10 +502,9 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationWithSeparateAddress(
       // The old mapping is the right VA but not enough physical memory. Wait
       // for its deferred teardown to finish, then let the fresh path create a
       // larger allocation and install a new mapping.
-      RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
-          state, PendingDeallocationKey{record.pending_deallocation_kind(),
-                                        record.allocator_stale_seqno(),
-                                        record.allocator_address()}));
+      uint64_t seqno = record.allocator_stale_seqno();
+      WaitUntilSeqno(state, seqno);
+      CompletePendingDeallocationBySeqno(state, seqno);
       return std::nullopt;
     }
 
@@ -548,13 +539,24 @@ DeviceAddressVmmAllocator::EnsureReservationAvailableForFreshMapping(
     // VA is still protected by stream order. Complete only that conflicting
     // stale record, then rescan because another thread may have changed the
     // allocator state while the lock was released.
-    auto stale_overlap = FindOverlappingRecord(
-        state, request.reservation_address, AddressRole::kBoth,
-        RecordState::kStale, OverlapKind::kExact);
-    if (!stale_overlap.has_value()) {
+    uint64_t pending_completion_seqno = 0;
+    {
+      auto stale_overlap = FindOverlappingRecord(
+          state, request.reservation_address, AddressRole::kBoth,
+          RecordState::kStale, OverlapKind::kExact);
+      if (stale_overlap.has_value()) {
+        CHECK(!stale_overlap->is_active);
+        AllocationRecord& record = *stale_overlap->record;
+        pending_completion_seqno =
+            stale_overlap->is_allocator ? record.allocator_stale_seqno()
+                                        : record.reservation_stale_seqno();
+      }
+    }
+    if (pending_completion_seqno == 0) {
       break;
     }
-    RETURN_IF_ERROR(WaitAndCompleteStaleOverlap(state, *stale_overlap));
+    WaitUntilSeqno(state, pending_completion_seqno);
+    CompletePendingDeallocationBySeqno(state, pending_completion_seqno);
   }
 
   // At this point stale exact overlaps have been drained. Any remaining
@@ -730,7 +732,7 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
       uint64_t accumulated_size = 0;
       uint64_t rounded_size = RoundUpToGranularity(state, reclaim_size);
       uint64_t target_seqno = 0;
-      std::vector<PendingDeallocationKey> selected;
+      std::vector<uint64_t> selected;
 
       // Target 1.1x the requested size to provide some headroom.
       uint64_t target_size = rounded_size + rounded_size / 10;
@@ -745,20 +747,21 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
         CHECK(record_it->second->allocator_stale());
         CHECK(record_it->second->allocator_matches(pending.addr));
         CHECK(record_it->second->raw_allocation() != nullptr);
-        accumulated_size += RoundUpToGranularity(
-            state, record_it->second->raw_allocation()->address().size());
+        uint64_t reclaimable_bytes =
+            record_it->second->raw_allocation()->address().size();
+        CHECK_GT(reclaimable_bytes, 0);
+        accumulated_size += reclaimable_bytes;
         target_seqno = std::max(target_seqno, pending.seqno);
-        selected.push_back(
-            PendingDeallocationKey{pending.kind, pending.seqno, pending.addr});
+        selected.push_back(pending.seqno);
         if (accumulated_size >= target_size) {
           break;
         }
       }
 
       if (!selected.empty()) {
-        RETURN_IF_ERROR(WaitUntilSeqno(state, target_seqno));
-        for (const PendingDeallocationKey& key : selected) {
-          CompletePendingDeallocationByKey(state, key);
+        WaitUntilSeqno(state, target_seqno);
+        for (uint64_t seqno : selected) {
+          CompletePendingDeallocationBySeqno(state, seqno);
         }
       }
     }
@@ -768,8 +771,8 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
   return result;
 }
 
-// Allocate() reuses pending kAllocate entries, otherwise tries a fresh
-// allocator-address mapping.
+// Allocate() reuses compatible pending regular-allocation records, otherwise
+// tries a fresh allocator-address mapping.
 absl::StatusOr<ScopedDeviceAddress<uint8_t>>
 DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
                                     bool /*retry_on_failure*/,
@@ -791,7 +794,7 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
     uint64_t rounded_size = RoundUpToGranularity(*state, size);
     for (auto it = state->pending_deallocations.begin();
          it != state->pending_deallocations.end(); ++it) {
-      if (it->kind != PendingDeallocationKind::kAllocate) {
+      if (it->kind != PendingDeallocationKind::kAllocation) {
         continue;
       }
       auto record_it =
@@ -800,6 +803,9 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
       AllocationRecord& record = *record_it->second;
       CHECK(record.allocator_stale());
       CHECK(record.allocator_matches(it->addr));
+      if (record.kind() != AllocationRecord::Kind::kAllocate) {
+        continue;
+      }
       if (record.multi_device() != multi_device) {
         continue;
       }
@@ -972,9 +978,6 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
       "on device ordinal %d",
       mem.opaque(), mem.size(), state->executor->device_ordinal());
 
-  const uint64_t reclaimable_bytes =
-      record.raw_allocation()->address().size();
-
   // Assign the next sequence number and enqueue a GPU write to the pinned
   // timeline when the stream reaches this point. The CPU polls the timeline
   // value to know when it is safe to free the memory.
@@ -990,9 +993,8 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   CHECK(allocator_record_it != state->records_by_allocator_address.end());
   CHECK_EQ(allocator_record_it->second.get(), &record);
   record.MarkAllocatorStale(seqno);
-  state->pending_deallocations.push_back(
-      PendingDeallocation{record.pending_deallocation_kind(), seqno,
-                          record.allocator_address(), reclaimable_bytes});
+  state->pending_deallocations.push_back(PendingDeallocation{
+      PendingDeallocationKind::kAllocation, seqno, record.allocator_address()});
   return absl::OkStatus();
 }
 
@@ -1134,7 +1136,7 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
   // a third attempt can install or reuse the requested mapping.
   constexpr int kMaxStaleMappingWaits = 2;
   for (int wait_count = 0;; ++wait_count) {
-    std::optional<PendingDeallocationKey> pending_completion_key;
+    uint64_t pending_completion_seqno = 0;
     {
       // Keep record pointers inside this scope so none survives a wait that
       // releases state.mu.
@@ -1167,14 +1169,12 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
       if (source_record->reservation_stale()) {
         CHECK(source_record->has_reservation_alias());
         if (!source_record->reservation_matches(request.reservation_address)) {
-          pending_completion_key =
-              PendingDeallocationKey{PendingDeallocationKind::kMap,
-                                     source_record->reservation_stale_seqno(),
-                                     source_record->reservation_address()};
+          pending_completion_seqno =
+              source_record->reservation_stale_seqno();
         }
       }
 
-      if (!pending_completion_key.has_value()) {
+      if (pending_completion_seqno == 0) {
         auto stale_reservation_overlap = FindOverlappingRecord(
             state, request.reservation_address, AddressRole::kReservation,
             RecordState::kStale, OverlapKind::kExact);
@@ -1193,27 +1193,21 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
                                      request.reservation_address);
             return absl::OkStatus();
           }
-          pending_completion_key =
-              PendingDeallocationKey{PendingDeallocationKind::kMap,
-                                     stale_record.reservation_stale_seqno(),
-                                     stale_record.reservation_address()};
+          pending_completion_seqno = stale_record.reservation_stale_seqno();
         }
       }
 
-      if (!pending_completion_key.has_value()) {
+      if (pending_completion_seqno == 0) {
         auto stale_allocator_overlap = FindOverlappingRecord(
             state, request.reservation_address, AddressRole::kAllocator,
             RecordState::kStale, OverlapKind::kExact);
         if (stale_allocator_overlap.has_value()) {
           AllocationRecord& stale_record = *stale_allocator_overlap->record;
-          pending_completion_key =
-              PendingDeallocationKey{stale_record.pending_deallocation_kind(),
-                                     stale_record.allocator_stale_seqno(),
-                                     stale_record.allocator_address()};
+          pending_completion_seqno = stale_record.allocator_stale_seqno();
         }
       }
 
-      if (!pending_completion_key.has_value()) {
+      if (pending_completion_seqno == 0) {
         // Map() aliases the beginning of the source allocation into the
         // caller's VA slice. No physical allocation or PA accounting is added.
         ASSIGN_OR_RETURN(
@@ -1242,14 +1236,9 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
       }
     }
 
-    CHECK(pending_completion_key.has_value());
-    if (pending_completion_key->kind == PendingDeallocationKind::kMap) {
-      RETURN_IF_ERROR(WaitAndCompleteStaleReservationMapping(
-          state, *pending_completion_key));
-    } else {
-      RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
-          state, *pending_completion_key));
-    }
+    CHECK_NE(pending_completion_seqno, 0);
+    WaitUntilSeqno(state, pending_completion_seqno);
+    CompletePendingDeallocationBySeqno(state, pending_completion_seqno);
   }
 }
 
@@ -1309,23 +1298,8 @@ void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
   record.ReactivateAllocator(new_size);
 }
 
-void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
-    PerDeviceState& state, AllocationRecord& record) {
-  if (!record.reservation_stale()) {
-    return;
-  }
-  CHECK(!record.reservation_active());
-  CHECK(record.has_reservation_alias());
-  void* reservation_va = record.reservation_key();
-  auto reservation_it = state.reservation_records.find(reservation_va);
-  CHECK(reservation_it != state.reservation_records.end());
-  CHECK_EQ(reservation_it->second, &record);
-  state.reservation_records.erase(reservation_it);
-  record.CompleteStaleReservation();
-}
-
-absl::Status DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
-                                                       uint64_t target_seqno) {
+void DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
+                                               uint64_t target_seqno) {
   // Release the lock before spin-waiting to avoid stalling other threads for
   // potentially milliseconds while the GPU drains its work queue.
   state.mu.unlock();
@@ -1338,86 +1312,34 @@ absl::Status DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
   }
 
   state.mu.lock();
-  return absl::OkStatus();
-}
-
-absl::Status
-DeviceAddressVmmAllocator::WaitAndDrainPendingDeallocationsUntilSeqno(
-    PerDeviceState& state, uint64_t target_seqno) {
-  RETURN_IF_ERROR(WaitUntilSeqno(state, target_seqno));
-  while (!state.pending_deallocations.empty() &&
-         state.pending_deallocations.front().seqno <= target_seqno) {
-    PendingDeallocation pending = state.pending_deallocations.front();
-    state.pending_deallocations.pop_front();
-    CompletePendingDeallocation(state, pending);
-  }
-  return absl::OkStatus();
 }
 
 void DeviceAddressVmmAllocator::CompleteReadyAllocatorDeallocationsForReclaim(
     PerDeviceState& state, uint64_t completed_seqno) {
-  std::vector<PendingDeallocationKey> selected;
+  std::vector<uint64_t> selected;
   for (const PendingDeallocation& pending : state.pending_deallocations) {
     if (pending.seqno > completed_seqno ||
         pending.kind == PendingDeallocationKind::kMap) {
       continue;
     }
-    selected.push_back(
-        PendingDeallocationKey{pending.kind, pending.seqno, pending.addr});
+    selected.push_back(pending.seqno);
   }
-  for (const PendingDeallocationKey& key : selected) {
-    CompletePendingDeallocationByKey(state, key);
+  for (uint64_t seqno : selected) {
+    CompletePendingDeallocationBySeqno(state, seqno);
   }
 }
 
-bool DeviceAddressVmmAllocator::CompletePendingDeallocationByKey(
-    PerDeviceState& state, const PendingDeallocationKey& key) {
+void DeviceAddressVmmAllocator::CompletePendingDeallocationBySeqno(
+    PerDeviceState& state, uint64_t seqno) {
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
-    if (it->kind == key.kind && it->seqno == key.seqno &&
-        it->addr.IsSameAs(key.addr)) {
+    if (it->seqno == seqno) {
       PendingDeallocation pending = *it;
       state.pending_deallocations.erase(it);
       CompletePendingDeallocation(state, pending);
-      return true;
+      return;
     }
   }
-  return false;
-}
-
-absl::Status
-DeviceAddressVmmAllocator::WaitAndCompleteStaleAllocatorDeallocation(
-    PerDeviceState& state, const PendingDeallocationKey& key) {
-  CHECK_NE(key.kind, PendingDeallocationKind::kMap);
-  RETURN_IF_ERROR(WaitUntilSeqno(state, key.seqno));
-  CompletePendingDeallocationByKey(state, key);
-  return absl::OkStatus();
-}
-
-absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleReservationMapping(
-    PerDeviceState& state, const PendingDeallocationKey& key) {
-  CHECK_EQ(key.kind, PendingDeallocationKind::kMap);
-  RETURN_IF_ERROR(WaitUntilSeqno(state, key.seqno));
-  CompletePendingDeallocationByKey(state, key);
-  return absl::OkStatus();
-}
-
-absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleOverlap(
-    PerDeviceState& state, const OverlappingRecord& overlap) {
-  CHECK(!overlap.is_active);
-  if (overlap.is_allocator) {
-    AllocationRecord& record = *overlap.record;
-    return WaitAndCompleteStaleAllocatorDeallocation(
-        state, PendingDeallocationKey{record.pending_deallocation_kind(),
-                                      record.allocator_stale_seqno(),
-                                      record.allocator_address()});
-  }
-  CHECK(overlap.record->reservation_stale());
-  CHECK(overlap.record->has_reservation_alias());
-  return WaitAndCompleteStaleReservationMapping(
-      state, PendingDeallocationKey{PendingDeallocationKind::kMap,
-                                    overlap.record->reservation_stale_seqno(),
-                                    overlap.record->reservation_address()});
 }
 
 void DeviceAddressVmmAllocator::CompletePendingDeallocation(
@@ -1425,18 +1347,22 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
   if (pending.kind == PendingDeallocationKind::kMap) {
     auto record_it = state.reservation_records.find(pending.addr.opaque());
     CHECK(record_it != state.reservation_records.end());
-    CHECK(record_it->second->reservation_stale());
-    CHECK_EQ(record_it->second->reservation_stale_seqno(), pending.seqno);
-    CompleteStaleReservationMapping(state, *record_it->second);
+    AllocationRecord& record = *record_it->second;
+    CHECK(record.reservation_stale());
+    CHECK_EQ(record.reservation_stale_seqno(), pending.seqno);
+    CHECK(record.has_reservation_alias());
+    CHECK_EQ(record.reservation_key(), pending.addr.opaque());
+    state.reservation_records.erase(record_it);
+    record.CompleteStaleReservation();
     return;
   }
 
   auto record_it =
       state.records_by_allocator_address.find(pending.addr.opaque());
   CHECK(record_it != state.records_by_allocator_address.end());
+  CHECK_EQ(pending.kind, PendingDeallocationKind::kAllocation);
   CHECK(record_it->second->allocator_stale());
   CHECK(record_it->second->allocator_matches(pending.addr));
-  CHECK_EQ(record_it->second->pending_deallocation_kind(), pending.kind);
   CHECK_EQ(record_it->second->allocator_stale_seqno(), pending.seqno);
   // Complete allocator-address teardown. If this allocation still has an
   // explicitly unmapped stale reservation alias, drop that mapping first, then
@@ -1446,19 +1372,8 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
   CHECK(!record.reservation_active());
   if (record.reservation_stale()) {
     CHECK(record.has_reservation_alias());
-    PendingDeallocationKey reservation_key{PendingDeallocationKind::kMap,
-                                           record.reservation_stale_seqno(),
-                                           record.reservation_address()};
-    for (auto it = state.pending_deallocations.begin();
-         it != state.pending_deallocations.end(); ++it) {
-      if (it->kind == reservation_key.kind &&
-          it->seqno == reservation_key.seqno &&
-          it->addr.IsSameAs(reservation_key.addr)) {
-        state.pending_deallocations.erase(it);
-        break;
-      }
-    }
-    CompleteStaleReservationMapping(state, record);
+    CompletePendingDeallocationBySeqno(state, record.reservation_stale_seqno());
+    CHECK(!record.has_reservation_alias());
   }
   void* allocator_va = record.allocator_key();
   auto owning_record_it = state.records_by_allocator_address.find(allocator_va);
@@ -1526,9 +1441,8 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
   uint64_t seqno = state->next_seqno++;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
   record->MarkReservationStale(seqno);
-  state->pending_deallocations.push_back(
-      PendingDeallocation{PendingDeallocationKind::kMap, seqno,
-                          reservation_address, /*reclaimable_bytes=*/0});
+  state->pending_deallocations.push_back(PendingDeallocation{
+      PendingDeallocationKind::kMap, seqno, reservation_address});
   return absl::OkStatus();
 }
 

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -393,21 +393,53 @@ uint64_t DeviceAddressVmmAllocator::GetAllocationGranularity(
 
 // Allocate helpers.
 
+absl::StatusOr<std::unique_ptr<MemoryAllocation>>
+DeviceAddressVmmAllocator::AllocatePhysicalWithinBudget(
+    PerDeviceState& state, uint64_t size, uint64_t& physical_size) {
+  // Returns ResourceExhausted if charging `bytes` more physical bytes would
+  // exceed the configured PA budget. Subtraction avoids unsigned overflow.
+  auto check_pa_budget = [&state](uint64_t bytes) -> absl::Status {
+    state.mu.AssertHeld();
+    if (state.pa_allocated <= state.pa_budget &&
+        bytes <= state.pa_budget - state.pa_allocated) {
+      return absl::OkStatus();
+    }
+    return absl::ResourceExhaustedError(absl::StrFormat(
+        "Not enough PA budget: pa_allocated=%uB, allocation_size=%uB, "
+        "pa_budget=%uB",
+        state.pa_allocated, bytes, state.pa_budget));
+  };
+
+  // Fail fast on an obvious budget miss before asking the driver to reserve
+  // physical memory. rounded_size only estimates what the driver will return;
+  // the authoritative check below uses the real committed size.
+  RETURN_IF_ERROR(check_pa_budget(RoundUpToGranularity(state, size)));
+  ASSIGN_OR_RETURN(auto raw_alloc, CreateAllocation(state.executor, size));
+  physical_size = raw_alloc->address().size();
+  // CreateAllocation rounds the request up to the allocation granularity, so
+  // the physical allocation is never smaller than requested.
+  DCHECK_GE(physical_size, size);
+  // Re-check against the actual size that will be charged to pa_allocated.
+  RETURN_IF_ERROR(check_pa_budget(physical_size));
+  return raw_alloc;
+}
+
 void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
     PerDeviceState& state, AllocationRecord::Kind kind,
     DeviceAddressBase allocator_address,
     std::unique_ptr<MemoryAllocation> raw_allocation,
     std::unique_ptr<MemoryReservation> reservation,
-    MemoryReservation::ScopedMapping mapping, uint64_t allocated_size,
-    bool multi_device) {
+    MemoryReservation::ScopedMapping mapping, bool multi_device) {
   void* va_ptr = allocator_address.opaque();
+  CHECK(raw_allocation != nullptr);
+  uint64_t physical_size = raw_allocation->address().size();
   auto record = std::make_unique<AllocationRecord>(
       kind, allocator_address, std::move(raw_allocation),
       std::move(reservation), std::move(mapping), multi_device);
   auto insert_result =
       state.records_by_allocator_address.emplace(va_ptr, std::move(record));
   CHECK(insert_result.second);
-  state.pa_allocated += allocated_size;
+  state.pa_allocated += physical_size;
   return va_ptr;
 }
 
@@ -573,25 +605,18 @@ DeviceAddressVmmAllocator::EnsureReservationAvailableForFreshMapping(
 absl::StatusOr<DeviceAddressBase>
 DeviceAddressVmmAllocator::CreateMappedAllocationAtReservationAddress(
     PerDeviceState& state, const MappedAllocateRequest& request) {
-  const uint64_t rounded_size =
-      RoundUpToGranularity(state, request.allocation_size);
   // The returned allocator address is the caller-owned reservation VA. The
   // record is keyed by that VA and owns only the raw allocation plus the scoped
   // mapping into the external reservation.
-  if (state.pa_allocated + rounded_size > state.pa_budget) {
-    return absl::ResourceExhaustedError(
-        absl::StrFormat("Not enough PA budget for mapping: pa_allocated=%uB, "
-                        "rounded_size=%uB, pa_budget=%uB",
-                        state.pa_allocated, rounded_size, state.pa_budget));
-  }
-
+  uint64_t physical_size = 0;
   ASSIGN_OR_RETURN(auto raw_alloc,
-                   CreateAllocation(state.executor, request.allocation_size));
-  if (request.mapping_size > raw_alloc->address().size()) {
+                   AllocatePhysicalWithinBudget(
+                       state, request.allocation_size, physical_size));
+  if (request.mapping_size > physical_size) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "physical allocation is smaller than requested mapping: "
         "allocation_size=%uB, mapping_size=%uB",
-        raw_alloc->address().size(), request.mapping_size));
+        physical_size, request.mapping_size));
   }
 
   ASSIGN_OR_RETURN(auto scoped_mapping, request.reservation->MapTo(
@@ -601,7 +626,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocationAtReservationAddress(
   TrackAllocatorAddressMappedAllocation(
       state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
       request.reservation_address, std::move(raw_alloc), nullptr,
-      std::move(scoped_mapping), rounded_size, request.multi_device);
+      std::move(scoped_mapping), request.multi_device);
 
   return request.reservation_address;
 }
@@ -609,26 +634,18 @@ DeviceAddressVmmAllocator::CreateMappedAllocationAtReservationAddress(
 absl::StatusOr<DeviceAddressBase>
 DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
     PerDeviceState& state, const MappedAllocateRequest& request) {
-  const uint64_t rounded_size =
-      RoundUpToGranularity(state, request.allocation_size);
   // This mode creates two VAs for the same raw allocation: an allocator-owned
   // VA returned to the caller, and a non-owning alias in the caller reservation
   // used by captured command buffers.
-  if (state.pa_allocated + rounded_size > state.pa_budget) {
-    return absl::ResourceExhaustedError(absl::StrFormat(
-        "Not enough PA budget for allocation: pa_allocated=%uB, "
-        "rounded_size=%uB, pa_budget=%uB",
-        state.pa_allocated, rounded_size, state.pa_budget));
-  }
-
+  uint64_t physical_size = 0;
   ASSIGN_OR_RETURN(auto raw_alloc,
-                   CreateAllocation(state.executor, request.allocation_size));
-  const uint64_t padded_size = raw_alloc->address().size();
-  if (request.mapping_size > padded_size) {
+                   AllocatePhysicalWithinBudget(
+                       state, request.allocation_size, physical_size));
+  if (request.mapping_size > physical_size) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "mapping size must not exceed physical allocation size: "
         "mapping_size=%uB, allocation_size=%uB",
-        request.mapping_size, padded_size));
+        request.mapping_size, physical_size));
   }
 
   ASSIGN_OR_RETURN(auto allocator_address_reservation,
@@ -636,7 +653,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
   ASSIGN_OR_RETURN(auto allocator_address_mapping,
                    allocator_address_reservation->MapTo(
                        /*reservation_offset=*/0, /*allocation_offset=*/0,
-                       padded_size, *raw_alloc));
+                       physical_size, *raw_alloc));
   ASSIGN_OR_RETURN(
       auto reservation_address_mapping,
       request.reservation->MapTo(request.reservation_offset,
@@ -660,7 +677,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
   auto reservation_insert = state.active_reservation_records.emplace(
       request.reservation_address.opaque(), record_ptr);
   CHECK(reservation_insert.second);
-  state.pa_allocated += rounded_size;
+  state.pa_allocated += physical_size;
 
   return DeviceAddressBase(allocator_va, request.allocation_size);
 }
@@ -833,17 +850,10 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
   };
   auto try_fresh = [&]() -> absl::StatusOr<DeviceAddressBase> {
     state->mu.AssertHeld();
-    uint64_t rounded_size = RoundUpToGranularity(*state, size);
-    if (state->pa_allocated + rounded_size > state->pa_budget) {
-      return absl::StatusOr<DeviceAddressBase>(
-          absl::ResourceExhaustedError(absl::StrFormat(
-              "Not enough PA budget for allocation: pa_allocated=%uB, "
-              "rounded_size=%uB, pa_budget=%uB",
-              state->pa_allocated, rounded_size, state->pa_budget)));
-    }
-
-    ASSIGN_OR_RETURN(auto raw_alloc, CreateAllocation(state->executor, size));
-    const uint64_t padded_size = raw_alloc->address().size();
+    uint64_t physical_size = 0;
+    ASSIGN_OR_RETURN(
+        auto raw_alloc,
+        AllocatePhysicalWithinBudget(*state, size, physical_size));
 
     ASSIGN_OR_RETURN(auto reservation,
                      CreateReservation(state->executor, size));
@@ -851,13 +861,13 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
     ASSIGN_OR_RETURN(
         auto scoped_mapping,
         reservation->MapTo(/*reservation_offset=*/0, /*allocation_offset=*/0,
-                           padded_size, *raw_alloc));
+                           physical_size, *raw_alloc));
 
     DeviceAddressBase allocator_address(reservation->address().opaque(), size);
     void* va_ptr = TrackAllocatorAddressMappedAllocation(
         *state, AllocationRecord::Kind::kAllocate, allocator_address,
         std::move(raw_alloc), std::move(reservation),
-        std::move(scoped_mapping), rounded_size, multi_device);
+        std::move(scoped_mapping), multi_device);
     // Return the original requested size, not the padded size.
     return absl::StatusOr<DeviceAddressBase>(DeviceAddressBase(va_ptr, size));
   };
@@ -992,7 +1002,7 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
       mem.opaque(), mem.size(), state->executor->device_ordinal());
 
   const uint64_t reclaimable_bytes =
-      RoundUpToGranularity(*state, record.raw_allocation()->address().size());
+      record.raw_allocation()->address().size();
 
   // Assign the next sequence number and enqueue a GPU write to the pinned
   // timeline when the stream reaches this point. The CPU polls the timeline
@@ -1601,8 +1611,7 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
   CHECK_EQ(owning_record_it->second.get(), &record);
 
   if (record.raw_allocation() != nullptr) {
-    uint64_t released_size =
-        RoundUpToGranularity(state, record.raw_allocation()->address().size());
+    uint64_t released_size = record.raw_allocation()->address().size();
     DCHECK_GE(state.pa_allocated, released_size);
     state.pa_allocated -= released_size;
   }

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -74,7 +74,7 @@ bool DeviceAddressVmmAllocator::CurrentMultiDevice() {
 
 DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
     Kind kind, DeviceAddressBase allocator_address,
-    std::shared_ptr<MemoryAllocation> raw_allocation,
+    std::unique_ptr<MemoryAllocation> raw_allocation,
     std::unique_ptr<MemoryReservation> allocator_address_reservation,
     MemoryReservation::ScopedMapping allocator_address_mapping,
     bool multi_device)
@@ -396,7 +396,7 @@ uint64_t DeviceAddressVmmAllocator::GetAllocationGranularity(
 void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
     PerDeviceState& state, AllocationRecord::Kind kind,
     DeviceAddressBase allocator_address,
-    std::shared_ptr<MemoryAllocation> raw_allocation,
+    std::unique_ptr<MemoryAllocation> raw_allocation,
     std::unique_ptr<MemoryReservation> reservation,
     MemoryReservation::ScopedMapping mapping, uint64_t allocated_size,
     bool multi_device) {
@@ -598,11 +598,9 @@ DeviceAddressVmmAllocator::CreateMappedAllocationAtReservationAddress(
                                             request.reservation_offset,
                                             /*allocation_offset=*/0,
                                             request.mapping_size, *raw_alloc));
-  auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
-
   TrackAllocatorAddressMappedAllocation(
       state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
-      request.reservation_address, std::move(shared_raw), nullptr,
+      request.reservation_address, std::move(raw_alloc), nullptr,
       std::move(scoped_mapping), rounded_size, request.multi_device);
 
   return request.reservation_address;
@@ -645,14 +643,13 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
                                  /*allocation_offset=*/0, request.mapping_size,
                                  *raw_alloc));
 
-  auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
   // Record the paired allocation: the allocator-owned returned VA owns the raw
   // allocation, and the caller reservation VA is a non-owning alias.
   void* allocator_va = allocator_address_reservation->address().opaque();
   DeviceAddressBase allocator_address(allocator_va, request.allocation_size);
   auto record = std::make_unique<AllocationRecord>(
       AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
-      std::move(shared_raw), std::move(allocator_address_reservation),
+      std::move(raw_alloc), std::move(allocator_address_reservation),
       std::move(allocator_address_mapping), request.multi_device);
   record->AddActiveReservationAlias(request.reservation_address,
                                     std::move(reservation_address_mapping));
@@ -856,11 +853,10 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
         reservation->MapTo(/*reservation_offset=*/0, /*allocation_offset=*/0,
                            padded_size, *raw_alloc));
 
-    auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
     DeviceAddressBase allocator_address(reservation->address().opaque(), size);
     void* va_ptr = TrackAllocatorAddressMappedAllocation(
         *state, AllocationRecord::Kind::kAllocate, allocator_address,
-        std::move(shared_raw), std::move(reservation),
+        std::move(raw_alloc), std::move(reservation),
         std::move(scoped_mapping), rounded_size, multi_device);
     // Return the original requested size, not the padded size.
     return absl::StatusOr<DeviceAddressBase>(DeviceAddressBase(va_ptr, size));

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -302,20 +302,11 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
  protected:
   enum class PendingDeallocationKind {
-    // Deferred Deallocate() of an Allocate() result backed by an
-    // allocator-owned reservation.
-    kAllocate,
-    // Deferred Deallocate() of an
-    // Allocate(..., return_reservation_address=true) result. The allocator
-    // address is a caller-owned reservation range.
-    kAllocateAndMapReturnMapAddr,
-    // Deferred Deallocate() of an
-    // Allocate(..., return_reservation_address=false) result. The record has
-    // an allocator-owned returned address and may also have a non-owning caller
-    // reservation mapping to unmap.
-    kAllocateAndMapReturnNewAddr,
-    // Deferred completion of a Map()-owned reservation address. The reservation
-    // address is a non-owning alias of an existing raw allocation.
+    // Deferred Deallocate() of any Allocate() result. AllocationRecord::kind()
+    // identifies the API mode that created the allocation.
+    kAllocation,
+    // Deferred completion of a reservation alias created by Map() or mapped
+    // Allocate(). The reservation address does not own the raw allocation.
     kMap,
   };
 
@@ -347,7 +338,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     AllocationRecord& operator=(AllocationRecord&&) = default;
 
     Kind kind() const { return kind_; }
-    PendingDeallocationKind pending_deallocation_kind() const;
     DeviceAddressBase allocator_address() const { return allocator_address_; }
     void* allocator_key() const { return allocator_address_.opaque(); }
     bool allocator_active() const { return allocator_stale_seqno_ == 0; }
@@ -413,25 +403,12 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // live in AllocationRecord; this entry only says which stale address becomes
   // safe to complete when the GPU timeline reaches `seqno`.
   struct PendingDeallocation {
-    PendingDeallocationKind kind = PendingDeallocationKind::kAllocate;
+    PendingDeallocationKind kind = PendingDeallocationKind::kAllocation;
     // GPU stream sequence number recorded at deallocation time. When the
     // pinned_timeline value reaches this seqno, the memory is safe to free.
     uint64_t seqno = 0;
     // Allocator address for allocation deallocations; reservation address for
     // kMap.
-    DeviceAddressBase addr;
-    // Physical-allocation bytes charged to the PA budget that become
-    // reclaimable when this pending operation completes. kMap entries do not
-    // own physical memory and therefore use zero.
-    uint64_t reclaimable_bytes = 0;
-  };
-
-  // Stable identity for a pending operation. Iterators into
-  // pending_deallocations must not be kept across waits because
-  // WaitUntilSeqno() releases state.mu.
-  struct PendingDeallocationKey {
-    PendingDeallocationKind kind = PendingDeallocationKind::kAllocate;
-    uint64_t seqno = 0;
     DeviceAddressBase addr;
   };
 
@@ -671,21 +648,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
                                    AllocationRecord& record, uint64_t new_size)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  void CompleteStaleReservationMapping(PerDeviceState& state,
-                                       AllocationRecord& record)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
   // Waits for the device timeline to reach `target_seqno`. Temporarily releases
   // and reacquires state.mu around the blocking wait. This does not complete
   // pending entries by itself.
-  absl::Status WaitUntilSeqno(PerDeviceState& state, uint64_t target_seqno)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Waits for pending operations through `target_seqno`, then completes all
-  // still-pending operations up to that sequence. Used only when preserving
-  // stale mappings for future reuse is no longer useful.
-  absl::Status WaitAndDrainPendingDeallocationsUntilSeqno(PerDeviceState& state,
-                                                          uint64_t target_seqno)
+  void WaitUntilSeqno(PerDeviceState& state, uint64_t target_seqno)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Completes ready allocator-address deallocations for PA reclaim while
@@ -703,28 +669,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Finds, erases, and completes the selected pending entry if it is still
-  // present. Returns false if another thread already reused or completed it
-  // while state.mu was released.
-  bool CompletePendingDeallocationByKey(PerDeviceState& state,
-                                        const PendingDeallocationKey& key)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Waits for and completes the selected allocator-address deallocation, if it
-  // is still pending after the wait.
-  absl::Status WaitAndCompleteStaleAllocatorDeallocation(
-      PerDeviceState& state, const PendingDeallocationKey& key)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Waits for and completes a stale reservation-address mapping queued by
-  // UnMap().
-  absl::Status WaitAndCompleteStaleReservationMapping(
-      PerDeviceState& state, const PendingDeallocationKey& key)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Completes only the stale allocator or reservation mapping that conflicts
-  // with the current request, leaving unrelated stale mappings reusable.
-  absl::Status WaitAndCompleteStaleOverlap(PerDeviceState& state,
-                                           const OverlappingRecord& overlap)
+  // present. Sequence numbers uniquely identify operations on a device; another
+  // thread may already have reused or completed the entry while state.mu was
+  // released.
+  void CompletePendingDeallocationBySeqno(PerDeviceState& state, uint64_t seqno)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Device ordinal -> per-device allocator state. Populated at construction by

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -348,7 +348,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
     AllocationRecord(
         Kind kind, DeviceAddressBase allocator_address,
-        std::shared_ptr<MemoryAllocation> raw_allocation,
+        std::unique_ptr<MemoryAllocation> raw_allocation,
         std::unique_ptr<MemoryReservation> allocator_address_reservation,
         MemoryReservation::ScopedMapping allocator_address_mapping,
         bool multi_device);
@@ -417,7 +417,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
    private:
     Kind kind_;
     DeviceAddressBase allocator_address_;
-    std::shared_ptr<MemoryAllocation> raw_allocation_;
+    std::unique_ptr<MemoryAllocation> raw_allocation_;
     bool multi_device_;
 
     // Present for Allocate() and
@@ -562,7 +562,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   void* TrackAllocatorAddressMappedAllocation(
       PerDeviceState& state, AllocationRecord::Kind kind,
       DeviceAddressBase allocator_address,
-      std::shared_ptr<MemoryAllocation> raw_allocation,
+      std::unique_ptr<MemoryAllocation> raw_allocation,
       std::unique_ptr<MemoryReservation> reservation,
       MemoryReservation::ScopedMapping mapping, uint64_t allocated_size,
       bool multi_device) ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -683,11 +683,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
                                   const MapRequest& request)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  // Installs and records a fresh reservation-address alias.
-  absl::Status InstallMapAlias(PerDeviceState& state, const MapRequest& request,
-                               AllocationRecord& source_record)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
   // UnMap/deferred teardown helpers.
 
   // Removes a pending entry when a stale record is reused.

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -686,19 +686,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       RecordState record_state, OverlapKind overlap_kind) const
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  // Resolves an active allocator address to its allocation record.
+  // Resolves an active allocator address and validates that `size` fits in its
+  // physical allocation.
   absl::StatusOr<AllocationRecord*> ResolveMapSourceRecord(
-      PerDeviceState& state, DeviceAddressBase source_address) const
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Validates that `size` fits in the source record's physical allocation.
-  absl::Status ValidateMapSourceSize(PerDeviceState& state,
-                                     const AllocationRecord& source_record,
-                                     uint64_t size) const
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Resolves and validates the Map() source before target preparation starts.
-  absl::StatusOr<AllocationRecord*> ResolveAndValidateMapSource(
       PerDeviceState& state, DeviceAddressBase source_address,
       uint64_t size) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -314,10 +314,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   //
   // The record is owned by records_by_allocator_address while either the
   // allocator address or a reservation-address alias is active, stale, or
-  // pending completion. Active indexes are callable by public APIs. Stale
-  // indexes are no longer callable by users, but still keep mappings alive
-  // until the stream-ordered deferred operation completes or a later Allocate()
-  // or Map() reuses them.
+  // pending completion. Stale addresses are no longer callable by users, but
+  // their records keep mappings alive until the stream-ordered deferred
+  // operation completes or a later Allocate() or Map() reuses them.
   class AllocationRecord {
    public:
     enum class Kind {
@@ -334,8 +333,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
         bool multi_device);
     AllocationRecord(const AllocationRecord&) = delete;
     AllocationRecord& operator=(const AllocationRecord&) = delete;
-    AllocationRecord(AllocationRecord&&) = default;
-    AllocationRecord& operator=(AllocationRecord&&) = default;
 
     Kind kind() const { return kind_; }
     DeviceAddressBase allocator_address() const { return allocator_address_; }
@@ -351,6 +348,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     MemoryReservation* allocator_address_reservation() const {
       return allocator_address_reservation_.get();
     }
+
     bool has_reservation_alias() const {
       return reservation_alias_.has_value();
     }
@@ -369,6 +367,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
     void MarkAllocatorStale(uint64_t seqno);
     void ReactivateAllocator(uint64_t new_size);
+
     void AddActiveReservationAlias(
         MemoryReservation::ScopedMapping reservation_address_mapping);
     void MarkReservationStale(uint64_t seqno);
@@ -403,10 +402,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // live in AllocationRecord; this entry only says which stale address becomes
   // safe to complete when the GPU timeline reaches `seqno`.
   struct PendingDeallocation {
-    PendingDeallocationKind kind = PendingDeallocationKind::kAllocation;
+    PendingDeallocationKind kind;
     // GPU stream sequence number recorded at deallocation time. When the
     // pinned_timeline value reaches this seqno, the memory is safe to free.
-    uint64_t seqno = 0;
+    uint64_t seqno;
     // Allocator address for allocation deallocations; reservation address for
     // kMap.
     DeviceAddressBase addr;
@@ -556,9 +555,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Shared allocation retry policy. First calls `try_reuse` to reactivate
-  // compatible pending state without blocking, then calls `try_fresh`. On
-  // ResourceExhausted, it completes ready pending entries and, if needed, waits
-  // for enough pending frees to reclaim approximately `reclaim_size` bytes.
+  // compatible pending state without blocking, then calls `try_fresh`. A
+  // ResourceExhausted result completes ready pending entries and, if needed,
+  // waits for enough pending frees to reclaim approximately `reclaim_size`
+  // bytes.
   template <typename TryReuseFn, typename TryFreshFn>
   absl::StatusOr<DeviceAddressBase> TryWithPendingReclaim(PerDeviceState& state,
                                                           uint64_t reclaim_size,
@@ -576,10 +576,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       uint64_t size) const;
 
   struct OverlappingRecord {
-    AllocationRecord* record = nullptr;
+    AllocationRecord* record;
     DeviceAddressBase tracked_address;
-    bool is_allocator = false;
-    bool is_active = false;
+    bool is_allocator;
+    bool is_active;
   };
 
   enum class AddressRole { kAllocator, kReservation, kBoth };
@@ -590,9 +590,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // helpers.
   struct MapRequest {
     DeviceAddressBase source_address;
-    MemoryReservation* reservation = nullptr;
-    uint64_t reservation_offset = 0;
-    uint64_t size = 0;
+    MemoryReservation* reservation;
+    uint64_t reservation_offset;
+    uint64_t size;
     DeviceAddressBase reservation_address;
   };
 

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -475,12 +475,11 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     absl::flat_hash_map<void*, std::unique_ptr<AllocationRecord>>
         records_by_allocator_address ABSL_GUARDED_BY(mu);
 
-    // Active/stale reservation-address indexes. Keys are reservation alias
-    // pointers (`AllocationRecord::reservation_address().opaque()`) created by
-    // Map() or by Allocate(..., return_reservation_address=false).
-    absl::flat_hash_map<void*, AllocationRecord*> active_reservation_records
-        ABSL_GUARDED_BY(mu);
-    absl::flat_hash_map<void*, AllocationRecord*> stale_reservation_records
+    // Reservation-address index. Keys are reservation alias pointers
+    // (`AllocationRecord::reservation_address().opaque()`) created by Map() or
+    // by Allocate(..., return_reservation_address=false). Active/stale state is
+    // stored in the record.
+    absl::flat_hash_map<void*, AllocationRecord*> reservation_records
         ABSL_GUARDED_BY(mu);
   };
 
@@ -670,14 +669,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   void MoveAllocatorRecordToActive(PerDeviceState& state,
                                    AllocationRecord& record, uint64_t new_size)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  void MoveReservationRecordToStale(PerDeviceState& state,
-                                    AllocationRecord& record, uint64_t seqno)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  void MoveReservationRecordToActive(PerDeviceState& state,
-                                     AllocationRecord& record)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   void CompleteStaleReservationMapping(PerDeviceState& state,

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -525,26 +525,22 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       MemoryReservation::ScopedMapping mapping, bool multi_device)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
+  enum class MappedAddressMode {
+    kReservationAddress,
+    kSeparateAllocatorAddress,
+  };
+
   struct MappedAllocateRequest {
     MemoryReservation* reservation;
     DeviceAddressBase reservation_address;
-    uint64_t allocation_size;
+    uint64_t size;
     uint64_t reservation_offset;
-    uint64_t mapping_size;
     bool multi_device;
+    MappedAddressMode mode;
   };
 
-  // Reactivates a stale mapped allocation whose returned allocator address is
-  // the requested caller-owned reservation address.
-  absl::StatusOr<std::optional<DeviceAddressBase>>
-  TryReuseMappedAllocationAtReservationAddress(
-      PerDeviceState& state, const MappedAllocateRequest& request)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Reactivates a stale mapped allocation with both a separate allocator-owned
-  // returned address and an alias at the requested reservation address.
-  absl::StatusOr<std::optional<DeviceAddressBase>>
-  TryReuseMappedAllocationWithSeparateAddress(
+  // Reactivates a compatible stale mapped allocation.
+  std::optional<DeviceAddressBase> TryReuseMappedAllocation(
       PerDeviceState& state, const MappedAllocateRequest& request)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -448,9 +448,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     // Allocator address for allocation deallocations; reservation address for
     // kMap.
     DeviceAddressBase addr;
-    // Rounded physical-allocation bytes that become reclaimable when this
-    // pending operation completes. kMap entries do not own physical memory and
-    // therefore use zero.
+    // Physical-allocation bytes charged to the PA budget that become
+    // reclaimable when this pending operation completes. kMap entries do not
+    // own physical memory and therefore use zero.
     uint64_t reclaimable_bytes = 0;
   };
 
@@ -555,17 +555,27 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   // Allocate helpers.
 
+  // Checks the PA budget for `size`, creates a physical allocation, and
+  // re-checks the budget against the actual (granularity-padded) size the
+  // driver returned, which is the size charged to pa_allocated. Returns the
+  // allocation and reports that size via `physical_size`.
+  absl::StatusOr<std::unique_ptr<MemoryAllocation>>
+  AllocatePhysicalWithinBudget(PerDeviceState& state, uint64_t size,
+                               uint64_t& physical_size)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
   // Records a raw allocation mapped at an owning allocator address. Takes
   // ownership of `reservation` when the allocator address was allocator-owned;
-  // reservation-backed returned addresses pass nullptr here. Charges
-  // `allocated_size` to the PA budget and returns the allocator VA pointer.
+  // reservation-backed returned addresses pass nullptr here. Charges the raw
+  // allocation's committed size to the PA budget and returns the allocator VA
+  // pointer.
   void* TrackAllocatorAddressMappedAllocation(
       PerDeviceState& state, AllocationRecord::Kind kind,
       DeviceAddressBase allocator_address,
       std::unique_ptr<MemoryAllocation> raw_allocation,
       std::unique_ptr<MemoryReservation> reservation,
-      MemoryReservation::ScopedMapping mapping, uint64_t allocated_size,
-      bool multi_device) ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+      MemoryReservation::ScopedMapping mapping, bool multi_device)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   struct MappedAllocateRequest {
     MemoryReservation* reservation;

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -645,6 +645,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     bool is_active = false;
   };
 
+  enum class AddressRole { kAllocator, kReservation, kBoth };
+  enum class RecordState { kActive, kStale, kBoth };
+  enum class OverlapKind { kExact, kPartial };
+
   // Immutable inputs shared by the Map() preparation and installation
   // helpers.
   struct MapRequest {
@@ -677,12 +681,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   };
 
   // Finds a tracked allocator or reservation range that overlaps `address`.
-  // `exact_only` returns only identical ranges; `partial_only` returns only
-  // non-identical overlapping ranges; both false returns any overlap.
   std::optional<OverlappingRecord> FindOverlappingRecord(
-      PerDeviceState& state, DeviceAddressBase address, bool include_allocator,
-      bool include_reservation, bool include_active, bool include_stale,
-      bool exact_only, bool partial_only) const
+      PerDeviceState& state, DeviceAddressBase address, AddressRole role,
+      RecordState record_state, OverlapKind overlap_kind) const
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Resolves an active allocator address to its allocation record.

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -515,9 +515,8 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // Records a raw allocation mapped at an owning allocator address. Takes
   // ownership of `reservation` when the allocator address was allocator-owned;
   // reservation-backed returned addresses pass nullptr here. Charges the raw
-  // allocation's committed size to the PA budget and returns the allocator VA
-  // pointer.
-  void* TrackAllocatorAddressMappedAllocation(
+  // allocation's committed size to the PA budget.
+  AllocationRecord& TrackAllocatorAddressMappedAllocation(
       PerDeviceState& state, AllocationRecord::Kind kind,
       DeviceAddressBase allocator_address,
       std::unique_ptr<MemoryAllocation> raw_allocation,
@@ -550,15 +549,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       PerDeviceState& state, const MappedAllocateRequest& request)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  // Creates a mapped allocation that uses the caller-owned reservation address
-  // as its returned allocator address.
-  absl::StatusOr<DeviceAddressBase> CreateMappedAllocationAtReservationAddress(
-      PerDeviceState& state, const MappedAllocateRequest& request)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Creates a mapped allocation with a separate allocator-owned returned
-  // address and a non-owning alias in the caller-owned reservation.
-  absl::StatusOr<DeviceAddressBase> CreateMappedAllocationWithSeparateAddress(
+  // Creates a mapped allocation with either the caller-owned reservation
+  // address or a separate allocator-owned address as its returned address.
+  absl::StatusOr<DeviceAddressBase> CreateMappedAllocation(
       PerDeviceState& state, const MappedAllocateRequest& request)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -659,27 +659,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     DeviceAddressBase reservation_address;
   };
 
-  // Result of inspecting the requested Map() target while holding state.mu.
-  // A stale record is consumed immediately for kReactivateStale; a pending key
-  // is copied out before kWait releases state.mu.
-  struct MapTargetEvaluation {
-    enum class Action { kInstallFresh, kReactivateStale, kWait };
-
-    Action action;
-    AllocationRecord* stale_record = nullptr;
-    std::optional<PendingDeallocationKey> pending_completion_key;
-  };
-
-  // Result of preparing a Map() target. kInstallFresh carries the current
-  // source record; kReusedStaleMapping means preparation already reactivated
-  // the requested mapping.
-  struct PreparedMapTarget {
-    enum class Action { kInstallFresh, kReusedStaleMapping };
-
-    Action action;
-    AllocationRecord* source_record = nullptr;
-  };
-
   // Finds a tracked allocator or reservation range that overlaps `address`.
   std::optional<OverlappingRecord> FindOverlappingRecord(
       PerDeviceState& state, DeviceAddressBase address, AddressRole role,
@@ -697,18 +676,11 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       PerDeviceState& state, DeviceAddressBase reservation_address) const
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  // Determines whether Map() can install a fresh mapping, reactivate a stale
-  // mapping, or must wait for a conflicting pending operation.
-  absl::StatusOr<MapTargetEvaluation> EvaluateMapTarget(
-      PerDeviceState& state, const MapRequest& request,
-      AllocationRecord& source_record) const
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Resolves up to two stale conflicts for a Map() request. Every wait is
-  // followed by a fresh source lookup and validation because waiting
-  // temporarily releases state.mu.
-  absl::StatusOr<PreparedMapTarget> PrepareMapTarget(PerDeviceState& state,
-                                                     const MapRequest& request)
+  // Resolves stale conflicts and installs or reactivates a reservation alias.
+  // Every wait is followed by a fresh source lookup and validation because
+  // waiting temporarily releases state.mu.
+  absl::Status ResolveAndMapAlias(PerDeviceState& state,
+                                  const MapRequest& request)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Installs and records a fresh reservation-address alias.

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -335,17 +335,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       kAllocateAndMapReturnNewAddr,
     };
 
-    enum class AllocatorState {
-      kActive,
-      kStale,
-    };
-
-    enum class ReservationState {
-      kNone,
-      kActive,
-      kStale,
-    };
-
     AllocationRecord(
         Kind kind, DeviceAddressBase allocator_address,
         std::unique_ptr<MemoryAllocation> raw_allocation,
@@ -361,12 +350,8 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     PendingDeallocationKind pending_deallocation_kind() const;
     DeviceAddressBase allocator_address() const { return allocator_address_; }
     void* allocator_key() const { return allocator_address_.opaque(); }
-    bool allocator_active() const {
-      return allocator_state_ == AllocatorState::kActive;
-    }
-    bool allocator_stale() const {
-      return allocator_state_ == AllocatorState::kStale;
-    }
+    bool allocator_active() const { return allocator_stale_seqno_ == 0; }
+    bool allocator_stale() const { return !allocator_active(); }
     bool allocator_matches(DeviceAddressBase address) const {
       return allocator_address_.IsSameAs(address);
     }
@@ -376,45 +361,37 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     MemoryReservation* allocator_address_reservation() const {
       return allocator_address_reservation_.get();
     }
-    bool has_allocator_address_mapping() const {
-      return allocator_address_mapping_.has_value();
-    }
-
     bool has_reservation_alias() const {
-      return reservation_state_ != ReservationState::kNone;
+      return reservation_alias_.has_value();
     }
     bool reservation_active() const {
-      return reservation_state_ == ReservationState::kActive;
+      return has_reservation_alias() && reservation_alias_->stale_seqno == 0;
     }
     bool reservation_stale() const {
-      return reservation_state_ == ReservationState::kStale;
-    }
-    bool has_reservation_address() const {
-      return reservation_address_.has_value();
+      return has_reservation_alias() && reservation_alias_->stale_seqno != 0;
     }
     DeviceAddressBase reservation_address() const;
     void* reservation_key() const { return reservation_address().opaque(); }
     bool reservation_matches(DeviceAddressBase address) const {
-      return has_reservation_address() &&
-             reservation_address_->IsSameAs(address);
+      return has_reservation_alias() && reservation_address().IsSameAs(address);
     }
-    uint64_t reservation_stale_seqno() const {
-      return reservation_stale_seqno_;
-    }
-    bool reservation_mapping_matches(DeviceAddressBase address) const;
+    uint64_t reservation_stale_seqno() const;
 
     void MarkAllocatorStale(uint64_t seqno);
     void ReactivateAllocator(uint64_t new_size);
-    void CompleteStaleAllocator();
-
     void AddActiveReservationAlias(
-        DeviceAddressBase reservation_address,
         MemoryReservation::ScopedMapping reservation_address_mapping);
     void MarkReservationStale(uint64_t seqno);
     void ReactivateReservation();
     void CompleteStaleReservation();
 
    private:
+    struct ReservationAlias {
+      MemoryReservation::ScopedMapping mapping;
+      // Zero while active; the deferred UnMap() sequence number while stale.
+      uint64_t stale_seqno = 0;
+    };
+
     Kind kind_;
     DeviceAddressBase allocator_address_;
     std::unique_ptr<MemoryAllocation> raw_allocation_;
@@ -423,18 +400,13 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     // Present for Allocate() and
     // Allocate(..., return_reservation_address=false).
     std::unique_ptr<MemoryReservation> allocator_address_reservation_;
-    // Present while the allocator address is active or stale.
-    std::optional<MemoryReservation::ScopedMapping> allocator_address_mapping_;
+    // Present for the lifetime of the allocation record.
+    MemoryReservation::ScopedMapping allocator_address_mapping_;
 
     // Present while a reservation alias is active or stale.
-    std::optional<DeviceAddressBase> reservation_address_;
-    std::optional<MemoryReservation::ScopedMapping>
-        reservation_address_mapping_;
+    std::optional<ReservationAlias> reservation_alias_;
 
-    AllocatorState allocator_state_ = AllocatorState::kActive;
-    ReservationState reservation_state_ = ReservationState::kNone;
     uint64_t allocator_stale_seqno_ = 0;
-    uint64_t reservation_stale_seqno_ = 0;
   };
 
   // Queue entry for a stream-ordered deferred operation. The heavy resources

--- a/xla/stream_executor/device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/device_address_vmm_allocator_test.cc
@@ -1,0 +1,237 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/device_address_vmm_allocator.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/mock_platform.h"
+#include "xla/stream_executor/mock_stream.h"
+#include "xla/stream_executor/mock_stream_executor.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor {
+namespace {
+
+using ::testing::NiceMock;
+using ::testing::Return;
+
+constexpr uint64_t kGranularity = 64;
+
+uint64_t RoundUpTestSize(uint64_t size) {
+  return ((size + kGranularity - 1) / kGranularity) * kGranularity;
+}
+
+class TestMemoryAllocation final : public MemoryAllocation {
+ public:
+  explicit TestMemoryAllocation(uint64_t size)
+      : storage_(std::make_unique<uint8_t[]>(size)), size_(size) {}
+
+  DeviceAddressBase address() const override {
+    return DeviceAddressBase(storage_.get(), size_);
+  }
+
+ private:
+  std::unique_ptr<uint8_t[]> storage_;
+  uint64_t size_;
+};
+
+class TestMemoryReservation final : public MemoryReservation {
+ public:
+  explicit TestMemoryReservation(uint64_t size)
+      : storage_(std::make_unique<uint8_t[]>(size)), size_(size) {}
+
+  DeviceAddressBase address() const override {
+    return DeviceAddressBase(storage_.get(), size_);
+  }
+
+  int active_mapping_count() const { return active_mapping_count_; }
+
+ private:
+  absl::Status Map(size_t reservation_offset, size_t allocation_offset,
+                   size_t size, MemoryAllocation& allocation) override {
+    if (reservation_offset > size_ || size > size_ - reservation_offset ||
+        allocation_offset > allocation.address().size() ||
+        size > allocation.address().size() - allocation_offset) {
+      return absl::InvalidArgumentError("mapping range is out of bounds");
+    }
+    ++active_mapping_count_;
+    return absl::OkStatus();
+  }
+
+  absl::Status SetAccess(uint64_t /*reservation_offset*/,
+                         size_t /*size*/) override {
+    return absl::OkStatus();
+  }
+
+  absl::Status UnMap(size_t /*reservation_offset*/, size_t /*size*/) override {
+    if (active_mapping_count_ == 0) {
+      return absl::FailedPreconditionError("reservation is not mapped");
+    }
+    --active_mapping_count_;
+    return absl::OkStatus();
+  }
+
+  std::unique_ptr<uint8_t[]> storage_;
+  uint64_t size_;
+  int active_mapping_count_ = 0;
+};
+
+class TestDeviceAddressVmmAllocator final : public DeviceAddressVmmAllocator {
+ public:
+  static absl::StatusOr<std::unique_ptr<TestDeviceAddressVmmAllocator>> Create(
+      const Platform* platform, absl::Span<const DeviceConfig> devices) {
+    auto allocator = std::unique_ptr<TestDeviceAddressVmmAllocator>(
+        new TestDeviceAddressVmmAllocator(platform));
+    absl::Status status = PopulateDevices(allocator.get(), devices);
+    if (!status.ok()) {
+      return status;
+    }
+    return allocator;
+  }
+
+  int allocation_count() const { return allocation_count_; }
+
+ protected:
+  absl::Status InitializeDeviceState(PerDeviceState& state) override {
+    state.allocation_granularity = kGranularity;
+    auto* timeline = new uint64_t(0);
+    state.pinned_timeline = timeline;
+    state.destroy_fn = [timeline] { delete timeline; };
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<std::unique_ptr<MemoryAllocation>> CreateAllocation(
+      StreamExecutor* /*executor*/, uint64_t size) override {
+    ++allocation_count_;
+    return std::make_unique<TestMemoryAllocation>(RoundUpTestSize(size));
+  }
+
+  absl::StatusOr<std::unique_ptr<MemoryReservation>> CreateReservation(
+      StreamExecutor* /*executor*/, uint64_t size) override {
+    return std::make_unique<TestMemoryReservation>(RoundUpTestSize(size));
+  }
+
+  absl::Status EnqueueDeferredDeallocation(PerDeviceState& state,
+                                           uint64_t seqno) override {
+    __atomic_store_n(state.pinned_timeline, seqno, __ATOMIC_RELEASE);
+    return absl::OkStatus();
+  }
+
+ private:
+  explicit TestDeviceAddressVmmAllocator(const Platform* platform)
+      : DeviceAddressVmmAllocator(platform) {}
+
+  int allocation_count_ = 0;
+};
+
+class DeviceAddressVmmAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ON_CALL(executor_, device_ordinal()).WillByDefault(Return(0));
+    ON_CALL(stream_, parent()).WillByDefault(Return(&executor_));
+  }
+
+  DeviceAddressVmmAllocator::DeviceConfig Config(uint64_t pa_budget) {
+    return {&executor_, &stream_, pa_budget};
+  }
+
+  NiceMock<MockPlatform> platform_;
+  NiceMock<MockStreamExecutor> executor_;
+  NiceMock<MockStream> stream_;
+};
+
+TEST_F(DeviceAddressVmmAllocatorTest, RetryFlagDoesNotDisablePendingReclaim) {
+  const DeviceAddressVmmAllocator::DeviceConfig config =
+      Config(2 * kGranularity);
+  ASSERT_OK_AND_ASSIGN(auto allocator, TestDeviceAddressVmmAllocator::Create(
+                                           &platform_, {config}));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto first,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/true, /*memory_space=*/0));
+  ASSERT_THAT(allocator->Deallocate(/*device_ordinal=*/0, first.Release()),
+              absl_testing::IsOk());
+
+  ASSERT_OK_AND_ASSIGN(
+      auto retried,
+      allocator->Allocate(/*device_ordinal=*/0, 2 * kGranularity,
+                          /*retry_on_failure=*/false, /*memory_space=*/0));
+  EXPECT_EQ(allocator->allocation_count(), 2);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       RetryDisabledStillReusesCompatiblePendingAllocation) {
+  const DeviceAddressVmmAllocator::DeviceConfig config = Config(kGranularity);
+  ASSERT_OK_AND_ASSIGN(auto allocator, TestDeviceAddressVmmAllocator::Create(
+                                           &platform_, {config}));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto first,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/true, /*memory_space=*/0));
+  void* first_address = first->opaque();
+  ASSERT_THAT(allocator->Deallocate(/*device_ordinal=*/0, first.Release()),
+              absl_testing::IsOk());
+
+  ASSERT_OK_AND_ASSIGN(
+      auto reused,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/false, /*memory_space=*/0));
+  EXPECT_EQ(reused->opaque(), first_address);
+  EXPECT_EQ(allocator->allocation_count(), 1);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       RetryFlagDoesNotDisableMappedPendingReclaim) {
+  auto reservation = std::make_unique<TestMemoryReservation>(2 * kGranularity);
+  const DeviceAddressVmmAllocator::DeviceConfig config =
+      Config(2 * kGranularity);
+  ASSERT_OK_AND_ASSIGN(auto allocator, TestDeviceAddressVmmAllocator::Create(
+                                           &platform_, {config}));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto first,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/true, /*memory_space=*/0));
+  ASSERT_THAT(allocator->Deallocate(/*device_ordinal=*/0, first.Release()),
+              absl_testing::IsOk());
+
+  ASSERT_OK_AND_ASSIGN(
+      auto retried,
+      allocator->Allocate(
+          /*device_ordinal=*/0, /*allocation_size=*/2 * kGranularity,
+          /*retry_on_failure=*/false, /*memory_space=*/0, reservation.get(),
+          /*reservation_offset=*/0, /*mapping_size=*/2 * kGranularity,
+          /*return_reservation_address=*/true));
+  EXPECT_EQ(reservation->active_mapping_count(), 1);
+  EXPECT_EQ(allocator->allocation_count(), 2);
+}
+
+}  // namespace
+}  // namespace stream_executor

--- a/xla/stream_executor/device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/device_address_vmm_allocator_test.cc
@@ -37,6 +37,7 @@ limitations under the License.
 namespace stream_executor {
 namespace {
 
+using ::absl_testing::StatusIs;
 using ::testing::NiceMock;
 using ::testing::Return;
 
@@ -104,9 +105,10 @@ class TestMemoryReservation final : public MemoryReservation {
 class TestDeviceAddressVmmAllocator final : public DeviceAddressVmmAllocator {
  public:
   static absl::StatusOr<std::unique_ptr<TestDeviceAddressVmmAllocator>> Create(
-      const Platform* platform, absl::Span<const DeviceConfig> devices) {
+      const Platform* platform, absl::Span<const DeviceConfig> devices,
+      uint64_t physical_size_padding = 0) {
     auto allocator = std::unique_ptr<TestDeviceAddressVmmAllocator>(
-        new TestDeviceAddressVmmAllocator(platform));
+        new TestDeviceAddressVmmAllocator(platform, physical_size_padding));
     absl::Status status = PopulateDevices(allocator.get(), devices);
     if (!status.ok()) {
       return status;
@@ -128,12 +130,14 @@ class TestDeviceAddressVmmAllocator final : public DeviceAddressVmmAllocator {
   absl::StatusOr<std::unique_ptr<MemoryAllocation>> CreateAllocation(
       StreamExecutor* /*executor*/, uint64_t size) override {
     ++allocation_count_;
-    return std::make_unique<TestMemoryAllocation>(RoundUpTestSize(size));
+    return std::make_unique<TestMemoryAllocation>(RoundUpTestSize(size) +
+                                                  physical_size_padding_);
   }
 
   absl::StatusOr<std::unique_ptr<MemoryReservation>> CreateReservation(
       StreamExecutor* /*executor*/, uint64_t size) override {
-    return std::make_unique<TestMemoryReservation>(RoundUpTestSize(size));
+    return std::make_unique<TestMemoryReservation>(RoundUpTestSize(size) +
+                                                   physical_size_padding_);
   }
 
   absl::Status EnqueueDeferredDeallocation(PerDeviceState& state,
@@ -143,9 +147,12 @@ class TestDeviceAddressVmmAllocator final : public DeviceAddressVmmAllocator {
   }
 
  private:
-  explicit TestDeviceAddressVmmAllocator(const Platform* platform)
-      : DeviceAddressVmmAllocator(platform) {}
+  TestDeviceAddressVmmAllocator(const Platform* platform,
+                                uint64_t physical_size_padding)
+      : DeviceAddressVmmAllocator(platform),
+        physical_size_padding_(physical_size_padding) {}
 
+  uint64_t physical_size_padding_;
   int allocation_count_ = 0;
 };
 
@@ -230,6 +237,44 @@ TEST_F(DeviceAddressVmmAllocatorTest,
           /*reservation_offset=*/0, /*mapping_size=*/2 * kGranularity,
           /*return_reservation_address=*/true));
   EXPECT_EQ(reservation->active_mapping_count(), 1);
+  EXPECT_EQ(allocator->allocation_count(), 2);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       PhysicalAllocationSizeControlsBudgetAccounting) {
+  const DeviceAddressVmmAllocator::DeviceConfig config =
+      Config(2 * kGranularity);
+  ASSERT_OK_AND_ASSIGN(auto allocator,
+                       TestDeviceAddressVmmAllocator::Create(
+                           &platform_, {config},
+                           /*physical_size_padding=*/kGranularity));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto first,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/true, /*memory_space=*/0));
+  ASSERT_NE(allocator->GetRawAllocation(/*device_ordinal=*/0, first.cref()),
+            nullptr);
+  EXPECT_EQ(allocator->GetRawAllocation(/*device_ordinal=*/0, first.cref())
+                ->address()
+                .size(),
+            2 * kGranularity);
+  // The first allocation consumes the full budget based on the physical size,
+  // even though its requested size was one granularity unit.
+  EXPECT_THAT(allocator->Allocate(/*device_ordinal=*/0, 2 * kGranularity,
+                                  /*retry_on_failure=*/false,
+                                  /*memory_space=*/0),
+              StatusIs(absl::StatusCode::kResourceExhausted));
+  EXPECT_EQ(allocator->allocation_count(), 1);
+
+  ASSERT_THAT(allocator->Deallocate(/*device_ordinal=*/0, first.Release()),
+              absl_testing::IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(/*device_ordinal=*/0),
+              absl_testing::IsOk());
+  ASSERT_OK_AND_ASSIGN(
+      auto second,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/false, /*memory_space=*/0));
   EXPECT_EQ(allocator->allocation_count(), 2);
 }
 


### PR DESCRIPTION
This PR does refactoring of existing code, and no functional behavior change is made.  

To make the review more easily, this PR has 13 commits, which gradually refactoring the code, each commit is kept simple and small. 

📝 Summary of Changes
- Simplify DeviceAddressVmmAllocator allocation-record and reservation-alias bookkeeping.
- Consolidate mapped allocation reuse/creation, Map target resolution, and pending deallocation handling.
- Account physical-address budget using the committed allocation size.
- Add focused tests for pending reclamation, mapped allocation reuse, and physical budget accounting.

🎯 Justification
The allocator had accumulated overlapping helpers and state representations that made ownership, stale mappings, and deferred completion difficult to reason about. This cleanup reduces code size and gives each lifecycle transition one implementation while preserving existing behavior.

🚀 Kind of Contribution
♻️ Cleanup, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Not applicable; this is a behavior-preserving cleanup rather than a performance change.

🧪 Unit Tests:
- `bazel test //xla/stream_executor:device_address_vmm_allocator_test`

🧪 Execution Tests:
- `bazel test //xla/stream_executor/cuda:cuda_device_address_vmm_allocator_test`
