### PR TITLE
[ROCm] Fix DotOperationTestWithCublasLt_F16F32F64CF64/1.GeneralMatMulActivat…

### DIFF
--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include "xla/backends/gpu/transforms/gemm_rewriter.h"
 
+#include <math.h>
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -39,7 +40,6 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
-#include <math.h>
 #include "xla/hlo/evaluator/hlo_evaluator.h"
 #include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"

--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -16,8 +16,6 @@ limitations under the License.
 
 #include "xla/backends/gpu/transforms/gemm_rewriter.h"
 
-#include <math.h>
-
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -41,6 +39,7 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
+#include <math.h>
 #include "xla/hlo/evaluator/hlo_evaluator.h"
 #include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
@@ -118,7 +117,6 @@ bool SupportsEpilogueFusion(PrimitiveType type) {
     case F16:
     case BF16:
     case F32:
-    case F64:
       return true;
     default:
       return false;

--- a/xla/backends/gpu/transforms/gemm_rewriter.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter.cc
@@ -104,25 +104,6 @@ absl::Status SetName(HloModule* module, HloInstruction* gemm) {
   return absl::OkStatus();
 }
 
-// Returns whether a given PrimitiveType is supported by cuBLASLt Epilogue
-// Fusion. A table of supported data types can be found in the cuBLASLt
-// documentation: https://docs.nvidia.com/cuda/cublas/index.html#cublasLtMatmul.
-// Note that `Ctype` also describes the output type of the GEMM. Rows with
-// `Non-default epilogue not supported` entries in the last column indicate data
-// types not compatible with Epilogue Fusion.
-bool SupportsEpilogueFusion(PrimitiveType type) {
-  switch (type) {
-    case F8E4M3FN:
-    case F8E5M2:
-    case F16:
-    case BF16:
-    case F32:
-      return true;
-    default:
-      return false;
-  }
-}
-
 bool IsF8Type(const HloInstruction* instr) {
   return primitive_util::IsF8Type(instr->shape().element_type());
 }
@@ -1807,6 +1788,33 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     RETURN_IF_ERROR(ReplaceInstruction(instr, d));
 
     return absl::OkStatus();
+  }
+
+  // Returns whether a given PrimitiveType is supported by cuBLASLt Epilogue
+  // Fusion. A table of supported data types can be found in the cuBLASLt
+  // documentation:
+  // https://docs.nvidia.com/cuda/cublas/index.html#cublasLtMatmul. Note that
+  // `Ctype` also describes the output type of the GEMM. Rows with `Non-default
+  // epilogue not supported` entries in the last column indicate data types not
+  // compatible with Epilogue Fusion. DEPRECATED: This standalone function has
+  // been moved to GemmRewriterVisitor as a member function to allow
+  bool SupportsEpilogueFusion(PrimitiveType type) {
+    // ROCm doesn't support F64 epilogue fusion
+    if (gpu_version_.IsRocm() && type == F64) {
+      return false;
+    }
+
+    switch (type) {
+      case F8E4M3FN:
+      case F8E5M2:
+      case F16:
+      case BF16:
+      case F32:
+      case F64:
+        return true;
+      default:
+        return false;
+    }
   }
 
   // Fuses a matrix bias into a cuBLAS call. 'instr' should be an Add


### PR DESCRIPTION
…ion for rocm

📝 Summary of Changes
Adjust gemm rewriter visitor to detect if epilogue is supported or not.
For rocm hipblaslt doesn't support f64 with epilogue. Hence 
the change avoid fusing to algo + epilogue in case of f64 types
are used.


🎯 Justification
Fix DotOperationTestWithCublasLt_F16F32F64CF64/1.GeneralMatMulActivat test under rocm.
Also fixes MatmulTestWithCublas.GemmRewriter_RegressionTestF64

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
