### PR TITLE
[ROCm][Triton] Replace hardcoded kWarpSize  by warp-size based on device_info for the All-Reduce triton backend

### DIFF
--- a/xla/backends/gpu/codegen/triton/collective_emitter.cc
+++ b/xla/backends/gpu/codegen/triton/collective_emitter.cc
@@ -237,11 +237,11 @@ GetBlockLevelFusionConfigForAllReduce(
   ASSIGN_OR_RETURN(AllReduceInfo all_reduce_info,
                    std::move(maybe_all_reduce_info));
   const Shape& output_shape = all_reduce->shape();
-  const LaunchDimensions launch_dims = AllReduceLaunchDimensions(
-      all_reduce_info.num_elements, all_reduce_info.num_devices,
-      all_reduce_info.all_reduce_strategy);
   const se::DeviceDescription& device_info =
       gpu_topology.gpu_target_config().device_description;
+  const LaunchDimensions launch_dims = AllReduceLaunchDimensions(
+      all_reduce_info.num_elements, all_reduce_info.num_devices,
+      all_reduce_info.all_reduce_strategy, device_info);
   BlockLevelFusionConfig block_level_config;
   block_level_config.set_num_warps(xla::CeilOfRatio(
       static_cast<int64_t>(launch_dims.num_threads_per_block()),

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -4112,6 +4112,7 @@ cc_library(
         "//xla/service:computation_placer_hdr",
         "//xla/service:gpu_topology",
         "//xla/service/gpu:gpu_constants",
+        "//xla/service/gpu:ir_emission_utils",
         "//xla/service/gpu:launch_dimensions",
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:device_description",

--- a/xla/backends/gpu/runtime/all_reduce.cc
+++ b/xla/backends/gpu/runtime/all_reduce.cc
@@ -44,6 +44,7 @@ limitations under the License.
 #include "xla/service/collective_ops_utils.h"
 #include "xla/service/computation_placer.h"
 #include "xla/service/gpu/gpu_constants.h"
+#include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/launch_dimensions.h"
 #include "xla/service/gpu_topology.h"
 #include "xla/shape_util.h"
@@ -94,7 +95,6 @@ static constexpr auto kOrPredTags = TagRegistry<bool, ReductionKind::MAX>{};
 // of 2 from a higher dimension to a lower dimension.
 static constexpr int64_t kMaxBlocksPerGrid = 32;
 static constexpr uint64_t kMaxThreadsPerBlock = 512;
-static constexpr int64_t kWarpSize = 32;
 
 template <typename TagType>
 absl::Status LaunchTypedKernel(
@@ -209,18 +209,20 @@ int64_t GetMaxSupportedAllReduceSizeBytes(AllReduceStrategy strategy) {
   }
 }
 
-LaunchDimensions AllReduceLaunchDimensions(int64_t elements, int64_t num_ranks,
-                                           AllReduceStrategy strategy) {
+LaunchDimensions AllReduceLaunchDimensions(
+    int64_t elements, int64_t num_ranks, AllReduceStrategy strategy,
+    const se::DeviceDescription& device_info) {
   int64_t threads_per_block;
   int64_t blocks_per_grid;
+  const int64_t warp_size = WarpSize(device_info);
   const int64_t elements_per_rank =
       elements / (strategy == AllReduceStrategy::kTwoShot ? num_ranks : 1);
   // Maximum number of threads such that each thread has elements to process.
   const int64_t total_threads =
       RoundUpTo(CeilOfRatio(elements_per_rank, se::gpu::kNumElementsPerThread),
-                kWarpSize);
+                warp_size);
   // Triton expects power of 2 for threads_per_block / threads_per_warp.
-  // Since threads_per_warp is 32 for all NVIDIA GPUs, power of 2 is guaranteed.
+  // Since threads_per_warp is always a power of 2, this is guaranteed.
   threads_per_block =
       std::min(kMaxThreadsPerBlock,
                llvm::bit_ceil(static_cast<uint64_t>(total_threads)));

--- a/xla/backends/gpu/runtime/all_reduce.h
+++ b/xla/backends/gpu/runtime/all_reduce.h
@@ -86,10 +86,11 @@ se::gpu::AllReduceStrategy GetAllReduceStrategy(int64_t input_size_bytes,
 int64_t GetMaxSupportedAllReduceSizeBytes(se::gpu::AllReduceStrategy strategy);
 
 // Returns the launch dimensions for the all-reduce kernel.
-// The launch dimensions are determined by the number of elements and the
-// the all-reduce strategy.
-LaunchDimensions AllReduceLaunchDimensions(int64_t elements, int64_t num_ranks,
-                                           se::gpu::AllReduceStrategy strategy);
+// The launch dimensions are determined by the number of elements, the
+// all-reduce strategy, and the warp size of the target device.
+LaunchDimensions AllReduceLaunchDimensions(
+    int64_t elements, int64_t num_ranks, se::gpu::AllReduceStrategy strategy,
+    const se::DeviceDescription& device_info);
 
 // Creates a CollectiveKernelSpec for a given all-reduce instruction.
 absl::StatusOr<CollectiveKernelSpec> CreateAllReduceKernelSpec(

--- a/xla/backends/gpu/runtime/all_reduce_test.cc
+++ b/xla/backends/gpu/runtime/all_reduce_test.cc
@@ -99,7 +99,8 @@ class AllReduceKernelTest : public ::testing::Test,
       const std::vector<Array<T>>& input_data, ReductionKind reduction_kind) {
     const int64_t num_ranks = input_data.size();
     const LaunchDimensions launch_dimensions = AllReduceLaunchDimensions(
-        input_data[0].num_elements(), num_ranks, params_.all_reduce_strategy);
+        input_data[0].num_elements(), num_ranks, params_.all_reduce_strategy,
+        executors[0]->GetDeviceDescription());
 
     int64_t num_elements = input_data[0].num_elements();
 


### PR DESCRIPTION
📝 Summary of Changes
Replace the hardcoded kWarpSize = 32 with WarpSize(device_info), which returns threads_per_warp() from the device description. This correctly handles AMD GPUs where the wavefront size is 64 rather than 32.

The AllReduceLaunchDimensions function now takes a const se::DeviceDescription& device_info parameter, and all callers (collective_emitter.cc and all_reduce_test.cc) are updated accordingly.

🎯 Justification
The warp-size was hardcoded to 32, while for sone AMD targets the actual warp size capacity is 64.
Defining the warp-size at runtime, based on the device info, enables optimal accommodation of the hardware’s capabilities.

On MI355 target, All-Reduce performance (and especially the two-shot strategy) is improved by this change.
On the MI355 target, this change improves the performance of the ‘All-Reduce’ operation for some configurations, and in particular for the ‘two-shot’ strategy..

#### Triton Two-Shot — `f32`

| Size   | GPUs | warp32 µs | warp64 µs | Speedup |
|--------|------|-----------|-----------|---------|
| 768 KB | 4    | 45.971    | 43.342    | 1.06×   |
| 1 MB   | 8    | 87.350    | 79.359    | 1.10×   |
| 2 MB   | 4    | 62.747    | 61.555    | 1.02×   |
| 2 MB   | 8    | 131.833   | 96.276    | 1.37× |

🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement
