### PR TITLE
[ROCm] Fall back to library collective for non-uniform replica groups

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -4151,6 +4151,7 @@ xla_cc_test(
         "//xla/service/gpu:gpu_constants",
         "//xla/service/gpu:gpu_device_info_for_tests",
         "//xla/stream_executor:device_description",
+        "//xla/stream_executor:device_description_proto_cc",
         "//xla/stream_executor/gpu:all_reduce_kernel",
         "//xla/stream_executor/host:host_platform",
         "//xla/tsl/lib/gtl:int_type",

--- a/xla/backends/gpu/runtime/all_reduce.cc
+++ b/xla/backends/gpu/runtime/all_reduce.cc
@@ -288,6 +288,17 @@ absl::Status IsAllReduceKernelSupported(
     return absl::UnimplementedError(
         "Replica groups must be explicitly provided for collective kernels.");
   }
+  // The kernel bakes world_size (from the first replica group) at codegen and
+  // sizes its buffers the same way, so it cannot serve cliques of different
+  // sizes. Fall back to the library collective for non-uniform replica groups.
+  for (const ReplicaGroup& group : replica_groups) {
+    if (group.replica_ids_size() != num_devices) {
+      return absl::UnimplementedError(absl::StrCat(
+          "Collective kernel requires all replica groups to have the same "
+          "size. Got a group of size ",
+          group.replica_ids_size(), " but expected ", num_devices, "."));
+    }
+  }
   if (!reduction_kind.has_value()) {
     return absl::UnimplementedError("Could not match reduction computation.");
   }

--- a/xla/backends/gpu/runtime/all_reduce.cc
+++ b/xla/backends/gpu/runtime/all_reduce.cc
@@ -293,10 +293,10 @@ absl::Status IsAllReduceKernelSupported(
   // sizes. Fall back to the library collective for non-uniform replica groups.
   for (const ReplicaGroup& group : replica_groups) {
     if (group.replica_ids_size() != num_devices) {
-      return absl::UnimplementedError(absl::StrCat(
+      return absl::UnimplementedError(absl::StrFormat(
           "Collective kernel requires all replica groups to have the same "
-          "size. Got a group of size ",
-          group.replica_ids_size(), " but expected ", num_devices, "."));
+          "size. Got a group of size %d but expected %d.",
+          group.replica_ids_size(), num_devices));
     }
   }
   if (!reduction_kind.has_value()) {

--- a/xla/backends/gpu/runtime/all_reduce_build_info_test.cc
+++ b/xla/backends/gpu/runtime/all_reduce_build_info_test.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -39,6 +40,7 @@ limitations under the License.
 #include "xla/service/gpu/gpu_device_info_for_tests.h"
 #include "xla/service/gpu_topology.h"
 #include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/device_description.pb.h"
 #include "xla/stream_executor/gpu/all_reduce_kernel.h"
 #include "xla/tsl/lib/gtl/int_type.h"
 #include "xla/tsl/platform/test.h"

--- a/xla/backends/gpu/runtime/all_reduce_build_info_test.cc
+++ b/xla/backends/gpu/runtime/all_reduce_build_info_test.cc
@@ -60,12 +60,13 @@ TSL_LIB_GTL_DEFINE_INT_TYPE(MultimemEnabled, bool);
 
 class BuildAllReduceInfoTest : public HloHardwareIndependentTestBase {
  protected:
-  // Helper to reduce boilerplate while keeping tests independent.
-  absl::StatusOr<AllReduceInfo> BuildInfo(
+  // Helper to reduce boilerplate while keeping tests independent. Supports
+  // multiple (possibly non-uniform) replica groups.
+  absl::StatusOr<AllReduceInfo> BuildInfoWithGroups(
       CollectiveKernelEnabled collective_kernel_enabled,
       MultimemEnabled multimem_enabled, PrimitiveType element_type,
       std::vector<int64_t> shape, HloOpcode hlo_opcode,
-      std::vector<int32_t> replica_groups) {
+      std::vector<std::vector<int64_t>> replica_groups) {
     constexpr absl::string_view kModuleStr = R"(
     HloModule test
      apply_op {
@@ -91,21 +92,23 @@ class BuildAllReduceInfoTest : public HloHardwareIndependentTestBase {
     GpuTopology gpu_topology("platform_version", /*num_partitions=*/1,
                              /*num_hosts_per_partition=*/1,
                              /*num_devices_per_host=*/16, target_config);
-    std::string replica_groups_str =
-        replica_groups.empty()
-            ? ""
-            : absl::StrFormat("{%s}", absl::StrJoin(replica_groups, ","));
+    int64_t num_replicas = 0;
+    std::vector<std::string> group_strs;
+    group_strs.reserve(replica_groups.size());
+    for (const std::vector<int64_t>& group : replica_groups) {
+      num_replicas += group.size();
+      group_strs.push_back(absl::StrFormat("{%s}", absl::StrJoin(group, ",")));
+    }
     const std::string module_str = absl::StrFormat(
         kModuleStr, primitive_util::LowercasePrimitiveTypeName(element_type),
         absl::StrJoin(shape, ","), HloOpcodeString(hlo_opcode),
-        replica_groups_str);
+        absl::StrJoin(group_strs, ","));
 
     SCOPED_TRACE(testing::Message() << "module_str: " << module_str);
 
-    ASSIGN_OR_RETURN(
-        std::unique_ptr<HloModule> module,
-        ParseAndReturnVerifiedModule(
-            module_str, replica_groups.empty() ? 1 : replica_groups.size()));
+    ASSIGN_OR_RETURN(std::unique_ptr<HloModule> module,
+                     ParseAndReturnVerifiedModule(
+                         module_str, num_replicas == 0 ? 1 : num_replicas));
     const HloInstruction* hlo_instr =
         HloHardwareIndependentTestBase::FindInstruction(module.get(),
                                                         HloOpcode::kAllReduce);
@@ -113,6 +116,21 @@ class BuildAllReduceInfoTest : public HloHardwareIndependentTestBase {
                               multimem_enabled.value(), gpu_topology,
                               Cast<HloAllReduceInstruction>(hlo_instr),
                               /*device_assignment=*/nullptr);
+  }
+
+  // Single-group convenience wrapper.
+  absl::StatusOr<AllReduceInfo> BuildInfo(
+      CollectiveKernelEnabled collective_kernel_enabled,
+      MultimemEnabled multimem_enabled, PrimitiveType element_type,
+      std::vector<int64_t> shape, HloOpcode hlo_opcode,
+      std::vector<int32_t> replica_groups) {
+    std::vector<std::vector<int64_t>> groups;
+    if (!replica_groups.empty()) {
+      groups.emplace_back(replica_groups.begin(), replica_groups.end());
+    }
+    return BuildInfoWithGroups(collective_kernel_enabled, multimem_enabled,
+                               element_type, std::move(shape), hlo_opcode,
+                               std::move(groups));
   }
 };
 
@@ -185,6 +203,22 @@ TEST_F(BuildAllReduceInfoTest, FailsIfReplicaGroupsEmpty) {
                 {1024}, HloOpcode::kAdd, {}),
       StatusIs(absl::StatusCode::kUnimplemented,
                HasSubstr("Replica groups must be explicitly provided")));
+}
+
+TEST_F(BuildAllReduceInfoTest, FailsForNonUniformReplicaGroups) {
+  EXPECT_THAT(
+      BuildInfoWithGroups(CollectiveKernelEnabled(true), MultimemEnabled(false),
+                          F32, {1024}, HloOpcode::kAdd, {{0, 1}, {2, 3, 4, 5}}),
+      StatusIs(absl::StatusCode::kUnimplemented,
+               HasSubstr("all replica groups to have the same size")));
+}
+
+TEST_F(BuildAllReduceInfoTest, SupportsUniformMultiGroup) {
+  EXPECT_THAT(
+      BuildInfoWithGroups(CollectiveKernelEnabled(true), MultimemEnabled(false),
+                          F32, {1024}, HloOpcode::kAdd, {{0, 1}, {2, 3}}),
+      IsOkAndHolds(Field(&AllReduceInfo::all_reduce_strategy,
+                         AllReduceStrategy::kOneShot)));
 }
 
 }  // namespace


### PR DESCRIPTION
The collective (one-shot/two-shot) AllReduce kernel bakes the clique size (world_size) as a compile-time constant from the first replica group and sizes its signal/staging buffers the same way. With non-uniform replica groups (e.g. axis_index_groups=[[0,1],[2,3,4,5,6,7]]) the single emitted kernel runs on cliques of different sizes, causing out-of-bounds peer accesses (GPU page fault) and hangs on gfx950.

Reject the collective kernel when replica groups differ in size so the op falls back to the library (RCCL/NCCL) collective, which handles heterogeneous cliques. Uniform replica groups are unaffected.

## 📝 Summary of Changes
Add a uniformity guard to `IsAllReduceKernelSupported` (`xla/backends/gpu/runtime/all_reduce.cc`): if any replica group's size differs from the first group's size, the custom collective AllReduce kernel is not selected and the op falls back to the library (RCCL/NCCL) collective. No device-code changes; uniform replica groups continue to use the kernel unchanged.

## 🎯 Justification
The collective kernel's clique size (`world_size`) is a codegen-time constant taken from the first replica group, and its signal/staging buffers are sized the same way. A single AllReduce with non-uniform replica groups therefore emits one kernel that is then run across cliques of *different* sizes, which reads/writes past the per-rank buffers → GPU page fault (`SQC` client, addr `0x0`) and/or a wedged HSA queue and hang. This is observed on ROCm/gfx950 with e.g. `pmap` + `axis_index_groups=[[0,1],[2,3,4,5,6,7]]`. Any workload that issues an AllReduce over uneven replica groups is affected; the kernel is architecturally single-clique-size, so falling back to the library collective (which handles heterogeneous cliques) is the correct behavior.

## 🚀 Kind of Contribution
🐛 Bug Fix

## 📊 Benchmark (for Performance Improvements)
N/A — this is a correctness fix. It only diverts non-uniform-group AllReduces (which are broken today) to the library collective; uniform-group AllReduces still use the custom kernel, so no performance change for supported cases.

## 🧪 Unit Tests:
No new unit test in this commit. A targeted addition would be an assertion that `IsAllReduceKernelSupported(...)` returns an `Unimplemented` status for a replica-group set with differing group sizes (e.g. `{{0,1},{2,3,4,5}}`) and remains supported for uniform groups — happy to add this if desired.

## 🧪 Execution Tests:
Covered by the existing `tests/pmap_test.py::PythonPmapTest::testPsumUnevenReplicaGroups`, which exercises uneven `axis_index_groups` and previously hung. Note this cannot be expressed within the "at most 2 GPUs" guidance: non-uniform replica groups require at least 3 devices (two groups of different sizes), and the test itself skips when `device_count <= 2`. Validated on 8x MI355X (gfx950) with the kernel enabled: full ROCm UT suite passes — single-accelerator `29118 passed` (1 pre-existing unrelated DLPack waiver), multi-accelerator `854 passed, 0 failed` (previously wedged at this test). Path confirmed via VLOG: uneven groups → 0 kernel launches / all RCCL; even groups → kernel used.