### PR TITLE
[ROCm] Update tsan_ignore_list.txt suppressions

### DIFF
--- a/build_tools/rocm/tsan_ignore_list.txt
+++ b/build_tools/rocm/tsan_ignore_list.txt
@@ -5,6 +5,12 @@ race:libhipblaslt.so
 race:libamd_comgr.so
 race:librccl.so
 
+# ROCr's os_thread destructor intentionally calls pthread_detach (not
+# pthread_join) on worker threads that are still running at teardown, so
+# they can exit on their own without blocking shutdown.
+thread:rocr::os::os_thread::os_thread
+thread:libhsa-runtime64.so
+
 # Abseil reference counting (DropRef / RefCount init)
 race:tsl::ReferenceCounted
 race:absl::lts_*::Mutex
@@ -12,16 +18,15 @@ race:absl::lts_*::CondVar
 
 # XLA GPU RawSEDeviceMemory RCReference reuse
 race:xla::RawSEDeviceMemory
-race:xla::gpu::AllocateDestinationBuffer
 race:xla::LocalDeviceState::ThenRelease
 
 # To be fixed
+race:xla::PjRtStreamExecutorClient::~PjRtStreamExecutorClient
 race:xla::GpuAsyncHostToDeviceTransferManager::TransferRawDataToSubBuffer
 race:xla::LiteralBase::Piece::DeallocateBuffers
-race:xla::PjRtStreamExecutorLoadedExecutable::ExecuteHelper
-race:xla::PjRtStreamExecutorClient::BufferFromHostBufferInternal
-race:xla::PjRtStreamExecutorClient::AllocateAndRecordEvent
-race:xla::HloRunnerPjRt::TransferLiteralsFromDevice
+race:xla::CommonPjRtLoadedExecutable::ExecuteHelperOnSingleDevice
+race:xla::LocalDeviceState::AllocateAndRecordEvent
+race:xla::HloRunner::TransferLiteralsFromDevice
 race:xla::MutableLiteralBase::~MutableLiteralBase
 race:xla::MutableLiteralBase::PopulateR1<int>
 race:xla::gpu::GpuCompiler::CompileSingleModule


### PR DESCRIPTION
Several suppressions no longer matched their target races after upstream renames/removals, silently letting TSan reports through: AllocateAndRecordEvent moved from PjRtStreamExecutorClient to LocalDeviceState (edaa01b9fb), ExecuteHelper was migrated to CommonPjRtLoadedExecutable::ExecuteHelperOnSingleDevice (d300770a92), HloRunnerPjRt was renamed to HloRunner (a15d305bbb), and AllocateDestinationBuffer/BufferFromHostBufferInternal were deleted outright (3cf1f0918b).

Also add two new suppressions for newly observed races: a thread suppression for ROCr's os_thread destructor, which intentionally calls pthread_detach (not pthread_join) on worker threads still running at teardown so they can exit without blocking shutdown, and race:xla::PjRtStreamExecutorClient::~PjRtStreamExecutorClient under "To be fixed".