### PR TITLE
[ROCm] Fix functional_hlo_runner_test

### DIFF
--- a/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
+++ b/xla/tools/multihost_hlo_runner/functional_hlo_runner_test.cc
@@ -640,7 +640,7 @@ absl::StatusOr<std::string> GetExpectedBackendFingerprint() {
   ASSIGN_OR_RETURN(std::string platform_name,
                    PlatformUtil::CanonicalPlatformName("gpu"));
   if (platform_name == "rocm") {
-    return "2971291867";
+    return "3128633344";
   }
   return "286644258";
 }


### PR DESCRIPTION
📝 Summary of Changes
PR updates stale backend fingerprint for ROCm platform.

🎯 Justification
This PR fixes `FunctionalHloRunnerTest.ShardedAutotuningWorks` subtest for ROCm backend.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix
