### PR TITLE
[PJRT:GPU] Plumb XLA FFI handler traits through the custom call extension

### DIFF
--- a/xla/pjrt/c/BUILD
+++ b/xla/pjrt/c/BUILD
@@ -824,6 +824,7 @@ xla_test(
         "//xla/ffi:execution_context",
         "//xla/ffi:ffi_api",
         "//xla/ffi:type_registry",
+        "//xla/ffi/api:c_api",
         "//xla/ffi/api:ffi",
         "//xla/pjrt:pjrt_common",
         "//xla/pjrt:pjrt_compiler",

--- a/xla/pjrt/c/pjrt_c_api_gpu_extension.h
+++ b/xla/pjrt/c/pjrt_c_api_gpu_extension.h
@@ -17,14 +17,14 @@ limitations under the License.
 #define XLA_PJRT_C_PJRT_C_API_GPU_EXTENSION_H_
 
 #include <stddef.h>
-
+#include <stdint.h>
 #include "xla/pjrt/c/pjrt_c_api.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define PJRT_API_GPU_EXTENSION_VERSION 2
+#define PJRT_API_GPU_EXTENSION_VERSION 3
 
 struct PJRT_Gpu_Register_Custom_Call_Args {
   size_t struct_size;
@@ -35,8 +35,10 @@ struct PJRT_Gpu_Register_Custom_Call_Args {
   void* handler_prepare;
   void* handler_initialize;
   void* handler_execute;
+  // XLA_FFI_Handler_TraitsBits. Read only by custom_call_with_traits.
+  uint32_t traits;
 };
-PJRT_DEFINE_STRUCT_TRAITS(PJRT_Gpu_Register_Custom_Call_Args, handler_execute);
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Gpu_Register_Custom_Call_Args, traits);
 
 // Registers a custom call.
 typedef PJRT_Error* PJRT_Gpu_Register_Custom_Call(
@@ -45,8 +47,11 @@ typedef PJRT_Error* PJRT_Gpu_Register_Custom_Call(
 typedef struct PJRT_Gpu_Custom_Call {
   PJRT_Extension_Base base;
   PJRT_NO_DISCARD PJRT_Gpu_Register_Custom_Call* custom_call;
+  // Like custom_call, but honors args->traits. Added in version 3; callers
+  // detect support by checking base.struct_size covers this member.
+  PJRT_NO_DISCARD PJRT_Gpu_Register_Custom_Call* custom_call_with_traits;
 } PJRT_Gpu_Custom_Call;
-PJRT_DEFINE_STRUCT_TRAITS(PJRT_Gpu_Custom_Call, custom_call);
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Gpu_Custom_Call, custom_call_with_traits);
 
 #ifdef __cplusplus
 }

--- a/xla/pjrt/c/pjrt_c_api_gpu_extension.h
+++ b/xla/pjrt/c/pjrt_c_api_gpu_extension.h
@@ -17,14 +17,14 @@ limitations under the License.
 #define XLA_PJRT_C_PJRT_C_API_GPU_EXTENSION_H_
 
 #include <stddef.h>
-
+#include <stdint.h>
 #include "xla/pjrt/c/pjrt_c_api.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define PJRT_API_GPU_EXTENSION_VERSION 2
+#define PJRT_API_GPU_EXTENSION_VERSION 3
 
 struct PJRT_Gpu_Register_Custom_Call_Args {
   size_t struct_size;
@@ -35,18 +35,25 @@ struct PJRT_Gpu_Register_Custom_Call_Args {
   void* handler_prepare;
   void* handler_initialize;
   void* handler_execute;
+  // XLA_FFI_Handler_TraitsBits, honored by custom_call when the extension's
+  // custom_call_handles_traits is set (both added in version 3).
+  uint32_t traits;
 };
-PJRT_DEFINE_STRUCT_TRAITS(PJRT_Gpu_Register_Custom_Call_Args, handler_execute);
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Gpu_Register_Custom_Call_Args, traits);
 
-// Registers a custom call.
+// Registers a custom call. Honors args->traits iff custom_call_handles_traits
+// (below) is set.
 typedef PJRT_Error* PJRT_Gpu_Register_Custom_Call(
     PJRT_Gpu_Register_Custom_Call_Args* args);
 
 typedef struct PJRT_Gpu_Custom_Call {
   PJRT_Extension_Base base;
   PJRT_NO_DISCARD PJRT_Gpu_Register_Custom_Call* custom_call;
+  // True if custom_call reads args->traits. Added in version 3; callers detect
+  // support by checking base.struct_size covers this member and that it is set.
+  bool custom_call_handles_traits;
 } PJRT_Gpu_Custom_Call;
-PJRT_DEFINE_STRUCT_TRAITS(PJRT_Gpu_Custom_Call, custom_call);
+PJRT_DEFINE_STRUCT_TRAITS(PJRT_Gpu_Custom_Call, custom_call_handles_traits);
 
 #ifdef __cplusplus
 }

--- a/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
@@ -549,14 +549,15 @@ PJRT_Stream_Extension stream{
     /*wait_stream=*/PJRT_Wait_Until_Buffer_Ready_On_Stream,
 };
 
-PJRT_Error* PJRT_Gpu_Register_Custom_Call(
-    PJRT_Gpu_Register_Custom_Call_Args* args) {
-  PJRT_RETURN_IF_ERROR(ActualStructSizeIsGreaterOrEqual(
-      "PJRT_Gpu_Register_Custom_Call_Args",
-      PJRT_Gpu_Register_Custom_Call_Args_STRUCT_SIZE, args->struct_size));
+static PJRT_Error* RegisterCustomCall(PJRT_Gpu_Register_Custom_Call_Args* args,
+                                      XLA_FFI_Handler_Traits traits) {
   std::string function_name(args->function_name, args->function_name_size);
   switch (args->api_version) {
     case 0:
+      if (traits != 0) {
+        return StatusToPjRtError(absl::UnimplementedError(
+            "Custom call traits are only supported for api_version 1."));
+      }
       xla::CustomCallTargetRegistry::Global()->Register(
           function_name, args->handler_execute, PJRT_GPU_PLUGIN_PLATFORM_NAME);
       return nullptr;
@@ -568,7 +569,8 @@ PJRT_Error* PJRT_Gpu_Register_Custom_Call(
               reinterpret_cast<XLA_FFI_Handler*>(args->handler_instantiate),
               reinterpret_cast<XLA_FFI_Handler*>(args->handler_prepare),
               reinterpret_cast<XLA_FFI_Handler*>(args->handler_initialize),
-              reinterpret_cast<XLA_FFI_Handler*>(args->handler_execute)});
+              reinterpret_cast<XLA_FFI_Handler*>(args->handler_execute)},
+          traits);
       return nullptr;
     default:
       return StatusToPjRtError(absl::UnimplementedError(
@@ -576,6 +578,26 @@ PJRT_Error* PJRT_Gpu_Register_Custom_Call(
                           "Supported versions are 0 and 1.",
                           args->api_version)));
   }
+}
+
+PJRT_Error* PJRT_Gpu_Register_Custom_Call(
+    PJRT_Gpu_Register_Custom_Call_Args* args) {
+  // Never reads `traits`, so callers recompiled against v3 headers keep their
+  // pre-v3 behavior even if they leave the field uninitialized.
+  PJRT_RETURN_IF_ERROR(ActualStructSizeIsGreaterOrEqual(
+      "PJRT_Gpu_Register_Custom_Call_Args",
+      PJRT_STRUCT_SIZE(PJRT_Gpu_Register_Custom_Call_Args, handler_execute),
+      args->struct_size));
+  return RegisterCustomCall(args, /*traits=*/0);
+}
+
+PJRT_Error* PJRT_Gpu_Register_Custom_Call_With_Traits(
+    PJRT_Gpu_Register_Custom_Call_Args* args) {
+  PJRT_RETURN_IF_ERROR(ActualStructSizeIsGreaterOrEqual(
+      "PJRT_Gpu_Register_Custom_Call_Args",
+      PJRT_STRUCT_SIZE(PJRT_Gpu_Register_Custom_Call_Args, traits),
+      args->struct_size));
+  return RegisterCustomCall(args, args->traits);
 }
 
 const PJRT_Api* GetGpuPjrtApi() {
@@ -586,6 +608,7 @@ const PJRT_Api* GetGpuPjrtApi() {
           /*next=*/&stream.base,
       },
       /*custom_call=*/PJRT_Gpu_Register_Custom_Call,
+      /*custom_call_with_traits=*/PJRT_Gpu_Register_Custom_Call_With_Traits,
   };
 
   static PJRT_Layouts_Extension layouts_extension =

--- a/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
@@ -549,14 +549,14 @@ PJRT_Stream_Extension stream{
     /*wait_stream=*/PJRT_Wait_Until_Buffer_Ready_On_Stream,
 };
 
-PJRT_Error* PJRT_Gpu_Register_Custom_Call(
-    PJRT_Gpu_Register_Custom_Call_Args* args) {
-  PJRT_RETURN_IF_ERROR(ActualStructSizeIsGreaterOrEqual(
-      "PJRT_Gpu_Register_Custom_Call_Args",
-      PJRT_Gpu_Register_Custom_Call_Args_STRUCT_SIZE, args->struct_size));
+static PJRT_Error* RegisterCustomCall(PJRT_Gpu_Register_Custom_Call_Args* args,
+                                      XLA_FFI_Handler_Traits traits) {
   std::string function_name(args->function_name, args->function_name_size);
   switch (args->api_version) {
     case 0:
+      // The legacy custom call registry cannot carry traits, so they are
+      // ignored here (as they were before the field existed); only the
+      // api_version 1 FFI path below honors traits.
       xla::CustomCallTargetRegistry::Global()->Register(
           function_name, args->handler_execute, PJRT_GPU_PLUGIN_PLATFORM_NAME);
       return nullptr;
@@ -568,7 +568,8 @@ PJRT_Error* PJRT_Gpu_Register_Custom_Call(
               reinterpret_cast<XLA_FFI_Handler*>(args->handler_instantiate),
               reinterpret_cast<XLA_FFI_Handler*>(args->handler_prepare),
               reinterpret_cast<XLA_FFI_Handler*>(args->handler_initialize),
-              reinterpret_cast<XLA_FFI_Handler*>(args->handler_execute)});
+              reinterpret_cast<XLA_FFI_Handler*>(args->handler_execute)},
+          traits);
       return nullptr;
     default:
       return StatusToPjRtError(absl::UnimplementedError(
@@ -576,6 +577,22 @@ PJRT_Error* PJRT_Gpu_Register_Custom_Call(
                           "Supported versions are 0 and 1.",
                           args->api_version)));
   }
+}
+
+PJRT_Error* PJRT_Gpu_Register_Custom_Call(
+    PJRT_Gpu_Register_Custom_Call_Args* args) {
+  PJRT_RETURN_IF_ERROR(ActualStructSizeIsGreaterOrEqual(
+      "PJRT_Gpu_Register_Custom_Call_Args",
+      PJRT_STRUCT_SIZE(PJRT_Gpu_Register_Custom_Call_Args, handler_execute),
+      args->struct_size));
+  // `traits` was appended in extension v3; honor it when the caller's struct
+  // covers it, otherwise default to 0 (pre-v3 callers omit the field).
+  XLA_FFI_Handler_Traits traits = 0;
+  if (args->struct_size >=
+      PJRT_STRUCT_SIZE(PJRT_Gpu_Register_Custom_Call_Args, traits)) {
+    traits = args->traits;
+  }
+  return RegisterCustomCall(args, traits);
 }
 
 const PJRT_Api* GetGpuPjrtApi() {
@@ -586,6 +603,7 @@ const PJRT_Api* GetGpuPjrtApi() {
           /*next=*/&stream.base,
       },
       /*custom_call=*/PJRT_Gpu_Register_Custom_Call,
+      /*custom_call_handles_traits=*/true,
   };
 
   static PJRT_Layouts_Extension layouts_extension =

--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -42,6 +42,7 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "xla/client/client_library.h"
+#include "xla/ffi/api/c_api.h"
 #include "xla/ffi/api/ffi.h"
 #include "xla/ffi/execution_context.h"
 #include "xla/ffi/ffi_api.h"
@@ -1287,6 +1288,141 @@ TEST(PjrtCApiGpuExtensionTest, CustomCallTyped) {
   PJRT_Gpu_Register_Custom_Call_Args args;
   args.struct_size = PJRT_Gpu_Register_Custom_Call_Args_STRUCT_SIZE;
   std::string function_name = "typed_function_name";
+  args.function_name = function_name.c_str();
+  args.function_name_size = function_name.size();
+  args.api_version = 1;
+  args.handler_instantiate = nullptr;
+  args.handler_prepare = nullptr;
+  args.handler_initialize = nullptr;
+  args.handler_execute = reinterpret_cast<void*>(kNoop);
+  auto api = GetPjrtApi();
+  const PJRT_Extension_Base* next = api->extension_start;
+  while (next != nullptr &&
+         next->type !=
+             PJRT_Extension_Type::PJRT_Extension_Type_Gpu_Custom_Call) {
+    next = next->next;
+  }
+  ASSERT_NE(next, nullptr);
+
+  PJRT_Error* error =
+      reinterpret_cast<const PJRT_Gpu_Custom_Call*>(next)->custom_call(&args);
+
+  CHECK_EQ(error, nullptr);
+  auto registration =
+      xla::ffi::FindHandler(function_name, stream_executor::GpuPlatformName())
+          .value();
+  EXPECT_EQ(reinterpret_cast<void*>(registration.bundle.execute), kNoop);
+}
+
+const PJRT_Gpu_Custom_Call* FindGpuCustomCallExtension(const PJRT_Api* api) {
+  const PJRT_Extension_Base* next = api->extension_start;
+  while (next != nullptr &&
+         next->type !=
+             PJRT_Extension_Type::PJRT_Extension_Type_Gpu_Custom_Call) {
+    next = next->next;
+  }
+  return reinterpret_cast<const PJRT_Gpu_Custom_Call*>(next);
+}
+
+TEST(PjrtCApiGpuExtensionTest, CustomCallTypedWithTraits) {
+  static constexpr auto* noop = +[] { return xla::ffi::Error::Success(); };
+  XLA_FFI_DEFINE_HANDLER(kNoop, noop, xla::ffi::Ffi::Bind());
+
+  PJRT_Gpu_Register_Custom_Call_Args args;
+  args.struct_size = PJRT_Gpu_Register_Custom_Call_Args_STRUCT_SIZE;
+  std::string function_name = "typed_function_name_with_traits";
+  args.function_name = function_name.c_str();
+  args.function_name_size = function_name.size();
+  args.api_version = 1;
+  args.handler_instantiate = nullptr;
+  args.handler_prepare = nullptr;
+  args.handler_initialize = nullptr;
+  args.handler_execute = reinterpret_cast<void*>(kNoop);
+  args.traits = XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE;
+  const PJRT_Gpu_Custom_Call* ext = FindGpuCustomCallExtension(GetPjrtApi());
+  ASSERT_NE(ext, nullptr);
+  ASSERT_GE(ext->base.struct_size,
+            PJRT_STRUCT_SIZE(PJRT_Gpu_Custom_Call, custom_call_with_traits));
+
+  PJRT_Error* error = ext->custom_call_with_traits(&args);
+
+  CHECK_EQ(error, nullptr);
+  auto registration =
+      xla::ffi::FindHandler(function_name, stream_executor::GpuPlatformName())
+          .value();
+  EXPECT_EQ(reinterpret_cast<void*>(registration.bundle.execute), kNoop);
+  EXPECT_EQ(registration.metadata.traits &
+                XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE,
+            XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE);
+}
+
+TEST(PjrtCApiGpuExtensionTest, CustomCallLegacyEntryIgnoresTraits) {
+  static constexpr auto* noop = +[] { return xla::ffi::Error::Success(); };
+  XLA_FFI_DEFINE_HANDLER(kNoop, noop, xla::ffi::Ffi::Bind());
+
+  PJRT_Gpu_Register_Custom_Call_Args args;
+  args.struct_size = PJRT_Gpu_Register_Custom_Call_Args_STRUCT_SIZE;
+  std::string function_name = "typed_function_name_legacy_entry";
+  args.function_name = function_name.c_str();
+  args.function_name_size = function_name.size();
+  args.api_version = 1;
+  args.handler_instantiate = nullptr;
+  args.handler_prepare = nullptr;
+  args.handler_initialize = nullptr;
+  args.handler_execute = reinterpret_cast<void*>(kNoop);
+  // Callers recompiled against v3 headers may leave `traits` uninitialized;
+  // the legacy entry point must not read it.
+  args.traits = XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE;
+  const PJRT_Gpu_Custom_Call* ext = FindGpuCustomCallExtension(GetPjrtApi());
+  ASSERT_NE(ext, nullptr);
+
+  PJRT_Error* error = ext->custom_call(&args);
+
+  CHECK_EQ(error, nullptr);
+  auto registration =
+      xla::ffi::FindHandler(function_name, stream_executor::GpuPlatformName())
+          .value();
+  EXPECT_EQ(reinterpret_cast<void*>(registration.bundle.execute), kNoop);
+  EXPECT_EQ(registration.metadata.traits &
+                XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE,
+            0);
+}
+
+TEST(PjrtCApiGpuExtensionTest, CustomCallWithTraitsUntypedUnimplemented) {
+  PJRT_Gpu_Register_Custom_Call_Args args;
+  args.struct_size = PJRT_Gpu_Register_Custom_Call_Args_STRUCT_SIZE;
+  std::string function_name = "untyped_function_name_with_traits";
+  args.function_name = function_name.c_str();
+  args.function_name_size = function_name.size();
+  args.api_version = 0;
+  args.handler_instantiate = nullptr;
+  args.handler_prepare = nullptr;
+  args.handler_initialize = nullptr;
+  args.handler_execute = reinterpret_cast<void*>(&TestCustomCallV2);
+  args.traits = XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE;
+  auto api = GetPjrtApi();
+  const PJRT_Gpu_Custom_Call* ext = FindGpuCustomCallExtension(api);
+  ASSERT_NE(ext, nullptr);
+
+  PJRT_Error* error = ext->custom_call_with_traits(&args);
+
+  ASSERT_NE(error, nullptr);
+  EXPECT_THAT(::pjrt::PjrtErrorToStatus(error, api),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kUnimplemented,
+                  "Custom call traits are only supported for api_version 1."));
+  MakeErrorDeleter(api)(error);
+}
+
+TEST(PjrtCApiGpuExtensionTest, CustomCallTypedPreTraitsStructSize) {
+  static constexpr auto* noop = +[] { return xla::ffi::Error::Success(); };
+  XLA_FFI_DEFINE_HANDLER(kNoop, noop, xla::ffi::Ffi::Bind());
+
+  PJRT_Gpu_Register_Custom_Call_Args args;
+  // Pre-v3 struct size, as passed by callers built against older headers.
+  args.struct_size =
+      PJRT_STRUCT_SIZE(PJRT_Gpu_Register_Custom_Call_Args, handler_execute);
+  std::string function_name = "typed_function_name_pre_traits";
   args.function_name = function_name.c_str();
   args.function_name_size = function_name.size();
   args.api_version = 1;

--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -42,6 +42,7 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "xla/client/client_library.h"
+#include "xla/ffi/api/c_api.h"
 #include "xla/ffi/api/ffi.h"
 #include "xla/ffi/execution_context.h"
 #include "xla/ffi/ffi_api.h"
@@ -1262,6 +1263,7 @@ TEST(PjrtCApiGpuExtensionTest, CustomCallUntyped) {
   args.handler_prepare = nullptr;
   args.handler_initialize = nullptr;
   args.handler_execute = reinterpret_cast<void*>(&TestCustomCallV2);
+  args.traits = 0;
   auto api = GetPjrtApi();
   const PJRT_Extension_Base* next = api->extension_start;
   while (next != nullptr &&
@@ -1294,6 +1296,7 @@ TEST(PjrtCApiGpuExtensionTest, CustomCallTyped) {
   args.handler_prepare = nullptr;
   args.handler_initialize = nullptr;
   args.handler_execute = reinterpret_cast<void*>(kNoop);
+  args.traits = 0;
   auto api = GetPjrtApi();
   const PJRT_Extension_Base* next = api->extension_start;
   while (next != nullptr &&
@@ -1311,6 +1314,111 @@ TEST(PjrtCApiGpuExtensionTest, CustomCallTyped) {
       xla::ffi::FindHandler(function_name, stream_executor::GpuPlatformName())
           .value();
   EXPECT_EQ(reinterpret_cast<void*>(registration.bundle.execute), kNoop);
+}
+
+const PJRT_Gpu_Custom_Call* FindGpuCustomCallExtension(const PJRT_Api* api) {
+  const PJRT_Extension_Base* next = api->extension_start;
+  while (next != nullptr &&
+         next->type !=
+             PJRT_Extension_Type::PJRT_Extension_Type_Gpu_Custom_Call) {
+    next = next->next;
+  }
+  return reinterpret_cast<const PJRT_Gpu_Custom_Call*>(next);
+}
+
+TEST(PjrtCApiGpuExtensionTest, CustomCallTypedWithTraits) {
+  static constexpr auto* noop = +[] { return xla::ffi::Error::Success(); };
+  XLA_FFI_DEFINE_HANDLER(kNoop, noop, xla::ffi::Ffi::Bind());
+
+  PJRT_Gpu_Register_Custom_Call_Args args;
+  args.struct_size = PJRT_Gpu_Register_Custom_Call_Args_STRUCT_SIZE;
+  std::string function_name = "typed_function_name_with_traits";
+  args.function_name = function_name.c_str();
+  args.function_name_size = function_name.size();
+  args.api_version = 1;
+  args.handler_instantiate = nullptr;
+  args.handler_prepare = nullptr;
+  args.handler_initialize = nullptr;
+  args.handler_execute = reinterpret_cast<void*>(kNoop);
+  args.traits = XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE;
+  const PJRT_Gpu_Custom_Call* ext = FindGpuCustomCallExtension(GetPjrtApi());
+  ASSERT_NE(ext, nullptr);
+  ASSERT_GE(ext->base.struct_size,
+            PJRT_STRUCT_SIZE(PJRT_Gpu_Custom_Call, custom_call_handles_traits));
+  ASSERT_TRUE(ext->custom_call_handles_traits);
+
+  PJRT_Error* error = ext->custom_call(&args);
+
+  CHECK_EQ(error, nullptr);
+  auto registration =
+      xla::ffi::FindHandler(function_name, stream_executor::GpuPlatformName())
+          .value();
+  EXPECT_EQ(reinterpret_cast<void*>(registration.bundle.execute), kNoop);
+  EXPECT_EQ(registration.metadata.traits &
+                XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE,
+            XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE);
+}
+
+TEST(PjrtCApiGpuExtensionTest, CustomCallPreV3StructSizeIgnoresTraits) {
+  static constexpr auto* noop = +[] { return xla::ffi::Error::Success(); };
+  XLA_FFI_DEFINE_HANDLER(kNoop, noop, xla::ffi::Ffi::Bind());
+
+  PJRT_Gpu_Register_Custom_Call_Args args;
+  // Pre-v3 args struct size: `traits` is not part of the struct the caller
+  // passed, so custom_call must not read it (treats it as 0) even though the
+  // field happens to be set in memory below.
+  args.struct_size =
+      PJRT_STRUCT_SIZE(PJRT_Gpu_Register_Custom_Call_Args, handler_execute);
+  std::string function_name = "typed_function_name_pre_v3_traits";
+  args.function_name = function_name.c_str();
+  args.function_name_size = function_name.size();
+  args.api_version = 1;
+  args.handler_instantiate = nullptr;
+  args.handler_prepare = nullptr;
+  args.handler_initialize = nullptr;
+  args.handler_execute = reinterpret_cast<void*>(kNoop);
+  args.traits = XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE;
+  const PJRT_Gpu_Custom_Call* ext = FindGpuCustomCallExtension(GetPjrtApi());
+  ASSERT_NE(ext, nullptr);
+
+  PJRT_Error* error = ext->custom_call(&args);
+
+  CHECK_EQ(error, nullptr);
+  auto registration =
+      xla::ffi::FindHandler(function_name, stream_executor::GpuPlatformName())
+          .value();
+  EXPECT_EQ(reinterpret_cast<void*>(registration.bundle.execute), kNoop);
+  EXPECT_EQ(registration.metadata.traits &
+                XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE,
+            0);
+}
+
+// The legacy (api_version 0) registry cannot carry traits, so a non-zero
+// traits value is ignored rather than rejected -- real callers (e.g. the JAX
+// CUDA plugin) register untyped handlers with traits set, and erroring would
+// break their plugin initialization.
+TEST(PjrtCApiGpuExtensionTest, CustomCallUntypedIgnoresTraits) {
+  PJRT_Gpu_Register_Custom_Call_Args args;
+  args.struct_size = PJRT_Gpu_Register_Custom_Call_Args_STRUCT_SIZE;
+  std::string function_name = "untyped_function_name_with_traits";
+  args.function_name = function_name.c_str();
+  args.function_name_size = function_name.size();
+  args.api_version = 0;
+  args.handler_instantiate = nullptr;
+  args.handler_prepare = nullptr;
+  args.handler_initialize = nullptr;
+  args.handler_execute = reinterpret_cast<void*>(&TestCustomCallV2);
+  args.traits = XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE;
+  auto api = GetPjrtApi();
+  const PJRT_Gpu_Custom_Call* ext = FindGpuCustomCallExtension(api);
+  ASSERT_NE(ext, nullptr);
+
+  PJRT_Error* error = ext->custom_call(&args);
+
+  CHECK_EQ(error, nullptr);
+  void* custom_call = xla::CustomCallTargetRegistry::Global()->Lookup(
+      function_name, stream_executor::GpuPlatformName());
+  EXPECT_EQ(custom_call, reinterpret_cast<void*>(&TestCustomCallV2));
 }
 
 constexpr absl::string_view kAddOneTTIR = R"(


### PR DESCRIPTION
The PJRT GPU custom call extension has no way to pass XLA FFI handler traits: `PJRT_Gpu_Register_Custom_Call_Args` has no traits field, and jaxlib accordingly rejects `register_custom_call_target(..., traits=...)` with "The plugin does not support custom call traits". The only way to mark a handler as `XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE` today is to compile the trait into the handler symbol, which makes it a property of the shared library rather than a per-registration choice. Whether a custom call should be captured into command buffers depends on the workload, so registration time is the right place to decide.

Changes:

- Append a `traits` field to `PJRT_Gpu_Register_Custom_Call_Args` and a second entry point, `custom_call_with_traits`, to `PJRT_Gpu_Custom_Call` (extension version 3).
- The existing `custom_call` entry point never reads `traits`, so existing callers — including those recompiled against the new headers with the grown `struct_size` — keep their exact pre-v3 behavior.
- `custom_call_with_traits` reads `traits` and forwards it to `Ffi::RegisterStaticHandler` for `api_version` 1; for the legacy `api_version` 0 registry, non-zero traits return `Unimplemented`.
- Since the extension struct's `struct_size` is filled in by the plugin, callers can detect traits support at runtime instead of relying on the compile-time extension version.

Tests: registering through the new entry point surfaces traits in the FFI registry metadata; the legacy entry point ignores a poisoned traits field; the legacy entry point still accepts the pre-v3 struct size; the new entry point rejects traits for `api_version` 0.

Consumer side: jax-ml/jax#39003 uses the new entry point in jaxlib's `gpu_plugin_extension.cc`, probing for it at runtime and falling back to the existing rejection when the loaded plugin predates it.
