### PR TITLE
[ROCm] undo PIN JAX checkout e9b2a417d294f100a3279228c016be8105fa6a7d

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -86,7 +86,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: jax-ml/jax
-          ref: 'e6299e2e5917c3856beece723a97e566708daaf8'
           path: jax
           persist-credentials: false
 


### PR DESCRIPTION
📝 Summary of Changes
Previous we had a hiccup on JAX side due to https://github.com/jax-ml/jax/pull/38762 , then pinned a JAX commit to unblock XLA CI https://github.com/openxla/xla/commit/e9b2a417d294f100a3279228c016be8105fa6a7d

Now the issue is fixed on JAX side by https://github.com/jax-ml/jax/commit/3783c11fe707eec93be593dc737e748adcb8b607 and https://github.com/jax-ml/jax/commit/88e96e1653d6cbcff5837144b7490c7e3c14b0aa

So we can use ToT of JAX now.
 
🚀 Kind of Contribution
Please remove what does not apply:   ♻️ Cleanup,  🧪 Tests

 