### PR TITLE
Re-enable host offloading auto-enablement at O1 (revert PR #37979)

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3727,7 +3727,6 @@ xla_cc_test(
     srcs = ["flag_utils_test.cc"],
     deps = [
         ":flag_utils",
-        "//xla:debug_options_flags",
         "//xla:xla_proto_cc",
         "//xla/backends/gpu/transforms:double_buffer_loop_unrolling",
         "//xla/hlo/ir:hlo",

--- a/xla/service/gpu/flag_utils_test.cc
+++ b/xla/service/gpu/flag_utils_test.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "xla/backends/gpu/transforms/double_buffer_loop_unrolling.h"
-#include "xla/debug_options_flags.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/transforms/simplifiers/hlo_dce.h"
 #include "xla/service/collective_pipeliner.h"
@@ -86,33 +85,6 @@ TEST(FlagUtilsTest, IsPassEnabledAtOptimizationLevel) {
       IsPassEnabledAtOptimizationEffort<DoubleBufferLoopUnrolling>(module));
   EXPECT_FALSE(
       IsPassEnabledAtOptimizationEffort<LatencyHidingScheduler>(module));
-}
-
-TEST(FlagUtilsTest, HostOffloadingNotAutoEnabledAtO1) {
-  // This test ensures that the host offloading collective pipeliner remains
-  // opt-in only and is not automatically enabled by optimization levels.
-  DebugOptions default_options = DefaultDebugOptionsIgnoringFlags();
-  EXPECT_FALSE(default_options.xla_gpu_enable_pipelined_host_offloading())
-      << "Host offloading must be disabled by default";
-
-  // Test across optimization levels
-  for (ExecutionOptions::EffortLevel level :
-       {ExecutionOptions::EFFORT_O0, ExecutionOptions::EFFORT_O1,
-        ExecutionOptions::EFFORT_O2, ExecutionOptions::EFFORT_O3}) {
-    HloModuleConfig config;
-    config.set_optimization_level(level);
-    HloModule module("test_module", config);
-
-    bool collective_pipeliner_enabled =
-        IsPassEnabledAtOptimizationEffort<CollectivePipeliner>(module);
-
-    if (level >= ExecutionOptions::EFFORT_O1) {
-      // Standard CollectivePipeliner is enabled at O1+
-      EXPECT_TRUE(collective_pipeliner_enabled);
-    } else {
-      EXPECT_FALSE(collective_pipeliner_enabled);
-    }
-  }
 }
 
 }  // namespace

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -1130,7 +1130,8 @@ absl::Status RunCollectiveOptimizationPasses(
     collectives_pipeline.AddPass<CollectivePipeliner>(config);
   }
 
-  if (debug_options.xla_gpu_enable_pipelined_host_offloading()) {
+  if (debug_options.xla_gpu_enable_pipelined_host_offloading() ||
+      IsPassEnabledAtOptimizationEffort<CollectivePipeliner>(*hlo_module)) {
     // Forward pass host offloading pipelining
     CollectivePipeliner::Config config{
         /*level_to_operate_on=*/0,
@@ -1160,7 +1161,8 @@ absl::Status RunCollectiveOptimizationPasses(
     collectives_pipeline.AddPass<CollectivePipeliner>(config);
   }
 
-  if (debug_options.xla_gpu_enable_pipelined_host_offloading()) {
+  if (debug_options.xla_gpu_enable_pipelined_host_offloading() ||
+      IsPassEnabledAtOptimizationEffort<CollectivePipeliner>(*hlo_module)) {
     // Backward pass host offloading pipelining
     auto acceptable_formatting = [](const HloInstruction* instr) {
       return instr->opcode() == HloOpcode::kReshape ||


### PR DESCRIPTION
📝 Summary of Changes
Re-enable pipelined host offloading at O1+ by restoring the pre-#37979 condition in gpu_compiler.cc.

Host offloading now runs when either:
- xla_gpu_enable_pipelined_host_offloading=true
- IsPassEnabledAtOptimizationEffort<CollectivePipeliner> is true (O1+)

Also removes the #37979 test that asserted host offloading was not auto-enabled at O1.

🎯 Justification
PR #37979 made host offloading opt-in only, which disabled the O1 default path. We want O1 to enable host offloading alongside the other collective pipelining optimizations again.

The removed test covered the behavior this PR intentionally reverses; O1 gating is already covered by FlagUtilsTest.IsPassEnabledAtOptimizationLevel.

🚀 Kind of Contribution
⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
N/A

🧪 Execution Tests:
MaxText models
