### PR TITLE
[HLO] Only CSE all-gathers with identical attributes

### DIFF
--- a/xla/hlo/transforms/collectives/all_gather_cse.cc
+++ b/xla/hlo/transforms/collectives/all_gather_cse.cc
@@ -51,12 +51,25 @@ absl::StatusOr<bool> AllGatherCSE::RunImpl(
         if (raw_parameter != nullptr &&
             raw_parameter->opcode() == HloOpcode::kParameter) {
           auto it = all_gather_map.find(raw_parameter_tuple);
-          if (it != all_gather_map.end()) {
+          // Only CSE all-gathers that are genuinely equivalent. The map key is
+          // just (raw_parameter, tuple_index, dtype), which does not capture the
+          // all-gather's own attributes, so require the candidates to be
+          // Identical (ignoring operands, which the raw-parameter tracing above
+          // already accounts for). Two all-gathers of the same parameter with
+          // different all_gather_dimension / replica_groups / channel_id /
+          // use_global_device_ids / constrain_layout compute different results
+          // and must not be merged.
+          if (it != all_gather_map.end() &&
+              instruction->Identical(
+                  *it->second,
+                  [](const HloInstruction*, const HloInstruction*) {
+                    return true;
+                  })) {
             VLOG(2) << "Replacing all-gather with previous result: "
                     << it->second->ToString();
             RETURN_IF_ERROR(instruction->ReplaceAllUsesWith(it->second));
             changed = true;
-          } else {
+          } else if (it == all_gather_map.end()) {
             VLOG(2) << "Storing all-gather result for future use";
             all_gather_map[raw_parameter_tuple] = instruction;
           }

--- a/xla/hlo/transforms/collectives/all_gather_cse_test.cc
+++ b/xla/hlo/transforms/collectives/all_gather_cse_test.cc
@@ -62,6 +62,30 @@ TEST_F(AllGatherCSETest, ReplacesRedundantAllGather) {
                         op::AllGather(op::Parameter(0))));
 }
 
+TEST_F(AllGatherCSETest, DoesNotMergeDifferentReplicaGroups) {
+  // Two all-gathers of the same parameter with the same shape but different
+  // replica groups compute different data and must NOT be CSE'd.
+  absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY main {
+      param0 = s32[4] parameter(0)
+      all-gather.1 = s32[8] all-gather(param0), dimensions={0}, replica_groups={{0,1},{2,3}}
+      all-gather.2 = s32[8] all-gather(param0), dimensions={0}, replica_groups={{0,2},{1,3}}
+      ROOT tuple = (s32[8], s32[8]) tuple(all-gather.1, all-gather.2)
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, pass_.Run(module.get()));
+  EXPECT_FALSE(changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::Tuple(op::AllGather(op::Parameter(0)),
+                        op::AllGather(op::Parameter(0))));
+}
+
 TEST_F(AllGatherCSETest, HandlesRawParameterGetTupleElement) {
   absl::string_view hlo_string = R"(
     HloModule module


### PR DESCRIPTION
### Problem
`AllGatherCSE` can merge two semantically-different all-gathers, producing wrong results (or a hard compile failure).

### Root cause
The CSE map key is only `(raw_parameter, tuple_index, dtype)`:
```cpp
absl::flat_hash_map<std::tuple<HloInstruction*, int64_t, PrimitiveType>,
                    HloInstruction*> all_gather_map;
...
auto it = all_gather_map.find(raw_parameter_tuple);
if (it != all_gather_map.end()) {
  instruction->ReplaceAllUsesWith(it->second);   // no attribute comparison
}
```
It omits the all-gather's own attributes — `all_gather_dimension`, `replica_groups`/device list, `channel_id`, `use_global_device_ids`, `constrain_layout`. `ReplaceAllUsesWith` only `TF_RET_CHECK`s shape compatibility, so:
- Two all-gathers of the same parameter with **different `replica_groups`** but the same shard count (e.g. `{{0,1},{2,3}}` vs `{{0,2},{1,3}}`) produce the same shape but different data. They collide on the key and one is silently rewired to the other — a **miscompile**.
- Two all-gathers differing in `all_gather_dimension` produce different shapes, so the `RET_CHECK` fails and turns valid HLO into a **compile error**.

The sibling CSE passes (`schedule_aware_collective_ops_cse`, generic `HloCSE`) compare with `HloInstruction::Identical`; this pass does not, and its tests only ever use identical replica groups.

### Fix
Before merging, require the candidate and the stored all-gather to be `Identical` (ignoring operands — the raw-parameter tracing already accounts for the operand chain). A non-match simply skips the CSE (a missed optimization, never a miscompile).

### Test
`DoesNotMergeDifferentReplicaGroups`: two same-shape all-gathers of one parameter with different replica groups are now left unmerged (previously they were incorrectly CSE'd).

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
