### PR TITLE
Drop redundant optional wrapping in send/recv conflict analysis

### DIFF
--- a/xla/service/collective_conflict_analysis.cc
+++ b/xla/service/collective_conflict_analysis.cc
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include <algorithm>
 #include <cstdint>
-#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -101,11 +100,10 @@ void GetAbstractReplicaGroups(HloInstruction* instr,
       instr->opcode() == HloOpcode::kRecv) {
     auto* sr = Cast<HloSendRecvInstruction>(instr);
     CHECK(!sr->is_host_transfer());
-    std::optional<std::string> source_target_pairs_str =
+    const std::string& source_target_pairs_str =
         sr->frontend_attributes().map().at(kSendRecvSourceTargetPairsAttr);
-    CHECK(source_target_pairs_str.has_value());
     absl::StatusOr<std::vector<ReplicaGroup>> source_target_pairs =
-        ParseReplicaGroupsOnly(*source_target_pairs_str);
+        ParseReplicaGroupsOnly(source_target_pairs_str);
     CHECK(source_target_pairs.ok() && "Expect valid source_target_pairs");
     for (auto& replica_group : *source_target_pairs) {
       add_replica_group(replica_group);


### PR DESCRIPTION
### Change
Cleanup in `GetAbstractReplicaGroups` (the send/recv branch). The source-target-pairs lookup assigned `Map::at()`'s returned `const std::string&` into a `std::optional<std::string>` and then `CHECK`'d `has_value()`, which is always true (the optional is constructed from a live reference). Use the string directly, drop the redundant `CHECK`, and remove the now-unused `<optional>` include.

The fail-loud `Map::at()` is kept: a device send/recv is expected to carry the source-target-pairs attribute here (device send/recv reach this via collective-permute decomposition, which always sets it), matching the sibling `CHECK(!sr->is_host_transfer())` invariant.

No functional change.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
