### PR TITLE
[GPU] Fix out-of-bounds read in AllReduceSplitter ReplicaGroups comparator

### DIFF
--- a/xla/backends/gpu/transforms/collectives/all_reduce_splitter.cc
+++ b/xla/backends/gpu/transforms/collectives/all_reduce_splitter.cc
@@ -95,9 +95,8 @@ struct ReplicaGroups {
   friend H AbslHashValue(H h, const ReplicaGroups& rg) {
     for (const ReplicaGroup& group : rg.replica_groups) {
       h = H::combine(std::move(h), group.replica_ids_size());
-      for (int64_t id : group.replica_ids()) {
-        h = H::combine(std::move(h), id);
-      }
+      h = H::combine_contiguous(std::move(h), group.replica_ids().data(),
+                                group.replica_ids_size());
     }
     return h;
   }

--- a/xla/backends/gpu/transforms/collectives/all_reduce_splitter.cc
+++ b/xla/backends/gpu/transforms/collectives/all_reduce_splitter.cc
@@ -93,7 +93,13 @@ struct ReplicaGroups {
 
   template <typename H>
   friend H AbslHashValue(H h, const ReplicaGroups& rg) {
-    return H::combine(std::move(h), rg.replica_groups.size());
+    for (const ReplicaGroup& group : rg.replica_groups) {
+      h = H::combine(std::move(h), group.replica_ids_size());
+      for (int64_t id : group.replica_ids()) {
+        h = H::combine(std::move(h), id);
+      }
+    }
+    return h;
   }
 
   friend bool operator==(const ReplicaGroups& item,
@@ -104,6 +110,10 @@ struct ReplicaGroups {
     for (int i = 0; i < item.replica_groups.size(); i++) {
       const ReplicaGroup& item_replica_group = item.replica_groups[i];
       const ReplicaGroup& other_replica_group = other.replica_groups[i];
+      if (item_replica_group.replica_ids_size() !=
+          other_replica_group.replica_ids_size()) {
+        return false;
+      }
       for (int i = 0; i < item_replica_group.replica_ids_size(); i++) {
         if (item_replica_group.replica_ids(i) !=
             other_replica_group.replica_ids(i)) {

--- a/xla/backends/gpu/transforms/collectives/all_reduce_splitter_test.cc
+++ b/xla/backends/gpu/transforms/collectives/all_reduce_splitter_test.cc
@@ -79,6 +79,37 @@ class AllReduceSplitterFilecheckTest : public AllReduceSplitterTest {
   }
 };
 
+TEST_F(AllReduceSplitterTest,
+       HandlesAllReducesWithNonUniformReplicaGroupsOfSameCount) {
+  // Two all-reduces whose replica-group sets have the same number of groups but
+  // different per-group sizes previously read out of bounds in the
+  // ReplicaGroups dedup comparator (which bounds the inner loop on one group's
+  // size while indexing the other). Building the replica-groups map must not
+  // crash.
+  absl::string_view hlo_string = R"(
+HloModule m
+
+sum {
+  a = bf16[] parameter(0)
+  b = bf16[] parameter(1)
+  ROOT _ = bf16[] add(a,b)
+}
+
+ENTRY main {
+  p = bf16[8] parameter(0)
+  ar0 = bf16[8] all-reduce(p), replica_groups={{0,1},{2,3}}, to_apply=sum, use_global_device_ids=true, channel_id=1
+  ROOT ar1 = bf16[8] all-reduce(ar0), replica_groups={{0,1,2},{3}}, to_apply=sum, use_global_device_ids=true, channel_id=2
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<HloModule> module,
+      PrepareModule(hlo_string, /*num_replicas=*/1, /*num_partitions=*/4));
+
+  EXPECT_THAT(AllReduceSplitter().Run(module.get()),
+              absl_testing::IsOkAndHolds(false));
+}
+
 TEST_F(
     AllReduceSplitterFilecheckTest,
     MatchBasicPatternIfDynamicSliceIsRootAndThereExistsAllReduceWithSameReplicaGroups) {  // NOLINT


### PR DESCRIPTION
### Problem
`AllReduceSplitter`'s `ReplicaGroups` dedup comparator reads out of bounds (and can report distinct replica-group sets as equal) when two all-reduces have the same number of groups but different per-group sizes.

### Root cause
```cpp
friend H AbslHashValue(H h, const ReplicaGroups& rg) {
  return H::combine(std::move(h), rg.replica_groups.size());   // only the group COUNT
}
friend bool operator==(const ReplicaGroups& item, const ReplicaGroups& other) {
  if (item.replica_groups.size() != other.replica_groups.size()) return false;
  for (int i = 0; i < item.replica_groups.size(); i++) {
    const ReplicaGroup& item_replica_group = item.replica_groups[i];
    const ReplicaGroup& other_replica_group = other.replica_groups[i];
    for (int i = 0; i < item_replica_group.replica_ids_size(); i++) {   // bound = item's size
      if (item_replica_group.replica_ids(i) != other_replica_group.replica_ids(i))  // indexes OTHER
        return false;
```
The inner loop is bounded by `item`'s group size but dereferences `other.replica_ids(i)`, with **no per-group size-equality check**. `RunImpl` calls `GetReplicaGroupsMap` unconditionally on every computation and inserts every all-reduce into a `flat_hash_map` keyed by `ReplicaGroups`, so this comparator runs for any two all-reduces with the same group count. The HLO verifier explicitly allows non-uniform replica-group sizes for all-reduce, so e.g. `{{0,1},{2,3}}` vs `{{0,1,2},{3}}` (both 2 groups) collide on the degenerate hash and the comparator reads `replica_ids(2)` past a size-2 `RepeatedField` — an out-of-bounds read (DCHECK/ASan abort, UB in release). In the reverse order it returns a false "equal" (prefix match), corrupting the split heuristic.

The sibling reassociate passes compare full `replica_groups` element- and size-wise via `AllReduceKey`.

### Fix
Add the missing per-group size-equality check before the inner loop (fixes the OOB and the false-equal), and hash the actual `replica_ids` instead of only the group count so semantically different groups don't all share one bucket.

### Test
`HandlesAllReducesWithNonUniformReplicaGroupsOfSameCount`: two all-reduces with 2 groups each but different per-group sizes; building the map no longer reads out of bounds (previously an ASan/DCHECK abort).

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
