### PR TITLE
[HLO] Rewrite a scalar-operand gather to a broadcast in GatherSimplifier

### DIFF
--- a/xla/hlo/transforms/simplifiers/gather_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/gather_simplifier.cc
@@ -49,6 +49,13 @@ absl::StatusOr<HloInstruction*> GatherSimplifier::ExpandInstruction(
   auto* operand = gather->operands()[0];
   auto* start_indices = gather->operands()[1];
 
+  // A gather from a scalar (rank-0) operand selects that same scalar for every
+  // index, so it is equivalent to broadcasting the operand to the result shape.
+  if (operand_rank == 0) {
+    return gather->AddInstruction(
+        HloInstruction::CreateBroadcast(gather->shape(), operand, {}));
+  }
+
   // Make the start_indices a two-dimensional tensor.
   ASSIGN_OR_RETURN(start_indices, TransformStartIndices(
                                       start_indices, dims.index_vector_dim()));
@@ -116,15 +123,18 @@ absl::StatusOr<HloInstruction*> GatherSimplifier::ExpandInstruction(
 bool GatherSimplifier::IsSimplifiedGather(const HloGatherInstruction* gather) {
   auto* start_indices = gather->operands()[1];
   const auto& dims = gather->gather_dimension_numbers();
-  // A gather from a scalar (rank-0) operand has no offset dims; treat it as
-  // already simplified instead of dereferencing an empty offset_dims (which
-  // would read out of bounds). This mirrors ScatterSimplifier, which returns
-  // early for a rank-0 operand.
+  // A gather from a scalar (rank-0) operand is not in simplified form; it is
+  // rewritten to a broadcast of the operand by ExpandInstruction. Returning
+  // false here also avoids dereferencing an empty offset_dims below.
+  const int64_t operand_rank =
+      dims.collapsed_slice_dims().size() + dims.offset_dims().size();
+  if (operand_rank == 0) {
+    return false;
+  }
   return start_indices->shape().dimensions().size() == 2 &&
          dims.index_vector_dim() == 1 && dims.collapsed_slice_dims().empty() &&
-         (dims.offset_dims().empty() ||
-          (*dims.offset_dims().begin() == 1 &&
-           *dims.offset_dims().rbegin() == dims.offset_dims().size()));
+         *dims.offset_dims().begin() == 1 &&
+         *dims.offset_dims().rbegin() == dims.offset_dims().size();
 }
 
 bool GatherSimplifier::InstructionMatchesPattern(HloInstruction* inst) {

--- a/xla/hlo/transforms/simplifiers/gather_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/gather_simplifier.cc
@@ -116,10 +116,15 @@ absl::StatusOr<HloInstruction*> GatherSimplifier::ExpandInstruction(
 bool GatherSimplifier::IsSimplifiedGather(const HloGatherInstruction* gather) {
   auto* start_indices = gather->operands()[1];
   const auto& dims = gather->gather_dimension_numbers();
+  // A gather from a scalar (rank-0) operand has no offset dims; treat it as
+  // already simplified instead of dereferencing an empty offset_dims (which
+  // would read out of bounds). This mirrors ScatterSimplifier, which returns
+  // early for a rank-0 operand.
   return start_indices->shape().dimensions().size() == 2 &&
          dims.index_vector_dim() == 1 && dims.collapsed_slice_dims().empty() &&
-         *dims.offset_dims().begin() == 1 &&
-         *dims.offset_dims().rbegin() == dims.offset_dims().size();
+         (dims.offset_dims().empty() ||
+          (*dims.offset_dims().begin() == 1 &&
+           *dims.offset_dims().rbegin() == dims.offset_dims().size()));
 }
 
 bool GatherSimplifier::InstructionMatchesPattern(HloInstruction* inst) {

--- a/xla/hlo/transforms/simplifiers/gather_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/gather_simplifier_test.cc
@@ -59,6 +59,28 @@ TEST_F(GatherSimplifierTest, TransformsStartIndices) {
   )");
 }
 
+TEST_F(GatherSimplifierTest, DoesNotCrashOnScalarOperandGather) {
+  // A gather from a scalar (rank-0) operand has empty offset_dims;
+  // IsSimplifiedGather previously dereferenced the empty offset_dims out of
+  // bounds. It is now treated as already simplified, so the pass makes no
+  // change.
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule gather_simplifier
+
+    ENTRY kernel_entry {
+      operand = f32[] parameter(0)
+      indices = s32[7,0] parameter(1)
+      ROOT gather = f32[7] gather(operand, indices),
+          offset_dims={},
+          collapsed_slice_dims={},
+          start_index_map={},
+          index_vector_dim=1,
+          slice_sizes={}
+    })";
+
+  RunAndFilecheckHloRewrite(kModuleStr, GatherSimplifier(), std::nullopt);
+}
+
 TEST_F(GatherSimplifierTest, RemovesCollapsedSliceDims) {
   // Verifies that GatherSimplifier sets the collapsed_slice_dims parameter to
   // the empty list.

--- a/xla/hlo/transforms/simplifiers/gather_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/gather_simplifier_test.cc
@@ -59,11 +59,10 @@ TEST_F(GatherSimplifierTest, TransformsStartIndices) {
   )");
 }
 
-TEST_F(GatherSimplifierTest, DoesNotCrashOnScalarOperandGather) {
-  // A gather from a scalar (rank-0) operand has empty offset_dims;
-  // IsSimplifiedGather previously dereferenced the empty offset_dims out of
-  // bounds. It is now treated as already simplified, so the pass makes no
-  // change.
+TEST_F(GatherSimplifierTest, RewritesScalarOperandGatherToBroadcast) {
+  // A gather from a scalar (rank-0) operand selects that scalar for every index,
+  // so it is rewritten to a broadcast of the operand. Previously
+  // IsSimplifiedGather dereferenced the empty offset_dims out of bounds.
   constexpr absl::string_view kModuleStr = R"(
     HloModule gather_simplifier
 
@@ -78,7 +77,9 @@ TEST_F(GatherSimplifierTest, DoesNotCrashOnScalarOperandGather) {
           slice_sizes={}
     })";
 
-  RunAndFilecheckHloRewrite(kModuleStr, GatherSimplifier(), std::nullopt);
+  RunAndFilecheckHloRewrite(kModuleStr, GatherSimplifier(), R"(
+      CHECK: ROOT {{.*}} = f32[7]{0} broadcast(%operand), dimensions={}
+  )");
 }
 
 TEST_F(GatherSimplifierTest, RemovesCollapsedSliceDims) {


### PR DESCRIPTION
### Problem
`GatherSimplifier` crashed on a gather from a scalar (rank-0) operand: such a gather has empty `offset_dims`, which `IsSimplifiedGather` dereferenced out of bounds (and the pass could otherwise loop without making progress).

### Fix
Rather than treating a scalar-operand gather as already-simplified (which just skips it), eliminate it — mirroring `ScatterSimplifier`:
- `IsSimplifiedGather` returns `false` for a rank-0 operand (`operand_rank == 0`), which also avoids the out-of-bounds `offset_dims` dereference.
- `ExpandInstruction` rewrites a rank-0-operand gather into a `broadcast` of the scalar operand to the result shape (matching the existing zero-slice-size → broadcast path), so the gather is removed instead of being left in place.

Behavior is unchanged for all other gathers.

### Test
`RewritesScalarOperandGatherToBroadcast` asserts a scalar-operand gather is rewritten to `broadcast(%operand), dimensions={}`.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
