### PR TITLE
[SPMD] Fall back when FFT halo exchange is not possible

### DIFF
--- a/xla/service/spmd/fft_handler.cc
+++ b/xla/service/spmd/fft_handler.cc
@@ -387,9 +387,15 @@ absl::Status SpmdPartitioningVisitor::HandleFft(HloInstruction* hlo) {
       partitioned_input.state().next_channel_id,
       partitioned_input.state().partition_id, partitioned_input.state().b);
 
-  if (padded_hlo.has_value()) {
-    result = padded_hlo.value();
+  if (!padded_hlo.has_value()) {
+    // Halo exchange is what establishes the divisibility that
+    // ShuffleWithinEachPartitionUsingOneHot requires (its CHECK_EQ). If it was
+    // not possible for this sharding (e.g. a halo larger than the per-shard
+    // size), fall back to the default partitioning instead of proceeding with
+    // an un-padded operand and hitting that CHECK.
+    return DefaultAction(hlo);
   }
+  result = padded_hlo.value();
 
   // 1.b Shuffle data within each partition using one hot and matmul.
   // If partition 0 has {0, 1, 2, 3} and num partitions is 2, after shuffling,

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -12105,6 +12105,34 @@ ENTRY entry {
                           op::Shape("c64[1,1,3]")));
 }
 
+TEST_P(SpmdPartitioningTest, Fft3DSmallShardFallsBack) {
+  // The last FFT dimension is sharded down to a per-shard size of 1, so halo
+  // exchange (which establishes the divisibility that the per-partition shuffle
+  // requires) is impossible. This previously proceeded with an un-padded
+  // operand and hit a CHECK failure; it must fall back to the default
+  // partitioning instead.
+  absl::string_view hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  constant = c64[1,1,2] constant({{{(0,0),(1,1)}}}),
+    sharding={devices=[1,1,2]<=[2]}
+  ROOT fft = c64[1,1,2] fft(c64[1,1,2] constant), fft_type=FFT, fft_length={2},
+    sharding={devices=[1,1,2]<=[2]}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          PartitionComputation(hlo_string, /*num_devices=*/2));
+  // Partitioning must succeed (no CHECK failure) and preserve the FFT.
+  bool has_fft = false;
+  for (const HloInstruction* instr :
+       module->entry_computation()->instructions()) {
+    if (instr->opcode() == HloOpcode::kFft) has_fft = true;
+  }
+  EXPECT_TRUE(has_fft);
+}
+
 TEST_P(SpmdPartitioningTest, DotInputsAreIdentical) {
   absl::string_view hlo_string = R"(
 HloModule module


### PR DESCRIPTION
### Problem
The SPMD FFT handler aborts the compiler (`CHECK_EQ`) when halo exchange can't be performed for the sharded FFT dimension.

### Root cause
```cpp
auto result = partitioned_input.hlo();
auto padded_hlo = PadEachPartitionWithHaloExchange(...);
if (padded_hlo.has_value()) {
  result = padded_hlo.value();
}
// falls through even when padded_hlo == nullopt (result stays un-padded)
result = ShuffleWithinEachPartitionUsingOneHot(result, num_partitions_, ...);
```
`PadEachPartitionWithHaloExchange` returns `std::nullopt` only when the per-shard size is **not** a multiple of `num_partitions` (padding is exactly what would make it divisible). When it returns `nullopt`, `HandleFft` ignores it and proceeds with the un-padded operand into `ShuffleWithinEachPartitionUsingOneHot`, whose `CHECK_EQ(size_per_partition % num_partitions, 0)` then fires — so a `nullopt` return *always* aborts the compiler.

This is reachable from verifier-valid HLO: an FFT whose last dimension is sharded down to a per-shard size too small to gather the halo, e.g. `fft(c64[1,1,2]), fft_length={2}, sharding={devices=[1,1,2]}` (per-shard size 1, halo length 2). The nullopt is returned inside `ExchangeHalo` (`max_right_halo_size > input_shard_size`).

### Fix
Treat a `nullopt` from `PadEachPartitionWithHaloExchange` as unsupported and return `DefaultAction(hlo)` — the replicated fallback the handler already uses for its other unsupported FFT cases — instead of proceeding with the un-padded operand.

### Test
`Fft3DSmallShardFallsBack`: an FFT with a per-shard size of 1 now partitions successfully (previously a `CHECK` abort).

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
