### PR TITLE
[XLA:SE] Add VMM allocator tests and simplify PA accounting

### DIFF
--- a/xla/stream_executor/BUILD
+++ b/xla/stream_executor/BUILD
@@ -380,6 +380,27 @@ cc_library(
     ],
 )
 
+xla_cc_test(
+    name = "device_address_vmm_allocator_test",
+    srcs = ["device_address_vmm_allocator_test.cc"],
+    deps = [
+        ":device_address",
+        ":device_address_vmm_allocator",
+        ":memory_allocation",
+        ":memory_reservation",
+        ":mock_platform",
+        ":mock_stream",
+        ":mock_stream_executor",
+        ":platform",
+        ":stream_executor_h",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 # Factory backends. Each implementation is free of platform `#if` macros; the
 # right one is selected by the top-level `device_address_vmm_allocator_factory`
 # dispatcher below (Stub / CUDA / ROCm), mirroring the //xla/pjrt:triton idiom.

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -393,21 +393,53 @@ uint64_t DeviceAddressVmmAllocator::GetAllocationGranularity(
 
 // Allocate helpers.
 
+absl::StatusOr<std::unique_ptr<MemoryAllocation>>
+DeviceAddressVmmAllocator::AllocatePhysicalWithinBudget(
+    PerDeviceState& state, uint64_t size, uint64_t& physical_size) {
+  // Returns ResourceExhausted if charging `bytes` more physical bytes would
+  // exceed the configured PA budget. Subtraction avoids unsigned overflow.
+  auto check_pa_budget = [&state](uint64_t bytes) -> absl::Status {
+    state.mu.AssertHeld();
+    if (state.pa_allocated <= state.pa_budget &&
+        bytes <= state.pa_budget - state.pa_allocated) {
+      return absl::OkStatus();
+    }
+    return absl::ResourceExhaustedError(absl::StrFormat(
+        "Not enough PA budget: pa_allocated=%uB, allocation_size=%uB, "
+        "pa_budget=%uB",
+        state.pa_allocated, bytes, state.pa_budget));
+  };
+
+  // Fail fast on an obvious budget miss before asking the driver to reserve
+  // physical memory. rounded_size only estimates what the driver will return;
+  // the authoritative check below uses the real committed size.
+  RETURN_IF_ERROR(check_pa_budget(RoundUpToGranularity(state, size)));
+  ASSIGN_OR_RETURN(auto raw_alloc, CreateAllocation(state.executor, size));
+  physical_size = raw_alloc->address().size();
+  // CreateAllocation rounds the request up to the allocation granularity, so
+  // the physical allocation is never smaller than requested.
+  DCHECK_GE(physical_size, size);
+  // Re-check against the actual size that will be charged to pa_allocated.
+  RETURN_IF_ERROR(check_pa_budget(physical_size));
+  return raw_alloc;
+}
+
 void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
     PerDeviceState& state, AllocationRecord::Kind kind,
     DeviceAddressBase allocator_address,
     std::unique_ptr<MemoryAllocation> raw_allocation,
     std::unique_ptr<MemoryReservation> reservation,
-    MemoryReservation::ScopedMapping mapping, uint64_t allocated_size,
-    bool multi_device) {
+    MemoryReservation::ScopedMapping mapping, bool multi_device) {
   void* va_ptr = allocator_address.opaque();
+  CHECK(raw_allocation != nullptr);
+  uint64_t physical_size = raw_allocation->address().size();
   auto record = std::make_unique<AllocationRecord>(
       kind, allocator_address, std::move(raw_allocation),
       std::move(reservation), std::move(mapping), multi_device);
   auto insert_result =
       state.records_by_allocator_address.emplace(va_ptr, std::move(record));
   CHECK(insert_result.second);
-  state.pa_allocated += allocated_size;
+  state.pa_allocated += physical_size;
   return va_ptr;
 }
 
@@ -573,25 +605,18 @@ DeviceAddressVmmAllocator::EnsureReservationAvailableForFreshMapping(
 absl::StatusOr<DeviceAddressBase>
 DeviceAddressVmmAllocator::CreateMappedAllocationAtReservationAddress(
     PerDeviceState& state, const MappedAllocateRequest& request) {
-  const uint64_t rounded_size =
-      RoundUpToGranularity(state, request.allocation_size);
   // The returned allocator address is the caller-owned reservation VA. The
   // record is keyed by that VA and owns only the raw allocation plus the scoped
   // mapping into the external reservation.
-  if (state.pa_allocated + rounded_size > state.pa_budget) {
-    return absl::ResourceExhaustedError(
-        absl::StrFormat("Not enough PA budget for mapping: pa_allocated=%uB, "
-                        "rounded_size=%uB, pa_budget=%uB",
-                        state.pa_allocated, rounded_size, state.pa_budget));
-  }
-
+  uint64_t physical_size = 0;
   ASSIGN_OR_RETURN(auto raw_alloc,
-                   CreateAllocation(state.executor, request.allocation_size));
-  if (request.mapping_size > raw_alloc->address().size()) {
+                   AllocatePhysicalWithinBudget(
+                       state, request.allocation_size, physical_size));
+  if (request.mapping_size > physical_size) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "physical allocation is smaller than requested mapping: "
         "allocation_size=%uB, mapping_size=%uB",
-        raw_alloc->address().size(), request.mapping_size));
+        physical_size, request.mapping_size));
   }
 
   ASSIGN_OR_RETURN(auto scoped_mapping, request.reservation->MapTo(
@@ -601,7 +626,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocationAtReservationAddress(
   TrackAllocatorAddressMappedAllocation(
       state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
       request.reservation_address, std::move(raw_alloc), nullptr,
-      std::move(scoped_mapping), rounded_size, request.multi_device);
+      std::move(scoped_mapping), request.multi_device);
 
   return request.reservation_address;
 }
@@ -609,26 +634,18 @@ DeviceAddressVmmAllocator::CreateMappedAllocationAtReservationAddress(
 absl::StatusOr<DeviceAddressBase>
 DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
     PerDeviceState& state, const MappedAllocateRequest& request) {
-  const uint64_t rounded_size =
-      RoundUpToGranularity(state, request.allocation_size);
   // This mode creates two VAs for the same raw allocation: an allocator-owned
   // VA returned to the caller, and a non-owning alias in the caller reservation
   // used by captured command buffers.
-  if (state.pa_allocated + rounded_size > state.pa_budget) {
-    return absl::ResourceExhaustedError(absl::StrFormat(
-        "Not enough PA budget for allocation: pa_allocated=%uB, "
-        "rounded_size=%uB, pa_budget=%uB",
-        state.pa_allocated, rounded_size, state.pa_budget));
-  }
-
+  uint64_t physical_size = 0;
   ASSIGN_OR_RETURN(auto raw_alloc,
-                   CreateAllocation(state.executor, request.allocation_size));
-  const uint64_t padded_size = raw_alloc->address().size();
-  if (request.mapping_size > padded_size) {
+                   AllocatePhysicalWithinBudget(
+                       state, request.allocation_size, physical_size));
+  if (request.mapping_size > physical_size) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "mapping size must not exceed physical allocation size: "
         "mapping_size=%uB, allocation_size=%uB",
-        request.mapping_size, padded_size));
+        request.mapping_size, physical_size));
   }
 
   ASSIGN_OR_RETURN(auto allocator_address_reservation,
@@ -636,7 +653,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
   ASSIGN_OR_RETURN(auto allocator_address_mapping,
                    allocator_address_reservation->MapTo(
                        /*reservation_offset=*/0, /*allocation_offset=*/0,
-                       padded_size, *raw_alloc));
+                       physical_size, *raw_alloc));
   ASSIGN_OR_RETURN(
       auto reservation_address_mapping,
       request.reservation->MapTo(request.reservation_offset,
@@ -660,7 +677,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
   auto reservation_insert = state.active_reservation_records.emplace(
       request.reservation_address.opaque(), record_ptr);
   CHECK(reservation_insert.second);
-  state.pa_allocated += rounded_size;
+  state.pa_allocated += physical_size;
 
   return DeviceAddressBase(allocator_va, request.allocation_size);
 }
@@ -833,17 +850,10 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
   };
   auto try_fresh = [&]() -> absl::StatusOr<DeviceAddressBase> {
     state->mu.AssertHeld();
-    uint64_t rounded_size = RoundUpToGranularity(*state, size);
-    if (state->pa_allocated + rounded_size > state->pa_budget) {
-      return absl::StatusOr<DeviceAddressBase>(
-          absl::ResourceExhaustedError(absl::StrFormat(
-              "Not enough PA budget for allocation: pa_allocated=%uB, "
-              "rounded_size=%uB, pa_budget=%uB",
-              state->pa_allocated, rounded_size, state->pa_budget)));
-    }
-
-    ASSIGN_OR_RETURN(auto raw_alloc, CreateAllocation(state->executor, size));
-    const uint64_t padded_size = raw_alloc->address().size();
+    uint64_t physical_size = 0;
+    ASSIGN_OR_RETURN(
+        auto raw_alloc,
+        AllocatePhysicalWithinBudget(*state, size, physical_size));
 
     ASSIGN_OR_RETURN(auto reservation,
                      CreateReservation(state->executor, size));
@@ -851,13 +861,13 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
     ASSIGN_OR_RETURN(
         auto scoped_mapping,
         reservation->MapTo(/*reservation_offset=*/0, /*allocation_offset=*/0,
-                           padded_size, *raw_alloc));
+                           physical_size, *raw_alloc));
 
     DeviceAddressBase allocator_address(reservation->address().opaque(), size);
     void* va_ptr = TrackAllocatorAddressMappedAllocation(
         *state, AllocationRecord::Kind::kAllocate, allocator_address,
         std::move(raw_alloc), std::move(reservation),
-        std::move(scoped_mapping), rounded_size, multi_device);
+        std::move(scoped_mapping), multi_device);
     // Return the original requested size, not the padded size.
     return absl::StatusOr<DeviceAddressBase>(DeviceAddressBase(va_ptr, size));
   };
@@ -992,7 +1002,7 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
       mem.opaque(), mem.size(), state->executor->device_ordinal());
 
   const uint64_t reclaimable_bytes =
-      RoundUpToGranularity(*state, record.raw_allocation()->address().size());
+      record.raw_allocation()->address().size();
 
   // Assign the next sequence number and enqueue a GPU write to the pinned
   // timeline when the stream reaches this point. The CPU polls the timeline
@@ -1601,8 +1611,7 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
   CHECK_EQ(owning_record_it->second.get(), &record);
 
   if (record.raw_allocation() != nullptr) {
-    uint64_t released_size =
-        RoundUpToGranularity(state, record.raw_allocation()->address().size());
+    uint64_t released_size = record.raw_allocation()->address().size();
     DCHECK_GE(state.pa_allocated, released_size);
     state.pa_allocated -= released_size;
   }

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -74,7 +74,7 @@ bool DeviceAddressVmmAllocator::CurrentMultiDevice() {
 
 DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
     Kind kind, DeviceAddressBase allocator_address,
-    std::shared_ptr<MemoryAllocation> raw_allocation,
+    std::unique_ptr<MemoryAllocation> raw_allocation,
     std::unique_ptr<MemoryReservation> allocator_address_reservation,
     MemoryReservation::ScopedMapping allocator_address_mapping,
     bool multi_device)
@@ -396,7 +396,7 @@ uint64_t DeviceAddressVmmAllocator::GetAllocationGranularity(
 void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
     PerDeviceState& state, AllocationRecord::Kind kind,
     DeviceAddressBase allocator_address,
-    std::shared_ptr<MemoryAllocation> raw_allocation,
+    std::unique_ptr<MemoryAllocation> raw_allocation,
     std::unique_ptr<MemoryReservation> reservation,
     MemoryReservation::ScopedMapping mapping, uint64_t allocated_size,
     bool multi_device) {
@@ -598,11 +598,9 @@ DeviceAddressVmmAllocator::CreateMappedAllocationAtReservationAddress(
                                             request.reservation_offset,
                                             /*allocation_offset=*/0,
                                             request.mapping_size, *raw_alloc));
-  auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
-
   TrackAllocatorAddressMappedAllocation(
       state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
-      request.reservation_address, std::move(shared_raw), nullptr,
+      request.reservation_address, std::move(raw_alloc), nullptr,
       std::move(scoped_mapping), rounded_size, request.multi_device);
 
   return request.reservation_address;
@@ -645,14 +643,13 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
                                  /*allocation_offset=*/0, request.mapping_size,
                                  *raw_alloc));
 
-  auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
   // Record the paired allocation: the allocator-owned returned VA owns the raw
   // allocation, and the caller reservation VA is a non-owning alias.
   void* allocator_va = allocator_address_reservation->address().opaque();
   DeviceAddressBase allocator_address(allocator_va, request.allocation_size);
   auto record = std::make_unique<AllocationRecord>(
       AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
-      std::move(shared_raw), std::move(allocator_address_reservation),
+      std::move(raw_alloc), std::move(allocator_address_reservation),
       std::move(allocator_address_mapping), request.multi_device);
   record->AddActiveReservationAlias(request.reservation_address,
                                     std::move(reservation_address_mapping));
@@ -856,11 +853,10 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
         reservation->MapTo(/*reservation_offset=*/0, /*allocation_offset=*/0,
                            padded_size, *raw_alloc));
 
-    auto shared_raw = std::shared_ptr<MemoryAllocation>(std::move(raw_alloc));
     DeviceAddressBase allocator_address(reservation->address().opaque(), size);
     void* va_ptr = TrackAllocatorAddressMappedAllocation(
         *state, AllocationRecord::Kind::kAllocate, allocator_address,
-        std::move(shared_raw), std::move(reservation),
+        std::move(raw_alloc), std::move(reservation),
         std::move(scoped_mapping), rounded_size, multi_device);
     // Return the original requested size, not the padded size.
     return absl::StatusOr<DeviceAddressBase>(DeviceAddressBase(va_ptr, size));

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -348,7 +348,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
     AllocationRecord(
         Kind kind, DeviceAddressBase allocator_address,
-        std::shared_ptr<MemoryAllocation> raw_allocation,
+        std::unique_ptr<MemoryAllocation> raw_allocation,
         std::unique_ptr<MemoryReservation> allocator_address_reservation,
         MemoryReservation::ScopedMapping allocator_address_mapping,
         bool multi_device);
@@ -417,7 +417,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
    private:
     Kind kind_;
     DeviceAddressBase allocator_address_;
-    std::shared_ptr<MemoryAllocation> raw_allocation_;
+    std::unique_ptr<MemoryAllocation> raw_allocation_;
     bool multi_device_;
 
     // Present for Allocate() and
@@ -562,7 +562,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   void* TrackAllocatorAddressMappedAllocation(
       PerDeviceState& state, AllocationRecord::Kind kind,
       DeviceAddressBase allocator_address,
-      std::shared_ptr<MemoryAllocation> raw_allocation,
+      std::unique_ptr<MemoryAllocation> raw_allocation,
       std::unique_ptr<MemoryReservation> reservation,
       MemoryReservation::ScopedMapping mapping, uint64_t allocated_size,
       bool multi_device) ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -448,9 +448,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     // Allocator address for allocation deallocations; reservation address for
     // kMap.
     DeviceAddressBase addr;
-    // Rounded physical-allocation bytes that become reclaimable when this
-    // pending operation completes. kMap entries do not own physical memory and
-    // therefore use zero.
+    // Physical-allocation bytes charged to the PA budget that become
+    // reclaimable when this pending operation completes. kMap entries do not
+    // own physical memory and therefore use zero.
     uint64_t reclaimable_bytes = 0;
   };
 
@@ -555,17 +555,27 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   // Allocate helpers.
 
+  // Checks the PA budget for `size`, creates a physical allocation, and
+  // re-checks the budget against the actual (granularity-padded) size the
+  // driver returned, which is the size charged to pa_allocated. Returns the
+  // allocation and reports that size via `physical_size`.
+  absl::StatusOr<std::unique_ptr<MemoryAllocation>>
+  AllocatePhysicalWithinBudget(PerDeviceState& state, uint64_t size,
+                               uint64_t& physical_size)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+
   // Records a raw allocation mapped at an owning allocator address. Takes
   // ownership of `reservation` when the allocator address was allocator-owned;
-  // reservation-backed returned addresses pass nullptr here. Charges
-  // `allocated_size` to the PA budget and returns the allocator VA pointer.
+  // reservation-backed returned addresses pass nullptr here. Charges the raw
+  // allocation's committed size to the PA budget and returns the allocator VA
+  // pointer.
   void* TrackAllocatorAddressMappedAllocation(
       PerDeviceState& state, AllocationRecord::Kind kind,
       DeviceAddressBase allocator_address,
       std::unique_ptr<MemoryAllocation> raw_allocation,
       std::unique_ptr<MemoryReservation> reservation,
-      MemoryReservation::ScopedMapping mapping, uint64_t allocated_size,
-      bool multi_device) ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+      MemoryReservation::ScopedMapping mapping, bool multi_device)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   struct MappedAllocateRequest {
     MemoryReservation* reservation;

--- a/xla/stream_executor/device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/device_address_vmm_allocator_test.cc
@@ -1,0 +1,237 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/device_address_vmm_allocator.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/memory_allocation.h"
+#include "xla/stream_executor/memory_reservation.h"
+#include "xla/stream_executor/mock_platform.h"
+#include "xla/stream_executor/mock_stream.h"
+#include "xla/stream_executor/mock_stream_executor.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace stream_executor {
+namespace {
+
+using ::testing::NiceMock;
+using ::testing::Return;
+
+constexpr uint64_t kGranularity = 64;
+
+uint64_t RoundUpTestSize(uint64_t size) {
+  return ((size + kGranularity - 1) / kGranularity) * kGranularity;
+}
+
+class TestMemoryAllocation final : public MemoryAllocation {
+ public:
+  explicit TestMemoryAllocation(uint64_t size)
+      : storage_(std::make_unique<uint8_t[]>(size)), size_(size) {}
+
+  DeviceAddressBase address() const override {
+    return DeviceAddressBase(storage_.get(), size_);
+  }
+
+ private:
+  std::unique_ptr<uint8_t[]> storage_;
+  uint64_t size_;
+};
+
+class TestMemoryReservation final : public MemoryReservation {
+ public:
+  explicit TestMemoryReservation(uint64_t size)
+      : storage_(std::make_unique<uint8_t[]>(size)), size_(size) {}
+
+  DeviceAddressBase address() const override {
+    return DeviceAddressBase(storage_.get(), size_);
+  }
+
+  int active_mapping_count() const { return active_mapping_count_; }
+
+ private:
+  absl::Status Map(size_t reservation_offset, size_t allocation_offset,
+                   size_t size, MemoryAllocation& allocation) override {
+    if (reservation_offset > size_ || size > size_ - reservation_offset ||
+        allocation_offset > allocation.address().size() ||
+        size > allocation.address().size() - allocation_offset) {
+      return absl::InvalidArgumentError("mapping range is out of bounds");
+    }
+    ++active_mapping_count_;
+    return absl::OkStatus();
+  }
+
+  absl::Status SetAccess(uint64_t /*reservation_offset*/,
+                         size_t /*size*/) override {
+    return absl::OkStatus();
+  }
+
+  absl::Status UnMap(size_t /*reservation_offset*/, size_t /*size*/) override {
+    if (active_mapping_count_ == 0) {
+      return absl::FailedPreconditionError("reservation is not mapped");
+    }
+    --active_mapping_count_;
+    return absl::OkStatus();
+  }
+
+  std::unique_ptr<uint8_t[]> storage_;
+  uint64_t size_;
+  int active_mapping_count_ = 0;
+};
+
+class TestDeviceAddressVmmAllocator final : public DeviceAddressVmmAllocator {
+ public:
+  static absl::StatusOr<std::unique_ptr<TestDeviceAddressVmmAllocator>> Create(
+      const Platform* platform, absl::Span<const DeviceConfig> devices) {
+    auto allocator = std::unique_ptr<TestDeviceAddressVmmAllocator>(
+        new TestDeviceAddressVmmAllocator(platform));
+    absl::Status status = PopulateDevices(allocator.get(), devices);
+    if (!status.ok()) {
+      return status;
+    }
+    return allocator;
+  }
+
+  int allocation_count() const { return allocation_count_; }
+
+ protected:
+  absl::Status InitializeDeviceState(PerDeviceState& state) override {
+    state.allocation_granularity = kGranularity;
+    auto* timeline = new uint64_t(0);
+    state.pinned_timeline = timeline;
+    state.destroy_fn = [timeline] { delete timeline; };
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<std::unique_ptr<MemoryAllocation>> CreateAllocation(
+      StreamExecutor* /*executor*/, uint64_t size) override {
+    ++allocation_count_;
+    return std::make_unique<TestMemoryAllocation>(RoundUpTestSize(size));
+  }
+
+  absl::StatusOr<std::unique_ptr<MemoryReservation>> CreateReservation(
+      StreamExecutor* /*executor*/, uint64_t size) override {
+    return std::make_unique<TestMemoryReservation>(RoundUpTestSize(size));
+  }
+
+  absl::Status EnqueueDeferredDeallocation(PerDeviceState& state,
+                                           uint64_t seqno) override {
+    __atomic_store_n(state.pinned_timeline, seqno, __ATOMIC_RELEASE);
+    return absl::OkStatus();
+  }
+
+ private:
+  explicit TestDeviceAddressVmmAllocator(const Platform* platform)
+      : DeviceAddressVmmAllocator(platform) {}
+
+  int allocation_count_ = 0;
+};
+
+class DeviceAddressVmmAllocatorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ON_CALL(executor_, device_ordinal()).WillByDefault(Return(0));
+    ON_CALL(stream_, parent()).WillByDefault(Return(&executor_));
+  }
+
+  DeviceAddressVmmAllocator::DeviceConfig Config(uint64_t pa_budget) {
+    return {&executor_, &stream_, pa_budget};
+  }
+
+  NiceMock<MockPlatform> platform_;
+  NiceMock<MockStreamExecutor> executor_;
+  NiceMock<MockStream> stream_;
+};
+
+TEST_F(DeviceAddressVmmAllocatorTest, RetryFlagDoesNotDisablePendingReclaim) {
+  const DeviceAddressVmmAllocator::DeviceConfig config =
+      Config(2 * kGranularity);
+  ASSERT_OK_AND_ASSIGN(auto allocator, TestDeviceAddressVmmAllocator::Create(
+                                           &platform_, {config}));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto first,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/true, /*memory_space=*/0));
+  ASSERT_THAT(allocator->Deallocate(/*device_ordinal=*/0, first.Release()),
+              absl_testing::IsOk());
+
+  ASSERT_OK_AND_ASSIGN(
+      auto retried,
+      allocator->Allocate(/*device_ordinal=*/0, 2 * kGranularity,
+                          /*retry_on_failure=*/false, /*memory_space=*/0));
+  EXPECT_EQ(allocator->allocation_count(), 2);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       RetryDisabledStillReusesCompatiblePendingAllocation) {
+  const DeviceAddressVmmAllocator::DeviceConfig config = Config(kGranularity);
+  ASSERT_OK_AND_ASSIGN(auto allocator, TestDeviceAddressVmmAllocator::Create(
+                                           &platform_, {config}));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto first,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/true, /*memory_space=*/0));
+  void* first_address = first->opaque();
+  ASSERT_THAT(allocator->Deallocate(/*device_ordinal=*/0, first.Release()),
+              absl_testing::IsOk());
+
+  ASSERT_OK_AND_ASSIGN(
+      auto reused,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/false, /*memory_space=*/0));
+  EXPECT_EQ(reused->opaque(), first_address);
+  EXPECT_EQ(allocator->allocation_count(), 1);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       RetryFlagDoesNotDisableMappedPendingReclaim) {
+  auto reservation = std::make_unique<TestMemoryReservation>(2 * kGranularity);
+  const DeviceAddressVmmAllocator::DeviceConfig config =
+      Config(2 * kGranularity);
+  ASSERT_OK_AND_ASSIGN(auto allocator, TestDeviceAddressVmmAllocator::Create(
+                                           &platform_, {config}));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto first,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/true, /*memory_space=*/0));
+  ASSERT_THAT(allocator->Deallocate(/*device_ordinal=*/0, first.Release()),
+              absl_testing::IsOk());
+
+  ASSERT_OK_AND_ASSIGN(
+      auto retried,
+      allocator->Allocate(
+          /*device_ordinal=*/0, /*allocation_size=*/2 * kGranularity,
+          /*retry_on_failure=*/false, /*memory_space=*/0, reservation.get(),
+          /*reservation_offset=*/0, /*mapping_size=*/2 * kGranularity,
+          /*return_reservation_address=*/true));
+  EXPECT_EQ(reservation->active_mapping_count(), 1);
+  EXPECT_EQ(allocator->allocation_count(), 2);
+}
+
+}  // namespace
+}  // namespace stream_executor

--- a/xla/stream_executor/device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/device_address_vmm_allocator_test.cc
@@ -37,6 +37,7 @@ limitations under the License.
 namespace stream_executor {
 namespace {
 
+using ::absl_testing::StatusIs;
 using ::testing::NiceMock;
 using ::testing::Return;
 
@@ -104,9 +105,10 @@ class TestMemoryReservation final : public MemoryReservation {
 class TestDeviceAddressVmmAllocator final : public DeviceAddressVmmAllocator {
  public:
   static absl::StatusOr<std::unique_ptr<TestDeviceAddressVmmAllocator>> Create(
-      const Platform* platform, absl::Span<const DeviceConfig> devices) {
+      const Platform* platform, absl::Span<const DeviceConfig> devices,
+      uint64_t physical_size_padding = 0) {
     auto allocator = std::unique_ptr<TestDeviceAddressVmmAllocator>(
-        new TestDeviceAddressVmmAllocator(platform));
+        new TestDeviceAddressVmmAllocator(platform, physical_size_padding));
     absl::Status status = PopulateDevices(allocator.get(), devices);
     if (!status.ok()) {
       return status;
@@ -128,12 +130,14 @@ class TestDeviceAddressVmmAllocator final : public DeviceAddressVmmAllocator {
   absl::StatusOr<std::unique_ptr<MemoryAllocation>> CreateAllocation(
       StreamExecutor* /*executor*/, uint64_t size) override {
     ++allocation_count_;
-    return std::make_unique<TestMemoryAllocation>(RoundUpTestSize(size));
+    return std::make_unique<TestMemoryAllocation>(RoundUpTestSize(size) +
+                                                  physical_size_padding_);
   }
 
   absl::StatusOr<std::unique_ptr<MemoryReservation>> CreateReservation(
       StreamExecutor* /*executor*/, uint64_t size) override {
-    return std::make_unique<TestMemoryReservation>(RoundUpTestSize(size));
+    return std::make_unique<TestMemoryReservation>(RoundUpTestSize(size) +
+                                                   physical_size_padding_);
   }
 
   absl::Status EnqueueDeferredDeallocation(PerDeviceState& state,
@@ -143,9 +147,12 @@ class TestDeviceAddressVmmAllocator final : public DeviceAddressVmmAllocator {
   }
 
  private:
-  explicit TestDeviceAddressVmmAllocator(const Platform* platform)
-      : DeviceAddressVmmAllocator(platform) {}
+  TestDeviceAddressVmmAllocator(const Platform* platform,
+                                uint64_t physical_size_padding)
+      : DeviceAddressVmmAllocator(platform),
+        physical_size_padding_(physical_size_padding) {}
 
+  uint64_t physical_size_padding_;
   int allocation_count_ = 0;
 };
 
@@ -230,6 +237,44 @@ TEST_F(DeviceAddressVmmAllocatorTest,
           /*reservation_offset=*/0, /*mapping_size=*/2 * kGranularity,
           /*return_reservation_address=*/true));
   EXPECT_EQ(reservation->active_mapping_count(), 1);
+  EXPECT_EQ(allocator->allocation_count(), 2);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       PhysicalAllocationSizeControlsBudgetAccounting) {
+  const DeviceAddressVmmAllocator::DeviceConfig config =
+      Config(2 * kGranularity);
+  ASSERT_OK_AND_ASSIGN(auto allocator,
+                       TestDeviceAddressVmmAllocator::Create(
+                           &platform_, {config},
+                           /*physical_size_padding=*/kGranularity));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto first,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/true, /*memory_space=*/0));
+  ASSERT_NE(allocator->GetRawAllocation(/*device_ordinal=*/0, first.cref()),
+            nullptr);
+  EXPECT_EQ(allocator->GetRawAllocation(/*device_ordinal=*/0, first.cref())
+                ->address()
+                .size(),
+            2 * kGranularity);
+  // The first allocation consumes the full budget based on the physical size,
+  // even though its requested size was one granularity unit.
+  EXPECT_THAT(allocator->Allocate(/*device_ordinal=*/0, 2 * kGranularity,
+                                  /*retry_on_failure=*/false,
+                                  /*memory_space=*/0),
+              StatusIs(absl::StatusCode::kResourceExhausted));
+  EXPECT_EQ(allocator->allocation_count(), 1);
+
+  ASSERT_THAT(allocator->Deallocate(/*device_ordinal=*/0, first.Release()),
+              absl_testing::IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(/*device_ordinal=*/0),
+              absl_testing::IsOk());
+  ASSERT_OK_AND_ASSIGN(
+      auto second,
+      allocator->Allocate(/*device_ordinal=*/0, kGranularity,
+                          /*retry_on_failure=*/false, /*memory_space=*/0));
   EXPECT_EQ(allocator->allocation_count(), 2);
 }
 


### PR DESCRIPTION
This is part 1 of a four-PR stack split from #45323. It contains the original commits 1–3 unchanged. PR #45323 and its branch remain unchanged.

Stack:

1. **#45413 — tests and physical-allocation accounting (this PR)**
2. #45414 — map resolution
3. #45415 — record bookkeeping
4. #45416 — allocation paths and final cleanup

📝 Summary of Changes

- Add focused tests for pending allocation reclamation.
- Use unique ownership for VMM physical allocations.
- Account the physical-address budget with the committed allocation size.

🎯 Justification

These changes establish focused lifecycle coverage and simplify physical-allocation ownership and budget accounting before the later allocator refactors.

🚀 Kind of Contribution

♻️ Cleanup, 🧪 Tests

📊 Benchmark (for Performance Improvements)

Not applicable; this is a behavior-preserving cleanup rather than a performance change.

🧪 Unit Tests:

- Adds coverage in `device_address_vmm_allocator_test.cc`.
- PASS at `45aa76b5e5a6`: `bazel test //xla/stream_executor:device_address_vmm_allocator_test --test_output=errors`.

🧪 Execution Tests:

No new execution test; this layer does not change GPU execution behavior.
