### PR TITLE
[XLA:SE] Simplify VMM allocator record bookkeeping

### DIFF
--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -95,7 +95,7 @@ DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
       CHECK(allocator_address_reservation_ == nullptr);
       break;
   }
-  CHECK(allocator_address_mapping_.has_value());
+  CHECK(!allocator_address_mapping_.is_null());
 }
 
 DeviceAddressVmmAllocator::PendingDeallocationKind
@@ -114,85 +114,57 @@ DeviceAddressVmmAllocator::AllocationRecord::pending_deallocation_kind() const {
 
 DeviceAddressBase
 DeviceAddressVmmAllocator::AllocationRecord::reservation_address() const {
-  CHECK(reservation_address_.has_value());
-  return *reservation_address_;
+  CHECK(has_reservation_alias());
+  return reservation_alias_->mapping.mapped_address();
 }
 
-bool DeviceAddressVmmAllocator::AllocationRecord::reservation_mapping_matches(
-    DeviceAddressBase address) const {
-  return reservation_address_mapping_.has_value() &&
-         reservation_address_mapping_->mapped_address().IsSameAs(address);
+uint64_t DeviceAddressVmmAllocator::AllocationRecord::reservation_stale_seqno()
+    const {
+  CHECK(has_reservation_alias());
+  return reservation_alias_->stale_seqno;
 }
 
 void DeviceAddressVmmAllocator::AllocationRecord::MarkAllocatorStale(
     uint64_t seqno) {
   CHECK(allocator_active());
-  CHECK(!allocator_stale());
-  CHECK(has_allocator_address_mapping());
+  CHECK(!allocator_address_mapping_.is_null());
   CHECK_NE(seqno, 0);
-  allocator_state_ = AllocatorState::kStale;
   allocator_stale_seqno_ = seqno;
 }
 
 void DeviceAddressVmmAllocator::AllocationRecord::ReactivateAllocator(
     uint64_t new_size) {
-  CHECK(!allocator_active());
   CHECK(allocator_stale());
-  CHECK(has_allocator_address_mapping());
+  CHECK(!allocator_address_mapping_.is_null());
   allocator_address_ = DeviceAddressBase(allocator_address_.opaque(), new_size);
-  allocator_state_ = AllocatorState::kActive;
   allocator_stale_seqno_ = 0;
 }
 
-void DeviceAddressVmmAllocator::AllocationRecord::CompleteStaleAllocator() {
-  CHECK(!allocator_active());
-  CHECK(allocator_stale());
-  CHECK(!reservation_active());
-  allocator_address_mapping_.reset();
-  allocator_address_reservation_.reset();
-  raw_allocation_.reset();
-}
-
 void DeviceAddressVmmAllocator::AllocationRecord::AddActiveReservationAlias(
-    DeviceAddressBase reservation_address,
     MemoryReservation::ScopedMapping reservation_address_mapping) {
   CHECK(!has_reservation_alias());
-  CHECK(!reservation_address.is_null());
-  reservation_address_ = reservation_address;
-  reservation_address_mapping_.emplace(std::move(reservation_address_mapping));
-  reservation_state_ = ReservationState::kActive;
+  CHECK(!reservation_address_mapping.is_null());
+  reservation_alias_.emplace(
+      ReservationAlias{std::move(reservation_address_mapping)});
 }
 
 void DeviceAddressVmmAllocator::AllocationRecord::MarkReservationStale(
     uint64_t seqno) {
   CHECK(reservation_active());
-  CHECK(!reservation_stale());
-  CHECK(has_reservation_address());
-  CHECK(reservation_address_mapping_.has_value());
   CHECK_NE(seqno, 0);
-  reservation_state_ = ReservationState::kStale;
-  reservation_stale_seqno_ = seqno;
+  reservation_alias_->stale_seqno = seqno;
 }
 
 void DeviceAddressVmmAllocator::AllocationRecord::ReactivateReservation() {
-  CHECK(!reservation_active());
   CHECK(reservation_stale());
-  CHECK(has_reservation_address());
-  CHECK(reservation_address_mapping_.has_value());
-  reservation_state_ = ReservationState::kActive;
-  reservation_stale_seqno_ = 0;
+  reservation_alias_->stale_seqno = 0;
 }
 
 void DeviceAddressVmmAllocator::AllocationRecord::CompleteStaleReservation() {
   if (!reservation_stale()) {
     return;
   }
-  CHECK(!reservation_active());
-  CHECK(has_reservation_address());
-  reservation_address_mapping_.reset();
-  reservation_address_.reset();
-  reservation_state_ = ReservationState::kNone;
-  reservation_stale_seqno_ = 0;
+  reservation_alias_.reset();
 }
 
 // Interval between CPU polls of the GPU-written deallocation timeline while
@@ -525,7 +497,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationWithSeparateAddress(
     if (!record.reservation_stale()) {
       continue;
     }
-    CHECK(record.has_reservation_address());
+    CHECK(record.has_reservation_alias());
     // The allocator address can be reused for command-buffer update-free
     // execution only if the external reservation VA is also the same VA the
     // command buffer captured.
@@ -664,8 +636,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
       AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
       std::move(raw_alloc), std::move(allocator_address_reservation),
       std::move(allocator_address_mapping), request.multi_device);
-  record->AddActiveReservationAlias(request.reservation_address,
-                                    std::move(reservation_address_mapping));
+  record->AddActiveReservationAlias(std::move(reservation_address_mapping));
   AllocationRecord* record_ptr = record.get();
   auto record_insert = state.records_by_allocator_address.emplace(
       allocator_va, std::move(record));
@@ -984,7 +955,7 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   AllocationRecord& record = *record_it->second;
   CHECK(!state->active_reservation_records.contains(mem.opaque()));
   if (record.reservation_active()) {
-    CHECK(record.has_reservation_address());
+    CHECK(record.has_reservation_alias());
     return absl::FailedPreconditionError(absl::StrFormat(
         "Deallocate() requires the active reservation alias at virtual address "
         "%p (%uB) to be released with UnMap() first",
@@ -1009,7 +980,6 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   // mapping alive as stale state until the stream reaches `seqno`.
   CHECK(record.allocator_active());
   CHECK(!record.allocator_stale());
-  CHECK(record.has_allocator_address_mapping());
   void* allocator_va = record.allocator_key();
   auto allocator_record_it =
       state->records_by_allocator_address.find(allocator_va);
@@ -1094,7 +1064,7 @@ DeviceAddressVmmAllocator::FindOverlappingRecord(
   }
   if (include_reservation && include_active) {
     for (const auto& [_, record] : state.active_reservation_records) {
-      CHECK(record->has_reservation_address());
+      CHECK(record->has_reservation_alias());
       if (auto overlap = check_record(record, record->reservation_address(),
                                       /*is_allocator=*/false,
                                       /*is_active=*/true)) {
@@ -1104,7 +1074,7 @@ DeviceAddressVmmAllocator::FindOverlappingRecord(
   }
   if (include_reservation && include_stale) {
     for (const auto& [_, record] : state.stale_reservation_records) {
-      CHECK(record->has_reservation_address());
+      CHECK(record->has_reservation_alias());
       if (auto overlap = check_record(record, record->reservation_address(),
                                       /*is_allocator=*/false,
                                       /*is_active=*/false)) {
@@ -1196,7 +1166,7 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
       }
 
       if (source_record->reservation_stale()) {
-        CHECK(source_record->has_reservation_address());
+        CHECK(source_record->has_reservation_alias());
         if (!source_record->reservation_matches(request.reservation_address)) {
           pending_completion_key =
               PendingDeallocationKey{PendingDeallocationKind::kMap,
@@ -1215,7 +1185,7 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
           // A deferred UnMap() leaves the old mapping valid. Reuse it when it
           // aliases the requested physical allocation; otherwise wait before
           // overwriting it.
-          CHECK(stale_record.has_reservation_address());
+          CHECK(stale_record.has_reservation_alias());
           CHECK(stale_record.reservation_matches(request.reservation_address));
           if (stale_record.raw_allocation() ==
               source_record->raw_allocation()) {
@@ -1260,7 +1230,7 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
 
         CHECK(!source_record->reservation_active());
         CHECK(!source_record->reservation_stale());
-        source_record->AddActiveReservationAlias(mapped, std::move(mapping));
+        source_record->AddActiveReservationAlias(std::move(mapping));
         auto mapping_insert_result = state.active_reservation_records.emplace(
             mapped.opaque(), source_record);
         CHECK(mapping_insert_result.second);
@@ -1333,7 +1303,6 @@ void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
     PerDeviceState& state, AllocationRecord& record, uint64_t new_size) {
   CHECK(!record.allocator_active());
   CHECK(record.allocator_stale());
-  CHECK(record.has_allocator_address_mapping());
   void* allocator_va = record.allocator_key();
   auto record_it = state.records_by_allocator_address.find(allocator_va);
   CHECK(record_it != state.records_by_allocator_address.end());
@@ -1345,7 +1314,7 @@ void DeviceAddressVmmAllocator::MoveReservationRecordToStale(
     PerDeviceState& state, AllocationRecord& record, uint64_t seqno) {
   CHECK(record.reservation_active());
   CHECK(!record.reservation_stale());
-  CHECK(record.has_reservation_address());
+  CHECK(record.has_reservation_alias());
   void* reservation_va = record.reservation_key();
   CHECK_EQ(state.active_reservation_records.erase(reservation_va), 1);
   auto insert_result =
@@ -1358,7 +1327,7 @@ void DeviceAddressVmmAllocator::MoveReservationRecordToActive(
     PerDeviceState& state, AllocationRecord& record) {
   CHECK(!record.reservation_active());
   CHECK(record.reservation_stale());
-  CHECK(record.has_reservation_address());
+  CHECK(record.has_reservation_alias());
   void* reservation_va = record.reservation_key();
   CHECK_EQ(state.stale_reservation_records.erase(reservation_va), 1);
   auto insert_result =
@@ -1373,7 +1342,7 @@ void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
     return;
   }
   CHECK(!record.reservation_active());
-  CHECK(record.has_reservation_address());
+  CHECK(record.has_reservation_alias());
   void* reservation_va = record.reservation_key();
   auto stale_it = state.stale_reservation_records.find(reservation_va);
   if (stale_it != state.stale_reservation_records.end()) {
@@ -1472,7 +1441,7 @@ absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleOverlap(
                                       record.allocator_address()});
   }
   CHECK(overlap.record->reservation_stale());
-  CHECK(overlap.record->has_reservation_address());
+  CHECK(overlap.record->has_reservation_alias());
   return WaitAndCompleteStaleReservationMapping(
       state, PendingDeallocationKey{PendingDeallocationKind::kMap,
                                     overlap.record->reservation_stale_seqno(),
@@ -1504,7 +1473,7 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
   CHECK(!record.allocator_active());
   CHECK(!record.reservation_active());
   if (record.reservation_stale()) {
-    CHECK(record.has_reservation_address());
+    CHECK(record.has_reservation_alias());
     PendingDeallocationKey reservation_key{PendingDeallocationKind::kMap,
                                            record.reservation_stale_seqno(),
                                            record.reservation_address()};
@@ -1529,7 +1498,6 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
     DCHECK_GE(state.pa_allocated, released_size);
     state.pa_allocated -= released_size;
   }
-  record.CompleteStaleAllocator();
   CHECK_EQ(state.records_by_allocator_address.erase(allocator_va), 1);
 }
 
@@ -1559,7 +1527,7 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
     auto stale_it =
         state->stale_reservation_records.find(reservation_address.opaque());
     if (stale_it != state->stale_reservation_records.end()) {
-      CHECK(stale_it->second->has_reservation_address());
+      CHECK(stale_it->second->has_reservation_alias());
     }
     if (stale_it != state->stale_reservation_records.end() &&
         stale_it->second->reservation_matches(reservation_address)) {
@@ -1577,14 +1545,12 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
   AllocationRecord* record = active_it->second;
   CHECK(record->reservation_active());
   CHECK(!record->reservation_stale());
-  CHECK(record->has_reservation_address());
+  CHECK(record->has_reservation_alias());
   if (!record->reservation_matches(reservation_address)) {
     return absl::InvalidArgumentError(
         "DeviceAddressVmmAllocator::UnMap requires the same full reservation "
         "range passed to Map");
   }
-  CHECK(record->reservation_mapping_matches(reservation_address));
-
   uint64_t seqno = state->next_seqno++;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
   MoveReservationRecordToStale(*state, *record, seqno);

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -324,10 +324,12 @@ MemoryAllocation* DeviceAddressVmmAllocator::GetRawAllocation(
   }
 
   // Reservation aliases created by Map() or by Allocate(...,
-  // return_reservation_address=false) are tracked in a separate active-only
-  // index. Stale or already-unmapped aliases intentionally return nullptr.
-  auto reservation_it = state->active_reservation_records.find(addr.opaque());
-  if (reservation_it != state->active_reservation_records.end()) {
+  // return_reservation_address=false) share one index. Only active aliases are
+  // exposed; stale or already-unmapped aliases intentionally return nullptr.
+  auto reservation_it = state->reservation_records.find(addr.opaque());
+  if (reservation_it != state->reservation_records.end() &&
+      reservation_it->second->reservation_active() &&
+      reservation_it->second->reservation_matches(addr)) {
     return reservation_it->second->raw_allocation();
   }
   return nullptr;
@@ -521,7 +523,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationWithSeparateAddress(
     // reservation VA. This cancels the pending allocator teardown and the
     // paired pending kMap unmap for the reservation mapping.
     MoveAllocatorRecordToActive(state, record, request.allocation_size);
-    MoveReservationRecordToActive(state, record);
+    record.ReactivateReservation();
     ErasePendingDeallocationAt(state, it);
     ErasePendingDeallocation(state, PendingDeallocationKind::kMap,
                              request.reservation_address);
@@ -641,7 +643,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
   auto record_insert = state.records_by_allocator_address.emplace(
       allocator_va, std::move(record));
   CHECK(record_insert.second);
-  auto reservation_insert = state.active_reservation_records.emplace(
+  auto reservation_insert = state.reservation_records.emplace(
       request.reservation_address.opaque(), record_ptr);
   CHECK(reservation_insert.second);
   state.pa_allocated += physical_size;
@@ -953,7 +955,9 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
         mem.opaque()));
   }
   AllocationRecord& record = *record_it->second;
-  CHECK(!state->active_reservation_records.contains(mem.opaque()));
+  auto reservation_it = state->reservation_records.find(mem.opaque());
+  CHECK(reservation_it == state->reservation_records.end() ||
+        !reservation_it->second->reservation_active());
   if (record.reservation_active()) {
     CHECK(record.has_reservation_alias());
     return absl::FailedPreconditionError(absl::StrFormat(
@@ -1062,22 +1066,17 @@ DeviceAddressVmmAllocator::FindOverlappingRecord(
       }
     }
   }
-  if (include_reservation && include_active) {
-    for (const auto& [_, record] : state.active_reservation_records) {
+  if (include_reservation) {
+    for (const auto& [_, record] : state.reservation_records) {
       CHECK(record->has_reservation_alias());
-      if (auto overlap = check_record(record, record->reservation_address(),
-                                      /*is_allocator=*/false,
-                                      /*is_active=*/true)) {
-        return overlap;
+      bool include_record = (include_active && record->reservation_active()) ||
+                            (include_stale && record->reservation_stale());
+      if (!include_record) {
+        continue;
       }
-    }
-  }
-  if (include_reservation && include_stale) {
-    for (const auto& [_, record] : state.stale_reservation_records) {
-      CHECK(record->has_reservation_alias());
-      if (auto overlap = check_record(record, record->reservation_address(),
-                                      /*is_allocator=*/false,
-                                      /*is_active=*/false)) {
+      if (auto overlap = check_record(
+              record, record->reservation_address(), /*is_allocator=*/false,
+              /*is_active=*/record->reservation_active())) {
         return overlap;
       }
     }
@@ -1189,7 +1188,7 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
           CHECK(stale_record.reservation_matches(request.reservation_address));
           if (stale_record.raw_allocation() ==
               source_record->raw_allocation()) {
-            MoveReservationRecordToActive(state, stale_record);
+            stale_record.ReactivateReservation();
             ErasePendingDeallocation(state, PendingDeallocationKind::kMap,
                                      request.reservation_address);
             return absl::OkStatus();
@@ -1231,8 +1230,8 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
         CHECK(!source_record->reservation_active());
         CHECK(!source_record->reservation_stale());
         source_record->AddActiveReservationAlias(std::move(mapping));
-        auto mapping_insert_result = state.active_reservation_records.emplace(
-            mapped.opaque(), source_record);
+        auto mapping_insert_result =
+            state.reservation_records.emplace(mapped.opaque(), source_record);
         CHECK(mapping_insert_result.second);
         return absl::OkStatus();
       }
@@ -1310,32 +1309,6 @@ void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
   record.ReactivateAllocator(new_size);
 }
 
-void DeviceAddressVmmAllocator::MoveReservationRecordToStale(
-    PerDeviceState& state, AllocationRecord& record, uint64_t seqno) {
-  CHECK(record.reservation_active());
-  CHECK(!record.reservation_stale());
-  CHECK(record.has_reservation_alias());
-  void* reservation_va = record.reservation_key();
-  CHECK_EQ(state.active_reservation_records.erase(reservation_va), 1);
-  auto insert_result =
-      state.stale_reservation_records.emplace(reservation_va, &record);
-  CHECK(insert_result.second);
-  record.MarkReservationStale(seqno);
-}
-
-void DeviceAddressVmmAllocator::MoveReservationRecordToActive(
-    PerDeviceState& state, AllocationRecord& record) {
-  CHECK(!record.reservation_active());
-  CHECK(record.reservation_stale());
-  CHECK(record.has_reservation_alias());
-  void* reservation_va = record.reservation_key();
-  CHECK_EQ(state.stale_reservation_records.erase(reservation_va), 1);
-  auto insert_result =
-      state.active_reservation_records.emplace(reservation_va, &record);
-  CHECK(insert_result.second);
-  record.ReactivateReservation();
-}
-
 void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
     PerDeviceState& state, AllocationRecord& record) {
   if (!record.reservation_stale()) {
@@ -1344,11 +1317,10 @@ void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
   CHECK(!record.reservation_active());
   CHECK(record.has_reservation_alias());
   void* reservation_va = record.reservation_key();
-  auto stale_it = state.stale_reservation_records.find(reservation_va);
-  if (stale_it != state.stale_reservation_records.end()) {
-    CHECK_EQ(stale_it->second, &record);
-    state.stale_reservation_records.erase(stale_it);
-  }
+  auto reservation_it = state.reservation_records.find(reservation_va);
+  CHECK(reservation_it != state.reservation_records.end());
+  CHECK_EQ(reservation_it->second, &record);
+  state.reservation_records.erase(reservation_it);
   record.CompleteStaleReservation();
 }
 
@@ -1451,9 +1423,9 @@ absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleOverlap(
 void DeviceAddressVmmAllocator::CompletePendingDeallocation(
     PerDeviceState& state, const PendingDeallocation& pending) {
   if (pending.kind == PendingDeallocationKind::kMap) {
-    auto record_it =
-        state.stale_reservation_records.find(pending.addr.opaque());
-    CHECK(record_it != state.stale_reservation_records.end());
+    auto record_it = state.reservation_records.find(pending.addr.opaque());
+    CHECK(record_it != state.reservation_records.end());
+    CHECK(record_it->second->reservation_stale());
     CHECK_EQ(record_it->second->reservation_stale_seqno(), pending.seqno);
     CompleteStaleReservationMapping(state, *record_it->second);
     return;
@@ -1521,16 +1493,19 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
   // UnMap() only accepts the exact active reservation range previously created
   // by Map() or Allocate(..., return_reservation_address=false). Allocator
   // addresses and subranges are not valid UnMap() inputs.
-  auto active_it =
-      state->active_reservation_records.find(reservation_address.opaque());
-  if (active_it == state->active_reservation_records.end()) {
-    auto stale_it =
-        state->stale_reservation_records.find(reservation_address.opaque());
-    if (stale_it != state->stale_reservation_records.end()) {
-      CHECK(stale_it->second->has_reservation_alias());
-    }
-    if (stale_it != state->stale_reservation_records.end() &&
-        stale_it->second->reservation_matches(reservation_address)) {
+  auto reservation_it =
+      state->reservation_records.find(reservation_address.opaque());
+  if (reservation_it == state->reservation_records.end()) {
+    return absl::NotFoundError(absl::StrFormat(
+        "UnMap() requires an exact active reservation range created by Map() "
+        "or Allocate(..., return_reservation_address=false): virtual address "
+        "%p (%uB)",
+        reservation_address.opaque(), reservation_address.size()));
+  }
+  AllocationRecord* record = reservation_it->second;
+  CHECK(record->has_reservation_alias());
+  if (record->reservation_stale()) {
+    if (record->reservation_matches(reservation_address)) {
       return absl::FailedPreconditionError(absl::StrFormat(
           "reservation range at virtual address %p (%uB) is already pending "
           "UnMap()",
@@ -1542,10 +1517,7 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
         "%p (%uB)",
         reservation_address.opaque(), reservation_address.size()));
   }
-  AllocationRecord* record = active_it->second;
   CHECK(record->reservation_active());
-  CHECK(!record->reservation_stale());
-  CHECK(record->has_reservation_alias());
   if (!record->reservation_matches(reservation_address)) {
     return absl::InvalidArgumentError(
         "DeviceAddressVmmAllocator::UnMap requires the same full reservation "
@@ -1553,7 +1525,7 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
   }
   uint64_t seqno = state->next_seqno++;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
-  MoveReservationRecordToStale(*state, *record, seqno);
+  record->MarkReservationStale(seqno);
   state->pending_deallocations.push_back(
       PendingDeallocation{PendingDeallocationKind::kMap, seqno,
                           reservation_address, /*reclaimable_bytes=*/0});

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -98,20 +98,6 @@ DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
   CHECK(!allocator_address_mapping_.is_null());
 }
 
-DeviceAddressVmmAllocator::PendingDeallocationKind
-DeviceAddressVmmAllocator::AllocationRecord::pending_deallocation_kind() const {
-  switch (kind_) {
-    case Kind::kAllocate:
-      return PendingDeallocationKind::kAllocate;
-    case Kind::kAllocateAndMapReturnMapAddr:
-      return PendingDeallocationKind::kAllocateAndMapReturnMapAddr;
-    case Kind::kAllocateAndMapReturnNewAddr:
-      return PendingDeallocationKind::kAllocateAndMapReturnNewAddr;
-  }
-  LOG(FATAL) << "Unknown AllocationRecord kind";
-  return PendingDeallocationKind::kAllocate;
-}
-
 DeviceAddressBase
 DeviceAddressVmmAllocator::AllocationRecord::reservation_address() const {
   CHECK(has_reservation_alias());
@@ -295,8 +281,15 @@ absl::Status DeviceAddressVmmAllocator::SynchronizePendingOperations(
   if (state->pending_deallocations.empty()) {
     return absl::OkStatus();
   }
-  return WaitAndDrainPendingDeallocationsUntilSeqno(
-      *state, state->pending_deallocations.back().seqno);
+  uint64_t target_seqno = state->pending_deallocations.back().seqno;
+  WaitUntilSeqno(*state, target_seqno);
+  while (!state->pending_deallocations.empty() &&
+         state->pending_deallocations.front().seqno <= target_seqno) {
+    PendingDeallocation pending = state->pending_deallocations.front();
+    state->pending_deallocations.pop_front();
+    CompletePendingDeallocation(*state, pending);
+  }
+  return absl::OkStatus();
 }
 
 absl::StatusOr<StreamExecutor*> DeviceAddressVmmAllocator::GetStreamExecutor(
@@ -433,8 +426,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationAtReservationAddress(
   if (!record.allocator_stale()) {
     return std::nullopt;
   }
-  if (record.pending_deallocation_kind() !=
-      PendingDeallocationKind::kAllocateAndMapReturnMapAddr) {
+  if (record.kind() != AllocationRecord::Kind::kAllocateAndMapReturnMapAddr) {
     return std::nullopt;
   }
   if (record.multi_device() != request.multi_device) {
@@ -449,10 +441,9 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationAtReservationAddress(
   // for the new request, wait for the old mapping to drain so the fresh path
   // can remap this reservation VA to a larger raw allocation.
   if (record.raw_allocation()->address().size() < request.allocation_size) {
-    RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
-        state, PendingDeallocationKey{record.pending_deallocation_kind(),
-                                      record.allocator_stale_seqno(),
-                                      record.allocator_address()}));
+    uint64_t seqno = record.allocator_stale_seqno();
+    WaitUntilSeqno(state, seqno);
+    CompletePendingDeallocationBySeqno(state, seqno);
     return std::nullopt;
   }
 
@@ -462,7 +453,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationAtReservationAddress(
   // it while leaving explicit pending kMap entries untouched.
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
-    if (it->kind == PendingDeallocationKind::kAllocateAndMapReturnMapAddr &&
+    if (it->kind == PendingDeallocationKind::kAllocation &&
         it->addr.IsSameAs(request.reservation_address)) {
       pending_it = it;
       break;
@@ -483,7 +474,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationWithSeparateAddress(
   // and its reservation side exactly matches this request.
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
-    if (it->kind != PendingDeallocationKind::kAllocateAndMapReturnNewAddr) {
+    if (it->kind != PendingDeallocationKind::kAllocation) {
       continue;
     }
     auto record_it = state.records_by_allocator_address.find(it->addr.opaque());
@@ -491,8 +482,9 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationWithSeparateAddress(
     AllocationRecord& record = *record_it->second;
     CHECK(record.allocator_stale());
     CHECK(record.allocator_matches(it->addr));
-    CHECK_EQ(record.pending_deallocation_kind(),
-             PendingDeallocationKind::kAllocateAndMapReturnNewAddr);
+    if (record.kind() != AllocationRecord::Kind::kAllocateAndMapReturnNewAddr) {
+      continue;
+    }
     if (record.multi_device() != request.multi_device) {
       continue;
     }
@@ -510,10 +502,9 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocationWithSeparateAddress(
       // The old mapping is the right VA but not enough physical memory. Wait
       // for its deferred teardown to finish, then let the fresh path create a
       // larger allocation and install a new mapping.
-      RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
-          state, PendingDeallocationKey{record.pending_deallocation_kind(),
-                                        record.allocator_stale_seqno(),
-                                        record.allocator_address()}));
+      uint64_t seqno = record.allocator_stale_seqno();
+      WaitUntilSeqno(state, seqno);
+      CompletePendingDeallocationBySeqno(state, seqno);
       return std::nullopt;
     }
 
@@ -548,13 +539,24 @@ DeviceAddressVmmAllocator::EnsureReservationAvailableForFreshMapping(
     // VA is still protected by stream order. Complete only that conflicting
     // stale record, then rescan because another thread may have changed the
     // allocator state while the lock was released.
-    auto stale_overlap = FindOverlappingRecord(
-        state, request.reservation_address, AddressRole::kBoth,
-        RecordState::kStale, OverlapKind::kExact);
-    if (!stale_overlap.has_value()) {
+    uint64_t pending_completion_seqno = 0;
+    {
+      auto stale_overlap = FindOverlappingRecord(
+          state, request.reservation_address, AddressRole::kBoth,
+          RecordState::kStale, OverlapKind::kExact);
+      if (stale_overlap.has_value()) {
+        CHECK(!stale_overlap->is_active);
+        AllocationRecord& record = *stale_overlap->record;
+        pending_completion_seqno =
+            stale_overlap->is_allocator ? record.allocator_stale_seqno()
+                                        : record.reservation_stale_seqno();
+      }
+    }
+    if (pending_completion_seqno == 0) {
       break;
     }
-    RETURN_IF_ERROR(WaitAndCompleteStaleOverlap(state, *stale_overlap));
+    WaitUntilSeqno(state, pending_completion_seqno);
+    CompletePendingDeallocationBySeqno(state, pending_completion_seqno);
   }
 
   // At this point stale exact overlaps have been drained. Any remaining
@@ -730,7 +732,7 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
       uint64_t accumulated_size = 0;
       uint64_t rounded_size = RoundUpToGranularity(state, reclaim_size);
       uint64_t target_seqno = 0;
-      std::vector<PendingDeallocationKey> selected;
+      std::vector<uint64_t> selected;
 
       // Target 1.1x the requested size to provide some headroom.
       uint64_t target_size = rounded_size + rounded_size / 10;
@@ -745,20 +747,21 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
         CHECK(record_it->second->allocator_stale());
         CHECK(record_it->second->allocator_matches(pending.addr));
         CHECK(record_it->second->raw_allocation() != nullptr);
-        accumulated_size += RoundUpToGranularity(
-            state, record_it->second->raw_allocation()->address().size());
+        uint64_t reclaimable_bytes =
+            record_it->second->raw_allocation()->address().size();
+        CHECK_GT(reclaimable_bytes, 0);
+        accumulated_size += reclaimable_bytes;
         target_seqno = std::max(target_seqno, pending.seqno);
-        selected.push_back(
-            PendingDeallocationKey{pending.kind, pending.seqno, pending.addr});
+        selected.push_back(pending.seqno);
         if (accumulated_size >= target_size) {
           break;
         }
       }
 
       if (!selected.empty()) {
-        RETURN_IF_ERROR(WaitUntilSeqno(state, target_seqno));
-        for (const PendingDeallocationKey& key : selected) {
-          CompletePendingDeallocationByKey(state, key);
+        WaitUntilSeqno(state, target_seqno);
+        for (uint64_t seqno : selected) {
+          CompletePendingDeallocationBySeqno(state, seqno);
         }
       }
     }
@@ -768,8 +771,8 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
   return result;
 }
 
-// Allocate() reuses pending kAllocate entries, otherwise tries a fresh
-// allocator-address mapping.
+// Allocate() reuses compatible pending regular-allocation records, otherwise
+// tries a fresh allocator-address mapping.
 absl::StatusOr<ScopedDeviceAddress<uint8_t>>
 DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
                                     bool /*retry_on_failure*/,
@@ -791,7 +794,7 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
     uint64_t rounded_size = RoundUpToGranularity(*state, size);
     for (auto it = state->pending_deallocations.begin();
          it != state->pending_deallocations.end(); ++it) {
-      if (it->kind != PendingDeallocationKind::kAllocate) {
+      if (it->kind != PendingDeallocationKind::kAllocation) {
         continue;
       }
       auto record_it =
@@ -800,6 +803,9 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
       AllocationRecord& record = *record_it->second;
       CHECK(record.allocator_stale());
       CHECK(record.allocator_matches(it->addr));
+      if (record.kind() != AllocationRecord::Kind::kAllocate) {
+        continue;
+      }
       if (record.multi_device() != multi_device) {
         continue;
       }
@@ -972,9 +978,6 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
       "on device ordinal %d",
       mem.opaque(), mem.size(), state->executor->device_ordinal());
 
-  const uint64_t reclaimable_bytes =
-      record.raw_allocation()->address().size();
-
   // Assign the next sequence number and enqueue a GPU write to the pinned
   // timeline when the stream reaches this point. The CPU polls the timeline
   // value to know when it is safe to free the memory.
@@ -990,9 +993,8 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   CHECK(allocator_record_it != state->records_by_allocator_address.end());
   CHECK_EQ(allocator_record_it->second.get(), &record);
   record.MarkAllocatorStale(seqno);
-  state->pending_deallocations.push_back(
-      PendingDeallocation{record.pending_deallocation_kind(), seqno,
-                          record.allocator_address(), reclaimable_bytes});
+  state->pending_deallocations.push_back(PendingDeallocation{
+      PendingDeallocationKind::kAllocation, seqno, record.allocator_address()});
   return absl::OkStatus();
 }
 
@@ -1134,7 +1136,7 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
   // a third attempt can install or reuse the requested mapping.
   constexpr int kMaxStaleMappingWaits = 2;
   for (int wait_count = 0;; ++wait_count) {
-    std::optional<PendingDeallocationKey> pending_completion_key;
+    uint64_t pending_completion_seqno = 0;
     {
       // Keep record pointers inside this scope so none survives a wait that
       // releases state.mu.
@@ -1167,14 +1169,12 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
       if (source_record->reservation_stale()) {
         CHECK(source_record->has_reservation_alias());
         if (!source_record->reservation_matches(request.reservation_address)) {
-          pending_completion_key =
-              PendingDeallocationKey{PendingDeallocationKind::kMap,
-                                     source_record->reservation_stale_seqno(),
-                                     source_record->reservation_address()};
+          pending_completion_seqno =
+              source_record->reservation_stale_seqno();
         }
       }
 
-      if (!pending_completion_key.has_value()) {
+      if (pending_completion_seqno == 0) {
         auto stale_reservation_overlap = FindOverlappingRecord(
             state, request.reservation_address, AddressRole::kReservation,
             RecordState::kStale, OverlapKind::kExact);
@@ -1193,27 +1193,21 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
                                      request.reservation_address);
             return absl::OkStatus();
           }
-          pending_completion_key =
-              PendingDeallocationKey{PendingDeallocationKind::kMap,
-                                     stale_record.reservation_stale_seqno(),
-                                     stale_record.reservation_address()};
+          pending_completion_seqno = stale_record.reservation_stale_seqno();
         }
       }
 
-      if (!pending_completion_key.has_value()) {
+      if (pending_completion_seqno == 0) {
         auto stale_allocator_overlap = FindOverlappingRecord(
             state, request.reservation_address, AddressRole::kAllocator,
             RecordState::kStale, OverlapKind::kExact);
         if (stale_allocator_overlap.has_value()) {
           AllocationRecord& stale_record = *stale_allocator_overlap->record;
-          pending_completion_key =
-              PendingDeallocationKey{stale_record.pending_deallocation_kind(),
-                                     stale_record.allocator_stale_seqno(),
-                                     stale_record.allocator_address()};
+          pending_completion_seqno = stale_record.allocator_stale_seqno();
         }
       }
 
-      if (!pending_completion_key.has_value()) {
+      if (pending_completion_seqno == 0) {
         // Map() aliases the beginning of the source allocation into the
         // caller's VA slice. No physical allocation or PA accounting is added.
         ASSIGN_OR_RETURN(
@@ -1242,14 +1236,9 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
       }
     }
 
-    CHECK(pending_completion_key.has_value());
-    if (pending_completion_key->kind == PendingDeallocationKind::kMap) {
-      RETURN_IF_ERROR(WaitAndCompleteStaleReservationMapping(
-          state, *pending_completion_key));
-    } else {
-      RETURN_IF_ERROR(WaitAndCompleteStaleAllocatorDeallocation(
-          state, *pending_completion_key));
-    }
+    CHECK_NE(pending_completion_seqno, 0);
+    WaitUntilSeqno(state, pending_completion_seqno);
+    CompletePendingDeallocationBySeqno(state, pending_completion_seqno);
   }
 }
 
@@ -1309,23 +1298,8 @@ void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
   record.ReactivateAllocator(new_size);
 }
 
-void DeviceAddressVmmAllocator::CompleteStaleReservationMapping(
-    PerDeviceState& state, AllocationRecord& record) {
-  if (!record.reservation_stale()) {
-    return;
-  }
-  CHECK(!record.reservation_active());
-  CHECK(record.has_reservation_alias());
-  void* reservation_va = record.reservation_key();
-  auto reservation_it = state.reservation_records.find(reservation_va);
-  CHECK(reservation_it != state.reservation_records.end());
-  CHECK_EQ(reservation_it->second, &record);
-  state.reservation_records.erase(reservation_it);
-  record.CompleteStaleReservation();
-}
-
-absl::Status DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
-                                                       uint64_t target_seqno) {
+void DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
+                                               uint64_t target_seqno) {
   // Release the lock before spin-waiting to avoid stalling other threads for
   // potentially milliseconds while the GPU drains its work queue.
   state.mu.unlock();
@@ -1338,86 +1312,34 @@ absl::Status DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
   }
 
   state.mu.lock();
-  return absl::OkStatus();
-}
-
-absl::Status
-DeviceAddressVmmAllocator::WaitAndDrainPendingDeallocationsUntilSeqno(
-    PerDeviceState& state, uint64_t target_seqno) {
-  RETURN_IF_ERROR(WaitUntilSeqno(state, target_seqno));
-  while (!state.pending_deallocations.empty() &&
-         state.pending_deallocations.front().seqno <= target_seqno) {
-    PendingDeallocation pending = state.pending_deallocations.front();
-    state.pending_deallocations.pop_front();
-    CompletePendingDeallocation(state, pending);
-  }
-  return absl::OkStatus();
 }
 
 void DeviceAddressVmmAllocator::CompleteReadyAllocatorDeallocationsForReclaim(
     PerDeviceState& state, uint64_t completed_seqno) {
-  std::vector<PendingDeallocationKey> selected;
+  std::vector<uint64_t> selected;
   for (const PendingDeallocation& pending : state.pending_deallocations) {
     if (pending.seqno > completed_seqno ||
         pending.kind == PendingDeallocationKind::kMap) {
       continue;
     }
-    selected.push_back(
-        PendingDeallocationKey{pending.kind, pending.seqno, pending.addr});
+    selected.push_back(pending.seqno);
   }
-  for (const PendingDeallocationKey& key : selected) {
-    CompletePendingDeallocationByKey(state, key);
+  for (uint64_t seqno : selected) {
+    CompletePendingDeallocationBySeqno(state, seqno);
   }
 }
 
-bool DeviceAddressVmmAllocator::CompletePendingDeallocationByKey(
-    PerDeviceState& state, const PendingDeallocationKey& key) {
+void DeviceAddressVmmAllocator::CompletePendingDeallocationBySeqno(
+    PerDeviceState& state, uint64_t seqno) {
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
-    if (it->kind == key.kind && it->seqno == key.seqno &&
-        it->addr.IsSameAs(key.addr)) {
+    if (it->seqno == seqno) {
       PendingDeallocation pending = *it;
       state.pending_deallocations.erase(it);
       CompletePendingDeallocation(state, pending);
-      return true;
+      return;
     }
   }
-  return false;
-}
-
-absl::Status
-DeviceAddressVmmAllocator::WaitAndCompleteStaleAllocatorDeallocation(
-    PerDeviceState& state, const PendingDeallocationKey& key) {
-  CHECK_NE(key.kind, PendingDeallocationKind::kMap);
-  RETURN_IF_ERROR(WaitUntilSeqno(state, key.seqno));
-  CompletePendingDeallocationByKey(state, key);
-  return absl::OkStatus();
-}
-
-absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleReservationMapping(
-    PerDeviceState& state, const PendingDeallocationKey& key) {
-  CHECK_EQ(key.kind, PendingDeallocationKind::kMap);
-  RETURN_IF_ERROR(WaitUntilSeqno(state, key.seqno));
-  CompletePendingDeallocationByKey(state, key);
-  return absl::OkStatus();
-}
-
-absl::Status DeviceAddressVmmAllocator::WaitAndCompleteStaleOverlap(
-    PerDeviceState& state, const OverlappingRecord& overlap) {
-  CHECK(!overlap.is_active);
-  if (overlap.is_allocator) {
-    AllocationRecord& record = *overlap.record;
-    return WaitAndCompleteStaleAllocatorDeallocation(
-        state, PendingDeallocationKey{record.pending_deallocation_kind(),
-                                      record.allocator_stale_seqno(),
-                                      record.allocator_address()});
-  }
-  CHECK(overlap.record->reservation_stale());
-  CHECK(overlap.record->has_reservation_alias());
-  return WaitAndCompleteStaleReservationMapping(
-      state, PendingDeallocationKey{PendingDeallocationKind::kMap,
-                                    overlap.record->reservation_stale_seqno(),
-                                    overlap.record->reservation_address()});
 }
 
 void DeviceAddressVmmAllocator::CompletePendingDeallocation(
@@ -1425,18 +1347,22 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
   if (pending.kind == PendingDeallocationKind::kMap) {
     auto record_it = state.reservation_records.find(pending.addr.opaque());
     CHECK(record_it != state.reservation_records.end());
-    CHECK(record_it->second->reservation_stale());
-    CHECK_EQ(record_it->second->reservation_stale_seqno(), pending.seqno);
-    CompleteStaleReservationMapping(state, *record_it->second);
+    AllocationRecord& record = *record_it->second;
+    CHECK(record.reservation_stale());
+    CHECK_EQ(record.reservation_stale_seqno(), pending.seqno);
+    CHECK(record.has_reservation_alias());
+    CHECK_EQ(record.reservation_key(), pending.addr.opaque());
+    state.reservation_records.erase(record_it);
+    record.CompleteStaleReservation();
     return;
   }
 
   auto record_it =
       state.records_by_allocator_address.find(pending.addr.opaque());
   CHECK(record_it != state.records_by_allocator_address.end());
+  CHECK_EQ(pending.kind, PendingDeallocationKind::kAllocation);
   CHECK(record_it->second->allocator_stale());
   CHECK(record_it->second->allocator_matches(pending.addr));
-  CHECK_EQ(record_it->second->pending_deallocation_kind(), pending.kind);
   CHECK_EQ(record_it->second->allocator_stale_seqno(), pending.seqno);
   // Complete allocator-address teardown. If this allocation still has an
   // explicitly unmapped stale reservation alias, drop that mapping first, then
@@ -1446,19 +1372,8 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
   CHECK(!record.reservation_active());
   if (record.reservation_stale()) {
     CHECK(record.has_reservation_alias());
-    PendingDeallocationKey reservation_key{PendingDeallocationKind::kMap,
-                                           record.reservation_stale_seqno(),
-                                           record.reservation_address()};
-    for (auto it = state.pending_deallocations.begin();
-         it != state.pending_deallocations.end(); ++it) {
-      if (it->kind == reservation_key.kind &&
-          it->seqno == reservation_key.seqno &&
-          it->addr.IsSameAs(reservation_key.addr)) {
-        state.pending_deallocations.erase(it);
-        break;
-      }
-    }
-    CompleteStaleReservationMapping(state, record);
+    CompletePendingDeallocationBySeqno(state, record.reservation_stale_seqno());
+    CHECK(!record.has_reservation_alias());
   }
   void* allocator_va = record.allocator_key();
   auto owning_record_it = state.records_by_allocator_address.find(allocator_va);
@@ -1526,9 +1441,8 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
   uint64_t seqno = state->next_seqno++;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
   record->MarkReservationStale(seqno);
-  state->pending_deallocations.push_back(
-      PendingDeallocation{PendingDeallocationKind::kMap, seqno,
-                          reservation_address, /*reclaimable_bytes=*/0});
+  state->pending_deallocations.push_back(PendingDeallocation{
+      PendingDeallocationKind::kMap, seqno, reservation_address});
   return absl::OkStatus();
 }
 

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -302,20 +302,11 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
  protected:
   enum class PendingDeallocationKind {
-    // Deferred Deallocate() of an Allocate() result backed by an
-    // allocator-owned reservation.
-    kAllocate,
-    // Deferred Deallocate() of an
-    // Allocate(..., return_reservation_address=true) result. The allocator
-    // address is a caller-owned reservation range.
-    kAllocateAndMapReturnMapAddr,
-    // Deferred Deallocate() of an
-    // Allocate(..., return_reservation_address=false) result. The record has
-    // an allocator-owned returned address and may also have a non-owning caller
-    // reservation mapping to unmap.
-    kAllocateAndMapReturnNewAddr,
-    // Deferred completion of a Map()-owned reservation address. The reservation
-    // address is a non-owning alias of an existing raw allocation.
+    // Deferred Deallocate() of any Allocate() result. AllocationRecord::kind()
+    // identifies the API mode that created the allocation.
+    kAllocation,
+    // Deferred completion of a reservation alias created by Map() or mapped
+    // Allocate(). The reservation address does not own the raw allocation.
     kMap,
   };
 
@@ -347,7 +338,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     AllocationRecord& operator=(AllocationRecord&&) = default;
 
     Kind kind() const { return kind_; }
-    PendingDeallocationKind pending_deallocation_kind() const;
     DeviceAddressBase allocator_address() const { return allocator_address_; }
     void* allocator_key() const { return allocator_address_.opaque(); }
     bool allocator_active() const { return allocator_stale_seqno_ == 0; }
@@ -413,25 +403,12 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // live in AllocationRecord; this entry only says which stale address becomes
   // safe to complete when the GPU timeline reaches `seqno`.
   struct PendingDeallocation {
-    PendingDeallocationKind kind = PendingDeallocationKind::kAllocate;
+    PendingDeallocationKind kind = PendingDeallocationKind::kAllocation;
     // GPU stream sequence number recorded at deallocation time. When the
     // pinned_timeline value reaches this seqno, the memory is safe to free.
     uint64_t seqno = 0;
     // Allocator address for allocation deallocations; reservation address for
     // kMap.
-    DeviceAddressBase addr;
-    // Physical-allocation bytes charged to the PA budget that become
-    // reclaimable when this pending operation completes. kMap entries do not
-    // own physical memory and therefore use zero.
-    uint64_t reclaimable_bytes = 0;
-  };
-
-  // Stable identity for a pending operation. Iterators into
-  // pending_deallocations must not be kept across waits because
-  // WaitUntilSeqno() releases state.mu.
-  struct PendingDeallocationKey {
-    PendingDeallocationKind kind = PendingDeallocationKind::kAllocate;
-    uint64_t seqno = 0;
     DeviceAddressBase addr;
   };
 
@@ -671,21 +648,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
                                    AllocationRecord& record, uint64_t new_size)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  void CompleteStaleReservationMapping(PerDeviceState& state,
-                                       AllocationRecord& record)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
   // Waits for the device timeline to reach `target_seqno`. Temporarily releases
   // and reacquires state.mu around the blocking wait. This does not complete
   // pending entries by itself.
-  absl::Status WaitUntilSeqno(PerDeviceState& state, uint64_t target_seqno)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Waits for pending operations through `target_seqno`, then completes all
-  // still-pending operations up to that sequence. Used only when preserving
-  // stale mappings for future reuse is no longer useful.
-  absl::Status WaitAndDrainPendingDeallocationsUntilSeqno(PerDeviceState& state,
-                                                          uint64_t target_seqno)
+  void WaitUntilSeqno(PerDeviceState& state, uint64_t target_seqno)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Completes ready allocator-address deallocations for PA reclaim while
@@ -703,28 +669,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Finds, erases, and completes the selected pending entry if it is still
-  // present. Returns false if another thread already reused or completed it
-  // while state.mu was released.
-  bool CompletePendingDeallocationByKey(PerDeviceState& state,
-                                        const PendingDeallocationKey& key)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Waits for and completes the selected allocator-address deallocation, if it
-  // is still pending after the wait.
-  absl::Status WaitAndCompleteStaleAllocatorDeallocation(
-      PerDeviceState& state, const PendingDeallocationKey& key)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Waits for and completes a stale reservation-address mapping queued by
-  // UnMap().
-  absl::Status WaitAndCompleteStaleReservationMapping(
-      PerDeviceState& state, const PendingDeallocationKey& key)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Completes only the stale allocator or reservation mapping that conflicts
-  // with the current request, leaving unrelated stale mappings reusable.
-  absl::Status WaitAndCompleteStaleOverlap(PerDeviceState& state,
-                                           const OverlappingRecord& overlap)
+  // present. Sequence numbers uniquely identify operations on a device; another
+  // thread may already have reused or completed the entry while state.mu was
+  // released.
+  void CompletePendingDeallocationBySeqno(PerDeviceState& state, uint64_t seqno)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Device ordinal -> per-device allocator state. Populated at construction by

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -475,12 +475,11 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     absl::flat_hash_map<void*, std::unique_ptr<AllocationRecord>>
         records_by_allocator_address ABSL_GUARDED_BY(mu);
 
-    // Active/stale reservation-address indexes. Keys are reservation alias
-    // pointers (`AllocationRecord::reservation_address().opaque()`) created by
-    // Map() or by Allocate(..., return_reservation_address=false).
-    absl::flat_hash_map<void*, AllocationRecord*> active_reservation_records
-        ABSL_GUARDED_BY(mu);
-    absl::flat_hash_map<void*, AllocationRecord*> stale_reservation_records
+    // Reservation-address index. Keys are reservation alias pointers
+    // (`AllocationRecord::reservation_address().opaque()`) created by Map() or
+    // by Allocate(..., return_reservation_address=false). Active/stale state is
+    // stored in the record.
+    absl::flat_hash_map<void*, AllocationRecord*> reservation_records
         ABSL_GUARDED_BY(mu);
   };
 
@@ -670,14 +669,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   void MoveAllocatorRecordToActive(PerDeviceState& state,
                                    AllocationRecord& record, uint64_t new_size)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  void MoveReservationRecordToStale(PerDeviceState& state,
-                                    AllocationRecord& record, uint64_t seqno)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  void MoveReservationRecordToActive(PerDeviceState& state,
-                                     AllocationRecord& record)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   void CompleteStaleReservationMapping(PerDeviceState& state,

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -335,17 +335,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       kAllocateAndMapReturnNewAddr,
     };
 
-    enum class AllocatorState {
-      kActive,
-      kStale,
-    };
-
-    enum class ReservationState {
-      kNone,
-      kActive,
-      kStale,
-    };
-
     AllocationRecord(
         Kind kind, DeviceAddressBase allocator_address,
         std::unique_ptr<MemoryAllocation> raw_allocation,
@@ -361,12 +350,8 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     PendingDeallocationKind pending_deallocation_kind() const;
     DeviceAddressBase allocator_address() const { return allocator_address_; }
     void* allocator_key() const { return allocator_address_.opaque(); }
-    bool allocator_active() const {
-      return allocator_state_ == AllocatorState::kActive;
-    }
-    bool allocator_stale() const {
-      return allocator_state_ == AllocatorState::kStale;
-    }
+    bool allocator_active() const { return allocator_stale_seqno_ == 0; }
+    bool allocator_stale() const { return !allocator_active(); }
     bool allocator_matches(DeviceAddressBase address) const {
       return allocator_address_.IsSameAs(address);
     }
@@ -376,45 +361,37 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     MemoryReservation* allocator_address_reservation() const {
       return allocator_address_reservation_.get();
     }
-    bool has_allocator_address_mapping() const {
-      return allocator_address_mapping_.has_value();
-    }
-
     bool has_reservation_alias() const {
-      return reservation_state_ != ReservationState::kNone;
+      return reservation_alias_.has_value();
     }
     bool reservation_active() const {
-      return reservation_state_ == ReservationState::kActive;
+      return has_reservation_alias() && reservation_alias_->stale_seqno == 0;
     }
     bool reservation_stale() const {
-      return reservation_state_ == ReservationState::kStale;
-    }
-    bool has_reservation_address() const {
-      return reservation_address_.has_value();
+      return has_reservation_alias() && reservation_alias_->stale_seqno != 0;
     }
     DeviceAddressBase reservation_address() const;
     void* reservation_key() const { return reservation_address().opaque(); }
     bool reservation_matches(DeviceAddressBase address) const {
-      return has_reservation_address() &&
-             reservation_address_->IsSameAs(address);
+      return has_reservation_alias() && reservation_address().IsSameAs(address);
     }
-    uint64_t reservation_stale_seqno() const {
-      return reservation_stale_seqno_;
-    }
-    bool reservation_mapping_matches(DeviceAddressBase address) const;
+    uint64_t reservation_stale_seqno() const;
 
     void MarkAllocatorStale(uint64_t seqno);
     void ReactivateAllocator(uint64_t new_size);
-    void CompleteStaleAllocator();
-
     void AddActiveReservationAlias(
-        DeviceAddressBase reservation_address,
         MemoryReservation::ScopedMapping reservation_address_mapping);
     void MarkReservationStale(uint64_t seqno);
     void ReactivateReservation();
     void CompleteStaleReservation();
 
    private:
+    struct ReservationAlias {
+      MemoryReservation::ScopedMapping mapping;
+      // Zero while active; the deferred UnMap() sequence number while stale.
+      uint64_t stale_seqno = 0;
+    };
+
     Kind kind_;
     DeviceAddressBase allocator_address_;
     std::unique_ptr<MemoryAllocation> raw_allocation_;
@@ -423,18 +400,13 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     // Present for Allocate() and
     // Allocate(..., return_reservation_address=false).
     std::unique_ptr<MemoryReservation> allocator_address_reservation_;
-    // Present while the allocator address is active or stale.
-    std::optional<MemoryReservation::ScopedMapping> allocator_address_mapping_;
+    // Present for the lifetime of the allocation record.
+    MemoryReservation::ScopedMapping allocator_address_mapping_;
 
     // Present while a reservation alias is active or stale.
-    std::optional<DeviceAddressBase> reservation_address_;
-    std::optional<MemoryReservation::ScopedMapping>
-        reservation_address_mapping_;
+    std::optional<ReservationAlias> reservation_alias_;
 
-    AllocatorState allocator_state_ = AllocatorState::kActive;
-    ReservationState reservation_state_ = ReservationState::kNone;
     uint64_t allocator_stale_seqno_ = 0;
-    uint64_t reservation_stale_seqno_ = 0;
   };
 
   // Queue entry for a stream-ordered deferred operation. The heavy resources


### PR DESCRIPTION
This is part 3 of a four-PR stack split from #45323 and is stacked on #45414. It contains the original commits 8–10 unchanged. PR #45323 and its branch remain unchanged.

Stack:

1. #45413 — tests and physical-allocation accounting
2. #45414 — map resolution
3. **#45415 — record bookkeeping (this PR)**
4. #45416 — allocation paths and final cleanup

📝 Summary of Changes

- Simplify VMM allocation-record state.
- Unify reservation-record indexing.
- Identify pending VMM operations by sequence number.

🎯 Justification

The allocator represented related lifecycle state in several overlapping fields and lookup paths. This layer gives record indexing and pending-operation identity a smaller, more consistent model.

🚀 Kind of Contribution

♻️ Cleanup

📊 Benchmark (for Performance Improvements)

Not applicable; this is a behavior-preserving cleanup rather than a performance change.

🧪 Unit Tests:

No new test is introduced in this layer. It is covered by the allocator tests added in #45413.

- PASS at `7d61027700c4`: `bazel test //xla/stream_executor:device_address_vmm_allocator_test --test_output=errors`.

🧪 Execution Tests:

No new execution test; this layer does not change GPU execution behavior.
