### PR TITLE
[XLA:SE] Consolidate VMM allocator mapped allocation paths

### DIFF
--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -16,7 +16,6 @@ limitations under the License.
 #include "xla/stream_executor/device_address_vmm_allocator.h"
 
 #include <algorithm>
-#include <cstddef>
 #include <cstdint>
 #include <deque>
 #include <limits>
@@ -25,7 +24,6 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -67,9 +65,8 @@ DeviceAddressVmmAllocator::DeviceAssignmentScope::~DeviceAssignmentScope() {
 bool DeviceAddressVmmAllocator::CurrentMultiDevice() {
   const xla::DeviceAssignment* device_assignment = current_device_assignment;
   return device_assignment != nullptr &&
-         device_assignment->replica_count() *
-                 device_assignment->computation_count() >
-             1;
+         (device_assignment->replica_count() > 1 ||
+          device_assignment->computation_count() > 1);
 }
 
 DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
@@ -86,6 +83,7 @@ DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
       allocator_address_mapping_(std::move(allocator_address_mapping)) {
   CHECK(raw_allocation_ != nullptr);
   CHECK(!allocator_address_.is_null());
+  CHECK_GT(raw_allocation_->address().size(), 0);
   switch (kind_) {
     case Kind::kAllocate:
     case Kind::kAllocateAndMapReturnNewAddr:
@@ -147,9 +145,7 @@ void DeviceAddressVmmAllocator::AllocationRecord::ReactivateReservation() {
 }
 
 void DeviceAddressVmmAllocator::AllocationRecord::CompleteStaleReservation() {
-  if (!reservation_stale()) {
-    return;
-  }
+  CHECK(reservation_stale());
   reservation_alias_.reset();
 }
 
@@ -201,9 +197,9 @@ absl::Status DeviceAddressVmmAllocator::PopulateDevices(
   for (const DeviceConfig& cfg : devices) {
     DCHECK_NE(cfg.executor, nullptr);
     DCHECK_NE(cfg.stream, nullptr);
+    DCHECK_EQ(cfg.stream->parent(), cfg.executor);
     int ordinal = cfg.executor->device_ordinal();
-    DCHECK(seen_ordinals.insert(ordinal).second)
-        << "Duplicate device ordinal: " << ordinal;
+    DCHECK(seen_ordinals.insert(ordinal).second);
   }
 
   for (const DeviceConfig& cfg : devices) {
@@ -218,7 +214,9 @@ absl::Status DeviceAddressVmmAllocator::PopulateDevices(
 
     VLOG(3) << "DeviceAddressVmmAllocator: registering device " << ordinal
             << " with pa_budget " << cfg.pa_budget;
-    allocator->per_device_.emplace(ordinal, std::move(state));
+    auto insert_result =
+        allocator->per_device_.emplace(ordinal, std::move(state));
+    CHECK(insert_result.second);
   }
 
   return absl::OkStatus();
@@ -495,9 +493,12 @@ DeviceAddressVmmAllocator::EnsureReservationAvailableForFreshMapping(
       if (stale_overlap.has_value()) {
         CHECK(!stale_overlap->is_active);
         AllocationRecord& record = *stale_overlap->record;
-        pending_completion_seqno = stale_overlap->is_allocator
-                                       ? record.allocator_stale_seqno()
-                                       : record.reservation_stale_seqno();
+        if (stale_overlap->is_allocator) {
+          pending_completion_seqno = record.allocator_stale_seqno();
+        } else {
+          CHECK(record.reservation_stale());
+          pending_completion_seqno = record.reservation_stale_seqno();
+        }
       }
     }
     if (pending_completion_seqno == 0) {
@@ -572,44 +573,9 @@ DeviceAddressVmmAllocator::CreateMappedAllocation(
   return allocator_address;
 }
 
-// Shared pending-reclaim retry flow:
-//
-// TryWithPendingReclaim(reclaim_size, try_reuse, try_fresh)
-//           │
-//           ▼
-// ┌─────────────────────────────────┐
-// │ try_reuse()                     │──found──► return reused address
-// └─────────────────────────────────┘
-//           │ not found
-//           ▼
-// ┌─────────────────────────────────┐
-// │ try_fresh()                     │──OK──► return fresh address
-// └─────────────────────────────────┘
-//           │ ResourceExhausted
-//           ▼
-// ┌─────────────────────────────────┐
-// │ Process completed pending       │
-// │ operations                      │
-// └─────────────────────────────────┘
-//           │
-//           ▼
-// ┌─────────────────────────────────┐
-// │ try_fresh()                     │──OK──► return fresh address
-// └─────────────────────────────────┘
-//           │ ResourceExhausted
-//           ▼
-// ┌─────────────────────────────────┐
-// │ Wait for pending operations     │
-// │ to reclaim enough memory        │
-// └─────────────────────────────────┘
-//           │
-//           ▼
-// ┌─────────────────────────────────┐
-// │ try_fresh()                     │──OK──► return fresh address
-// └─────────────────────────────────┘
-//           │ failed
-//           ▼
-//       return error
+// Reuses compatible pending state before trying a fresh allocation. On a
+// ResourceExhausted failure, first reclaim completed work, then wait for enough
+// queued allocator deallocations and try once more.
 template <typename TryReuseFn, typename TryFreshFn>
 absl::StatusOr<DeviceAddressBase>
 DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
@@ -628,7 +594,6 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
   // calls should finish here; the reclaim paths below are only for PA budget
   // pressure or allocator-level allocation failures.
   absl::StatusOr<DeviceAddressBase> result = try_fresh();
-
   if (absl::IsResourceExhausted(result.status())) {
     // A ResourceExhausted error may be stale: some pending deallocations can
     // already be past their stream timeline point. Complete ready allocator
@@ -647,41 +612,37 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
     // request, then wait for the selected tail seqno to become safe. Unrelated
     // kMap entries do not own physical memory, so leave them stale and
     // reusable.
-    if (!state.pending_deallocations.empty()) {
-      uint64_t accumulated_size = 0;
-      uint64_t rounded_size = RoundUpToGranularity(state, reclaim_size);
-      uint64_t target_seqno = 0;
-      std::vector<uint64_t> selected;
+    uint64_t accumulated_size = 0;
+    uint64_t rounded_size = RoundUpToGranularity(state, reclaim_size);
+    uint64_t target_seqno = 0;
+    std::vector<uint64_t> selected;
 
-      // Target 1.1x the requested size to provide some headroom.
-      uint64_t target_size = rounded_size + rounded_size / 10;
+    // Target 1.1x the requested size to provide some headroom.
+    uint64_t target_size = rounded_size + rounded_size / 10;
 
-      for (const PendingDeallocation& pending : state.pending_deallocations) {
-        if (pending.kind == PendingDeallocationKind::kMap) {
-          continue;
-        }
-        auto record_it =
-            state.records_by_allocator_address.find(pending.addr.opaque());
-        CHECK(record_it != state.records_by_allocator_address.end());
-        CHECK(record_it->second->allocator_stale());
-        CHECK(record_it->second->allocator_matches(pending.addr));
-        CHECK(record_it->second->raw_allocation() != nullptr);
-        uint64_t reclaimable_bytes =
-            record_it->second->raw_allocation()->address().size();
-        CHECK_GT(reclaimable_bytes, 0);
-        accumulated_size += reclaimable_bytes;
-        target_seqno = std::max(target_seqno, pending.seqno);
-        selected.push_back(pending.seqno);
-        if (accumulated_size >= target_size) {
-          break;
-        }
+    for (const PendingDeallocation& pending : state.pending_deallocations) {
+      if (pending.kind == PendingDeallocationKind::kMap) {
+        continue;
       }
+      auto record_it =
+          state.records_by_allocator_address.find(pending.addr.opaque());
+      CHECK(record_it != state.records_by_allocator_address.end());
+      CHECK(record_it->second->allocator_stale());
+      uint64_t reclaimable_bytes =
+          record_it->second->raw_allocation()->address().size();
+      CHECK_GT(reclaimable_bytes, 0);
+      accumulated_size += reclaimable_bytes;
+      target_seqno = std::max(target_seqno, pending.seqno);
+      selected.push_back(pending.seqno);
+      if (accumulated_size >= target_size) {
+        break;
+      }
+    }
 
-      if (!selected.empty()) {
-        WaitUntilSeqno(state, target_seqno);
-        for (uint64_t seqno : selected) {
-          CompletePendingDeallocationBySeqno(state, seqno);
-        }
+    if (!selected.empty()) {
+      WaitUntilSeqno(state, target_seqno);
+      for (uint64_t seqno : selected) {
+        CompletePendingDeallocationBySeqno(state, seqno);
       }
     }
     result = try_fresh();
@@ -882,13 +843,6 @@ absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
   // Move the returned allocator address out of active ownership and keep its
   // mapping alive as stale state until the stream reaches `seqno`.
-  CHECK(record.allocator_active());
-  CHECK(!record.allocator_stale());
-  void* allocator_va = record.allocator_key();
-  auto allocator_record_it =
-      state->records_by_allocator_address.find(allocator_va);
-  CHECK(allocator_record_it != state->records_by_allocator_address.end());
-  CHECK_EQ(allocator_record_it->second.get(), &record);
   record.MarkAllocatorStale(seqno);
   state->pending_deallocations.push_back(PendingDeallocation{
       PendingDeallocationKind::kAllocation, seqno, record.allocator_address()});
@@ -951,7 +905,6 @@ DeviceAddressVmmAllocator::FindOverlappingRecord(
   if (include_allocator) {
     for (const auto& [_, record_owner] : state.records_by_allocator_address) {
       AllocationRecord* record = record_owner.get();
-      CHECK_NE(record->allocator_active(), record->allocator_stale());
       bool include_record = (include_active && record->allocator_active()) ||
                             (include_stale && record->allocator_stale());
       if (!include_record) {
@@ -1117,8 +1070,6 @@ absl::Status DeviceAddressVmmAllocator::ResolveAndMapAlias(
             << request.reservation_address.opaque()
             << ", actual=" << mapped.opaque();
 
-        CHECK(!source_record->reservation_active());
-        CHECK(!source_record->reservation_stale());
         source_record->AddActiveReservationAlias(std::move(mapping));
         auto mapping_insert_result =
             state.reservation_records.emplace(mapped.opaque(), source_record);
@@ -1185,8 +1136,6 @@ void DeviceAddressVmmAllocator::ErasePendingDeallocation(
 
 void DeviceAddressVmmAllocator::MoveAllocatorRecordToActive(
     PerDeviceState& state, AllocationRecord& record, uint64_t new_size) {
-  CHECK(!record.allocator_active());
-  CHECK(record.allocator_stale());
   void* allocator_va = record.allocator_key();
   auto record_it = state.records_by_allocator_address.find(allocator_va);
   CHECK(record_it != state.records_by_allocator_address.end());
@@ -1264,24 +1213,17 @@ void DeviceAddressVmmAllocator::CompletePendingDeallocation(
   // explicitly unmapped stale reservation alias, drop that mapping first, then
   // release allocator VA state and physical allocation accounting.
   AllocationRecord& record = *record_it->second;
-  CHECK(!record.allocator_active());
   CHECK(!record.reservation_active());
   if (record.reservation_stale()) {
     CHECK(record.has_reservation_alias());
     CompletePendingDeallocationBySeqno(state, record.reservation_stale_seqno());
     CHECK(!record.has_reservation_alias());
   }
-  void* allocator_va = record.allocator_key();
-  auto owning_record_it = state.records_by_allocator_address.find(allocator_va);
-  CHECK(owning_record_it != state.records_by_allocator_address.end());
-  CHECK_EQ(owning_record_it->second.get(), &record);
-
-  if (record.raw_allocation() != nullptr) {
-    uint64_t released_size = record.raw_allocation()->address().size();
-    DCHECK_GE(state.pa_allocated, released_size);
-    state.pa_allocated -= released_size;
-  }
-  CHECK_EQ(state.records_by_allocator_address.erase(allocator_va), 1);
+  uint64_t physical_size = record.raw_allocation()->address().size();
+  CHECK_GT(physical_size, 0);
+  CHECK_GE(state.pa_allocated, physical_size);
+  state.pa_allocated -= physical_size;
+  state.records_by_allocator_address.erase(record_it);
 }
 
 absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
@@ -1334,6 +1276,7 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
         "DeviceAddressVmmAllocator::UnMap requires the same full reservation "
         "range passed to Map");
   }
+
   uint64_t seqno = state->next_seqno++;
   RETURN_IF_ERROR(EnqueueDeferredDeallocation(*state, seqno));
   record->MarkReservationStale(seqno);

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -410,117 +410,63 @@ void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
   return va_ptr;
 }
 
-absl::StatusOr<std::optional<DeviceAddressBase>>
-DeviceAddressVmmAllocator::TryReuseMappedAllocationAtReservationAddress(
+std::optional<DeviceAddressBase>
+DeviceAddressVmmAllocator::TryReuseMappedAllocation(
     PerDeviceState& state, const MappedAllocateRequest& request) {
-  // Look for a pending deallocation that already owns the requested
-  // reservation VA as its returned allocator address. Reusing it keeps the
-  // same virtual address mapped and avoids waiting for the GPU timeline when
-  // the pending raw allocation is compatible with this request.
-  auto record_it = state.records_by_allocator_address.find(
-      request.reservation_address.opaque());
-  if (record_it == state.records_by_allocator_address.end()) {
-    return std::nullopt;
-  }
-  AllocationRecord& record = *record_it->second;
-  if (!record.allocator_stale()) {
-    return std::nullopt;
-  }
-  if (record.kind() != AllocationRecord::Kind::kAllocateAndMapReturnMapAddr) {
-    return std::nullopt;
-  }
-  if (record.multi_device() != request.multi_device) {
-    return std::nullopt;
-  }
-  if (!record.allocator_matches(request.reservation_address)) {
-    return std::nullopt;
+  const bool separate_address =
+      request.mode == MappedAddressMode::kSeparateAllocatorAddress;
+  AllocationRecord* record;
+  if (separate_address) {
+    auto record_it =
+        state.reservation_records.find(request.reservation_address.opaque());
+    if (record_it == state.reservation_records.end()) {
+      return std::nullopt;
+    }
+    record = record_it->second;
+  } else {
+    auto record_it = state.records_by_allocator_address.find(
+        request.reservation_address.opaque());
+    if (record_it == state.records_by_allocator_address.end()) {
+      return std::nullopt;
+    }
+    record = record_it->second.get();
   }
 
-  // Allocate(..., return_reservation_address=true) returns the reservation VA
-  // as an owning allocator address. If the pending raw allocation is too small
-  // for the new request, wait for the old mapping to drain so the fresh path
-  // can remap this reservation VA to a larger raw allocation.
-  if (record.raw_allocation()->address().size() < request.allocation_size) {
-    uint64_t seqno = record.allocator_stale_seqno();
-    WaitUntilSeqno(state, seqno);
-    CompletePendingDeallocationBySeqno(state, seqno);
+  AllocationRecord::Kind expected_kind =
+      separate_address ? AllocationRecord::Kind::kAllocateAndMapReturnNewAddr
+                       : AllocationRecord::Kind::kAllocateAndMapReturnMapAddr;
+  bool address_matches =
+      separate_address
+          ? record->reservation_matches(request.reservation_address)
+          : record->allocator_matches(request.reservation_address);
+  if (record->kind() != expected_kind || !record->allocator_stale() ||
+      record->multi_device() != request.multi_device || !address_matches ||
+      (separate_address && !record->reservation_stale())) {
     return std::nullopt;
   }
 
   auto pending_it = state.pending_deallocations.end();
-  // The record is indexed by allocator address, but the FIFO queue owns the
-  // stream-ordered allocator teardown. Find the queue entry so reuse can cancel
-  // it while leaving explicit pending kMap entries untouched.
   for (auto it = state.pending_deallocations.begin();
        it != state.pending_deallocations.end(); ++it) {
     if (it->kind == PendingDeallocationKind::kAllocation &&
-        it->addr.IsSameAs(request.reservation_address)) {
+        it->addr.IsSameAs(record->allocator_address())) {
       pending_it = it;
       break;
     }
   }
   CHECK(pending_it != state.pending_deallocations.end());
-  MoveAllocatorRecordToActive(state, record, request.allocation_size);
+
+  DeviceAddressBase reused_mem(record->allocator_key(), request.size);
+  MoveAllocatorRecordToActive(state, *record, request.size);
+  if (separate_address) {
+    record->ReactivateReservation();
+  }
   ErasePendingDeallocationAt(state, pending_it);
-  return request.reservation_address;
-}
-
-absl::StatusOr<std::optional<DeviceAddressBase>>
-DeviceAddressVmmAllocator::TryReuseMappedAllocationWithSeparateAddress(
-    PerDeviceState& state, const MappedAllocateRequest& request) {
-  // This mode returns a distinct allocator-owned VA while also mapping that
-  // allocation into the caller-owned reservation. Reuse is possible only when
-  // a pending kAllocateAndMapReturnNewAddr record still has both sides stale
-  // and its reservation side exactly matches this request.
-  for (auto it = state.pending_deallocations.begin();
-       it != state.pending_deallocations.end(); ++it) {
-    if (it->kind != PendingDeallocationKind::kAllocation) {
-      continue;
-    }
-    auto record_it = state.records_by_allocator_address.find(it->addr.opaque());
-    CHECK(record_it != state.records_by_allocator_address.end());
-    AllocationRecord& record = *record_it->second;
-    CHECK(record.allocator_stale());
-    CHECK(record.allocator_matches(it->addr));
-    if (record.kind() != AllocationRecord::Kind::kAllocateAndMapReturnNewAddr) {
-      continue;
-    }
-    if (record.multi_device() != request.multi_device) {
-      continue;
-    }
-    if (!record.reservation_stale()) {
-      continue;
-    }
-    CHECK(record.has_reservation_alias());
-    // The allocator address can be reused for command-buffer update-free
-    // execution only if the external reservation VA is also the same VA the
-    // command buffer captured.
-    if (!record.reservation_matches(request.reservation_address)) {
-      continue;
-    }
-    if (record.raw_allocation()->address().size() < request.allocation_size) {
-      // The old mapping is the right VA but not enough physical memory. Wait
-      // for its deferred teardown to finish, then let the fresh path create a
-      // larger allocation and install a new mapping.
-      uint64_t seqno = record.allocator_stale_seqno();
-      WaitUntilSeqno(state, seqno);
-      CompletePendingDeallocationBySeqno(state, seqno);
-      return std::nullopt;
-    }
-
-    DeviceAddressBase reused_mem(record.allocator_key(),
-                                 request.allocation_size);
-    // Reactivate both aliases: the returned allocator VA and the external
-    // reservation VA. This cancels the pending allocator teardown and the
-    // paired pending kMap unmap for the reservation mapping.
-    MoveAllocatorRecordToActive(state, record, request.allocation_size);
-    record.ReactivateReservation();
-    ErasePendingDeallocationAt(state, it);
+  if (separate_address) {
     ErasePendingDeallocation(state, PendingDeallocationKind::kMap,
                              request.reservation_address);
-    return reused_mem;
   }
-  return std::nullopt;
+  return reused_mem;
 }
 
 absl::Status
@@ -581,20 +527,19 @@ DeviceAddressVmmAllocator::CreateMappedAllocationAtReservationAddress(
   // record is keyed by that VA and owns only the raw allocation plus the scoped
   // mapping into the external reservation.
   uint64_t physical_size = 0;
-  ASSIGN_OR_RETURN(auto raw_alloc,
-                   AllocatePhysicalWithinBudget(state, request.allocation_size,
-                                                physical_size));
-  if (request.mapping_size > physical_size) {
+  ASSIGN_OR_RETURN(auto raw_alloc, AllocatePhysicalWithinBudget(
+                                       state, request.size, physical_size));
+  if (request.size > physical_size) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "physical allocation is smaller than requested mapping: "
         "allocation_size=%uB, mapping_size=%uB",
-        physical_size, request.mapping_size));
+        physical_size, request.size));
   }
 
   ASSIGN_OR_RETURN(auto scoped_mapping, request.reservation->MapTo(
                                             request.reservation_offset,
                                             /*allocation_offset=*/0,
-                                            request.mapping_size, *raw_alloc));
+                                            request.size, *raw_alloc));
   TrackAllocatorAddressMappedAllocation(
       state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
       request.reservation_address, std::move(raw_alloc), nullptr,
@@ -610,18 +555,17 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
   // VA returned to the caller, and a non-owning alias in the caller reservation
   // used by captured command buffers.
   uint64_t physical_size = 0;
-  ASSIGN_OR_RETURN(auto raw_alloc,
-                   AllocatePhysicalWithinBudget(state, request.allocation_size,
-                                                physical_size));
-  if (request.mapping_size > physical_size) {
+  ASSIGN_OR_RETURN(auto raw_alloc, AllocatePhysicalWithinBudget(
+                                       state, request.size, physical_size));
+  if (request.size > physical_size) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "mapping size must not exceed physical allocation size: "
         "mapping_size=%uB, allocation_size=%uB",
-        request.mapping_size, physical_size));
+        request.size, physical_size));
   }
 
   ASSIGN_OR_RETURN(auto allocator_address_reservation,
-                   CreateReservation(state.executor, request.allocation_size));
+                   CreateReservation(state.executor, request.size));
   ASSIGN_OR_RETURN(auto allocator_address_mapping,
                    allocator_address_reservation->MapTo(
                        /*reservation_offset=*/0, /*allocation_offset=*/0,
@@ -629,13 +573,13 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
   ASSIGN_OR_RETURN(
       auto reservation_address_mapping,
       request.reservation->MapTo(request.reservation_offset,
-                                 /*allocation_offset=*/0, request.mapping_size,
+                                 /*allocation_offset=*/0, request.size,
                                  *raw_alloc));
 
   // Record the paired allocation: the allocator-owned returned VA owns the raw
   // allocation, and the caller reservation VA is a non-owning alias.
   void* allocator_va = allocator_address_reservation->address().opaque();
-  DeviceAddressBase allocator_address(allocator_va, request.allocation_size);
+  DeviceAddressBase allocator_address(allocator_va, request.size);
   auto record = std::make_unique<AllocationRecord>(
       AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
       std::move(raw_alloc), std::move(allocator_address_reservation),
@@ -650,7 +594,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
   CHECK(reservation_insert.second);
   state.pa_allocated += physical_size;
 
-  return DeviceAddressBase(allocator_va, request.allocation_size);
+  return DeviceAddressBase(allocator_va, request.size);
 }
 
 // Shared pending-reclaim retry flow:
@@ -700,7 +644,7 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
   // First try to reactivate a compatible pending deallocation without waiting.
   // Reuse is stream-order safe and avoids both a fresh VMM allocation and any
   // host-side wait for the GPU timeline.
-  ASSIGN_OR_RETURN(std::optional<DeviceAddressBase> reused, try_reuse());
+  std::optional<DeviceAddressBase> reused = try_reuse();
   if (reused.has_value()) {
     return *reused;
   }
@@ -789,7 +733,7 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
   // Clang cannot propagate TryWithPendingReclaim's state.mu lock requirement
   // into its callbacks. AssertHeld makes that invariant explicit within each
   // independently analyzed lambda.
-  auto try_reuse = [&]() -> absl::StatusOr<std::optional<DeviceAddressBase>> {
+  auto try_reuse = [&]() -> std::optional<DeviceAddressBase> {
     state->mu.AssertHeld();
     uint64_t rounded_size = RoundUpToGranularity(*state, size);
     for (auto it = state->pending_deallocations.begin();
@@ -818,10 +762,10 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
       MoveAllocatorRecordToActive(*state, record, size);
       ErasePendingDeallocationAt(*state, it);
 
-      return std::optional<DeviceAddressBase>(reused_mem);
+      return reused_mem;
     }
 
-    return std::optional<DeviceAddressBase>();
+    return std::nullopt;
   };
   auto try_fresh = [&]() -> absl::StatusOr<DeviceAddressBase> {
     state->mu.AssertHeld();
@@ -900,25 +844,25 @@ DeviceAddressVmmAllocator::Allocate(
       DeviceAddressBase reservation_address,
       ValidateReservationRange(reservation, reservation_offset, mapping_size));
 
+  const MappedAddressMode mode =
+      return_reservation_address ? MappedAddressMode::kReservationAddress
+                                 : MappedAddressMode::kSeparateAllocatorAddress;
   const MappedAllocateRequest request{reservation,     reservation_address,
                                       allocation_size, reservation_offset,
-                                      mapping_size,    multi_device};
+                                      multi_device,    mode};
 
   absl::MutexLock lock(state->mu);
   // Clang cannot propagate TryWithPendingReclaim's state.mu lock requirement
   // into its callbacks. AssertHeld makes that invariant explicit within each
   // independently analyzed lambda; stateful work stays in annotated helpers.
-  auto try_reuse = [&]() -> absl::StatusOr<std::optional<DeviceAddressBase>> {
+  auto try_reuse = [&]() -> std::optional<DeviceAddressBase> {
     state->mu.AssertHeld();
-    if (return_reservation_address) {
-      return TryReuseMappedAllocationAtReservationAddress(*state, request);
-    }
-    return TryReuseMappedAllocationWithSeparateAddress(*state, request);
+    return TryReuseMappedAllocation(*state, request);
   };
   auto try_fresh = [&]() -> absl::StatusOr<DeviceAddressBase> {
     state->mu.AssertHeld();
     RETURN_IF_ERROR(EnsureReservationAvailableForFreshMapping(*state, request));
-    if (return_reservation_address) {
+    if (request.mode == MappedAddressMode::kReservationAddress) {
       return CreateMappedAllocationAtReservationAddress(*state, request);
     }
     return CreateMappedAllocationWithSeparateAddress(*state, request);

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -391,7 +391,8 @@ DeviceAddressVmmAllocator::AllocatePhysicalWithinBudget(
   return raw_alloc;
 }
 
-void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
+DeviceAddressVmmAllocator::AllocationRecord&
+DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
     PerDeviceState& state, AllocationRecord::Kind kind,
     DeviceAddressBase allocator_address,
     std::unique_ptr<MemoryAllocation> raw_allocation,
@@ -403,11 +404,12 @@ void* DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
   auto record = std::make_unique<AllocationRecord>(
       kind, allocator_address, std::move(raw_allocation),
       std::move(reservation), std::move(mapping), multi_device);
+  AllocationRecord* record_ptr = record.get();
   auto insert_result =
       state.records_by_allocator_address.emplace(va_ptr, std::move(record));
   CHECK(insert_result.second);
   state.pa_allocated += physical_size;
-  return va_ptr;
+  return *record_ptr;
 }
 
 std::optional<DeviceAddressBase>
@@ -521,80 +523,53 @@ DeviceAddressVmmAllocator::EnsureReservationAvailableForFreshMapping(
 }
 
 absl::StatusOr<DeviceAddressBase>
-DeviceAddressVmmAllocator::CreateMappedAllocationAtReservationAddress(
+DeviceAddressVmmAllocator::CreateMappedAllocation(
     PerDeviceState& state, const MappedAllocateRequest& request) {
-  // The returned allocator address is the caller-owned reservation VA. The
-  // record is keyed by that VA and owns only the raw allocation plus the scoped
-  // mapping into the external reservation.
   uint64_t physical_size = 0;
   ASSIGN_OR_RETURN(auto raw_alloc, AllocatePhysicalWithinBudget(
                                        state, request.size, physical_size));
-  if (request.size > physical_size) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "physical allocation is smaller than requested mapping: "
-        "allocation_size=%uB, mapping_size=%uB",
-        physical_size, request.size));
+
+  const bool separate_address =
+      request.mode == MappedAddressMode::kSeparateAllocatorAddress;
+  AllocationRecord::Kind kind =
+      AllocationRecord::Kind::kAllocateAndMapReturnMapAddr;
+  DeviceAddressBase allocator_address = request.reservation_address;
+  std::unique_ptr<MemoryReservation> allocator_address_reservation;
+  MemoryReservation::ScopedMapping allocator_address_mapping;
+
+  if (separate_address) {
+    kind = AllocationRecord::Kind::kAllocateAndMapReturnNewAddr;
+    ASSIGN_OR_RETURN(allocator_address_reservation,
+                     CreateReservation(state.executor, request.size));
+    allocator_address = DeviceAddressBase(
+        allocator_address_reservation->address().opaque(), request.size);
+    ASSIGN_OR_RETURN(allocator_address_mapping,
+                     allocator_address_reservation->MapTo(
+                         /*reservation_offset=*/0, /*allocation_offset=*/0,
+                         physical_size, *raw_alloc));
   }
 
-  ASSIGN_OR_RETURN(auto scoped_mapping, request.reservation->MapTo(
-                                            request.reservation_offset,
-                                            /*allocation_offset=*/0,
-                                            request.size, *raw_alloc));
-  TrackAllocatorAddressMappedAllocation(
-      state, AllocationRecord::Kind::kAllocateAndMapReturnMapAddr,
-      request.reservation_address, std::move(raw_alloc), nullptr,
-      std::move(scoped_mapping), request.multi_device);
+  ASSIGN_OR_RETURN(auto reservation_address_mapping,
+                   request.reservation->MapTo(request.reservation_offset,
+                                              /*allocation_offset=*/0,
+                                              request.size, *raw_alloc));
 
-  return request.reservation_address;
-}
-
-absl::StatusOr<DeviceAddressBase>
-DeviceAddressVmmAllocator::CreateMappedAllocationWithSeparateAddress(
-    PerDeviceState& state, const MappedAllocateRequest& request) {
-  // This mode creates two VAs for the same raw allocation: an allocator-owned
-  // VA returned to the caller, and a non-owning alias in the caller reservation
-  // used by captured command buffers.
-  uint64_t physical_size = 0;
-  ASSIGN_OR_RETURN(auto raw_alloc, AllocatePhysicalWithinBudget(
-                                       state, request.size, physical_size));
-  if (request.size > physical_size) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "mapping size must not exceed physical allocation size: "
-        "mapping_size=%uB, allocation_size=%uB",
-        request.size, physical_size));
+  if (!separate_address) {
+    allocator_address_mapping = std::move(reservation_address_mapping);
+    reservation_address_mapping = MemoryReservation::ScopedMapping();
   }
-
-  ASSIGN_OR_RETURN(auto allocator_address_reservation,
-                   CreateReservation(state.executor, request.size));
-  ASSIGN_OR_RETURN(auto allocator_address_mapping,
-                   allocator_address_reservation->MapTo(
-                       /*reservation_offset=*/0, /*allocation_offset=*/0,
-                       physical_size, *raw_alloc));
-  ASSIGN_OR_RETURN(
-      auto reservation_address_mapping,
-      request.reservation->MapTo(request.reservation_offset,
-                                 /*allocation_offset=*/0, request.size,
-                                 *raw_alloc));
-
-  // Record the paired allocation: the allocator-owned returned VA owns the raw
-  // allocation, and the caller reservation VA is a non-owning alias.
-  void* allocator_va = allocator_address_reservation->address().opaque();
-  DeviceAddressBase allocator_address(allocator_va, request.size);
-  auto record = std::make_unique<AllocationRecord>(
-      AllocationRecord::Kind::kAllocateAndMapReturnNewAddr, allocator_address,
-      std::move(raw_alloc), std::move(allocator_address_reservation),
+  AllocationRecord& record = TrackAllocatorAddressMappedAllocation(
+      state, kind, allocator_address, std::move(raw_alloc),
+      std::move(allocator_address_reservation),
       std::move(allocator_address_mapping), request.multi_device);
-  record->AddActiveReservationAlias(std::move(reservation_address_mapping));
-  AllocationRecord* record_ptr = record.get();
-  auto record_insert = state.records_by_allocator_address.emplace(
-      allocator_va, std::move(record));
-  CHECK(record_insert.second);
-  auto reservation_insert = state.reservation_records.emplace(
-      request.reservation_address.opaque(), record_ptr);
-  CHECK(reservation_insert.second);
-  state.pa_allocated += physical_size;
+  if (separate_address) {
+    record.AddActiveReservationAlias(std::move(reservation_address_mapping));
+    auto reservation_insert = state.reservation_records.emplace(
+        request.reservation_address.opaque(), &record);
+    CHECK(reservation_insert.second);
+  }
 
-  return DeviceAddressBase(allocator_va, request.size);
+  return allocator_address;
 }
 
 // Shared pending-reclaim retry flow:
@@ -782,26 +757,22 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
                            physical_size, *raw_alloc));
 
     DeviceAddressBase allocator_address(reservation->address().opaque(), size);
-    void* va_ptr = TrackAllocatorAddressMappedAllocation(
+    TrackAllocatorAddressMappedAllocation(
         *state, AllocationRecord::Kind::kAllocate, allocator_address,
         std::move(raw_alloc), std::move(reservation), std::move(scoped_mapping),
         multi_device);
     // Return the original requested size, not the padded size.
-    return absl::StatusOr<DeviceAddressBase>(DeviceAddressBase(va_ptr, size));
+    return absl::StatusOr<DeviceAddressBase>(allocator_address);
   };
 
-  absl::StatusOr<DeviceAddressBase> result =
-      TryWithPendingReclaim(*state, size, try_reuse, try_fresh);
-
-  if (!result.ok()) {
-    return result.status();
-  }
+  ASSIGN_OR_RETURN(DeviceAddressBase result,
+                   TryWithPendingReclaim(*state, size, try_reuse, try_fresh));
 
   VLOG(3) << absl::StreamFormat(
       "Allocated virtual address %p (%uB) on device ordinal %d",
-      result->opaque(), size, device_ordinal);
+      result.opaque(), size, device_ordinal);
 
-  return ScopedDeviceAddress<uint8_t>(*result, device_ordinal, this);
+  return ScopedDeviceAddress<uint8_t>(result, device_ordinal, this);
 }
 
 // Mapped Allocate() reuses matching pending mapped deallocations, otherwise
@@ -812,26 +783,15 @@ DeviceAddressVmmAllocator::Allocate(
     int64_t /*memory_space*/, MemoryReservation* reservation,
     uint64_t reservation_offset, uint64_t mapping_size,
     bool return_reservation_address) {
-  // Keep zero-sized mapped allocation consistent with regular Allocate(): no
-  // physical allocation or mapping is created, so the requested mapping size
-  // must also be zero.
-  if (allocation_size == 0) {
-    if (mapping_size != 0) {
-      return absl::InvalidArgumentError(
-          "mapping_size must be zero when allocation_size is zero");
-    }
-    return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
-                                        this);
-  }
-  // A mapped allocation with a nonzero physical allocation must establish a
-  // nonempty mapping into the caller-owned reservation.
-  if (mapping_size == 0) {
-    return absl::InvalidArgumentError(
-        "mapping_size must be nonzero for mapped Allocate");
-  }
   if (allocation_size != mapping_size) {
     return absl::InvalidArgumentError(
         "allocation_size must equal mapping_size for mapped Allocate");
+  }
+  // Keep zero-sized mapped allocation consistent with regular Allocate(): no
+  // physical allocation or mapping is created.
+  if (allocation_size == 0) {
+    return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
+                                        this);
   }
 
   ASSIGN_OR_RETURN(auto state, GetPerDeviceState(device_ordinal));
@@ -862,26 +822,20 @@ DeviceAddressVmmAllocator::Allocate(
   auto try_fresh = [&]() -> absl::StatusOr<DeviceAddressBase> {
     state->mu.AssertHeld();
     RETURN_IF_ERROR(EnsureReservationAvailableForFreshMapping(*state, request));
-    if (request.mode == MappedAddressMode::kReservationAddress) {
-      return CreateMappedAllocationAtReservationAddress(*state, request);
-    }
-    return CreateMappedAllocationWithSeparateAddress(*state, request);
+    return CreateMappedAllocation(*state, request);
   };
 
   // The shared retry helper handles PA-budget pressure: try reuse, try fresh,
   // complete already-finished pending work on ResourceExhausted, and finally
   // wait for enough pending deallocations only if necessary.
-  absl::StatusOr<DeviceAddressBase> result =
-      TryWithPendingReclaim(*state, allocation_size, try_reuse, try_fresh);
-
-  if (!result.ok()) {
-    return result.status();
-  }
+  ASSIGN_OR_RETURN(
+      DeviceAddressBase result,
+      TryWithPendingReclaim(*state, allocation_size, try_reuse, try_fresh));
 
   // For return_reservation_address=true this is `reservation_address`; for
   // return_reservation_address=false it is the allocator-owned address paired
   // with the reservation mapping.
-  return ScopedDeviceAddress<uint8_t>(*result, device_ordinal, this);
+  return ScopedDeviceAddress<uint8_t>(result, device_ordinal, this);
 }
 
 absl::Status DeviceAddressVmmAllocator::Deallocate(int device_ordinal,

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -314,10 +314,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   //
   // The record is owned by records_by_allocator_address while either the
   // allocator address or a reservation-address alias is active, stale, or
-  // pending completion. Active indexes are callable by public APIs. Stale
-  // indexes are no longer callable by users, but still keep mappings alive
-  // until the stream-ordered deferred operation completes or a later Allocate()
-  // or Map() reuses them.
+  // pending completion. Stale addresses are no longer callable by users, but
+  // their records keep mappings alive until the stream-ordered deferred
+  // operation completes or a later Allocate() or Map() reuses them.
   class AllocationRecord {
    public:
     enum class Kind {
@@ -334,8 +333,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
         bool multi_device);
     AllocationRecord(const AllocationRecord&) = delete;
     AllocationRecord& operator=(const AllocationRecord&) = delete;
-    AllocationRecord(AllocationRecord&&) = default;
-    AllocationRecord& operator=(AllocationRecord&&) = default;
 
     Kind kind() const { return kind_; }
     DeviceAddressBase allocator_address() const { return allocator_address_; }
@@ -351,6 +348,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     MemoryReservation* allocator_address_reservation() const {
       return allocator_address_reservation_.get();
     }
+
     bool has_reservation_alias() const {
       return reservation_alias_.has_value();
     }
@@ -369,6 +367,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
     void MarkAllocatorStale(uint64_t seqno);
     void ReactivateAllocator(uint64_t new_size);
+
     void AddActiveReservationAlias(
         MemoryReservation::ScopedMapping reservation_address_mapping);
     void MarkReservationStale(uint64_t seqno);
@@ -403,10 +402,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // live in AllocationRecord; this entry only says which stale address becomes
   // safe to complete when the GPU timeline reaches `seqno`.
   struct PendingDeallocation {
-    PendingDeallocationKind kind = PendingDeallocationKind::kAllocation;
+    PendingDeallocationKind kind;
     // GPU stream sequence number recorded at deallocation time. When the
     // pinned_timeline value reaches this seqno, the memory is safe to free.
-    uint64_t seqno = 0;
+    uint64_t seqno;
     // Allocator address for allocation deallocations; reservation address for
     // kMap.
     DeviceAddressBase addr;
@@ -556,9 +555,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Shared allocation retry policy. First calls `try_reuse` to reactivate
-  // compatible pending state without blocking, then calls `try_fresh`. On
-  // ResourceExhausted, it completes ready pending entries and, if needed, waits
-  // for enough pending frees to reclaim approximately `reclaim_size` bytes.
+  // compatible pending state without blocking, then calls `try_fresh`. A
+  // ResourceExhausted result completes ready pending entries and, if needed,
+  // waits for enough pending frees to reclaim approximately `reclaim_size`
+  // bytes.
   template <typename TryReuseFn, typename TryFreshFn>
   absl::StatusOr<DeviceAddressBase> TryWithPendingReclaim(PerDeviceState& state,
                                                           uint64_t reclaim_size,
@@ -576,10 +576,10 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       uint64_t size) const;
 
   struct OverlappingRecord {
-    AllocationRecord* record = nullptr;
+    AllocationRecord* record;
     DeviceAddressBase tracked_address;
-    bool is_allocator = false;
-    bool is_active = false;
+    bool is_allocator;
+    bool is_active;
   };
 
   enum class AddressRole { kAllocator, kReservation, kBoth };
@@ -590,9 +590,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // helpers.
   struct MapRequest {
     DeviceAddressBase source_address;
-    MemoryReservation* reservation = nullptr;
-    uint64_t reservation_offset = 0;
-    uint64_t size = 0;
+    MemoryReservation* reservation;
+    uint64_t reservation_offset;
+    uint64_t size;
     DeviceAddressBase reservation_address;
   };
 

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -525,26 +525,22 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       MemoryReservation::ScopedMapping mapping, bool multi_device)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
+  enum class MappedAddressMode {
+    kReservationAddress,
+    kSeparateAllocatorAddress,
+  };
+
   struct MappedAllocateRequest {
     MemoryReservation* reservation;
     DeviceAddressBase reservation_address;
-    uint64_t allocation_size;
+    uint64_t size;
     uint64_t reservation_offset;
-    uint64_t mapping_size;
     bool multi_device;
+    MappedAddressMode mode;
   };
 
-  // Reactivates a stale mapped allocation whose returned allocator address is
-  // the requested caller-owned reservation address.
-  absl::StatusOr<std::optional<DeviceAddressBase>>
-  TryReuseMappedAllocationAtReservationAddress(
-      PerDeviceState& state, const MappedAllocateRequest& request)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Reactivates a stale mapped allocation with both a separate allocator-owned
-  // returned address and an alias at the requested reservation address.
-  absl::StatusOr<std::optional<DeviceAddressBase>>
-  TryReuseMappedAllocationWithSeparateAddress(
+  // Reactivates a compatible stale mapped allocation.
+  std::optional<DeviceAddressBase> TryReuseMappedAllocation(
       PerDeviceState& state, const MappedAllocateRequest& request)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -515,9 +515,8 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // Records a raw allocation mapped at an owning allocator address. Takes
   // ownership of `reservation` when the allocator address was allocator-owned;
   // reservation-backed returned addresses pass nullptr here. Charges the raw
-  // allocation's committed size to the PA budget and returns the allocator VA
-  // pointer.
-  void* TrackAllocatorAddressMappedAllocation(
+  // allocation's committed size to the PA budget.
+  AllocationRecord& TrackAllocatorAddressMappedAllocation(
       PerDeviceState& state, AllocationRecord::Kind kind,
       DeviceAddressBase allocator_address,
       std::unique_ptr<MemoryAllocation> raw_allocation,
@@ -550,15 +549,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       PerDeviceState& state, const MappedAllocateRequest& request)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  // Creates a mapped allocation that uses the caller-owned reservation address
-  // as its returned allocator address.
-  absl::StatusOr<DeviceAddressBase> CreateMappedAllocationAtReservationAddress(
-      PerDeviceState& state, const MappedAllocateRequest& request)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
-
-  // Creates a mapped allocation with a separate allocator-owned returned
-  // address and a non-owning alias in the caller-owned reservation.
-  absl::StatusOr<DeviceAddressBase> CreateMappedAllocationWithSeparateAddress(
+  // Creates a mapped allocation with either the caller-owned reservation
+  // address or a separate allocator-owned address as its returned address.
+  absl::StatusOr<DeviceAddressBase> CreateMappedAllocation(
       PerDeviceState& state, const MappedAllocateRequest& request)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 


### PR DESCRIPTION
Stack:

1. #45419 — reclaim tests, PA accounting, and typed overlap filters
2. #45420 — map resolution
3. #45421 — allocation-record and pending-operation state
4. #45422 — mapped allocation reuse and creation

This is the fourth and final PR in a four-part DeviceAddressVmmAllocator cleanup stack and is stacked on #45421. PR #45323 is intentionally left unchanged.

📝 Summary of Changes

- Represent the two mapped-allocation address layouts with an explicit `MappedAddressMode` request field.
- Replace separate reservation-address and separate-address reuse helpers with one `TryReuseMappedAllocation` implementation.
- Replace the corresponding creation helpers with one `CreateMappedAllocation` implementation.
- Return the tracked allocation record directly from record installation and tighten checks around mapping, retry, and pending-reclaim transitions.
- Remove redundant helpers, branches, and state cleanup made unnecessary by the unified paths.

🎯 Justification

Mapped allocation reuse and creation previously duplicated most of their logic for two address layouts. The paths could drift in budget handling, pending reclamation, and record installation despite implementing the same lifecycle. An explicit mode keeps the layout-specific decisions visible while sharing the ownership, retry, mapping, and bookkeeping logic.

🚀 Kind of Contribution

♻️ Cleanup

📊 Benchmark (for Performance Improvements)

Not applicable; this is a behavior-preserving implementation cleanup.

🧪 Unit Tests:

No new test is introduced in this layer. It is covered by the pending-reclaim and mapping tests in #45419.

- PASS at `4bafd1101e5e`: `bazel test //xla/stream_executor:device_address_vmm_allocator_test --test_output=errors`.

🧪 Execution Tests:

No new GPU execution test; this layer unifies existing allocator implementation paths.