### PR TITLE
[XLA] Fix wrong reshape dimension in while-loop concat code motion

### DIFF
--- a/xla/service/while_loop_concat_code_motion.cc
+++ b/xla/service/while_loop_concat_code_motion.cc
@@ -908,7 +908,7 @@ absl::Status RewriteLoopWithConcatGroups(
           // Concat on existing dim. Reshape to merge the broadcast dim.
           data_shape.set_dimensions(
               operand_concat_dim,
-              data_shape.dimensions(operand_inserted_concat_dim) *
+              data_shape.dimensions(operand_concat_dim) *
                   group.elements.size());
           broadcast = body->AddInstruction(
               HloInstruction::CreateReshape(data_shape, broadcast));

--- a/xla/service/while_loop_concat_code_motion_test.cc
+++ b/xla/service/while_loop_concat_code_motion_test.cc
@@ -100,6 +100,57 @@ TEST_F(WhileLoopConcatCodeMotionTest, SimpleMotion) {
                                 op::Reshape(op::Broadcast(op::CustomCall())))));
 }
 
+TEST_F(WhileLoopConcatCodeMotionTest, SharedBroadcastOperandNonZeroConcatDim) {
+  // A grouped op with a shared operand (%ccall2) needs a broadcast+reshape, and
+  // the concat is on dimension 1 of a non-square tensor. The reshape previously
+  // used dimension 0's size (a bool index) instead of the concat dimension's
+  // size, producing a shape with the wrong element count and a CreateReshape
+  // CHECK failure. Partitioning must succeed instead.
+  constexpr absl::string_view kHloModule = R"(
+    HloModule test
+
+    %cond {
+      %param = (s32[], f32[3,5], f32[3,5]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %constant = s32[] constant(5)
+      ROOT result = pred[] compare(%gte.0, %constant), direction=LT
+    }
+
+    %body {
+      %param = (s32[], f32[3,5], f32[3,5]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = f32[3,5] get-tuple-element(%param), index=1
+      %gte.2 = f32[3,5] get-tuple-element(%param), index=2
+      %concat = f32[3,10] concatenate(%gte.1, %gte.2), dimensions={1}
+      %ccall = f32[3,10] custom-call(%concat), custom_call_target="test"
+      %slice.0 = f32[3,5] slice(%ccall), slice={[0:3], [0:5]}
+      %slice.1 = f32[3,5] slice(%ccall), slice={[0:3], [5:10]}
+      %ccall2 = f32[3,5] custom-call(), custom_call_target="test2"
+      %add.0 = f32[3,5] add(%slice.0, %ccall2)
+      %add.1 = f32[3,5] add(%slice.1, %ccall2)
+      %t0 = token[] after-all()
+      %outfeed = token[] outfeed(%slice.1, %t0)
+      %constant = s32[] constant(1)
+      %increment_iteration = s32[] add(s32[] %gte.0, s32[] %constant)
+      ROOT %loop_result = (s32[], f32[3,5], f32[3,5])
+        tuple(%increment_iteration, %add.0, %add.1)
+    }
+
+    ENTRY test_main {
+      %param.0 = f32[3,5] parameter(0)
+      %param.1 = f32[3,5] parameter(1)
+      %constant.0 = s32[] constant(0)
+      %while_init = (s32[], f32[3,5], f32[3,5]) tuple(%constant.0, %param.0, %param.1)
+      ROOT %while = (s32[], f32[3,5], f32[3,5]) while(%while_init), condition=%cond, body=%body
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          WhileLoopConcatCodeMotion(2).Run(module.get()));
+  EXPECT_TRUE(changed);
+}
+
 TEST_F(WhileLoopConcatCodeMotionTest, SimpleMotionMultipleUses) {
   constexpr absl::string_view kHloModule = R"(
     HloModule test


### PR DESCRIPTION
### Problem
`WhileLoopConcatCodeMotion` crashes with a `CreateReshape` element-count `CHECK` failure on valid HLO when a grouped op has a **shared operand** that must be broadcast and the concatenation is on a **non-zero dimension** whose size differs from dimension 0.

### Root cause
In `RewriteLoopWithConcatGroups`, when a group element's operand is shared across the group it is broadcast and then reshaped to merge the broadcast dimension into the concat dimension:

```cpp
if (!operand_inserted_concat_dim) {
  // Concat on existing dim. Reshape to merge the broadcast dim.
  data_shape.set_dimensions(
      operand_concat_dim,
      data_shape.dimensions(operand_inserted_concat_dim) *   // <-- bug
          group.elements.size());
  broadcast = body->AddInstruction(
      HloInstruction::CreateReshape(data_shape, broadcast));
}
```

`operand_inserted_concat_dim` is a `bool`. Using it as the argument to `dimensions()` reads dimension `0` (since `false == 0`) instead of the concat dimension. The new dimension size is therefore computed from the wrong dimension. When `dimensions(operand_concat_dim) != dimensions(0)`, the reshaped shape has a different element count than the broadcast, and `CreateReshape` fails its `ShapeUtil::ElementsIn` `CHECK`, aborting compilation.

The intended value is the concat dimension's own size, which is exactly the dimension being overwritten by `set_dimensions(operand_concat_dim, ...)`.

### Fix
Read the size of `operand_concat_dim`, not dimension 0:

```cpp
data_shape.set_dimensions(
    operand_concat_dim,
    data_shape.dimensions(operand_concat_dim) * group.elements.size());
```

When the concat is on dimension 0 (the case the existing tests cover) the two indices coincide, so this is a no-op there and only corrects the non-zero-dimension case.

### Test
`SharedBroadcastOperandNonZeroConcatDim`: a while loop whose body concatenates two `f32[3,5]` group elements on dimension 1 and feeds each through an `add` with a shared operand. The shared operand takes the broadcast+reshape path; under the old code the reshape targets `f32[3,6]` (18 elements) from a `f32[3,2,5]` broadcast (30 elements) and crashes. With the fix it reshapes to `f32[3,10]` and partitioning succeeds.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
