### PR TITLE
spmd-enzyme: Be more conservative when walking constant DUS chain

### DIFF
--- a/xla/service/spmd/spmd_partitioner.cc
+++ b/xla/service/spmd/spmd_partitioner.cc
@@ -4150,7 +4150,6 @@ SpmdPartitioningVisitor::ProcessUpdatePieceExtractOperand(
     return b_.AddInstruction(std::move(to_add));
   };
 
-  std::vector<int64_t> accumulated_offsets(hlo->shape().dimensions().size(), 0);
   const HloInstruction* actual_update = piece_update_tensor;
   std::optional<ShapeUtil::ShapeEqualityDescriptor> reshape_desc;
   while (actual_update->user_count() == 1) {
@@ -4172,35 +4171,31 @@ SpmdPartitioningVisitor::ProcessUpdatePieceExtractOperand(
       }
     } else if (actual_update->opcode() == HloOpcode::kDynamicUpdateSlice &&
                !reshape_desc.has_value()) {
+      const HloInstruction* update_operand = actual_update->operand(1);
+      bool update_covers_whole_piece = true;
       bool all_constant = true;
-      for (int i = 2; i < actual_update->operand_count(); ++i) {
-        if (actual_update->operand(i)->opcode() != HloOpcode::kConstant) {
-          all_constant = false;
-          break;
-        }
-      }
-      if (!all_constant) {
-        break;
-      }
 
       for (int i = 0; i < actual_update->shape().dimensions().size(); ++i) {
-        auto const_op =
-            DynCast<HloConstantInstruction>(actual_update->operand(2 + i));
-        auto val = const_op->literal().GetIntegralAsS64({});
-
-        if (!val.has_value()) {
+        if (actual_update->operand(2 + i)->opcode() != HloOpcode::kConstant) {
           all_constant = false;
           break;
         }
-
-        accumulated_offsets[i] += *val;
+        if (update_operand->shape().dimensions(i) !=
+            actual_update->shape().dimensions(i)) {
+          update_covers_whole_piece = false;
+          break;
+        }
       }
 
       if (!all_constant) {
         break;
       }
 
-      actual_update = actual_update->operand(1);
+      if (!update_covers_whole_piece) {
+        break;
+      }
+
+      actual_update = update_operand;
     } else {
       break;
     }
@@ -4421,8 +4416,7 @@ SpmdPartitioningVisitor::ProcessUpdatePieceExtractOperand(
             for (int64_t i = 0; i < hlo->shape().dimensions().size(); ++i) {
               int64_t pre_dim = post_to_pre[i];
               if (pre_dim != -1 && ShardCountAtDim(hlo_sharding, i) > 1) {
-                int64_t dus_start =
-                    piece_dus_starts[i] + accumulated_offsets[i];
+                int64_t dus_start = piece_dus_starts[i];
                 int64_t slice_start = slice->slice_starts(pre_dim);
                 int64_t slice_size = slice->shape().dimensions(pre_dim);
                 if (dus_start != slice_start) {

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -15693,6 +15693,36 @@ TEST_P(SpmdPartitioningTest, DusOfSliceWithEnzymeOptNotSinglePartition) {
                     op::Shape("f32[20,40,50]")));
 }
 
+TEST_P(SpmdPartitioningTest, DusOfNestedDusOverPadWithEnzymeOpt) {
+  absl::string_view hlo_string = R"hlo(
+  HloModule module
+
+  ENTRY entry {
+    %base = f32[48,32] parameter(0), sharding={devices=[2,1]<=[2]}
+    %interior = f32[31,32] slice(%base), slice={[9:40], [0:32]}, sharding={devices=[2,1]<=[2]}
+    %zero = f32[] constant(0)
+    %padded = f32[33,32] pad(%interior, %zero), padding=1_1x0_0, sharding={devices=[2,1]<=[2]}
+    %zero_row = f32[1,32] broadcast(%zero), dimensions={}, sharding={devices=[2,1]<=[2]}
+    c0 = s32[] constant(0)
+    c32 = s32[] constant(32)
+    %dus0 = f32[33,32] dynamic-update-slice(%padded, %zero_row, c0, c0), sharding={devices=[2,1]<=[2]}
+    %dus1 = f32[33,32] dynamic-update-slice(%dus0, %zero_row, c32, c0), sharding={devices=[2,1]<=[2]}
+    c8 = s32[] constant(8)
+    ROOT %dus2 = f32[48,32] dynamic-update-slice(%base, %dus1, c8, c0), sharding={devices=[2,1]<=[2]}
+  }
+)hlo";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          PartitionComputation(hlo_string, /*num_devices=*/2,
+                                               SpmdPartitionerOptions(),
+                                               /*enable_enzyme_opt=*/true));
+
+  const HloInstruction* root = module->entry_computation()->root_instruction();
+  EXPECT_THAT(root,
+              AllOf(op::Select(_, op::Parameter(0), op::Select(_, _, _)),
+                    op::Shape("f32[24,32]")));
+}
+
 TEST_P(SpmdPartitioningTest, AddBroadcastWithEnzymeOpt) {
   absl::string_view hlo_string = R"hlo(
   HloModule module


### PR DESCRIPTION
📝 Summary of Changes

This fixes a bug in enzyme-comms-opts gated (cc @wsmoses) spmd partitioner where it would too eagerly follow a constant dus chain. If a dus with constant starts had an update which is a constant dus as well, it would take that dus update as the update but that is only valid is that dus covers the whole update.

🎯 Justification

this caused a bug where the update value taken for the dus was wrong.

🚀 Kind of Contribution

🐛 Bug Fix

🧪 Unit Tests:

added a test where the update taken was wrong because the update dus was wrong.
