### PR TITLE
[XLA:GPU][codegen] Simplify noalias IR checks

### DIFF
--- a/xla/backends/gpu/tests/BUILD
+++ b/xla/backends/gpu/tests/BUILD
@@ -579,6 +579,7 @@ xla_test(
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
         "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
         "@tsl//tsl/platform:test",
     ],

--- a/xla/backends/gpu/tests/gpu_noalias_test.cc
+++ b/xla/backends/gpu/tests/gpu_noalias_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "absl/status/status_matchers.h"
+#include "absl/strings/str_cat.h"
 #include "xla/backends/gpu/tests/gpu_pjrt_codegen_test.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -28,10 +29,7 @@ limitations under the License.
 namespace xla::gpu {
 namespace {
 
-class GpuNoAliasTest : public GpuPjRtCodegenTest {
- protected:
-  bool is_built_with_sycl_ = false;
-};
+class GpuNoAliasTest : public GpuPjRtCodegenTest {};
 
 TEST_F(GpuNoAliasTest, Concat) {
   HloComputation::Builder builder(TestName());
@@ -55,18 +53,10 @@ TEST_F(GpuNoAliasTest, Concat) {
   // - After optimizations we have "concatenate(x, y, x)".
   // - We only pass the same parameters once, so the kernel will have these
   // parameters: (x, y, output), and all of them will be noalias.
-  const char* expected_ir;
-  if (IsBuiltWithRocm()) {
-    expected_ir = R"(
-CHECK: define amdgpu_kernel void @{{[a-zA-Z0-9_]+}}(ptr noalias align 16 dereferenceable(16) %{{[a-zA-Z0-9_]+}}, ptr noalias align 16 dereferenceable(16) %{{[a-zA-Z0-9_]+}}, ptr noalias align 256 dereferenceable(48) %{{[a-zA-Z0-9_]+}}) #0
-  )";
-  } else if (is_built_with_sycl_) {
-    expected_ir = R"(CHECK: define spir_kernel {{.*}})";
-  } else {
-    expected_ir = R"(
-CHECK: define ptx_kernel void @{{[a-zA-Z0-9_]+}}(ptr noalias align 16 dereferenceable(16) %{{[a-zA-Z0-9_]+}}, ptr noalias align 16 dereferenceable(16) %{{[a-zA-Z0-9_]+}}, ptr noalias align 256 dereferenceable(48) %{{[a-zA-Z0-9_]+}})
-  )";
-  }
+  const std::string expected_ir = absl::StrCat(
+      "CHECK: define ", GpuKernelType(),
+      R"( void @{{[a-zA-Z0-9_]+}}(ptr noalias align 16 dereferenceable(16) %{{[a-zA-Z0-9_]+}}, ptr noalias align 16 dereferenceable(16) %{{[a-zA-Z0-9_]+}}, ptr noalias align 256 dereferenceable(48) %{{[a-zA-Z0-9_]+}}) )",
+      IsBuiltWithRocm() ? "#0" : "");
   EXPECT_OK(CompileAndVerifyIr(std::move(hlo_module), expected_ir,
                                /*match_optimized_ir=*/false));
 }

--- a/xla/backends/gpu/tests/gpu_noalias_test.cc
+++ b/xla/backends/gpu/tests/gpu_noalias_test.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include <gtest/gtest.h>

--- a/xla/backends/gpu/tests/gpu_pjrt_codegen_test.h
+++ b/xla/backends/gpu/tests/gpu_pjrt_codegen_test.h
@@ -84,12 +84,21 @@ class GpuPjRtCodegenTest : public HloPjRtGpuTestBase {
                                   bool match_optimized_ir = false,
                                   bool run_optimization_passes = true);
 
-  bool IsBuiltWithRocm() {
+  bool IsBuiltWithRocm() const {
     return runner_type_ == HloRunnerPropertyTag::kUsingGpuRocm;
   }
 
-  bool IsBuiltWithOneAPI() {
+  bool IsBuiltWithOneAPI() const {
     return runner_type_ == HloRunnerPropertyTag::kUsingGpuOneAPI;
+  }
+
+  std::string GpuKernelType() const {
+    if (IsBuiltWithRocm()) {
+      return "amdgpu_kernel";
+    } else if (IsBuiltWithOneAPI()) {
+      return "spir_kernel";
+    }
+    return "ptx_kernel";
   }
 
  private:

--- a/xla/backends/gpu/tests/gpu_pjrt_codegen_test.h
+++ b/xla/backends/gpu/tests/gpu_pjrt_codegen_test.h
@@ -95,7 +95,8 @@ class GpuPjRtCodegenTest : public HloPjRtGpuTestBase {
   std::string GpuKernelType() const {
     if (IsBuiltWithRocm()) {
       return "amdgpu_kernel";
-    } else if (IsBuiltWithOneAPI()) {
+    }
+    if (IsBuiltWithOneAPI()) {
       return "spir_kernel";
     }
     return "ptx_kernel";


### PR DESCRIPTION
This PR adds a utility function that returns backend specific kernel annotations and simplifies IR checks for noalias tests. It fixes the below filecheck errors in `xla/backends/gpu/tests/gpu_noalias_test.cc` for sycl backend.

`FileCheck stderr: CHECK: expected string not found in input`