### PR TITLE
[ROCm] Use llvm symbolizer from hermetic llvm

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -45,9 +45,9 @@ bazel_dep(name = "rules_ml_toolchain")
 # echo "sha256-${HASH}"
 archive_override(
     module_name = "rules_ml_toolchain",
-    integrity = "sha256-axspTL7LmKCLz+WWQUYfcuET2zD6kbRPzEnZgJm1umU=",
-    strip_prefix = "rules_ml_toolchain-b11745590f513ec55b32e2d126073576fde18c71",
-    urls = ["https://github.com/google-ml-infra/rules_ml_toolchain/archive/b11745590f513ec55b32e2d126073576fde18c71.tar.gz"],
+    integrity = "sha256-izPVqzV2I7ox7EYzRzcRY6ogeLcHUr4LRP2xMrkWh6A=",
+    strip_prefix = "rules_ml_toolchain-236a498d8624bef88e35ce2518a833204b0db19f",
+    urls = ["https://github.com/google-ml-infra/rules_ml_toolchain/archive/236a498d8624bef88e35ce2518a833204b0db19f.tar.gz"],
 )
 
 # TODO: Upstream the patch?

--- a/build_tools/rocm/BUILD
+++ b/build_tools/rocm/BUILD
@@ -22,26 +22,6 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-string_flag(
-    name = "sanitizer",
-    build_setting_default = "none",
-    values = [
-        "none",
-        "asan",
-        "tsan",
-    ],
-)
-
-config_setting(
-    name = "asan",
-    flag_values = {"//build_tools/rocm:sanitizer": "asan"},
-)
-
-config_setting(
-    name = "tsan",
-    flag_values = {"//build_tools/rocm:sanitizer": "tsan"},
-)
-
 # Export ignore lists for use by sanitizer wrappers
 exports_files([
     "asan_ignore_list.txt",

--- a/build_tools/rocm/BUILD
+++ b/build_tools/rocm/BUILD
@@ -14,6 +14,7 @@
 # ============================================================================
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@rules_ml_toolchain//cc/sanitizers:sanitizer_wrapper.bzl", "sanitizer_wrapper")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 package(
@@ -41,37 +42,26 @@ config_setting(
     flag_values = {"//build_tools/rocm:sanitizer": "tsan"},
 )
 
-filegroup(
-    name = "sanitizer_ignore_lists",
-    srcs = select({
-        ":asan": [
-            "asan_ignore_list.txt",
-            "lsan_ignore_list.txt",
-        ],
-        ":tsan": ["tsan_ignore_list.txt"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
-)
+# Export ignore lists for use by sanitizer wrappers
+exports_files([
+    "asan_ignore_list.txt",
+    "lsan_ignore_list.txt",
+    "tsan_ignore_list.txt",
+])
 
-genrule(
-    name = "san_wrapper_script",
-    srcs = [":sanitizer_ignore_lists"],
-    outs = ["san_wrapper.sh"],
-    cmd = """
-      echo '#!/bin/bash' > $@
-      echo 'exec "$$@"' >> $@
-      chmod +x $@
-    """,
-)
-
-# this wrapper ensures the test target
-# take into account any changes in the ignore list files
-sh_binary(
+# Sanitizer wrapper using rules_ml_toolchain macro
+# This replaces the custom genrule+sh_binary implementation
+# Uses XLA's custom suppression lists for ROCm/HIP libraries
+sanitizer_wrapper(
     name = "sanitizer_wrapper",
-    srcs = [":san_wrapper_script"],
-    data = [":sanitizer_ignore_lists"],
-    tags = ["manual"],
+    additional_data = ["@llvm_linux_x86_64//:distro_libs"],
+    asan_ignore_list = ":asan_ignore_list.txt",
+    # XLA-specific sanitizer options
+    asan_options = "detect_leaks=0:use_sigaltstack=0",
+    llvm_symbolizer = "@llvm_linux_x86_64//:llvm-symbolizer",
+    lsan_ignore_list = ":lsan_ignore_list.txt",
+    tsan_ignore_list = ":tsan_ignore_list.txt",
+    tsan_options = "halt_on_error=1:exitcode=66:history_size=7:ignore_noninstrumented_modules=1",
     visibility = ["//visibility:public"],
 )
 
@@ -79,9 +69,26 @@ sh_binary(
     name = "parallel_gpu_execute",
     srcs = ["parallel_gpu_execute.sh"],
     data = [
-        ":sanitizer_ignore_lists",
         "@local_config_rocm//rocm:rocminfo",
     ],
     tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+# Sanitizer wrapper that runs under parallel_gpu_execute
+# Combines sanitizer setup with GPU locking and device visibility
+sanitizer_wrapper(
+    name = "sanitizer_wrapper_parallel_gpu_execute",
+    additional_data = [
+        "@llvm_linux_x86_64//:distro_libs",
+        "@local_config_rocm//rocm:rocminfo",
+    ],
+    asan_ignore_list = ":asan_ignore_list.txt",
+    asan_options = "detect_leaks=0:use_sigaltstack=0",
+    llvm_symbolizer = "@llvm_linux_x86_64//:llvm-symbolizer",
+    lsan_ignore_list = ":lsan_ignore_list.txt",
+    run_under = ":parallel_gpu_execute",
+    tsan_ignore_list = ":tsan_ignore_list.txt",
+    tsan_options = "halt_on_error=1:exitcode=66:history_size=7:ignore_noninstrumented_modules=1",
     visibility = ["//visibility:public"],
 )

--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -39,10 +39,8 @@ build:tsan --copt -g
 build:tsan --copt -fno-omit-frame-pointer
 build:tsan --linkopt -fsanitize=thread
 build:tsan --linkopt -g
-build:tsan --//build_tools/rocm:sanitizer=tsan
 build:tsan --run_under=//build_tools/rocm:sanitizer_wrapper
 
-build:asan --//build_tools/rocm:sanitizer=asan
 build:asan --run_under=//build_tools/rocm:sanitizer_wrapper
 
 build:ci_single_gpu --run_under=//build_tools/rocm:parallel_gpu_execute
@@ -50,15 +48,15 @@ build:ci_single_gpu --flaky_test_attempts=3
 
 build:ci_multi_gpu --action_env=XLA_FLAGS="--xla_gpu_force_compilation_parallelism=16"
 build:ci_multi_gpu --action_env=NCCL_MAX_NCHANNELS=1
-build:ci_multi_gpu --run_under=//build_tools/rocm:sanitizer_wrapper
 build:ci_multi_gpu --test_sharding_strategy=disabled
 build:ci_multi_gpu --flaky_test_attempts=3
 build:ci_multi_gpu --experimental_guard_against_concurrent_changes
 build:ci_multi_gpu --test_env=HIP_VISIBLE_DEVICES=0,1,2,3
+build:ci_multi_gpu --run_under=
 
-build:ci_rocm_cpu --run_under=//build_tools/rocm:sanitizer_wrapper
 build:ci_rocm_cpu --local_test_jobs=200
 build:ci_rocm_cpu --strategy=TestRunner=local
+build:ci_rocm_cpu --run_under=
 
 test:xla_sgpu -- \
 //xla/... \

--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -43,7 +43,6 @@ build:tsan --run_under=//build_tools/rocm:sanitizer_wrapper
 
 build:asan --run_under=//build_tools/rocm:sanitizer_wrapper
 
-build:ci_single_gpu --run_under=//build_tools/rocm:parallel_gpu_execute
 build:ci_single_gpu --flaky_test_attempts=3
 
 build:ci_multi_gpu --action_env=XLA_FLAGS="--xla_gpu_force_compilation_parallelism=16"
@@ -52,11 +51,9 @@ build:ci_multi_gpu --test_sharding_strategy=disabled
 build:ci_multi_gpu --flaky_test_attempts=3
 build:ci_multi_gpu --experimental_guard_against_concurrent_changes
 build:ci_multi_gpu --test_env=HIP_VISIBLE_DEVICES=0,1,2,3
-build:ci_multi_gpu --run_under=
 
 build:ci_rocm_cpu --local_test_jobs=200
 build:ci_rocm_cpu --strategy=TestRunner=local
-build:ci_rocm_cpu --run_under=
 
 test:xla_sgpu -- \
 //xla/... \

--- a/build_tools/rocm/rocm_xla.bazelrc
+++ b/build_tools/rocm/rocm_xla.bazelrc
@@ -40,11 +40,8 @@ build:tsan --copt -fno-omit-frame-pointer
 build:tsan --linkopt -fsanitize=thread
 build:tsan --linkopt -g
 build:tsan --//build_tools/rocm:sanitizer=tsan
-build:tsan --test_env=TSAN_OPTIONS=suppressions=build_tools/rocm/tsan_ignore_list.txt::history_size=7:ignore_noninstrumented_modules=1
 build:tsan --run_under=//build_tools/rocm:sanitizer_wrapper
 
-build:asan --test_env=ASAN_OPTIONS=suppressions=build_tools/rocm/asan_ignore_list.txt:use_sigaltstack=0
-build:asan --test_env=LSAN_OPTIONS=suppressions=build_tools/rocm/lsan_ignore_list.txt:use_sigaltstack=0
 build:asan --//build_tools/rocm:sanitizer=asan
 build:asan --run_under=//build_tools/rocm:sanitizer_wrapper
 

--- a/build_tools/rocm/run_xla_ci_build.sh
+++ b/build_tools/rocm/run_xla_ci_build.sh
@@ -44,5 +44,4 @@ bazel --bazelrc="$SCRIPT_DIR/rocm_xla_ci.bazelrc" test \
     --test_env=TF_TESTS_PER_GPU=1 \
     --action_env=XLA_FLAGS="--xla_gpu_force_compilation_parallelism=16" \
     --test_output=errors \
-    --run_under=//build_tools/rocm:parallel_gpu_execute \
     "$@"

--- a/workspace3.bzl
+++ b/workspace3.bzl
@@ -61,10 +61,10 @@ def workspace():
     # Details: https://github.com/google-ml-infra/rules_ml_toolchain
     tf_http_archive(
         name = "rules_ml_toolchain",
-        sha256 = "6b1b294cbecb98a08bcfe59641461f72e113db30fa91b44fcc49d98099b5ba65",
-        strip_prefix = "rules_ml_toolchain-b11745590f513ec55b32e2d126073576fde18c71",
+        sha256 = "8b33d5ab357623ba31ec463347371163aa2078b70752be0b44fdb132b91687a0",
+        strip_prefix = "rules_ml_toolchain-236a498d8624bef88e35ce2518a833204b0db19f",
         urls = tf_mirror_urls(
-            "https://github.com/google-ml-infra/rules_ml_toolchain/archive/b11745590f513ec55b32e2d126073576fde18c71.tar.gz",
+            "https://github.com/google-ml-infra/rules_ml_toolchain/archive/236a498d8624bef88e35ce2518a833204b0db19f.tar.gz",
         ),
     )
 


### PR DESCRIPTION
📝 Summary of Changes
Use sanitizer_wrapper from within rules_ml_toolchain to provide ignore_list, 
sanitizer options and llvm-symbolizer files to the test.

🎯 Justification
We have to provide llvm-symbolizer to our asan/tsan pipelines.
The file provided will depend on which toolchain is use, hermetic (version) vs local
hence we need to use different sanitizer_wrapper for each config. We also
need to chain parallel_gpu_execute script so to remove the ugly dependnecy to
igno_list files from that.

🚀 Kind of Contribution
Please remove what does not apply: ✨ New Feature, ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
