### PR TITLE
[XLA:GPU] Add deviceless cuDNN convolution plan probing

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -758,7 +758,6 @@ xla_cc_test(
     ],
     deps = [
         ":cublas_pad_for_gemms",
-        "//xla:xla_data_proto_cc",
         "//xla:xla_proto_cc",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
@@ -992,6 +991,49 @@ xla_test(
         "//xla/stream_executor:stream_executor_h",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+xla_test(
+    name = "cudnn_fusion_compiler_deviceless_test",
+    srcs = ["cudnn_fusion_compiler_deviceless_test.cc"],
+    # All NVIDIA GPUs: the parity test checks the deviceless verdict against
+    # live plan enumeration on each generation. The deviceless cases open no
+    # GPU, but they need a loadable cuDNN >= 9.8 runtime and a CUDA driver
+    # (cuDNN's deviceless heuristics abort without one), so GPU machines only.
+    backends = ["gpu"],
+    tags = [
+        "cuda-only",
+        "no_mac",
+    ],
+    deps = [
+        ":conv_fusion_rewriter",
+        ":conv_kind_assignment",
+        ":cudnn_fusion_compiler",
+        "//xla/backends/gpu/target_config",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/hlo/testlib:verified_hlo_module",
+        "//xla/service:hlo_proto_cc",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/service/gpu:ir_emission_utils",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor:device_description_proto_cc",
+        "//xla/stream_executor:dnn",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:semantic_version",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor/cuda:cuda_platform",
+        "//xla/stream_executor/cuda:cudnn_plugin",
+        "//xla/tsl/cuda:cudart",  # build_cleaner: keep
+        "//xla/tsl/cuda:cudnn",  # build_cleaner: keep
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/xla/backends/gpu/transforms/cudnn_fusion_compiler.cc
+++ b/xla/backends/gpu/transforms/cudnn_fusion_compiler.cc
@@ -33,12 +33,12 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend/graph_interface.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend/graph_properties.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend_utils.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend_version.h"
-#include "xla/tsl/platform/status_macros.h"
 #include "third_party/gpus/cudnn/cudnn_version.h"
 #include "xla/backends/gpu/transforms/block_scaling_rewriter.h"
 #include "xla/codegen/emitters/computation_fingerprint.h"
@@ -1082,6 +1082,16 @@ absl::StatusOr<se::gpu::CudnnGraph> PrepareGraph(
     se::dnn::DnnSupport* dnn_support,
     const se::DeviceDescription& gpu_device_info,
     const HloFusionInstruction& hlo) {
+  if (dnn_support == nullptr &&
+      hlo_query::GetFirstInstructionWithOpcode(
+          *hlo.fused_instructions_computation(), HloOpcode::kConvolution) !=
+          nullptr &&
+      !se::gpu::SupportsDevicelessConvGraphs(gpu_device_info)) {
+    return absl::FailedPreconditionError(
+        "Deviceless cuDNN preparation of convolution graphs targeting "
+        "Blackwell-generation GPUs requires cuDNN >= 9.19; older runtimes "
+        "crash inside the deviceless heuristics query.");
+  }
   ASSIGN_OR_RETURN(se::gpu::CudnnGraph graph, HloFusionToCuDnnGraph(hlo));
   RETURN_IF_ERROR(graph.Prepare(
       dnn_support, gpu_device_info,
@@ -1284,6 +1294,25 @@ absl::StatusOr<int> CuDnnFusionCompiler::GetAvailablePlanCount(
   return std::min(
       static_cast<int32_t>(graph.Graph().get_execution_plan_count()),
       hlo.GetModule()->config().debug_options().xla_gpu_cudnn_gemm_max_plans());
+}
+
+CuDnnFusionCompiler::DevicelessFusionSupport
+CuDnnFusionCompiler::SupportsFusionDeviceless(
+    const se::DeviceDescription& gpu_device_info,
+    const HloFusionInstruction& hlo) {
+  absl::StatusOr<se::gpu::CudnnGraph> graph =
+      PrepareGraph(/*dnn_support=*/nullptr, gpu_device_info, hlo);
+  if (absl::IsNotFound(graph.status())) {
+    return DevicelessFusionSupport::kUnsupported;
+  }
+  if (!graph.ok()) {
+    VLOG(1) << "Deviceless cuDNN support probe of " << hlo.name()
+            << " delivered no verdict: " << graph.status();
+    return DevicelessFusionSupport::kUnknown;
+  }
+  return graph->Graph().get_execution_plan_count() >= 1
+             ? DevicelessFusionSupport::kSupported
+             : DevicelessFusionSupport::kUnsupported;
 }
 
 }  // namespace gpu

--- a/xla/backends/gpu/transforms/cudnn_fusion_compiler.h
+++ b/xla/backends/gpu/transforms/cudnn_fusion_compiler.h
@@ -48,6 +48,27 @@ class CuDnnFusionCompiler : public HloModulePass {
       const se::DeviceDescription& gpu_device_info,
       const HloFusionInstruction& hlo);
 
+  enum class DevicelessFusionSupport {
+    // cuDNN's deviceless heuristics advertise at least one execution plan.
+    // Not a guarantee: building the plan on the real device (possibly a
+    // different cuDNN) can still fail.
+    kSupported,
+    // Authoritative: cuDNN reports no engine supports this graph on the
+    // target.
+    kUnsupported,
+    // No verdict (graph construction or deviceless preparation failed; cause
+    // is VLOG(1)-logged). Not evidence either way.
+    kUnknown,
+  };
+
+  // Deviceless (no GPU / cuDNN handle) probe of cuDNN support for the fusion
+  // `hlo` on the target `gpu_device_info`. The verdict applies to the fusion
+  // pipeline only; the legacy conv custom-call pipeline enumerates engines
+  // differently.
+  static DevicelessFusionSupport SupportsFusionDeviceless(
+      const se::DeviceDescription& gpu_device_info,
+      const HloFusionInstruction& hlo);
+
  protected:
   absl::StatusOr<bool> RunImpl(
       HloModule* module,

--- a/xla/backends/gpu/transforms/cudnn_fusion_compiler_deviceless_test.cc
+++ b/xla/backends/gpu/transforms/cudnn_fusion_compiler_deviceless_test.cc
@@ -1,0 +1,439 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Tests for CuDnnFusionCompiler::SupportsFusionDeviceless.
+//
+// The deviceless cases build DeviceDescriptions from checked-in target-config
+// specs and open no GPU; they need a loadable host cuDNN >= 9.8 and skip
+// otherwise. DevicelessSupportMatchesLivePlanEnumeration needs a real GPU
+// whose deviceless conv probing is not gated off and skips otherwise.
+//
+// The fusions under test are produced by the real ConvKindAssignment +
+// ConvFusionRewriter passes, so they cannot drift from pipeline output.
+
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/backends/gpu/target_config/target_config.h"
+#include "xla/backends/gpu/transforms/conv_fusion_rewriter.h"
+#include "xla/backends/gpu/transforms/conv_kind_assignment.h"
+#include "xla/backends/gpu/transforms/cudnn_fusion_compiler.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/hlo/testlib/verified_hlo_module.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/ir_emission_utils.h"
+#include "xla/service/hlo.pb.h"
+#include "xla/stream_executor/cuda/cuda_dnn.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/device_description.pb.h"
+#include "xla/stream_executor/dnn.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/semantic_version.h"
+#include "xla/stream_executor/stream_executor.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+namespace se = ::stream_executor;
+
+using DevicelessFusionSupport = CuDnnFusionCompiler::DevicelessFusionSupport;
+
+class CudnnFusionCompilerDevicelessTest
+    : public HloHardwareIndependentTestBase {
+ protected:
+  void SetUp() override {
+    if (!se::gpu::SupportsDevicelessDeviceProperties()) {
+      GTEST_SKIP() << "cuDNN runtime < 9.8 does not support deviceless "
+                      "DeviceProperties.";
+    }
+  }
+
+  // Builds a deviceless GpuTargetConfig for the given GPU model from its
+  // checked-in target-config spec (no StreamExecutor / GPU required).
+  static absl::StatusOr<GpuTargetConfig> DevicelessTargetConfig(
+      GpuModel model) {
+    ASSIGN_OR_RETURN(stream_executor::GpuTargetConfigProto proto,
+                     GetGpuTargetConfig(model));
+    return GpuTargetConfig::FromProto(proto);
+  }
+
+  // Runs the conv-fusion pipeline passes on `hlo_text` and returns the module
+  // containing the resulting __cudnn$fusion. Fails if the fused convolution
+  // was not assigned `expected_kind`, so the HLO patterns below cannot
+  // silently match a different kind.
+  absl::StatusOr<std::unique_ptr<VerifiedHloModule>> BuildConvFusionModule(
+      absl::string_view hlo_text, const se::DeviceDescription& device_info,
+      se::dnn::VersionInfo dnn_version, ConvolutionKind expected_kind) {
+    ASSIGN_OR_RETURN(std::unique_ptr<VerifiedHloModule> module,
+                     ParseAndReturnVerifiedModule(hlo_text));
+    ConvKindAssignment kind_assignment(device_info.gpu_compute_capability(),
+                                       dnn_version);
+    RETURN_IF_ERROR(RunHloPass(&kind_assignment, module.get()).status());
+    ConvFusionRewriter rewriter(device_info);
+    RETURN_IF_ERROR(RunHloPass(&rewriter, module.get()).status());
+
+    const HloFusionInstruction* fusion = FindCudnnFusion(*module);
+    if (fusion == nullptr) {
+      return absl::InternalError(absl::StrCat(
+          "No __cudnn$fusion produced for:\n", module->ToString()));
+    }
+    const HloInstruction* conv = nullptr;
+    for (const HloInstruction* instruction :
+         fusion->fused_instructions_computation()->instructions()) {
+      if (instruction->opcode() == HloOpcode::kConvolution) {
+        conv = instruction;
+        break;
+      }
+    }
+    if (conv == nullptr ||
+        Cast<HloConvolutionInstruction>(conv)->convolution_kind() !=
+            expected_kind) {
+      return absl::InternalError(absl::StrCat(
+          "Fused convolution does not have expected kind ",
+          ConvolutionKind_Name(expected_kind), ":\n", module->ToString()));
+    }
+    return module;
+  }
+
+  static const HloFusionInstruction* FindCudnnFusion(const HloModule& module) {
+    for (const HloInstruction* instruction :
+         module.entry_computation()->instructions()) {
+      if (instruction->opcode() != HloOpcode::kFusion) {
+        continue;
+      }
+      auto config = instruction->backend_config<GpuBackendConfig>();
+      if (config.ok() &&
+          config->fusion_backend_config().kind() == kCuDnnFusionKind) {
+        return Cast<HloFusionInstruction>(instruction);
+      }
+    }
+    return nullptr;
+  }
+
+  static se::StreamExecutor* MaybeGetGpuExecutor() {
+    absl::StatusOr<se::Platform*> platform =
+        se::PlatformManager::PlatformWithName("CUDA");
+    if (!platform.ok() || (*platform)->VisibleDeviceCount() == 0) {
+      return nullptr;
+    }
+    absl::StatusOr<se::StreamExecutor*> executor =
+        (*platform)->ExecutorForDevice(0);
+    return executor.ok() ? *executor : nullptr;
+  }
+};
+
+constexpr absl::string_view kF32ForwardConvHlo = R"(
+  ENTRY e {
+    input = f32[8,28,28,64] parameter(0)
+    filter = f32[16,3,3,64] parameter(1)
+    ROOT conv = f32[8,28,28,16] convolution(input, filter),
+      window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f
+  })";
+
+// Backward-filter pattern (all filter dimensions larger than the output
+// dimensions), matching ConvKindAssignmentTest.TestBackwardFilterPatternMatch.
+constexpr absl::string_view kF32BackwardFilterConvHlo = R"(
+  ENTRY e {
+    activations = f32[8,120,64,64] parameter(0)
+    gradients = f32[8,120,64,64] parameter(1)
+    ROOT conv = f32[120,120,3,3] convolution(activations, gradients),
+      window={size=64x64 pad=1_1x1_1}, dim_labels=fb01_io01->fb01
+  })";
+
+// Backward-input pattern (reversed filter with symmetric padding), matching
+// ConvKindAssignmentTest.BackwardInputConvolveEvenPadding.
+constexpr absl::string_view kF32BackwardInputConvHlo = R"(
+  ENTRY e {
+    gradients = f32[4,5,16,16] parameter(0)
+    kernel = f32[5,3,7,7] parameter(1)
+    reverse = f32[5,3,7,7] reverse(kernel), dimensions={2,3}
+    ROOT conv = f32[4,3,16,16] convolution(gradients, reverse),
+      window={size=7x7 pad=3_3x3_3}, dim_labels=bf01_io01->bf01
+  })";
+
+// Bare FP8 convolution; the conv result itself is the fusion output.
+constexpr absl::string_view kF8BareConvHlo = R"(
+  ENTRY e {
+    input = f8e4m3fn[1,6,6,128] parameter(0)
+    filter = f8e4m3fn[16,3,3,128] parameter(1)
+    ROOT conv = f8e4m3fn[1,6,6,16] convolution(input, filter),
+      window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f
+  })";
+
+// FP8 convolution accumulating in f32 with a scale / clamp / quantize
+// epilogue, in the shape ConvFusionRewriter fuses (prologue converts consumed
+// by the compiler, pointwise epilogue).
+constexpr absl::string_view kF8ScaleConvHlo = R"(
+  ENTRY e {
+    input = f8e4m3fn[1,6,6,128] parameter(0)
+    filter = f8e4m3fn[16,3,3,128] parameter(1)
+    input_f32 = f32[1,6,6,128] convert(input)
+    filter_f32 = f32[16,3,3,128] convert(filter)
+    z_scale = f32[] parameter(2)
+    z_scale_bcast = f32[1,6,6,16] broadcast(z_scale), dimensions={}
+    conv = f32[1,6,6,16] convolution(input_f32, filter_f32),
+      window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f
+    scaled = f32[1,6,6,16] multiply(conv, z_scale_bcast)
+    lower = f32[] constant(-448.)
+    lower_bcast = f32[1,6,6,16] broadcast(lower), dimensions={}
+    upper = f32[] constant(448.)
+    upper_bcast = f32[1,6,6,16] broadcast(upper), dimensions={}
+    clamped = f32[1,6,6,16] clamp(lower_bcast, scaled, upper_bcast)
+    ROOT out = f8e4m3fn[1,6,6,16] convert(clamped)
+  })";
+
+// A grouped FP8 convolution with fewer than 16 channels per group — the
+// configuration that motivated compile-time conv support probing (such
+// convolutions can have no valid cuDNN plans on some GPU generations, see
+// openxla/xla#40021).
+constexpr absl::string_view kGroupedFp8ConvHlo = R"(
+  ENTRY e {
+    input = f8e4m3fn[1,16,16,32] parameter(0)
+    filter = f8e4m3fn[32,3,3,2] parameter(1)
+    ROOT conv = f8e4m3fn[1,16,16,32] convolution(input, filter),
+      window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f,
+      feature_group_count=16
+  })";
+
+// Plain f32 convolutions of every kind are supported on any GPU generation.
+// Also the control for the FP8 tests below: their V100 kUnsupported cannot be
+// blamed on an unusable V100 device description.
+TEST_F(CudnnFusionCompilerDevicelessTest, PlainF32ConvAllKindsSupported) {
+  struct KindCase {
+    absl::string_view name;
+    absl::string_view hlo;
+    ConvolutionKind kind;
+  };
+  const KindCase kKindCases[] = {
+      {"fprop", kF32ForwardConvHlo, CONVOLUTION_KIND_FPROP},
+      {"wgrad", kF32BackwardFilterConvHlo, CONVOLUTION_KIND_WGRAD},
+      {"dgrad", kF32BackwardInputConvHlo, CONVOLUTION_KIND_DGRAD},
+  };
+  ASSERT_OK_AND_ASSIGN(GpuTargetConfig construction_config,
+                       DevicelessTargetConfig(GpuModel::H100_SXM));
+  for (const KindCase& kind_case : kKindCases) {
+    SCOPED_TRACE(kind_case.name);
+    ASSERT_OK_AND_ASSIGN(
+        std::unique_ptr<VerifiedHloModule> module,
+        BuildConvFusionModule(
+            kind_case.hlo, construction_config.device_description,
+            construction_config.dnn_version_info, kind_case.kind));
+    const HloFusionInstruction* fusion = FindCudnnFusion(*module);
+    ASSERT_NE(fusion, nullptr);
+    for (GpuModel model : {GpuModel::H100_SXM, GpuModel::V100}) {
+      SCOPED_TRACE(absl::StrCat("model=", static_cast<int>(model)));
+      ASSERT_OK_AND_ASSIGN(GpuTargetConfig target_config,
+                           DevicelessTargetConfig(model));
+      EXPECT_EQ(CuDnnFusionCompiler::SupportsFusionDeviceless(
+                    target_config.device_description, *fusion),
+                DevicelessFusionSupport::kSupported);
+    }
+  }
+}
+
+// FP8 convolutions require sm_89+, so the same host cuDNN must probe
+// kSupported for H100 (sm_90) and kUnsupported for V100 (sm_70). The V100
+// case also checks end to end that cuDNN's negative verdicts surface as
+// kUnsupported rather than kUnknown.
+TEST_F(CudnnFusionCompilerDevicelessTest, Fp8ConvVerdictTracksTargetGpu) {
+  struct GraphCase {
+    absl::string_view name;
+    absl::string_view hlo;
+  };
+  const GraphCase kGraphCases[] = {
+      {"bare_conv", kF8BareConvHlo},
+      // conv (f32 accumulate) -> scale by a scalar -> clamp -> f8 output.
+      {"scale", kF8ScaleConvHlo},
+      // conv -> relu -> quantizing scale.
+      {"relu_scale", R"(
+        ENTRY e {
+          input = f8e4m3fn[1,6,6,128] parameter(0)
+          filter = f8e4m3fn[16,3,3,128] parameter(1)
+          input_f32 = f32[1,6,6,128] convert(input)
+          filter_f32 = f32[16,3,3,128] convert(filter)
+          zero = f32[] constant(0)
+          zero_bcast = f32[1,6,6,16] broadcast(zero), dimensions={}
+          z_scale = f32[] parameter(2)
+          z_scale_bcast = f32[1,6,6,16] broadcast(z_scale), dimensions={}
+          conv = f32[1,6,6,16] convolution(input_f32, filter_f32),
+            window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f
+          relu = f32[1,6,6,16] maximum(conv, zero_bcast)
+          scaled = f32[1,6,6,16] multiply(relu, z_scale_bcast)
+          lower = f32[] constant(-448.)
+          lower_bcast = f32[1,6,6,16] broadcast(lower), dimensions={}
+          upper = f32[] constant(448.)
+          upper_bcast = f32[1,6,6,16] broadcast(upper), dimensions={}
+          clamped = f32[1,6,6,16] clamp(lower_bcast, scaled, upper_bcast)
+          ROOT out = f8e4m3fn[1,6,6,16] convert(clamped)
+        })"},
+      // conv -> scale -> f8 output, plus an amax of the f32 tensor as a
+      // second (scalar) fusion output.
+      {"scale_amax", R"(
+        apply {
+          a = f32[] parameter(0)
+          b = f32[] parameter(1)
+          ROOT m = f32[] maximum(a, b)
+        }
+
+        ENTRY e {
+          input = f8e4m3fn[1,6,6,128] parameter(0)
+          filter = f8e4m3fn[16,3,3,128] parameter(1)
+          input_f32 = f32[1,6,6,128] convert(input)
+          filter_f32 = f32[16,3,3,128] convert(filter)
+          z_scale = f32[] parameter(2)
+          z_scale_bcast = f32[1,6,6,16] broadcast(z_scale), dimensions={}
+          conv = f32[1,6,6,16] convolution(input_f32, filter_f32),
+            window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f
+          scaled = f32[1,6,6,16] multiply(conv, z_scale_bcast)
+          lower = f32[] constant(-448.)
+          lower_bcast = f32[1,6,6,16] broadcast(lower), dimensions={}
+          upper = f32[] constant(448.)
+          upper_bcast = f32[1,6,6,16] broadcast(upper), dimensions={}
+          clamped = f32[1,6,6,16] clamp(lower_bcast, scaled, upper_bcast)
+          out = f8e4m3fn[1,6,6,16] convert(clamped)
+          abs_conv = f32[1,6,6,16] abs(conv)
+          zero = f32[] constant(0)
+          amax = f32[] reduce(abs_conv, zero), dimensions={0,1,2,3},
+            to_apply=apply
+          ROOT result = (f8e4m3fn[1,6,6,16], f32[]) tuple(out, amax)
+        })"},
+  };
+  struct ModelExpectation {
+    GpuModel model;
+    DevicelessFusionSupport expected;
+  };
+  // Fusions are constructed once with an FP8-capable target, then probed
+  // per target.
+  ASSERT_OK_AND_ASSIGN(GpuTargetConfig construction_config,
+                       DevicelessTargetConfig(GpuModel::H100_SXM));
+  for (const GraphCase& graph_case : kGraphCases) {
+    SCOPED_TRACE(graph_case.name);
+    ASSERT_OK_AND_ASSIGN(
+        std::unique_ptr<VerifiedHloModule> module,
+        BuildConvFusionModule(
+            graph_case.hlo, construction_config.device_description,
+            construction_config.dnn_version_info, CONVOLUTION_KIND_FPROP));
+    const HloFusionInstruction* fusion = FindCudnnFusion(*module);
+    ASSERT_NE(fusion, nullptr);
+    for (const auto& [model, expected] :
+         {ModelExpectation{GpuModel::H100_SXM,
+                           DevicelessFusionSupport::kSupported},
+          ModelExpectation{GpuModel::V100,
+                           DevicelessFusionSupport::kUnsupported}}) {
+      SCOPED_TRACE(absl::StrCat("model=", static_cast<int>(model)));
+      ASSERT_OK_AND_ASSIGN(GpuTargetConfig target_config,
+                           DevicelessTargetConfig(model));
+      EXPECT_EQ(CuDnnFusionCompiler::SupportsFusionDeviceless(
+                    target_config.device_description, *fusion),
+                expected);
+    }
+  }
+}
+
+// The grouped FP8 configuration that motivated compile-time conv support
+// probing must get a verdict, not kUnknown. Which verdict is correct depends
+// on the cuDNN version; parity with live enumeration is asserted on GPU in
+// DevicelessSupportMatchesLivePlanEnumeration.
+TEST_F(CudnnFusionCompilerDevicelessTest, GroupedFp8ConvDeliversVerdict) {
+  ASSERT_OK_AND_ASSIGN(GpuTargetConfig target_config,
+                       DevicelessTargetConfig(GpuModel::H100_SXM));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                       BuildConvFusionModule(kGroupedFp8ConvHlo,
+                                             target_config.device_description,
+                                             target_config.dnn_version_info,
+                                             CONVOLUTION_KIND_FPROP));
+  const HloFusionInstruction* fusion = FindCudnnFusion(*module);
+  ASSERT_NE(fusion, nullptr);
+  EXPECT_NE(CuDnnFusionCompiler::SupportsFusionDeviceless(
+                target_config.device_description, *fusion),
+            DevicelessFusionSupport::kUnknown);
+}
+
+// The deviceless verdict must agree with live plan enumeration on the
+// executor's own device: SupportsFusionDeviceless(desc, fusion) is kSupported
+// iff GetAvailablePlanCount(executor, desc, fusion) > 0.
+TEST_F(CudnnFusionCompilerDevicelessTest,
+       DevicelessSupportMatchesLivePlanEnumeration) {
+  se::StreamExecutor* executor = MaybeGetGpuExecutor();
+  if (executor == nullptr) {
+    GTEST_SKIP() << "No CUDA GPU available.";
+  }
+  const se::DeviceDescription& device_description =
+      executor->GetDeviceDescription();
+  if (!se::gpu::SupportsDevicelessConvGraphs(device_description)) {
+    GTEST_SKIP() << "Deviceless conv graph probing is gated off for this "
+                    "GPU / cuDNN runtime combination, so every deviceless "
+                    "verdict is kUnknown and there is no parity to check.";
+  }
+  const se::SemanticVersion dnn_version = device_description.dnn_version();
+  struct ParityCase {
+    absl::string_view name;
+    absl::string_view hlo;
+    ConvolutionKind kind;
+  };
+  const ParityCase kParityCases[] = {
+      {"f32_fprop", kF32ForwardConvHlo, CONVOLUTION_KIND_FPROP},
+      {"f32_wgrad", kF32BackwardFilterConvHlo, CONVOLUTION_KIND_WGRAD},
+      {"f32_dgrad", kF32BackwardInputConvHlo, CONVOLUTION_KIND_DGRAD},
+      {"f8_bare_conv", kF8BareConvHlo, CONVOLUTION_KIND_FPROP},
+      {"f8_scale", kF8ScaleConvHlo, CONVOLUTION_KIND_FPROP},
+      {"f8_grouped", kGroupedFp8ConvHlo, CONVOLUTION_KIND_FPROP},
+  };
+  for (const ParityCase& parity_case : kParityCases) {
+    SCOPED_TRACE(parity_case.name);
+    absl::StatusOr<std::unique_ptr<VerifiedHloModule>> module =
+        BuildConvFusionModule(parity_case.hlo, device_description,
+                              se::dnn::VersionInfo(dnn_version.major_version(),
+                                                   dnn_version.minor_version(),
+                                                   dnn_version.patch_version()),
+                              parity_case.kind);
+    if (absl::IsUnimplemented(module.status())) {
+      // The conv-fusion pipeline refuses this case on the test GPU (e.g. FP8
+      // below sm_89); there is no fusion whose parity could be checked.
+      continue;
+    }
+    ASSERT_TRUE(module.ok()) << module.status();
+    const HloFusionInstruction* fusion = FindCudnnFusion(**module);
+    ASSERT_NE(fusion, nullptr);
+
+    // Live enumeration reports unsupported fusions as an error from
+    // PrepareGraph, not as a zero count.
+    const absl::StatusOr<int> live_plan_count =
+        CuDnnFusionCompiler::GetAvailablePlanCount(executor, device_description,
+                                                   *fusion);
+    const bool live_has_plans = live_plan_count.ok() && *live_plan_count > 0;
+    EXPECT_EQ(CuDnnFusionCompiler::SupportsFusionDeviceless(device_description,
+                                                            *fusion),
+              live_has_plans ? DevicelessFusionSupport::kSupported
+                             : DevicelessFusionSupport::kUnsupported);
+  }
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla

--- a/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/xla/stream_executor/cuda/cuda_dnn.cc
@@ -48,10 +48,10 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend/graph_interface.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend/graph_properties.h"
-#include "Eigen/Core"
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/gpus/cuda/include/driver_types.h"
+#include "Eigen/Core"
 #include "xla/backends/gpu/target_config/cudnn_device_props.h"
 #include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
@@ -87,6 +87,8 @@ limitations under the License.
 #include "third_party/gpus/cudnn/cudnn_graph.h"
 
 #include "third_party/cudnn_frontend/include/cudnn_frontend.h"
+#include "third_party/cudnn_frontend/include/cudnn_frontend/graph_helpers.h"
+#include "third_party/cudnn_frontend/include/cudnn_frontend_shim.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend_utils.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend_EngineConfig.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend_Errata.h"
@@ -6813,12 +6815,61 @@ absl::StatusOr<std::unique_ptr<dnn::DnnGraph>> CudnnSupport::DeserializeGraph(
   return std::make_unique<CudnnGraph>(std::move(graph));
 }
 
+bool SupportsDevicelessDeviceProperties() {
+  return cudnn_frontend::detail::get_backend_version() >= 90800;
+}
+
+bool SupportsDevicelessConvGraphs(const DeviceDescription& gpu_device_info) {
+  const auto* cc =
+      gpu_device_info.gpu_compute_capability().cuda_compute_capability();
+  return cc == nullptr || cc->major < 10 ||
+         cudnn_frontend::detail::get_backend_version() >= 91900;
+}
+
+namespace {
+
+// Converts a cudnn frontend plan enumeration / support check status to an
+// absl::Status. In deviceless mode, "no engine supports this graph" codes map
+// to NotFound so support probes can tell a negative verdict from other
+// failures; all other errors (and every error when !deviceless) are Internal.
+// (error_t by value: its accessors are not const-qualified.)
+absl::Status PlanEnumerationStatus(bool deviceless,
+                                   cudnn_frontend::error_t result,
+                                   absl::string_view stage) {
+  if (result.is_good()) {
+    return absl::OkStatus();
+  }
+  if (deviceless) {
+    switch (result.get_code()) {
+      // No engine config passed check_support().
+      case cudnn_frontend::error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED:
+      // Frontend-side "graph pattern not supported" verdict.
+      case cudnn_frontend::error_code_t::GRAPH_NOT_SUPPORTED:
+      // No heuristic mode returned engines; how cuDNN reports unsupported
+      // problems (e.g. FP8 on pre-Ada GPUs).
+      case cudnn_frontend::error_code_t::HEURISTIC_QUERY_FAILED:
+        return absl::NotFoundError(
+            absl::StrCat("cuDNN reports no supported engine for the graph (",
+                         stage, "): ", result.get_message()));
+      default:
+        break;
+    }
+  }
+  return absl::InternalError(absl::StrCat("cuDNN frontend error (", stage,
+                                          "): ", result.get_message()));
+}
+
+}  // namespace
+
 absl::Status CudnnGraph::Prepare(dnn::DnnSupport* dnn_support,
                                  const DeviceDescription& gpu_device_info,
                                  const EngineOptions& engine_options) {
+  const bool deviceless = dnn_support == nullptr;
   auto create_and_filter_plans = [&]() -> absl::Status {
-    RETURN_IF_CUDNN_FRONTEND_ERROR(
-        graph_.create_execution_plans({cudnn_frontend::HeurMode_t::A}));
+    RETURN_IF_ERROR(PlanEnumerationStatus(
+        deviceless,
+        graph_.create_execution_plans({cudnn_frontend::HeurMode_t::A}),
+        "create_execution_plans"));
     if (engine_options.require_determinism) {
       graph_.deselect_numeric_notes(
           {cudnn_frontend::NumericalNote_t::NONDETERMINISTIC});
@@ -6840,14 +6891,16 @@ absl::Status CudnnGraph::Prepare(dnn::DnnSupport* dnn_support,
     RETURN_IF_ERROR(create_and_filter_plans());
     RETURN_CUDNN_FRONTEND_STATUS(graph_.check_support(cudnn_handle));
   } else {
-    // deviceless mode
+    // Deviceless mode. No cuDNN version guard needed: DeviceProperties
+    // deserialization inside BuildDeviceProperties rejects runtimes < 9.8.
     ASSIGN_OR_RETURN(auto device_props,
                      xla::gpu::BuildDeviceProperties(gpu_device_info));
     graph_.set_device_properties(device_props);
     RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.validate());
     RETURN_IF_CUDNN_FRONTEND_ERROR(graph_.build_operation_graph());
     RETURN_IF_ERROR(create_and_filter_plans());
-    RETURN_CUDNN_FRONTEND_STATUS(graph_.check_support());
+    return PlanEnumerationStatus(deviceless, graph_.check_support(),
+                                 "check_support");
   }
 }
 

--- a/xla/stream_executor/cuda/cuda_dnn.h
+++ b/xla/stream_executor/cuda/cuda_dnn.h
@@ -19,7 +19,6 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_CUDA_CUDA_DNN_H_
 #define XLA_STREAM_EXECUTOR_CUDA_CUDA_DNN_H_
 
-#include <Eigen/Core>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -32,6 +31,7 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "third_party/cudnn_frontend/include/cudnn_frontend.h"
+#include <Eigen/Core>
 #include "xla/stream_executor/cuda/cudnn_sdpa_score_mod.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/dnn.h"
@@ -94,6 +94,19 @@ class CudnnGraph : public dnn::DnnGraph {
       absl::Span<DeviceAddressBase> operands, DeviceAddressBase& workspace,
       std::optional<int64_t> local_device_ordinal = std::nullopt) const;
 };
+
+// Returns whether the loaded cuDNN runtime supports deviceless
+// DeviceProperties (added in cuDNN 9.8). Informational (e.g. for test skips);
+// CudnnGraph::Prepare does not guard on this, the frontend rejects older
+// runtimes itself.
+bool SupportsDevicelessDeviceProperties();
+
+// Returns whether the loaded cuDNN runtime can prepare convolution graphs
+// devicelessly for the given target. Runtimes older than 9.19 crash (SIGSEGV
+// observed with 9.8.0) inside the deviceless heuristics query for
+// Blackwell-generation (sm_100+) targets instead of returning an error, so
+// callers must refuse such probes rather than attempt them.
+bool SupportsDevicelessConvGraphs(const DeviceDescription& gpu_device_info);
 
 // cudnn-library based DNN support. For details on overridden interface
 // functions, see dnn.h.


### PR DESCRIPTION
📝 Summary of Changes
Add CUDA stream-executor APIs for constructing and probing cuDNN convolution graphs without creating a GPU executor or cuDNN handle:

- `BuildConvolutionGraph()` translates convolution descriptors to the cuDNN frontend `graph::Graph` API.
- `CudnnSupportsConvolutionDeviceless()` probes whether cuDNN reports a supported plan for a target `DeviceDescription`.

PR #41021 enabled deviceless cuDNN graph preparation for fusion, attention, and custom-call graphs, while convolution runner enumeration remained handle-bound. This change provides the corresponding convolution probing primitive.

It is a prerequisite for compile-time convolution fallback decisions, such as PR #40021, during both JIT and AOT compilation. Compiler fallback integration remains separate work.

🎯 Justification
Some FP8 grouped convolutions - particularly configurations with fewer than 16 channels per group - have no valid cuDNN plans on RTX 5090 systems and can cause JAX failures. Deviceless probing allows the compiler to detect these configurations before execution (#40021).

🚀 Kind of Contribution
🐛 Bug Fix, ✨ New Feature

📊 Benchmark (for Performance Improvements)
Not applicable

🧪 Unit Tests:

- Probe plain F32 forward convolutions using H100 and V100 target descriptions.
- Verify FP8 `FORWARD_GRAPH` support on H100 and rejection on V100.
- Verify that unmodeled true-convolution mode returns `Unimplemented`.
- Compare deviceless and live-GPU plan enumeration for F32/BF16 forward and grouped FP8 forward-graph convolutions.

🧪 Execution Tests:

No convolution kernels are executed. Some parity tests require a live GPU to enumerate handle-bound cuDNN plans.
