### PR TITLE
[HLO] Return parse errors instead of CHECK-failing on malformed replica_groups=mesh[...]

### DIFF
--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -4190,11 +4190,24 @@ bool HloParserImpl::ParseMesh(std::optional<Mesh>& mesh) {
     if (!ParseToken(TokKind::kRparen, "expected ')' to end device_ids")) {
       return false;
     }
+    // Validate the device_ids count against the mesh size before allocating the
+    // device-id array, returning a parse error instead of CHECK-failing (or
+    // attempting an unbounded allocation for a huge, mismatched mesh).
+    int64_t num_elements = 1;
+    for (int64_t axis_size : axis_sizes) {
+      if (axis_size < 0 ||
+          (axis_size != 0 &&
+           num_elements > std::numeric_limits<int64_t>::max() / axis_size)) {
+        return TokenError("mesh size overflows int64");
+      }
+      num_elements *= axis_size;
+    }
+    if (static_cast<int64_t>(devices.size()) != num_elements) {
+      return TokenError(absl::StrFormat(
+          "Expected %d device_ids based on mesh axes, but got %d", num_elements,
+          devices.size()));
+    }
     Array<int64_t> device_ids_array(axis_sizes);
-    CHECK_EQ(devices.size(), device_ids_array.num_elements())
-        << absl::StrFormat(
-               "Expected %d device_ids based on mesh axes, but got %d",
-               device_ids_array.num_elements(), devices.size());
     absl::c_copy(devices, device_ids_array.begin());
     mesh.emplace(device_ids_array, axis_names_views);
     return true;
@@ -4218,16 +4231,18 @@ bool HloParserImpl::ParseAxisRef(
   auto it = axis_name_to_idx.find(axis_name_or_index);
   if (it != axis_name_to_idx.end()) {
     axis_index = it->second;
-  } else {
-    CHECK(absl::SimpleAtoi(axis_name_or_index, &axis_index))
-        << "axis '" << axis_name_or_index
-        << "' is not a valid axis name or index in mesh " << mesh.ToString();
+  } else if (!absl::SimpleAtoi(axis_name_or_index, &axis_index)) {
+    return TokenError(
+        absl::StrCat("axis '", axis_name_or_index,
+                     "' is not a valid axis name or index in mesh ",
+                     mesh.ToString()));
   }
 
-  CHECK(axis_index >= 0 && axis_index < mesh.axis_names().size())
-      << "axis index " << axis_index << " is out of bounds for mesh "
-      << mesh.ToString() << " which has " << mesh.axis_names().size()
-      << " axes";
+  if (axis_index < 0 || axis_index >= mesh.axis_names().size()) {
+    return TokenError(absl::StrCat(
+        "axis index ", axis_index, " is out of bounds for mesh ",
+        mesh.ToString(), " which has ", mesh.axis_names().size(), " axes"));
+  }
 
   if (!EatIfPresent(TokKind::kColon)) {
     axis = AxisRef(axis_index);

--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -4191,8 +4191,7 @@ bool HloParserImpl::ParseMesh(std::optional<Mesh>& mesh) {
       return false;
     }
     // Validate the device_ids count against the mesh size before allocating the
-    // device-id array, returning a parse error instead of CHECK-failing (or
-    // attempting an unbounded allocation for a huge, mismatched mesh).
+    // device-id array (using an overflow-checked product of the axis sizes).
     int64_t num_elements = 1;
     for (int64_t axis_size : axis_sizes) {
       if (axis_size < 0 ||

--- a/xla/hlo/parser/hlo_parser_test.cc
+++ b/xla/hlo/parser/hlo_parser_test.cc
@@ -3276,6 +3276,61 @@ ENTRY test {
               HasSubstr("GTE index -1 out of bounds"));
 }
 
+TEST_F(HloParserTest, MeshReplicaGroupInvalidAxisName) {
+  const std::string original = R"(HloModule m
+
+add {
+  lhs = f32[] parameter(0)
+  rhs = f32[] parameter(1)
+  ROOT a = f32[] add(lhs, rhs)
+}
+
+ENTRY e {
+  p = f32[128,32] parameter(0)
+  ROOT ar = f32[128,32] all-reduce(p), replica_groups=mesh['axis_0'=2,'axis_1'=2] {'bogus'}, to_apply=add
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(),
+              HasSubstr("is not a valid axis name or index"));
+}
+
+TEST_F(HloParserTest, MeshReplicaGroupAxisIndexOutOfBounds) {
+  const std::string original = R"(HloModule m
+
+add {
+  lhs = f32[] parameter(0)
+  rhs = f32[] parameter(1)
+  ROOT a = f32[] add(lhs, rhs)
+}
+
+ENTRY e {
+  p = f32[128,32] parameter(0)
+  ROOT ar = f32[128,32] all-reduce(p), replica_groups=mesh['axis_0'=2,'axis_1'=2] {'5'}, to_apply=add
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(), HasSubstr("out of bounds for mesh"));
+}
+
+TEST_F(HloParserTest, MeshReplicaGroupDeviceIdsCountMismatch) {
+  const std::string original = R"(HloModule m
+
+add {
+  lhs = f32[] parameter(0)
+  rhs = f32[] parameter(1)
+  ROOT a = f32[] add(lhs, rhs)
+}
+
+ENTRY e {
+  p = f32[128,32] parameter(0)
+  ROOT ar = f32[128,32] all-reduce(p), replica_groups=mesh['axis_0'=2,'axis_1'=2, device_ids=(0,1,2)] {'axis_0'}, to_apply=add
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(), HasSubstr("device_ids"));
+}
+
 TEST_F(HloParserTest, CompactGteRoundTrip) {
   const std::string original =
       R"(HloModule test, entry_computation_layout={((f32[10]{0}, f16[10]{0}))->f32[10]{0}}


### PR DESCRIPTION
### Problem
The HLO text parser aborts (via `CHECK`/`CHECK_EQ`) instead of returning a parse error on a malformed `replica_groups=mesh[...]` collective-device list. Because these come straight from user-provided HLO text (`ParseAndReturnUnverifiedModule` and friends), a malformed axis reference or device-id list crashes the process rather than producing a diagnostic. Three sites in `ParseAxisRef`/`ParseMesh`:

1. **Invalid axis ref** — `CHECK(absl::SimpleAtoi(axis_name_or_index, &axis_index))` fires when the axis reference is neither a known mesh axis name nor an integer:
   ```
   replica_groups=mesh['axis_0'=2,'axis_1'=2] {'bogus'}
   ```
2. **Axis index out of bounds** — `CHECK(axis_index >= 0 && axis_index < mesh.axis_names().size())` fires on an out-of-range (or negative) index:
   ```
   replica_groups=mesh['axis_0'=2,'axis_1'=2] {'5'}
   ```
3. **device_ids count mismatch** — `CHECK_EQ(devices.size(), device_ids_array.num_elements())` fires when the `device_ids=(...)` count doesn't match the mesh size:
   ```
   replica_groups=mesh['axis_0'=2,'axis_1'=2, device_ids=(0,1,2)] {'axis_0'}
   ```
   The `Array<int64_t>` is also constructed (allocating the product of the axis sizes) *before* the check, so a huge mesh with a mismatched device list can attempt an unbounded allocation.

### Fix
Return a `TokenError` from each site instead of `CHECK`-failing, matching how the rest of the parser reports malformed input. For (3), the device-id count is validated against an overflow-checked product of the axis sizes *before* the `Array` is allocated, so a mismatched or overflowing mesh yields a parse error rather than a bad-alloc or abort.

Valid `mesh[...]` lists are unaffected (the existing `AllReduceWithMeshAxesReplicaGroupList` round-trip test still passes).

### Tests
Three `HloParserTest` cases assert the malformed inputs above now return an error status instead of crashing.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
