### PR TITLE
Gate unsound inverse-function folds behind fast-math

### DIFF
--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -5229,9 +5229,19 @@ absl::Status AlgebraicSimplifierVisitor::HandleOr(HloInstruction* logical_or) {
 
 absl::Status AlgebraicSimplifierVisitor::HandleLog(HloInstruction* log) {
   // ln(exp(A)) => A
+  //
+  // This identity holds over the reals, but not for IEEE 754 floating point:
+  // if exp(A) overflows to inf (A >= ~88.7 for f32, ~709.8 for f64), eager
+  // evaluation gives log(inf) = inf, while the folded form silently returns
+  // the finite A instead -- changing both the forward value and the gradient
+  // (chain rule through the unfolded form gives NaN at the overflow point,
+  // vs. 1 for the folded identity). Restrict to fast-math mode, matching how
+  // this file already gates other identities that are unsound at special
+  // values (e.g. "A - A => 0" above, unsound for NaN).
   VLOG(10) << "trying transform [ln(exp(A)) => A]: " << log->ToString();
   HloInstruction *a, *b;
-  if (Match(log, m::Log(m::Exp(m::Op(&a)))) &&
+  if (options_.enable_fast_math() &&
+      Match(log, m::Log(m::Exp(m::Op(&a)))) &&
       ReplaceInstructionIfCompatible(log, a)) {
     return absl::OkStatus();
   }
@@ -9551,7 +9561,14 @@ absl::Status AlgebraicSimplifierVisitor::HandleSort(HloInstruction* sort) {
 absl::Status AlgebraicSimplifierVisitor::HandleSqrt(HloInstruction* sqrt) {
   VLOG(10) << "trying transform [sqrt(A*A) => |A|] " << sqrt->ToString();
   HloInstruction* sqrt_operand = sqrt->mutable_operand(0);
-  if (sqrt_operand->opcode() == HloOpcode::kMultiply &&
+  // sqrt(A*A) => |A| holds over the reals, but not for IEEE 754 floating
+  // point: if A*A overflows to inf (|A| > ~1.84e19 for f32), eager evaluation
+  // gives sqrt(inf) = inf, while the folded form silently returns the finite
+  // |A| instead. Restrict to fast-math mode, matching HandleLog's identical
+  // ln(exp(A)) => A guard immediately above in this file for the same
+  // reason.
+  if (options_.enable_fast_math() &&
+      sqrt_operand->opcode() == HloOpcode::kMultiply &&
       sqrt_operand->operand(0) == sqrt_operand->operand(1)) {
     PrimitiveType element_type = sqrt_operand->shape().element_type();
     // For 'A' of type C{64,128}, |A| has type F{32,64}, and the transformation

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -5228,20 +5228,10 @@ absl::Status AlgebraicSimplifierVisitor::HandleOr(HloInstruction* logical_or) {
 }
 
 absl::Status AlgebraicSimplifierVisitor::HandleLog(HloInstruction* log) {
-  // ln(exp(A)) => A
-  //
-  // This identity holds over the reals, but not for IEEE 754 floating point:
-  // if exp(A) overflows to inf (A >= ~88.7 for f32, ~709.8 for f64), eager
-  // evaluation gives log(inf) = inf, while the folded form silently returns
-  // the finite A instead -- changing both the forward value and the gradient
-  // (chain rule through the unfolded form gives NaN at the overflow point,
-  // vs. 1 for the folded identity). Restrict to fast-math mode, matching how
-  // this file already gates other identities that are unsound at special
-  // values (e.g. "A - A => 0" above, unsound for NaN).
+  // ln(exp(A)) => A optimization is gated behind fast math flag.
   VLOG(10) << "trying transform [ln(exp(A)) => A]: " << log->ToString();
   HloInstruction *a, *b;
-  if (options_.enable_fast_math() &&
-      Match(log, m::Log(m::Exp(m::Op(&a)))) &&
+  if (options_.enable_fast_math() && Match(log, m::Log(m::Exp(m::Op(&a)))) &&
       ReplaceInstructionIfCompatible(log, a)) {
     return absl::OkStatus();
   }
@@ -9561,12 +9551,7 @@ absl::Status AlgebraicSimplifierVisitor::HandleSort(HloInstruction* sort) {
 absl::Status AlgebraicSimplifierVisitor::HandleSqrt(HloInstruction* sqrt) {
   VLOG(10) << "trying transform [sqrt(A*A) => |A|] " << sqrt->ToString();
   HloInstruction* sqrt_operand = sqrt->mutable_operand(0);
-  // sqrt(A*A) => |A| holds over the reals, but not for IEEE 754 floating
-  // point: if A*A overflows to inf (|A| > ~1.84e19 for f32), eager evaluation
-  // gives sqrt(inf) = inf, while the folded form silently returns the finite
-  // |A| instead. Restrict to fast-math mode, matching HandleLog's identical
-  // ln(exp(A)) => A guard immediately above in this file for the same
-  // reason.
+  // sqrt(A*A) => |A| optimization is gated behind fast math flag.
   if (options_.enable_fast_math() &&
       sqrt_operand->opcode() == HloOpcode::kMultiply &&
       sqrt_operand->operand(0) == sqrt_operand->operand(1)) {

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -2957,9 +2957,7 @@ TEST_F(AlgebraicSimplifierTest, LnExp) {
   EXPECT_THAT(computation->root_instruction(),
               GmockMatch(m::Log(m::Exp(m::Parameter(0)))));
 
-  // ln(exp(A)) => A is unsound under IEEE 754 when exp(A) overflows (eager
-  // gives log(inf) = inf, the fold gives the finite A), so it's gated behind
-  // fast-math.
+  // ln(exp(A)) => A optimization is gated behind fast math flag.
   AlgebraicSimplifierOptions options = default_options_;
   options.set_enable_fast_math(true);
   AlgebraicSimplifier simplifier(options);
@@ -2968,10 +2966,6 @@ TEST_F(AlgebraicSimplifierTest, LnExp) {
   EXPECT_EQ(computation->root_instruction(), param0);
 }
 
-// Regression test: ln(exp(A)) => A must NOT fire under default (non-fast-math)
-// options, since it silently hides f32 overflow in exp(A) for A >= ~88.7
-// (log(exp(89.0)) is inf under IEEE 754, but the fold would return the
-// finite 89.0).
 TEST_F(AlgebraicSimplifierTest, LnExpNotFoldedByDefault) {
   auto m = CreateNewVerifiedModule();
   Shape r0f32 = ShapeUtil::MakeShape(F32, {});
@@ -2986,9 +2980,6 @@ TEST_F(AlgebraicSimplifierTest, LnExpNotFoldedByDefault) {
   auto computation = m->AddEntryComputationWithLayouts(builder.Build());
 
   AlgebraicSimplifier simplifier(default_options_);
-  // The simplifier may return true/false depending on whether *other*
-  // instructions were simplified elsewhere in the graph; what matters is
-  // that this specific pattern is left untouched.
   ASSERT_TRUE(simplifier.Run(m.get()).ok());
 
   EXPECT_THAT(computation->root_instruction(),
@@ -3019,8 +3010,7 @@ TEST_F(AlgebraicSimplifierTest, LnExpDiv) {
               GmockMatch(m::Log(m::Divide(m::Exp(m::Parameter(0)),
                                           m::Exp(m::Parameter(1))))));
 
-  // Reaching the fully-reduced A-B form relies on ln(exp(A)) => A firing on
-  // each side of the division, which is gated behind fast-math (see LnExp).
+  // ln(exp(A)) => A optimization is gated behind fast math flag.
   AlgebraicSimplifierOptions options = default_options_;
   options.set_enable_fast_math(true);
   AlgebraicSimplifier simplifier(options);
@@ -12750,9 +12740,7 @@ TEST_F(AlgebraicSimplifierTest, SquaredComplexSqrtIsFloat) {
 
   TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
   SCOPED_TRACE("Before rewrite\n" + m->ToString());
-  // sqrt(A*A) => |A| is unsound under IEEE 754 when A*A overflows (eager
-  // gives sqrt(inf) = inf, the fold gives the finite |A|), so it's gated
-  // behind fast-math (see HandleSqrt).
+  // sqrt(A*A) => |A| optimization is gated behind fast math flag.
   AlgebraicSimplifierOptions options = default_options_;
   options.set_enable_fast_math(true);
   AlgebraicSimplifier simplifier(options);
@@ -12763,7 +12751,6 @@ TEST_F(AlgebraicSimplifierTest, SquaredComplexSqrtIsFloat) {
   EXPECT_THAT(root, GmockMatch(m::Convert(m::Abs(m::Parameter(0)))));
 }
 
-// sqrt(A*A) => |A| for a real-valued operand, under fast-math.
 TEST_F(AlgebraicSimplifierTest, SquaredSqrtIsAbsUnderFastMath) {
   const absl::string_view kModuleStr = R"(
   HloModule module
@@ -12785,10 +12772,6 @@ TEST_F(AlgebraicSimplifierTest, SquaredSqrtIsAbsUnderFastMath) {
   EXPECT_THAT(root, GmockMatch(m::Abs(m::Parameter(0))));
 }
 
-// Regression test: sqrt(A*A) => |A| must NOT fire under default
-// (non-fast-math) options, since it silently hides f32 overflow in A*A for
-// |A| > ~1.84e19 (sqrt(1e20*1e20) is inf under IEEE 754, but the fold would
-// return the finite 1e20).
 TEST_F(AlgebraicSimplifierTest, SquaredSqrtNotFoldedByDefault) {
   const absl::string_view kModuleStr = R"(
   HloModule module
@@ -12804,8 +12787,8 @@ TEST_F(AlgebraicSimplifierTest, SquaredSqrtNotFoldedByDefault) {
   AlgebraicSimplifier simplifier(default_options_);
   ASSERT_TRUE(simplifier.Run(m.get()).ok());
   auto* root = m->entry_computation()->root_instruction();
-  EXPECT_THAT(root, GmockMatch(m::Sqrt(m::Multiply(m::Parameter(0),
-                                                    m::Parameter(0)))));
+  EXPECT_THAT(
+      root, GmockMatch(m::Sqrt(m::Multiply(m::Parameter(0), m::Parameter(0)))));
 }
 
 // Don't replace root instruction with the copy-to-operand optimization if

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -2957,10 +2957,42 @@ TEST_F(AlgebraicSimplifierTest, LnExp) {
   EXPECT_THAT(computation->root_instruction(),
               GmockMatch(m::Log(m::Exp(m::Parameter(0)))));
 
-  AlgebraicSimplifier simplifier(default_options_);
+  // ln(exp(A)) => A is unsound under IEEE 754 when exp(A) overflows (eager
+  // gives log(inf) = inf, the fold gives the finite A), so it's gated behind
+  // fast-math.
+  AlgebraicSimplifierOptions options = default_options_;
+  options.set_enable_fast_math(true);
+  AlgebraicSimplifier simplifier(options);
   ASSERT_TRUE(simplifier.Run(m.get()).value());
 
   EXPECT_EQ(computation->root_instruction(), param0);
+}
+
+// Regression test: ln(exp(A)) => A must NOT fire under default (non-fast-math)
+// options, since it silently hides f32 overflow in exp(A) for A >= ~88.7
+// (log(exp(89.0)) is inf under IEEE 754, but the fold would return the
+// finite 89.0).
+TEST_F(AlgebraicSimplifierTest, LnExpNotFoldedByDefault) {
+  auto m = CreateNewVerifiedModule();
+  Shape r0f32 = ShapeUtil::MakeShape(F32, {});
+  HloComputation::Builder builder(TestName());
+  HloInstruction* param0 = builder.AddInstruction(
+      HloInstruction::CreateParameter(0, r0f32, "param0"));
+  HloInstruction* exp0 = builder.AddInstruction(
+      HloInstruction::CreateUnary(r0f32, HloOpcode::kExp, param0));
+  builder.AddInstruction(
+      HloInstruction::CreateUnary(r0f32, HloOpcode::kLog, exp0));
+
+  auto computation = m->AddEntryComputationWithLayouts(builder.Build());
+
+  AlgebraicSimplifier simplifier(default_options_);
+  // The simplifier may return true/false depending on whether *other*
+  // instructions were simplified elsewhere in the graph; what matters is
+  // that this specific pattern is left untouched.
+  ASSERT_TRUE(simplifier.Run(m.get()).ok());
+
+  EXPECT_THAT(computation->root_instruction(),
+              GmockMatch(m::Log(m::Exp(m::Parameter(0)))));
 }
 
 // Test that ln(exp(A)/exp(B)) is simplified to A-B
@@ -2987,7 +3019,11 @@ TEST_F(AlgebraicSimplifierTest, LnExpDiv) {
               GmockMatch(m::Log(m::Divide(m::Exp(m::Parameter(0)),
                                           m::Exp(m::Parameter(1))))));
 
-  AlgebraicSimplifier simplifier(default_options_);
+  // Reaching the fully-reduced A-B form relies on ln(exp(A)) => A firing on
+  // each side of the division, which is gated behind fast-math (see LnExp).
+  AlgebraicSimplifierOptions options = default_options_;
+  options.set_enable_fast_math(true);
+  AlgebraicSimplifier simplifier(options);
   ASSERT_TRUE(simplifier.Run(m.get()).value());
 
   EXPECT_THAT(computation->root_instruction(),
@@ -12714,13 +12750,62 @@ TEST_F(AlgebraicSimplifierTest, SquaredComplexSqrtIsFloat) {
 
   TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
   SCOPED_TRACE("Before rewrite\n" + m->ToString());
+  // sqrt(A*A) => |A| is unsound under IEEE 754 when A*A overflows (eager
+  // gives sqrt(inf) = inf, the fold gives the finite |A|), so it's gated
+  // behind fast-math (see HandleSqrt).
   AlgebraicSimplifierOptions options = default_options_;
+  options.set_enable_fast_math(true);
   AlgebraicSimplifier simplifier(options);
   TF_ASSERT_OK_AND_ASSIGN(auto result, simplifier.Run(m.get()));
   SCOPED_TRACE("After rewrite\n" + m->ToString());
   ASSERT_TRUE(result);
   auto* root = m->entry_computation()->root_instruction();
   EXPECT_THAT(root, GmockMatch(m::Convert(m::Abs(m::Parameter(0)))));
+}
+
+// sqrt(A*A) => |A| for a real-valued operand, under fast-math.
+TEST_F(AlgebraicSimplifierTest, SquaredSqrtIsAbsUnderFastMath) {
+  const absl::string_view kModuleStr = R"(
+  HloModule module
+
+  ENTRY entry {
+    arg = f32[7]{0} parameter(0)
+    multiply = f32[7]{0} multiply(arg, arg)
+    ROOT sqrt = f32[7]{0} sqrt(multiply)
+  }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  AlgebraicSimplifierOptions options = default_options_;
+  options.set_enable_fast_math(true);
+  AlgebraicSimplifier simplifier(options);
+  TF_ASSERT_OK_AND_ASSIGN(auto result, simplifier.Run(m.get()));
+  ASSERT_TRUE(result);
+  auto* root = m->entry_computation()->root_instruction();
+  EXPECT_THAT(root, GmockMatch(m::Abs(m::Parameter(0))));
+}
+
+// Regression test: sqrt(A*A) => |A| must NOT fire under default
+// (non-fast-math) options, since it silently hides f32 overflow in A*A for
+// |A| > ~1.84e19 (sqrt(1e20*1e20) is inf under IEEE 754, but the fold would
+// return the finite 1e20).
+TEST_F(AlgebraicSimplifierTest, SquaredSqrtNotFoldedByDefault) {
+  const absl::string_view kModuleStr = R"(
+  HloModule module
+
+  ENTRY entry {
+    arg = f32[7]{0} parameter(0)
+    multiply = f32[7]{0} multiply(arg, arg)
+    ROOT sqrt = f32[7]{0} sqrt(multiply)
+  }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  AlgebraicSimplifier simplifier(default_options_);
+  ASSERT_TRUE(simplifier.Run(m.get()).ok());
+  auto* root = m->entry_computation()->root_instruction();
+  EXPECT_THAT(root, GmockMatch(m::Sqrt(m::Multiply(m::Parameter(0),
+                                                    m::Parameter(0)))));
 }
 
 // Don't replace root instruction with the copy-to-operand optimization if

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -10908,7 +10908,9 @@ TEST_F(AlgebraicSimplifierTest, SqrtOfSelfMultiply) {
     }
   )";
   TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
-  ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  AlgebraicSimplifierOptions options = default_options_;
+  options.set_enable_fast_math(true);
+  ASSERT_TRUE(AlgebraicSimplifier(options).Run(m.get()).value());
   EXPECT_THAT(m->entry_computation()->root_instruction(),
               GmockMatch(m::Abs(m::Parameter(0))));
 }


### PR DESCRIPTION
`ln(exp(A)) => A` and `sqrt(A*A) => |A|` in `AlgebraicSimplifierVisitor` hold over the reals but not under IEEE 754: if `exp(A)` overflows to `inf`, eager evaluation gives `log(inf) = inf`, but the unconditional fold silently returns the finite `A` instead, changing both the value and the gradient. Reproduces identically under JAX and TF-XLA, confirming it's an XLA-level bug rather than either framework's own code.

This file already gates this class of transform behind fast-math elsewhere (e.g. `A - A => 0` is unsound for `NaN` and sits behind `enable_fast_math()`), so both folds now use that same guard rather than a new mechanism.

The originating report also mentions `exp(log(x))` losing precision under GPU flush-to-zero — couldn't find that fold in `HandleExp`, so it's out of scope here.

Fixes #42732
