### PR TITLE
[HLO] Return parse errors instead of OOB on malformed sharding/window/conv attributes

### DIFF
--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -4846,6 +4846,12 @@ bool HloParserImpl::ParseSingleSharding(std::optional<HloSharding>& sharding,
             "non-maximal shardings must have more than one device assigned");
       }
       auto tiles = std::make_shared<Array<int64_t>>(tile_assignment_dimensions);
+      if (devices.size() != tiles->num_elements()) {
+        return Error(
+            loc, absl::StrFormat("sharding device count %d does not match the "
+                                 "tile assignment size %d",
+                                 devices.size(), tiles->num_elements()));
+      }
       absl::c_copy(devices, tiles->begin());
       sharding =
           subgroup_types.empty()
@@ -6545,6 +6551,9 @@ bool HloParserImpl::ParseWindow(Window* window, bool expect_outer_curlies) {
   if (!pad.empty() && pad.size() != size.size()) {
     return Error(loc, "expects 'pad=' has the same size as 'size='");
   }
+  if (!rhs_reversal.empty() && rhs_reversal.size() != size.size()) {
+    return Error(loc, "expects 'rhs_reversal=' has the same size as 'size='");
+  }
 
   for (int i = 0; i < size.size(); i++) {
     window->add_dimensions()->set_size(size[i]);
@@ -6628,11 +6637,13 @@ bool HloParserImpl::ParseConvolutionDimensionNumbers(
         dnums->set_input_batch_dimension(i);
       } else if (c == 'f') {
         dnums->set_input_feature_dimension(i);
-      } else if (c < '0' + lhs.size() && c >= '0') {
+      } else if (c < '0' + dnums->input_spatial_dimensions_size() &&
+                 c >= '0') {
         dnums->set_input_spatial_dimensions(c - '0', i);
       } else {
-        return TokenError(StrFormat(
-            "expects [0-%dbf?] in lhs dimension numbers", lhs.size() - 1));
+        return TokenError(
+            StrFormat("expects [0-%dbf?] in lhs dimension numbers",
+                      dnums->input_spatial_dimensions_size() - 1));
       }
     }
   }
@@ -6657,11 +6668,13 @@ bool HloParserImpl::ParseConvolutionDimensionNumbers(
         dnums->set_kernel_input_feature_dimension(i);
       } else if (c == 'o') {
         dnums->set_kernel_output_feature_dimension(i);
-      } else if (c < '0' + rhs.size() && c >= '0') {
+      } else if (c < '0' + dnums->kernel_spatial_dimensions_size() &&
+                 c >= '0') {
         dnums->set_kernel_spatial_dimensions(c - '0', i);
       } else {
-        return TokenError(StrFormat(
-            "expects [0-%dio?] in rhs dimension numbers", rhs.size() - 1));
+        return TokenError(
+            StrFormat("expects [0-%dio?] in rhs dimension numbers",
+                      dnums->kernel_spatial_dimensions_size() - 1));
       }
     }
   }
@@ -6686,11 +6699,13 @@ bool HloParserImpl::ParseConvolutionDimensionNumbers(
         dnums->set_output_batch_dimension(i);
       } else if (c == 'f') {
         dnums->set_output_feature_dimension(i);
-      } else if (c < '0' + out.size() && c >= '0') {
+      } else if (c < '0' + dnums->output_spatial_dimensions_size() &&
+                 c >= '0') {
         dnums->set_output_spatial_dimensions(c - '0', i);
       } else {
-        return TokenError(StrFormat(
-            "expects [0-%dbf?] in output dimension numbers", out.size() - 1));
+        return TokenError(
+            StrFormat("expects [0-%dbf?] in output dimension numbers",
+                      dnums->output_spatial_dimensions_size() - 1));
       }
     }
   }

--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -4847,10 +4847,10 @@ bool HloParserImpl::ParseSingleSharding(std::optional<HloSharding>& sharding,
       }
       auto tiles = std::make_shared<Array<int64_t>>(tile_assignment_dimensions);
       if (devices.size() != tiles->num_elements()) {
-        return Error(loc, absl::StrCat("sharding device count ", devices.size(),
-                                       " does not match the tile assignment "
-                                       "size ",
-                                       tiles->num_elements()));
+        return Error(
+            loc, absl::StrCat("sharding device count ", devices.size(),
+                              " does not match the tile assignment size ",
+                              tiles->num_elements()));
       }
       absl::c_copy(devices, tiles->begin());
       sharding =

--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -4847,10 +4847,10 @@ bool HloParserImpl::ParseSingleSharding(std::optional<HloSharding>& sharding,
       }
       auto tiles = std::make_shared<Array<int64_t>>(tile_assignment_dimensions);
       if (devices.size() != tiles->num_elements()) {
-        return Error(
-            loc, absl::StrFormat("sharding device count %d does not match the "
-                                 "tile assignment size %d",
-                                 devices.size(), tiles->num_elements()));
+        return Error(loc, absl::StrCat("sharding device count ", devices.size(),
+                                       " does not match the tile assignment "
+                                       "size ",
+                                       tiles->num_elements()));
       }
       absl::c_copy(devices, tiles->begin());
       sharding =

--- a/xla/hlo/parser/hlo_parser_test.cc
+++ b/xla/hlo/parser/hlo_parser_test.cc
@@ -3513,6 +3513,44 @@ ENTRY e {
   EXPECT_FALSE(result.ok());
 }
 
+TEST_F(HloParserTest, ShardingDeviceCountExceedsTileAssignment) {
+  const std::string original = R"(HloModule m
+ENTRY e {
+  p = f32[4,4] parameter(0)
+  ROOT c = f32[4,4] copy(p), sharding={devices=[2,2]0,1,2,3,4,5,6,7,8,9}
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(),
+              HasSubstr("does not match the tile assignment size"));
+}
+
+TEST_F(HloParserTest, WindowRhsReversalWrongSize) {
+  const std::string original = R"(HloModule m
+ENTRY e {
+  input = f32[1,2,2,1] parameter(0)
+  filter = f32[1,1,1,1] parameter(1)
+  ROOT conv = f32[1,2,2,1] convolution(input, filter),
+      window={size=1x1 rhs_reversal=1}, dim_labels=b01f_01io->b01f
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(), HasSubstr("rhs_reversal"));
+}
+
+TEST_F(HloParserTest, ConvDimLabelDigitExceedsSpatialDims) {
+  const std::string original = R"(HloModule m
+ENTRY e {
+  input = f32[1,2,1] parameter(0)
+  filter = f32[1,1,1] parameter(1)
+  ROOT conv = f32[1,2,1] convolution(input, filter),
+      window={size=1}, dim_labels=9?????????_io->bf
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(), HasSubstr("dimension numbers"));
+}
+
 TEST_F(HloParserTest, CompactGteRoundTrip) {
   const std::string original =
       R"(HloModule test, entry_computation_layout={((f32[10]{0}, f16[10]{0}))->f32[10]{0}}


### PR DESCRIPTION
### Problem
Three attribute handlers in the HLO text parser read or write out of bounds (one overflows the heap) on malformed-but-lexable HLO text, instead of returning a parse error. Because these come straight from user text (`ParseAndReturnUnverifiedModule`, `xla::ParseSharding`, `xla::ParseWindow`, `xla::ParseConvolutionDimensionNumbers`), malformed input crashes / corrupts memory rather than producing a diagnostic.

1. **Sharding tile assignment — heap-buffer-overflow.** `ParseSingleSharding` allocates the tile-assignment `Array` sized to the product of the bracketed tile dimensions, then copies the full device list with no count check:
   ```cpp
   auto tiles = std::make_shared<Array<int64_t>>(tile_assignment_dimensions);
   absl::c_copy(devices, tiles->begin());   // writes devices.size() into product(dims) slots
   ```
   `sharding={devices=[2,2]0,1,...,31}` allocates 4 slots but copies 32 devices — a heap-buffer-overflow write. (The analogous `mesh[... device_ids=...]` path is guarded; this classic `devices=[...]` path is not.)

2. **Window `rhs_reversal` — OOB read.** `ParseWindow` length-checks `stride`, `lhs_dilate`, `rhs_dilate` and `pad` against `size`, but not `rhs_reversal`, then reads `rhs_reversal[i]` for every dimension:
   ```cpp
   window->mutable_dimensions(i)->set_window_reversal(
       rhs_reversal.empty() ? false : (rhs_reversal[i] == 1));
   ```
   `window={size=2x2 rhs_reversal=1}` reads `rhs_reversal[1]` out of bounds.

3. **Conv `dim_labels` — OOB write.** `ParseConvolutionDimensionNumbers` sizes the spatial-dimensions repeated field to the number of digit chars, but bounds each digit by the *full* label length:
   ```cpp
   } else if (c < '0' + lhs.size() && c >= '0') {
     dnums->set_input_spatial_dimensions(c - '0', i);   // index can exceed the field size
   ```
   `dim_labels=9?????????_io->bf` (one spatial dim, digit value 9) writes at index 9 of a size-1 field. Same for the rhs and output labels.

### Fix
- Sharding: check `devices.size() == tiles->num_elements()` and return an error on mismatch before the copy.
- Window: add the missing `rhs_reversal` size check alongside the others.
- Conv: bound each digit by the spatial-dimensions field size (`input/kernel/output_spatial_dimensions_size()`) instead of the label length, and report the accurate valid range.

All three are behavior-preserving on valid HLO (the printer always emits matching counts) and convert the corruption/OOB into a returned error `Status`.

### Tests
Three `HloParserTest` cases assert the malformed inputs above now return an error instead of crashing.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
