### PR TITLE
[XLA:GPU] Add RHS transpose fold test for dot

### DIFF
--- a/xla/service/gpu/matmul_utils_test.cc
+++ b/xla/service/gpu/matmul_utils_test.cc
@@ -56,6 +56,25 @@ ENTRY AddDotsFunc {
               absl_testing::IsOkAndHolds(true));
 }
 
+TEST_F(CanFoldTransposeOperandIntoDotTest, RhsTransposeFoldGemm) {
+  const char* hlo_text = R"(
+HloModule RhsTransposeFoldGemm
+
+ENTRY AddDotsFunc {
+  x = f32[2,3] parameter(0)
+  y = f32[4,3] parameter(1)
+  y_transposed = f32[3,4] transpose(y), dimensions={1, 0}
+  ROOT dot_a = f32[2,4] dot(x, y_transposed), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+}
+
+)";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(hlo_text));
+  auto dot = module->entry_computation()->root_instruction();
+  EXPECT_THAT(CanFoldTransposeOperandIntoDot(*dot, 1),
+              absl_testing::IsOkAndHolds(true));
+}
+
 TEST_F(CanFoldTransposeOperandIntoDotTest, BatchedArgRowColTransposeFoldGemm) {
   const char* hlo_text = R"(
 HloModule BatchedArgRowColTransposeFoldGemm


### PR DESCRIPTION
Add test coverage for folding a transpose on the RHS operand of a dot.

Existing tests cover positive LHS transpose folding and a negative RHS case (TransposedNonContractingDimsDontFold). This adds the corresponding positive RHS case where the RHS contracting dimension is transposed.

📝 Summary of Changes
Added RhsTransposeFoldGemm to matmul_utils_test.cc.
The test covers CanFoldTransposeOperandIntoDot(*dot, 1) returning true for a valid RHS transpose fold case.

🎯 Justification
The function CanFoldTransposeOperandIntoDot handles both LHS (operand_idx=0)
and RHS (operand_idx=1) operands. Existing tests cover positive LHS folding
and a negative RHS case (TransposedNonContractingDimsDontFold), but the
positive RHS fold case was not tested. This adds the missing coverage.

🚀 Kind of Contribution
🧪 Tests

🧪 Unit Tests:
Added RhsTransposeFoldGemm test in matmul_utils_test.cc.
Tests that CanFoldTransposeOperandIntoDot returns true when the RHS
operand has a transpose on the contracting dimension.