### PR TITLE
[XLA:GPU] Support VA remapping of output buffer allocations

### DIFF
--- a/xla/service/gpu/gpu_executable_va_remap_allocator.cc
+++ b/xla/service/gpu/gpu_executable_va_remap_allocator.cc
@@ -103,10 +103,10 @@ class GpuExecutableVaRemapAllocator::VaRemapExecutionScope
   bool va_remap_enabled() const override { return true; }
 
   // Builds an execution-only address table, maps caller- or allocator-owned
-  // parameter buffers into their stable reservation addresses, and passes the
-  // persistent allocation indices (constants and VA-remapped allocations) to
-  // `execute`. The owning address table remains unchanged for result handling
-  // and TearDown.
+  // input/output buffers into their stable reservation addresses, and passes
+  // the persistent allocation indices (constants and VA-remapped allocations)
+  // to `execute`. The owning address table remains unchanged for result
+  // handling and TearDown.
   absl::Status ExecuteWithBufferAllocations(
       const BufferAllocations& owning_buffer_allocations, int device_ordinal,
       absl::FunctionRef<
@@ -141,9 +141,9 @@ class GpuExecutableVaRemapAllocator::VaRemapExecutionScope
   absl::StatusOr<se::ScopedDeviceAddress<uint8_t>> AllocateBuffer(
       int device_ordinal, const BufferAllocation& allocation,
       int64_t buffer_size);
-  // Installs reservation aliases for selected parameter buffers and returns an
-  // execution-only address table that refers to them. The owning address table
-  // remains unchanged.
+  // Installs reservation aliases for selected input/output buffers and returns
+  // an execution-only address table that refers to them. The owning address
+  // table remains unchanged.
   absl::StatusOr<BufferAllocations> GetRemappedBufferAllocations(
       const BufferAllocations& owning_buffer_allocations, int device_ordinal);
 
@@ -260,9 +260,9 @@ absl::StatusOr<BufferAllocations> GpuExecutableVaRemapAllocator::
         const BufferAllocations& owning_buffer_allocations,
         int device_ordinal) {
   // This is a non-owning copy of the finalized address table. Output donation
-  // and copy protection run before this method and may replace parameter
-  // entries, so parameter aliases must be installed from these current
-  // addresses instead of during GenerateBufferAllocations.
+  // and copy protection run before this method and may replace input/output
+  // entries, so aliases must be installed from these current addresses instead
+  // of during GenerateBufferAllocations.
   BufferAllocations execution_allocations(
       owning_buffer_allocations.buffers(),
       owning_buffer_allocations.device_ordinal(),
@@ -270,15 +270,15 @@ absl::StatusOr<BufferAllocations> GpuExecutableVaRemapAllocator::
 
   for (BufferAllocation::Index index : owner_->va_remapped_alloc_indices_) {
     const BufferAllocation& allocation = *owner_->allocations()[index];
-    if (!allocation.is_entry_computation_parameter()) {
+    if (!allocation.IsInputOrOutput()) {
       continue;
     }
     const se::DeviceAddressBase buffer =
         owning_buffer_allocations.GetDeviceAddress(index);
     if (buffer.is_null()) {
       return Internal(
-          "Command buffer VA remapping selected parameter allocation %d, but "
-          "the parameter buffer is null for this execution",
+          "Command buffer VA remapping selected input/output allocation %d, "
+          "but its buffer is null for this execution",
           allocation.index());
     }
     ASSIGN_OR_RETURN(uint64_t va_offset,
@@ -286,8 +286,8 @@ absl::StatusOr<BufferAllocations> GpuExecutableVaRemapAllocator::
     ASSIGN_OR_RETURN(uint64_t mapping_size,
                      remapping_->GetMappingSize(allocation.index()));
     // Map() reactivates a matching stale mapping from the previous execution,
-    // so a parameter that keeps its address across executions performs no VMM
-    // driver calls here.
+    // so an input/output that keeps its address across executions performs no
+    // VMM driver calls here.
     RETURN_IF_ERROR(vmm_allocator_->Map(device_ordinal, buffer,
                                         remapping_->va_reservation.get(),
                                         va_offset, mapping_size));
@@ -316,7 +316,8 @@ absl::StatusOr<se::DeviceAddressBase>
 GpuExecutableVaRemapAllocator::VaRemapExecutionScope::AllocateTransientBuffer(
     int device_ordinal, const BufferAllocation& allocation, int64_t buffer_size,
     se::DeviceAddressAllocator* memory_allocator) {
-  if (!ShouldRemapAllocation(allocation.index())) {
+  if (!ShouldRemapAllocation(allocation.index()) ||
+      allocation.maybe_live_out()) {
     return ExecutionScope::AllocateTransientBuffer(
         device_ordinal, allocation, buffer_size, memory_allocator);
   }

--- a/xla/service/gpu/gpu_executable_va_remap_allocator_test.cc
+++ b/xla/service/gpu/gpu_executable_va_remap_allocator_test.cc
@@ -15,10 +15,12 @@ limitations under the License.
 
 #include "xla/service/gpu/gpu_executable_va_remap_allocator.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>
@@ -93,7 +95,16 @@ class TestMemoryAllocation final : public se::MemoryAllocation {
 
 class TestMemoryReservation final : public se::MemoryReservation {
  public:
-  explicit TestMemoryReservation(uint64_t size) : storage_(size), size_(size) {}
+  TestMemoryReservation(
+      uint64_t size,
+      std::shared_ptr<std::vector<TestMemoryReservation*>> registry)
+      : storage_(size), size_(size), registry_(std::move(registry)) {
+    registry_->push_back(this);
+  }
+
+  ~TestMemoryReservation() override {
+    registry_->erase(std::find(registry_->begin(), registry_->end(), this));
+  }
 
   se::DeviceAddressBase address() const override {
     return se::DeviceAddressBase(storage_.data(), size_);
@@ -102,6 +113,12 @@ class TestMemoryReservation final : public se::MemoryReservation {
   int active_mapping_count() const { return active_mapping_count_; }
   const void* last_mapped_allocation_address() const {
     return last_mapped_allocation_address_;
+  }
+
+  bool Contains(const void* addr) const {
+    const uintptr_t base = reinterpret_cast<uintptr_t>(storage_.data());
+    const uintptr_t ptr = reinterpret_cast<uintptr_t>(addr);
+    return ptr >= base && ptr < base + size_;
   }
 
  private:
@@ -132,6 +149,7 @@ class TestMemoryReservation final : public se::MemoryReservation {
 
   AlignedStorage storage_;
   uint64_t size_;
+  std::shared_ptr<std::vector<TestMemoryReservation*>> registry_;
   int active_mapping_count_ = 0;
   const void* last_mapped_allocation_address_ = nullptr;
 };
@@ -159,6 +177,16 @@ class TestVmmAllocator final : public se::DeviceAddressVmmAllocator {
     fail_next_deferred_deallocation_ = true;
   }
 
+  // Returns the live reservation whose storage contains `addr`, or null.
+  TestMemoryReservation* FindReservationContaining(const void* addr) const {
+    for (TestMemoryReservation* reservation : *live_reservations_) {
+      if (reservation->Contains(addr)) {
+        return reservation;
+      }
+    }
+    return nullptr;
+  }
+
  protected:
   absl::Status InitializeDeviceState(PerDeviceState& state) override {
     state.allocation_granularity = kGranularity;
@@ -178,8 +206,8 @@ class TestVmmAllocator final : public se::DeviceAddressVmmAllocator {
 
   absl::StatusOr<std::unique_ptr<se::MemoryReservation>> CreateReservation(
       se::StreamExecutor* /*executor*/, uint64_t size) override {
-    auto reservation =
-        std::make_unique<TestMemoryReservation>(RoundUpTestSize(size));
+    auto reservation = std::make_unique<TestMemoryReservation>(
+        RoundUpTestSize(size), live_reservations_);
     last_reservation_ = reservation.get();
     return reservation;
   }
@@ -201,6 +229,8 @@ class TestVmmAllocator final : public se::DeviceAddressVmmAllocator {
   TestMemoryReservation* last_reservation_ = nullptr;
   const void* last_created_allocation_address_ = nullptr;
   bool fail_next_deferred_deallocation_ = false;
+  std::shared_ptr<std::vector<TestMemoryReservation*>> live_reservations_ =
+      std::make_shared<std::vector<TestMemoryReservation*>>();
 };
 
 class GpuExecutableVaRemapAllocatorTest : public ::testing::Test {
@@ -471,6 +501,100 @@ TEST_F(GpuExecutableVaRemapAllocatorTest,
   scope.reset();
   ASSERT_OK(vmm_allocator->SynchronizePendingOperations(/*device_ordinal=*/0));
   EXPECT_EQ(vmm_allocator->last_reservation()->active_mapping_count(), 0);
+}
+
+TEST_F(GpuExecutableVaRemapAllocatorTest,
+       RemapsOutputBufferUsingExecutionOnlyAllocationTable) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<TestVmmAllocator> vmm_allocator,
+                       CreateAllocator());
+
+  // Exercise a logical allocation size that is not VMM-granularity aligned.
+  constexpr int64_t kBufferSize = 1000;
+  BufferAllocation output_alloc(/*index=*/0, kBufferSize, /*color=*/0);
+  output_alloc.set_maybe_live_out(true);
+  std::vector<const BufferAllocation*> allocations = {&output_alloc};
+
+  ThunkExecutor thunk_executor{ThunkSequence{}};
+  DebugOptions debug_options;
+  debug_options.set_xla_gpu_command_buffer_update_mode(DebugOptions::SKIP_TEMP);
+  GpuExecutableVaRemapAllocator allocator("test", allocations,
+                                          ShapeUtil::MakeShape(F32, {250}),
+                                          &debug_options, &thunk_executor);
+  allocator.AddVaRemappedAllocationForTesting(0);
+
+  auto get_parameter_buffer = [&](const BufferAllocation& allocation)
+      -> absl::StatusOr<GpuExecutableBufferAllocator::ParameterBuffer> {
+    return absl::InternalError("no parameters in this test");
+  };
+  GpuExecutableBufferAllocator::BufferAllocToDeviceMemoryMap globals;
+
+  const void* reservation_address = nullptr;
+  TestMemoryReservation* va_reservation = nullptr;
+  for (int run = 0; run < 2; ++run) {
+    ASSERT_OK_AND_ASSIGN(
+        std::unique_ptr<GpuExecutableBufferAllocator::ExecutionScope> scope,
+        allocator.CreateExecutionScope(&service_run_options_,
+                                       vmm_allocator.get(),
+                                       /*device_ordinal=*/0));
+    ASSERT_OK_AND_ASSIGN(BufferAllocations buffer_allocations,
+                         scope->GenerateBufferAllocations(
+                             &service_run_options_, get_parameter_buffer,
+                             &globals, vmm_allocator.get(),
+                             /*device_ordinal=*/0));
+
+    // GenerateBufferAllocations leaves an allocator-owned address in the
+    // owning table, so callers can expose and eventually deallocate it.
+    const se::DeviceAddressBase external =
+        buffer_allocations.GetDeviceAddress(0);
+    EXPECT_EQ(external.size(), kBufferSize);
+    se::MemoryAllocation* raw_allocation =
+        vmm_allocator->GetRawAllocation(/*device_ordinal=*/0, external);
+    ASSERT_NE(raw_allocation, nullptr);
+
+    bool executed = false;
+    ASSERT_OK(scope->ExecuteWithBufferAllocations(
+        buffer_allocations, /*device_ordinal=*/0,
+        [&](const BufferAllocations& execution_buffers,
+            std::optional<absl::Span<const BufferAllocation::Index>>
+                persistent_alloc_indices) {
+          executed = true;
+          const se::DeviceAddressBase mapped =
+              execution_buffers.GetDeviceAddress(0);
+          EXPECT_NE(mapped.opaque(), external.opaque());
+          if (run == 0) {
+            reservation_address = mapped.opaque();
+            va_reservation =
+                vmm_allocator->FindReservationContaining(mapped.opaque());
+            if (va_reservation == nullptr) {
+              return absl::InternalError(
+                  "execution address is outside the VA reservation");
+            }
+            EXPECT_EQ(mapped.opaque(), va_reservation->address().opaque());
+          }
+          EXPECT_EQ(mapped.opaque(), reservation_address);
+          EXPECT_EQ(va_reservation->last_mapped_allocation_address(),
+                    raw_allocation->address().opaque());
+          EXPECT_TRUE(persistent_alloc_indices.has_value());
+          EXPECT_THAT(*persistent_alloc_indices, ElementsAre(0));
+          return absl::OkStatus();
+        }));
+    EXPECT_TRUE(executed);
+
+    // ExecuteWithBufferAllocations remaps only its local copy.
+    EXPECT_EQ(buffer_allocations.GetDeviceAddress(0).opaque(),
+              external.opaque());
+    EXPECT_EQ(buffer_allocations.GetDeviceAddress(0).size(), kBufferSize);
+
+    // The external buffer escapes to the caller; release it like a result
+    // consumer would.
+    ASSERT_OK(vmm_allocator->Deallocate(/*device_ordinal=*/0, external));
+  }
+
+  // All reservation-address aliases are released once deferred operations
+  // complete.
+  ASSERT_OK(vmm_allocator->SynchronizePendingOperations(/*device_ordinal=*/0));
+  ASSERT_NE(va_reservation, nullptr);
+  EXPECT_EQ(va_reservation->active_mapping_count(), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
## 📝 Summary of Changes

This PR extends command-buffer virtual-address remapping to allocations that
escape to the caller (`maybe_live_out`) while preserving the const ownership
model introduced by #45595.

- Keeps selected live-out allocations at normal allocator-owned addresses in
  the owning `BufferAllocations` table.
- Extends `GetRemappedBufferAllocations` to map finalized selected input/output
  addresses into their stable reservation slices immediately before execution.
- Rewrites only the non-owning execution copy, so result handling and teardown
  continue to see external, deallocatable addresses.
- Handles donated and copy-protected aliases by mapping after output setup has
  finalized the owning address table.
- Extends the host-only fake-VMM tests to cover stable execution aliases,
  logical external sizes, output deallocation, and deferred alias cleanup.

This PR is stacked on #45595, **[XLA:GPU] Support VA remapping of parameter
buffer allocations**. It is part 2 of 3 splitting the former #45568
implementation; #45597 adds the `SKIP_PROFILED` mode.

## 🎯 Justification

Live-out buffers can outlive an execution scope, so the caller must retain a
normal allocator-owned address that remains valid and can be passed to
`Deallocate()`. At the same time, recorded command buffers need a stable
reservation address.

Building a separate execution allocation table provides both properties
without mutating the owning table or removing its const qualifier. Deferring
the mapping until execution also ensures donation and copy protection have
already selected the final external address.

## 🚀 Kind of Contribution

✨ New Feature

## 📊 Benchmark (for Performance Improvements)

Not applicable as a standalone change. This PR adds output-buffer remapping
support but does not independently enable a new command-buffer update mode.
Performance evaluation belongs to the final `SKIP_PROFILED` policy in #45597.

## 🧪 Unit Tests:

- Extends the host-only fake-VMM allocator test with a non-granularity-aligned
  remapped live-out allocation.
- Verifies the owning table contains the logical-size external address before
  and after execution.
- Verifies execution receives the same stable reservation address across runs
  and maps the correct raw physical allocation.
- Verifies the external address is deallocatable and all aliases are released.

## 🧪 Execution Tests:

No standalone execution test is added for this enabling layer. End-to-end
live-out selection, execution, and output deallocation are covered by the
stacked `SKIP_PROFILED` change in #45597.
