### PR TITLE
[XLA:GPU] Skip grouped gemm tests for SYCL

### DIFF
--- a/xla/backends/gpu/transforms/gemm_rewriter_test_lib.cc
+++ b/xla/backends/gpu/transforms/gemm_rewriter_test_lib.cc
@@ -76,9 +76,9 @@ bool GemmRewriteTestBase::SkipGpuBlasLtTest() {
 
 bool GemmRewriteTestBase::SkipGroupedGemmTest() {
   // Grouped GEMM is only supported on ROCm with hipBLASLt on gfx942 or gfx950
-  return IsCuda() || !Capability().rocm_compute_capability()->has_hipblaslt() ||
-         (Capability().rocm_compute_capability()->has_hipblaslt() &&
-          !Capability().rocm_compute_capability()->gfx9_mi300_series());
+  const auto* rocm_cc = Capability().rocm_compute_capability();
+  return IsCuda() || IsSycl() || !rocm_cc->has_hipblaslt() ||
+         (rocm_cc->has_hipblaslt() && !rocm_cc->gfx9_mi300_series());
 }
 
 bool GemmRewriteTestBase::HasFp8Support() const {


### PR DESCRIPTION
This PR adds a check to skip Grouped Gemm tests for SYCL since Grouped GEMM is only supported on ROCm
