### PR TITLE
Revert "PR #45383: [ROCm] undo PIN JAX checkout e9b2a417d294f100a3279…

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -86,6 +86,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: jax-ml/jax
+          ref: 'e6299e2e5917c3856beece723a97e566708daaf8'
           path: jax
           persist-credentials: false
 


### PR DESCRIPTION
…228c016be8105fa6a7d"

This reverts commit b7a8f90cc5dc1e90aa5cb1d81a5577892ed8234e.

📝 Summary of Changes
Reverts PR #45383

🎯 Justification
We have new hickups with JAX CI. Revert to last know to work configuration.