### PR TITLE
[xla:gpu] Add an API to wait on multiple peers with one NCCL API call

### DIFF
--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -510,6 +510,134 @@ TEST(GpuCollectivesTest, PutAndWaitSignal) {
   EXPECT_THAT(h_recv1, testing::ElementsAre(1.0f, 2.0f, 3.0f, 4.0f));
 }
 
+TEST(GpuCollectivesTest, PutAndWaitSignals) {
+  ASSERT_OK_AND_ASSIGN(se::Platform * platform,
+                       PlatformUtil::GetPlatform("gpu"));
+
+  if (platform->VisibleDeviceCount() < 4) {
+    GTEST_SKIP() << "Test requires at least 4 GPUs";
+  }
+
+  ASSERT_OK_AND_ASSIGN(std::vector<se::StreamExecutor*> executors,
+                       CreateExecutors(platform, 4));
+  for (se::StreamExecutor* executor : executors) {
+    auto cc = executor->GetDeviceDescription().gpu_compute_capability();
+    if (!cc.IsCuda()) {
+      GTEST_SKIP() << "Test requires CUDA";
+    }
+    if (!cc.cuda_compute_capability()->IsAtLeastHopper()) {
+      GTEST_SKIP() << "Test requires at least Hopper architecture";
+    }
+  }
+  for (size_t peer = 1; peer < executors.size(); ++peer) {
+    if (!executors[peer]->CanEnablePeerAccessTo(executors[0])) {
+      GTEST_SKIP() << "Test requires peer access to device 0";
+    }
+  }
+
+  ASSERT_OK_AND_ASSIGN(auto comms,
+                       CreateCommunicators(executors, {kD0, kD1, kD2, kD3}));
+  ASSERT_OK_AND_ASSIGN(auto allocators, CreateMemoryAllocators(executors));
+
+  constexpr size_t kChunkFloats = 4;
+  constexpr size_t kChunkBytes = kChunkFloats * sizeof(float);
+  constexpr size_t kRecvFloats = 3 * kChunkFloats;
+  constexpr size_t kRecvBytes = kRecvFloats * sizeof(float);
+
+  ASSERT_OK_AND_ASSIGN(auto send_allocs, Allocate(allocators, kChunkBytes));
+  ASSERT_OK_AND_ASSIGN(auto recv_allocs, Allocate(allocators, kRecvBytes));
+
+  ASSERT_OK_AND_ASSIGN(auto stream0, executors[0]->CreateStream());
+  ASSERT_OK_AND_ASSIGN(auto stream1, executors[1]->CreateStream());
+  ASSERT_OK_AND_ASSIGN(auto stream2, executors[2]->CreateStream());
+  ASSERT_OK_AND_ASSIGN(auto stream3, executors[3]->CreateStream());
+
+  float h_send1[] = {1.0f, 2.0f, 3.0f, 4.0f};
+  float h_send2[] = {5.0f, 6.0f, 7.0f, 8.0f};
+  float h_send3[] = {9.0f, 10.0f, 11.0f, 12.0f};
+
+  se::DeviceAddressBase send1_addr = send_allocs[1]->address();
+  se::DeviceAddressBase send2_addr = send_allocs[2]->address();
+  se::DeviceAddressBase send3_addr = send_allocs[3]->address();
+  se::DeviceAddressBase recv0_addr = recv_allocs[0]->address();
+
+  ASSERT_OK(stream1->Memcpy(&send1_addr, h_send1, kChunkBytes));
+  ASSERT_OK(stream2->Memcpy(&send2_addr, h_send2, kChunkBytes));
+  ASSERT_OK(stream3->Memcpy(&send3_addr, h_send3, kChunkBytes));
+  std::array<se::Stream*, 4> streams = {stream0.get(), stream1.get(),
+                                        stream2.get(), stream3.get()};
+  for (size_t i = 0; i < executors.size(); ++i) {
+    se::DeviceAddressBase recv_addr = recv_allocs[i]->address();
+    ASSERT_OK(streams[i]->MemZero(&recv_addr, kRecvBytes));
+    ASSERT_OK(streams[i]->BlockHostUntilDone());
+  }
+
+  tsl::thread::ThreadPool pool(tsl::Env::Default(), "collectives", 4);
+  tsl::Executor& exec = *pool.AsExecutor();
+
+  auto fsymm_send = CreateSymmetricMemory(exec, comms, send_allocs);
+  ASSERT_OK_AND_ASSIGN(auto symm_send,
+                       AwaitSymmetricMemory(std::move(fsymm_send)));
+
+  auto fsymm_recv = CreateSymmetricMemory(exec, comms, recv_allocs);
+  ASSERT_OK_AND_ASSIGN(auto symm_recv,
+                       AwaitSymmetricMemory(std::move(fsymm_recv)));
+
+  GpuSignalDesc signal_desc(0, 0);
+
+  auto f0 = MakeFutureOn<void>(exec, [&]() -> absl::Status {
+    GpuCollectives::Executor gpu_exec(stream0.get());
+    std::array<Communicator::PeerWaitDesc, 3> peer_wait_descs = {
+        Communicator::PeerWaitDesc{RankId(1), 1, signal_desc},
+        Communicator::PeerWaitDesc{RankId(2), 1, signal_desc},
+        Communicator::PeerWaitDesc{RankId(3), 1, signal_desc}};
+    return comms[0]->WaitSignals(peer_wait_descs, gpu_exec).Await();
+  });
+
+  auto f1 = MakeFutureOn<void>(exec, [&]() -> absl::Status {
+    GpuCollectives::Executor gpu_exec(stream1.get());
+    return comms[1]
+        ->Put(send1_addr, symm_recv[1].get(), /*offset=*/0, kChunkBytes,
+              RankId(0), gpu_exec)
+        .Await();
+  });
+
+  auto f2 = MakeFutureOn<void>(exec, [&]() -> absl::Status {
+    GpuCollectives::Executor gpu_exec(stream2.get());
+    return comms[2]
+        ->Put(send2_addr, symm_recv[2].get(), /*offset=*/kChunkBytes,
+              kChunkBytes, RankId(0), gpu_exec)
+        .Await();
+  });
+
+  auto f3 = MakeFutureOn<void>(exec, [&]() -> absl::Status {
+    GpuCollectives::Executor gpu_exec(stream3.get());
+    return comms[3]
+        ->Put(send3_addr, symm_recv[3].get(), /*offset=*/2 * kChunkBytes,
+              kChunkBytes, RankId(0), gpu_exec)
+        .Await();
+  });
+
+  ASSERT_OK(f0.Await());
+  ASSERT_OK(f1.Await());
+  ASSERT_OK(f2.Await());
+  ASSERT_OK(f3.Await());
+
+  ASSERT_OK(stream0->BlockHostUntilDone());
+
+  float h_recv0[kRecvFloats];
+  ASSERT_OK(stream0->Memcpy(h_recv0, recv0_addr, kRecvBytes));
+  ASSERT_OK(stream0->BlockHostUntilDone());
+
+  EXPECT_THAT(h_recv0,
+              testing::ElementsAre(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f,
+                                   8.0f, 9.0f, 10.0f, 11.0f, 12.0f));
+
+  ASSERT_OK(stream1->BlockHostUntilDone());
+  ASSERT_OK(stream2->BlockHostUntilDone());
+  ASSERT_OK(stream3->BlockHostUntilDone());
+}
+
 // Verifies that AllocatorMemoryRegistration registers recorded allocator ranges
 // with the clique communicator that runs on the same device.
 TEST(GpuCollectivesTest, AllocatorMemoryRegistrationRegistersWithClique) {

--- a/xla/backends/gpu/collectives/gpu_communicator.h
+++ b/xla/backends/gpu/collectives/gpu_communicator.h
@@ -247,6 +247,12 @@ class GpuCommunicator : public Communicator {
     return Unimplemented("LaunchWaitSignal is not implemented");
   }
 
+  virtual absl::Status LaunchWaitSignals(
+      absl::Span<const PeerWaitDesc> peer_wait_descs,
+      const Executor& executor) {
+    return Unimplemented("LaunchWaitSignals is not implemented");
+  }
+
   virtual absl::Status LaunchMultiGpuBarrier(const Executor& executor) {
     return Unimplemented("LaunchMultiGpuBarrier is not implemented");
   }

--- a/xla/backends/gpu/collectives/nccl_communicator.cc
+++ b/xla/backends/gpu/collectives/nccl_communicator.cc
@@ -174,8 +174,8 @@ NcclCommunicator::NcclCommunicator(se::StreamExecutor* stream_executor,
       executor_(std::move(executor)),
       cancel_(std::move(cancel)) {
   capabilities_ = GetCapabilities(comm_);
-  VLOG(1) << absl::StreamFormat("[%d] Created NCCL communicator %v",
-                                stream_executor_->device_ordinal(), *this);
+  XLA_VLOG_DEVICE(1, stream_executor_->device_ordinal())
+      << absl::StreamFormat("Created NCCL communicator %v", *this);
 }
 
 bool NcclCommunicator::SupportsDeviceComm() const {
@@ -188,8 +188,9 @@ NcclCommunicator::CreateDeviceComm(
   return ExecuteAwait<std::unique_ptr<GpuDeviceCommunicator>>(
       [this, requirements]()
           -> absl::StatusOr<std::unique_ptr<GpuDeviceCommunicator>> {
-        VLOG(5) << "Creating device communicator with requirements: "
-                << requirements;
+        XLA_VLOG_DEVICE(5, stream_executor_->device_ordinal())
+            << "Creating device communicator with requirements: "
+            << requirements;
         if (cancel_->IsCancelled()) {
           return FailedPrecondition("NcclCommunicator aborted");
         }
@@ -202,7 +203,8 @@ absl::StatusOr<std::unique_ptr<RegisteredMemory>>
 NcclCommunicator::CreateRegisteredMemory(se::DeviceAddressBase addr) {
   return ExecuteAwait<std::unique_ptr<RegisteredMemory>>(
       [this, addr]() -> absl::StatusOr<std::unique_ptr<RegisteredMemory>> {
-        VLOG(5) << "Registering buffer for device address: " << addr.opaque();
+        XLA_VLOG_DEVICE(5, stream_executor_->device_ordinal())
+            << "Registering buffer for device address: " << addr.opaque();
         if (cancel_->IsCancelled()) {
           return FailedPrecondition("NcclCommunicator aborted");
         }
@@ -215,8 +217,9 @@ absl::StatusOr<std::unique_ptr<SymmetricMemory>>
 NcclCommunicator::CreateSymmetricMemory(se::DeviceAddressBase addr) {
   return ExecuteAwait<std::unique_ptr<SymmetricMemory>>(
       [this, addr]() -> absl::StatusOr<std::unique_ptr<SymmetricMemory>> {
-        VLOG(5) << "Creating symmetric memory for device address: "
-                << addr.opaque();
+        XLA_VLOG_DEVICE(5, stream_executor_->device_ordinal())
+            << "Creating symmetric memory for device address: "
+            << addr.opaque();
         if (cancel_->IsCancelled()) {
           return FailedPrecondition("NcclCommunicator aborted");
         }
@@ -267,12 +270,14 @@ absl::StatusOr<std::unique_ptr<NcclCommunicator>> NcclCommunicator::Create(
 NcclCommunicator::~NcclCommunicator() {
   auto f = [this]() -> absl::Status {
     if (comm_ == nullptr) {
-      VLOG(1) << "Skipping destruction; null comm_ " << *this;
+      XLA_VLOG_DEVICE(1, stream_executor_->device_ordinal())
+          << "Skipping destruction; null comm_ " << *this;
       return absl::OkStatus();
     }
 
     if (aborted_) {
-      VLOG(1) << "Skipping destruction; already aborted " << *this;
+      XLA_VLOG_DEVICE(1, stream_executor_->device_ordinal())
+          << "Skipping destruction; already aborted " << *this;
       return absl::OkStatus();
     }
 
@@ -280,16 +285,19 @@ NcclCommunicator::~NcclCommunicator() {
     // been destroyed, we can no longer safely touch it.
     absl::MutexLock lock(comm_->mutex);
     if (comm_->comm == nullptr) {
-      VLOG(1) << "Skipping destruction; null comm " << *this;
+      XLA_VLOG_DEVICE(1, stream_executor_->device_ordinal())
+          << "Skipping destruction; null comm " << *this;
       return absl::OkStatus();
     }
 
-    VLOG(1) << "Destroy " << *this;
+    XLA_VLOG_DEVICE(1, stream_executor_->device_ordinal())
+        << "Destroy " << *this;
     return XLA_NCCL_STATUS(ncclCommDestroy(comm_->comm));
   };
 
   if (absl::Status s = Execute(f).Await(); !s.ok()) {
-    LOG(ERROR) << "NcclCommunicator::~NcclCommunicator: " << s;
+    XLA_LOG_DEVICE(ERROR, stream_executor_->device_ordinal())
+        << "NcclCommunicator::~NcclCommunicator: " << s;
   }
 }
 
@@ -299,7 +307,8 @@ absl::Status NcclCommunicator::Abort() {
   cancel_->Cancel();
 
   return ExecuteAwait([this]() -> absl::Status {
-    VLOG(1) << "Abort NCCL communicator: " << *this;
+    XLA_VLOG_DEVICE(1, stream_executor_->device_ordinal())
+        << "Abort NCCL communicator: " << *this;
     if (aborted_) {
       return FailedPrecondition("NcclCommunicator already aborted");
     }
@@ -313,7 +322,8 @@ absl::Status NcclCommunicator::Abort() {
 
 absl::Status NcclCommunicator::HealthCheck() const {
   return ExecuteAwait([this]() -> absl::Status {
-    VLOG(5) << "Get last async error for NCCL communicator: " << *this;
+    XLA_VLOG_DEVICE(5, stream_executor_->device_ordinal())
+        << "Get last async error for NCCL communicator: " << *this;
     if (cancel_->IsCancelled()) {
       return FailedPrecondition("NcclCommunicator aborted");
     }
@@ -333,7 +343,8 @@ absl::Status NcclCommunicator::HealthCheck() const {
 
 absl::StatusOr<size_t> NcclCommunicator::NumRanks() const {
   return ExecuteAwait<size_t>([this]() -> absl::StatusOr<size_t> {
-    VLOG(5) << "Get the number of ranks in NCCL communicator: " << *this;
+    XLA_VLOG_DEVICE(5, stream_executor_->device_ordinal())
+        << "Get the number of ranks in NCCL communicator: " << *this;
     if (cancel_->IsCancelled()) {
       return FailedPrecondition("NcclCommunicator aborted");
     }
@@ -485,6 +496,18 @@ Future<> NcclCommunicator::WaitSignal(RankId peer, int op_cnt,
   });
 }
 
+Future<> NcclCommunicator::WaitSignals(
+    absl::Span<const PeerWaitDesc> peer_wait_descs, const Executor& executor) {
+  // Copy the aggregate descriptors before scheduling asynchronous work. The
+  // SignalDesc references remain borrowed until the returned Future is ready.
+  std::vector<PeerWaitDesc> peer_wait_descs_vec(peer_wait_descs.begin(),
+                                                peer_wait_descs.end());
+  return Execute(
+      [peer_wait_descs = std::move(peer_wait_descs_vec), &executor, this]() {
+        return LaunchWaitSignals(peer_wait_descs, executor);
+      });
+}
+
 absl::Status NcclCommunicator::LaunchAllReduce(
     se::DeviceAddressBase send_buffer, se::DeviceAddressBase recv_buffer,
     PrimitiveType dtype, size_t count, ReductionKind reduction_kind,
@@ -496,13 +519,14 @@ absl::Status NcclCommunicator::LaunchAllReduce(
 
   {
     absl::MutexLock lock(comm_->mutex);
-    VLOG(3) << absl::StreamFormat(
-        "[%d] Launch NCCL AllReduce operation; send_buffer=%p; "
-        "recv_buffer=%p; dtype=%s; count=%d; reduction_kind=%v; comm=%p; "
-        "stream=%p",
-        stream->parent()->device_ordinal(), send_buffer.opaque(),
-        recv_buffer.opaque(), primitive_util::LowercasePrimitiveTypeName(dtype),
-        count, reduction_kind, comm_->comm, stream);
+    XLA_VLOG_DEVICE(3, stream->parent()->device_ordinal())
+        << absl::StreamFormat(
+               "Launch NCCL AllReduce operation; send_buffer=%p; "
+               "recv_buffer=%p; dtype=%s; count=%d; reduction_kind=%v; "
+               "comm=%p; stream=%p",
+               send_buffer.opaque(), recv_buffer.opaque(),
+               primitive_util::LowercasePrimitiveTypeName(dtype), count,
+               reduction_kind, comm_->comm, stream);
 
     ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype,
                      ToNcclDataType(dtype, /*is_reduction_op=*/true,
@@ -531,13 +555,14 @@ absl::Status NcclCommunicator::LaunchBroadcast(
 
   {
     absl::MutexLock lock(comm_->mutex);
-    VLOG(3) << absl::StreamFormat(
-        "[%d] Launch NCCL Broadcast operation; send_buffer=%p; "
-        "recv_buffer=%p; dtype=%s; count=%d; root=%d; comm=%p; "
-        "stream=%p",
-        stream->parent()->device_ordinal(), send_buffer.opaque(),
-        recv_buffer.opaque(), primitive_util::LowercasePrimitiveTypeName(dtype),
-        count, root.value(), comm_->comm, stream);
+    XLA_VLOG_DEVICE(3, stream->parent()->device_ordinal())
+        << absl::StreamFormat(
+               "Launch NCCL Broadcast operation; send_buffer=%p; "
+               "recv_buffer=%p; dtype=%s; count=%d; root=%d; comm=%p; "
+               "stream=%p",
+               send_buffer.opaque(), recv_buffer.opaque(),
+               primitive_util::LowercasePrimitiveTypeName(dtype), count,
+               root.value(), comm_->comm, stream);
 
     ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype,
                      ToNcclDataType(dtype, false,
@@ -566,13 +591,14 @@ absl::Status NcclCommunicator::LaunchReduceScatter(
 
   {
     absl::MutexLock lock(comm_->mutex);
-    VLOG(3) << absl::StreamFormat(
-        "[%d] Launch NCCL ReduceScatter operation; send_buffer=%p; "
-        "recv_buffer=%p; dtype=%s; count=%d; reduction_kind=%v; comm=%p; "
-        "stream=%p",
-        stream->parent()->device_ordinal(), send_buffer.opaque(),
-        recv_buffer.opaque(), primitive_util::LowercasePrimitiveTypeName(dtype),
-        count, reduction_kind, comm_->comm, stream);
+    XLA_VLOG_DEVICE(3, stream->parent()->device_ordinal())
+        << absl::StreamFormat(
+               "Launch NCCL ReduceScatter operation; send_buffer=%p; "
+               "recv_buffer=%p; dtype=%s; count=%d; reduction_kind=%v; "
+               "comm=%p; stream=%p",
+               send_buffer.opaque(), recv_buffer.opaque(),
+               primitive_util::LowercasePrimitiveTypeName(dtype), count,
+               reduction_kind, comm_->comm, stream);
 
     ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype,
                      ToNcclDataType(dtype, /*is_reduction_op=*/true,
@@ -601,12 +627,13 @@ absl::Status NcclCommunicator::LaunchAllGather(
 
   {
     absl::MutexLock lock(comm_->mutex);
-    VLOG(3) << absl::StreamFormat(
-        "[%d] Launch NCCL AllGather operation; send_buffer=%p; "
-        "recv_buffer=%p; dtype=%s; count=%d; comm=%p; stream=%p",
-        stream->parent()->device_ordinal(), send_buffer.opaque(),
-        recv_buffer.opaque(), primitive_util::LowercasePrimitiveTypeName(dtype),
-        count, comm_->comm, stream);
+    XLA_VLOG_DEVICE(3, stream->parent()->device_ordinal())
+        << absl::StreamFormat(
+               "Launch NCCL AllGather operation; send_buffer=%p; "
+               "recv_buffer=%p; dtype=%s; count=%d; comm=%p; stream=%p",
+               send_buffer.opaque(), recv_buffer.opaque(),
+               primitive_util::LowercasePrimitiveTypeName(dtype), count,
+               comm_->comm, stream);
 
     ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype,
                      ToNcclDataType(dtype, false,
@@ -668,17 +695,17 @@ absl::Status NcclCommunicator::LaunchAllToAll(
 
   {
     absl::MutexLock lock(comm_->mutex);
-    VLOG(3) << absl::StreamFormat(
-        "[%d] Launch NCCL AllToAll operation; send_buffers=[%s]; "
-        "send_contiguous=%v; recv_buffers=[%s]; recv_contiguous=%v; dtype=%s; "
-        "count=%d; comm=%p; stream=%p",
-        stream->parent()->device_ordinal(),
-        absl::StrJoin(send_buffers, ", ", buffer_formatter),
-        send_contiguous.has_value(),
-        absl::StrJoin(recv_buffers, ", ", buffer_formatter),
-        recv_contiguous.has_value(),
-        primitive_util::LowercasePrimitiveTypeName(dtype), count, comm_->comm,
-        stream);
+    XLA_VLOG_DEVICE(3, stream->parent()->device_ordinal())
+        << absl::StreamFormat(
+               "Launch NCCL AllToAll operation; send_buffers=[%s]; "
+               "send_contiguous=%v; recv_buffers=[%s]; recv_contiguous=%v; "
+               "dtype=%s; count=%d; comm=%p; stream=%p",
+               absl::StrJoin(send_buffers, ", ", buffer_formatter),
+               send_contiguous.has_value(),
+               absl::StrJoin(recv_buffers, ", ", buffer_formatter),
+               recv_contiguous.has_value(),
+               primitive_util::LowercasePrimitiveTypeName(dtype), count,
+               comm_->comm, stream);
   }
 
   if (send_buffers.size() != recv_buffers.size()) {
@@ -762,16 +789,16 @@ absl::Status NcclCommunicator::LaunchCollectivePermute(
 
   {
     absl::MutexLock lock(comm_->mutex);
-    VLOG(3) << absl::StreamFormat(
-        "[%d] Launch NCCL CollectivePermute operation; send_buffer=%p; "
-        "recv_buffer=%p; dtype=%s; source_rank=%s; target_[ranks=%s]; "
-        "count=%d; "
-        "comm=%p; stream=%p",
-        stream->parent()->device_ordinal(), send_buffer.opaque(),
-        recv_buffer.opaque(), primitive_util::LowercasePrimitiveTypeName(dtype),
-        source_rank ? absl::StrCat(source_rank->value()) : "<empty>",
-        absl::StrJoin(target_ranks, ", ", rank_formatter), count, comm_->comm,
-        stream);
+    XLA_VLOG_DEVICE(3, stream->parent()->device_ordinal())
+        << absl::StreamFormat(
+               "Launch NCCL CollectivePermute operation; send_buffer=%p; "
+               "recv_buffer=%p; dtype=%s; source_rank=%s; target_[ranks=%s]; "
+               "count=%d; comm=%p; stream=%p",
+               send_buffer.opaque(), recv_buffer.opaque(),
+               primitive_util::LowercasePrimitiveTypeName(dtype),
+               source_rank ? absl::StrCat(source_rank->value()) : "<empty>",
+               absl::StrJoin(target_ranks, ", ", rank_formatter), count,
+               comm_->comm, stream);
   }
 
   ASSIGN_OR_RETURN(
@@ -822,12 +849,13 @@ absl::Status NcclCommunicator::LaunchSend(se::DeviceAddressBase send_buffer,
   {
     absl::MutexLock lock(comm_->mutex);
 
-    VLOG(3) << absl::StreamFormat(
-        "[%d] Launch NCCL Send operation; send_buffer=%p; dtype=%s; "
-        "count=%d; peer=%d; comm=%p; stream=%p",
-        stream->parent()->device_ordinal(), send_buffer.opaque(),
-        primitive_util::LowercasePrimitiveTypeName(dtype), count, peer.value(),
-        comm_->comm, stream);
+    XLA_VLOG_DEVICE(3, stream->parent()->device_ordinal())
+        << absl::StreamFormat(
+               "Launch NCCL Send operation; send_buffer=%p; dtype=%s; "
+               "count=%d; peer=%d; comm=%p; stream=%p",
+               send_buffer.opaque(),
+               primitive_util::LowercasePrimitiveTypeName(dtype), count,
+               peer.value(), comm_->comm, stream);
 
     ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype,
                      ToNcclDataType(dtype, false,
@@ -855,12 +883,13 @@ absl::Status NcclCommunicator::LaunchRecv(se::DeviceAddressBase recv_buffer,
 
   {
     absl::MutexLock lock(comm_->mutex);
-    VLOG(3) << absl::StreamFormat(
-        "[%d] Launch NCCL Recv operation; recv_buffer=%p; dtype=%s; "
-        "count=%d; peer=%d; comm=%p; stream=%p",
-        stream->parent()->device_ordinal(), recv_buffer.opaque(),
-        primitive_util::LowercasePrimitiveTypeName(dtype), count, peer.value(),
-        comm_->comm, stream);
+    XLA_VLOG_DEVICE(3, stream->parent()->device_ordinal())
+        << absl::StreamFormat(
+               "Launch NCCL Recv operation; recv_buffer=%p; dtype=%s; "
+               "count=%d; peer=%d; comm=%p; stream=%p",
+               recv_buffer.opaque(),
+               primitive_util::LowercasePrimitiveTypeName(dtype), count,
+               peer.value(), comm_->comm, stream);
 
     ASSIGN_OR_RETURN(ncclDataType_t nccl_dtype,
                      ToNcclDataType(dtype, false,
@@ -895,11 +924,12 @@ absl::Status NcclCommunicator::LaunchPut(se::DeviceAddressBase send_buffer,
   auto& peer_win = absl::down_cast<NcclSymmetricMemory&>(*recv_buffer);
   {
     absl::MutexLock lock(comm_->mutex);
-    VLOG(3) << absl::StreamFormat(
-        "[%d] Launch NCCL Put operation; send_buffer=%p; peer_win=%v; "
-        "offset=%d; count=%d; peer=%d; comm=%p; stream=%p",
-        stream->parent()->device_ordinal(), send_buffer.opaque(), peer_win,
-        offset, count, peer.value(), comm_->comm, stream);
+    XLA_VLOG_DEVICE(3, stream->parent()->device_ordinal())
+        << absl::StreamFormat(
+               "Launch NCCL Put operation; send_buffer=%p; peer_win=%v; "
+               "offset=%d; count=%d; peer=%d; comm=%p; stream=%p",
+               send_buffer.opaque(), peer_win, offset, count, peer.value(),
+               comm_->comm, stream);
     XLA_NCCL_RETURN_IF_ERROR(ncclPutSignal(
         send_buffer.opaque(), count, ncclInt8, peer.value(), peer_win.win(),
         offset, 0, 0, 0, comm_->comm, AsCudaStream(stream)));
@@ -929,11 +959,12 @@ absl::Status NcclCommunicator::LaunchSignal(RankId peer,
   const auto& nccl_desc = absl::down_cast<const GpuSignalDesc&>(signal_desc);
   {
     absl::MutexLock lock(comm_->mutex);
-    VLOG(3) << absl::StreamFormat(
-        "[%d] Launch NCCL Signal operation; peer=%d; sig_idx=%d; ctx=%d; "
-        "comm=%p; stream=%p",
-        stream->parent()->device_ordinal(), peer.value(), nccl_desc.sig_idx(),
-        nccl_desc.ctx(), comm_->comm, stream);
+    XLA_VLOG_DEVICE(3, stream->parent()->device_ordinal())
+        << absl::StreamFormat(
+               "Launch NCCL Signal operation; peer=%d; sig_idx=%d; ctx=%d; "
+               "comm=%p; stream=%p",
+               peer.value(), nccl_desc.sig_idx(), nccl_desc.ctx(), comm_->comm,
+               stream);
     XLA_NCCL_RETURN_IF_ERROR(ncclSignal(peer.value(), nccl_desc.sig_idx(),
                                         nccl_desc.ctx(), 0, comm_->comm,
                                         AsCudaStream(stream)));
@@ -950,40 +981,64 @@ absl::Status NcclCommunicator::LaunchSignal(RankId peer,
 absl::Status NcclCommunicator::LaunchWaitSignal(RankId peer, int op_cnt,
                                                 const SignalDesc& signal_desc,
                                                 const Executor& executor) {
+  PeerWaitDesc peer_wait_desc{peer, op_cnt, signal_desc};
+  return LaunchWaitSignals(absl::Span<const PeerWaitDesc>(&peer_wait_desc, 1),
+                           executor);
+}
+
+absl::Status NcclCommunicator::LaunchWaitSignals(
+    absl::Span<const PeerWaitDesc> peer_wait_descs, const Executor& executor) {
   if (!capabilities_.supports_one_sided_comm) {
-    return capabilities_.GetOneSidedCommUnsupportedError("WaitSignal");
+    return capabilities_.GetOneSidedCommUnsupportedError("WaitSignals");
   }
   if (cancel_->IsCancelled()) {
     return FailedPrecondition("NcclCommunicator aborted");
+  }
+  if (peer_wait_descs.empty()) {
+    return absl::OkStatus();
   }
 
 #if NCCL_VERSION_CODE >= 22900
   se::Stream* stream = ToStream(executor);
 
-  const auto& nccl_desc = absl::down_cast<const GpuSignalDesc&>(signal_desc);
+  std::vector<ncclWaitSignalDesc_t> nccl_descs(peer_wait_descs.size());
 
-  ncclWaitSignalDesc_t desc;
-  desc.peer = peer.value();
-  desc.opCnt = op_cnt;
-  desc.sigIdx = nccl_desc.sig_idx();
-  desc.ctx = nccl_desc.ctx();
+  for (size_t i = 0; i < peer_wait_descs.size(); ++i) {
+    const auto* signal_desc =
+        absl::down_cast<const GpuSignalDesc*>(&peer_wait_descs[i].signal_desc);
+
+    ncclWaitSignalDesc_t& nccl_desc = nccl_descs[i];
+    nccl_desc.peer = peer_wait_descs[i].peer.value();
+    nccl_desc.opCnt = peer_wait_descs[i].op_cnt;
+    nccl_desc.sigIdx = signal_desc->sig_idx();
+    nccl_desc.ctx = signal_desc->ctx();
+  }
+
+  auto desc_formatter = [](std::string* out, const ncclWaitSignalDesc_t& desc) {
+    absl::StrAppendFormat(out, "{peer=%d, op_cnt=%d, sig_idx=%d, ctx=%d}",
+                          desc.peer, desc.opCnt, desc.sigIdx, desc.ctx);
+  };
 
   {
     absl::MutexLock lock(comm_->mutex);
-    VLOG(3) << absl::StreamFormat(
-        "[%d] Launch NCCL WaitSignal operation; peer=%d; op_cnt=%d; "
-        "sig_idx=%d; ctx=%d; comm=%p; stream=%p",
-        stream->parent()->device_ordinal(), peer.value(), op_cnt,
-        nccl_desc.sig_idx(), nccl_desc.ctx(), comm_->comm, stream);
-    XLA_NCCL_RETURN_IF_ERROR(
-        ncclWaitSignal(1, &desc, comm_->comm, AsCudaStream(stream)));
+    XLA_VLOG_DEVICE(3, stream->parent()->device_ordinal())
+        << absl::StreamFormat(
+               "Launch NCCL WaitSignals operation; descs=[%s]; comm=%p; "
+               "stream=%p",
+               absl::StrJoin(nccl_descs, ", ", desc_formatter), comm_->comm,
+               stream);
+    XLA_NCCL_RETURN_IF_ERROR(ncclWaitSignal(static_cast<int>(nccl_descs.size()),
+                                            nccl_descs.data(), comm_->comm,
+                                            AsCudaStream(stream)));
   }
 #else
-  return Unimplemented("WaitSignal requires NCCL >= 2.29.0");
+  return Unimplemented("WaitSignals requires NCCL >= 2.29.0");
 #endif
+
   if (!IsInsideNcclGroupLaunch()) {
     RETURN_IF_ERROR(PollUntilDone());
   }
+
   return absl::OkStatus();
 }
 
@@ -1063,10 +1118,11 @@ NcclDeviceCommunicator::NcclDeviceCommunicator(
       dev_comm_(dev_comm) {}
 
 NcclDeviceCommunicator::~NcclDeviceCommunicator() {
-  VLOG(3) << absl::StreamFormat("Destroy NCCL device comm %v", *this);
+  DCHECK(stream_executor_) << "StreamExecutor is unavailable";
+  XLA_VLOG_DEVICE(3, stream_executor_->device_ordinal())
+      << absl::StreamFormat("Destroy NCCL device comm %v", *this);
 
   auto destroy_fn = [this]() -> absl::Status {
-    DCHECK(stream_executor_) << "StreamExecutor is unavailable";
     auto activation = stream_executor_->Activate();
     {
       absl::MutexLock lock(parent_comm_->mutex);
@@ -1080,18 +1136,20 @@ NcclDeviceCommunicator::~NcclDeviceCommunicator() {
                     : Future<>(std::move(destroy_fn)());
   absl::Status s = future.Await();
   if (!s.ok()) {
-    LOG(ERROR) << "Failed to destroy device comm: " << s;
+    XLA_LOG_DEVICE(ERROR, stream_executor_->device_ordinal())
+        << "Failed to destroy device comm: " << s;
   }
 }
 
 absl::StatusOr<std::unique_ptr<NcclDeviceCommunicator>>
 NcclDeviceCommunicator::CreateFrom(const NcclCommunicator& comm,
                                    const Requirements& requirements) {
-  VLOG(3) << absl::StreamFormat(
-      "Create NCCL device comm from %v: lsa_barrier_count=%d", comm,
-      requirements.lsa_barrier_count);
-
   DCHECK(comm.stream_executor()) << "StreamExecutor is unavailable";
+  XLA_VLOG_DEVICE(3, comm.stream_executor()->device_ordinal())
+      << absl::StreamFormat(
+             "Create NCCL device comm from %v: lsa_barrier_count=%d", comm,
+             requirements.lsa_barrier_count);
+
   auto activation = comm.stream_executor()->Activate();
 
   ncclDevCommRequirements reqs{};

--- a/xla/backends/gpu/collectives/nccl_communicator.h
+++ b/xla/backends/gpu/collectives/nccl_communicator.h
@@ -177,6 +177,9 @@ class NcclCommunicator : public GpuCommunicator {
   Future<> WaitSignal(RankId peer, int op_cnt, const SignalDesc& signal_desc,
                       const Executor& executor) final;
 
+  Future<> WaitSignals(absl::Span<const PeerWaitDesc> peer_wait_descs,
+                       const Executor& executor) final;
+
   std::string ToString() const final;
 
   std::shared_ptr<NcclCommState> comm_state() const { return comm_; }
@@ -252,6 +255,9 @@ class NcclCommunicator : public GpuCommunicator {
   absl::Status LaunchWaitSignal(RankId peer, int op_cnt,
                                 const SignalDesc& signal_desc,
                                 const Executor& executor) final;
+
+  absl::Status LaunchWaitSignals(absl::Span<const PeerWaitDesc> peer_wait_descs,
+                                 const Executor& executor) final;
 
   absl::Status LaunchMultiGpuBarrier(const Executor& executor) final;
 

--- a/xla/core/collectives/communicator.h
+++ b/xla/core/collectives/communicator.h
@@ -56,9 +56,20 @@ class Communicator {
     virtual ~Executor() = default;
   };
 
+  // Backend-specific descriptor used to identify a signal. It must outlive any
+  // operation that uses it; communicators do not take ownership.
   class SignalDesc {
    public:
     virtual ~SignalDesc() = default;
+  };
+
+  // Describes a counted wait for signals from a peer. `signal_desc` is not
+  // owned and must remain valid until the Future returned by WaitSignals
+  // becomes ready.
+  struct PeerWaitDesc {
+    RankId peer;
+    int op_cnt;
+    const SignalDesc& signal_desc;
   };
 
   // Register `buffer_range` once for efficient collective operations (i.e. on
@@ -173,14 +184,25 @@ class Communicator {
     return Unimplemented("Signal is not implemented");
   }
 
-  // Counted wait: completes when this rank has received op_cnt signals from
-  // peer that match signal_desc (e.g. same sigIdx/ctx). Used to synchronize
-  // after Put/Signal; the backend uses signal_desc to match which signals to
-  // wait for.
+  // Enqueues a counted wait that blocks subsequent work on the executor until
+  // this rank has received op_cnt signals from peer that match signal_desc
+  // (e.g. same sigIdx/ctx). Used to synchronize after Put/Signal; the backend
+  // uses signal_desc to match which signals to wait for.
+  // `signal_desc` must remain valid until the returned Future becomes ready.
   virtual Future<> WaitSignal(RankId peer, int op_cnt,
                               const SignalDesc& signal_desc,
                               const Executor& executor) {
     return Unimplemented("WaitSignal is not implemented");
+  }
+
+  // Enqueues counted waits that block subsequent work on the executor until
+  // every wait in `peer_wait_descs` has received the requested number of
+  // matching signals. The descriptor array is consumed before this method
+  // returns; the SignalDesc objects it references must remain valid until the
+  // returned Future becomes ready.
+  virtual Future<> WaitSignals(absl::Span<const PeerWaitDesc> peer_wait_descs,
+                               const Executor& executor) {
+    return Unimplemented("WaitSignals is not implemented");
   }
 
   // Returns the number of ranks in the communicator.
@@ -212,8 +234,5 @@ inline std::ostream& operator<<(std::ostream& os, const Communicator& comm) {
 }
 
 }  // namespace xla
-
-namespace stream_executor {
-}  // namespace stream_executor
 
 #endif  // XLA_CORE_COLLECTIVES_COMMUNICATOR_H_


### PR DESCRIPTION
`ncclWaitSignal` supports waiting on multiple signals in a single API call and it's more efficient than waiting on signals inside a group call. Add a new API to `xla::Communicator` that allows a more efficient wait.

While I'm here also updated all `VLOG` to `XLA_VLOG_DEVICE` inside `nccl_communicator.cc`.