### PR TITLE
[XLA:CPU/GPU][oneDNN][BugFix] Exclude non-library files from oneDNN build target

### DIFF
--- a/third_party/mkl_dnn/mkldnn_v1_async.BUILD
+++ b/third_party/mkl_dnn/mkldnn_v1_async.BUILD
@@ -329,6 +329,7 @@ sycl_library(
             "src/cpu/sycl/**",
             "src/common/ittnotify/**",
             "src/gpu/amd/**",
+            "src/gpu/intel/conv/jit/v2/planner/planner_main.cpp",
             "src/gpu/nvidia/**",
         ],
     ) + [


### PR DESCRIPTION
This PR updates the oneDNN BUILD file to stop linking `planner_main.cpp` into the main oneDNN library target. `planner_main.cpp` is an internal oneDNN source file that defines its own main() and is excluded from oneDNN release builds. Not excluding it in XLA can cause test binaries to resolve main from oneDNN instead of the expected gtest entry point.

Eg: Without this change, tests like `xla/service/gpu/model/coalescing_analysis_test.cc` fail with a "missing hw error" from oneDNN because the test binary incorrectly links oneDNN's main() from planner_main.cpp instead of gtest's entry point.