### PR TITLE
[XLA:GPU] Restrict generic Triton FP4 codegen

### DIFF
--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_deviceless_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_deviceless_test.cc
@@ -160,6 +160,47 @@ ENTRY entry {
                          mlir_context));
 }
 
+TEST_F(TritonEmitterDevicelessTest, RejectsGenericFp4FusionOutput) {
+  constexpr absl::string_view kHloText = R"(
+fusion {
+  p0 = f4e2m1fn[128,256]{1,0:E(4)} parameter(0)
+  ROOT copy = f4e2m1fn[128,256]{1,0:E(4)} copy(p0)
+}
+
+ENTRY entry {
+  p0 = f4e2m1fn[128,256]{1,0:E(4)} parameter(0)
+  ROOT triton_fusion = f4e2m1fn[128,256]{1,0:E(4)} fusion(p0),
+    kind=kCustom, calls=fusion,
+    backend_config={"fusion_backend_config":{
+      "kind":"__triton",
+      "block_level_fusion_config":{
+        "num_warps":"1",
+        "output_tiles":[{"sizes":["1","1"]}],
+        "num_ctas":"1",
+        "num_stages":"1"}}}
+}
+)";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(kHloText));
+  const HloFusionInstruction* triton_fusion = Cast<HloFusionInstruction>(
+      hlo_module->entry_computation()->root_instruction());
+  const se::DeviceDescription dev_info = TestGpuDeviceInfo::B200SXMDeviceInfo();
+  mlir::MLIRContext mlir_context;
+  RegisterSymbolicExprStorage(&mlir_context);
+
+  EXPECT_THAT(
+      CreateTritonModule("test_fn", *triton_fusion, dev_info,
+                         BlockLevelParameters::FromBlockLevelFusionConfig(
+                             triton_fusion->backend_config<GpuBackendConfig>()
+                                 ->fusion_backend_config()
+                                 .block_level_fusion_config()),
+                         mlir_context),
+      absl_testing::StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          ::testing::HasSubstr(
+              "f4e2m1fn storage value must feed scaled-dot operand 0 or 1")));
+}
+
 TEST_F(WarpSpecializationTritonEmitterTest,
        ExtraWarpsAreRequestedForWarpSpecialization) {
   const std::string hlo_text = R"(

--- a/xla/backends/gpu/codegen/triton/xtile_compiler.cc
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.cc
@@ -104,6 +104,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/hlo/ir/hlo_print_options.h"
 #include "xla/hlo/translate/hlo_to_mhlo/hlo_function_importer.h"
 #include "xla/hlo/utils/hlo_traversal.h"
@@ -141,6 +142,73 @@ absl::Status CheckAtLeastAmpere(const se::GpuComputeCapability& gpu_cc) {
         absl::StrCat("Triton support is only enabled for Ampere GPUs (compute ",
                      "capability 8.0) and up, but got compute capability ",
                      cuda_cc->ToString(), "."));
+  }
+  return absl::OkStatus();
+}
+
+bool IsF4Array(const HloInstruction& instruction) {
+  return instruction.shape().IsArray() &&
+         instruction.shape().element_type() == F4E2M1FN;
+}
+
+// Packed f4 values are represented as i8 storage in Triton lowering. These HLO
+// ops can forward that storage without interpreting or changing the logical f4
+// values.
+bool IsF4StoragePreservingOpcode(HloOpcode opcode) {
+  switch (opcode) {
+    case HloOpcode::kBitcast:
+    case HloOpcode::kCopy:
+    case HloOpcode::kParameter:
+    case HloOpcode::kReshape:
+    case HloOpcode::kSlice:
+    case HloOpcode::kTranspose:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Scaled-dot lhs/rhs operands are terminal consumers that decode i8-packed f4
+// storage. Scale operands use their own element types.
+bool IsScaledDotDataOperandUser(const HloInstruction& instruction,
+                                const HloInstruction& scaled_dot) {
+  if (scaled_dot.opcode() != HloOpcode::kScaledDot) {
+    return false;
+  }
+  // Operands 0 and 1 carry packed f4 data; operands 2 and 3 are scale tensors.
+  return scaled_dot.operand(0) == &instruction ||
+         scaled_dot.operand(1) == &instruction;
+}
+
+// Every f4 array in a Triton fusion must stay on an i8-packed storage path that
+// terminates in scaled-dot data operands. Generic f4 arithmetic and f4 outputs
+// are not supported by this lowering.
+absl::Status ValidateF4UseInTritonFusion(const HloComputation& computation) {
+  for (const HloInstruction* instruction : computation.instructions()) {
+    if (!IsF4Array(*instruction)) {
+      continue;
+    }
+    if (!IsF4StoragePreservingOpcode(instruction->opcode())) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Generic f4e2m1fn Triton codegen is unsupported outside "
+          "storage-preserving scaled-dot operand paths: ",
+          instruction->ToString(HloPrintOptions::ShortParsable())));
+    }
+    if (instruction->users().empty()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "f4e2m1fn storage value must feed scaled-dot operand 0 or 1: ",
+          instruction->ToString(HloPrintOptions::ShortParsable())));
+    }
+    for (const HloInstruction* user : instruction->users()) {
+      if (IsScaledDotDataOperandUser(*instruction, *user) ||
+          (IsF4Array(*user) && IsF4StoragePreservingOpcode(user->opcode()))) {
+        continue;
+      }
+      return absl::InvalidArgumentError(absl::StrCat(
+          "f4e2m1fn storage value has unsupported Triton user: ",
+          instruction->ToString(HloPrintOptions::ShortParsable()), " -> ",
+          user->ToString(HloPrintOptions::ShortParsable())));
+    }
   }
   return absl::OkStatus();
 }
@@ -334,6 +402,8 @@ absl::StatusOr<TritonKernelSource> CreateTritonModule(
         num_metadata_arguments,
         AddCollectiveMetadataArguments(opaque_args_types, b, hlo_computation));
   }
+
+  RETURN_IF_ERROR(ValidateF4UseInTritonFusion(*hlo_computation));
 
   ASSIGN_OR_RETURN(auto triton_module,
                    TileAndEmitXTileModule(


### PR DESCRIPTION
📝 Summary of Changes
Restrict generic Triton codegen for `f4E2M1FN` values to storage-preserving paths that terminate at scaled-dot data operands. Generic FP4 arithmetic and FP4 fusion outputs are rejected before XTile/Triton lowering. This is another PR in the decomposition of the larger scaled-dot fix series: https://github.com/openxla/xla/pull/44223.

🎯 Justification
Packed FP4 scaled-dot support carries logical `f4E2M1FN` values through XTile as physical `i8` storage. That is required for scaled-dot operands, but it must not imply generic FP4 Triton codegen support.

Earlier https://github.com/openxla/xla/pull/45082 introduces test regressions: `IsTritonSupportedInstruction` rejects generic `f4e2m1fn` output, while XTile/Triton lowering could succeed for some generic FP4 paths ScaledDotOperandTypes/f4e2m1fn_SymbolicTiling, ScaledDotOperandTypes/f4e2m1fn_ExperimentalTiling). If current PR merged first, issues in github.com/openxla/xla/pull/45082 are expected to be fixable with a small follow up commit.

This PR makes the codegen boundary explicit: FP4 arrays may flow through storage-preserving ops such as parameter, bitcast, copy, reshape, slice, and transpose only when the path feeds scaled-dot operands 0 or 1. Other FP4 users or FP4 fusion outputs return `InvalidArgument`.


🚀 Kind of Contribution
🐛 Bug Fix, 🧪 Tests

🧪 Unit Tests:
`TritonEmitterDevicelessTest.RejectsGenericFp4FusionOutput` verifies that generic `f4e2m1fn` Triton fusion output is rejected before lowering.

@loislo 