### PR TITLE
pjrt: propagate Prepare failure on non-two-phase multi-device Execute

### DIFF
--- a/xla/pjrt/BUILD
+++ b/xla/pjrt/BUILD
@@ -174,6 +174,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
         "@llvm-project//llvm:Support",

--- a/xla/pjrt/common_pjrt_client.cc
+++ b/xla/pjrt/common_pjrt_client.cc
@@ -2269,6 +2269,16 @@ CommonPjRtLoadedExecutable::Execute(
                   --launching;
                   return;
                 }
+              } else {
+                // Non-two-phase clients have no barrier to participate in, but
+                // the Prepare status must still be checked before Launch:
+                // launch_args.executable is only populated on Prepare success.
+                if (!launch_status.ok()) {
+                  results[i] = launch_status;
+                  absl::MutexLock lock(mu);
+                  --launching;
+                  return;
+                }
               }
 
               // Phase 2: Launch. It cannot fail.

--- a/xla/pjrt/cpu/BUILD
+++ b/xla/pjrt/cpu/BUILD
@@ -296,6 +296,7 @@ xla_cc_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/synchronization",
         "@com_google_googletest//:gtest",
         "@llvm-project//mlir:FuncDialect",

--- a/xla/pjrt/cpu/cpu_client_test.cc
+++ b/xla/pjrt/cpu/cpu_client_test.cc
@@ -1299,6 +1299,65 @@ TEST(PjRtCpuClientTest, TupleInputWithErrorBuffer) {
       absl_testing::StatusIs(tsl::error::INTERNAL, HasSubstr("forced error")));
 }
 
+// Regression test: CpuClient has supports_two_phase_launch()==false, so the
+// multi-device Execute path does not take the two-phase barrier. A Prepare
+// failure on any device must still propagate as an error rather than fall
+// through to ExecuteLaunch with an unpopulated launch_args (null executable).
+TEST(PjRtCpuClientTest, MultiDevicePrepareFailurePropagatesError) {
+  constexpr int kNumDevices = 2;
+  CpuClientOptions cpu_options;
+  cpu_options.cpu_device_count = kNumDevices;
+  ASSERT_OK_AND_ASSIGN(auto client,
+                       GetXlaPjrtCpuClient(std::move(cpu_options)));
+  ASSERT_EQ(client->addressable_devices().size(), kNumDevices);
+
+  static constexpr char kProgram[] = R"(
+    HloModule m
+    ENTRY e {
+      ROOT p = f32[] parameter(0)
+    })";
+  ASSERT_OK_AND_ASSIGN(auto hlo_module,
+                       ParseAndReturnUnverifiedModule(kProgram, {}));
+  XlaComputation xla_computation(hlo_module->ToProto());
+  CompileOptions compile_options;
+  compile_options.executable_build_options.set_num_replicas(kNumDevices);
+  ASSERT_OK_AND_ASSIGN(
+      auto executable,
+      client->CompileAndLoad(xla_computation, std::move(compile_options)));
+  ASSERT_EQ(executable->addressable_devices().size(), kNumDevices);
+
+  // Device 0 gets a correctly-shaped scalar; device 1 gets a wrong-size
+  // buffer so ExecutePrepare fails in CheckBufferCompatibilities before
+  // launch_args.executable is populated.
+  std::vector<float> scalar = {1.0f};
+  std::vector<float> vec = {1.0f, 2.0f};
+  ASSERT_OK_AND_ASSIGN(
+      auto ok_buf,
+      client->BufferFromHostBuffer(
+          scalar.data(), F32, /*dims=*/{}, /*byte_strides=*/std::nullopt,
+          PjRtClient::HostBufferSemantics::kImmutableOnlyDuringCall, nullptr,
+          *client->addressable_devices()[0]->default_memory_space(),
+          /*device_layout=*/nullptr));
+  ASSERT_OK_AND_ASSIGN(
+      auto wrong_buf,
+      client->BufferFromHostBuffer(
+          vec.data(), F32, /*dims=*/{2}, /*byte_strides=*/std::nullopt,
+          PjRtClient::HostBufferSemantics::kImmutableOnlyDuringCall, nullptr,
+          *client->addressable_devices()[1]->default_memory_space(),
+          /*device_layout=*/nullptr));
+
+  auto result = executable->Execute(
+      /*argument_handles=*/{{ok_buf.get()}, {wrong_buf.get()}},
+      /*options=*/{});
+  // Without the fix this crashes (null unique_ptr deref in ExecuteLaunch);
+  // with it, the Prepare status propagates.
+  ASSERT_FALSE(result.ok());
+  // Asserting the specific Prepare-path rejection guards against the test
+  // going vacuous if a future top-level validation rejects the arguments
+  // before the per-device Prepare runs.
+  EXPECT_THAT(result.status().message(), HasSubstr("incompatible size"));
+}
+
 }  // namespace
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## The bug

`CommonPjRtLoadedExecutable::Execute`'s multi-device path calls `ExecutePrepareWithOomRetries` per device, then — only when `supports_two_phase_launch()` is true — checks the returned status inside the two-phase barrier block. `CpuClient` overrides `supports_two_phase_launch()` to `false`, so on a multi-device CpuClient a Prepare failure is never checked and execution falls through to `ExecuteLaunch(*launch_args, ...)` with `launch_args.executable` still null → null-deref crash instead of a clean error.

## The fix

Add an `else if (!launch_status.ok())` branch after the two-phase block: record the failure in `results[i]`, decrement `launching` under `mu`, return. Same shape as the two-phase failure path minus the barrier it doesn't participate in.

## Scope

`CpuClient` is the only in-tree client with `supports_two_phase_launch()==false`. Two-phase clients (GPU/TPU stream-executor) are unchanged — the diff is purely additive.

## Test

`MultiDevicePrepareFailurePropagatesError` in `[cpu_client_test.cc](http://cpu_client_test.cc/)`: 2-device CpuClient, 2-replica identity program, wrong-size buffer on device 1 so `CheckBufferCompatibilities` rejects it during Prepare. Asserts `Execute()` returns an error (not a crash) and that the error comes from the per-device Prepare path.