### PR TITLE
pjrt: record Prepare failure before the two-phase barrier

### DIFF
--- a/xla/pjrt/common_pjrt_client.cc
+++ b/xla/pjrt/common_pjrt_client.cc
@@ -2047,6 +2047,9 @@ absl::Status CommonPjRtLoadedExecutable::CheckBufferCompatibilities(
 absl::StatusOr<PjRtLoadedExecutable::Result>
 CommonPjRtLoadedExecutable::ExecuteLaunch(ExecuteLaunchArgs& launch_args,
                                           bool fill_future) const {
+  if (execute_launch_hook_) {
+    execute_launch_hook_(launch_args.device);
+  }
   auto results = std::move(*launch_args.executable)
                      .Execute(*launch_args.options, launch_args.input_buffers,
                               launch_args.output_leaf_buffers,

--- a/xla/pjrt/common_pjrt_client.cc
+++ b/xla/pjrt/common_pjrt_client.cc
@@ -2324,17 +2324,17 @@ CommonPjRtLoadedExecutable::Execute(
               // Wait for prepare to finish on all cores.
               if (client()->supports_two_phase_launch()) {
                 absl::MutexLock lock(mu);
-                preparing--;
-                auto done_preparing = [&]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu) {
-                  return preparing == 0;
-                };
-                mu.Await(absl::Condition(&done_preparing));
                 if (!launch_status.ok()) {
                   if (failed == 0) {
                     first_failure_status = launch_status;
                   }
                   failed++;
                 }
+                preparing--;
+                auto done_preparing = [&]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu) {
+                  return preparing == 0;
+                };
+                mu.Await(absl::Condition(&done_preparing));
                 if (failed > 0) {
                   // Poison results for all cores.
                   results[i] = first_failure_status;

--- a/xla/pjrt/common_pjrt_client.h
+++ b/xla/pjrt/common_pjrt_client.h
@@ -699,6 +699,15 @@ class CommonPjRtLoadedExecutable : public PjRtLoadedExecutable {
     return GetExecutable()->FingerprintExecutable();
   }
 
+  // Invoked once per device at the top of ExecuteLaunch (phase 2 of the
+  // two-phase launch). The hook must be thread-safe: it may be called
+  // concurrently from per-device launch threads. Must not be set concurrently
+  // with Execute. Intended for tests that need to observe which devices reach
+  // phase 2.
+  void SetExecuteLaunchHookForTesting(std::function<void(PjRtDevice*)> hook) {
+    execute_launch_hook_ = std::move(hook);
+  }
+
  protected:
   // Execute is split into Prepare and Launch.
   // Prepare can fail and be retried, while Launch is guaranteed to succeed.
@@ -797,6 +806,8 @@ class CommonPjRtLoadedExecutable : public PjRtLoadedExecutable {
   std::shared_ptr<DeviceAssignment> device_assignment_;
 
   std::unique_ptr<DispatchInfo::Extras> extras_;
+
+  std::function<void(PjRtDevice*)> execute_launch_hook_;
 };
 
 class CommonPjRtRawBufferImpl : public PjRtRawBuffer {

--- a/xla/pjrt/se/BUILD
+++ b/xla/pjrt/se/BUILD
@@ -304,6 +304,9 @@ cc_library(
 xla_cc_test(
     name = "pjrt_stream_executor_client_test",
     srcs = ["pjrt_stream_executor_client_test.cc"],
+    # TwoPhaseExecutePrepareFailureSkipsLaunch needs a two-device Host backend;
+    # PlatformUtil caps Host device_count at this flag (default 1).
+    env = {"XLA_FLAGS": "--xla_force_host_platform_device_count=2"},
     deps = [
         ":local_device_state",
         ":pjrt_stream_executor_client",
@@ -326,6 +329,7 @@ xla_cc_test(
         "//xla/pjrt:pjrt_executable",
         "//xla/pjrt/plugin/xla_cpu:cpu_topology",
         "//xla/pjrt/plugin/xla_cpu:cpu_topology_description",
+        "//xla/service:computation_placer_hdr",
         "//xla/service:cpu_plugin",
         "//xla/service:platform_util",
         "//xla/stream_executor:platform",
@@ -339,8 +343,11 @@ xla_cc_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:casts",
         "@tsl//tsl/platform:path",
     ],
 )

--- a/xla/pjrt/se/pjrt_stream_executor_client_test.cc
+++ b/xla/pjrt/se/pjrt_stream_executor_client_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "xla/pjrt/se/pjrt_stream_executor_client.h"
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -30,7 +31,10 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/synchronization/notification.h"
+#include "absl/time/time.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/cpu/target_machine_options.h"
 #include "xla/client/client_library.h"
@@ -43,12 +47,14 @@ limitations under the License.
 #include "xla/literal_comparison.h"
 #include "xla/literal_util.h"
 #include "xla/pjrt/abstract_tracked_device_buffer.h"
+#include "xla/pjrt/common_pjrt_client.h"
 #include "xla/pjrt/pjrt_client.h"
 #include "xla/pjrt/pjrt_compiler.h"
 #include "xla/pjrt/pjrt_executable.h"
 #include "xla/pjrt/plugin/xla_cpu/cpu_topology.h"
 #include "xla/pjrt/plugin/xla_cpu/cpu_topology_description.h"
 #include "xla/pjrt/se/local_device_state.h"
+#include "xla/service/computation_placer.h"
 #include "xla/service/platform_util.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
@@ -60,6 +66,7 @@ limitations under the License.
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/xla_data.pb.h"
+#include "tsl/platform/casts.h"
 #include "tsl/platform/path.h"
 
 namespace xla {
@@ -104,6 +111,53 @@ absl::StatusOr<std::unique_ptr<PjRtStreamExecutorClient>> GetClient() {
   return std::make_unique<PjRtStreamExecutorClient>(
       "cpu", local_client, std::move(devices),
       /*process_index=*/0, std::move(memory_spaces),
+      /*topology=*/std::move(topology), /*allocator=*/nullptr,
+      /*host_memory_allocator=*/nullptr,
+      /*should_stage_host_to_device_transfers=*/false,
+      /*gpu_run_options=*/nullptr);
+}
+
+// Variant of GetClient() that creates `num_devices` Host-platform devices, so
+// multi-device code paths in CommonPjRtLoadedExecutable::Execute can be
+// exercised without accelerator hardware. The client's allocator is
+// `local_client->backend().memory_allocator()`, which only knows the
+// device ordinals PlatformUtil enumerated for the LocalClient's Backend —
+// on Host that is `xla_force_host_platform_device_count` (set via XLA_FLAGS
+// on this test target), not VisibleDeviceCount().
+absl::StatusOr<std::unique_ptr<PjRtStreamExecutorClient>> GetClientWithDevices(
+    int num_devices) {
+  LocalClient* local_client = xla::ClientLibrary::LocalClientOrDie();
+  ASSIGN_OR_RETURN(se::Platform * platform, PlatformUtil::GetPlatform("Host"));
+  if (local_client->device_count() < num_devices) {
+    return absl::FailedPreconditionError(absl::StrFormat(
+        "LocalClient has %d Host devices, need %d; set "
+        "--xla_force_host_platform_device_count=%d",
+        local_client->device_count(), num_devices, num_devices));
+  }
+  std::vector<std::unique_ptr<PjRtStreamExecutorDevice>> devices;
+  devices.reserve(num_devices);
+  std::vector<std::unique_ptr<PjRtMemorySpace>> memory_spaces;
+  memory_spaces.reserve(num_devices);
+  for (int i = 0; i < num_devices; ++i) {
+    ASSIGN_OR_RETURN(se::StreamExecutor * executor,
+                     platform->ExecutorForDevice(i));
+    auto device_state = std::make_unique<LocalDeviceState>(
+        executor, local_client, LocalDeviceState::kSynchronous,
+        /*max_inflight_computations=*/32,
+        /*allow_event_reuse=*/false, /*use_callback_stream=*/false);
+    int local_device_id = device_state->local_device_id().value();
+    devices.emplace_back(std::make_unique<PjRtStreamExecutorDevice>(
+        i, std::move(device_state), local_device_id, /*process_index=*/0,
+        /*process_index_in_partition=*/0, /*partition_index=*/0, "cpu"));
+    memory_spaces.emplace_back(std::make_unique<PjRtStreamExecutorMemorySpace>(
+        i, devices.back().get(), "cpu", 0));
+    devices.back()->AttachMemorySpace(memory_spaces.back().get(),
+                                      /*is_default=*/true);
+  }
+  auto topology = CreateCpuTopologyDescription(devices.size());
+  return std::make_unique<PjRtStreamExecutorClient>(
+      "cpu", local_client, std::move(devices), /*process_index=*/0,
+      std::move(memory_spaces),
       /*topology=*/std::move(topology), /*allocator=*/nullptr,
       /*host_memory_allocator=*/nullptr,
       /*should_stage_host_to_device_transfers=*/false,
@@ -369,6 +423,100 @@ TEST(PjRtStreamExecutorClientTest, MakeAllocationReadyEventAsync) {
   if (auto* error = slice_ready_event.async_value()->GetErrorIfPresent()) {
     ASSERT_OK(*error);
   }
+}
+
+// Regression test for the two-phase launch barrier: when any device's Prepare
+// fails, no device may proceed to ExecuteLaunch. Before the fix, a device
+// whose Prepare succeeded could observe `failed == 0` (because a failing peer
+// had passed the preparing==0 barrier but not yet written `failed`) and enter
+// ExecuteLaunch; with a real cross-device collective that device then hangs
+// at the rendezvous waiting for a peer that never arrives. The test asserts
+// the invariant directly (zero ExecuteLaunch calls) rather than via a hang,
+// so it needs no collective. PjRtStreamExecutorClient is the production
+// client with supports_two_phase_launch()==true, so Host-backed SE devices
+// exercise the real barrier path without accelerator hardware.
+TEST(PjRtStreamExecutorClientTest, TwoPhaseExecutePrepareFailureSkipsLaunch) {
+  constexpr int kNumDevices = 2;
+  // The pre-fix race is schedule-dependent (it fires only when a succeeding
+  // device is last to the barrier), so repeat with the failing device
+  // alternating. On Host-SE each iteration is microseconds.
+  constexpr int kIterations = 50;
+
+  ASSERT_OK_AND_ASSIGN(auto client, GetClientWithDevices(kNumDevices));
+  ASSERT_TRUE(client->supports_two_phase_launch());
+
+  Shape shape = ShapeUtil::MakeScalarShape(F32);
+  // CheckBufferCompatibilities rejects this on the failing device — different
+  // on-device size from the compiled scalar parameter.
+  Shape wrong_shape = ShapeUtil::MakeShape(F32, {2});
+
+  CompileOptions compile_options;
+  compile_options.executable_build_options.set_num_replicas(kNumDevices);
+  DeviceAssignment assignment(kNumDevices, /*computation_count=*/1);
+  for (int i = 0; i < kNumDevices; ++i) {
+    assignment(i, 0) = i;
+  }
+  compile_options.executable_build_options.set_device_assignment(assignment);
+  ASSERT_OK_AND_ASSIGN(auto executable, ToyExecutable(
+                                            *client, shape, [](XlaBuilder&) {},
+                                            compile_options));
+  ASSERT_EQ(executable->addressable_devices().size(), kNumDevices);
+
+  std::atomic<int> launch_calls{0};
+  tensorflow::down_cast<CommonPjRtLoadedExecutable*>(executable.get())
+      ->SetExecuteLaunchHookForTesting([&](PjRtDevice*) {
+        launch_calls.fetch_add(1, std::memory_order_relaxed);
+      });
+
+  std::vector<std::unique_ptr<PjRtBuffer>> ok_bufs(kNumDevices);
+  std::vector<std::unique_ptr<PjRtBuffer>> wrong_bufs(kNumDevices);
+  for (int d = 0; d < kNumDevices; ++d) {
+    auto* mem = *client->addressable_devices()[d]->default_memory_space();
+    ASSERT_OK_AND_ASSIGN(ok_bufs[d],
+                         client->CreateUninitializedBuffer(shape, mem));
+    ASSERT_OK_AND_ASSIGN(wrong_bufs[d],
+                         client->CreateUninitializedBuffer(wrong_shape, mem));
+  }
+
+  absl::Notification done;
+  absl::Status last_result;
+  std::unique_ptr<tsl::Thread> t(tsl::Env::Default()->StartThread(
+      tsl::ThreadOptions(), "TwoPhaseExecute", [&] {
+        for (int i = 0; i < kIterations; ++i) {
+          int failing = i % kNumDevices;
+          std::vector<std::vector<PjRtBuffer*>> args(kNumDevices);
+          for (int d = 0; d < kNumDevices; ++d) {
+            PjRtBuffer* b =
+                (d == failing) ? wrong_bufs[d].get() : ok_bufs[d].get();
+            args[d] = {b, b};
+          }
+          ExecuteOptions options;
+          last_result = executable->Execute(args, options).status();
+          if (last_result.ok()) {
+            break;
+          }
+        }
+        done.Notify();
+      }));
+  if (!done.WaitForNotificationWithTimeout(absl::Seconds(60))) {
+    // Leak the tsl::Thread rather than block in its join-on-destruct
+    // destructor. FAIL() records the diagnostic before return; teardown then
+    // blocks (the client's per-device worker threads are parked in mu.Await()
+    // inside the leaked Execute call) and the test framework's timeout reaps
+    // the process.
+    (void)t.release();
+    FAIL() << "Execute() did not return within 60s with one device's Prepare "
+              "failing; two-phase barrier exit path is wedged.";
+  }
+  t.reset();
+  EXPECT_FALSE(last_result.ok()) << last_result;
+  // The load-bearing assertion: with any Prepare failure, no device reaches
+  // phase 2. On a regressed barrier this count is nonzero for some schedule.
+  EXPECT_EQ(launch_calls.load(), 0)
+      << "ExecuteLaunch was reached on " << launch_calls.load()
+      << " device(s) across " << kIterations
+      << " iterations despite a peer Prepare failure; the two-phase barrier "
+         "let a succeeding device past before the failure was recorded.";
 }
 
 }  // namespace


### PR DESCRIPTION
## The bug

`CommonPjRtLoadedExecutable::Execute`'s two-phase launch runs Prepare on every device in parallel, then each device reads a shared `failed` counter to decide whether to proceed to Launch. A `preparing==0` barrier ensures every device finishes Prepare before any device reads `failed` — but each device writes `failed++` *after* passing that barrier. So a device whose Prepare succeeded can read `failed == 0` (a failing peer has passed the barrier but not yet written), proceed to ExecuteLaunch, and block forever at the collective rendezvous waiting for a peer that never launches.

This happens during multi-GPU bringup: a transient CUDA allocation failure on one device during Prepare wedges the whole process at the NCCL rendezvous instead of returning an error.

## The fix

Move each device's `failed++` write to before its `preparing--`, still under the same mutex. Now `preparing==0` implies every device has already recorded its Prepare outcome, so any device that passes the barrier observes the final `failed` count. No new barrier is needed; the existing one now also covers the failure write.

## Commits

1. **pjrt: record Prepare failure before the two-phase barrier** — the fix proper. Self-contained (only reorders the failure-recording block in `Execute`) and safe to cherry-pick on its own.
2. **pjrt: add ExecuteLaunch hook and two-phase barrier regression test** — test-only. Adds `SetExecuteLaunchHook` (a null-checked `std::function` invoked at the top of ExecuteLaunch; never set in production) plus the regression test. No behavior change when the hook is unset.

## Tests

`TwoPhaseExecutePrepareFailureSkipsLaunch` (new, in `pjrt_stream_executor_client_test.cc`): a 2-device Host-platform StreamExecutor client runs Execute with one device given a wrong-size buffer so `CheckBufferCompatibilities` fails its Prepare. The new `SetExecuteLaunchHook` test hook counts how many devices reach ExecuteLaunch (phase 2). The test asserts that across 50 iterations with the failing device alternating, (a) Execute returns an error within 60s, and (b) **zero** devices reach ExecuteLaunch. (b) is the regression assertion — on a regressed barrier, a succeeding device reaches phase 2 on some schedules.

Covers barrier exit-path correctness without accelerator hardware; does not reproduce the original GPU-collective hang directly (that needs real collectives and timing control).

### On the testing approach (feedback welcome)

We're not fully settled on the hook being the right seam, so flagging the reasoning for reviewers. The invariant under test — no device enters Launch when any peer's Prepare failed — is not observable through the public API on the Host platform: `Execute` returns the same error status whether or not a device slipped into phase 2, and the real symptom (a collective rendezvous hang) only manifests with real collectives on multi-accelerator hardware. So the test observes phase-2 entry directly via a settable hook on the production class, following the ModuleHook pattern in `xla/service/llvm_compiler.h` (see also `GpuCompiler::SetAsmHook` and `DistributedRuntimeClient::Options::missed_heartbeat_callback`).

Alternatives considered: reproducing the actual hang (needs real collectives plus schedule control, and a hang-based oracle); mocking `ExecuteLaunch` (not virtual, and a test double would bypass the production barrier path under test); a friend-class test peer (phase-2 entry is a transient event, not inspectable state). If reviewers prefer, we're happy to rename the setter to `SetExecuteLaunchHookForTest` and/or add mutex-guarded set-once semantics like `LLVMCompiler`'s hooks.
