### PR TITLE
pjrt_c_api_gpu: plumb max_inflight_computations through PJRT C-API create options

### DIFF
--- a/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
@@ -119,6 +119,8 @@ PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args) {
           {"enable_mock_nccl", PJRT_NamedValue_Type::PJRT_NamedValue_kBool},
           {"mock_gpu_topology", PJRT_NamedValue_Type::PJRT_NamedValue_kString},
           {"partition_index", PJRT_NamedValue_Type::PJRT_NamedValue_kInt64},
+          {"max_inflight_computations",
+           PJRT_NamedValue_Type::PJRT_NamedValue_kInt64},
       });
   PJRT_RETURN_IF_ERROR(
       ValidateCreateOptions(create_options, kExpectedOptionNameAndTypes));
@@ -206,6 +208,11 @@ PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args) {
       it != create_options.end()) {
     partition_index = std::get<int64_t>(it->second);
   }
+  std::optional<int64_t> max_inflight_computations;
+  if (auto it = create_options.find("max_inflight_computations");
+      it != create_options.end()) {
+    max_inflight_computations = std::get<int64_t>(it->second);
+  }
 
   xla::GpuClientOptions options;
   options.allocator_config = allocator_config;
@@ -223,6 +230,14 @@ PJRT_Error* PJRT_Client_Create(PJRT_Client_Create_Args* args) {
   options.enable_mock_nccl = enable_mock_nccl;
   options.mock_gpu_topology = mock_gpu_topology;
   options.partition_index = partition_index;
+  if (max_inflight_computations.has_value()) {
+    int64_t v = *max_inflight_computations;
+    if (v <= 0 || v > INT32_MAX) {
+      return StatusToPjRtError(absl::InvalidArgumentError(absl::StrFormat(
+          "max_inflight_computations must be in (0, INT32_MAX], got %d", v)));
+    }
+    options.max_inflight_computations = static_cast<int>(v);
+  }
   PJRT_ASSIGN_OR_RETURN(std::unique_ptr<xla::PjRtClient> client,
                         xla::GetXlaPjrtGpuClient(options));
   args->client = pjrt::CreateWrapperClient(GetGpuPjrtApi(), std::move(client));

--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -789,6 +789,77 @@ TEST(PjrtCApiGpuAllocatorTest, InvalidAllocatorOptionsParsing) {
   api->PJRT_Error_Destroy(&error_destroy_args);
 }
 
+TEST(PjrtCApiGpuMaxInflightComputationsTest, ValidOptionsParsing) {
+  auto api = GetPjrtApi();
+  absl::flat_hash_map<std::string, xla::PjRtValueType> options = {
+      {"max_inflight_computations", static_cast<int64_t>(64)},
+      {"visible_devices", xla::PjRtValueType(std::vector<int64_t>{0})},
+  };
+  ASSERT_OK_AND_ASSIGN(std::vector<PJRT_NamedValue> c_options,
+                       ::pjrt::ConvertToPjRtNamedValueList(options));
+  PJRT_Client_Create_Args create_arg;
+  create_arg.struct_size = PJRT_Client_Create_Args_STRUCT_SIZE;
+  create_arg.extension_start = nullptr;
+  create_arg.client = nullptr;
+  create_arg.create_options = c_options.data();
+  create_arg.num_options = c_options.size();
+  create_arg.kv_get_callback = nullptr;
+  create_arg.kv_get_user_arg = nullptr;
+  create_arg.kv_try_get_callback = nullptr;
+  create_arg.kv_try_get_user_arg = nullptr;
+  create_arg.kv_put_callback = nullptr;
+  create_arg.kv_put_user_arg = nullptr;
+  PJRT_Error* error = api->PJRT_Client_Create(&create_arg);
+  EXPECT_EQ(error, nullptr) << GetErrorMessage(error, api);
+
+  PJRT_Client_Destroy_Args destroy_args;
+  destroy_args.struct_size = PJRT_Client_Destroy_Args_STRUCT_SIZE;
+  destroy_args.extension_start = nullptr;
+  destroy_args.client = create_arg.client;
+
+  PJRT_Error* destroy_error = api->PJRT_Client_Destroy(&destroy_args);
+  CHECK_EQ(destroy_error, nullptr);
+}
+
+TEST(PjrtCApiGpuMaxInflightComputationsTest, InvalidOptionsParsing) {
+  auto api = GetPjrtApi();
+  std::vector<int64_t> invalid_values = {0, -1,
+                                         static_cast<int64_t>(INT32_MAX) + 1};
+  for (int64_t invalid_value : invalid_values) {
+    absl::flat_hash_map<std::string, xla::PjRtValueType> options = {
+        {"max_inflight_computations", invalid_value},
+    };
+    ASSERT_OK_AND_ASSIGN(std::vector<PJRT_NamedValue> c_options,
+                         ::pjrt::ConvertToPjRtNamedValueList(options));
+    PJRT_Client_Create_Args create_arg;
+    create_arg.struct_size = PJRT_Client_Create_Args_STRUCT_SIZE;
+    create_arg.extension_start = nullptr;
+    create_arg.client = nullptr;
+    create_arg.create_options = c_options.data();
+    create_arg.num_options = c_options.size();
+    create_arg.kv_get_callback = nullptr;
+    create_arg.kv_get_user_arg = nullptr;
+    create_arg.kv_try_get_callback = nullptr;
+    create_arg.kv_try_get_user_arg = nullptr;
+    create_arg.kv_put_callback = nullptr;
+    create_arg.kv_put_user_arg = nullptr;
+    PJRT_Error* error = api->PJRT_Client_Create(&create_arg);
+    EXPECT_NE(error, nullptr);
+    EXPECT_THAT(
+        ::pjrt::PjrtErrorToStatus(error, api),
+        absl_testing::StatusIs(
+            absl::StatusCode::kInvalidArgument,
+            HasSubstr("max_inflight_computations must be in (0, INT32_MAX]")));
+
+    PJRT_Error_Destroy_Args error_destroy_args;
+    error_destroy_args.struct_size = PJRT_Error_Destroy_Args_STRUCT_SIZE;
+    error_destroy_args.extension_start = nullptr;
+    error_destroy_args.error = error;
+
+    api->PJRT_Error_Destroy(&error_destroy_args);
+  }
+}
+
 TEST(PjrtCApiPlatformNameTest, AvailablePlatformName) {
   auto api = GetPjrtApi();
   std::string expected_platform_name_for_cuda = "cuda";


### PR DESCRIPTION
b261c3b677 ("Respect `GpuOptions::max_inflight_computations` in SE GPU") added `GpuClientOptions::max_inflight_computations` and wired it through the StreamExecutor GPU client, but did not add the corresponding key to the GPU PJRT C API plugin's create-options allowlist. Since `ValidateCreateOptions` rejects unrecognized keys, passing `"max_inflight_computations"` via the plugin path (e.g. JAX's `jax_pjrt_client_create_options`) fails client creation with `Unexpected option name passed to PJRT_Client_Create`, so the field can't be set from Python.

This PR adds the key to `kExpectedOptionNameAndTypes` and forwards it to `GpuClientOptions`. The value is validated to be in `(0, INT32_MAX]`: the field is `int`, and a zero value would construct a compute semaphore that blocks forever on the first `Execute()`. When the option is omitted, the `GpuClientOptions` default (32) is preserved; disabling the semaphore entirely (`std::nullopt`) remains C++-only, since expressing "no limit" through an int64 option would need a sentinel value.

This is GPU-specific because `"max_inflight_computations"` is already among the TPU plugin's published create-option names (`pjrt::tpu_configs::kMaxInflightComputations`, `xla/pjrt/c/pjrt_c_api_tpu_constants.h`); this change brings the GPU plugin to parity.

Tested: `pjrt_c_api_gpu_test` — `PjrtCApiGpuMaxInflightComputationsTest.{Valid,Invalid}OptionsParsing`.
