### PR TITLE
[XLA:GPU[oneAPI] Removed limit on stream creation per device for oneAPI backend

### DIFF
--- a/xla/stream_executor/sycl/sycl_gpu_runtime.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.cc
@@ -279,16 +279,8 @@ absl::StatusOr<StreamPtr> SyclStreamPool::GetOrCreateStream(
   ASSIGN_OR_RETURN(StreamPool * stream_pool,
                    SyclStreamPool::InitStreamPool(device_ordinal));
   // If multiple streams are enabled, create a new stream and add it
-  // to the pool, unless the pool has reached kMaxStreamsPerDevice.
+  // to the pool.
   absl::MutexLock write_lock(&stream_pool_mu_);
-  if (stream_pool->size() >= kMaxStreamsPerDevice) {
-    VLOG(2) << "Stream pool size for device ordinal " << device_ordinal
-            << " exceeds the maximum limit of " << kMaxStreamsPerDevice;
-    return absl::ResourceExhaustedError(
-        absl::StrCat("SyclStreamPool::GetOrCreateStream: Maximum number of "
-                     "streams reached for device ordinal ",
-                     device_ordinal, "."));
-  }
   VLOG(2) << "Stream pool size for device ordinal " << device_ordinal << ": "
           << stream_pool->size();
   ::sycl::property_list prop_list{::sycl::property::queue::enable_profiling(),

--- a/xla/stream_executor/sycl/sycl_gpu_runtime.h
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.h
@@ -79,14 +79,6 @@ using StreamPtr = std::shared_ptr<::sycl::queue>;
 using StreamPool = std::vector<StreamPtr>;
 using StreamPoolMap = absl::flat_hash_map<int /*device_ordinal*/, StreamPool>;
 
-// TODO(intel-tf): kMaxStreamsPerDevice is the maximum number of streams that
-// can be created per device via GetOrCreateStream when multiple streams are
-// enabled.
-//
-// For now, we set it to 32 so that there is no unbounded growth. However, it
-// can be adjusted based on the device capabilities and workload requirements.
-constexpr int kMaxStreamsPerDevice = 32;
-
 // Manages pools of SYCL streams (queues) per device. All methods are static and
 // thread-safe via a global mutex. For high concurrency workloads, consider
 // refactoring to use per-device mutexes.
@@ -105,8 +97,7 @@ class SyclStreamPool {
   // pool) SYCL stream. If the stream pool is empty, returns an error.
   //
   // If multiple streams are enabled (via enable_multiple_streams), creates
-  // a new stream up to the maximum limit (kMaxStreamsPerDevice). Returns an
-  // error if the limit is reached.
+  // a new stream.
   static absl::StatusOr<StreamPtr> GetOrCreateStream(
       int device_ordinal, bool enable_multiple_streams);
 

--- a/xla/stream_executor/sycl/sycl_gpu_runtime_test.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime_test.cc
@@ -196,24 +196,6 @@ TEST_F(SyclGpuRuntimeTest, TestStreamPoolDestroy_Negative) {
   EXPECT_EQ(stream_handle, nullptr);
 }
 
-TEST_F(SyclGpuRuntimeTest, TestMaxStreamsPerDevice) {
-  // Ensure that the maximum number of streams per device is respected.
-  constexpr int kMaxStreams = kMaxStreamsPerDevice;
-  std::vector<StreamPtr> streams(kMaxStreams);
-  for (int i = 0; i < kMaxStreams - 1; ++i) {
-    TF_ASSERT_OK_AND_ASSIGN(streams[i], SyclStreamPool::GetOrCreateStream(
-                                            kDefaultDeviceOrdinal,
-                                            /*enable_multiple_streams=*/true));
-    ASSERT_NE(streams[i], nullptr);
-  }
-
-  // Attempt to create one more stream, which should fail.
-  EXPECT_THAT(
-      SyclStreamPool::GetOrCreateStream(kDefaultDeviceOrdinal,
-                                        /*enable_multiple_streams=*/true),
-      absl_testing::StatusIs(absl::StatusCode::kResourceExhausted));
-}
-
 TEST_F(SyclGpuRuntimeTest, TestGetTimerProperties) {
   TF_ASSERT_OK_AND_ASSIGN(SyclTimerProperties timer_props,
                           SyclGetTimerProperties(kDefaultDeviceOrdinal));


### PR DESCRIPTION
This PR removes the limit on stream creation per device (`kMaxStreamsPerDevice`) on the oneAPI backend. This is done to maintain consistency with other GPU backends.

If the Level Zero GPU driver cannot create a stream at runtime, it will return an error that gets propagated as a status.
