### PR TITLE
[XLA:GPU][oneAPI] Implement pointer memory space for the oneAPI backend

### DIFF
--- a/xla/stream_executor/gpu/gpu_executor_test.cc
+++ b/xla/stream_executor/gpu/gpu_executor_test.cc
@@ -41,13 +41,9 @@ class GpuExecutorTest : public testing::Test {
   }
 };
 
-// TODO(intel-tf): Support GetPointerMemorySpace for host memory.
 using GetPointerMemorySpaceTest = GpuExecutorTest;
 
 TEST_F(GetPointerMemorySpaceTest, Host) {
-  if (GetPlatform()->Name() == "SYCL") {
-    GTEST_SKIP() << "SYCL does not support GetPointerMemorySpace";
-  }
   StreamExecutor* executor = GetPlatform()->ExecutorForDevice(0).value();
   TF_ASSERT_OK_AND_ASSIGN(auto host_ptr, executor->HostMemoryAllocate(64));
   TF_ASSERT_OK_AND_ASSIGN(auto memory_space, executor->GetPointerMemorySpace(
@@ -56,9 +52,6 @@ TEST_F(GetPointerMemorySpaceTest, Host) {
 }
 
 TEST_F(GetPointerMemorySpaceTest, HostAllocatedWithMemoryKind) {
-  if (GetPlatform()->Name() == "SYCL") {
-    GTEST_SKIP() << "SYCL does not support GetPointerMemorySpace";
-  }
   StreamExecutor* executor = GetPlatform()->ExecutorForDevice(0).value();
   DeviceAddressBase host_ptr = executor->Allocate(
       64, static_cast<int64_t>(stream_executor::MemorySpace::kHost));
@@ -70,9 +63,6 @@ TEST_F(GetPointerMemorySpaceTest, HostAllocatedWithMemoryKind) {
 }
 
 TEST_F(GetPointerMemorySpaceTest, Device) {
-  if (GetPlatform()->Name() == "SYCL") {
-    GTEST_SKIP() << "SYCL does not support GetPointerMemorySpace";
-  }
   StreamExecutor* executor = GetPlatform()->ExecutorForDevice(0).value();
   auto mem = executor->Allocate(64);
   ASSERT_NE(mem, nullptr);

--- a/xla/stream_executor/sycl/sycl_executor.cc
+++ b/xla/stream_executor/sycl/sycl_executor.cc
@@ -751,6 +751,26 @@ absl::Status SyclExecutor::SynchronousMemcpy(void* host_dst,
                                   AsSyclDevicePtr(gpu_src), size);
 }
 
+absl::StatusOr<MemorySpace> SyclExecutor::GetPointerMemorySpace(
+    const void* ptr) {
+  ASSIGN_OR_RETURN(sycl::context context, GetContext());
+  sycl::usm::alloc alloc_type = sycl::get_pointer_type(ptr, context);
+  switch (alloc_type) {
+    case sycl::usm::alloc::device:
+      return MemorySpace::kDevice;
+    case sycl::usm::alloc::host:
+      return MemorySpace::kHost;
+    case sycl::usm::alloc::shared:
+      return MemorySpace::kUnified;
+    case sycl::usm::alloc::unknown:
+    default:
+      return absl::InternalError(
+          absl::StrFormat("SyclExecutor::GetPointerMemorySpace: unknown USM "
+                          "allocation type (%d) for pointer %p",
+                          static_cast<int>(alloc_type), ptr));
+  }
+}
+
 absl::StatusOr<std::unique_ptr<DeviceDescription>>
 SyclExecutor::CreateDeviceDescription(int device_ordinal) {
   return CreateOneApiDeviceDescription(device_ordinal);

--- a/xla/stream_executor/sycl/sycl_executor.h
+++ b/xla/stream_executor/sycl/sycl_executor.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "xla/stream_executor/dnn.h"
 #include "xla/stream_executor/gpu/gpu_executor.h"
+#include "xla/stream_executor/memory_space.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/sycl/sycl_kernel.h"
 #include "xla/stream_executor/sycl/sycl_stream.h"
@@ -105,7 +106,8 @@ class SyclExecutor : public gpu::GpuExecutor {
                                  const DeviceMemoryBase& gpu_src,
                                  uint64_t size) override;
 
-  // TODO(intel-tf): Implement GetPointerMemorySpace for SYCL.
+  absl::StatusOr<MemorySpace> GetPointerMemorySpace(const void* ptr) override;
+
   // Returns the Stream for the given raw GPU stream pointer, or nullptr if
   // not found.
   Stream* FindAllocatedStream(void* gpu_stream) override {


### PR DESCRIPTION
This PR implements pointer memory space for the oneAPI backend. This is used to describe where a pointer's memory physically resides (i.e. device, host, or unified/shared memory). 

This PR also enables corresponding unit tests.