### PR TITLE
[xla:gpu] ThunkSequence construction cleanup

### DIFF
--- a/xla/backends/gpu/codegen/cudnn.cc
+++ b/xla/backends/gpu/codegen/cudnn.cc
@@ -40,13 +40,13 @@ AsyncThunkSequence CuDnnFusion::Emit(IrEmitterContext& ir_emitter_context,
       auto kernel_arguments,
       emitters::KernelArguments::Create(ir_emitter_context.buffer_assignment(),
                                         GetDefaultBufferAlignment(), &fusion));
-  return ThunkSequence::Of(std::make_unique<CuDnnThunk>(
+  return ThunkSequence::Of<CuDnnThunk>(
       emitters::GetComputationFingerprint(
           fusion.fused_instructions_computation(), {}),
       Thunk::ThunkInfo::WithProfileAnnotation(
           &fusion, ir_emitter_context.GetNextThunkId()),
       kernel_arguments.GetArgumentShapedSlices(),
-      kernel_arguments.GetArgumentOutputFlags()));
+      kernel_arguments.GetArgumentOutputFlags());
 }
 
 }  // namespace gpu

--- a/xla/backends/gpu/codegen/emitters/mlir_kernel_emitter.cc
+++ b/xla/backends/gpu/codegen/emitters/mlir_kernel_emitter.cc
@@ -418,8 +418,8 @@ AsyncThunkSequence MlirKernelFusion::Emit(
                          entry->launch_dimensions.thread_counts_per_block(),
                          entry->shmem_bytes));
 
-    return ThunkSequence::Of(std::make_unique<CustomKernelThunk>(
-        thunk_info, std::move(custom_kernel), args, entry->use_pdl));
+    return ThunkSequence::Of<CustomKernelThunk>(
+        thunk_info, std::move(custom_kernel), args, entry->use_pdl);
   });
 }
 

--- a/xla/backends/gpu/codegen/triton/fusion.cc
+++ b/xla/backends/gpu/codegen/triton/fusion.cc
@@ -140,10 +140,10 @@ AsyncThunkSequence TritonFusion::Emit(
                     result.entry.launch_dimensions.block_counts(),
                     result.entry.launch_dimensions.thread_counts_per_block(),
                     result.entry.shmem_bytes));
-            return ThunkSequence::Of(std::make_unique<CustomKernelThunk>(
+            return ThunkSequence::Of<CustomKernelThunk>(
                 thunk_info, std::move(custom_kernel), result.kernel_arguments,
                 result.entry.use_pdl, std::vector<int64_t>{},
-                result.entry.tma_metadata));
+                result.entry.tma_metadata);
           });
 }
 

--- a/xla/backends/gpu/runtime/async_thunk_test.cc
+++ b/xla/backends/gpu/runtime/async_thunk_test.cc
@@ -93,22 +93,21 @@ TEST(AsyncThunkTest, ConcurrentMemsets) {
     BufferAllocation::Slice slice(&alloc, i * kChunkBytes, kChunkBytes);
     uint32_t value = static_cast<uint32_t>(100 + i);
 
-    ThunkSequence nested;
-    nested.push_back(std::make_unique<Memset32BitValueThunk>(Thunk::ThunkInfo(),
-                                                             value, slice));
+    ThunkSequence nested = ThunkSequence::Of<Memset32BitValueThunk>(
+        Thunk::ThunkInfo(), value, slice);
 
     Thunk::ThunkInfo start_info;
     start_info.profile_annotation = absl::StrCat("start#", i);
     start_info.thunk_id = ThunkId(i + 1);
 
-    thunks.push_back(std::make_unique<AsyncStartThunk>(
-        std::move(start_info), ComputationStreamId(i), std::move(nested)));
+    thunks.Emplace<AsyncStartThunk>(std::move(start_info),
+                                    ComputationStreamId(i), std::move(nested));
   }
 
   for (int i = 0; i < kNumChunks; ++i) {
     auto* start = static_cast<AsyncStartThunk*>(thunks[i].get());
-    thunks.push_back(std::make_unique<AsyncDoneThunk>(
-        Thunk::ThunkInfo(), start->async_execution()));
+    thunks.Emplace<AsyncDoneThunk>(Thunk::ThunkInfo(),
+                                   start->async_execution());
   }
 
   // Build a ThunkExecutor to execute all thunks.

--- a/xla/backends/gpu/runtime/command_buffer_cmd_emitter_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_cmd_emitter_test.cc
@@ -105,11 +105,9 @@ TEST_F(CommandBufferCmdEmitterTest, ConcurrentAndSequentialExecutionGraphs) {
 
   ThunkSequence thunks;
   BufferAllocation::Slice slice_a(&allocation, /*offset=*/0, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("a"), slice_a));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("a"), slice_a);
   BufferAllocation::Slice slice_b(&allocation, /*offset=*/1024, /*size=*/2048);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("b"), slice_b));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("b"), slice_b);
 
   ConvertToCommandsOptions options;
   {
@@ -152,21 +150,17 @@ TEST_F(CommandBufferCmdEmitterTest,
   ThunkSequence thunks;
 
   BufferAllocation::Slice slice_a(&allocation, /*offset=*/0, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("a"), slice_a));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("a"), slice_a);
 
   BufferAllocation::Slice slice_b(&allocation, /*offset=*/2 * 1024,
                                   /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("b"), slice_b));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("b"), slice_b);
 
   BufferAllocation::Slice slice_c(&allocation, /*offset=*/0, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("c"), slice_c));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("c"), slice_c);
 
   BufferAllocation::Slice slice_d(&allocation, /*offset=*/1024, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("d"), slice_d));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("d"), slice_d);
 
   ConvertToCommandsOptions options;
   // In kConcurrent mode, there are 3 source nodes (a, b, d) and 3 sink nodes
@@ -217,21 +211,17 @@ TEST_F(CommandBufferCmdEmitterTest, ConcurrentRegionsExecutesOutOfOrder) {
   ThunkSequence thunks;
 
   BufferAllocation::Slice slice_a(&allocation, /*offset=*/0, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("a"), slice_a));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("a"), slice_a);
 
   BufferAllocation::Slice slice_b(&allocation, /*offset=*/0,
                                   /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("b"), slice_b));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("b"), slice_b);
 
   BufferAllocation::Slice slice_c(&allocation, /*offset=*/1024, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("c"), slice_c));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("c"), slice_c);
 
   BufferAllocation::Slice slice_d(&allocation, /*offset=*/1024, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("d"), slice_d));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("d"), slice_d);
 
   ConvertToCommandsOptions options;
   options.synchronization_mode =
@@ -269,31 +259,26 @@ TEST_F(CommandBufferCmdEmitterTest,
   ThunkSequence thunks;
 
   BufferAllocation::Slice slice_a(&allocation, /*offset=*/0, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("a"), slice_a));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("a"), slice_a);
   thunks.back()->set_concurrent_region_id(42);
 
   BufferAllocation::Slice slice_b(&allocation, /*offset=*/1024, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("b"), slice_b));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("b"), slice_b);
   thunks.back()->set_concurrent_region_id(42);
 
   BufferAllocation::Slice slice_c(&allocation, /*offset=*/2 * 1024,
                                   /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("c"), slice_c));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("c"), slice_c);
   thunks.back()->set_concurrent_region_id(43);
 
   BufferAllocation::Slice slice_d(&allocation, /*offset=*/3 * 1024,
                                   /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("d"), slice_d));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("d"), slice_d);
   thunks.back()->set_concurrent_region_id(43);
 
   BufferAllocation::Slice slice_e(&allocation, /*offset=*/4 * 1024,
                                   /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("e"), slice_e));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("e"), slice_e);
   thunks.back()->set_concurrent_region_id(44);
 
   ConvertToCommandsOptions options;
@@ -323,31 +308,26 @@ TEST_F(CommandBufferCmdEmitterTest,
   ThunkSequence thunks;
 
   BufferAllocation::Slice slice_a(&allocation, /*offset=*/0, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("a"), slice_a));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("a"), slice_a);
   thunks.back()->set_concurrent_region_id(42);
 
   BufferAllocation::Slice slice_b(&allocation, /*offset=*/1024, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("b"), slice_b));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("b"), slice_b);
   thunks.back()->set_concurrent_region_id(42);
 
   BufferAllocation::Slice slice_c(&allocation, /*offset=*/2 * 1024,
                                   /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("c"), slice_c));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("c"), slice_c);
   thunks.back()->set_concurrent_region_id(42);
 
   BufferAllocation::Slice slice_d(&allocation, /*offset=*/3 * 1024,
                                   /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("d"), slice_d));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("d"), slice_d);
   thunks.back()->set_concurrent_region_id(43);
 
   BufferAllocation::Slice slice_e(&allocation, /*offset=*/4 * 1024,
                                   /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("e"), slice_e));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("e"), slice_e);
   thunks.back()->set_concurrent_region_id(43);
 
   ConvertToCommandsOptions options;
@@ -372,26 +352,21 @@ TEST_F(CommandBufferCmdEmitterTest, ConcurrentRegionsScheduleHasLaneAffinity) {
   ThunkSequence thunks;
 
   BufferAllocation::Slice slice_a(&allocation, /*offset=*/0, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("a"), slice_a));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("a"), slice_a);
 
   BufferAllocation::Slice slice_b(&allocation, /*offset=*/1024, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("b"), slice_b));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("b"), slice_b);
 
   BufferAllocation::Slice slice_c(&allocation, /*offset=*/2 * 1024,
                                   /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("c"), slice_c));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("c"), slice_c);
 
   BufferAllocation::Slice slice_d(&allocation, /*offset=*/3 * 1024,
                                   /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("d"), slice_d));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("d"), slice_d);
 
   BufferAllocation::Slice slice_e(&allocation, /*offset=*/0, /*size=*/1024);
-  thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("e"), slice_e));
+  thunks.Emplace<FakeKernelThunk>(NextThunkInfo("e"), slice_e);
   for (auto& thunk : thunks) {
     thunk->set_concurrent_region_id(44);
   }
@@ -429,13 +404,11 @@ TEST_F(CommandBufferCmdEmitterTest, ConvertsConditionalThunkToCommand) {
   BufferAllocation::Slice branch1_slice(&data_alloc, /*offset=*/1024,
                                         /*size=*/1024);
 
-  ThunkSequence branch0;
-  branch0.push_back(std::make_unique<FakeKernelThunk>(NextThunkInfo("branch0"),
-                                                      branch0_slice));
+  ThunkSequence branch0 = ThunkSequence::Of<FakeKernelThunk>(
+      NextThunkInfo("branch0"), branch0_slice);
 
-  ThunkSequence branch1;
-  branch1.push_back(std::make_unique<FakeKernelThunk>(NextThunkInfo("branch1"),
-                                                      branch1_slice));
+  ThunkSequence branch1 = ThunkSequence::Of<FakeKernelThunk>(
+      NextThunkInfo("branch1"), branch1_slice);
 
   std::vector<ThunkSequence> branches;
   branches.push_back(std::move(branch0));
@@ -474,13 +447,11 @@ TEST_F(CommandBufferCmdEmitterTest, ConvertsWhileThunkToCommand) {
   BufferAllocation::Slice body_slice(&data_alloc, /*offset=*/1024,
                                      /*size=*/1024);
 
-  ThunkSequence cond_thunks;
-  cond_thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("cond"), cond_slice));
+  ThunkSequence cond_thunks =
+      ThunkSequence::Of<FakeKernelThunk>(NextThunkInfo("cond"), cond_slice);
 
-  ThunkSequence body_thunks;
-  body_thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("body"), body_slice));
+  ThunkSequence body_thunks =
+      ThunkSequence::Of<FakeKernelThunk>(NextThunkInfo("body"), body_slice);
 
   auto while_thunk = std::make_unique<WhileThunk>(
       NextThunkInfo("while"), pred_slice, std::move(cond_thunks),
@@ -514,18 +485,15 @@ TEST_F(CommandBufferCmdEmitterTest, ConvertsWhileThunkRepeatedly) {
   BufferAllocation::Slice body_slice(&data_alloc, /*offset=*/1024,
                                      /*size=*/1024);
 
-  ThunkSequence cond_thunks;
-  cond_thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("cond"), cond_slice));
+  ThunkSequence cond_thunks =
+      ThunkSequence::Of<FakeKernelThunk>(NextThunkInfo("cond"), cond_slice);
 
-  ThunkSequence body_thunks;
-  body_thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("body"), body_slice));
+  ThunkSequence body_thunks =
+      ThunkSequence::Of<FakeKernelThunk>(NextThunkInfo("body"), body_slice);
 
-  ThunkSequence thunks;
-  thunks.push_back(std::make_unique<WhileThunk>(
+  ThunkSequence thunks = ThunkSequence::Of<WhileThunk>(
       NextThunkInfo("while"), pred_slice, std::move(cond_thunks),
-      std::move(body_thunks)));
+      std::move(body_thunks));
 
   auto collect_command_names = [](CommandExecutor& commands) {
     std::vector<std::string> command_names;
@@ -563,23 +531,20 @@ TEST_F(CommandBufferCmdEmitterTest, ConvertsConditionalThunkRepeatedly) {
   BufferAllocation::Slice branch1_slice(&data_alloc, /*offset=*/1024,
                                         /*size=*/1024);
 
-  ThunkSequence branch0;
-  branch0.push_back(std::make_unique<FakeKernelThunk>(NextThunkInfo("branch0"),
-                                                      branch0_slice));
+  ThunkSequence branch0 = ThunkSequence::Of<FakeKernelThunk>(
+      NextThunkInfo("branch0"), branch0_slice);
 
-  ThunkSequence branch1;
-  branch1.push_back(std::make_unique<FakeKernelThunk>(NextThunkInfo("branch1"),
-                                                      branch1_slice));
+  ThunkSequence branch1 = ThunkSequence::Of<FakeKernelThunk>(
+      NextThunkInfo("branch1"), branch1_slice);
 
   std::vector<ThunkSequence> branches;
   branches.push_back(std::move(branch0));
   branches.push_back(std::move(branch1));
 
-  ThunkSequence thunks;
-  thunks.push_back(std::make_unique<ConditionalThunk>(
+  ThunkSequence thunks = ThunkSequence::Of<ConditionalThunk>(
       NextThunkInfo("conditional"),
       ShapedSlice{branch_index_slice, ShapeUtil::MakeShape(S32, {})},
-      std::move(branches)));
+      std::move(branches));
 
   auto collect_command_names = [](CommandExecutor& commands) {
     std::vector<std::string> command_names;
@@ -617,23 +582,20 @@ TEST_F(CommandBufferCmdEmitterTest,
   BufferAllocation::Slice true_slice(&data_alloc, /*offset=*/1024,
                                      /*size=*/1024);
 
-  ThunkSequence false_branch;
-  false_branch.push_back(std::make_unique<FakeKernelThunk>(
-      NextThunkInfo("false_branch"), false_slice));
+  ThunkSequence false_branch = ThunkSequence::Of<FakeKernelThunk>(
+      NextThunkInfo("false_branch"), false_slice);
 
-  ThunkSequence true_branch;
-  true_branch.push_back(std::make_unique<FakeKernelThunk>(
-      NextThunkInfo("true_branch"), true_slice));
+  ThunkSequence true_branch = ThunkSequence::Of<FakeKernelThunk>(
+      NextThunkInfo("true_branch"), true_slice);
 
   std::vector<ThunkSequence> branches;
   branches.push_back(std::move(false_branch));
   branches.push_back(std::move(true_branch));
 
-  ThunkSequence thunks;
-  thunks.push_back(std::make_unique<ConditionalThunk>(
+  ThunkSequence thunks = ThunkSequence::Of<ConditionalThunk>(
       NextThunkInfo("conditional"),
       ShapedSlice{branch_index_slice, ShapeUtil::MakeShape(PRED, {})},
-      std::move(branches)));
+      std::move(branches));
 
   ASSERT_OK_AND_ASSIGN(CommandExecutor commands,
                        ConvertToCommands(thunks, ConvertToCommandsOptions()));
@@ -651,9 +613,8 @@ TEST_F(CommandBufferCmdEmitterTest, ConcurrentRegionsNestedThunk) {
   BufferAllocation allocation(/*index=*/0, /*size=*/1024, /*color=*/0);
   BufferAllocation::Slice slice(&allocation, /*offset=*/0, /*size=*/1024);
 
-  ThunkSequence nested_thunks;
-  nested_thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("nested_kernel"), slice));
+  ThunkSequence nested_thunks =
+      ThunkSequence::Of<FakeKernelThunk>(NextThunkInfo("nested_kernel"), slice);
   auto seq_thunk = std::make_unique<SequentialThunk>(NextThunkInfo("seq_thunk"),
                                                      std::move(nested_thunks));
   seq_thunk->set_concurrent_region_id(42);
@@ -700,19 +661,15 @@ TEST_F(CommandBufferCmdEmitterTest, ConcurrentRegionsNestedThunksMultiple) {
   BufferAllocation::Slice slice(&allocation, /*offset=*/0, /*size=*/1024);
 
   ThunkSequence nested_thunks_1;
-  nested_thunks_1.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("k1"), slice));
-  nested_thunks_1.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("k2"), slice));
+  nested_thunks_1.Emplace<FakeKernelThunk>(NextThunkInfo("k1"), slice);
+  nested_thunks_1.Emplace<FakeKernelThunk>(NextThunkInfo("k2"), slice);
   auto seq_thunk_1 = std::make_unique<SequentialThunk>(
       NextThunkInfo("seq1"), std::move(nested_thunks_1));
   seq_thunk_1->set_concurrent_region_id(42);
 
   ThunkSequence nested_thunks_2;
-  nested_thunks_2.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("k3"), slice));
-  nested_thunks_2.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("k4"), slice));
+  nested_thunks_2.Emplace<FakeKernelThunk>(NextThunkInfo("k3"), slice);
+  nested_thunks_2.Emplace<FakeKernelThunk>(NextThunkInfo("k4"), slice);
   auto seq_thunk_2 = std::make_unique<SequentialThunk>(
       NextThunkInfo("seq2"), std::move(nested_thunks_2));
   seq_thunk_2->set_concurrent_region_id(42);
@@ -818,10 +775,8 @@ TEST_F(CommandBufferCmdEmitterTest,
   thunks.push_back(std::move(k1));
   // seq_thunk (42) contains k2 (slice_b, 42) and k3 (slice_c, 42)
   ThunkSequence nested_thunks;
-  nested_thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("k2"), slice_b));
-  nested_thunks.push_back(
-      std::make_unique<FakeKernelThunk>(NextThunkInfo("k3"), slice_c));
+  nested_thunks.Emplace<FakeKernelThunk>(NextThunkInfo("k2"), slice_b);
+  nested_thunks.Emplace<FakeKernelThunk>(NextThunkInfo("k3"), slice_c);
   auto seq_thunk = std::make_unique<SequentialThunk>(NextThunkInfo("seq"),
                                                      std::move(nested_thunks));
   seq_thunk->set_concurrent_region_id(42);

--- a/xla/backends/gpu/runtime/command_buffer_conversion_pass_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_conversion_pass_test.cc
@@ -194,10 +194,9 @@ std::unique_ptr<DynamicSliceFusionV2Thunk> CreateDynamicSliceFusionV2Thunk(
   Shape src_shape = ShapeUtil::MakeShape(S32, {16});
   Shape slice_shape = ShapeUtil::MakeShape(S32, {4});
 
-  ThunkSequence embedded_thunks;
-  embedded_thunks.push_back(std::make_unique<DeviceToDeviceCopyThunk>(
+  ThunkSequence embedded_thunks = ThunkSequence::Of<DeviceToDeviceCopyThunk>(
       Thunk::ThunkInfo(), ShapedSlice{embedded_src, slice_shape},
-      ShapedSlice{embedded_dst, slice_shape}, kSliceBytes));
+      ShapedSlice{embedded_dst, slice_shape}, kSliceBytes);
 
   return std::make_unique<DynamicSliceFusionV2Thunk>(
       Thunk::ThunkInfo(),
@@ -1237,8 +1236,7 @@ TEST(CommandBufferConversionPassTest, ConvertAsyncStartDonePair) {
   thunks.push_back(std::move(start_thunk));
 
   // Create AsyncDoneThunk paired with the start thunk.
-  thunks.push_back(
-      std::make_unique<AsyncDoneThunk>(Thunk::ThunkInfo(), async_execution));
+  thunks.Emplace<AsyncDoneThunk>(Thunk::ThunkInfo(), async_execution);
 
   se::DeviceDescription device_info = TestGpuDeviceInfo::CudaOrRocmDeviceInfo();
   DebugOptions debug_options;
@@ -1268,8 +1266,7 @@ TEST(CommandBufferConversionPassTest,
   thunks.push_back(CreateCopyThunk(alloc0));
 
   // Create AsyncDoneThunk paired with the start thunk.
-  thunks.push_back(
-      std::make_unique<AsyncDoneThunk>(Thunk::ThunkInfo(), async_execution));
+  thunks.Emplace<AsyncDoneThunk>(Thunk::ThunkInfo(), async_execution);
 
   se::DeviceDescription device_info = TestGpuDeviceInfo::CudaOrRocmDeviceInfo();
   DebugOptions debug_options;

--- a/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
@@ -1466,10 +1466,9 @@ TEST(CommandBufferThunkTest, ConditionalThunkCaseCommand) {
   }
 
   // Prepare thunk sequence for command buffer conversion.
-  ThunkSequence thunks;
-  thunks.push_back(std::make_unique<ConditionalThunk>(
+  ThunkSequence thunks = ThunkSequence::Of<ConditionalThunk>(
       Thunk::ThunkInfo(), ShapedSlice{slice_i, i_shape},
-      std::move(branch_thunks)));
+      std::move(branch_thunks));
 
   ConvertToCommandsOptions options;
   options.synchronization_mode = serialize;
@@ -1579,10 +1578,9 @@ TEST(CommandBufferThunkTest, WhileThunk) {
       /*shmem_bytes=*/0));
 
   // Prepare thunk sequence for command buffer conversion.
-  ThunkSequence thunks;
-  thunks.push_back(std::make_unique<WhileThunk>(Thunk::ThunkInfo(), slice_pred,
-                                                std::move(cond_thunks),
-                                                std::move(body_thunks)));
+  ThunkSequence thunks = ThunkSequence::Of<WhileThunk>(
+      Thunk::ThunkInfo(), slice_pred, std::move(cond_thunks),
+      std::move(body_thunks));
 
   ConvertToCommandsOptions options;
   options.synchronization_mode = serialize;

--- a/xla/backends/gpu/runtime/conditional_thunk_test.cc
+++ b/xla/backends/gpu/runtime/conditional_thunk_test.cc
@@ -186,12 +186,12 @@ TEST(ConditionalThunkTest, BufferUses) {
   Shape shape = ShapeUtil::MakeShape(PRED, {});
 
   ThunkSequence false_seq;
-  false_seq.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
-  false_seq.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
+  false_seq.Emplace<DummyThunk>(Kind::kGemm, thunk_info);
+  false_seq.Emplace<DummyThunk>(Kind::kGemm, thunk_info);
 
   ThunkSequence true_seq;
-  true_seq.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
-  true_seq.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
+  true_seq.Emplace<DummyThunk>(Kind::kGemm, thunk_info);
+  true_seq.Emplace<DummyThunk>(Kind::kGemm, thunk_info);
 
   std::vector<ThunkSequence> branch_thunk_sequences;
   branch_thunk_sequences.push_back(std::move(false_seq));
@@ -401,12 +401,12 @@ TEST(ConditionalThunkTest, ToProto) {
   Shape shape = ShapeUtil::MakeShape(PRED, {});
 
   ThunkSequence false_seq;
-  false_seq.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
-  false_seq.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
+  false_seq.Emplace<DummyThunk>(Kind::kGemm, thunk_info);
+  false_seq.Emplace<DummyThunk>(Kind::kGemm, thunk_info);
 
   ThunkSequence true_seq;
-  true_seq.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
-  true_seq.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
+  true_seq.Emplace<DummyThunk>(Kind::kGemm, thunk_info);
+  true_seq.Emplace<DummyThunk>(Kind::kGemm, thunk_info);
 
   std::vector<ThunkSequence> branch_thunk_seq;
   branch_thunk_seq.push_back(std::move(false_seq));
@@ -492,12 +492,12 @@ TEST(ConditionalThunkTest, ToString) {
   Shape int_shape = ShapeUtil::MakeShape(S32, {});
 
   auto create_branch_thunk_sequences = [&]() -> std::vector<ThunkSequence> {
-    ThunkSequence false_seq;
-    false_seq.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
+    ThunkSequence false_seq =
+        ThunkSequence::Of<DummyThunk>(Kind::kGemm, thunk_info);
 
     ThunkSequence true_seq;
-    true_seq.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
-    true_seq.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
+    true_seq.Emplace<DummyThunk>(Kind::kGemm, thunk_info);
+    true_seq.Emplace<DummyThunk>(Kind::kGemm, thunk_info);
 
     std::vector<ThunkSequence> branch_thunk_sequences;
     branch_thunk_sequences.push_back(std::move(false_seq));
@@ -533,10 +533,10 @@ TEST(ConditionalThunkTest, TransformNested) {
   Shape shape = ShapeUtil::MakeShape(S32, {});
   Thunk::ThunkInfo thunk_info;
 
-  ThunkSequence branch0;
-  branch0.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
-  ThunkSequence branch1;
-  branch1.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
+  ThunkSequence branch0 =
+      ThunkSequence::Of<DummyThunk>(Kind::kGemm, thunk_info);
+  ThunkSequence branch1 =
+      ThunkSequence::Of<DummyThunk>(Kind::kGemm, thunk_info);
 
   std::vector<ThunkSequence> branch_thunks;
   branch_thunks.push_back(std::move(branch0));

--- a/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk_test.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk_test.cc
@@ -675,10 +675,9 @@ TEST(DynamicSliceFusionV2ThunkTest,
   Shape src_shape = ShapeUtil::MakeShape(S32, {4});
   Shape slice_shape = ShapeUtil::MakeShape(S32, {1});
 
-  ThunkSequence embedded_thunks;
-  embedded_thunks.push_back(std::make_unique<DeviceToDeviceCopyThunk>(
+  ThunkSequence embedded_thunks = ThunkSequence::Of<DeviceToDeviceCopyThunk>(
       Thunk::ThunkInfo(), ShapedSlice{embedded_src, slice_shape},
-      ShapedSlice{embedded_dst, slice_shape}, kSliceBytes));
+      ShapedSlice{embedded_dst, slice_shape}, kSliceBytes);
 
   CommandSequence embedded_commands;
   embedded_commands.Emplace<DeviceToDeviceCopyThunk>(
@@ -800,8 +799,7 @@ TEST(DynamicSliceFusionV2ThunkTest, SerializeDeserializeRoundTrip) {
        BufferAllocation::Slice(&buffer1, 0, 4096)},
       /*result_buffers=*/{BufferAllocation::Slice(&buffer1, 0, 4096)},
       slice_allocs,
-      ThunkSequence::Of(
-          std::make_unique<MemzeroThunk>(Thunk::ThunkInfo(), memzero_dest)));
+      ThunkSequence::Of<MemzeroThunk>(Thunk::ThunkInfo(), memzero_dest));
 
   ASSERT_OK_AND_ASSIGN(ThunkProto proto, thunk.ToProto());
   const auto& dsf = proto.dynamic_slice_fusion_thunk();
@@ -876,8 +874,8 @@ TEST(DynamicSliceFusionV2ThunkTest,
       /*result_buffers=*/
       {BufferAllocation::Slice(&parent_allocations[1], 0, 64)},
       embedded_allocations,
-      ThunkSequence::Of(std::make_unique<DeviceToDeviceCopyThunk>(
-          Thunk::ThunkInfo(), src_slice, dst_slice, 1024)));
+      ThunkSequence::Of<DeviceToDeviceCopyThunk>(Thunk::ThunkInfo(), src_slice,
+                                                 dst_slice, 1024));
 
   Thunk::PrepareParams prepare_params;
   prepare_params.buffer_allocations = &parent_buffer_allocations;

--- a/xla/backends/gpu/runtime/sequential_thunk_test.cc
+++ b/xla/backends/gpu/runtime/sequential_thunk_test.cc
@@ -130,16 +130,13 @@ TEST(SequentialThunkTest, ToString) {
   thunk_info.thunk_id = ThunkId(1);
 
   ThunkSequence thunks;
-  thunks.push_back(
-      std::make_unique<DummyThunk>(Thunk::Kind::kGemm, thunk_info));
+  thunks.Emplace<DummyThunk>(Thunk::Kind::kGemm, thunk_info);
 
   thunk_info.thunk_id = ThunkId(2);
-  thunks.push_back(
-      std::make_unique<DummyThunk>(Thunk::Kind::kGemm, thunk_info));
+  thunks.Emplace<DummyThunk>(Thunk::Kind::kGemm, thunk_info);
 
   thunk_info.thunk_id = ThunkId(3);
-  thunks.push_back(
-      std::make_unique<DummyThunk>(Thunk::Kind::kGemm, thunk_info));
+  thunks.Emplace<DummyThunk>(Thunk::Kind::kGemm, thunk_info);
 
   thunk_info.thunk_id = ThunkId(4);
   SequentialThunk sequential_thunk(thunk_info, std::move(thunks));
@@ -160,12 +157,9 @@ TEST(SequentialThunkTest, TransformNested) {
     return info;
   };
   ThunkSequence thunks;
-  thunks.push_back(
-      std::make_unique<DummyThunk>(Thunk::Kind::kGemm, make_info(1)));
-  thunks.push_back(
-      std::make_unique<DummyThunk>(Thunk::Kind::kGemm, make_info(2)));
-  thunks.push_back(
-      std::make_unique<DummyThunk>(Thunk::Kind::kGemm, make_info(3)));
+  thunks.Emplace<DummyThunk>(Thunk::Kind::kGemm, make_info(1));
+  thunks.Emplace<DummyThunk>(Thunk::Kind::kGemm, make_info(2));
+  thunks.Emplace<DummyThunk>(Thunk::Kind::kGemm, make_info(3));
   SequentialThunk sequential_thunk(Thunk::ThunkInfo(), std::move(thunks));
 
   TF_EXPECT_OK(sequential_thunk.TransformNested(

--- a/xla/backends/gpu/runtime/thunk.cc
+++ b/xla/backends/gpu/runtime/thunk.cc
@@ -508,6 +508,22 @@ static std::optional<int64_t> NextDep(
   return std::nullopt;
 }
 
+ThunkSequence::ThunkSequence(int64_t len)
+    : std::vector<std::unique_ptr<Thunk>>(len) {}
+
+ThunkSequence::ThunkSequence(std::vector<std::unique_ptr<Thunk>> thunks)
+    : std::vector<std::unique_ptr<Thunk>>(std::move(thunks)) {}
+
+void ThunkSequence::Append(std::unique_ptr<Thunk> thunk) {
+  push_back(std::move(thunk));
+}
+
+ThunkSequence ThunkSequence::Of(std::unique_ptr<Thunk> thunk) {
+  ThunkSequence thunks;
+  thunks.Append(std::move(thunk));
+  return thunks;
+}
+
 absl::Status ThunkSequence::WalkNested(Thunk::Walker callback) {
   for (auto& thunk : *this) {
     RETURN_IF_ERROR(thunk->Walk(callback));

--- a/xla/backends/gpu/runtime/thunk.h
+++ b/xla/backends/gpu/runtime/thunk.h
@@ -523,22 +523,30 @@ class Thunk {
 class ThunkSequence : public std::vector<std::unique_ptr<Thunk>> {
  public:
   ThunkSequence() = default;
-  ThunkSequence(ThunkSequence&&) = default;
-  explicit ThunkSequence(std::vector<std::unique_ptr<Thunk>>&& thunks)
-      : std::vector<std::unique_ptr<Thunk>>(std::move(thunks)) {};
-  ThunkSequence(const ThunkSequence&) = delete;
+  explicit ThunkSequence(int64_t len);
+  explicit ThunkSequence(std::vector<std::unique_ptr<Thunk>> thunks);
 
-  ThunkSequence& operator=(const ThunkSequence&) = delete;
+  ThunkSequence(ThunkSequence&&) = default;
   ThunkSequence& operator=(ThunkSequence&&) = default;
 
-  explicit ThunkSequence(int64_t len)
-      : std::vector<std::unique_ptr<Thunk>>::vector(len) {}
+  // Appends a thunk to this sequence.
+  void Append(std::unique_ptr<Thunk> thunk);
 
   // Creates a thunks sequence from a single thunk.
-  static ThunkSequence Of(std::unique_ptr<Thunk> thunk) {
-    ThunkSequence thunks;
-    thunks.push_back(std::move(thunk));
-    return thunks;
+  static ThunkSequence Of(std::unique_ptr<Thunk> thunk);
+
+  // Creates a thunk sequence by constructing a single thunk of type `T`.
+  template <typename T, typename... Args,
+            std::enable_if_t<std::is_base_of_v<Thunk, T>>* = nullptr>
+  static ThunkSequence Of(Args&&... args) {
+    return ThunkSequence::Of(std::make_unique<T>(std::forward<Args>(args)...));
+  }
+
+  // Constructs a new thunk in place and appends it to this sequence.
+  template <typename T, typename... Args,
+            std::enable_if_t<std::is_base_of_v<Thunk, T>>* = nullptr>
+  void Emplace(Args&&... args) {
+    Append(std::make_unique<T>(std::forward<Args>(args)...));
   }
 
   // Walks/Transforms all thunks nested in *this sequence.

--- a/xla/backends/gpu/runtime/thunk_buffer_debug_pass_test.cc
+++ b/xla/backends/gpu/runtime/thunk_buffer_debug_pass_test.cc
@@ -951,8 +951,7 @@ TEST_F(ThunkBufferDebugPassTest, BufferSaverInserter) {
   Thunk::ThunkInfo fake_thunk_info;
   fake_thunk_info.thunk_id = kTestThunkId;
 
-  ThunkSequence thunks;
-  thunks.push_back(std::make_unique<FakeThunk>(
+  ThunkSequence thunks = ThunkSequence::Of<FakeThunk>(
       fake_thunk_info,
       Thunk::BufferUses{
           // Write is undefined on input, but defined on output.
@@ -960,7 +959,7 @@ TEST_F(ThunkBufferDebugPassTest, BufferSaverInserter) {
           // Unlike Consume, Read is supposed to preserve the contents of the
           // buffer, so we check it on input *and* output.
           BufferUse::Read(slice_io, arg_shape),
-      }));
+      });
 
   DebugOptions debug_options = xla::GetDebugOptionsFromFlags();
   debug_options.set_xla_dump_to("/tmp/123");

--- a/xla/backends/gpu/runtime/thunk_executor_test.cc
+++ b/xla/backends/gpu/runtime/thunk_executor_test.cc
@@ -105,8 +105,8 @@ TEST(SequentialThunkProgressTrackerTest, TrackProgress) {
   }
 
   // Create a nested sequential thunk in the outer thunk sequence.
-  outer_sequence.push_back(std::make_unique<SequentialThunk>(
-      ThunkInfo("nested"), std::move(nested_sequence)));
+  outer_sequence.Emplace<SequentialThunk>(ThunkInfo("nested"),
+                                          std::move(nested_sequence));
 
   ThunkExecutor executor(std::move(outer_sequence));
   ASSERT_OK_AND_ASSIGN(ThunkExecutor::ScopedProgressTracker tracker,
@@ -189,14 +189,12 @@ TEST(SequentialThunkProgressTrackerTest, TrackWhileLoopNest) {
 
   // Build a while loop with a known trip count containing a single body thunk.
   ThunkSequence condition_thunks;  // empty, not used with trip_count
-  ThunkSequence body_thunks;
-  body_thunks.push_back(std::make_unique<MemzeroThunk>(
-      ThunkInfo("loop_body_memzero"), ShapedSlice{slice, shape}));
+  ThunkSequence body_thunks = ThunkSequence::Of<MemzeroThunk>(
+      ThunkInfo("loop_body_memzero"), ShapedSlice{slice, shape});
 
-  ThunkSequence outer_sequence;
-  outer_sequence.push_back(std::make_unique<WhileThunk>(
+  ThunkSequence outer_sequence = ThunkSequence::Of<WhileThunk>(
       ThunkInfo("while_loop"), slice, std::move(condition_thunks),
-      std::move(body_thunks), /*trip_count=*/kTripCount));
+      std::move(body_thunks), /*trip_count=*/kTripCount);
 
   ThunkExecutor executor(std::move(outer_sequence));
   ASSERT_OK_AND_ASSIGN(ThunkExecutor::ScopedProgressTracker tracker,

--- a/xla/backends/gpu/runtime/while_thunk_test.cc
+++ b/xla/backends/gpu/runtime/while_thunk_test.cc
@@ -456,15 +456,12 @@ TEST(WhileThunkTest, ToProto) {
   BufferAllocation::Slice slice(&alloc, /*offset=*/0, /*size=*/256);
 
   ThunkSequence condition_thunks;
-  condition_thunks.push_back(
-      std::make_unique<DummyThunk>(Kind::kConditional, thunk_info));
-  condition_thunks.push_back(
-      std::make_unique<DummyThunk>(Kind::kConditional, thunk_info));
+  condition_thunks.Emplace<DummyThunk>(Kind::kConditional, thunk_info);
+  condition_thunks.Emplace<DummyThunk>(Kind::kConditional, thunk_info);
 
   ThunkSequence body_thunks;
-  body_thunks.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
-  body_thunks.push_back(
-      std::make_unique<DummyThunk>(Kind::kCustomCall, thunk_info));
+  body_thunks.Emplace<DummyThunk>(Kind::kGemm, thunk_info);
+  body_thunks.Emplace<DummyThunk>(Kind::kCustomCall, thunk_info);
 
   WhileThunk thunk =
       CreateWhileThunk(thunk_info, slice, std::move(condition_thunks),
@@ -535,11 +532,10 @@ TEST(WhileThunkTest, TransformNested) {
   Thunk::ThunkInfo thunk_info;
   BufferAllocation::Slice slice;
 
-  ThunkSequence condition_thunks;
-  condition_thunks.push_back(
-      std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
-  ThunkSequence body_thunks;
-  body_thunks.push_back(std::make_unique<DummyThunk>(Kind::kGemm, thunk_info));
+  ThunkSequence condition_thunks =
+      ThunkSequence::Of<DummyThunk>(Kind::kGemm, thunk_info);
+  ThunkSequence body_thunks =
+      ThunkSequence::Of<DummyThunk>(Kind::kGemm, thunk_info);
 
   auto while_thunk = std::make_unique<WhileThunk>(
       Thunk::ThunkInfo(),

--- a/xla/service/gpu/gpu_aot_compilation_result_test.cc
+++ b/xla/service/gpu/gpu_aot_compilation_result_test.cc
@@ -109,12 +109,12 @@ class GpuAotCompilationResultTest : public ::testing::Test {
     thunk_info.thunk_id = 123;
 
     ThunkSequence thunk_sequence;
-    thunk_sequence.push_back(std::make_unique<KernelThunk>(
+    thunk_sequence.Emplace<KernelThunk>(
         thunk_info,
         /*kernel_name=*/"test_kernel", emitters::KernelArguments({}),
         LaunchDimensions(),
         /*cluster_dim=*/std::nullopt,
-        /*shmem_bytes=*/0, ::stream_executor::gpu::TmaMetadata()));
+        /*shmem_bytes=*/0, ::stream_executor::gpu::TmaMetadata());
     CustomKernel custom_kernel{
         "custom_kernel_name",
         stream_executor::KernelLoaderSpec::
@@ -123,8 +123,8 @@ class GpuAotCompilationResultTest : public ::testing::Test {
                 /*arity=*/42),
         stream_executor::BlockDim(), stream_executor::ThreadDim(),
         /*shared_memory_bytes=*/23};
-    thunk_sequence.push_back(std::make_unique<CustomKernelThunk>(
-        thunk_info, custom_kernel, emitters::KernelArguments({})));
+    thunk_sequence.Emplace<CustomKernelThunk>(thunk_info, custom_kernel,
+                                              emitters::KernelArguments({}));
 
     auto hlo_module = std::make_unique<HloModule>("test_module_with_shape",
                                                   HloModuleConfig());

--- a/xla/service/gpu/gpu_executable_test.cc
+++ b/xla/service/gpu/gpu_executable_test.cc
@@ -185,17 +185,16 @@ TEST_F(GpuExecutableTest, RunThunkPasses) {
     BufferAllocation::Slice slice(&alloc, 0, 1024);
 
     ThunkSequence thunk_sequence;
-    thunk_sequence.push_back(std::make_unique<KernelThunk>(
+    thunk_sequence.Emplace<KernelThunk>(
         thunk_info,
         /*kernel_name=*/"test_kernel",
         /*kernel_arguments=*/emitters::KernelArguments({}),
         /*launch_dimensions=*/LaunchDimensions(),
         /*cluster_dim=*/std::nullopt,
         /*shmem_bytes=*/0,
-        /*tma_metadata=*/se::gpu::TmaMetadata()));
-    thunk_sequence.push_back(std::make_unique<DeviceToDeviceCopyThunk>(
-        thunk_info, ShapedSlice{slice, shape}, ShapedSlice{slice, shape},
-        1024));
+        /*tma_metadata=*/se::gpu::TmaMetadata());
+    thunk_sequence.Emplace<DeviceToDeviceCopyThunk>(
+        thunk_info, ShapedSlice{slice, shape}, ShapedSlice{slice, shape}, 1024);
 
     GpuExecutable::Params params;
     params.executable =
@@ -262,8 +261,7 @@ TEST_F(GpuExecutableTest, CommandBufferAllocationPolicy) {
   emitters::KernelArgument live_out_arg(shape, live_out_slice);
   emitters::KernelArgument zero_sized_temp_arg(shape, zero_sized_temp_slice);
 
-  ThunkSequence command_thunks;
-  command_thunks.push_back(std::make_unique<KernelThunk>(
+  ThunkSequence command_thunks = ThunkSequence::Of<KernelThunk>(
       ThunkInfoWithId(123),
       /*kernel_name=*/"test_kernel",
       /*kernel_arguments=*/
@@ -273,16 +271,15 @@ TEST_F(GpuExecutableTest, CommandBufferAllocationPolicy) {
       /*launch_dimensions=*/LaunchDimensions(),
       /*cluster_dim=*/std::nullopt,
       /*shmem_bytes=*/0,
-      /*tma_metadata=*/se::gpu::TmaMetadata()));
+      /*tma_metadata=*/se::gpu::TmaMetadata());
 
   ASSERT_OK_AND_ASSIGN(
       CommandExecutor commands,
       ConvertToCommands(command_thunks, ConvertToCommandsOptions{}));
   auto sequential_thunk = std::make_unique<SequentialThunk>(
       Thunk::ThunkInfo(), std::move(command_thunks));
-  ThunkSequence thunk_sequence;
-  thunk_sequence.push_back(std::make_unique<CommandBufferThunk>(
-      std::move(commands), Thunk::ThunkInfo(), std::move(sequential_thunk)));
+  ThunkSequence thunk_sequence = ThunkSequence::Of<CommandBufferThunk>(
+      std::move(commands), Thunk::ThunkInfo(), std::move(sequential_thunk));
   ThunkExecutor thunk_executor(std::move(thunk_sequence));
 
   std::vector<const BufferAllocation*> allocation_ptrs;
@@ -469,8 +466,7 @@ TEST_F(GpuExecutableTest, ThunkChecksumPassAddsAllocation) {
   // checked, otherwise the pass is a no-op and doesn't need to allocate.
   auto make_test_thunk_sequence = [&]() {
     Thunk::ThunkInfo thunk_info;
-    ThunkSequence thunk_sequence;
-    thunk_sequence.push_back(std::make_unique<KernelThunk>(
+    ThunkSequence thunk_sequence = ThunkSequence::Of<KernelThunk>(
         thunk_info,
         /*kernel_name=*/"test_kernel",
         /*kernel_arguments=*/
@@ -481,7 +477,7 @@ TEST_F(GpuExecutableTest, ThunkChecksumPassAddsAllocation) {
         /*launch_dimensions=*/LaunchDimensions(),
         /*cluster_dim=*/std::nullopt,
         /*shmem_bytes=*/0,
-        /*tma_metadata=*/se::gpu::TmaMetadata()));
+        /*tma_metadata=*/se::gpu::TmaMetadata());
     return thunk_sequence;
   };
   auto make_test_hlo_module = []() {
@@ -533,17 +529,17 @@ TEST_F(GpuExecutableTest, DumpsMetadataListProto) {
     Shape shape = ShapeUtil::MakeShape(S32, {256});
 
     ThunkSequence thunk_sequence;
-    thunk_sequence.push_back(std::make_unique<KernelThunk>(
+    thunk_sequence.Emplace<KernelThunk>(
         ThunkInfoWithId(123),
         /*kernel_name=*/"test_kernel",
         /*kernel_arguments=*/emitters::KernelArguments({}),
         /*launch_dimensions=*/LaunchDimensions(),
         /*cluster_dim=*/std::nullopt,
         /*shmem_bytes=*/0,
-        /*tma_metadata=*/se::gpu::TmaMetadata()));
-    thunk_sequence.push_back(std::make_unique<DeviceToDeviceCopyThunk>(
+        /*tma_metadata=*/se::gpu::TmaMetadata());
+    thunk_sequence.Emplace<DeviceToDeviceCopyThunk>(
         ThunkInfoWithId(456), ShapedSlice{slice, shape},
-        ShapedSlice{slice, shape}, 1024));
+        ShapedSlice{slice, shape}, 1024);
 
     GpuExecutable::Params params;
     params.executable =
@@ -595,13 +591,12 @@ TEST_F(GpuExecutableTest, ProtoConversion) {
   device_description.set_driver_version({12, 3, 0});
   device_description.set_runtime_version({12, 3, 0});
 
-  ThunkSequence thunk_sequence;
-  thunk_sequence.push_back(std::make_unique<KernelThunk>(
+  ThunkSequence thunk_sequence = ThunkSequence::Of<KernelThunk>(
       ThunkInfoWithId(123),
       /*kernel_name=*/"test_kernel", emitters::KernelArguments({}),
       LaunchDimensions(),
       /*cluster_dim=*/std::nullopt,
-      /*shmem_bytes=*/0, se::gpu::TmaMetadata()));
+      /*shmem_bytes=*/0, se::gpu::TmaMetadata());
 
   GpuExecutable::Params params;
   params.binary = {1, 2, 3};
@@ -719,17 +714,17 @@ TEST_F(GpuExecutableTest, GpuExecutableDump) {
     BufferAllocation::Slice slice(&alloc, 0, 1024);
     Shape shape = ShapeUtil::MakeShape(S32, {256});
 
-    thunk_sequence.push_back(std::make_unique<KernelThunk>(
+    thunk_sequence.Emplace<KernelThunk>(
         ThunkInfoWithId(123),
         /*kernel_name=*/"test_kernel",
         /*kernel_arguments=*/emitters::KernelArguments({}),
         /*launch_dimensions=*/LaunchDimensions(),
         /*cluster_dim=*/std::nullopt,
         /*shmem_bytes=*/0,
-        /*tma_metadata=*/se::gpu::TmaMetadata()));
-    thunk_sequence.push_back(std::make_unique<DeviceToDeviceCopyThunk>(
+        /*tma_metadata=*/se::gpu::TmaMetadata());
+    thunk_sequence.Emplace<DeviceToDeviceCopyThunk>(
         ThunkInfoWithId(456), ShapedSlice{slice, shape},
-        ShapedSlice{slice, shape}, 1024));
+        ShapedSlice{slice, shape}, 1024);
 
     GpuExecutable::Params params;
     params.executable =
@@ -855,46 +850,46 @@ TEST_F(GpuExecutableTest, ToProtoReturnsUnchangedThunkGraph) {
 
   auto create_executable = [&]() {
     ThunkSequence thunk_sequence;
-    thunk_sequence.push_back(std::make_unique<KernelThunk>(
+    thunk_sequence.Emplace<KernelThunk>(
         ThunkInfoWithId(1),
         /*kernel_name=*/"test_kernel_0",
         /*kernel_arguments=*/emitters::KernelArguments({}),
         /*launch_dimensions=*/LaunchDimensions(),
         /*cluster_dim=*/std::nullopt,
         /*shmem_bytes=*/0,
-        /*tma_metadata=*/se::gpu::TmaMetadata()));
-    thunk_sequence.push_back(std::make_unique<KernelThunk>(
+        /*tma_metadata=*/se::gpu::TmaMetadata());
+    thunk_sequence.Emplace<KernelThunk>(
         ThunkInfoWithId(2),
         /*kernel_name=*/"test_kernel_1",
         /*kernel_arguments=*/emitters::KernelArguments({}),
         /*launch_dimensions=*/LaunchDimensions(),
         /*cluster_dim=*/std::nullopt,
         /*shmem_bytes=*/0,
-        /*tma_metadata=*/se::gpu::TmaMetadata()));
-    thunk_sequence.push_back(std::make_unique<KernelThunk>(
+        /*tma_metadata=*/se::gpu::TmaMetadata());
+    thunk_sequence.Emplace<KernelThunk>(
         ThunkInfoWithId(3),
         /*kernel_name=*/"test_kernel_2",
         /*kernel_arguments=*/emitters::KernelArguments({}),
         /*launch_dimensions=*/LaunchDimensions(),
         /*cluster_dim=*/std::nullopt,
         /*shmem_bytes=*/0,
-        /*tma_metadata=*/se::gpu::TmaMetadata()));
-    thunk_sequence.push_back(std::make_unique<KernelThunk>(
+        /*tma_metadata=*/se::gpu::TmaMetadata());
+    thunk_sequence.Emplace<KernelThunk>(
         ThunkInfoWithId(4),
         /*kernel_name=*/"test_kernel_3",
         /*kernel_arguments=*/emitters::KernelArguments({}),
         /*launch_dimensions=*/LaunchDimensions(),
         /*cluster_dim=*/std::nullopt,
         /*shmem_bytes=*/0,
-        /*tma_metadata=*/se::gpu::TmaMetadata()));
-    thunk_sequence.push_back(std::make_unique<KernelThunk>(
+        /*tma_metadata=*/se::gpu::TmaMetadata());
+    thunk_sequence.Emplace<KernelThunk>(
         ThunkInfoWithId(5),
         /*kernel_name=*/"test_kernel_4",
         /*kernel_arguments=*/emitters::KernelArguments({}),
         /*launch_dimensions=*/LaunchDimensions(),
         /*cluster_dim=*/std::nullopt,
         /*shmem_bytes=*/0,
-        /*tma_metadata=*/se::gpu::TmaMetadata()));
+        /*tma_metadata=*/se::gpu::TmaMetadata());
 
     GpuExecutable::Params params;
     params.executable =

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -414,12 +414,6 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitConstant(
   return ThunkSequence{};
 }
 
-ThunkSequence GetThunkSequence(std::unique_ptr<Thunk> ir_emitter) {
-  ThunkSequence thunk_sequence;
-  thunk_sequence.push_back(std::move(ir_emitter));
-  return thunk_sequence;
-}
-
 AsyncThunkSequence ThunkEmitter::EmitConditional(const HloInstruction* instr) {
   std::vector<AsyncThunkSequence> branch_thunks;
   branch_thunks.reserve(instr->branch_count());
@@ -436,9 +430,9 @@ AsyncThunkSequence ThunkEmitter::EmitConditional(const HloInstruction* instr) {
       .Map([thunk_info = std::move(thunk_info),
             shaped_slice = std::move(shaped_slice)](
                std::vector<ThunkSequence> branch_thunks) {
-        return GetThunkSequence(std::make_unique<ConditionalThunk>(
-            std::move(thunk_info), std::move(shaped_slice),
-            std::move(branch_thunks)));
+        return ThunkSequence::Of<ConditionalThunk>(std::move(thunk_info),
+                                                   std::move(shaped_slice),
+                                                   std::move(branch_thunks));
       });
 }
 
@@ -465,9 +459,7 @@ AsyncThunkSequence ThunkEmitter::EmitPadToStatic(
                     instr, ir_emitter_context_->GetNextThunkId()),
                 std::move(kernel_def).TakeSource(), std::string(spec.name()),
                 kernel_arguments, launch_dimensions)
-      .Map([](std::unique_ptr<Thunk> thunk) {
-        return ThunkSequence::Of(std::move(thunk));
-      });
+      .Map([](auto thunk) { return ThunkSequence::Of(std::move(thunk)); });
 }
 
 // Input = {dynamic array(with dynamic dimension meta data at the end)}
@@ -492,9 +484,7 @@ AsyncThunkSequence ThunkEmitter::EmitSliceToDynamic(
                     instr, ir_emitter_context_->GetNextThunkId()),
                 std::move(kernel_def).TakeSource(), std::string(spec.name()),
                 kernel_arguments, launch_dimensions)
-      .Map([](std::unique_ptr<Thunk> thunk) {
-        return ThunkSequence::Of(std::move(thunk));
-      });
+      .Map([](auto thunk) { return ThunkSequence::Of(std::move(thunk)); });
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitConvolutionThunk(
@@ -540,7 +530,7 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitConvolutionThunk(
                            instr, ir_emitter_context_->GetNextThunkId()),
                        std::move(descriptor), std::move(operand_slices),
                        std::move(result_slices), scratch_slice));
-  return GetThunkSequence(std::move(thunk));
+  return ThunkSequence::Of(std::move(thunk));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunk(
@@ -613,12 +603,11 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunk(
       instr, ir_emitter_context_->GetNextThunkId());
 
   ASSIGN_OR_RETURN(std::string canonical_hlo, CanonicalGemmHlo(instr));
-  auto thunk = std::make_unique<CublasLtMatmulThunk>(
+  return ThunkSequence::Of<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
       blas_lt_epilogue, algorithm, config.autotune_workspace_size(), a, b, c, d,
       /*group_sizes=*/std::nullopt, bias, aux, std::nullopt, std::nullopt,
       std::nullopt, std::nullopt, std::nullopt, workspace_buffer);
-  return GetThunkSequence(std::move(thunk));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunkF8(
@@ -702,12 +691,11 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunkF8(
   Thunk::ThunkInfo thunk_info = Thunk::ThunkInfo::WithProfileAnnotation(
       instr, ir_emitter_context_->GetNextThunkId());
   ASSIGN_OR_RETURN(std::string canonical_hlo, CanonicalGemmHlo(instr));
-  auto thunk = std::make_unique<CublasLtMatmulThunk>(
+  return ThunkSequence::Of<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
       blas_lt_epilogue, algorithm, config.autotune_workspace_size(), a, b, c, d,
       /*group_sizes=*/std::nullopt, bias, std::nullopt, a_scale, b_scale,
       std::nullopt, d_scale, d_amax, workspace_buffer);
-  return GetThunkSequence(std::move(thunk));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtGroupedMatmulThunk(
@@ -778,12 +766,11 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtGroupedMatmulThunk(
       instr, ir_emitter_context_->GetNextThunkId());
   ASSIGN_OR_RETURN(std::string canonical_hlo, CanonicalGemmHlo(instr));
 
-  auto thunk = std::make_unique<CublasLtMatmulThunk>(
+  return ThunkSequence::Of<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
       blas_lt_epilogue, algorithm, config.autotune_workspace_size(), a, b, c, d,
       std::move(group_sizes), bias, std::nullopt, std::nullopt, std::nullopt,
       std::nullopt, std::nullopt, std::nullopt, workspace_buffer);
-  return GetThunkSequence(std::move(thunk));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunkMx(
@@ -830,14 +817,13 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCublasLtMatmulThunkMx(
   Thunk::ThunkInfo thunk_info = Thunk::ThunkInfo::WithProfileAnnotation(
       instr, ir_emitter_context_->GetNextThunkId());
   ASSIGN_OR_RETURN(std::string canonical_hlo, CanonicalGemmHlo(instr));
-  auto thunk = std::make_unique<CublasLtMatmulThunk>(
+  return ThunkSequence::Of<CublasLtMatmulThunk>(
       std::move(thunk_info), std::move(canonical_hlo), std::move(gemm_config),
       blas_lt_epilogue, algorithm, config.autotune_workspace_size(), a, b, c, d,
       /*group_sizes=*/std::nullopt,
       /*bias=*/std::nullopt, /*aux=*/std::nullopt, a_scale, b_scale,
       /*c_scale=*/std::nullopt, /*d_scale=*/std::nullopt,
       /*d_amax=*/std::nullopt, workspace_buffer);
-  return GetThunkSequence(std::move(thunk));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitConvolutionReorderThunk(
@@ -865,7 +851,7 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitConvolutionReorderThunk(
                        Thunk::ThunkInfo::WithProfileAnnotation(
                            instr, ir_emitter_context_->GetNextThunkId()),
                        filter_input, filter_output, biases));
-  return GetThunkSequence(std::move(thunk));
+  return ThunkSequence::Of(std::move(thunk));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitNormThunk(
@@ -946,7 +932,7 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitNormThunk(
                         y_or_dx_slice, bias_slice, expectation_slice,
                         norm_factor_slice, dy_slice, dscale_slice, dbias_slice,
                         scratch_slice.slice));
-  return GetThunkSequence(std::move(thunk));
+  return ThunkSequence::Of(std::move(thunk));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCuDnnThunk(
@@ -964,20 +950,20 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCuDnnThunk(
                      instr->backend_config<xla::gpu::GpuBackendConfig>());
     dropout_seed = gpu_config.cudnn_fmha_backend_config().seed();
   }
-  return GetThunkSequence(std::make_unique<CuDnnThunk>(
+  return ThunkSequence::Of<CuDnnThunk>(
       fingerprint,
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
       kernel_arguments.GetArgumentShapedSlices(),
       kernel_arguments.GetArgumentOutputFlags(),
-      /*should_memzero=*/IsCustomCallTofMHA(*instr), dropout_seed));
+      /*should_memzero=*/IsCustomCallTofMHA(*instr), dropout_seed);
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitPtxCustomCall(
     const HloCustomCallInstruction* instr) {
   ASSIGN_OR_RETURN(auto thunk,
                    EmitPtxCustomKernelThunk(instr, ir_emitter_context_));
-  return GetThunkSequence(std::move(thunk));
+  return ThunkSequence::Of(std::move(thunk));
 }
 
 std::optional<BufferAllocation::Slice> ThunkEmitter::GetAllocationOverride(
@@ -1146,14 +1132,14 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitFftThunk(
                    GetAllocationSliceForHlo(instr->operand(0)));
   ASSIGN_OR_RETURN(BufferAllocation::Slice dest_slice,
                    GetAllocationSliceForHlo(instr));
-  return GetThunkSequence(std::make_unique<FftThunk>(
+  return ThunkSequence::Of<FftThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
       instr->fft_type(), instr->fft_length(),
       /*input_buffer=*/arg_slice,
       /*output_buffer=*/dest_slice,
       /*input_shape=*/instr->operand(0)->shape(),
-      /*output_shape=*/instr->shape()));
+      /*output_shape=*/instr->shape());
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitTriangularSolveCustomCall(
@@ -1193,18 +1179,18 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitTriangularSolveCustomCall(
   // Triangular solve is in-place on 'b', so copy 'b' to the output
   // if they aren't the same buffer.
   if (b_slice.slice != result_slice.slice) {
-    thunks.push_back(std::make_unique<DeviceToDeviceCopyThunk>(
+    thunks.Emplace<DeviceToDeviceCopyThunk>(
         Thunk::ThunkInfo::WithProfileAnnotation(
             instr, ir_emitter_context_->GetNextThunkId()),
         /*source_buffer=*/b_slice,
         /*destination_buffer=*/result_slice,
-        /*mem_size=*/ShapeUtil::ByteSizeOf(b_slice.shape)));
+        /*mem_size=*/ShapeUtil::ByteSizeOf(b_slice.shape));
   }
 
-  thunks.push_back(std::make_unique<TriangularSolveThunk>(
+  thunks.Emplace<TriangularSolveThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
-      backend_config, a_slice, result_slice, temp_slice));
+      backend_config, a_slice, result_slice, temp_slice);
 
   // Elide the sequential thunk if there's no copy.
   if (thunks.size() == 1) {
@@ -1214,8 +1200,7 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitTriangularSolveCustomCall(
       instr, ir_emitter_context_->GetNextThunkId());
   // Don't repeat the annotation from inside thunks
   thunk_info.profile_annotation = {};
-  return GetThunkSequence(
-      std::make_unique<SequentialThunk>(thunk_info, std::move(thunks)));
+  return ThunkSequence::Of<SequentialThunk>(thunk_info, std::move(thunks));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitTopKCustomCall(
@@ -1284,8 +1269,8 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitTopKCustomCall(
     Thunk::ThunkInfo thunk_info = Thunk::ThunkInfo::WithProfileAnnotation(
         instr, ir_emitter_context_->GetNextThunkId());
     if (use_raft_select_k) {
-      return GetThunkSequence(std::make_unique<SelectKThunk>(
-          std::move(thunk_info), batch_size, n, k, dtype, kernel_arguments));
+      return ThunkSequence::Of<SelectKThunk>(std::move(thunk_info), batch_size,
+                                             n, k, dtype, kernel_arguments);
     }
   }
 
@@ -1300,8 +1285,8 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitTopKCustomCall(
 
   Thunk::ThunkInfo thunk_info = Thunk::ThunkInfo::WithProfileAnnotation(
       instr, ir_emitter_context_->GetNextThunkId());
-  return GetThunkSequence(std::make_unique<CustomKernelThunk>(
-      std::move(thunk_info), std::move(kernel), kernel_arguments));
+  return ThunkSequence::Of<CustomKernelThunk>(
+      std::move(thunk_info), std::move(kernel), kernel_arguments);
 }
 
 AsyncThunkSequence ThunkEmitter::EmitTritonCustomCall(
@@ -1411,9 +1396,9 @@ AsyncThunkSequence ThunkEmitter::EmitTritonCustomCall(
                              entry->launch_dimensions.block_counts(),
                              entry->launch_dimensions.thread_counts_per_block(),
                              entry->shmem_bytes));
-        return ThunkSequence::Of(std::make_unique<CustomKernelThunk>(
+        return ThunkSequence::Of<CustomKernelThunk>(
             thunk_info, std::move(custom_kernel), kernel_arguments,
-            entry->use_pdl, call_zeroed_outputs, entry->tma_metadata));
+            entry->use_pdl, call_zeroed_outputs, entry->tma_metadata);
       });
 }
 
@@ -1446,9 +1431,9 @@ AsyncThunkSequence ThunkEmitter::EmitAsyncComputation(
       .Map([thunk_info = std::move(thunk_info),
             async_execution = std::move(async_execution),
             execution_stream_id](ThunkSequence nested_thunks) {
-        return ThunkSequence::Of(std::make_unique<AsyncStartThunk>(
+        return ThunkSequence::Of<AsyncStartThunk>(
             std::move(thunk_info), execution_stream_id,
-            std::move(nested_thunks), async_execution));
+            std::move(nested_thunks), async_execution);
       });
 }
 
@@ -1478,12 +1463,11 @@ AsyncThunkSequence ThunkEmitter::EmitDynamicSliceCopyFusion(
   BufferAllocation::Slice dst_slice(
       &embedded_allocations[copy.parameters.size()], 0, byte_size);
 
-  ThunkSequence embedded_thunks =
-      ThunkSequence::Of(std::make_unique<DeviceToDeviceCopyThunk>(
-          Thunk::ThunkInfo::WithProfileAnnotation(
-              instr, ir_emitter_context_->GetNextThunkId()),
-          ShapedSlice{src_slice, copy_shape},
-          ShapedSlice{dst_slice, copy.results[0].update_shape}, byte_size));
+  ThunkSequence embedded_thunks = ThunkSequence::Of<DeviceToDeviceCopyThunk>(
+      Thunk::ThunkInfo::WithProfileAnnotation(
+          instr, ir_emitter_context_->GetNextThunkId()),
+      ShapedSlice{src_slice, copy_shape},
+      ShapedSlice{dst_slice, copy.results[0].update_shape}, byte_size);
 
   std::vector<BufferAllocation::Slice> parameter_buffers;
   parameter_buffers.reserve(instr->operand_count());
@@ -1510,11 +1494,11 @@ AsyncThunkSequence ThunkEmitter::EmitDynamicSliceCopyFusion(
       ir_emitter_context_->debug_options()
           .xla_gpu_experimental_dynamic_slice_fusion_verify_offsets();
 
-  return ThunkSequence::Of(std::make_unique<DynamicSliceFusionV2Thunk>(
+  return ThunkSequence::Of<DynamicSliceFusionV2Thunk>(
       std::move(thunk_info), std::move(copy.parameters),
       std::move(copy.results), std::move(parameter_buffers),
       std::move(result_buffers), std::move(embedded_allocations),
-      std::move(embedded_thunks), verify_offsets));
+      std::move(embedded_thunks), verify_offsets);
 }
 
 AsyncThunkSequence ThunkEmitter::EmitStaticSliceCopyFusion(
@@ -1536,11 +1520,11 @@ AsyncThunkSequence ThunkEmitter::EmitStaticSliceCopyFusion(
       arg_slice.allocation(), arg_slice.offset() + copy.source_byte_offset,
       byte_size, arg_slice.element_type());
 
-  return GetThunkSequence(std::make_unique<DeviceToDeviceCopyThunk>(
+  return ThunkSequence::Of<DeviceToDeviceCopyThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
       ShapedSlice{src_slice, copy.slice_shape},
-      ShapedSlice{dst_slice, instr->shape()}, byte_size));
+      ShapedSlice{dst_slice, instr->shape()}, byte_size);
 }
 
 AsyncThunkSequence ThunkEmitter::EmitFusion(const HloFusionInstruction* instr) {
@@ -1668,11 +1652,11 @@ AsyncThunkSequence ThunkEmitter::EmitDynamicSliceFusionV2(
        parameter_buffers = std::move(parameter_buffers),
        embedded_allocations = std::move(embedded_allocations),
        verify_offsets](ThunkSequence embedded_thunks) mutable {
-        return ThunkSequence::Of(std::make_unique<DynamicSliceFusionV2Thunk>(
+        return ThunkSequence::Of<DynamicSliceFusionV2Thunk>(
             std::move(thunk_info), std::move(parameters), std::move(results),
             std::move(parameter_buffers), std::move(result_buffers),
             std::move(embedded_allocations), std::move(embedded_thunks),
-            verify_offsets));
+            verify_offsets);
       });
 }
 
@@ -1685,12 +1669,12 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCopy(
                    GetAllocationSliceForHlo(instr->operand(0)));
   ASSIGN_OR_RETURN(BufferAllocation::Slice dst_buffer,
                    GetAllocationSliceForHlo(instr));
-  return GetThunkSequence(std::make_unique<DeviceToDeviceCopyThunk>(
+  return ThunkSequence::Of<DeviceToDeviceCopyThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
       /*source_buffer=*/ShapedSlice{src_buffer, instr->operand(0)->shape()},
       /*destination_buffer=*/ShapedSlice{dst_buffer, instr->shape()},
-      /*mem_size=*/src_buffer.size()));
+      /*mem_size=*/src_buffer.size());
 }
 
 AsyncThunkSequence ThunkEmitter::EmitAsyncCustomCallStart(
@@ -1719,9 +1703,9 @@ AsyncThunkSequence ThunkEmitter::EmitAsyncCustomCallStart(
       .Map([start_thunk_info = std::move(start_thunk_info),
             async_execution = std::move(async_execution),
             execution_stream_id](ThunkSequence custom_call_thunks) {
-        return ThunkSequence::Of(std::make_unique<AsyncStartThunk>(
+        return ThunkSequence::Of<AsyncStartThunk>(
             std::move(start_thunk_info), execution_stream_id,
-            std::move(custom_call_thunks), std::move(async_execution)));
+            std::move(custom_call_thunks), std::move(async_execution));
       });
 }
 
@@ -1760,9 +1744,9 @@ AsyncThunkSequence ThunkEmitter::EmitWhile(const HloInstruction* instr) {
       .Map([info = std::move(info), pred = pred, trip_count = trip_count](
                std::tuple<ThunkSequence, ThunkSequence> tuple) {
         auto [cond_thunks, body_thunks] = std::move(tuple);
-        return GetThunkSequence(std::make_unique<WhileThunk>(
+        return ThunkSequence::Of<WhileThunk>(
             std::move(info), std::move(pred), std::move(cond_thunks),
-            std::move(body_thunks), trip_count));
+            std::move(body_thunks), trip_count);
       });
 }
 
@@ -1794,9 +1778,7 @@ AsyncThunkSequence ThunkEmitter::EmitRngGetAndUpdateState(
                     instr, ir_emitter_context_->GetNextThunkId()),
                 std::move(kernel_def).TakeSource(), std::string(spec.name()),
                 kernel_arguments, launch_dimensions)
-      .Map([](std::unique_ptr<Thunk> thunk) {
-        return ThunkSequence::Of(std::move(thunk));
-      });
+      .Map([](auto thunk) { return ThunkSequence::Of(std::move(thunk)); });
 }
 
 AsyncThunkSequence ThunkEmitter::EmitSort(const HloSortInstruction* sort) {
@@ -1833,14 +1815,14 @@ AsyncThunkSequence ThunkEmitter::EmitSort(const HloSortInstruction* sort) {
       // TODO(b/26783907): Figure out why we never seem to share
       // buffers for key/value sort.
       VLOG(2) << op_name << " requires initial D2D copy for operand " << i;
-      thunks.push_back(std::make_unique<DeviceToDeviceCopyThunk>(
+      thunks.Emplace<DeviceToDeviceCopyThunk>(
           Thunk::ThunkInfo::WithProfileAnnotation(
               sort, ir_emitter_context_->GetNextThunkId()),
           /*source_buffer=*/
           ShapedSlice{source_address, sort->operand(i)->shape()},
           /*destination_buffer=*/
           ShapedSlice{destination_buffer, sort->operand(i)->shape()},
-          ShapeUtil::ByteSizeOf(sort->operand(i)->shape())));
+          ShapeUtil::ByteSizeOf(sort->operand(i)->shape()));
     }
   }
 
@@ -1856,20 +1838,20 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitReplicaOrPartitionId(
     const HloInstruction* instr) {
   ASSIGN_OR_RETURN(BufferAllocation::Slice result_slice,
                    GetAllocationSliceForHlo(instr, {}));
-  return GetThunkSequence(std::make_unique<ThunkType>(
+  return ThunkSequence::Of<ThunkType>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
-      result_slice));
+      result_slice);
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitRngSeedThunk(
     const HloInstruction* instr) {
   ASSIGN_OR_RETURN(BufferAllocation::Slice result_slice,
                    GetAllocationSliceForHlo(instr, {}));
-  return GetThunkSequence(std::make_unique<RngSeedThunk>(
+  return ThunkSequence::Of<RngSeedThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
-      result_slice));
+      result_slice);
 }
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectivePermute(
     const HloCollectivePermuteInstruction* instr,
@@ -1922,13 +1904,13 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectivePermute(
                                              partition_count)) {
       // For a degenerate collective permute, just generate a copy
       // thunk.
-      thunks.push_back(std::make_unique<DeviceToDeviceCopyThunk>(
+      thunks.Emplace<DeviceToDeviceCopyThunk>(
           Thunk::ThunkInfo::WithProfileAnnotation(
               async_start, ir_emitter_context_->GetNextThunkId()),
           /*source_buffer=*/ShapedSlice{source_slice, operand_shape},
           /*destination_buffer=*/
           ShapedSlice{result_slice, result_buffer_shape},
-          /*mem_size=*/ShapeUtil::ByteSizeOf(operand_shape)));
+          /*mem_size=*/ShapeUtil::ByteSizeOf(operand_shape));
     } else {
       const CollectiveThunk::Buffer buffer = {
           /*element_count=*/ShapeUtil::ElementsIn(operand_shape),
@@ -1941,13 +1923,13 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectivePermute(
   }
   if (!CollectivePermuteThunk::IsDegenerate(instr, replica_count,
                                             partition_count)) {
-    thunks.push_back(std::make_unique<CollectivePermuteThunk>(
+    thunks.Emplace<CollectivePermuteThunk>(
         Thunk::ThunkInfo::WithProfileAnnotation(
             async_start, ir_emitter_context_->GetNextThunkId()),
         instr, replica_count, partition_count, buffers,
         ir_emitter_context_->debug_options().xla_gpu_collective_permute_mode(),
         ir_emitter_context_->debug_options()
-            .xla_gpu_collective_permute_connected_components()));
+            .xla_gpu_collective_permute_connected_components());
   }
 
   // For synchronous collectives, emit thunks directly without async wrapping.
@@ -1980,7 +1962,7 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectivePermute(
                     async_start->ToString());
   }
 
-  return GetThunkSequence(std::move(start_thunk));
+  return ThunkSequence::Of(std::move(start_thunk));
 }
 
 template <typename CollectiveThunkType, typename HloInstType>
@@ -2095,12 +2077,12 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveThunk(
     if constexpr (std::is_constructible_v<
                       CollectiveThunkType, Thunk::ThunkInfo, decltype(inst),
                       std::vector<CollectiveThunk::Buffer>>) {
-      thunks = ThunkSequence::Of(std::make_unique<CollectiveThunkType>(
-          thunk_info, inst, /*buffers=*/std::move(buffers)));
+      thunks = ThunkSequence::Of<CollectiveThunkType>(
+          thunk_info, inst, /*buffers=*/std::move(buffers));
     } else {
-      thunks = ThunkSequence::Of(std::make_unique<CollectiveThunkType>(
+      thunks = ThunkSequence::Of<CollectiveThunkType>(
           thunk_info, inst, /*buffers=*/std::move(buffers),
-          ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p()));
+          ir_emitter_context_->debug_options().xla_gpu_use_memcpy_local_p2p());
     }
   }
 
@@ -2138,9 +2120,9 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveThunk(
       [async_start_thunk_info = std::move(async_start_thunk_info),
        execution_stream_id,
        async_execution = std::move(async_execution)](ThunkSequence thunks) {
-        return ThunkSequence::Of(std::make_unique<AsyncStartThunk>(
+        return ThunkSequence::Of<AsyncStartThunk>(
             async_start_thunk_info, execution_stream_id, std::move(thunks),
-            async_execution));
+            async_execution);
       });
 }
 
@@ -2195,10 +2177,10 @@ AsyncThunkSequence ThunkEmitter::EmitCollectiveGroupStartThunk(
           return ThunkSequence::Of(std::move(group_thunk));
         }
 
-        return ThunkSequence::Of(std::make_unique<AsyncStartThunk>(
+        return ThunkSequence::Of<AsyncStartThunk>(
             std::move(start_thunk_info), *execution_stream_id,
             ThunkSequence::Of(std::move(group_thunk)),
-            std::move(async_execution)));
+            std::move(async_execution));
       });
 }
 
@@ -2225,10 +2207,10 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCollectiveAsyncDone(
     return ThunkSequence{};
   }
 
-  return GetThunkSequence(std::make_unique<AsyncDoneThunk>(
+  return ThunkSequence::Of<AsyncDoneThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           inst, ir_emitter_context_->GetNextThunkId()),
-      it->second));
+      it->second);
 }
 
 template <typename HloInstType>
@@ -2243,20 +2225,20 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitDegeneratedCollectiveThunk(
   ThunkSequence thunks;
   for (int64_t i = 0; i < buffers.size(); i++) {
     const Shape shape = inst->operand(i)->shape();
-    thunks.push_back(std::make_unique<DeviceToDeviceCopyThunk>(
+    thunks.Emplace<DeviceToDeviceCopyThunk>(
         Thunk::ThunkInfo::WithProfileAnnotation(
             inst, ir_emitter_context_->GetNextThunkId()),
         ShapedSlice{buffers[i].source_buffer.slice, shape},
         ShapedSlice{buffers[i].destination_buffer.slice, shape},
-        ShapeUtil::ByteSizeOf(shape)));
+        ShapeUtil::ByteSizeOf(shape));
   }
   if (thunks.size() == 1) {
     return thunks;
   }
-  return GetThunkSequence(std::make_unique<SequentialThunk>(
+  return ThunkSequence::Of<SequentialThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           inst, ir_emitter_context_->GetNextThunkId()),
-      std::move(thunks)));
+      std::move(thunks));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitInfeed(
@@ -2280,10 +2262,10 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitInfeed(
                         instr->ToString(), index.ToString());
       }));
 
-  return GetThunkSequence(std::make_unique<InfeedThunk>(
+  return ThunkSequence::Of<InfeedThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
-      std::move(shaped_slices)));
+      std::move(shaped_slices));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitOutfeed(
@@ -2307,10 +2289,10 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitOutfeed(
                         source->ToString(), index.ToString());
       }));
 
-  return GetThunkSequence(std::make_unique<OutfeedThunk>(
+  return ThunkSequence::Of<OutfeedThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
-      std::move(shaped_slices)));
+      std::move(shaped_slices));
 }
 
 static absl::flat_hash_map<std::string, std::string> ConvertFrontendAttributes(
@@ -2392,7 +2374,7 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCopyStartThunk(
 
   // If copy-start is not a scope-start operation, the copy is synchronous.
   if (!execution_stream_id.ok()) {
-    return GetThunkSequence(std::move(copy_thunk));
+    return ThunkSequence::Of(std::move(copy_thunk));
   }
 
   // Wrap the copy thunk in an AsyncStartThunk for asynchronous execution.
@@ -2411,7 +2393,7 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCopyStartThunk(
                     copy_start_instr->ToString());
   }
 
-  return GetThunkSequence(std::move(start_thunk));
+  return ThunkSequence::Of(std::move(start_thunk));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCopyDoneThunk(
@@ -2422,10 +2404,10 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitCopyDoneThunk(
   // If the copy-start was asynchronous, emit an AsyncDoneThunk.
   auto it = hlo_async_executions_.find(copy_start_instr);
   if (it != hlo_async_executions_.end()) {
-    return GetThunkSequence(std::make_unique<AsyncDoneThunk>(
+    return ThunkSequence::Of<AsyncDoneThunk>(
         Thunk::ThunkInfo::WithProfileAnnotation(
             instr, ir_emitter_context_->GetNextThunkId()),
-        it->second));
+        it->second);
   }
 
   // Synchronous copy: copy-done is a no-op.
@@ -2471,12 +2453,11 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitSendThunk(
       // send/recv pair (pipelined send/recv share the same async stream).
       auto existing_it = hlo_async_executions_.find(canonical_send_instr);
       if (existing_it != hlo_async_executions_.end()) {
-        auto start_thunk = std::make_unique<AsyncStartThunk>(
+        return ThunkSequence::Of<AsyncStartThunk>(
             Thunk::ThunkInfo::WithProfileAnnotation(
                 instr, ir_emitter_context_->GetNextThunkId()),
             execution_stream_id, ThunkSequence::Of(std::move(thunk)),
             existing_it->second);
-        return GetThunkSequence(std::move(start_thunk));
       }
 
       auto start_thunk = std::make_unique<AsyncStartThunk>(
@@ -2486,9 +2467,9 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitSendThunk(
 
       hlo_async_executions_.try_emplace(canonical_send_instr,
                                         start_thunk->async_execution());
-      return GetThunkSequence(std::move(start_thunk));
+      return ThunkSequence::Of(std::move(start_thunk));
     }
-    return GetThunkSequence(std::move(thunk));
+    return ThunkSequence::Of(std::move(thunk));
   }
 
   if (!instr->channel_id().has_value()) {
@@ -2496,12 +2477,12 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitSendThunk(
         "Unknown channel id in host transfer send instruction");
   }
 
-  return GetThunkSequence(std::make_unique<HostSendThunk>(
+  return ThunkSequence::Of<HostSendThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
       src->shape(), slice.slice, *instr->channel_id(), send_recv_events_,
       ConvertFrontendAttributes(instr->frontend_attributes()),
-      DeviceConstraint(instr)));
+      DeviceConstraint(instr));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitSendDoneThunk(
@@ -2516,10 +2497,10 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitSendDoneThunk(
         "instruction");
   }
 
-  return GetThunkSequence(std::make_unique<HostSendDoneThunk>(
+  return ThunkSequence::Of<HostSendDoneThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
-      *instr->channel_id(), send_recv_events_, DeviceConstraint(instr)));
+      *instr->channel_id(), send_recv_events_, DeviceConstraint(instr));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitRecvThunk(
@@ -2563,12 +2544,11 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitRecvThunk(
       // send/recv pair (pipelined send/recv share the same async stream).
       auto existing_it = hlo_async_executions_.find(canonical_recv_instr);
       if (existing_it != hlo_async_executions_.end()) {
-        auto start_thunk = std::make_unique<AsyncStartThunk>(
+        return ThunkSequence::Of<AsyncStartThunk>(
             Thunk::ThunkInfo::WithProfileAnnotation(
                 instr, ir_emitter_context_->GetNextThunkId()),
             execution_stream_id, ThunkSequence::Of(std::move(thunk)),
             existing_it->second);
-        return GetThunkSequence(std::move(start_thunk));
       }
 
       auto start_thunk = std::make_unique<AsyncStartThunk>(
@@ -2578,9 +2558,9 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitRecvThunk(
 
       hlo_async_executions_.try_emplace(canonical_recv_instr,
                                         start_thunk->async_execution());
-      return GetThunkSequence(std::move(start_thunk));
+      return ThunkSequence::Of(std::move(start_thunk));
     }
-    return GetThunkSequence(std::move(thunk));
+    return ThunkSequence::Of(std::move(thunk));
   }
 
   if (!instr->channel_id().has_value()) {
@@ -2588,13 +2568,13 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitRecvThunk(
         "Unknown channel id in host transfer recv instruction");
   }
 
-  return GetThunkSequence(std::make_unique<HostRecvThunk>(
+  return ThunkSequence::Of<HostRecvThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
       instr->shape().tuple_shapes()[0], slice.slice, *instr->channel_id(),
       send_recv_events_,
       ConvertFrontendAttributes(instr->frontend_attributes()),
-      DeviceConstraint(instr)));
+      DeviceConstraint(instr));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitRecvDoneThunk(
@@ -2607,10 +2587,10 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitRecvDoneThunk(
         "Unknown channel id in host transfer recv done "
         "instruction");
   }
-  return GetThunkSequence(std::make_unique<HostRecvDoneThunk>(
+  return ThunkSequence::Of<HostRecvDoneThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(
           instr, ir_emitter_context_->GetNextThunkId()),
-      *instr->channel_id(), send_recv_events_, DeviceConstraint(instr)));
+      *instr->channel_id(), send_recv_events_, DeviceConstraint(instr));
 }
 
 absl::StatusOr<ThunkSequence> ThunkEmitter::EmitAsyncDone(
@@ -2619,7 +2599,6 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitAsyncDone(
     return EmitCollectiveAsyncDone(instr);
   }
   const HloInstruction* wrapped = instr->async_wrapped_instruction();
-  ThunkSequence thunks;
   switch (wrapped->opcode()) {
     case HloOpcode::kAllReduce:
     case HloOpcode::kAllGather:
@@ -2640,11 +2619,10 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitAsyncDone(
         auto async_events =
             GetInstructionToHostExecuteAsyncEvents().at(custom_call);
 
-        thunks.push_back(std::make_unique<HostExecuteDoneThunk>(
+        return ThunkSequence::Of<HostExecuteDoneThunk>(
             Thunk::ThunkInfo::WithProfileAnnotation(
                 instr, ir_emitter_context_->GetNextThunkId()),
-            async_events));
-        return thunks;
+            async_events);
       }
       auto it = hlo_async_executions_.find(wrapped);
       if (it == hlo_async_executions_.end()) {
@@ -2653,11 +2631,10 @@ absl::StatusOr<ThunkSequence> ThunkEmitter::EmitAsyncDone(
             "EmitAsyncComputation must be called before EmitAsyncDone.",
             wrapped->ToString());
       }
-      thunks.push_back(std::make_unique<AsyncDoneThunk>(
+      return ThunkSequence::Of<AsyncDoneThunk>(
           Thunk::ThunkInfo::WithProfileAnnotation(
               instr, ir_emitter_context_->GetNextThunkId()),
-          it->second));
-      return thunks;
+          it->second);
     }
     default:
       return Internal("Unsupported async done wrapped instruction: %s",
@@ -2740,9 +2717,9 @@ AsyncThunkSequence ThunkEmitter::EmitAsyncStart(const HloInstruction* instr) {
           .Map([start_thunk_info = std::move(start_thunk_info),
                 async_execution = std::move(async_execution),
                 execution_stream_id](ThunkSequence fusion_thunks) {
-            return ThunkSequence::Of(std::make_unique<AsyncStartThunk>(
+            return ThunkSequence::Of<AsyncStartThunk>(
                 std::move(start_thunk_info), execution_stream_id,
-                std::move(fusion_thunks), std::move(async_execution)));
+                std::move(fusion_thunks), std::move(async_execution));
           });
     }
     case HloOpcode::kCall: {
@@ -2810,7 +2787,7 @@ AsyncThunkSequence ThunkEmitter::EmitAsyncStart(const HloInstruction* instr) {
               "%s.",
               custom_call->ToString());
         }
-        return GetThunkSequence(std::move(thunk));
+        return ThunkSequence::Of(std::move(thunk));
       }
       return EmitAsyncCustomCallStart(instr);
     }


### PR DESCRIPTION
Add `ThunkSequence::Of<T>` and `ThunkSequence::Emplace<T>` helpers to constructs thunks inplace. This makes `ThunkSequence` consistent with `CommandSequence` and reduces boilerplate in thunk emitter.
