### PR TITLE
[XLA] Drop rank-mismatched op sharding during StableHLO→HLO import instead of failing

### DIFF
--- a/xla/hlo/builder/xla_builder.cc
+++ b/xla/hlo/builder/xla_builder.cc
@@ -147,7 +147,18 @@ absl::Status NormalizeAndAssignSharing(HloInstructionProto* instr,
   ASSIGN_OR_RETURN(Shape shape, Shape::FromProto(instr->shape()));
   ASSIGN_OR_RETURN(HloSharding sharding, HloSharding::FromProto(op_sharding));
   sharding = sharding.NormalizeTupleSharding(shape);
-  RETURN_IF_ERROR(sharding.Validate(shape));
+  absl::Status validate_status = sharding.Validate(shape);
+  if (!validate_status.ok()) {
+    // A tiled sharding whose rank doesn't match the op shape (e.g. propagated
+    // onto a scalar) is invalid; drop it and let XLA infer a valid sharding
+    // instead of aborting the import.
+    if (!shape.IsTuple() && sharding.IsTiled() &&
+        sharding.TiledDataRank() !=
+            static_cast<int64_t>(shape.dimensions().size())) {
+      return absl::OkStatus();
+    }
+    return validate_status;
+  }
   *instr->mutable_sharding() = sharding.ToProto();
   return absl::OkStatus();
 }

--- a/xla/hlo/translate/mhlo_to_hlo/tests/sharding.mlir
+++ b/xla/hlo/translate/mhlo_to_hlo/tests/sharding.mlir
@@ -496,3 +496,18 @@ func.func @main() -> tensor<4xf32> {
   return %1#0 : tensor<4xf32>
 }
 
+// -----
+
+// A tiled sharding whose rank does not match the op shape is invalid: here a
+// rank-3 {devices=[1,2,1]} sharding on a rank-0 scalar constant, which sharding
+// propagation can produce. It must be dropped so the export succeeds (XLA
+// infers a valid sharding) instead of aborting with "Number of tile assignment
+// dimensions ... different than the input rank".
+// CHECK-LABEL: HloModule main
+// CHECK: constant(3.1415925)
+// CHECK-NOT: sharding
+func.func @main() -> tensor<f32> {
+  %0 = mhlo.constant {mhlo.sharding = "{devices=[1,2,1]0,1}"} dense<3.1415926> : tensor<f32>
+  return %0 : tensor<f32>
+}
+


### PR DESCRIPTION
## 📝 Summary of Changes
In `NormalizeAndAssignSharing` (`xla_builder.cc`), drop a **tiled** sharding
whose rank doesn't match its op shape (instead of failing the StableHLO→HLO
import); other validation failures still error.

## 🎯 Justification
Sharding propagation can leave a tiled sharding whose rank doesn't match its op
— e.g. a rank-3 `{devices=[8,1,1]}` sharding on a rank-0 scalar constant — which
aborts the whole import ("Number of tile assignment dimensions … different than
the input rank"). Dropping it lets XLA infer a valid sharding.

Observed as a **regression in MaxText MoE runs**: Mixtral-8x7B, DeepSeek2-16B and
GPT-OSS-20B fail to compile with Shardy on, because `top_k`/`sort` routing
(decomposed in a `closed_call`) leaves a scalar constant with the router's
rank-3 sharding.

## 🚀 Kind of Contribution
🐛 Bug Fix

## 📊 Benchmark
N/A — compile-time correctness fix.

## 🧪 Unit Tests
FileCheck test in `mhlo_to_hlo/tests/sharding.mlir`: a rank-3 sharding on a
scalar constant is dropped and the module exports successfully.

## 🧪 Execution Tests
MaxText Mixtral-8x7B / DeepSeek2-16B / GPT-OSS-20B train on 8 GPUs with Shardy
enabled (all previously failed to compile).