### PR TITLE
[ROCm] Pass through hsa env variables through the lit config

### DIFF
--- a/xla/lit.cfg.py
+++ b/xla/lit.cfg.py
@@ -52,6 +52,13 @@ for env in [
     "LLVM_COVERAGE_FILE",
     "GCOV_PREFIX",
     "GCOV_PREFIX_STRIP",
+    # ROCm related env variables
+    "HSA_MODEL_TOPOLOGY",
+    "HSA_MODEL_LIB",
+    "HSA_KMT_MODEL_GPUVM_BASE",
+    "HSA_ENABLE_SDMA",
+    "HSA_ENABLE_INTERRUPT",
+    "LD_LIBRARY_PATH",
 ] + extra_env_flags:
   value = os.environ.get(env)
   if value:


### PR DESCRIPTION
📝 Summary of Changes
Pass through rocm related hsa env variables in lit.cfg.py script.

🎯 Justification
Some rocm ci jobs are using env variables to customize the test execution.
lit tests are hermetic and do not leak env variables used by rocm. 
We explicitly pass through these env variables now.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
