### PR TITLE
[XLA:GPU] Enforce the LHS scheduler memory limit as a soft-capped skip filter

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -515,6 +515,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_experimental_thunk_buffer_debug_module_outputs(false);
   opts.set_xla_gpu_enable_gxl_ragged_all_to_all(false);
   opts.set_xla_gpu_gxl_scratch_size_bytes(64 * 1024 * 1024);
+  opts.set_xla_gpu_experimental_lhs_enforce_memory_limit(false);
 
   // Disable float checks.
   opts.set_xla_gpu_detect_nan(DebugOptions::DETECTION_MODE_NONE);
@@ -3266,6 +3267,14 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       int64_setter_for(&DebugOptions::set_xla_gpu_gxl_scratch_size_bytes),
       debug_options->xla_gpu_gxl_scratch_size_bytes(),
       "Size in bytes of the scratch buffer for GXL collectives."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_experimental_lhs_enforce_memory_limit",
+      bool_setter_for(
+          &DebugOptions::set_xla_gpu_experimental_lhs_enforce_memory_limit),
+      debug_options->xla_gpu_experimental_lhs_enforce_memory_limit(),
+      "If true, the latency-hiding scheduler avoids scheduling nodes that "
+      "would push memory usage above the scheduler memory limit when any "
+      "alternative node is available."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_use_ragged_dot_grouped_gemm",
       bool_setter_for(

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -657,6 +657,8 @@ absl::Status RunLatencyHidingSchedulerPasses(
       memory_limit,
       options.xla_gpu_experimental_parallel_collective_overlap_limit(),
       options.xla_gpu_experimental_parallel_async_compute_limit());
+  config.enforce_memory_limit =
+      options.xla_gpu_experimental_lhs_enforce_memory_limit();
 
   auto shape_size_in_bytes = ShapeSizeBytesFunction(pointer_size);
 

--- a/xla/service/latency_hiding_scheduler.cc
+++ b/xla/service/latency_hiding_scheduler.cc
@@ -1924,6 +1924,7 @@ enum SkipNodeReason {
   kShouldSkipNodeFunction,
   kExceedsOverlapLimit,
   kAnnotationGroupNotReady,
+  kExceedsMemoryLimit,
 };
 
 absl::string_view SkipNodeReasonString(SkipNodeReason reason) {
@@ -1934,6 +1935,8 @@ absl::string_view SkipNodeReasonString(SkipNodeReason reason) {
       return "Skipped due to kExceedsOverlapLimit.";
     case SkipNodeReason::kAnnotationGroupNotReady:
       return "Skipped due to kAnnotationNotReady.";
+    case SkipNodeReason::kExceedsMemoryLimit:
+      return "Skipped due to kExceedsMemoryLimit.";
   }
 }
 
@@ -1951,6 +1954,13 @@ DefaultSchedulerCore::FindAndExtractBestNodeAvailable(
     DefaultSchedulerCore::SchedulingState& sched_state,
     DefaultSchedulerCore::ShouldSkipNodeFunction should_skip_node) {
   auto ready_lt = CreateReadySetComparator(sched_state);
+  const uint64_t config_memory_limit = sched_state.config.memory_limit;
+  // Memory usage is constant within this call since nothing gets scheduled
+  // while selecting a node.
+  const int64_t memory_usage =
+      sched_state.memory_pressure_tracker->memory_usage();
+  bool memory_filter_enabled = sched_state.config.enforce_memory_limit &&
+                               config_memory_limit != UINT64_MAX;
   while (true) {
     // Schedule a nop instruction if available.
     if (!sched_state.nop_set.empty()) {
@@ -2029,6 +2039,31 @@ DefaultSchedulerCore::FindAndExtractBestNodeAvailable(
       }
       ScheduleCandidate ready_candidate =
           InitializeCandidate(ready_node, sched_state);
+      // If scheduling this node would push memory usage above the configured
+      // limit, do not schedule it while any other node is available. If every
+      // node exceeds the limit, the filter is disabled below and the ready set
+      // is re-scanned (soft cap). Note that nodes scheduled through the
+      // annotation-group path do not go through this filter.
+      if (memory_filter_enabled) {
+        std::pair<int64_t, int64_t> pressure_change =
+            ready_lt->GetMemoryPressureChanges(sched_state, ready_candidate,
+                                               ready_node);
+        if (pressure_change.first > 0 &&
+            static_cast<uint64_t>(memory_usage + pressure_change.first) >
+                config_memory_limit) {
+          if (!ready_chosen_valid) {
+            skipped_nodes_and_reasons.push_back(
+                {ready_node, SkipNodeReason::kExceedsMemoryLimit});
+            if (ABSL_PREDICT_FALSE(vlog_2)) {
+              VLOG(2) << SkipNodeReasonString(
+                             skipped_nodes_and_reasons.back().second)
+                      << " node: " << ready_node->GetInstr().name()
+                      << " memory increase: " << pressure_change.first;
+            }
+          }
+          continue;
+        }
+      }
       if (!ready_chosen_valid) {
         ready_chosen = ready_candidate;
         chosen_it = ready_node_it;
@@ -2071,6 +2106,21 @@ DefaultSchedulerCore::FindAndExtractBestNodeAvailable(
       std::swap(*chosen_it, sched_state.ready_set.back());
       sched_state.ready_set.pop_back();
       return ready_chosen.node;
+    }
+
+    // Progress guarantee for the memory-limit filter (soft cap): if no node
+    // was selectable only because scheduling it would exceed the memory limit,
+    // retry with the filter disabled. The over-limit comparator rules
+    // (kDecreaseMemoryOverLimit/kMemoryPeakOverLimit) then pick the node with
+    // the smallest memory increase.
+    if (memory_filter_enabled &&
+        absl::c_any_of(skipped_nodes_and_reasons, [](const auto& pair) {
+          return pair.second == SkipNodeReason::kExceedsMemoryLimit;
+        })) {
+      VLOG(2) << "No node schedulable under the memory limit filter; retrying "
+                 "with the filter disabled.";
+      memory_filter_enabled = false;
+      continue;
     }
 
     if (sched_state.config.deannotate_group_if_blocked) {

--- a/xla/service/latency_hiding_scheduler.h
+++ b/xla/service/latency_hiding_scheduler.h
@@ -181,6 +181,11 @@ struct SchedulerConfig {
   // If true, estimate the fragmentation size of the module by running the heap
   // simulator.
   bool estimate_fragmentation_size = false;
+  // If true, FindAndExtractBestNodeAvailable skips ready nodes whose projected
+  // memory-pressure increase would bring memory usage above memory_limit,
+  // unless no node can be scheduled otherwise (soft cap). Has no effect when
+  // memory_limit is UINT64_MAX.
+  bool enforce_memory_limit = false;
   // If true, track the resource usage of sync ops in latency hiding scheduler.
   bool track_sync_op_resource_usage = false;
   // If true, use top down scheduling.
@@ -1985,6 +1990,11 @@ class ReadySetLt {
                               DefaultSchedulerCore::ScheduleCandidate& b,
                               const char** reason) const;
 
+  std::pair<int64_t, int64_t> GetMemoryPressureChanges(
+      const DefaultSchedulerCore::SchedulingState& state,
+      DefaultSchedulerCore::ScheduleCandidate& cand,
+      const HloGraphNode* cand_node) const;
+
  protected:
   template <typename T>
   static int ThreeWay(T avalue, T bvalue) {
@@ -2063,11 +2073,6 @@ class ReadySetLt {
 
   HloGraphNode::TimeCost PastDueCyclesForNonextendableResource(
       const DefaultSchedulerCore::SchedulingState& state,
-      const HloGraphNode* cand_node) const;
-
-  std::pair<int64_t, int64_t> GetMemoryPressureChanges(
-      const DefaultSchedulerCore::SchedulingState& state,
-      DefaultSchedulerCore::ScheduleCandidate& cand,
       const HloGraphNode* cand_node) const;
 
   int64_t GetNumConflictingSerialResources(

--- a/xla/service/latency_hiding_scheduler_test.cc
+++ b/xla/service/latency_hiding_scheduler_test.cc
@@ -3469,6 +3469,181 @@ TEST_F(LatencyHidingSchedulerTest, RerunWithSmallerMemoryLimit) {
             PositionInVector(new_instruction_sequence, cps));
 }
 
+TEST_F(LatencyHidingSchedulerTest, EnforceMemoryLimitAvoidsOverlapAboveLimit) {
+  // Same module as RerunWithSmallerMemoryLimit: overlapping the slice with the
+  // collective-permute requires keeping the 86-byte broadcast alive across the
+  // collective, with a peak memory usage of 136 bytes. With
+  // enforce_memory_limit and a limit of 110 bytes, the scheduler must reach
+  // the memory-friendly order (slice scheduled outside of the
+  // collective-permute overlap window) in a single scheduling pass, without
+  // any rerun.
+  absl::string_view hlo_string = R"(
+    HloModule enforce_memory_limit_test, is_scheduled=true
+    ENTRY main {
+     p0 = bf16[8]{0} parameter(0)
+     c = bf16[] constant(0)
+     b = bf16[43]{0} broadcast(c), dimensions={}
+     s = bf16[1]{0} slice(b), slice={[0:1]}
+     cp = bf16[8]{0} collective-permute(p0), source_target_pairs={{0,1},{1,2},{2,3}}
+    ROOT tuple = (bf16[8]{0}, bf16[1]{0}) tuple(cp, s)
+  }
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseHloText(hlo_string));
+  HloSchedule& module_schedule = hlo_module->schedule();
+  EXPECT_TRUE(hlo_module->has_entry_computation());
+  HloComputation* entry_computation = hlo_module->entry_computation();
+  auto sched_config = GetDefaultSchedConfig();
+  sched_config.memory_limit = 110;
+  sched_config.enforce_memory_limit = true;
+  TF_EXPECT_OK(RunScheduler(hlo_module.get(), sched_config));
+  std::vector<HloInstruction*> new_instruction_sequence =
+      module_schedule.sequence(entry_computation).instructions();
+  if (VLOG_IS_ON(1)) {
+    for (auto* new_i : new_instruction_sequence) {
+      VLOG(1) << new_i->ToString();
+    }
+  }
+  const HloInstruction* s = FindInstruction(hlo_module.get(), "s");
+  const HloInstruction* cps =
+      FindInstruction(hlo_module.get(), "collective-permute-start");
+  EXPECT_LT(PositionInVector(new_instruction_sequence, s),
+            PositionInVector(new_instruction_sequence, cps));
+}
+
+TEST_F(LatencyHidingSchedulerTest, EnforceMemoryLimitNoEffectWithHeadroom) {
+  // Same module as above, but with a memory limit well above the peak (136
+  // bytes): the filter must never fire and the scheduler must keep overlapping
+  // the slice with the collective-permute, exactly as with the feature off.
+  absl::string_view hlo_string = R"(
+    HloModule enforce_memory_limit_headroom_test, is_scheduled=true
+    ENTRY main {
+     p0 = bf16[8]{0} parameter(0)
+     c = bf16[] constant(0)
+     b = bf16[43]{0} broadcast(c), dimensions={}
+     s = bf16[1]{0} slice(b), slice={[0:1]}
+     cp = bf16[8]{0} collective-permute(p0), source_target_pairs={{0,1},{1,2},{2,3}}
+    ROOT tuple = (bf16[8]{0}, bf16[1]{0}) tuple(cp, s)
+  }
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseHloText(hlo_string));
+  HloSchedule& module_schedule = hlo_module->schedule();
+  EXPECT_TRUE(hlo_module->has_entry_computation());
+  HloComputation* entry_computation = hlo_module->entry_computation();
+  auto sched_config = GetDefaultSchedConfig();
+  sched_config.memory_limit = 1000;
+  sched_config.enforce_memory_limit = true;
+  TF_EXPECT_OK(RunScheduler(hlo_module.get(), sched_config));
+  std::vector<HloInstruction*> new_instruction_sequence =
+      module_schedule.sequence(entry_computation).instructions();
+  const HloInstruction* s = FindInstruction(hlo_module.get(), "s");
+  const HloInstruction* cps =
+      FindInstruction(hlo_module.get(), "collective-permute-start");
+  const HloInstruction* cpd =
+      FindInstruction(hlo_module.get(), "collective-permute-done");
+  EXPECT_GT(PositionInVector(new_instruction_sequence, s),
+            PositionInVector(new_instruction_sequence, cps));
+  EXPECT_LT(PositionInVector(new_instruction_sequence, s),
+            PositionInVector(new_instruction_sequence, cpd));
+}
+
+TEST_F(LatencyHidingSchedulerTest, EnforceMemoryLimitTinyLimitStillSchedules) {
+  // With a limit that nothing fits under, every candidate is skipped by the
+  // memory filter; the soft-cap fallback must disable the filter and still
+  // produce a complete schedule instead of failing.
+  absl::string_view hlo_string = R"(
+    HloModule enforce_memory_limit_tiny_test, is_scheduled=true
+    ENTRY main {
+     p0 = bf16[8]{0} parameter(0)
+     c = bf16[] constant(0)
+     b = bf16[43]{0} broadcast(c), dimensions={}
+     s = bf16[1]{0} slice(b), slice={[0:1]}
+     cp = bf16[8]{0} collective-permute(p0), source_target_pairs={{0,1},{1,2},{2,3}}
+    ROOT tuple = (bf16[8]{0}, bf16[1]{0}) tuple(cp, s)
+  }
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseHloText(hlo_string));
+  HloSchedule& module_schedule = hlo_module->schedule();
+  EXPECT_TRUE(hlo_module->has_entry_computation());
+  HloComputation* entry_computation = hlo_module->entry_computation();
+  auto sched_config = GetDefaultSchedConfig();
+  sched_config.memory_limit = 1;
+  sched_config.enforce_memory_limit = true;
+  TF_EXPECT_OK(RunScheduler(hlo_module.get(), sched_config));
+  std::vector<HloInstruction*> new_instruction_sequence =
+      module_schedule.sequence(entry_computation).instructions();
+  EXPECT_EQ(new_instruction_sequence.size(),
+            entry_computation->instruction_count());
+}
+
+TEST_F(LatencyHidingSchedulerTest, EnforceMemoryLimitDelaysWgradLikeSinks) {
+  // Miniature of an unrolled transformer backward pass with two layers.
+  // Per layer i (backward order: layer 2 then layer 1):
+  //   - the "dgrad" chain runs through a collective-permute and produces the
+  //     gradient for the next layer,
+  //   - the "wgrad" (sl_i + wg_i) consumes a large saved "activation" act_i
+  //     and the incoming gradient, and produces a small output feeding only
+  //     the root.
+  // The activation's live range ends at sl_i. With enforce_memory_limit and a
+  // limit that fits only one activation at a time, the live ranges must not
+  // overlap regardless of how the comparator heuristics evolve: each
+  // activation is consumed before the other one is materialized. (The
+  // behavior contrast between filter on/off is covered by
+  // EnforceMemoryLimitAvoidsOverlapAboveLimit; at this miniature scale the
+  // default heuristics happen to produce a tight pairing even without
+  // enforcement.)
+  absl::string_view hlo_string = R"(
+    HloModule enforce_memory_limit_wgrad_test, is_scheduled=true
+    ENTRY main {
+     p0 = bf16[8]{0} parameter(0)
+     c = bf16[] constant(0)
+     act1 = bf16[64]{0} broadcast(c), dimensions={}
+     act2 = bf16[64]{0} broadcast(c), dimensions={}
+     sl2 = bf16[8]{0} slice(act2), slice={[0:8]}
+     wg2 = bf16[8]{0} add(sl2, p0)
+     cp2 = bf16[8]{0} collective-permute(p0), source_target_pairs={{0,1},{1,2},{2,3}}
+     dg2 = bf16[8]{0} add(cp2, p0)
+     sl1 = bf16[8]{0} slice(act1), slice={[0:8]}
+     wg1 = bf16[8]{0} add(sl1, dg2)
+     cp1 = bf16[8]{0} collective-permute(dg2), source_target_pairs={{0,1},{1,2},{2,3}}
+     dg1 = bf16[8]{0} add(cp1, dg2)
+    ROOT t = (bf16[8]{0}, bf16[8]{0}, bf16[8]{0}) tuple(dg1, wg1, wg2)
+  }
+)";
+
+  auto acts_overlap = [](absl::Span<HloInstruction* const> seq) {
+    // act_i is live from its position to the position of its consumer sl_i.
+    int act1 = GetIndex(seq, "act1");
+    int act2 = GetIndex(seq, "act2");
+    int sl1 = GetIndex(seq, "sl1");
+    int sl2 = GetIndex(seq, "sl2");
+    return act2 < sl1 && act1 < sl2;
+  };
+
+  // GPU-like aggressive scheduling plus a memory limit that fits only one
+  // activation at a time.
+  TF_ASSERT_OK_AND_ASSIGN(auto hlo_module, ParseHloText(hlo_string));
+  auto sched_config = GetDefaultSchedConfig();
+  sched_config.aggressive_scheduling_policies = true;
+  sched_config.memory_limit = 250;
+  sched_config.enforce_memory_limit = true;
+  TF_EXPECT_OK(RunScheduler(hlo_module.get(), sched_config));
+  std::vector<HloInstruction*> new_instruction_sequence =
+      hlo_module->schedule()
+          .sequence(hlo_module->entry_computation())
+          .instructions();
+  if (VLOG_IS_ON(1)) {
+    for (auto* new_i : new_instruction_sequence) {
+      VLOG(1) << new_i->ToString();
+    }
+  }
+  EXPECT_EQ(new_instruction_sequence.size(),
+            hlo_module->entry_computation()->instruction_count());
+  EXPECT_FALSE(acts_overlap(new_instruction_sequence));
+}
+
 TEST_F(LatencyHidingSchedulerTest, MultipleAsyncDoneOperationsDoNotCreateLoop) {
   absl::string_view hlo_string = R"(
 HloModule multiple_async_done_scheduler_test, is_scheduled=true

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1661,6 +1661,13 @@ message DebugOptions {
   // Scratch buffer size (in bytes) for GXL collectives.
   optional int64 xla_gpu_gxl_scratch_size_bytes = 514;
 
+  // If true, the latency-hiding scheduler skips scheduling a ready node whose
+  // projected memory increase would push memory usage above the scheduler
+  // memory limit, as long as any other node can be scheduled instead (soft
+  // cap: if no node fits under the limit, the filter is disabled for that
+  // selection step).
+  optional bool xla_gpu_experimental_lhs_enforce_memory_limit = 515;
+
   // If true, enable experimental tiling propagation.
   optional bool xla_gpu_experimental_enable_tiling_propagation = 456;
 
@@ -1675,7 +1682,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 515
+  // Next id: 516
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
# Enforce the LHS scheduler memory limit as a soft-capped skip filter

## Problem

The latency-hiding scheduler's `memory_limit` only participates in pairwise candidate-comparison tie-breakers (`kDecreaseMemoryOverLimit`, `kMemoryPeakOverLimit` in `ReadySetLt::MemoryPressurePolicy`); it is never enforced as a constraint on which node may be scheduled. On large unrolled graphs the aggressive latency-hiding policies can commit many long-lived buffers as overlap filler before the comparator rules engage, producing schedules whose estimated peak far exceeds the configured limit.

Concretely, on MaxText Llama3-8B with `scan_layers=false` (32 unrolled layers, context parallelism 8, sequence length 128K, 8xH200), the scheduler defers the weight-gradient GEMMs of the unrolled backward pass to the end of the schedule while advancing through hundreds of data-gradient GEMMs. Each deferred weight gradient keeps its saved forward activation and incoming activation gradient alive, so temporary memory grows roughly linearly with the number of unrolled layers:

| Configuration | Temporary memory | Result |
|---|---|---|
| scan=false, LHS enabled | 290 GB | OOM |
| scan=true, LHS enabled | 62 GB | fits |
| scan=false, LHS disabled | 65 GB | fits |

The scheduler itself estimated a peak of ~329 GB against a configured limit of ~95.5 GB and accepted the schedule anyway.

## Fix

Add `SchedulerConfig.enforce_memory_limit`, gated behind a new debug option `xla_gpu_experimental_lhs_enforce_memory_limit` (default off):

- In `DefaultSchedulerCore::FindAndExtractBestNodeAvailable`, skip any ready node whose projected net memory-pressure increase would push tracked usage above `memory_limit`, as long as any alternative node is available (new `SkipNodeReason::kExceedsMemoryLimit`, mirroring the existing overlap-limit skip).
- **Soft cap / progress guarantee:** if no node was selectable only because of memory skips, the selection is retried once with the filter disabled, falling back to the existing over-limit min-increase comparator rules. Scheduling always makes progress and can never fail due to the filter.
- The projected increase reuses `ReadySetLt::GetMemoryPressureChanges` (moved to public), so async-done nodes are judged with their paired async-start folded in, consistent with the comparator. Net-negative or neutral candidates are never skipped, so the filter cannot block a memory-reducing schedule.
- Nodes scheduled through the annotation-group path are not filtered (documented limitation).

Under memory pressure this stops the scheduler from grabbing far-away weight-gradient GEMMs as overlap filler; each one is instead scheduled at its dataflow-forced position (the shared incoming-gradient operand forces `WG_i` before the climb past layer i), which reproduces the memory-friendly per-layer interleaving. With headroom, the filter never fires and latency hiding is unaffected.

## Testing

- `EnforceMemoryLimitAvoidsOverlapAboveLimit`: reuses the `RerunWithSmallerMemoryLimit` module; with the flag on, the scheduler reaches the memory-friendly order (peak 88 bytes <= 110-byte limit) in a single pass, where the flag-off schedule peaks at 136 bytes.
- `EnforceMemoryLimitNoEffectWithHeadroom`: with a generous limit the filter never fires and the collective still overlaps independent work.
- `EnforceMemoryLimitTinyLimitStillSchedules`: with a 1-byte limit every candidate is skipped; the soft-cap fallback still produces a complete schedule.
- `EnforceMemoryLimitDelaysWgradLikeSinks`: miniature two-layer unrolled backward pass (GPU-like aggressive policies); under enforcement the two saved activations' live ranges must not overlap.
- Full `//xla/service:latency_hiding_scheduler_test` suite passes (98/98). No behavior change with the flag off.
