### PR TITLE
[ROCm] Added support for waves_per_eu function attribute

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -654,10 +654,22 @@ cc_library(
     hdrs = ["triton_call.h"],
     deps = [
         "@com_google_absl//absl/strings:string_view",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AsmParser",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Support",
+    ],
+)
+
+xla_cc_test(
+    name = "triton_call_test",
+    srcs = ["triton_call_test.cc"],
+    deps = [
+        ":triton_call",
+        "//xla/tests:xla_internal_test_main",
+        "@com_google_googletest//:gtest",
+        "@llvm-project//mlir:IR",
     ],
 )
 

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -1323,6 +1323,7 @@ AsyncThunkSequence ThunkEmitter::EmitTritonCustomCall(
     block_level_parameters.global_scratch_memory_size =
         call.global_scratch_memory_size;
     block_level_parameters.is_tma_allowed = call.is_tma_allowed;
+    block_level_parameters.waves_per_eu = call.waves_per_eu;
 
     return ir_emitter_context_->kernel_compiler()
         ->CompileTritonToLlvm(

--- a/xla/service/gpu/triton_call.cc
+++ b/xla/service/gpu/triton_call.cc
@@ -73,16 +73,18 @@ TritonCall TritonCall::Parse(absl::string_view backend_config,
   int64_t waves_per_eu = 0;
   if (auto attr = attrs.getAs<mlir::StringAttr>("serialized_metadata")) {
     llvm::Expected<llvm::json::Value> parsed =
-        llvm::json::parse(attr.getValue().str());
+        llvm::json::parse(attr.getValue());
     if (parsed) {
       if (llvm::json::Object* obj = parsed->getAsObject()) {
         if (std::optional<llvm::StringRef> v = obj->getString("waves_per_eu")) {
           int64_t tmp = 0;
-          if (llvm::to_integer(*v, tmp)) {
+          if (llvm::to_integer(*v, tmp) && tmp > 0) {
             waves_per_eu = tmp;
           }
         } else if (std::optional<int64_t> n = obj->getInteger("waves_per_eu")) {
-          waves_per_eu = *n;
+          if (*n > 0) {
+            waves_per_eu = *n;
+          }
         }
       }
     } else {

--- a/xla/service/gpu/triton_call.cc
+++ b/xla/service/gpu/triton_call.cc
@@ -16,10 +16,15 @@ limitations under the License.
 #include "xla/service/gpu/triton_call.h"
 
 #include <cstdint>
+#include <optional>
 #include <utility>
 #include <vector>
 
 #include "absl/strings/string_view.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/JSON.h"
 #include "mlir/AsmParser/AsmParser.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/MLIRContext.h"
@@ -61,11 +66,35 @@ TritonCall TritonCall::Parse(absl::string_view backend_config,
           mlir::cast<mlir::IntegerAttr>(val).getValue().getSExtValue());
     }
   }
+  // The optional `serialized_metadata` attribute carries a JSON object emitted
+  // from JAX's `pl.pallas_call(..., metadata=...)`. It is used to pass the
+  // ROCm `waves_per_eu`. Any parse failure leaves `waves_per_eu`
+  // unset (0).
+  int64_t waves_per_eu = 0;
+  if (auto attr = attrs.getAs<mlir::StringAttr>("serialized_metadata")) {
+    llvm::Expected<llvm::json::Value> parsed =
+        llvm::json::parse(attr.getValue().str());
+    if (parsed) {
+      if (llvm::json::Object* obj = parsed->getAsObject()) {
+        if (std::optional<llvm::StringRef> v = obj->getString("waves_per_eu")) {
+          int64_t tmp = 0;
+          if (llvm::to_integer(*v, tmp)) {
+            waves_per_eu = tmp;
+          }
+        } else if (std::optional<int64_t> n = obj->getInteger("waves_per_eu")) {
+          waves_per_eu = *n;
+        }
+      }
+    } else {
+      llvm::consumeError(parsed.takeError());
+    }
+  }
   return TritonCall{std::move(name), std::move(ir),
                     num_stages,      num_warps,
                     grid_x,          grid_y,
                     grid_z,          global_scratch_memory_size,
-                    is_tma_allowed,  std::move(zeroed_outputs)};
+                    is_tma_allowed,  std::move(zeroed_outputs),
+                    waves_per_eu};
 }
 
 }  // namespace xla::gpu

--- a/xla/service/gpu/triton_call.h
+++ b/xla/service/gpu/triton_call.h
@@ -35,6 +35,7 @@ struct TritonCall {
   int64_t global_scratch_memory_size = 0;
   bool is_tma_allowed = false;
   std::vector<int64_t> zeroed_outputs;
+  int64_t waves_per_eu = 0;  // ROCm occupancy knob; 0 = unset.
 
   // Parse the metadata of a __gpu$xla.gpu.triton call.
   static TritonCall Parse(absl::string_view backend_config,

--- a/xla/service/gpu/triton_call_test.cc
+++ b/xla/service/gpu/triton_call_test.cc
@@ -1,0 +1,75 @@
+/* Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/service/gpu/triton_call.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+#include "mlir/IR/MLIRContext.h"
+
+namespace xla::gpu {
+namespace {
+
+// Builds a minimal __gpu$xla.gpu.triton backend config dictionary, optionally
+// appending an extra attribute (e.g. serialized_metadata).
+std::string BackendConfig(const std::string& extra_attrs) {
+  std::string config =
+      R"({name = "k", ir = "", num_stages = 1 : i32, num_warps = 4 : i32, )"
+      R"(grid_x = 1 : i32, grid_y = 1 : i32, grid_z = 1 : i32)";
+  if (!extra_attrs.empty()) {
+    config += ", " + extra_attrs;
+  }
+  config += "}";
+  return config;
+}
+
+TEST(TritonCallTest, WavesPerEuDefaultsToZeroWhenAbsent) {
+  mlir::MLIRContext ctx;
+  TritonCall call = TritonCall::Parse(BackendConfig(/*extra_attrs=*/""), &ctx);
+  EXPECT_EQ(call.waves_per_eu, 0);
+}
+
+TEST(TritonCallTest, WavesPerEuParsedFromSerializedMetadataStringValue) {
+  mlir::MLIRContext ctx;
+  TritonCall call = TritonCall::Parse(
+      BackendConfig(R"(serialized_metadata = "{\"waves_per_eu\": \"2\"}")"),
+      &ctx);
+  EXPECT_EQ(call.waves_per_eu, 2);
+}
+
+TEST(TritonCallTest, WavesPerEuParsedFromSerializedMetadataNumberValue) {
+  mlir::MLIRContext ctx;
+  TritonCall call = TritonCall::Parse(
+      BackendConfig(R"(serialized_metadata = "{\"waves_per_eu\": 3}")"), &ctx);
+  EXPECT_EQ(call.waves_per_eu, 3);
+}
+
+TEST(TritonCallTest, WavesPerEuUnsetWhenMetadataHasNoSuchKey) {
+  mlir::MLIRContext ctx;
+  TritonCall call = TritonCall::Parse(
+      BackendConfig(R"(serialized_metadata = "{\"other\": \"1\"}")"), &ctx);
+  EXPECT_EQ(call.waves_per_eu, 0);
+}
+
+TEST(TritonCallTest, WavesPerEuUnsetWhenMetadataIsNotValidJson) {
+  mlir::MLIRContext ctx;
+  TritonCall call = TritonCall::Parse(
+      BackendConfig(R"(serialized_metadata = "not-json")"), &ctx);
+  EXPECT_EQ(call.waves_per_eu, 0);
+}
+
+}  // namespace
+}  // namespace xla::gpu


### PR DESCRIPTION
📝 Summary of Changes
Parses an optional waves_per_eu value from the serialized_metadata JSON on Triton custom calls and threads it through to the ROCm amdgpu-waves-per-eu LLVM function attribute when emitting the kernel.

🎯 Justification
Makes possible to tune kernel occupancy (waves_per_eu), form ROCm/JAX Pallas, for Triton kernels using the existing metadata mechanism

🚀 Kind of Contribution
Please remove what does not apply: ✨ New Feature, 🧪 Tests

🧪 Unit Tests:
triton_call_test.cc
