### PR TITLE
[ROCm] Add support of data files dependency to a wheel, required for rocm he…

### DIFF
--- a/third_party/py/py_import.bzl
+++ b/third_party/py/py_import.bzl
@@ -9,10 +9,21 @@ def _unpacked_wheel_impl(ctx):
     args.add("--wheel=%s" % wheel.path)
     args.add("--output_dir=%s" % output_dir.path)
     srcs = [wheel]
+
+    # Collect runfiles from wheel_deps for propagation
+    runfiles_depsets = []
     for d in ctx.attr.wheel_deps:
-        for f in d[DefaultInfo].default_runfiles.files.to_list():
-            srcs.append(f)
-            args.add("--wheel_files=%s" % (f.path))
+        # Collect default_runfiles and pass them to --wheel_files (for copying into wheel)
+        if hasattr(d[DefaultInfo], 'default_runfiles'):
+            default_files = d[DefaultInfo].default_runfiles.files
+            for f in default_files.to_list():
+                srcs.append(f)
+                args.add("--wheel_files=%s" % (f.path))
+
+        # Collect data_runfiles for propagation to tests (not copied into wheel)
+        if hasattr(d[DefaultInfo], 'data_runfiles'):
+            runfiles_depsets.append(d[DefaultInfo].data_runfiles)
+
     for z in ctx.files.zip_deps:
         srcs.append(z)
         args.add("--zip_files=%s" % (z.path))
@@ -27,7 +38,10 @@ def _unpacked_wheel_impl(ctx):
     )
 
     return [
-        DefaultInfo(files = depset([output_dir])),
+        DefaultInfo(
+            files = depset([output_dir]),
+            runfiles = ctx.runfiles(files = [output_dir]).merge_all(runfiles_depsets),
+        ),
     ]
 
 _unpacked_wheel = rule(

--- a/third_party/py/py_import.bzl
+++ b/third_party/py/py_import.bzl
@@ -9,21 +9,10 @@ def _unpacked_wheel_impl(ctx):
     args.add("--wheel=%s" % wheel.path)
     args.add("--output_dir=%s" % output_dir.path)
     srcs = [wheel]
-
-    # Collect runfiles from wheel_deps for propagation
-    runfiles_depsets = []
     for d in ctx.attr.wheel_deps:
-        # Collect default_runfiles and pass them to --wheel_files (for copying into wheel)
-        if hasattr(d[DefaultInfo], 'default_runfiles'):
-            default_files = d[DefaultInfo].default_runfiles.files
-            for f in default_files.to_list():
-                srcs.append(f)
-                args.add("--wheel_files=%s" % (f.path))
-
-        # Collect data_runfiles for propagation to tests (not copied into wheel)
-        if hasattr(d[DefaultInfo], 'data_runfiles'):
-            runfiles_depsets.append(d[DefaultInfo].data_runfiles)
-
+        for f in d[DefaultInfo].default_runfiles.files.to_list():
+            srcs.append(f)
+            args.add("--wheel_files=%s" % (f.path))
     for z in ctx.files.zip_deps:
         srcs.append(z)
         args.add("--zip_files=%s" % (z.path))
@@ -38,10 +27,7 @@ def _unpacked_wheel_impl(ctx):
     )
 
     return [
-        DefaultInfo(
-            files = depset([output_dir]),
-            runfiles = ctx.runfiles(files = [output_dir]).merge_all(runfiles_depsets),
-        ),
+        DefaultInfo(files = depset([output_dir])),
     ]
 
 _unpacked_wheel = rule(
@@ -75,7 +61,7 @@ def py_import(
     )
     py_library(
         name = name,
-        data = [":" + unpacked_wheel_name],
+        data = [":" + unpacked_wheel_name] + wheel_deps,
         imports = [unpacked_wheel_name],
         deps = deps,
         visibility = ["//visibility:public"],

--- a/third_party/py/python_wheel.bzl
+++ b/third_party/py/python_wheel.bzl
@@ -237,9 +237,12 @@ def _collect_data_files_impl(ctx):
     for symlink_dep in ctx.attr.symlink_deps:
         for f in symlink_dep[FilePathInfo].files.to_list():
             files[f] = True
-    return [DefaultInfo(files = depset(
-        files.keys(),
-    ))]
+
+    files_depset = depset(files.keys())
+    return [DefaultInfo(
+        files = files_depset,
+        runfiles = ctx.runfiles(files = files_depset.to_list()),
+    )]
 
 collect_data_files = rule(
     implementation = _collect_data_files_impl,

--- a/third_party/py/python_wheel.bzl
+++ b/third_party/py/python_wheel.bzl
@@ -241,7 +241,7 @@ def _collect_data_files_impl(ctx):
     files_depset = depset(files.keys())
     return [DefaultInfo(
         files = files_depset,
-        runfiles = ctx.runfiles(files = files_depset.to_list()),
+        runfiles = ctx.runfiles(transitive_files = files_depset),
     )]
 
 collect_data_files = rule(


### PR DESCRIPTION
…rmetic builds

📝 Summary of Changes
Add support of transitive data dependency to the wheel targets

🎯 Justification
Rocm builds require rocm libs in its runfiles dir to be able to
be built executed in a hermetic manner. Therefore we propagate
data dependency from the rocm libs

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix,

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
