### PR TITLE
[XLA:GPU][codegen] Add SPIR-V barrier type for codegen tests

### DIFF
--- a/xla/backends/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/xla/backends/gpu/tests/gpu_kernel_tiling_test.cc
@@ -84,7 +84,7 @@ TEST_F(GpuKernelTilingTest, UnnestedTransposeWithProperDimensionsTiled) {
           .value();
 
   auto expected_ir = R"(
-; CHECK: call void BARRIER()
+; CHECK: call BARRIER()
 )";
   ASSERT_OK(CompileAndVerifyIr(std::move(hlo_module),
                                MakePlatformSpecificLlvm(expected_ir),
@@ -110,7 +110,7 @@ TEST_F(GpuKernelTilingTest, UnnestedTransposeWithSmallDimensionsNotTiled) {
       ParseAndReturnVerifiedModule(kHloString, ConfigWithLayoutAssignment())
           .value();
   auto expected_ir = R"(
-; CHECK-NOT: call void BARRIER()
+; CHECK-NOT: call BARRIER()
 )";
   EXPECT_OK(CompileAndVerifyIr(std::move(hlo_module),
                                MakePlatformSpecificLlvm(expected_ir),
@@ -130,7 +130,7 @@ TEST_F(GpuKernelTilingTest, UnnestedTransposeC128TypeRun) {
       ParseAndReturnVerifiedModule(kHloString, ConfigWithLayoutAssignment())
           .value();
   auto expected_ir = R"(
-; CHECK: call void BARRIER()
+; CHECK: call BARRIER()
 )";
   ASSERT_OK(CompileAndVerifyIr(std::move(hlo_module),
                                MakePlatformSpecificLlvm(expected_ir),
@@ -161,7 +161,7 @@ TEST_F(GpuKernelTilingTest, SimpleFusionWithTransposeTiled) {
   // Check that a call to llvm.nvvm.barrier0 is generated.
   auto expected_ir = R"(
 ; CHECK-LABEL: define KERNEL_ANNOTATION @{{[a-z_]*}}fusion
-; CHECK: call void BARRIER()
+; CHECK: call BARRIER()
 ; CHECK: }
 )";
   ASSERT_OK(CompileAndVerifyIr(std::move(hlo_module),
@@ -197,7 +197,7 @@ TEST_F(GpuKernelTilingTest, MultipleOutputFusionWithOnePossibleTransposeTiled) {
           .value();
   auto expected_ir = R"(
 ; CHECK-LABEL: define KERNEL_ANNOTATION @{{[a-z_]*}}fusion
-; CHECK: call void BARRIER()
+; CHECK: call BARRIER()
 ; CHECK: }
 )";
   ASSERT_OK(CompileAndVerifyIr(std::move(hlo_module),
@@ -229,7 +229,7 @@ TEST_F(GpuKernelTilingTest, TransposedInputWithUserReverseNotTiled) {
           .value();
   auto expected_ir = R"(
 ; CHECK-LABEL: define KERNEL_ANNOTATION @{{[a-z_]*}}fusion
-; CHECK-NOT: call void BARRIER()
+; CHECK-NOT: call BARRIER()
 ; CHECK: }
 )";
   EXPECT_OK(CompileAndVerifyIr(std::move(hlo_module),
@@ -258,7 +258,7 @@ TEST_F(GpuKernelTilingTest, TransposedInputWithUserBitcastNotTiled) {
           .value();
   auto expected_ir = R"(
 ; CHECK-LABEL: define KERNEL_ANNOTATION @{{[a-z_]*}}fusion
-; CHECK-NOT: call void BARRIER()
+; CHECK-NOT: call BARRIER()
 ; CHECK: }
 )";
   ASSERT_OK(CompileAndVerifyIr(std::move(hlo_module),
@@ -295,7 +295,7 @@ TEST_F(GpuKernelTilingTest, TransposedInputWithoutUnsafeUseTiled) {
           .value();
   auto expected_ir = R"(
 ; CHECK-LABEL: define KERNEL_ANNOTATION @{{[a-z_]*}}fusion
-; CHECK: call void BARRIER()
+; CHECK: call BARRIER()
 ; CHECK: }
 )";
   ASSERT_OK(CompileAndVerifyIr(std::move(hlo_module),
@@ -519,12 +519,18 @@ TEST_F(GpuKernelTilingTest, ReductionInputTooLarge) {
   absl::Status status =
       CompileToExecutable(std::move(hlo_module), true).status();
 
-  if (xla::PlatformUtil::CanonicalPlatformName("gpu").value() == "rocm") {
+  std::string platform_name =
+      xla::PlatformUtil::CanonicalPlatformName("gpu").value();
+  if (platform_name == "rocm") {
     EXPECT_THAT(
         status.message(),
         ::testing::ContainsRegex(
             "Kernel '.*' launch needs more blocks [(]4294967296, 65536[)] "
             "than allowed by hardware [(]2147483647, 65536[)]"));
+  } else if (platform_name == "sycl") {
+    // oneAPI has a higher block-count limit than CUDA/ROCm, so this should
+    // compile successfully.
+    EXPECT_OK(status);
   } else {
     EXPECT_THAT(status.message(),
                 ::testing::ContainsRegex(

--- a/xla/backends/gpu/tests/gpu_pjrt_codegen_test.cc
+++ b/xla/backends/gpu/tests/gpu_pjrt_codegen_test.cc
@@ -85,11 +85,8 @@ std::string GpuPjRtCodegenTest::MakePlatformSpecificLlvm(
     absl::string_view input) {
   return absl::StrReplaceAll(
       input,
-      {{"KERNEL_ANNOTATION",
-        IsBuiltWithRocm() ? "amdgpu_kernel void" : "ptx_kernel void"},
-       {"BARRIER()", IsBuiltWithRocm()
-                         ? "@llvm.amdgcn.s.barrier()"
-                         : "@llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)"},
+      {{"KERNEL_ANNOTATION", GpuKernelType() + " void"},
+       {"BARRIER()", GpuBarrier()},
        {"SHUFFLE", IsBuiltWithRocm() ? "i32 @llvm.amdgcn.ds.swizzle"
                                      : "float @llvm.nvvm.shfl.sync.down.f32"},
        {"TIDX", IsBuiltWithRocm() ? "@llvm.amdgcn.workitem.id.x"

--- a/xla/backends/gpu/tests/gpu_pjrt_codegen_test.h
+++ b/xla/backends/gpu/tests/gpu_pjrt_codegen_test.h
@@ -102,6 +102,16 @@ class GpuPjRtCodegenTest : public HloPjRtGpuTestBase {
     return "ptx_kernel";
   }
 
+  std::string GpuBarrier() const {
+    if (IsBuiltWithRocm()) {
+      return "void @llvm.amdgcn.s.barrier()";
+    }
+    if (IsBuiltWithOneAPI()) {
+      return "spir_func void @_Z7barrierj(i32 3)";
+    }
+    return "void @llvm.nvvm.barrier.cta.sync.aligned.all(i32 0)";
+  }
+
  private:
   Compiler::CompileOptions compile_options_;
   HloRunnerPropertyTag::Type runner_type_{0};


### PR DESCRIPTION
This PR adds a utility function that returns backend specific barrier types for GPU codegen tests. It fixes filecheck errors in tests like `xla/backends/gpu/tests/gpu_kernel_tiling_test.cc` for sycl backend.