### PR TITLE
[GPU] Reroute external hero users to the fusion output in DSFv2 rewriter

### DIFF
--- a/xla/backends/gpu/tests/dynamic_slice_fusion_v2_test.cc
+++ b/xla/backends/gpu/tests/dynamic_slice_fusion_v2_test.cc
@@ -28,6 +28,10 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/while_loop.h"
 #include "xla/backends/gpu/tests/hlo_pjrt_gpu_test_base.h"
 #include "xla/ffi/ffi.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/literal.h"
 #include "xla/literal_util.h"
 #include "xla/shape_util.h"
@@ -103,6 +107,7 @@ class DynamicSliceFusionV2Test : public HloPjRtGpuTestBase {
  protected:
   DebugOptions GetDebugOptionsForTest() const override {
     DebugOptions debug_options = HloPjRtGpuTestBase::GetDebugOptionsForTest();
+    debug_options.set_xla_gpu_enable_dynamic_slice_fusion(true);
     debug_options.set_xla_gpu_experimental_dynamic_slice_fusion_verify_offsets(
         true);
     return debug_options;
@@ -170,6 +175,71 @@ TEST_F(DynamicSliceFusionV2Test, SingleOutputOneDUS) {
       Literal result, Execute(std::move(*ParseAndReturnVerifiedModule(hlo)), {},
                               /*run_hlo_passes=*/false));
   EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
+}
+
+TEST_F(DynamicSliceFusionV2Test, HeroWithExternalUserRunsOncePerIteration) {
+  // A duplicate hero surviving the rewrite would show up in the optimized
+  // HLO as a second custom-call and skew the accumulated result.
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      param = (s32[], f32[64], f32[4,64]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      res = f32[64] get-tuple-element(param), index=1
+      buf = f32[4,64] get-tuple-element(param), index=2
+      hero = f32[64] custom-call(res),
+        custom_call_target="__xla_test$$memset_const",
+        api_version=API_VERSION_TYPED_FFI,
+        backend_config="{value = 7.0 : f32}"
+      hero_2d = f32[1,64] reshape(hero)
+      zero = s32[] constant(0)
+      updated = f32[4,64] dynamic-update-slice(buf, hero_2d, i, zero)
+      new_res = f32[64] add(res, hero)
+      one = s32[] constant(1)
+      next_i = s32[] add(i, one)
+      ROOT tuple = (s32[], f32[64], f32[4,64]) tuple(next_i, new_res, updated)
+    }
+
+    cond {
+      param = (s32[], f32[64], f32[4,64]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      limit = s32[] constant(4)
+      ROOT cmp = pred[] compare(i, limit), direction=LT
+    }
+
+    ENTRY main {
+      zero = s32[] constant(0)
+      init_res = f32[64] broadcast(f32[] constant(0)), dimensions={}
+      init_buf = f32[4,64] broadcast(f32[] constant(0)), dimensions={}
+      init = (s32[], f32[64], f32[4,64]) tuple(zero, init_res, init_buf)
+      ROOT while = (s32[], f32[64], f32[4,64])
+        while(init), condition=cond, body=body
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(
+      Literal result, Execute(std::move(*ParseAndReturnVerifiedModule(hlo)), {},
+                              /*run_hlo_passes=*/true));
+
+  Literal expected = LiteralUtil::MakeTupleOwned(
+      LiteralUtil::CreateR0<int32_t>(4),
+      LiteralUtil::CreateFullWithDescendingLayout<float>({64}, 28.0f),
+      LiteralUtil::CreateFullWithDescendingLayout<float>({4, 64}, 7.0f));
+  EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
+
+  // A duplicate of the hero surviving the rewrite is visible in the optimized
+  // HLO as a second custom-call next to the one inside the fusion.
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> optimized,
+                       GetOptimizedModule(hlo));
+  int64_t hero_count = 0;
+  for (const HloComputation* computation : optimized->computations()) {
+    for (const HloInstruction* instr : computation->instructions()) {
+      hero_count += instr->opcode() == HloOpcode::kCustomCall &&
+                    instr->custom_call_target() == "__xla_test$$memset_const";
+    }
+  }
+  EXPECT_EQ(hero_count, 1);
 }
 
 TEST_F(DynamicSliceFusionV2Test, SingleOutputOneDUSWithOffsetExpression) {

--- a/xla/backends/gpu/tests/dynamic_slice_fusion_v2_test.cc
+++ b/xla/backends/gpu/tests/dynamic_slice_fusion_v2_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 #include <gmock/gmock.h>
@@ -178,8 +179,8 @@ TEST_F(DynamicSliceFusionV2Test, SingleOutputOneDUS) {
 }
 
 TEST_F(DynamicSliceFusionV2Test, HeroWithExternalUserRunsOncePerIteration) {
-  // A duplicate hero surviving the rewrite would show up in the optimized
-  // HLO as a second custom-call and skew the accumulated result.
+  // A surviving duplicate computes identical values -- a pure performance
+  // defect, visible as a second custom-call in the optimized HLO.
   const char* hlo = R"(
     HloModule test
 
@@ -228,8 +229,6 @@ TEST_F(DynamicSliceFusionV2Test, HeroWithExternalUserRunsOncePerIteration) {
       LiteralUtil::CreateFullWithDescendingLayout<float>({4, 64}, 7.0f));
   EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
 
-  // A duplicate of the hero surviving the rewrite is visible in the optimized
-  // HLO as a second custom-call next to the one inside the fusion.
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> optimized,
                        GetOptimizedModule(hlo));
   int64_t hero_count = 0;

--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1663,6 +1663,7 @@ cc_library(
     hdrs = ["dynamic_slice_fusion_rewriter_v2.h"],
     tags = ["gpu"],
     deps = [
+        "//xla/hlo/analysis:hlo_reachability",
         ":dynamic_slice_fusion",
         "//xla:shape_util",
         "//xla/hlo/ir:hlo",

--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1663,7 +1663,7 @@ cc_library(
     hdrs = ["dynamic_slice_fusion_rewriter_v2.h"],
     tags = ["gpu"],
     deps = [
-        "//xla/hlo/analysis:hlo_reachability",
+        "//xla/hlo/analysis:hlo_dfs_reachability",
         ":dynamic_slice_fusion",
         "//xla:shape_util",
         "//xla/hlo/ir:hlo",

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.h"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -34,6 +35,7 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/transforms/dynamic_slice_fusion.h"
+#include "xla/hlo/analysis/hlo_reachability.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -665,6 +667,87 @@ absl::Status SetDynamicSliceFusionBackendConfig(HloInstruction* fusion) {
   return fusion->set_backend_config(std::move(gpu_config));
 }
 
+// Reroutes hero users outside the DUS chains, leaving the original hero dead.
+absl::Status RerouteExternalUsers(
+    HloInstruction* hero, HloInstruction* fusion,
+    absl::Span<const SlicedResult> sliced_results) {
+  HloComputation* parent = fusion->parent();
+  bool tuple_hero = hero->shape().IsTuple();
+
+  if (tuple_hero) {
+    // Non-GTE consumers need the raw tuple, which the fusion lacks; skip.
+    if (absl::c_any_of(hero->users(), [](const HloInstruction* user) {
+          return user->opcode() != HloOpcode::kGetTupleElement;
+        })) {
+      VLOG(2) << "Not rerouting " << hero->name() << ": non-GTE tuple user";
+      return absl::OkStatus();
+    }
+    // Fold duplicate GTEs into the resolved one so each result has one head.
+    absl::flat_hash_map<int64_t, HloInstruction*> canonical;
+    for (const SlicedResult& sliced_result : sliced_results) {
+      if (!sliced_result.noops.empty())
+        canonical[sliced_result.result_number] = sliced_result.noops.front();
+    }
+    std::vector<HloInstruction*> users(hero->users().begin(),
+                                       hero->users().end());
+    for (HloInstruction* user : users) {
+      auto* gte = Cast<HloGetTupleElementInstruction>(user);
+      auto [it, inserted] = canonical.try_emplace(gte->tuple_index(), gte);
+      if (inserted || it->second == gte) continue;
+      RETURN_IF_ERROR(gte->ReplaceAllUsesWith(it->second));
+      RETURN_IF_ERROR(parent->RemoveInstruction(gte));
+    }
+  }
+
+  // Rerouting a user that (transitively) feeds the fusion would create a
+  // cycle; such users keep reading the original hero.
+  std::unique_ptr<HloReachabilityMap> reachability =
+      HloReachabilityMap::Build(parent);
+
+  for (const SlicedResult& sliced_result : sliced_results) {
+    if (sliced_result.update_slice == nullptr) {
+      continue;  // RewriteHero's GTE replacement covers these.
+    }
+    // Noops are single-user, so exactly one user of head continues the chain.
+    HloInstruction* head = hero;
+    absl::Span<HloInstruction* const> tail = sliced_result.noops;
+    if (tuple_hero) {
+      head = tail.front();
+      tail.remove_prefix(1);
+    }
+    HloInstruction* chain_user =
+        tail.empty() ? sliced_result.update_slice : tail.front();
+    std::vector<HloInstruction*> external_users;
+    for (HloInstruction* user : head->users()) {
+      if (user != chain_user && !reachability->IsReachable(user, fusion)) {
+        external_users.push_back(user);
+      }
+    }
+    if (external_users.empty()) continue;
+
+    HloInstruction* slot =
+        fusion->shape().IsTuple()
+            ? parent->AddInstruction(HloInstruction::CreateGetTupleElement(
+                  fusion, sliced_result.result_number))
+            : fusion;
+    const Shape& update_shape = sliced_result.update_slice->operand(1)->shape();
+    HloInstruction* value =
+        parent->AddInstruction(HloInstruction::CreateDynamicSlice(
+            update_shape, slot,
+            Cast<HloDynamicUpdateSliceInstruction>(sliced_result.update_slice)
+                ->index_operands(),
+            update_shape.dimensions()));
+    if (!ShapeUtil::Equal(head->shape(), update_shape)) {
+      value = parent->AddInstruction(
+          HloInstruction::CreateBitcast(head->shape(), value));
+    }
+    VLOG(2) << "Rerouted " << external_users.size() << " external user(s) of "
+            << head->name() << " to " << value->name();
+    RETURN_IF_ERROR(head->ReplaceUsesWith(external_users, value));
+  }
+  return absl::OkStatus();
+}
+
 //===----------------------------------------------------------------------===//
 // Rewrite sync hero
 //===----------------------------------------------------------------------===//
@@ -688,6 +771,9 @@ absl::StatusOr<bool> RewriteHero(
                                    plan->external_operands, fusion_body));
   module->SetAndUniquifyInstrName(fusion, "dynamic_slice_fusion");
   RETURN_IF_ERROR(SetDynamicSliceFusionBackendConfig(fusion));
+
+  // Must run before the DUS chains are replaced below (it reads DUS operands).
+  RETURN_IF_ERROR(RerouteExternalUsers(hero, fusion, sliced_results));
 
   if (sliced_results.size() > 1) {
     bool any_result_replaced = false;

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2.cc
@@ -35,7 +35,7 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/transforms/dynamic_slice_fusion.h"
-#include "xla/hlo/analysis/hlo_reachability.h"
+#include "xla/hlo/analysis/hlo_dfs_reachability.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -667,6 +667,48 @@ absl::Status SetDynamicSliceFusionBackendConfig(HloInstruction* fusion) {
   return fusion->set_backend_config(std::move(gpu_config));
 }
 
+// Returns an existing GetTupleElement of `fusion` at `index`, or creates one.
+HloInstruction* GetOrCreateGte(HloInstruction* fusion, int64_t index) {
+  for (HloInstruction* user : fusion->users()) {
+    auto* gte = DynCast<HloGetTupleElementInstruction>(user);
+    if (gte != nullptr && gte->tuple_index() == index) {
+      return gte;
+    }
+  }
+  return fusion->parent()->AddInstruction(
+      HloInstruction::CreateGetTupleElement(fusion, index));
+}
+
+// Returns true if some consumer of the hero's values cannot be rerouted to
+// the fusion output: raw-tuple consumers, and consumers feeding a fusion
+// operand (rerouting those would form a cycle).
+bool HasUnroutableUsers(HloInstruction* hero,
+                        absl::Span<HloInstruction* const> fusion_operands) {
+  std::vector<HloInstruction*> heads;
+  if (hero->shape().IsTuple()) {
+    for (HloInstruction* user : hero->users()) {
+      if (user->opcode() != HloOpcode::kGetTupleElement) {
+        return true;
+      }
+      heads.push_back(user);
+    }
+  } else {
+    heads.push_back(hero);
+  }
+  std::unique_ptr<HloDfsReachability> reachability =
+      HloDfsReachability::Build(hero->parent());
+  for (HloInstruction* head : heads) {
+    for (HloInstruction* user : head->users()) {
+      for (const HloInstruction* operand : fusion_operands) {
+        if (reachability->IsReachable(user, operand)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
 // Reroutes hero users outside the DUS chains, leaving the original hero dead.
 absl::Status RerouteExternalUsers(
     HloInstruction* hero, HloInstruction* fusion,
@@ -675,40 +717,32 @@ absl::Status RerouteExternalUsers(
   bool tuple_hero = hero->shape().IsTuple();
 
   if (tuple_hero) {
-    // Non-GTE consumers need the raw tuple, which the fusion lacks; skip.
-    if (absl::c_any_of(hero->users(), [](const HloInstruction* user) {
-          return user->opcode() != HloOpcode::kGetTupleElement;
-        })) {
-      VLOG(2) << "Not rerouting " << hero->name() << ": non-GTE tuple user";
-      return absl::OkStatus();
-    }
     // Fold duplicate GTEs into the resolved one so each result has one head.
     absl::flat_hash_map<int64_t, HloInstruction*> canonical;
     for (const SlicedResult& sliced_result : sliced_results) {
-      if (!sliced_result.noops.empty())
+      if (!sliced_result.noops.empty()) {
         canonical[sliced_result.result_number] = sliced_result.noops.front();
+      }
     }
     std::vector<HloInstruction*> users(hero->users().begin(),
                                        hero->users().end());
     for (HloInstruction* user : users) {
       auto* gte = Cast<HloGetTupleElementInstruction>(user);
       auto [it, inserted] = canonical.try_emplace(gte->tuple_index(), gte);
-      if (inserted || it->second == gte) continue;
+      if (inserted || it->second == gte) {
+        continue;
+      }
       RETURN_IF_ERROR(gte->ReplaceAllUsesWith(it->second));
       RETURN_IF_ERROR(parent->RemoveInstruction(gte));
     }
   }
-
-  // Rerouting a user that (transitively) feeds the fusion would create a
-  // cycle; such users keep reading the original hero.
-  std::unique_ptr<HloReachabilityMap> reachability =
-      HloReachabilityMap::Build(parent);
 
   for (const SlicedResult& sliced_result : sliced_results) {
     if (sliced_result.update_slice == nullptr) {
       continue;  // RewriteHero's GTE replacement covers these.
     }
     // Noops are single-user, so exactly one user of head continues the chain.
+    // Tuple heroes carry their GTE as noops[0]; heads are never tuple-shaped.
     HloInstruction* head = hero;
     absl::Span<HloInstruction* const> tail = sliced_result.noops;
     if (tuple_hero) {
@@ -719,16 +753,17 @@ absl::Status RerouteExternalUsers(
         tail.empty() ? sliced_result.update_slice : tail.front();
     std::vector<HloInstruction*> external_users;
     for (HloInstruction* user : head->users()) {
-      if (user != chain_user && !reachability->IsReachable(user, fusion)) {
+      if (user != chain_user) {
         external_users.push_back(user);
       }
     }
-    if (external_users.empty()) continue;
+    if (external_users.empty()) {
+      continue;
+    }
 
     HloInstruction* slot =
         fusion->shape().IsTuple()
-            ? parent->AddInstruction(HloInstruction::CreateGetTupleElement(
-                  fusion, sliced_result.result_number))
+            ? GetOrCreateGte(fusion, sliced_result.result_number)
             : fusion;
     const Shape& update_shape = sliced_result.update_slice->operand(1)->shape();
     HloInstruction* value =
@@ -761,6 +796,12 @@ absl::StatusOr<bool> RewriteHero(
     return false;
   }
 
+  // Skip the rewrite entirely rather than leave a duplicated hero.
+  if (HasUnroutableUsers(hero, plan->external_operands)) {
+    VLOG(2) << "Skipping " << hero->name() << ": unroutable users";
+    return false;
+  }
+
   ASSIGN_OR_RETURN(HloComputation * fusion_body,
                    CreateFusionBody(module, *plan, sliced_results, hero));
 
@@ -778,8 +819,7 @@ absl::StatusOr<bool> RewriteHero(
   if (sliced_results.size() > 1) {
     bool any_result_replaced = false;
     for (int64_t i = 0; i < sliced_results.size(); ++i) {
-      auto* gte = parent->AddInstruction(
-          HloInstruction::CreateGetTupleElement(fusion, i));
+      HloInstruction* gte = GetOrCreateGte(fusion, i);
       if (sliced_results[i].update_slice != nullptr) {
         RETURN_IF_ERROR(
             parent->ReplaceInstruction(sliced_results[i].update_slice, gte));

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
@@ -640,6 +640,64 @@ TEST_F(DynamicSliceFusionRewriterV2Test, DUSOnlyNoSlicedInput) {
   RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected, fusion_checks);
 }
 
+TEST_F(DynamicSliceFusionRewriterV2Test, HeroWithExternalUserIsRerouted) {
+  // The rewriter must reroute the residual add and leave the hero dead.
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      param = (s32[], f32[64], f32[4,64]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      res = f32[64] get-tuple-element(param), index=1
+      buf = f32[4,64] get-tuple-element(param), index=2
+      hero = f32[64] custom-call(res), custom_call_target="fake_target"
+      hero_2d = f32[1,64] bitcast(hero)
+      zero = s32[] constant(0)
+      updated = f32[4,64] dynamic-update-slice(buf, hero_2d, i, zero)
+      new_res = f32[64] add(res, hero)
+      one = s32[] constant(1)
+      next_i = s32[] add(i, one)
+      ROOT tuple = (s32[], f32[64], f32[4,64]) tuple(next_i, new_res, updated)
+    }
+
+    cond {
+      param = (s32[], f32[64], f32[4,64]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      limit = s32[] constant(4)
+      ROOT cmp = pred[] compare(i, limit), direction=LT
+    }
+
+    ENTRY main {
+      res = f32[64] parameter(0)
+      buf = f32[4,64] parameter(1)
+      zero = s32[] constant(0)
+      init = (s32[], f32[64], f32[4,64]) tuple(zero, res, buf)
+      ROOT while = (s32[], f32[64], f32[4,64]) while(init),
+          condition=cond, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  // No custom-call outside the fusion; the add reads back via dynamic-slice.
+  const char* expected = R"(
+    ; CHECK:     %dynamic-slice-fusion{{.*}} {
+    ; CHECK:       {{.*}} custom-call(
+    ; CHECK:              custom_call_target="fake_target"
+    ; CHECK:       ROOT {{.*}} dynamic-update-slice(
+    ; CHECK:     }
+    ; CHECK:     body
+    ; CHECK-NOT:   custom-call(
+    ; CHECK:       {{.*}} = f32[1,64]{{.*}} dynamic-slice(
+    ; CHECK:       {{.*}} = f32[64]{{.*}} add(
+    ; CHECK-NOT:   custom-call(
+    ; CHECK:       ROOT
+  )";
+
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected);
+}
+
 TEST_F(DynamicSliceFusionRewriterV2Test, DUSWithConstantOffset) {
   const char* hlo = R"(
     HloModule test
@@ -2544,6 +2602,59 @@ TEST_F(DynamicSliceFusionRewriterV2Test, O2LooksThroughOptBarrier) {
 
   RunAndFilecheckHloRewrite(hlo, MakePipeline(OptLevel::kO2), expected,
                             fusion_checks);
+}
+
+TEST_F(DynamicSliceFusionRewriterV2Test,
+       ExternalUserFeedingFusionIsNotRerouted) {
+  // The hero's external user is also the DUS target buffer; rerouting it to
+  // the fusion output would create a cycle, so it keeps the original hero.
+  const char* hlo = R"(
+    HloModule test
+
+    body {
+      param = (s32[], f32[64], f32[4,64]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      res = f32[64] get-tuple-element(param), index=1
+      hero = f32[64] custom-call(res), custom_call_target="fake_target"
+      buf = f32[4,64] broadcast(hero), dimensions={1}
+      hero_2d = f32[1,64] bitcast(hero)
+      zero = s32[] constant(0)
+      updated = f32[4,64] dynamic-update-slice(buf, hero_2d, i, zero)
+      one = s32[] constant(1)
+      next_i = s32[] add(i, one)
+      ROOT tuple = (s32[], f32[64], f32[4,64]) tuple(next_i, res, updated)
+    }
+
+    cond {
+      param = (s32[], f32[64], f32[4,64]) parameter(0)
+      i = s32[] get-tuple-element(param), index=0
+      limit = s32[] constant(4)
+      ROOT cmp = pred[] compare(i, limit), direction=LT
+    }
+
+    ENTRY main {
+      res = f32[64] parameter(0)
+      buf = f32[4,64] parameter(1)
+      zero = s32[] constant(0)
+      init = (s32[], f32[64], f32[4,64]) tuple(zero, res, buf)
+      ROOT while = (s32[], f32[64], f32[4,64]) while(init),
+          condition=cond, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    }
+  )";
+
+  // The fusion forms, and the broadcast still consumes the original hero.
+  const char* expected = R"(
+    ; CHECK: %dynamic-slice-fusion{{.*}} {
+    ; CHECK:   ROOT {{.*}} dynamic-update-slice(
+    ; CHECK: }
+    ; CHECK: body
+    ; CHECK:   %hero = {{.*}} custom-call(
+    ; CHECK:   {{.*}} = f32[4,64]{{.*}} broadcast(%hero)
+  )";
+  RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected);
 }
 
 }  // namespace

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
@@ -2605,9 +2605,9 @@ TEST_F(DynamicSliceFusionRewriterV2Test, O2LooksThroughOptBarrier) {
 }
 
 TEST_F(DynamicSliceFusionRewriterV2Test,
-       ExternalUserFeedingFusionIsNotRerouted) {
+       ExternalUserFeedingFusionSkipsRewrite) {
   // The hero's external user is also the DUS target buffer; rerouting it to
-  // the fusion output would create a cycle, so it keeps the original hero.
+  // the fusion output would create a cycle, so the rewrite is skipped.
   const char* hlo = R"(
     HloModule test
 
@@ -2645,14 +2645,11 @@ TEST_F(DynamicSliceFusionRewriterV2Test,
     }
   )";
 
-  // The fusion forms, and the broadcast still consumes the original hero.
   const char* expected = R"(
-    ; CHECK: %dynamic-slice-fusion{{.*}} {
-    ; CHECK:   ROOT {{.*}} dynamic-update-slice(
-    ; CHECK: }
-    ; CHECK: body
-    ; CHECK:   %hero = {{.*}} custom-call(
-    ; CHECK:   {{.*}} = f32[4,64]{{.*}} broadcast(%hero)
+    ; CHECK-NOT: dynamic-slice-fusion
+    ; CHECK:     %hero = {{.*}} custom-call(
+    ; CHECK:     {{.*}} = f32[4,64]{{.*}} broadcast(%hero)
+    ; CHECK-NOT: dynamic-slice-fusion
   )";
   RunAndFilecheckHloRewrite(hlo, MakePipeline(), expected);
 }

--- a/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_fusion_rewriter_v2_test.cc
@@ -1915,8 +1915,8 @@ TEST_F(DynamicSliceFusionRewriterV2Test,
 
 TEST_F(DynamicSliceFusionRewriterV2Test, TupleOutputOneDUS) {
   // Hero produces (f32[8,8], f32[8,8]). Only the first output flows through
-  // DUS; the second is returned directly (passthrough). The fusion output
-  // must be a tuple containing both the DUS result and the passthrough GTE.
+  // DUS. External users of the sliced and passthrough outputs must read the
+  // corresponding fusion outputs.
   const char* hlo = R"(
     HloModule test
 
@@ -1930,11 +1930,13 @@ TEST_F(DynamicSliceFusionRewriterV2Test, TupleOutputOneDUS) {
           custom_call_target="fake_target"
       gte0 = f32[8,8] get-tuple-element(hero), index=0
       gte1 = f32[8,8] get-tuple-element(hero), index=1
+      gte0_external = f32[8,8] get-tuple-element(hero), index=0
       bc0 = f32[1,8,8] bitcast(gte0)
       dus = f32[4,8,8] dynamic-update-slice(buf, bc0, ivar, c0, c0)
+      new_prev = f32[8,8] add(gte0_external, gte1)
       c1 = s32[] constant(1)
       next_ivar = s32[] add(ivar, c1)
-      ROOT result = (s32[], f32[4,8,8], f32[8,8]) tuple(next_ivar, dus, gte1)
+      ROOT result = (s32[], f32[4,8,8], f32[8,8]) tuple(next_ivar, dus, new_prev)
     }
 
     condition {
@@ -1968,9 +1970,14 @@ TEST_F(DynamicSliceFusionRewriterV2Test, TupleOutputOneDUS) {
     ; CHECK:       ROOT {{.*}} tuple(
     ; CHECK:     }
     ; CHECK:     body
-    ; CHECK:       {{.*}} fusion(
+    ; CHECK:       [[FUSION:%[^ ]+]] = {{.*}} fusion(
     ; CHECK-SAME:         kind=kCustom
     ; CHECK-SAME:         "name":"dynamic_slice_fusion"
+    ; CHECK:       [[GTE0:%[^ ]+]] = f32[4,8,8]{{.*}} get-tuple-element([[FUSION]]), index=0
+    ; CHECK:       [[DS:%[^ ]+]] = f32[1,8,8]{{.*}} dynamic-slice([[GTE0]],
+    ; CHECK:       [[BC:%[^ ]+]] = f32[8,8]{{.*}} bitcast([[DS]])
+    ; CHECK:       [[GTE1:%[^ ]+]] = f32[8,8]{{.*}} get-tuple-element([[FUSION]]), index=1
+    ; CHECK:       {{.*}} = f32[8,8]{{.*}} add([[BC]], [[GTE1]])
     ; CHECK:     }
   )";
 


### PR DESCRIPTION
📝 Summary of Changes
Reroute other users of DSF hero to the fusion result, so the original hero can be removed.

🎯 Justification
DSFv2 moved hero into the fusion and removes the original hero, but the original hero cannot be removed if it has other users outside the chain. The will cause duplicated hero operations.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
Added.

🧪 Execution Tests:
Added.
