### PR TITLE
[ROCm] Remove native suppoprt for exp gfx1250 because of accuracy issue

### DIFF
--- a/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
@@ -71,9 +71,6 @@ namespace {
 
 namespace se = ::stream_executor;
 
-// log2(e), used to express exp(x) = exp2(x * log2(e)).
-constexpr double kLog2E = 1.4426950408889634;
-
 // ln(2), used to express log(x) = log2(x) * ln(2).
 constexpr double kLn2 = 0.6931471805599453;
 
@@ -107,34 +104,6 @@ struct TranscendentalBF16ToAMDGPU : public mlir::ConvertOpToLLVMPattern<OpTy> {
   }
 
   llvm::StringRef intrinsic;
-};
-
-// Lowers a scalar bf16 `math.exp` to the native gfx1250 `v_exp_bf16`
-// instruction by rewriting exp(x) = exp2(x * log2(e)) and emitting the
-// `llvm.amdgcn.exp2` intrinsic. See TranscendentalBF16ToAMDGPU for the
-// rationale.
-struct ExpBF16ToAMDGPU
-    : public mlir::ConvertOpToLLVMPattern<mlir::math::ExpOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
-
-  mlir::LogicalResult matchAndRewrite(
-      mlir::math::ExpOp op, OpAdaptor adaptor,
-      mlir::ConversionPatternRewriter& rewriter) const override {
-    if (!op.getType().isBF16()) {
-      return rewriter.notifyMatchFailure(op, "not a scalar bf16 exp");
-    }
-    mlir::Location loc = op.getLoc();
-    mlir::Value operand = adaptor.getOperands().front();
-    mlir::Type bf16 = operand.getType();
-    mlir::Value log2e = rewriter.create<mlir::LLVM::ConstantOp>(
-        loc, bf16, rewriter.getFloatAttr(bf16, kLog2E));
-    mlir::Value scaled =
-        rewriter.create<mlir::LLVM::FMulOp>(loc, operand, log2e);
-    rewriter.replaceOpWithNewOp<mlir::LLVM::CallIntrinsicOp>(
-        op, /*resultType=*/bf16, rewriter.getStringAttr("llvm.amdgcn.exp2"),
-        mlir::ValueRange{scaled});
-    return mlir::success();
-  }
 };
 
 // Lowers a scalar bf16 `math.log` to the native gfx1250 `v_log_bf16`
@@ -217,7 +186,6 @@ class LowerToLLVMGPUPass
                 .rocm_compute_capability()
                 .has_bf16_transcendental_support()) {
           mlir::PatternBenefit benefit(2);
-          patterns.add<ExpBF16ToAMDGPU>(converter, benefit);
           patterns.add<LogBF16ToAMDGPU>(converter, benefit);
           patterns.add<TranscendentalBF16ToAMDGPU<mlir::math::Exp2Op>>(
               converter, "llvm.amdgcn.exp2", benefit);

--- a/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
+++ b/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
@@ -18,21 +18,6 @@ module {
 
 // -----
 
-// A plain bf16 exp is rewritten to exp2(x * log2(e)) on gfx1250 so it also uses
-// the native instruction.
-module {
-  func.func @exp_bf16(%arg0: bf16) -> bf16 {
-    %0 = math.exp %arg0 : bf16
-    return %0 : bf16
-  }
-}
-
-// CHECK-LABEL: llvm.func @exp_bf16
-// CHECK: llvm.fmul
-// CHECK: llvm.call_intrinsic "llvm.amdgcn.exp2"({{.*}}) : (bf16) -> bf16
-
-// -----
-
 // gfx1250 has a native bf16 sqrt instruction (v_sqrt_bf16), reached via the
 // llvm.amdgcn.sqrt intrinsic.
 module {

--- a/xla/service/gpu/gpu_float_support.cc
+++ b/xla/service/gpu/gpu_float_support.cc
@@ -140,14 +140,7 @@ bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
     // Elementwise ops.
     case HloOpcode::kExp:
       if (LowPrecisionType() == BF16) {
-        if (compute_capability_.IsCuda()) {
-          return true;
-        }
-        // gfx1250 has a native bf16 exponential instruction, so there is no
-        // need to upcast bf16 exp to f32.
-        if (auto* rocm_cc = compute_capability_.rocm_compute_capability()) {
-          return rocm_cc->has_bf16_transcendental_support();
-        }
+        return compute_capability_.IsCuda();
       }
       return false;
     case HloOpcode::kLog:

--- a/xla/service/gpu/gpu_float_support_test.cc
+++ b/xla/service/gpu/gpu_float_support_test.cc
@@ -668,13 +668,23 @@ ENTRY main {
       ROOT r = bf16[4] $0(p0)
 })";
 
-  for (absl::string_view op : {"exponential", "log", "sqrt", "rsqrt", "tanh"}) {
+  for (absl::string_view op : {"log", "sqrt", "rsqrt", "tanh"}) {
     ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(
                                           absl::Substitute(kHloModule, op)));
     EXPECT_FALSE(
         Normalize(module.get(), se::GpuComputeCapability{cc}, BF16, F32))
         << "bf16 " << op << " should not be normalized on gfx1250";
   }
+
+  // bf16 exp is rewritten as exp2(x * log2(e)), whose rounded-to-bf16
+  // exponent gets exponentiated, so error grows (and can overflow to inf)
+  // with the input magnitude. It is kept on the f32 path rather than using
+  // the native v_exp_bf16 instruction directly.
+  ASSERT_OK_AND_ASSIGN(auto module_exp,
+                       ParseAndReturnVerifiedModule(
+                           absl::Substitute(kHloModule, "exponential")));
+  EXPECT_TRUE(
+      Normalize(module_exp.get(), se::GpuComputeCapability{cc}, BF16, F32));
 
   // sine has a native bf16 hardware instruction (v_sin_bf16) but is not yet
   // wired up in XLA (no lowering / gate), so it is still normalized to f32.

--- a/xla/stream_executor/rocm/rocm_compute_capability.h
+++ b/xla/stream_executor/rocm/rocm_compute_capability.h
@@ -202,7 +202,7 @@ class RocmComputeCapability {
   // Native bf16 transcendental instructions (v_exp_bf16, v_sqrt_bf16,
   // v_rsq_bf16, v_tanh_bf16, v_log_bf16, etc.), backed by the LLVM
   // FeatureBF16TransInsts subtarget feature. Lets us compute these bf16 ops
-  // without upcasting to f32 (currently used for exp, log, sqrt, rsqrt, tanh).
+  // without upcasting to f32 (currently used for log, sqrt, rsqrt, tanh).
   bool has_bf16_transcendental_support() const { return gfx1250(); }
 
   bool has_tdm_support() const { return gfx1250(); }


### PR DESCRIPTION
📝 Summary of Changes
Reverts native bf16 exp on gfx1250 so it normalizes to f32 again (partial revert of 8720220a5ff9)

🎯 Justification
exp was lowered as exp2(x·log2e), which rounds the exponent to bf16 and then exponentiates the error — accuracy issue

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, , 🧪 Tests

🧪 Unit Tests:
Updated gpu_float_support_test.cc

