### PR TITLE
[XLA:GPU] Don't let rank-0 dimension-size scalars inherit op sharding

### DIFF
--- a/xla/hlo/builder/xla_builder.cc
+++ b/xla/hlo/builder/xla_builder.cc
@@ -5016,9 +5016,10 @@ XlaOp XlaBuilder::GetDimensionSize(XlaOp operand, int64_t dimension) {
     ASSIGN_OR_RETURN(const Shape* operand_shape, GetShapePtr(operand));
     ASSIGN_OR_RETURN(Shape shape, ShapeInference::InferGetDimensionSizeShape(
                                       *operand_shape, dimension));
-    // Calling GetDimensionSize on a static dimension returns a constant
-    // instruction.
+    // A static dimension returns a rank-0 constant, which must not pick up the
+    // enclosing op's (possibly rank>0) sharding.
     if (operand_shape->is_static_dimension(dimension)) {
+      XlaScopedShardingAssignment scoped_sharding(this, std::nullopt);
       return ConstantR0<int32_t>(this, operand_shape->dimensions(dimension));
     }
     *instr.mutable_shape() = shape.ToProto();
@@ -5034,10 +5035,15 @@ XlaOp XlaBuilder::RemoveDynamicDimension(XlaOp operand, int64_t dimension) {
 
     Shape shape = *operand_shape;
     shape.set_dynamic_dimension(dimension, false);
-    // Setting an op's dynamic dimension to its static size removes the dynamic
-    // dimension.
-    XlaOp static_size =
-        ConstantR0<int32_t>(this, operand_shape->dimensions(dimension));
+    // Setting a dynamic dimension to its static size removes the dynamic
+    // dimension. The rank-0 size constant must not pick up the enclosing op's
+    // (possibly rank>0) sharding.
+    XlaOp static_size;
+    {
+      XlaScopedShardingAssignment scoped_sharding(this, std::nullopt);
+      static_size =
+          ConstantR0<int32_t>(this, operand_shape->dimensions(dimension));
+    }
     return SetDimensionSizeInternal(shape, operand, static_size, dimension);
   });
 }

--- a/xla/hlo/translate/mhlo_to_hlo/tests/sharding.mlir
+++ b/xla/hlo/translate/mhlo_to_hlo/tests/sharding.mlir
@@ -496,3 +496,16 @@ func.func @main() -> tensor<4xf32> {
   return %1#0 : tensor<4xf32>
 }
 
+// -----
+// CHECK-LABEL: ENTRY %main{{.*}} (Arg_0.1: s32[128,8]) -> s32[128,8] {
+// CHECK: %[[ARG:.*]] = s32[128,8] parameter(0)
+// CHECK-NOT: s32[] constant(8), sharding={devices=[8,1]<=[8]}, metadata=
+// CHECK: %[[SIZE:.*]] = s32[] constant(8), metadata=
+// CHECK: ROOT %{{.*}} = s32[128,8] set-dimension-size(%[[ARG]], %[[SIZE]]), dimensions={1}, sharding={devices=[8,1]<=[8]}, metadata=
+func.func @main(%arg0: tensor<128x8xi32>) -> tensor<128x8xi32> {
+  %size = stablehlo.constant dense<8> : tensor<i32>
+  %0 = "stablehlo.set_dimension_size"(%arg0, %size) <{dimension = 1 : i64}>
+      {mhlo.sharding = "{devices=[8,1]<=[8]}"}
+      : (tensor<128x8xi32>, tensor<i32>) -> tensor<128x8xi32>
+  func.return %0 : tensor<128x8xi32>
+}


### PR DESCRIPTION
📝 Summary of Changes
Stop rank-0 dimension-size scalars from inheriting the enclosing op's sharding.

🎯 Justification
Shardy-partitioned MoE models (MaxText Mixtral, DeepSeek2, GPT-OSS) fail to compile. Their bf16 top-k routing lowers into an op that, under a tiled sharding, passes a multi-dimensional sharding onto a scalar, which is invalid and aborts compilation. This has been latent and only surfaced after this #44538

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
New case in `mhlo_to_hlo/tests/sharding.mlir`