### PR TITLE
[HLO] Validate the dimensions attribute in the HLO parser to avoid crashes

### DIFF
--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -1937,7 +1937,8 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
       attrs["use_global_device_ids"] = {/*required=*/false, AttrTy::kBool,
                                         &use_global_device_ids};
       if ((!preset_operands && !ParseOperands(&operands, builder)) ||
-          !ParseAttributes(attrs, allow_attributes, shape)) {
+          !ParseAttributes(attrs, allow_attributes, shape) ||
+          dimensions->size() != 1) {
         return nullptr;
       }
       if (opcode == HloOpcode::kAllGather) {
@@ -1988,7 +1989,8 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
       }
       const LocTy loc = lexer_.GetLoc();
       if ((!preset_operands && !ParseOperands(&operands, builder)) ||
-          !ParseAttributes(attrs, allow_attributes, shape)) {
+          !ParseAttributes(attrs, allow_attributes, shape) ||
+          (opcode == HloOpcode::kReduceScatter && dimensions->size() != 1)) {
         return nullptr;
       }
       if (!collective_op_group_mode.has_value()) {
@@ -2885,6 +2887,13 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
             if (num_inputs == 0) {
               return InvalidArgument(
                   "Cannot infer shape for scan with no inputs");
+            }
+            const int64_t operand_rank =
+                operands[0]->shape().dimensions().size();
+            if (scan_dim < 0 || scan_dim >= operand_rank) {
+              return InvalidArgument(
+                  "scan dimension %d is out of range for operand of rank %d",
+                  scan_dim, operand_rank);
             }
 
             int64_t scan_dim_size = operands[0]->shape().dimensions(scan_dim);
@@ -3872,7 +3881,8 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
                              &dimensions};
       if ((!preset_operands &&
            !ParseOperands(&operands, builder, /*expected_size=*/1)) ||
-          !ParseAttributes(attrs, allow_attributes, shape)) {
+          !ParseAttributes(attrs, allow_attributes, shape) ||
+          dimensions->size() != 1) {
         return nullptr;
       }
       if (!maybe_infer_shape([&] {
@@ -3890,7 +3900,8 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
                              &dimensions};
       if ((!preset_operands &&
            !ParseOperands(&operands, builder, /*expected_size=*/2)) ||
-          !ParseAttributes(attrs, allow_attributes, shape)) {
+          !ParseAttributes(attrs, allow_attributes, shape) ||
+          dimensions->size() != 1) {
         return nullptr;
       }
       if (!maybe_infer_shape([&] {

--- a/xla/hlo/parser/hlo_parser_test.cc
+++ b/xla/hlo/parser/hlo_parser_test.cc
@@ -3420,6 +3420,57 @@ ENTRY e {
   EXPECT_THAT(result.status().message(), HasSubstr("device_ids"));
 }
 
+TEST_F(HloParserTest, AllGatherEmptyDimensions) {
+  const std::string original = R"(HloModule m
+ENTRY e {
+  input = f32[128,32]{0,1} parameter(0)
+  ROOT ag = f32[128,128]{0,1} all-gather(input), replica_groups={}, dimensions={}
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+}
+
+TEST_F(HloParserTest, ReduceScatterEmptyDimensions) {
+  const std::string original = R"(HloModule m
+add {
+  a = f32[] parameter(0)
+  b = f32[] parameter(1)
+  ROOT s = f32[] add(a, b)
+}
+ENTRY e {
+  input = f32[8,4] parameter(0)
+  ROOT rs = f32[4,4] reduce-scatter(input), replica_groups={}, to_apply=add, dimensions={}
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+}
+
+TEST_F(HloParserTest, GetDimensionSizeEmptyDimensions) {
+  const std::string original = R"(HloModule m
+ENTRY e {
+  p = f32[2,3] parameter(0)
+  ROOT gds = get-dimension-size(p), dimensions={}
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+}
+
+TEST_F(HloParserTest, ScanDimensionOutOfRange) {
+  const std::string original = R"(HloModule m
+add {
+  x = f32[] parameter(0)
+  y = f32[] parameter(1)
+  ROOT a = f32[] add(x, y)
+}
+ENTRY main {
+  input = f32[4] parameter(0)
+  init = f32[] parameter(1)
+  ROOT scan = scan(input, init), dimensions={-1}, num_carries=0, to_apply=add
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+}
+
 TEST_F(HloParserTest, CompactGteRoundTrip) {
   const std::string original =
       R"(HloModule test, entry_computation_layout={((f32[10]{0}, f16[10]{0}))->f32[10]{0}}


### PR DESCRIPTION
### Problem
Several opcode handlers extract or use a value from the `dimensions={...}` attribute without validating it, so malformed-but-lexable HLO text crashes the parser (a `std::out_of_range` throw, an out-of-bounds read, or a `CHECK`-fail) instead of returning an error `Status`.

**Empty `dimensions={}`** — `all-gather`, `all-gather-start`, `reduce-scatter`, and `get-dimension-size` / `set-dimension-size` extract `dimensions->at(0)`, but the parser only checks that the required attribute is *present*, not non-empty. An empty list therefore throws `std::out_of_range`:
```
all-gather(input), replica_groups={}, dimensions={}
reduce-scatter(input), replica_groups={}, to_apply=add, dimensions={}
get-dimension-size(p), dimensions={}
```

**Out-of-range dimension value** — `scan` checks `dimensions->size() == 1` but then uses the value as `operands[0]->shape().dimensions(scan_dim)` with no range check, so an out-of-range value reads out of bounds (and the downstream `ShapeUtil::InsertDimensionAtIndex` `CHECK`-fails):
```
scan(input, init), dimensions={-1}, num_carries=0, to_apply=add
```

### Fix
- Require `dimensions->size() == 1` in the all-gather / reduce-scatter / get-dimension-size / set-dimension-size handlers before extracting `dimensions->at(0)`, matching the checks the sibling `kSort` and `kAllToAll` handlers already have. (`all-reduce`/`all-reduce-start` share the reduce-scatter parse block and don't take a `dimensions` attribute, so the new check is guarded by `opcode == kReduceScatter`.)
- Range-check `scan`'s dimension against the operand rank and return a parse error if it is out of range.

### Tests
Four `HloParserTest` cases assert that `all-gather`, `reduce-scatter`, and `get-dimension-size` with `dimensions={}`, and `scan` with an out-of-range dimension, now return an error instead of crashing.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
