### PR TITLE
[HLO] Validate operand count and shape in recv/conditional/rng-bit-generator/reduce-window parsing

### DIFF
--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -2487,6 +2487,10 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
         return nullptr;
       }
       // If the is_host_transfer attribute is not present then default to false.
+      if (!shape->IsTuple() || shape->tuple_shapes().empty()) {
+        TokenError("recv must have a non-empty tuple shape");
+        return nullptr;
+      }
       return builder->AddInstruction(HloInstruction::CreateRecv(
           shape->tuple_shapes(0), operands[0], channel_id, *is_host_transfer));
     }
@@ -2609,6 +2613,10 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
       if (operands.size() % 2) {
         TokenError(StrCat("expects an even number of operands, but has ",
                           operands.size(), " operands"));
+        return nullptr;
+      }
+      if (operands.empty()) {
+        TokenError("reduce-window expects at least one input and init operand");
         return nullptr;
       }
       if (!maybe_infer_shape([&] {
@@ -3250,7 +3258,8 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
       optional<RandomAlgorithm> algorithm;
       attrs["algorithm"] = {/*required=*/true, AttrTy::kRandomAlgorithm,
                             &algorithm};
-      if ((!preset_operands && !ParseOperands(&operands, builder)) ||
+      if ((!preset_operands &&
+           !ParseOperands(&operands, builder, /*expected_size=*/1)) ||
           !ParseAttributes(attrs, allow_attributes, shape)) {
         return nullptr;
       }
@@ -3278,6 +3287,10 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
       optional<HloComputation*> false_computation;
       optional<std::vector<HloComputation*>> branch_computations;
       if (!preset_operands && !ParseOperands(&operands, builder)) {
+        return nullptr;
+      }
+      if (operands.empty()) {
+        TokenError("conditional requires at least one operand");
         return nullptr;
       }
       if (!ShapeUtil::IsScalar(operands[0]->shape())) {

--- a/xla/hlo/parser/hlo_parser_test.cc
+++ b/xla/hlo/parser/hlo_parser_test.cc
@@ -3420,6 +3420,48 @@ ENTRY e {
   EXPECT_THAT(result.status().message(), HasSubstr("device_ids"));
 }
 
+TEST_F(HloParserTest, RecvNonTupleShape) {
+  const std::string original = R"(HloModule m
+ENTRY e {
+  tok = token[] after-all()
+  ROOT recv = f32[10] recv(tok)
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+}
+
+TEST_F(HloParserTest, ConditionalNoOperands) {
+  const std::string original = R"(HloModule m
+ENTRY e {
+  ROOT c = f32[] conditional()
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+}
+
+TEST_F(HloParserTest, RngBitGeneratorNoOperands) {
+  const std::string original = R"(HloModule m
+ENTRY e {
+  ROOT r = (u64[2], u32[4]) rng-bit-generator(), algorithm=rng_three_fry
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+}
+
+TEST_F(HloParserTest, ReduceWindowNoOperands) {
+  const std::string original = R"(HloModule m
+add {
+  a = f32[] parameter(0)
+  b = f32[] parameter(1)
+  ROOT s = f32[] add(a, b)
+}
+ENTRY e {
+  ROOT rw = reduce-window(), to_apply=add
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+}
+
 TEST_F(HloParserTest, CompactGteRoundTrip) {
   const std::string original =
       R"(HloModule test, entry_computation_layout={((f32[10]{0}, f16[10]{0}))->f32[10]{0}}


### PR DESCRIPTION
### Problem
Four opcode handlers in `HloParserImpl::CreateInstruction` read a parsed operand or the result shape without validating it, so malformed-but-lexable HLO aborts the parser (a `CHECK` failure or an out-of-bounds read) instead of returning an error `Status`:

- **`recv`** — `CreateRecv(shape->tuple_shapes(0), ...)` calls `tuple_shapes(0)` without checking the result shape is a non-empty tuple, so a non-tuple shape `CHECK`-fails in `Shape::tuple_state()`:
  ```
  tok = token[] after-all()
  ROOT recv = f32[10] recv(tok)
  ```
- **`conditional`** — reads `operands[0]->shape()` immediately after a count-agnostic `ParseOperands`, so zero operands reads past the end (the later count check is downstream):
  ```
  ROOT c = f32[] conditional()
  ```
- **`rng-bit-generator`** — reads `operands[0]` after a count-agnostic `ParseOperands`:
  ```
  ROOT r = (u64[2], u32[4]) rng-bit-generator(), algorithm=rng_three_fry
  ```
- **`reduce-window`** — its operand-count check only rejects an *odd* count, so zero operands passes and the shape-inference lambda reads `operands[0]`/`operands[1]`:
  ```
  ROOT rw = reduce-window(), to_apply=add
  ```

### Fix
- `recv`: guard `!shape->IsTuple() || shape->tuple_shapes().empty()` before `tuple_shapes(0)`, mirroring the existing `kInfeed` guard.
- `conditional`, `reduce-window`: return a parse error when `operands` is empty.
- `rng-bit-generator`: pass `ParseOperands(..., /*expected_size=*/1)`.

### Tests
Four `HloParserTest` cases assert these malformed inputs now return an error instead of crashing.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
