### PR TITLE
[XLA:GPU][oneAPI/SPIR-V] Skip compilation and loading of empty constants modules

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -948,6 +948,8 @@ xla_cc_test(
         "//xla/stream_executor/abi:executable_abi_version_proto_cc",
         "//xla/stream_executor/cuda:cuda_compute_capability",
         "//xla/stream_executor/gpu:tma_metadata",
+        "//xla/stream_executor:mock_stream",
+        "//xla/stream_executor:mock_stream_executor",
         "//xla/tsl/lib/core:status_test_util",
         "//xla/tsl/platform:env",
         "//xla/tsl/platform:status_macros",

--- a/xla/service/gpu/compile_module_to_llvm_ir.cc
+++ b/xla/service/gpu/compile_module_to_llvm_ir.cc
@@ -265,7 +265,9 @@ absl::StatusOr<CompileModuleResults> CompileModuleToLlvmIr(
       thunk_emitter.EmitHloEntryComputation(hlo_module);
 
   llvm::Module* constants_module = thunk_emitter.constants_module();
-  if (!constants_module->empty() || !constants_module->global_empty()) {
+  const bool has_constants_module =
+    !constants_module->empty() || !constants_module->global_empty();
+  if (has_constants_module) {
     ASSIGN_OR_RETURN(
         results.constants_binary,
         compiler->CompileToTargetBinary(thunk_emitter.ConsumeConstantsModule())

--- a/xla/service/gpu/compile_module_to_llvm_ir.cc
+++ b/xla/service/gpu/compile_module_to_llvm_ir.cc
@@ -264,10 +264,16 @@ absl::StatusOr<CompileModuleResults> CompileModuleToLlvmIr(
   xla::Future<std::unique_ptr<SequentialThunk>> future_sequential_thunk =
       thunk_emitter.EmitHloEntryComputation(hlo_module);
 
-  ASSIGN_OR_RETURN(
-      results.constants_binary,
-      compiler->CompileToTargetBinary(thunk_emitter.ConsumeConstantsModule())
-          .Await());
+  llvm::Module* constants_module = thunk_emitter.constants_module();
+  if (!constants_module->empty() || !constants_module->global_empty()) {
+    ASSIGN_OR_RETURN(
+        results.constants_binary,
+        compiler->CompileToTargetBinary(thunk_emitter.ConsumeConstantsModule())
+            .Await());
+  } else {
+    VLOG(2) << "Constants LLVM module is empty; skipping target compilation.";
+  }
+
   ASSIGN_OR_RETURN(results.executable,
                    std::move(future_sequential_thunk).Await());
 

--- a/xla/service/gpu/gpu_executable_test.cc
+++ b/xla/service/gpu/gpu_executable_test.cc
@@ -79,6 +79,9 @@ limitations under the License.
 #include "xla/stream_executor/gpu/tma_metadata.h"
 #include "xla/stream_executor/semantic_version.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/mock_stream.h"
+#include "xla/stream_executor/mock_stream_executor.h"
+#include "xla/service/gpu/gpu_module_globals.h"
 #include "xla/tsl/lib/core/status_test_util.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/threadpool.h"
@@ -100,6 +103,7 @@ using ::testing::Pair;
 using ::testing::Pointee;
 using ::testing::Property;
 using ::testing::SizeIs;
+using ::testing::Return;
 using ::testing::UnorderedElementsAre;
 using ::tsl::proto_testing::EqualsProto;
 using ::tsl::proto_testing::ParseTextProtoOrDie;
@@ -121,6 +125,23 @@ Thunk::ThunkInfo ThunkInfoWithId(int thunk_id) {
   Thunk::ThunkInfo thunk_info;
   thunk_info.thunk_id = thunk_id;
   return thunk_info;
+}
+
+TEST(GpuModuleGlobalsTest, EmptyBinarySkipsModuleLoading) {
+  std::vector<uint8_t> binary;
+  std::vector<GpuModuleGlobals::ConstantInfo> constants;
+  se::MockStreamExecutor executor;
+  se::MockStream stream;
+  GpuModuleGlobals module_globals(binary, constants);
+
+  EXPECT_CALL(stream, parent()).WillOnce(Return(&executor));
+  EXPECT_CALL(executor, GetPlatform()).Times(0);
+  EXPECT_CALL(executor, LoadModule(::testing::_)).Times(0);
+
+  ASSERT_OK_AND_ASSIGN(const auto* resolved,
+                       module_globals.Resolve(&stream));
+
+  EXPECT_TRUE(resolved->empty());
 }
 
 TEST_F(GpuExecutableTest, OutputInfoToAndFromProto) {

--- a/xla/service/gpu/gpu_module_globals.cc
+++ b/xla/service/gpu/gpu_module_globals.cc
@@ -34,10 +34,8 @@ limitations under the License.
 #include "xla/map_util.h"
 #include "xla/service/gpu/dense_data_intermediate.h"
 #include "xla/service/gpu/gpu_executable.pb.h"
-#include "xla/stream_executor/cuda/cuda_platform_id.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/module_spec.h"
-#include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/scoped_module_handle.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
@@ -96,11 +94,9 @@ GpuModuleGlobals::Resolve(se::Stream* stream) {
 
   auto globals = std::make_unique<BufferAllocToDeviceMemoryMap>();
   se::ModuleHandle module_handle;
-  // The CUDA driver isn't able to load a PTX and a binary which are both empty.
-  // It's okay if we skip loading in this case; if the module isn't loaded, all
-  // symbol lookups will fail, just as they should for an empty module.
-  if (!(executor->GetPlatform()->id() == se::cuda::kCudaPlatformId &&
-        binary_.empty())) {
+  // There is no module to load when constants compilation produced no binary.
+  // In this case `constants_` is also empty, so there are no symbols to resolve.
+  if (!binary_.empty()) {
     ASSIGN_OR_RETURN(module_handle, executor->LoadModule(module_spec));
   }
 

--- a/xla/service/gpu/gpu_module_globals.cc
+++ b/xla/service/gpu/gpu_module_globals.cc
@@ -95,8 +95,10 @@ GpuModuleGlobals::Resolve(se::Stream* stream) {
   auto globals = std::make_unique<BufferAllocToDeviceMemoryMap>();
   se::ModuleHandle module_handle;
   // There is no module to load when constants compilation produced no binary.
-  // In this case `constants_` is also empty, so there are no symbols to resolve.
-  if (!binary_.empty()) {
+  if (binary_.empty()) {
+    TF_RET_CHECK(constants_.empty())
+        << "Constants metadata is present without a constants binary";
+  } else {
     ASSIGN_OR_RETURN(module_handle, executor->LoadModule(module_spec));
   }
 

--- a/xla/tests/codegen_utils.cc
+++ b/xla/tests/codegen_utils.cc
@@ -69,6 +69,10 @@ void ResetIrHook(LLVMCompiler* llvm_compiler) {
   llvm_compiler->RemovePostOptimizationHook();
 }
 
+std::string FileCheckInput(const std::string& ir) {
+  return ir.empty() ? ";\n" : ir;
+}
+
 class ScopedHookHandler final {
  public:
   ScopedHookHandler(LLVMCompiler* compiler, bool match_optimized_ir)
@@ -99,7 +103,9 @@ absl::Status CompileAndVerifyIr(LLVMCompiler* compiler,
                                       run_optimization_passes)
                       .status());
 
-  ASSIGN_OR_RETURN(bool succeeded, RunFileCheck(hook_handler.ir(), pattern));
+  ASSIGN_OR_RETURN(
+      bool succeeded,
+      RunFileCheck(FileCheckInput(hook_handler.ir()), pattern));
   if (!succeeded) {
     return absl::InternalError(
         absl::StrCat("FileCheck failed. Full IR: ", hook_handler.ir()));
@@ -117,7 +123,8 @@ absl::Status CompileAheadOfTimeAndVerifyIr(
       compiler->CompileAheadOfTime(std::move(hlo_module), aot_options)
           .status());
 
-  ASSIGN_OR_RETURN(bool succeeded, RunFileCheck(hook_handler.ir(), pattern));
+  ASSIGN_OR_RETURN(
+      bool succeeded,      RunFileCheck(FileCheckInput(hook_handler.ir()), pattern));
   if (!succeeded) {
     return absl::InternalError(
         absl::StrCat("FileCheck failed. Full IR: ", hook_handler.ir()));


### PR DESCRIPTION
Hello, xla and intel team, in my journey to understand and improve the SPIR-V compilation pipeline in PJRT, I found that XLA always passes the constants LLVM module to the target compiler, even when the module is empty.
<img width="783" height="465" alt="Screenshot 2026-07-17 at 18 24 17" src="https://github.com/user-attachments/assets/87066d5b-dfa1-44a4-b31c-0aab611ce004" />

I observed 2 time the `oneAPI::zeModuleCreate_SPIRVToNative` function being called, once for the kernel and once for the empty constants module.

This can be seen by a [perfetto](https://perfetto.dev/) screenshot.

I think the empty constants module can be skipped entirely, avoiding unnecessary compilation and module loading.

## 📝 Summary of Changes

* Skip target-binary compilation when the emitted constants LLVM module contains no functions or globals.
* Skip device-module loading whenever the constants binary is empty, instead of handling this case only for CUDA.
* Verify that constants metadata is not present without a corresponding constants binary.
* Add a regression test covering resolution of an empty constants binary.

## 🎯 Justification

Previously, XLA always passed the constants LLVM module to the target compiler, even when the module was empty. \
At runtime, loading an empty constants module was skipped only for CUDA.

This unnecessarily requires other GPU backends to support compilation and loading of empty modules. \
In particular, it blocks SPIR-V-oriented GPU compilation paths for HLO modules that do not emit device constants.

The change makes the empty-constants case platform-independent. Constant-free GPU workloads benefit from avoiding an invalid or unnecessary constants compilation and module-loading step.

## 🚀 Kind of Contribution

🐛 Bug Fix, 🧪 Tests

## 📊 Benchmark

This is mainly a correctness and backend-portability fix, but the purpose is to avoid unnecessary compilation and module loading for empty constants modules so it may improve performance in such cases.

## 🧪 Unit Tests

Added `GpuModuleGlobalsTest.EmptyBinarySkipsModuleLoading` to `gpu_executable_test.cc`.

The test uses mock stream and stream-executor objects to verify that resolving an empty constants binary:

* does not query the platform;
* does not call `LoadModule`; and
* returns an empty globals map.

Test target:

```bash
ONEAPI_DEVICE_SELECTOR=level_zero:0
bazel test //xla/service/gpu:gpu_executable_test \
  --test_filter=GpuModuleGlobalsTest.EmptyBinarySkipsModuleLoading
```

```bash
bazel build //xla/pjrt/c:pjrt_c_api_gpu_plugin.so \
  --config=sycl_hermetic \
  --repo_env=ONEAPI_VERSION=2026.0 \
  --repo_env=OS=ubuntu_24.10
```

## 🧪 Execution Tests

None added. The changed behavior concerns empty constants-module handling and is covered by the focused hardware-independent unit test above.
