### PR TITLE
[XLA:GPU] Simplify DeviceAddressVmmAllocator mapped Allocate() API

### DIFF
--- a/xla/service/gpu/gpu_executable_va_remap_allocator.cc
+++ b/xla/service/gpu/gpu_executable_va_remap_allocator.cc
@@ -31,7 +31,6 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
-#include "xla/tsl/platform/status_macros.h"
 #include "xla/service/buffer_assignment.h"
 #include "xla/service/gpu/buffer_allocations.h"
 #include "xla/service/gpu/gpu_executable_buffer_allocator.h"
@@ -42,6 +41,7 @@ limitations under the License.
 #include "xla/stream_executor/device_address_vmm_allocator.h"
 #include "xla/stream_executor/memory_allocation.h"
 #include "xla/stream_executor/stream.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "xla/xla.pb.h"
 
@@ -359,7 +359,7 @@ GpuExecutableVaRemapAllocator::VaRemapExecutionScope::AllocateBuffer(
   return vmm_allocator_->Allocate(
       device_ordinal, mapping_size, /*retry_on_failure=*/true,
       /*memory_space=*/allocation.color(), remapping_->va_reservation.get(),
-      va_offset, mapping_size, /*return_reservation_address=*/true);
+      va_offset, mapping_size);
 }
 
 absl::StatusOr<se::DeviceAddressBase>

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -15,14 +15,15 @@ limitations under the License.
 
 #include "xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h"
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <array>
 #include <cstdint>
 #include <memory>
 #include <utility>
 #include <vector>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "xla/service/computation_placer.h"
@@ -746,42 +747,12 @@ TEST_F(DeviceAddressVmmAllocatorTest,
       allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
                           static_cast<int64_t>(MemorySpace::kCollective),
                           reservation.get(), /*reservation_offset=*/0,
-                          granularity,
-                          /*return_reservation_address=*/true));
+                          granularity));
 
   EXPECT_EQ(address->opaque(), reservation->address().opaque());
   EXPECT_NE(allocator->GetRawAllocation(ordinal, address.cref()), nullptr);
 
   ASSERT_THAT(allocator->Deallocate(ordinal, address.Release()), IsOk());
-  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
-}
-
-TEST_F(DeviceAddressVmmAllocatorTest,
-       AllocateIntoReservationReturnsAllocatorAddress) {
-  ASSERT_OK_AND_ASSIGN(
-      auto allocator,
-      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
-
-  const int ordinal = executor_->device_ordinal();
-  uint64_t granularity = allocator->GetAllocationGranularity(executor_);
-  ASSERT_GT(granularity, 0);
-
-  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
-                                             executor_, granularity));
-  ASSERT_OK_AND_ASSIGN(
-      auto address,
-      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
-                          static_cast<int64_t>(MemorySpace::kCollective),
-                          reservation.get(), /*reservation_offset=*/0,
-                          granularity,
-                          /*return_reservation_address=*/false));
-
-  EXPECT_NE(address->opaque(), reservation->address().opaque());
-  EXPECT_THAT(allocator->Deallocate(ordinal, address.cref()),
-              absl_testing::StatusIs(absl::StatusCode::kFailedPrecondition));
-  ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
-                               /*reservation_offset=*/0, granularity),
-              IsOk());
   ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
 }
 
@@ -804,19 +775,18 @@ TEST_F(DeviceAddressVmmAllocatorTest,
       allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
                           static_cast<int64_t>(MemorySpace::kCollective),
                           reservation.get(), /*reservation_offset=*/0,
-                          granularity,
-                          /*return_reservation_address=*/true));
+                          granularity));
   auto* raw_allocation = allocator->GetRawAllocation(ordinal, address.cref());
   ASSERT_NE(raw_allocation, nullptr);
 
   ASSERT_THAT(allocator->Deallocate(ordinal, address.Release()), IsOk());
 
   ASSERT_OK_AND_ASSIGN(
-      auto reused, allocator->Allocate(
-                       ordinal, granularity, /*retry_on_failure=*/true,
-                       static_cast<int64_t>(MemorySpace::kCollective),
-                       reservation.get(), /*reservation_offset=*/0, granularity,
-                       /*return_reservation_address=*/true));
+      auto reused,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective),
+                          reservation.get(), /*reservation_offset=*/0,
+                          granularity));
   EXPECT_TRUE(reused.cref().IsSameAs(reservation_address));
   EXPECT_EQ(allocator->GetRawAllocation(ordinal, reused.cref()),
             raw_allocation);
@@ -824,68 +794,6 @@ TEST_F(DeviceAddressVmmAllocatorTest,
   EXPECT_EQ(allocator->GetRawAllocation(ordinal, reused.cref()),
             raw_allocation);
 
-  ASSERT_THAT(allocator->Deallocate(ordinal, reused.Release()), IsOk());
-  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
-}
-
-TEST_F(DeviceAddressVmmAllocatorTest,
-       AllocateIntoReservationReusesPendingAllocatorAndReservationAddresses) {
-  ASSERT_OK_AND_ASSIGN(
-      auto allocator,
-      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
-
-  const int ordinal = executor_->device_ordinal();
-  const uint64_t granularity = allocator->GetAllocationGranularity(executor_);
-  ASSERT_GT(granularity, 0);
-
-  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
-                                             executor_, granularity));
-  DeviceAddressBase reservation_address = reservation->address().GetByteSlice(
-      /*offset_bytes=*/0, granularity);
-  ASSERT_OK_AND_ASSIGN(
-      auto address,
-      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
-                          static_cast<int64_t>(MemorySpace::kCollective),
-                          reservation.get(), /*reservation_offset=*/0,
-                          granularity,
-                          /*return_reservation_address=*/false));
-  DeviceAddressBase allocator_address = address.cref();
-  auto* raw_allocation =
-      allocator->GetRawAllocation(ordinal, allocator_address);
-  auto* allocator_owned_reservation =
-      allocator->GetReservation(ordinal, allocator_address);
-  ASSERT_NE(raw_allocation, nullptr);
-  ASSERT_NE(allocator_owned_reservation, nullptr);
-  ASSERT_EQ(allocator->GetRawAllocation(ordinal, reservation_address),
-            raw_allocation);
-
-  ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
-                               /*reservation_offset=*/0, granularity),
-              IsOk());
-  ASSERT_THAT(allocator->Deallocate(ordinal, address.Release()), IsOk());
-
-  ASSERT_OK_AND_ASSIGN(
-      auto reused, allocator->Allocate(
-                       ordinal, granularity, /*retry_on_failure=*/true,
-                       static_cast<int64_t>(MemorySpace::kCollective),
-                       reservation.get(), /*reservation_offset=*/0, granularity,
-                       /*return_reservation_address=*/false));
-  EXPECT_TRUE(reused.cref().IsSameAs(allocator_address));
-  EXPECT_EQ(allocator->GetRawAllocation(ordinal, reused.cref()),
-            raw_allocation);
-  EXPECT_EQ(allocator->GetRawAllocation(ordinal, reservation_address),
-            raw_allocation);
-  EXPECT_EQ(allocator->GetReservation(ordinal, reused.cref()),
-            allocator_owned_reservation);
-  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
-  EXPECT_EQ(allocator->GetRawAllocation(ordinal, reused.cref()),
-            raw_allocation);
-  EXPECT_EQ(allocator->GetRawAllocation(ordinal, reservation_address),
-            raw_allocation);
-
-  ASSERT_THAT(allocator->UnMap(ordinal, reservation.get(),
-                               /*reservation_offset=*/0, granularity),
-              IsOk());
   ASSERT_THAT(allocator->Deallocate(ordinal, reused.Release()), IsOk());
   ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
 }
@@ -926,8 +834,7 @@ TEST_F(DeviceAddressVmmAllocatorTest,
           allocator->Allocate(
               ordinal, granularity, /*retry_on_failure=*/true,
               static_cast<int64_t>(MemorySpace::kCollective), reservation.get(),
-              /*reservation_offset=*/slice * granularity, granularity,
-              /*return_reservation_address=*/true));
+              /*reservation_offset=*/slice * granularity, granularity));
       EXPECT_TRUE(address.cref().IsSameAs(reservation->address().GetByteSlice(
           slice * granularity, granularity)));
       auto* raw_allocation =
@@ -998,8 +905,7 @@ TEST_F(DeviceAddressVmmAllocatorTest,
       allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
                           static_cast<int64_t>(MemorySpace::kCollective),
                           reservation.get(), /*reservation_offset=*/0,
-                          granularity,
-                          /*return_reservation_address=*/true));
+                          granularity));
   auto* raw_allocation = allocator->GetRawAllocation(ordinal, address.cref());
   ASSERT_NE(raw_allocation, nullptr);
   ASSERT_THAT(allocator->Deallocate(ordinal, address.Release()), IsOk());
@@ -1011,18 +917,17 @@ TEST_F(DeviceAddressVmmAllocatorTest,
                               /*retry_on_failure=*/true,
                               static_cast<int64_t>(MemorySpace::kCollective),
                               reservation.get(), /*reservation_offset=*/0,
-                              2 * granularity,
-                              /*return_reservation_address=*/true)
+                              2 * granularity)
                    .ok());
 
   // The failed attempt must leave the stale mapping intact: a matching-size
   // request still reuses it.
   ASSERT_OK_AND_ASSIGN(
-      auto reused, allocator->Allocate(
-                       ordinal, granularity, /*retry_on_failure=*/true,
-                       static_cast<int64_t>(MemorySpace::kCollective),
-                       reservation.get(), /*reservation_offset=*/0, granularity,
-                       /*return_reservation_address=*/true));
+      auto reused,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          static_cast<int64_t>(MemorySpace::kCollective),
+                          reservation.get(), /*reservation_offset=*/0,
+                          granularity));
   EXPECT_EQ(allocator->GetRawAllocation(ordinal, reused.cref()),
             raw_allocation);
 

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -34,7 +34,6 @@ limitations under the License.
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
-#include "xla/tsl/platform/status_macros.h"
 #include "xla/service/computation_placer.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/device_address_allocator.h"
@@ -43,6 +42,7 @@ limitations under the License.
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/status_macros.h"
 
 namespace stream_executor {
 
@@ -86,10 +86,9 @@ DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
   CHECK_GT(raw_allocation_->address().size(), 0);
   switch (kind_) {
     case Kind::kAllocate:
-    case Kind::kAllocateAndMapReturnNewAddr:
       CHECK(allocator_address_reservation_ != nullptr);
       break;
-    case Kind::kAllocateAndMapReturnMapAddr:
+    case Kind::kAllocateAndMap:
       CHECK(allocator_address_reservation_ == nullptr);
       break;
   }
@@ -314,9 +313,9 @@ MemoryAllocation* DeviceAddressVmmAllocator::GetRawAllocation(
     return allocation_it->second->raw_allocation();
   }
 
-  // Reservation aliases created by Map() or by Allocate(...,
-  // return_reservation_address=false) share one index. Only active aliases are
-  // exposed; stale or already-unmapped aliases intentionally return nullptr.
+  // Reservation aliases created by Map() share one index. Only active aliases
+  // are exposed; stale or already-unmapped aliases intentionally return
+  // nullptr.
   auto reservation_it = state->reservation_records.find(addr.opaque());
   if (reservation_it != state->reservation_records.end() &&
       reservation_it->second->reservation_active() &&
@@ -413,35 +412,17 @@ DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
 std::optional<DeviceAddressBase>
 DeviceAddressVmmAllocator::TryReuseMappedAllocation(
     PerDeviceState& state, const MappedAllocateRequest& request) {
-  const bool separate_address =
-      request.mode == MappedAddressMode::kSeparateAllocatorAddress;
-  AllocationRecord* record;
-  if (separate_address) {
-    auto record_it =
-        state.reservation_records.find(request.reservation_address.opaque());
-    if (record_it == state.reservation_records.end()) {
-      return std::nullopt;
-    }
-    record = record_it->second;
-  } else {
-    auto record_it = state.records_by_allocator_address.find(
-        request.reservation_address.opaque());
-    if (record_it == state.records_by_allocator_address.end()) {
-      return std::nullopt;
-    }
-    record = record_it->second.get();
+  auto record_it = state.records_by_allocator_address.find(
+      request.reservation_address.opaque());
+  if (record_it == state.records_by_allocator_address.end()) {
+    return std::nullopt;
   }
+  AllocationRecord* record = record_it->second.get();
 
-  AllocationRecord::Kind expected_kind =
-      separate_address ? AllocationRecord::Kind::kAllocateAndMapReturnNewAddr
-                       : AllocationRecord::Kind::kAllocateAndMapReturnMapAddr;
-  bool address_matches =
-      separate_address
-          ? record->reservation_matches(request.reservation_address)
-          : record->allocator_matches(request.reservation_address);
-  if (record->kind() != expected_kind || !record->allocator_stale() ||
-      record->multi_device() != request.multi_device || !address_matches ||
-      (separate_address && !record->reservation_stale())) {
+  if (record->kind() != AllocationRecord::Kind::kAllocateAndMap ||
+      !record->allocator_stale() ||
+      record->multi_device() != request.multi_device ||
+      !record->allocator_matches(request.reservation_address)) {
     return std::nullopt;
   }
 
@@ -458,14 +439,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocation(
 
   DeviceAddressBase reused_mem(record->allocator_key(), request.size);
   MoveAllocatorRecordToActive(state, *record, request.size);
-  if (separate_address) {
-    record->ReactivateReservation();
-  }
   ErasePendingDeallocationAt(state, pending_it);
-  if (separate_address) {
-    ErasePendingDeallocation(state, PendingDeallocationKind::kMap,
-                             request.reservation_address);
-  }
   return reused_mem;
 }
 
@@ -530,47 +504,18 @@ DeviceAddressVmmAllocator::CreateMappedAllocation(
   ASSIGN_OR_RETURN(auto raw_alloc, AllocatePhysicalWithinBudget(
                                        state, request.size, physical_size));
 
-  const bool separate_address =
-      request.mode == MappedAddressMode::kSeparateAllocatorAddress;
-  AllocationRecord::Kind kind =
-      AllocationRecord::Kind::kAllocateAndMapReturnMapAddr;
-  DeviceAddressBase allocator_address = request.reservation_address;
-  std::unique_ptr<MemoryReservation> allocator_address_reservation;
-  MemoryReservation::ScopedMapping allocator_address_mapping;
-
-  if (separate_address) {
-    kind = AllocationRecord::Kind::kAllocateAndMapReturnNewAddr;
-    ASSIGN_OR_RETURN(allocator_address_reservation,
-                     CreateReservation(state.executor, request.size));
-    allocator_address = DeviceAddressBase(
-        allocator_address_reservation->address().opaque(), request.size);
-    ASSIGN_OR_RETURN(allocator_address_mapping,
-                     allocator_address_reservation->MapTo(
-                         /*reservation_offset=*/0, /*allocation_offset=*/0,
-                         physical_size, *raw_alloc));
-  }
-
-  ASSIGN_OR_RETURN(auto reservation_address_mapping,
+  ASSIGN_OR_RETURN(auto allocator_address_mapping,
                    request.reservation->MapTo(request.reservation_offset,
                                               /*allocation_offset=*/0,
                                               request.size, *raw_alloc));
 
-  if (!separate_address) {
-    allocator_address_mapping = std::move(reservation_address_mapping);
-    reservation_address_mapping = MemoryReservation::ScopedMapping();
-  }
-  AllocationRecord& record = TrackAllocatorAddressMappedAllocation(
-      state, kind, allocator_address, std::move(raw_alloc),
-      std::move(allocator_address_reservation),
-      std::move(allocator_address_mapping), request.multi_device);
-  if (separate_address) {
-    record.AddActiveReservationAlias(std::move(reservation_address_mapping));
-    auto reservation_insert = state.reservation_records.emplace(
-        request.reservation_address.opaque(), &record);
-    CHECK(reservation_insert.second);
-  }
+  TrackAllocatorAddressMappedAllocation(
+      state, AllocationRecord::Kind::kAllocateAndMap,
+      request.reservation_address, std::move(raw_alloc),
+      /*reservation=*/nullptr, std::move(allocator_address_mapping),
+      request.multi_device);
 
-  return allocator_address;
+  return request.reservation_address;
 }
 
 // Reuses compatible pending state before trying a fresh allocation. On a
@@ -742,8 +687,7 @@ absl::StatusOr<ScopedDeviceAddress<uint8_t>>
 DeviceAddressVmmAllocator::Allocate(
     int device_ordinal, uint64_t allocation_size, bool /*retry_on_failure*/,
     int64_t /*memory_space*/, MemoryReservation* reservation,
-    uint64_t reservation_offset, uint64_t mapping_size,
-    bool return_reservation_address) {
+    uint64_t reservation_offset, uint64_t mapping_size) {
   if (allocation_size != mapping_size) {
     return absl::InvalidArgumentError(
         "allocation_size must equal mapping_size for mapped Allocate");
@@ -765,12 +709,9 @@ DeviceAddressVmmAllocator::Allocate(
       DeviceAddressBase reservation_address,
       ValidateReservationRange(reservation, reservation_offset, mapping_size));
 
-  const MappedAddressMode mode =
-      return_reservation_address ? MappedAddressMode::kReservationAddress
-                                 : MappedAddressMode::kSeparateAllocatorAddress;
-  const MappedAllocateRequest request{reservation,     reservation_address,
+  const MappedAllocateRequest request{reservation, reservation_address,
                                       allocation_size, reservation_offset,
-                                      multi_device,    mode};
+                                      multi_device};
 
   absl::MutexLock lock(state->mu);
   // Clang cannot propagate TryWithPendingReclaim's state.mu lock requirement
@@ -793,9 +734,8 @@ DeviceAddressVmmAllocator::Allocate(
       DeviceAddressBase result,
       TryWithPendingReclaim(*state, allocation_size, try_reuse, try_fresh));
 
-  // For return_reservation_address=true this is `reservation_address`; for
-  // return_reservation_address=false it is the allocator-owned address paired
-  // with the reservation mapping.
+  // `result` is the reservation slice, which acts as the allocator address for
+  // this allocation.
   return ScopedDeviceAddress<uint8_t>(result, device_ordinal, this);
 }
 
@@ -1235,24 +1175,22 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
     return absl::OkStatus();
   }
 
-  // Map() and Allocate(..., return_reservation_address=false) record
-  // reservation mappings by the mapped reservation VA. Reconstruct the same
-  // reservation slice here so callers do not need to hold a ScopedMapping.
+  // Map() records reservation mappings by the mapped reservation VA.
+  // Reconstruct the same reservation slice here so callers do not need to hold
+  // a ScopedMapping.
   ASSIGN_OR_RETURN(
       DeviceAddressBase reservation_address,
       ValidateReservationRange(reservation, reservation_offset, size));
 
   absl::MutexLock lock(state->mu);
   // UnMap() only accepts the exact active reservation range previously created
-  // by Map() or Allocate(..., return_reservation_address=false). Allocator
-  // addresses and subranges are not valid UnMap() inputs.
+  // by Map(). Allocator addresses and subranges are not valid UnMap() inputs.
   auto reservation_it =
       state->reservation_records.find(reservation_address.opaque());
   if (reservation_it == state->reservation_records.end()) {
     return absl::NotFoundError(absl::StrFormat(
-        "UnMap() requires an exact active reservation range created by Map() "
-        "or Allocate(..., return_reservation_address=false): virtual address "
-        "%p (%uB)",
+        "UnMap() requires an exact active reservation range created by Map(): "
+        "virtual address %p (%uB)",
         reservation_address.opaque(), reservation_address.size()));
   }
   AllocationRecord* record = reservation_it->second;
@@ -1265,9 +1203,8 @@ absl::Status DeviceAddressVmmAllocator::UnMap(int device_ordinal,
           reservation_address.opaque(), reservation_address.size()));
     }
     return absl::NotFoundError(absl::StrFormat(
-        "UnMap() requires an exact active reservation range created by Map() "
-        "or Allocate(..., return_reservation_address=false): virtual address "
-        "%p (%uB)",
+        "UnMap() requires an exact active reservation range created by Map(): "
+        "virtual address %p (%uB)",
         reservation_address.opaque(), reservation_address.size()));
   }
   CHECK(record->reservation_active());

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -71,45 +71,37 @@ namespace stream_executor {
 // NOLINTBEGIN(whitespace/line_length)
 // Allowed address behavior:
 //
-// +--------------------------------------------------------+---------------------+------------+-----+-------+
-// | Address                                                | Role                | Deallocate | Map | UnMap |
-// +--------------------------------------------------------+---------------------+------------+-----+-------+
-// | Allocate() return                                      | allocator address   | yes        | yes | no    |
-// | Allocate(..., return_reservation_address=true) return  | allocator address   | yes        | yes | no    |
-// | Allocate(..., return_reservation_address=false) return | allocator address   | yes        | yes | no    |
-// | reservation slice from Allocate(..., false)            | reservation address | no         | no  | yes   |
-// | reservation slice from Map()                           | reservation address | no         | no  | yes   |
-// +--------------------------------------------------------+---------------------+------------+-----+-------+
+// +----------------------------------+---------------------+------------+-----+-------+
+// | Address                          | Role                | Deallocate | Map | UnMap |
+// +----------------------------------+---------------------+------------+-----+-------+
+// | Allocate() return                | allocator address   | yes        | yes | no    |
+// | mapped Allocate() return         | allocator address   | yes        | yes | no    |
+// | reservation slice from Map()     | reservation address | no         | no  | yes   |
+// +----------------------------------+---------------------+------------+-----+-------+
 // NOLINTEND(whitespace/line_length)
 // clang-format on
 //
 // The table uses "yes" for API calls that accept the address in that row. For
 // example, Map() takes an allocator address as its source, while UnMap() takes
 // a reservation address to tear down. Map() still requires the allocator
-// address to have no active reservation-address alias; for example, an
-// Allocate(..., return_reservation_address=false) result can be remapped only
-// after its initial reservation-address alias is released with UnMap().
+// address to have no active reservation-address alias.
 //
 // The main API flows are:
 //
 //  1. Allocate(size) creates an allocator-owned VA reservation, allocates raw
 //     physical memory, maps that memory into the owned reservation, and returns
 //     the allocator address.
-//  2. Allocate(..., return_reservation_address=true) allocates raw physical
-//     memory and maps it directly into the caller reservation. The returned VA
-//     comes from the caller reservation, but it is still the allocator address
-//     for this allocation.
-//  3. Allocate(..., return_reservation_address=false) returns a separate
-//     allocator-owned address and also maps the same raw physical allocation
-//     into the caller reservation as a reservation address.
-//  4. Map(addr, reservation, ...) maps the raw physical allocation currently
+//  2. The mapped Allocate() overload allocates raw physical memory and maps it
+//     directly into the caller reservation. The returned VA comes from the
+//     caller reservation, but it is still the allocator address for this
+//     allocation.
+//  3. Map(addr, reservation, ...) maps the raw physical allocation currently
 //     backing allocator address `addr` into one caller reservation slice.
 //     UnMap(reservation, ...) removes that reservation-address alias.
 //
 // Deallocate() accepts only allocator addresses and requires any active
 // reservation-address alias to be released with UnMap() first. UnMap() accepts
-// only reservation addresses created by Map() or by
-// Allocate(..., return_reservation_address=false). Passing an allocator address
+// only reservation addresses created by Map(). Passing an allocator address
 // to UnMap(), or a reservation address to Deallocate(), is an error.
 // Each allocator address may have at most one active reservation-address alias.
 // A reservation mapping is owned as the same full range that created it:
@@ -182,17 +174,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // MemoryReservation range.
   // `allocation_size` and `mapping_size` must be equal.
   //
-  // There are two modes:
-  //
-  //  * `return_reservation_address=true`: the mapped reservation slice is
-  //    returned and is treated as the allocator address. The caller releases it
-  //    with Deallocate(), may use it as a Map() source, and must not pass it to
-  //    UnMap().
-  //  * `return_reservation_address=false`: the allocator creates and returns a
-  //    separate allocator-owned address. The same raw physical allocation is
-  //    also mapped into the caller reservation as a reservation address. The
-  //    returned allocator address is released with Deallocate(); the
-  //    reservation-address alias may be released earlier with UnMap().
+  // The mapped reservation slice is returned and is treated as the allocator
+  // address. The caller releases it with Deallocate(), may use it as a Map()
+  // source, and must not pass it to UnMap().
   //
   // The caller owns `reservation` and must keep it alive while any mapping into
   // it is active or waiting for deferred unmap completion. Deallocate() never
@@ -200,8 +184,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   absl::StatusOr<ScopedDeviceAddress<uint8_t>> Allocate(
       int device_ordinal, uint64_t allocation_size, bool retry_on_failure,
       int64_t memory_space, MemoryReservation* reservation,
-      uint64_t reservation_offset, uint64_t mapping_size,
-      bool return_reservation_address);
+      uint64_t reservation_offset, uint64_t mapping_size);
 
   // Pull in two-arg overload that sets retry_on_failure to true.
   using DeviceAddressAllocator::Allocate;
@@ -222,8 +205,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
 
   // Deallocates an allocator address asynchronously. `mem` must be an address
   // returned by Allocate(), including reservation-derived addresses returned by
-  // Allocate(..., return_reservation_address=true). Reservation addresses
-  // created by Map() or by Allocate(..., return_reservation_address=false) must
+  // the mapped Allocate() overload. Reservation addresses created by Map() must
   // not be passed to Deallocate(). If `mem` has an active reservation-address
   // alias, the caller must release that alias with UnMap() before calling
   // Deallocate(). The caller can call this function while device kernels are
@@ -236,28 +218,25 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // `reservation` at `reservation_offset`.
   //
   // `addr` must be an active allocator address returned by this allocator,
-  // including reservation-derived addresses returned by
-  // Allocate(..., return_reservation_address=true). Non-owning reservation
-  // addresses created by Map() or by
-  // Allocate(..., return_reservation_address=false), and addresses from other
-  // allocators, are not supported. The physical allocation backing `addr` must
-  // be at least `size` bytes. Each allocator address may have at most one
-  // active reservation-address alias at a time. The caller owns `reservation`
-  // and must keep it alive until UnMap() is called and the allocator stream
-  // reaches that deferred unmap point.
+  // including reservation-derived addresses returned by the mapped Allocate()
+  // overload. Non-owning reservation addresses created by Map(), and addresses
+  // from other allocators, are not supported. The physical allocation backing
+  // `addr` must be at least `size` bytes. Each allocator address may have at
+  // most one active reservation-address alias at a time. The caller owns
+  // `reservation` and must keep it alive until UnMap() is called and the
+  // allocator stream reaches that deferred unmap point.
   absl::Status Map(int device_ordinal, DeviceAddressBase addr,
                    MemoryReservation* reservation, uint64_t reservation_offset,
                    uint64_t size);
 
-  // Defers unmapping the reservation address created by Map() or by
-  // Allocate(..., return_reservation_address=false) for the given reservation
-  // range until all previously enqueued work on the allocator stream has
-  // completed.
+  // Defers unmapping the reservation address created by Map() for the given
+  // reservation range until all previously enqueued work on the allocator
+  // stream has completed.
   // The caller must pass the same full reservation range that created the
   // mapping; partial ranges that overlap a tracked mapping are rejected.
-  // The reservation-derived allocator address returned by
-  // Allocate(..., return_reservation_address=true) is not a reservation
-  // address for this API and must be released with Deallocate() instead.
+  // The reservation-derived allocator address returned by the mapped
+  // Allocate() overload is not a reservation address for this API and must be
+  // released with Deallocate() instead.
   //
   // On success this method moves the active mapping to the deferred unmap
   // queue. On error, active bookkeeping is unchanged. Empty mappings, such as
@@ -305,8 +284,8 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     // Deferred Deallocate() of any Allocate() result. AllocationRecord::kind()
     // identifies the API mode that created the allocation.
     kAllocation,
-    // Deferred completion of a reservation alias created by Map() or mapped
-    // Allocate(). The reservation address does not own the raw allocation.
+    // Deferred completion of a reservation alias created by Map(). The
+    // reservation address does not own the raw allocation.
     kMap,
   };
 
@@ -321,8 +300,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
    public:
     enum class Kind {
       kAllocate,
-      kAllocateAndMapReturnMapAddr,
-      kAllocateAndMapReturnNewAddr,
+      kAllocateAndMap,
     };
 
     AllocationRecord(
@@ -386,8 +364,8 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     std::unique_ptr<MemoryAllocation> raw_allocation_;
     bool multi_device_;
 
-    // Present for Allocate() and
-    // Allocate(..., return_reservation_address=false).
+    // Present for Allocate(); the mapped Allocate() overload returns a
+    // caller-reservation address and owns no reservation.
     std::unique_ptr<MemoryReservation> allocator_address_reservation_;
     // Present for the lifetime of the allocation record.
     MemoryReservation::ScopedMapping allocator_address_mapping_;
@@ -444,17 +422,15 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     std::deque<PendingDeallocation> pending_deallocations ABSL_GUARDED_BY(mu);
     // Owns AllocationRecord objects. Key is the allocator address pointer
     // (`AllocationRecord::allocator_address().opaque()`), including the
-    // reservation-derived allocator address returned by
-    // Allocate(..., return_reservation_address=true). Allocator-address
-    // active/stale state is stored in
+    // reservation-derived allocator address returned by the mapped Allocate()
+    // overload. Allocator-address active/stale state is stored in
     // AllocationRecord::allocator_active()/allocator_stale().
     absl::flat_hash_map<void*, std::unique_ptr<AllocationRecord>>
         records_by_allocator_address ABSL_GUARDED_BY(mu);
 
     // Reservation-address index. Keys are reservation alias pointers
-    // (`AllocationRecord::reservation_address().opaque()`) created by Map() or
-    // by Allocate(..., return_reservation_address=false). Active/stale state is
-    // stored in the record.
+    // (`AllocationRecord::reservation_address().opaque()`) created by Map().
+    // Active/stale state is stored in the record.
     absl::flat_hash_map<void*, AllocationRecord*> reservation_records
         ABSL_GUARDED_BY(mu);
   };
@@ -523,18 +499,12 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       MemoryReservation::ScopedMapping mapping, bool multi_device)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  enum class MappedAddressMode {
-    kReservationAddress,
-    kSeparateAllocatorAddress,
-  };
-
   struct MappedAllocateRequest {
     MemoryReservation* reservation;
     DeviceAddressBase reservation_address;
     uint64_t size;
     uint64_t reservation_offset;
     bool multi_device;
-    MappedAddressMode mode;
   };
 
   // Reactivates a compatible stale mapped allocation.
@@ -548,8 +518,8 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       PerDeviceState& state, const MappedAllocateRequest& request)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
-  // Creates a mapped allocation with either the caller-owned reservation
-  // address or a separate allocator-owned address as its returned address.
+  // Creates a mapped allocation with the caller-owned reservation address as
+  // its returned address.
   absl::StatusOr<DeviceAddressBase> CreateMappedAllocation(
       PerDeviceState& state, const MappedAllocateRequest& request)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);

--- a/xla/stream_executor/device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/device_address_vmm_allocator_test.cc
@@ -15,12 +15,13 @@ limitations under the License.
 
 #include "xla/stream_executor/device_address_vmm_allocator.h"
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
@@ -234,8 +235,7 @@ TEST_F(DeviceAddressVmmAllocatorTest,
       allocator->Allocate(
           /*device_ordinal=*/0, /*allocation_size=*/2 * kGranularity,
           /*retry_on_failure=*/false, /*memory_space=*/0, reservation.get(),
-          /*reservation_offset=*/0, /*mapping_size=*/2 * kGranularity,
-          /*return_reservation_address=*/true));
+          /*reservation_offset=*/0, /*mapping_size=*/2 * kGranularity));
   EXPECT_EQ(reservation->active_mapping_count(), 1);
   EXPECT_EQ(allocator->allocation_count(), 2);
 }


### PR DESCRIPTION
## Summary

Removes the `return_reservation_address=false` mode from `DeviceAddressVmmAllocator`'s mapped `Allocate()` overload and drops the `return_reservation_address` parameter entirely. There is no use case for the mode that returned a separate allocator-owned address alongside a reservation-address alias, so the mapped `Allocate()` now always returns the mapped reservation slice as the allocator address:

```cpp
absl::StatusOr<ScopedDeviceAddress<uint8_t>> Allocate(
    int device_ordinal, uint64_t allocation_size, bool retry_on_failure,
    int64_t memory_space, MemoryReservation* reservation,
    uint64_t reservation_offset, uint64_t mapping_size);
```

## Details

- Removed the `MappedAddressMode` enum and the `mode` field of `MappedAllocateRequest`.
- Collapsed `AllocationRecord::Kind::{kAllocateAndMapReturnMapAddr, kAllocateAndMapReturnNewAddr}` into a single `kAllocateAndMap`.
- `TryReuseMappedAllocation()` and `CreateMappedAllocation()` lost their separate-address branches (no allocator-owned reservation creation, alias installation, or dual pending-entry handling in the mapped path).
- Reservation-address aliases are now created only by `Map()`; class docs (address-behavior table, API flows, `Deallocate`/`Map`/`UnMap` contracts) and error messages updated accordingly.
- Updated the single production call site in `gpu_executable_va_remap_allocator.cc`.
- Deleted the two CUDA tests that existed solely for the removed mode; other call sites just drop the argument.

Net: **−188 lines**.

## Testing

- `bazel build --config=cuda` of `//xla/stream_executor:device_address_vmm_allocator{,_test}`, `//xla/service/gpu:gpu_executable_buffer_allocator`, and `//xla/stream_executor/cuda:cuda_device_address_vmm_allocator_test`: success.
- `device_address_vmm_allocator_test`: 4/4 passed.
- `cuda_device_address_vmm_allocator_test` (H200): 31/31 passed.