### PR TITLE
[XLA:GPU] Do not fuse a slice onto a costly-to-duplicate operand.

### DIFF
--- a/xla/service/gpu/triton_tiling_propagation.cc
+++ b/xla/service/gpu/triton_tiling_propagation.cc
@@ -1035,6 +1035,25 @@ bool AllUsersAreSlicesWithSameShape(const HloInstruction& operand,
   return true;
 }
 
+// Returns true if every user of `hlo` is a slice.
+bool AllUsersAreSlices(const HloInstruction& hlo) {
+  return absl::c_all_of(hlo.users(), [](const HloInstruction* user) {
+    return user->opcode() == HloOpcode::kSlice;
+  });
+}
+
+// Whether giving each consumer of `hlo` its own copy is cheap. True when `hlo`
+// is cheap to recompute (a parameter/constant read, or an elementwise op that
+// recomputes only the needed tile), or when every user only slices it, so each
+// reads a sub-region of the one materialized result without re-running `hlo`.
+// Anything else is conservatively assumed to redo its full computation per
+// consumer.
+bool IsCheapToDuplicate(const HloInstruction& hlo) {
+  return hlo.opcode() == HloOpcode::kParameter ||
+         hlo.opcode() == HloOpcode::kConstant || hlo.IsElementwise() ||
+         AllUsersAreSlices(hlo);
+}
+
 }  // namespace
 
 // Tells that fusing an instruction as an input is efficient.
@@ -1059,6 +1078,8 @@ bool IsInputWorthFusing(const HloInstruction& hlo) {
   //   the slice can be fused into the producer instead of here.
   // * AllUsersAreSlicesWithSameShape - slices of the same shape can be
   //   fused into the producer by the multi output fusion pass.
+  // * IsCheapToDuplicate - fusing the slice duplicates the shared operand into
+  //   each consumer, so only do it when that duplication is cheap.
   if (hlo.opcode() == HloOpcode::kSlice) {
     const HloInstruction* operand = hlo.operand(0);
     while (HloPredicateIsOp<HloOpcode::kBitcast, HloOpcode::kTranspose,
@@ -1067,7 +1088,8 @@ bool IsInputWorthFusing(const HloInstruction& hlo) {
       operand = operand->operand(0);
     }
     if (operand->user_count() > 1 &&
-        !AllUsersAreSlicesWithSameShape(*operand, hlo.shape())) {
+        !AllUsersAreSlicesWithSameShape(*operand, hlo.shape()) &&
+        IsCheapToDuplicate(*operand)) {
       return true;
     }
   }

--- a/xla/service/gpu/triton_tiling_propagation_test.cc
+++ b/xla/service/gpu/triton_tiling_propagation_test.cc
@@ -120,5 +120,30 @@ ENTRY entry {
   EXPECT_TRUE(triton_fusion::IsInputWorthFusing(*slice));
 }
 
+TEST_F(TritonTilingPropagationTest,
+       IsInputWorthFusingSliceNotWorthThroughSharedNonElementwiseOperand) {
+  // `slice` reaches `ds` through a single-user reshape, but `ds` is a
+  // dynamic-slice shared with `keep0`. Fusing the slice would recompute `ds` in
+  // each consumer, so it is not worth fusing.
+  const char* hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  w = f32[4,2,512] parameter(0)
+  idx = s32[] parameter(1)
+  zero = s32[] constant(0)
+  ds = f32[1,2,512] dynamic-slice(w, idx, zero, zero), dynamic_slice_sizes={1,2,512}
+  keep0 = f32[1,1,512] slice(ds), slice={[0:1], [0:1], [0:512]}
+  reshape = f32[2,512] reshape(ds)
+  slice = f32[1,512] slice(reshape), slice={[1:2], [0:512]}
+  ROOT root = tuple(slice, keep0)
+}
+)";
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  const HloInstruction* slice =
+      module->entry_computation()->root_instruction()->operand(0);
+  EXPECT_FALSE(triton_fusion::IsInputWorthFusing(*slice));
+}
+
 }  // namespace
 }  // namespace xla::gpu


### PR DESCRIPTION
📝 Summary of Changes
Adds an `IsCheapToDuplicate` operand check to the slice-fusion path in `IsInputWorthFusing`. A slice reaching a producer shared by multiple consumers (through single-user reshapes/bitcasts/transposes) is now fused only if that producer is cheap to duplicate. Otherwise, e.g., a dynamic-slice reached through a reshape, as in paligemma, are left unfused.

🎯 Justification
Commit ac6958edf3 caused a ~6% regression in paligemma inference. This restores it.

🚀 Kind of Contribution
🐛 Bug Fix, ⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
paligemma inference 1 GPU MI350X, 23.43 ms → 22.07 ms (−5.8%)

🧪 Unit Tests:
`IsInputWorthFusingSliceNotWorthThroughSharedNonElementwiseOperand`