### PR TITLE
[XLA:GPU][oneAPI] Enable PJRT_Client_DmaMap for SYCL

### DIFF
--- a/xla/pjrt/c/pjrt_c_api_gpu_test.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_test.cc
@@ -396,11 +396,6 @@ TEST_F(PjrtCApiGpuTest, CreateAndDestroyExecuteContext) {
 }
 
 TEST_F(PjrtCApiGpuTest, DmaMapAndUnmap) {
-// TODO(Intel-tf) : DMA map/unmap is currently not supported
-// on SYCL backend, re-enable the test once it's supported.
-#ifdef TENSORFLOW_USE_SYCL
-  GTEST_SKIP() << "DMA map/unmap not supported on SYCL backend";
-#endif
   size_t dma_size = 1024 * 1024;
   size_t alignment = 1024 * 1024;
   void* host_dma_ptr = tsl::port::AlignedMalloc(

--- a/xla/stream_executor/sycl/sycl_executor.cc
+++ b/xla/stream_executor/sycl/sycl_executor.cc
@@ -15,8 +15,6 @@ limitations under the License.
 
 #include "xla/stream_executor/sycl/sycl_executor.h"
 
-#include <unistd.h>
-
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -36,6 +34,9 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
+#include <sycl/feature_test.hpp>
+#include <sycl/usm.hpp>
+#include <unistd.h>
 #include "xla/stream_executor/device_description.h"
 #include "xla/stream_executor/device_memory.h"
 #include "xla/stream_executor/dnn.h"
@@ -774,6 +775,50 @@ absl::StatusOr<std::unique_ptr<Event>> SyclExecutor::CreateEvent() {
 absl::StatusOr<std::unique_ptr<MemoryAllocation>>
 SyclExecutor::HostMemoryAllocate(uint64_t size) {
   return AllocateHostMemory(sycl_context_.get(), device_ordinal(), size);
+}
+
+bool SyclExecutor::HostMemoryRegister(void* location, uint64_t size) {
+  VLOG(1) << "Registering host memory at " << location << " (" << size
+          << " bytes) for SYCL DMA";
+#if defined(SYCL_EXT_ONEAPI_COPY_OPTIMIZE)
+  try {
+    const sycl::context context = sycl_context_->context();
+    sycl::ext::oneapi::experimental::prepare_for_device_copy(location, size,
+                                                             context);
+    if (SyclIsHostMemoryRegistered(device_, location)) {
+      return true;
+    }
+    sycl::ext::oneapi::experimental::release_from_device_copy(location,
+                                                              context);
+    LOG(ERROR) << "SYCL did not register host memory at " << location;
+  } catch (const sycl::exception& e) {
+    LOG(ERROR) << "Failed to register host memory at " << location << ": "
+               << e.what();
+  }
+#else
+  LOG(ERROR) << "The SYCL toolchain does not support host memory import";
+#endif
+  return false;
+}
+
+bool SyclExecutor::HostMemoryUnregister(void* location) {
+  VLOG(1) << "Unregistering host memory at " << location << " from SYCL DMA";
+#if defined(SYCL_EXT_ONEAPI_COPY_OPTIMIZE)
+  try {
+    sycl::ext::oneapi::experimental::release_from_device_copy(
+        location, sycl_context_->context());
+    if (!SyclIsHostMemoryRegistered(device_, location)) {
+      return true;
+    }
+    LOG(ERROR) << "SYCL did not unregister host memory at " << location;
+  } catch (const sycl::exception& e) {
+    LOG(ERROR) << "Failed to unregister host memory at " << location << ": "
+               << e.what();
+  }
+#else
+  LOG(ERROR) << "The SYCL toolchain does not support host memory import";
+#endif
+  return false;
 }
 
 void SyclExecutor::DeallocateStream(Stream* stream) {

--- a/xla/stream_executor/sycl/sycl_executor.h
+++ b/xla/stream_executor/sycl/sycl_executor.h
@@ -144,6 +144,9 @@ class SyclExecutor : public gpu::GpuExecutor {
   absl::StatusOr<std::unique_ptr<MemoryAllocation>> HostMemoryAllocate(
       uint64_t size) override;
 
+  bool HostMemoryRegister(void* location, uint64_t size) override;
+  bool HostMemoryUnregister(void* location) override;
+
   // Deallocates the given stream.
   void DeallocateStream(Stream* stream) override;
 

--- a/xla/stream_executor/sycl/sycl_gpu_runtime.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.cc
@@ -27,6 +27,9 @@ namespace stream_executor::sycl {
 
 namespace {
 
+using HostPointerQueryFn = ze_result_t(ZE_APICALL*)(ze_driver_handle_t, void*,
+                                                    void**);
+
 absl::Status IsValidDeviceOrdinal(int device_ordinal,
                                   const absl::string_view& function_name) {
   ASSIGN_OR_RETURN(int device_count, SyclDevicePool::GetDeviceCount());
@@ -128,6 +131,37 @@ absl::Status MemfillDevice(::sycl::queue* stream_handle, void* dst_device,
 }
 
 }  // namespace
+
+// PJRT DmaMap uses prepare_for_device_copy to register ordinary host memory,
+// but SYCL still classifies the imported pointer as usm::alloc::unknown. Query
+// Level Zero directly so registration can be verified and copies from the
+// DmaMapped range can remain asynchronous.
+bool SyclIsHostMemoryRegistered(const ::sycl::device& device,
+                                const void* location) {
+  if (location == nullptr) {
+    return false;
+  }
+  try {
+    const ze_driver_handle_t driver =
+        ::sycl::get_native<::sycl::backend::ext_oneapi_level_zero>(
+            device.get_platform());
+    thread_local ze_driver_handle_t cached_driver = nullptr;
+    thread_local HostPointerQueryFn query = nullptr;
+    if (cached_driver != driver) {
+      query = nullptr;
+      if (zeDriverGetExtensionFunctionAddress(
+              driver, "zexDriverGetHostPointerBaseAddress",
+              reinterpret_cast<void**>(&query)) != ZE_RESULT_SUCCESS) {
+        return false;
+      }
+      cached_driver = driver;
+    }
+    return query != nullptr && query(driver, const_cast<void*>(location),
+                                     nullptr) == ZE_RESULT_SUCCESS;
+  } catch (const ::sycl::exception&) {
+    return false;
+  }
+}
 
 DevicePool SyclDevicePool::device_pool_;
 
@@ -541,7 +575,9 @@ absl::Status SyclMemcpyDeviceToHostAsync(::sycl::queue* stream_handle,
   }
   ::sycl::usm::alloc dst_alloc_type =
       ::sycl::get_pointer_type(dst_host, stream_handle->get_context());
-  bool async = (dst_alloc_type == ::sycl::usm::alloc::host);
+  bool async =
+      dst_alloc_type == ::sycl::usm::alloc::host ||
+      SyclIsHostMemoryRegistered(stream_handle->get_device(), dst_host);
   return MemcpyDeviceToHost(stream_handle, dst_host, src_device, byte_count,
                             async);
 }
@@ -561,7 +597,9 @@ absl::Status SyclMemcpyHostToDeviceAsync(::sycl::queue* stream_handle,
   }
   ::sycl::usm::alloc src_alloc_type =
       ::sycl::get_pointer_type(src_host, stream_handle->get_context());
-  bool async = (src_alloc_type == ::sycl::usm::alloc::host);
+  bool async =
+      src_alloc_type == ::sycl::usm::alloc::host ||
+      SyclIsHostMemoryRegistered(stream_handle->get_device(), src_host);
   return MemcpyHostToDevice(stream_handle, dst_device, src_host, byte_count,
                             async);
 }

--- a/xla/stream_executor/sycl/sycl_gpu_runtime.h
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.h
@@ -148,6 +148,10 @@ struct SyclTimerProperties {
   uint64_t timestamp_mask;
 };
 
+// Returns whether location belongs to a driver-imported host-memory range.
+bool SyclIsHostMemoryRegistered(const ::sycl::device& device,
+                                const void* location);
+
 // Returns the timer frequency (Hz) and valid timestamp bitmask for the given
 // device ordinal using the Level Zero backend.
 absl::StatusOr<SyclTimerProperties> SyclGetTimerProperties(int device_ordinal);


### PR DESCRIPTION
📝 Summary of Changes
Adding support for DMA Map for Intel GPUs. DPC++ exposes the necessary functions (https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_copy_optimize.asciidoc) to (un)register pinned memory since Jul 2023 (https://github.com/intel/llvm/commit/65cc0cf) and Level zero exposes the relevant functions since the 22.16.22992 release (https://github.com/intel/compute-runtime/commit/9f79e432bb229915e018dda37f8726986aa336f5).

I'm adding the necessary guards just in case with `SYCL_EXT_ONEAPI_COPY_OPTIMIZE` for DPC++. And I'm double-checking with `zexDriverGetHostPointerBaseAddress` if it's present to ensure the registration does succeed as DPC++ will silently fail otherwise.

I've tested this change on a b70 with latest drivers.

🎯 Justification
Allows the use of DmaMap on Intel GPU.

🚀 Kind of Contribution
⚡️ Performance Improvement ✨ New Feature

