### PR TITLE
[XLA:GPU] Add scheduler memory-fencing fence-to-done mode

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -470,6 +470,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_experimental_enable_scheduler_memory_fencing(false);
   opts.set_xla_gpu_experimental_scheduler_memory_fencing_threshold_bytes(0);
   opts.set_xla_gpu_experimental_scheduler_memory_fencing_slack_windows(1);
+  opts.set_xla_gpu_experimental_scheduler_memory_fencing_to_done(false);
   opts.set_xla_pjrt_allow_auto_layout_in_hlo(false);
   opts.set_xla_gpu_enable_scatter_determinism_expander(false);
   opts.set_xla_gpu_unsupported_enable_all_reduce_decomposer(false);
@@ -3034,6 +3035,16 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
           ->xla_gpu_experimental_scheduler_memory_fencing_slack_windows(),
       "How many async collective windows the users of a fenced buffer may be "
       "deferred past the buffer's last-use window in the pre-LHS schedule."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_experimental_scheduler_memory_fencing_to_done",
+      bool_setter_for(
+          &DebugOptions::
+              set_xla_gpu_experimental_scheduler_memory_fencing_to_done),
+      debug_options->xla_gpu_experimental_scheduler_memory_fencing_to_done(),
+      "If true, the SchedulerMemoryFencing pass fences buffer users to the "
+      "async collective done closing their target window instead of the "
+      "start opening the following window, preventing users from being "
+      "placed after that collective completes."));
   flag_list->push_back(tsl::Flag(
       "xla_pjrt_allow_auto_layout_in_hlo",
       bool_setter_for(&DebugOptions::set_xla_pjrt_allow_auto_layout_in_hlo),

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -755,6 +755,7 @@ absl::Status RunLatencyHidingSchedulerPasses(
     pipeline.AddPass<SchedulerMemoryFencing>(
         shape_size_in_bytes, fencing_threshold_bytes,
         options.xla_gpu_experimental_scheduler_memory_fencing_slack_windows(),
+        options.xla_gpu_experimental_scheduler_memory_fencing_to_done(),
         alias_info);
   }
   pipeline.AddPass<LatencyHidingScheduler>(scheduling_context,

--- a/xla/service/gpu/gpu_hlo_schedule_test.cc
+++ b/xla/service/gpu/gpu_hlo_schedule_test.cc
@@ -171,7 +171,8 @@ ENTRY entry {
 
 class GpuHloScheduleFencingTest : public GpuHloScheduleTest {
  protected:
-  HloModuleConfig GetFencingModuleConfig(bool enable_memory_fencing) {
+  HloModuleConfig GetFencingModuleConfig(bool enable_memory_fencing,
+                                         bool fence_to_done = false) {
     TestConfig test_config;
     test_config.enable_latency_hiding_scheduler = true;
     HloModuleConfig config = GetModuleConfig(test_config);
@@ -180,6 +181,8 @@ class GpuHloScheduleFencingTest : public GpuHloScheduleTest {
         enable_memory_fencing);
     options.set_xla_gpu_experimental_scheduler_memory_fencing_threshold_bytes(
         1024 * 1024);
+    options.set_xla_gpu_experimental_scheduler_memory_fencing_to_done(
+        fence_to_done);
     config.set_debug_options(options);
     config.set_replica_count(2);
     return config;
@@ -209,6 +212,36 @@ TEST_F(GpuHloScheduleFencingTest, MemoryFencingAddsScheduleRespectedFences) {
   for (const HloInstruction* instruction : entry->instructions()) {
     for (const HloInstruction* successor : instruction->control_successors()) {
       EXPECT_EQ(successor->opcode(), HloOpcode::kCollectivePermuteStart);
+      EXPECT_LT(position(instruction), position(successor));
+      ++fence_count;
+    }
+  }
+  EXPECT_GT(fence_count, 0);
+}
+
+TEST_F(GpuHloScheduleFencingTest, MemoryFencingToDoneFencesToWindowDones) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(
+                           kFencingHloText, GetFencingModuleConfig(
+                                                /*enable_memory_fencing=*/true,
+                                                /*fence_to_done=*/true)));
+  ASSERT_OK(ScheduleGpuModule(module.get()).status());
+
+  const HloComputation* entry = module->entry_computation();
+  const std::vector<HloInstruction*>& sequence =
+      module->schedule().sequence(entry).instructions();
+  auto position = [&](const HloInstruction* instruction) {
+    return std::distance(
+        sequence.begin(),
+        std::find(sequence.begin(), sequence.end(), instruction));
+  };
+
+  // Every fence ends at an async collective done, and the post-LHS schedule
+  // respects it: the fenced compute runs before the collective completes.
+  int64_t fence_count = 0;
+  for (const HloInstruction* instruction : entry->instructions()) {
+    for (const HloInstruction* successor : instruction->control_successors()) {
+      EXPECT_EQ(successor->opcode(), HloOpcode::kCollectivePermuteDone);
       EXPECT_LT(position(instruction), position(successor));
       ++fence_count;
     }

--- a/xla/service/scheduler_memory_fencing.cc
+++ b/xla/service/scheduler_memory_fencing.cc
@@ -46,8 +46,10 @@ struct ComputationFencingInfo {
   // Schedule position of every instruction in the computation.
   absl::flat_hash_map<const HloInstruction*, int64_t> position;
   // Async collective windows, ordered by the schedule position of their start
-  // operations.
+  // operations. `window_dones` is nullptr for a window whose done operation
+  // could not be located in the sequence.
   std::vector<HloInstruction*> window_starts;
+  std::vector<HloInstruction*> window_dones;
   std::vector<int64_t> window_start_positions;
   std::vector<int64_t> window_done_positions;
   std::unique_ptr<HloReachabilityMap> reachability;
@@ -69,18 +71,21 @@ ComputationFencingInfo BuildComputationFencingInfo(
     }
     // The window closes at the corresponding done operation. If it cannot be
     // located in this sequence, treat the window as closing immediately.
+    HloInstruction* done = nullptr;
     int64_t done_position = i;
-    for (const HloInstruction* user : instruction->users()) {
+    for (HloInstruction* user : instruction->users()) {
       if (hlo_query::IsAsyncCollectiveDoneOp(user,
                                              /*include_send_recv=*/false)) {
         auto it = info.position.find(user);
         if (it != info.position.end()) {
+          done = user;
           done_position = it->second;
         }
         break;
       }
     }
     info.window_starts.push_back(instruction);
+    info.window_dones.push_back(done);
     info.window_start_positions.push_back(i);
     info.window_done_positions.push_back(done_position);
   }
@@ -209,19 +214,38 @@ absl::StatusOr<bool> SchedulerMemoryFencing::RunImpl(
       ++window_index;
     }
 
-    int64_t target_index = window_index + slack_windows_;
-    // Never fence backwards: the target start must come after the last use in
-    // the reference schedule, otherwise the edge could contradict existing
-    // dependencies. This keeps every edge forward in the schedule order and
-    // therefore acyclic.
-    while (target_index < info.window_starts.size() &&
-           info.window_start_positions[target_index] <= last_use_position) {
-      ++target_index;
+    // Pick the fence target. Fence-to-start uses the start that opens window
+    // W + slack. Fence-to-done uses the done that closes window W + slack - 1,
+    // preventing users from being placed after that collective completes.
+    // The target must come after the last use in the reference schedule so
+    // every added edge remains forward and therefore acyclic.
+    HloInstruction* target = nullptr;
+    if (fence_to_done_) {
+      int64_t target_index = window_index + slack_windows_ - 1;
+      if (target_index < window_index) {
+        target_index = window_index;
+      }
+      while (target_index < info.window_starts.size() &&
+             (info.window_dones[target_index] == nullptr ||
+              info.window_done_positions[target_index] <= last_use_position)) {
+        ++target_index;
+      }
+      if (target_index < info.window_starts.size()) {
+        target = info.window_dones[target_index];
+      }
+    } else {
+      int64_t target_index = window_index + slack_windows_;
+      while (target_index < info.window_starts.size() &&
+             info.window_start_positions[target_index] <= last_use_position) {
+        ++target_index;
+      }
+      if (target_index < info.window_starts.size()) {
+        target = info.window_starts[target_index];
+      }
     }
-    if (target_index >= info.window_starts.size()) {
+    if (target == nullptr) {
       continue;
     }
-    HloInstruction* target = info.window_starts[target_index];
 
     // Fence every user: the buffer stays live until all of its users have
     // executed, so a single fenced user would not bound the live range — an
@@ -247,7 +271,7 @@ absl::StatusOr<bool> SchedulerMemoryFencing::RunImpl(
   VLOG(1) << "SchedulerMemoryFencing: considered " << buffers_considered
           << " buffers >= " << size_threshold_bytes_ << " bytes, added "
           << edges_added << " control edges (slack_windows=" << slack_windows_
-          << ").";
+          << ", fence_to_done=" << fence_to_done_ << ").";
   return edges_added > 0;
 }
 

--- a/xla/service/scheduler_memory_fencing.h
+++ b/xla/service/scheduler_memory_fencing.h
@@ -36,13 +36,21 @@ namespace xla {
 // For every buffer of at least `size_threshold_bytes`, the pass finds the
 // buffer's users and the async collective window W in which (or before which)
 // the last use is scheduled in the reference schedule, and adds a control
-// dependency from every user to the async collective start that opens window
-// W + `slack_windows`. Any schedule that respects the dependency graph can
-// then defer the buffer's release by at most `slack_windows` collective
-// windows relative to the reference schedule, which bounds how many such
-// buffers a scheduler can keep simultaneously live by deferring their last
-// users ("release before advance"). All users are fenced because the buffer
-// stays live until every user has executed.
+// dependency from every user to a fence target:
+//
+// * fence-to-start (default): the async collective start that opens window
+//   W + `slack_windows`.
+// * fence-to-done (`fence_to_done`): the async collective done that closes
+//   window W + `slack_windows` - 1. This prevents a fenced user from being
+//   placed after the target collective completes and can preserve the
+//   opportunity for compute/communication overlap.
+//
+// Any schedule that respects the dependency graph can then defer the buffer's
+// release by at most `slack_windows` collective windows relative to the
+// reference schedule, which bounds how many such buffers a scheduler can keep
+// simultaneously live by deferring their last users ("release before
+// advance"). All users are fenced because the buffer stays live until every
+// user has executed.
 //
 // Every added edge points forward in the reference schedule, which is a valid
 // topological order, so the added edges can never create a cycle, and the
@@ -55,10 +63,11 @@ class SchedulerMemoryFencing : public HloModulePass {
  public:
   SchedulerMemoryFencing(HloCostAnalysis::ShapeSizeFunction shape_size_bytes,
                          int64_t size_threshold_bytes, int32_t slack_windows,
-                         const AliasInfo* alias_info)
+                         bool fence_to_done, const AliasInfo* alias_info)
       : shape_size_bytes_(std::move(shape_size_bytes)),
         size_threshold_bytes_(size_threshold_bytes),
         slack_windows_(slack_windows),
+        fence_to_done_(fence_to_done),
         alias_info_(alias_info) {}
 
   absl::string_view name() const override { return "scheduler-memory-fencing"; }
@@ -72,6 +81,7 @@ class SchedulerMemoryFencing : public HloModulePass {
   HloCostAnalysis::ShapeSizeFunction shape_size_bytes_;
   int64_t size_threshold_bytes_;
   int32_t slack_windows_;
+  bool fence_to_done_;
   const AliasInfo* alias_info_;
 };
 

--- a/xla/service/scheduler_memory_fencing_test.cc
+++ b/xla/service/scheduler_memory_fencing_test.cc
@@ -45,9 +45,10 @@ class SchedulerMemoryFencingTest : public HloHardwareIndependentTestBase {
  protected:
   absl::StatusOr<bool> RunFencing(HloModule* module,
                                   int64_t size_threshold_bytes,
-                                  int32_t slack_windows) {
+                                  int32_t slack_windows,
+                                  bool fence_to_done = false) {
     SchedulerMemoryFencing pass(&ShapeSize, size_threshold_bytes, slack_windows,
-                                &alias_info_);
+                                fence_to_done, &alias_info_);
     return pass.Run(module);
   }
 
@@ -248,6 +249,44 @@ ENTRY entry {
   EXPECT_THAT(Instr(module.get(), "sibling")->control_successors(),
               UnorderedElementsAre(Instr(module.get(), "cp2s")));
   EXPECT_OK(module->schedule().Verify());
+}
+
+TEST_F(SchedulerMemoryFencingTest, FenceToDoneTargetsOwnWindowDone) {
+  // With slack 1, the last use inside window 0 is fenced to that window's
+  // done, so it cannot be placed after the collective completes.
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kLayeredHlo));
+  ASSERT_OK_AND_ASSIGN(
+      bool changed, RunFencing(module.get(), /*size_threshold_bytes=*/kMebibyte,
+                               /*slack_windows=*/1, /*fence_to_done=*/true));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(Instr(module.get(), "wg")->control_successors(),
+              UnorderedElementsAre(Instr(module.get(), "cp1d")));
+  EXPECT_OK(module->schedule().Verify());
+}
+
+TEST_F(SchedulerMemoryFencingTest, FenceToDoneWithUseBeforeWindow) {
+  // The last use precedes window 0, so fence-to-done with slack 1 targets
+  // window 0's done. The user may move into the window but not past its done.
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kUseBeforeWindowHlo));
+  ASSERT_OK_AND_ASSIGN(
+      bool changed, RunFencing(module.get(), /*size_threshold_bytes=*/kMebibyte,
+                               /*slack_windows=*/1, /*fence_to_done=*/true));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(Instr(module.get(), "wg")->control_successors(),
+              UnorderedElementsAre(Instr(module.get(), "cp1d")));
+}
+
+TEST_F(SchedulerMemoryFencingTest, FenceToDoneWithSlackTwoTargetsNextDone) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kLayeredHlo));
+  ASSERT_OK_AND_ASSIGN(
+      bool changed, RunFencing(module.get(), /*size_threshold_bytes=*/kMebibyte,
+                               /*slack_windows=*/2, /*fence_to_done=*/true));
+  EXPECT_TRUE(changed);
+  EXPECT_THAT(Instr(module.get(), "wg")->control_successors(),
+              UnorderedElementsAre(Instr(module.get(), "cp2d")));
 }
 
 TEST_F(SchedulerMemoryFencingTest, SkipsWhenSlackExceedsRemainingWindows) {

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -995,6 +995,13 @@ message DebugOptions {
   optional int32 xla_gpu_experimental_scheduler_memory_fencing_slack_windows =
       517;
 
+  // If true, the SchedulerMemoryFencing pass fences buffer users to the async
+  // collective done that closes their target window instead of the start that
+  // opens the following window. This prevents a fenced user from being placed
+  // after that collective completes and can preserve the opportunity for
+  // compute/communication overlap.
+  optional bool xla_gpu_experimental_scheduler_memory_fencing_to_done = 518;
+
   // This controls how many in-flight collectives latency hiding scheduler
   // can schedule. Example usage:
   // With xla_gpu_experimental_parallel_collective_overlap_limit = 1:
@@ -1686,7 +1693,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 518
+  // Next id: 519
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
📝 Summary of Changes

Adds an optional fence-to-done policy to `SchedulerMemoryFencing`, stacked on
#45929. When enabled, every user of a qualifying buffer is fenced to the async
collective done that closes window `W + slack - 1`, instead of the start that
opens window `W + slack`.

The new debug option is disabled by default:

`xla_gpu_experimental_scheduler_memory_fencing_to_done=false`

This draft is intentionally separate from #45929 so all-users fence-to-start
can be reviewed and validated independently.

🎯 Justification

Fence-to-start bounds how far a buffer user can be deferred, but it does not
structurally require that user to run before its collective completes. The
fence-to-done edge provides that upper bound directly: a fenced user cannot be
scheduled after the target `Done`. This preserves an opportunity for
compute/communication overlap without claiming that the edge alone guarantees
`Start < user < Done` for every dependency graph and scheduler heuristic.

🚀 Kind of Contribution

⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)

The exact CP16/4-node GB200 MaxText workload comparison is pending. This draft
should remain separate from #45929 until that validation determines whether the
tighter policy is needed and beneficial. No public-HLO speedup is claimed yet.

🧪 Unit Tests:

- Added fence-to-done target tests for an in-window use, a use before the first
  window, and slack of two windows.
- Added a GPU scheduling integration test that verifies every generated fence
  targets a collective `Done` and remains respected after LHS.
- `//xla/service:scheduler_memory_fencing_test` passes.

🧪 Execution Tests:

- `//xla/service/gpu:gpu_hlo_schedule_test` passes for A100, B200, GB200,
  GB300, H100, generic NVIDIA GPU, and RTX 6000 Pro configurations (8/8 focused
  test targets including the hardware-independent unit test).
- Exact CP16/4-node GB200 execution validation is pending.
