### PR TITLE
[ROCM] MORI backbone integration

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -48,6 +48,8 @@ cc_library(
         ":loopback_collectives",
     ] + if_cuda_or_rocm_is_configured([
         ":nccl_or_rccl_collectives",
+    ]) + if_rocm_is_configured([
+        ":mori_collectives",
     ]) + if_sycl_is_configured([
         ":oneccl_collectives",
     ]),
@@ -285,6 +287,7 @@ cc_library(
     deps = [
         ":cancellation_token",
         ":gpu_communicator",
+        "//xla:debug_options_flags",
         "//xla:shape_util",
         "//xla:util",
         "//xla:xla_data_proto_cc",
@@ -389,7 +392,9 @@ xla_test(
         "@com_google_googletest//:gtest_main",  # buildcleaner: keep
     ] + if_cuda_or_rocm_is_configured([
         ":nccl_or_rccl_collectives",
-    ]),
+    ]) + if_rocm_is_configured([
+        ":mori_collectives",
+    ])
 )
 
 xla_test(
@@ -1195,6 +1200,77 @@ cc_library(
         "@local_config_rocm//rocm:rccl",  # buildcleaner: keep
         "@local_config_rocm//rocm:rocm_headers",
     ],
+)
+
+cc_library(
+    name = "mori_collectives",
+    hdrs = ["mori_collectives.h",
+            "mori_communicator.h",
+            "mori_stub.h",
+           ],
+    srcs = ["mori_collectives.cc",
+            "mori_communicator.cc",
+            ],
+    tags = [
+        "gpu",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cancellation_token",
+        ":gpu_clique_key",
+        ":gpu_collectives",
+        ":gpu_communicator",
+        "//xla:debug_options_flags",
+        "//xla:future",
+        "//xla:shape_util",
+        "//xla:status_macros",
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla/core/collectives",
+        "//xla/core/collectives:clique_id",
+        "//xla/core/collectives:clique_key",
+        "//xla/core/collectives:collectives_registry",
+        "//xla/core/collectives:communicator",
+        "//xla/core/collectives:rank_id",
+        "//xla/core/collectives:reduction_kind",
+        "//xla/core/collectives:symmetric_memory",
+        "//xla/pjrt/distributed:key_value_store_interface",
+        "//xla/runtime:device_id",
+        "//xla/runtime:process_id",
+        "//xla/service:collective_ops_utils",
+        "//xla/stream_executor:device_address",
+        "//xla/stream_executor:device_memory",
+        "//xla/stream_executor:platform",
+        "//xla/stream_executor:platform_manager",
+        "//xla/stream_executor:stream",
+        "//xla/stream_executor:stream_executor_h",
+        "//xla/tsl/concurrency:async_value",
+        "//xla/tsl/platform:env",
+        "//xla/tsl/platform:errors",
+        "//xla/tsl/platform:status_macros",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/functional:any_invocable",
+        "@com_google_absl//absl/functional:function_ref",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
+        "@tsl//tsl/platform:casts",
+        "@tsl//tsl/platform:numbers",
+    ],
+    alwayslink = True,
 )
 
 cc_library(

--- a/xla/backends/gpu/collectives/collectives_test_util.cc
+++ b/xla/backends/gpu/collectives/collectives_test_util.cc
@@ -66,10 +66,13 @@ std::vector<std::unique_ptr<GpuCommunicator>> DowncastComms(
 absl::StatusOr<std::vector<std::unique_ptr<GpuCommunicator>>>
 CreateCommunicators(absl::Span<se::StreamExecutor* const> executors,
                     std::vector<GlobalDeviceId> device_ids, bool blocking,
-                    size_t num_ids) {
+                    size_t num_ids, GpuCollectives* custom_backend) {
   CHECK_EQ(executors.size(), device_ids.size());
 
-  GpuCollectives* collectives = GpuCollectives::Default("GPU");
+  GpuCollectives* collectives = custom_backend;
+  if (custom_backend == nullptr) {
+    collectives = GpuCollectives::Default("GPU");
+  }
 
   std::vector<GpuCollectives::Device> devices;
   devices.reserve(executors.size());

--- a/xla/backends/gpu/collectives/collectives_test_util.h
+++ b/xla/backends/gpu/collectives/collectives_test_util.h
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
+#include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/symmetric_memory.h"
@@ -44,7 +45,8 @@ std::vector<std::unique_ptr<GpuCommunicator>> DowncastComms(
 absl::StatusOr<std::vector<std::unique_ptr<GpuCommunicator>>>
 CreateCommunicators(absl::Span<se::StreamExecutor* const> executors,
                     std::vector<GlobalDeviceId> device_ids,
-                    bool blocking = true, size_t num_ids = 1);
+                    bool blocking = true, size_t num_ids = 1,
+                    GpuCollectives* custom_backend = nullptr);
 
 absl::StatusOr<std::vector<std::unique_ptr<GpuCommunicator>>>
 SplitCommunicators(

--- a/xla/backends/gpu/collectives/gpu_collectives.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <cstddef>
 #include <optional>
+#include <string>
 
 #include "absl/base/casts.h"
 #include "absl/log/check.h"
@@ -26,6 +27,7 @@ limitations under the License.
 #include "xla/core/collectives/clique_key.h"
 #include "xla/core/collectives/collectives.h"
 #include "xla/core/collectives/collectives_registry.h"
+#include "xla/debug_options_flags.h"
 #include "xla/runtime/device_id.h"
 #include "xla/shape_util.h"
 #include "xla/stream_executor/device_address.h"
@@ -47,6 +49,25 @@ GpuCollectives* GpuCollectives::Default(absl::string_view platform_name) {
     return gpu_collectives;
   }
 
+  LOG(FATAL) << "Unsupported collectives implementation for GPU";
+}
+
+GpuCollectives* GpuCollectives::Resolve(absl::string_view platform_name,
+                                        std::optional<std::string> impl) {
+  auto debug_options = xla::GetDebugOptionsFromFlags();
+  if (!impl.has_value() &&
+      !debug_options.xla_gpu_collectives_implementation().empty()) {
+    impl = debug_options.xla_gpu_collectives_implementation();
+  }
+  auto collectives_or = impl.has_value()
+                            ? CollectivesRegistry::Get(platform_name, *impl)
+                            : CollectivesRegistry::Default(platform_name);
+
+  CHECK_OK(collectives_or) << "Failed to get GPU collectives implementation: "
+                           << impl.value_or("default");
+  if (auto* gpu_coll = absl::down_cast<GpuCollectives*>(*collectives_or)) {
+    return gpu_coll;
+  }
   LOG(FATAL) << "Unsupported collectives implementation for GPU";
 }
 

--- a/xla/backends/gpu/collectives/gpu_collectives.h
+++ b/xla/backends/gpu/collectives/gpu_collectives.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
@@ -52,6 +53,12 @@ class GpuCollectives : public Collectives {
  public:
   // Returns the default collectives implementation for the given platform.
   static GpuCollectives* Default(absl::string_view platform_name);
+
+  // Returns the collectives implementation for the given platform  and
+  // implementation name or the default implementation if not specified.
+  static GpuCollectives* Resolve(
+      absl::string_view platform_name,
+      std::optional<std::string> impl = std::nullopt);
 
   // A callback to get a unique clique ids.
   using CliqueIdCallback =  // NOLINT

--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -678,5 +678,43 @@ TEST(GpuCollectivesTest, AllocatorMemoryRegistrationRegistersWithClique) {
   ASSERT_OK(registration->RegisterWithClique(clique));
 }
 
+// Smoke test for the MORI backbone: creates a MORI communicator and exercises
+// MoriCollectives::Allocate/Deallocate. MORI is a ROCm-only backend and the
+// current implementation is bindings-free (stubbed), so this only verifies the
+// plumbing is reachable and does not crash.
+TEST(GpuCollectivesTest, MoriCreateCommunicatorAndAllocate) {
+  ASSERT_OK_AND_ASSIGN(se::Platform * platform,
+                       PlatformUtil::GetPlatform("gpu"));
+
+  // MORI is a ROCm-only backend; skip on any other platform.
+  if (platform->Name() != "ROCM") {
+    GTEST_SKIP() << "MORI is only available on the ROCM platform";
+  }
+
+  if (platform->VisibleDeviceCount() < 4) {
+    GTEST_SKIP() << "Test requires at least 4 GPUs";
+  }
+
+  auto* mori = xla::gpu::GpuCollectives::Resolve("ROCM", "mori");
+  ASSERT_NE(mori, nullptr);
+  ASSERT_OK_AND_ASSIGN(std::vector<se::StreamExecutor*> executors,
+                       CreateExecutors(platform, 4));
+  ASSERT_OK_AND_ASSIGN(
+      auto comms,
+      CreateCommunicators(executors, {kD0, kD1, kD2, kD3}, /*blocking=*/true,
+                          /*num_ids=*/1, mori));
+  ASSERT_EQ(comms.size(), 4u);
+  ASSERT_NE(comms[0], nullptr);
+  ASSERT_OK_AND_ASSIGN(size_t num_ranks, comms[0]->NumRanks());
+  EXPECT_EQ(num_ranks, 4u);
+
+  // Exercise Allocate/Deallocate wiring. The bindings-free stubs are inert
+  // (Allocate returns an error, Deallocate is unimplemented), so we only verify
+  // the calls are reachable and do not crash.
+  auto buffer_or = mori->Allocate(1024);
+  void* buffer = buffer_or.ok() ? *buffer_or : nullptr;
+  ASSERT_OK(mori->Deallocate(buffer));
+}
+
 }  // namespace
 }  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/mori_collectives.cc
+++ b/xla/backends/gpu/collectives/mori_collectives.cc
@@ -1,0 +1,352 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "xla/backends/gpu/collectives/mori_collectives.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/algorithm/container.h"
+#include "absl/base/call_once.h"
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
+#include "absl/types/span.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/backends/gpu/collectives/cancellation_token.h"
+#include "xla/backends/gpu/collectives/gpu_clique_key.h"
+#include "xla/backends/gpu/collectives/gpu_collectives.h"
+#include "xla/backends/gpu/collectives/mori_communicator.h"
+#include "xla/backends/gpu/collectives/mori_stub.h"
+#include "xla/core/collectives/clique_id.h"
+#include "xla/core/collectives/clique_key.h"
+#include "xla/core/collectives/collectives.h"
+#include "xla/core/collectives/collectives_registry.h"
+#include "xla/core/collectives/communicator.h"
+#include "xla/core/collectives/rank_id.h"
+#include "xla/pjrt/distributed/key_value_store_interface.h"
+#include "xla/runtime/device_id.h"
+#include "xla/runtime/process_id.h"
+#include "xla/status_macros.h"
+#include "xla/stream_executor/platform.h"
+#include "xla/stream_executor/platform_manager.h"
+#include "xla/stream_executor/stream_executor.h"
+#include "xla/tsl/platform/env.h"
+#include "xla/tsl/platform/threadpool.h"
+#include "xla/util.h"
+#include "tsl/platform/casts.h"
+#include "tsl/platform/numbers.h"
+
+namespace shmem = ::mori::shmem;
+
+namespace xla::gpu {
+
+#define XLA_MORI_RETURN_IF_ERROR(expr)                           \
+  do {                                                           \
+    auto status = (expr);                                        \
+    if (status != 0) {                                           \
+      return absl::InternalError(                                \
+          absl::StrFormat("MORI operation failed: %d", status)); \
+    }                                                            \
+  } while (0)
+
+//===----------------------------------------------------------------------===//
+// MoriIdStore
+//===----------------------------------------------------------------------===//
+
+namespace {
+class MoriIdStore {
+ public:
+  MoriIdStore(ProcessId process_id,
+              absl::flat_hash_map<GlobalDeviceId, ProcessId> device_to_process,
+              std::shared_ptr<KeyValueStoreInterface> kv_store)
+      : process_id_(process_id),
+        device_to_process_(std::move(device_to_process)),
+        kv_store_(std::move(kv_store)) {}
+
+  absl::StatusOr<CliqueIds> GetCliqueIds(const CliqueKey& key,
+                                         MoriCollectives& mori_collectives) {
+    auto* gpu_key = tsl::down_cast<const gpu::GpuCliqueKey*>(&key);
+    if (gpu_key == nullptr) {
+      return InvalidArgument("Expected GPU clique key");
+    }
+
+    // The caller must ensure that threads calling this method concurrently have
+    // unique keys, otherwise the global key-value store may hold the wrong
+    // value.
+    {
+      absl::MutexLock lock(mu_);
+      auto it = cache_.find(*gpu_key);
+      if (it != cache_.end()) {
+        return CliqueIds(it->second);
+      }
+    }
+
+    CliqueId clique_id;
+    if (process_id_ == device_to_process_.at(gpu_key->devices().front())) {
+      ASSIGN_OR_RETURN(clique_id, mori_collectives.CreateUniqueCliqueId());
+      RETURN_IF_ERROR(
+          kv_store_->Set(gpu_key->ToString(), clique_id.ToString()));
+    } else {
+      ASSIGN_OR_RETURN(std::string id_str,
+                       kv_store_->Get(gpu_key->ToString(), absl::Minutes(10)));
+      clique_id = CliqueId(id_str);
+    }
+
+    absl::MutexLock lock(mu_);
+    auto result = cache_.emplace(*gpu_key, std::move(clique_id));
+    TF_RET_CHECK(result.second) << "Unique ID already in cache.";
+    return CliqueIds(result.first->second);
+  }
+
+ private:
+  ProcessId process_id_;
+  const absl::flat_hash_map<GlobalDeviceId, ProcessId> device_to_process_;
+  const std::shared_ptr<KeyValueStoreInterface> kv_store_;
+
+  absl::Mutex mu_;
+  absl::flat_hash_map<gpu::GpuCliqueKey, CliqueId> cache_ ABSL_GUARDED_BY(mu_);
+};
+}  // namespace
+
+MoriCollectives::~MoriCollectives() {
+  // NOTE this is most probably wrong since we need to call finalize
+  // for all threads !
+  if (initialized_) {
+    Finalize();
+  }
+}
+
+absl::StatusOr<CliqueId> MoriCollectives::CreateUniqueCliqueId() const {
+  VLOG(3) << "Create MORI unique clique id";
+  shmem::mori_shmem_uniqueid_t id;
+  XLA_MORI_RETURN_IF_ERROR(shmem::ShmemGetUniqueId(&id));
+  return CliqueId(absl::string_view(reinterpret_cast<char*>(id.data()),
+                                    MORI_SHMEM_UNIQUE_ID_BYTES));
+}
+
+static absl::StatusOr<shmem::mori_shmem_uniqueid_t> AsMoriUniqueId(
+    const CliqueId& clique_id) {
+  if (clique_id.size() != MORI_SHMEM_UNIQUE_ID_BYTES) {
+    return Internal(
+        "CliqueId size is not equal to MORI_SHMEM_UNIQUE_ID_BYTES: %d vs %d",
+        clique_id.size(), MORI_SHMEM_UNIQUE_ID_BYTES);
+  }
+  shmem::mori_shmem_uniqueid_t id;
+  absl::c_copy(clique_id.data(), id.data());
+  return id;
+}
+
+void MoriCollectives::Finalize() {
+  VLOG(3) << "Finilizing MORI";
+  shmem::ShmemFinalize();
+}
+
+absl::Status MoriCollectives::InitPe(int32_t rank, int32_t nranks,
+                                     const CliqueId& clique_id,
+                                     se::StreamExecutor* executor) {
+  // ShmemInitAttr keys the per-device MORI state off the calling thread's
+  // active HIP device, so we must activate `executor`'s context here.
+  auto activate_context = executor->Activate();
+  ASSIGN_OR_RETURN(auto uid, AsMoriUniqueId(clique_id));
+  shmem::mori_shmem_init_attr_t init_attr;
+  XLA_MORI_RETURN_IF_ERROR(
+      shmem::ShmemSetAttrUniqueIdArgs(rank, nranks, &uid, &init_attr));
+  XLA_MORI_RETURN_IF_ERROR(
+      shmem::ShmemInitAttr(shmem::MORI_SHMEM_INIT_WITH_UNIQUEID, &init_attr));
+  VLOG(1) << "Initialized MORI PE rank " << rank << " of " << nranks;
+  return absl::OkStatus();
+}
+
+absl::StatusOr<void*> MoriCollectives::Allocate(uint64_t bytes) {
+  void* buffer = shmem::ShmemMalloc(bytes);  // ShmemMallocAlign
+  if (buffer == nullptr) {
+    return absl::InternalError(
+        absl::StrFormat("Failed to allocate %s (%llu bytes) from MORI memory",
+                        tsl::strings::HumanReadableNumBytes(bytes), bytes));
+  }
+  VLOG(3) << absl::StreamFormat("Allocated %s (%llu bytes) for MORI: %p",
+                                tsl::strings::HumanReadableNumBytes(bytes),
+                                bytes, buffer);
+  return buffer;
+}
+
+absl::Status MoriCollectives::Deallocate(void* buffer) {
+  VLOG(3) << absl::StreamFormat("Start de-allocation for MORI buffer: %p",
+                                buffer);
+  shmem::ShmemFree(buffer);
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
+MoriCollectives::CreateCommunicatorsWithCancel(
+    const CliqueKey& clique_key, const std::optional<CliqueIds>& clique_ids,
+    absl::Span<const DeviceRank> ranks, const Collectives::Config& config,
+    std::shared_ptr<CancellationToken> cancel) {
+  // Validate clique ids. With the MORI backend, we rely on the host to exchange
+  // unique clique ids.
+  if (!clique_ids.has_value() || clique_ids->data().empty()) {
+    return InvalidArgument("CliqueId is required to create MORI communicators");
+  }
+  if (clique_ids->data().size() != 1) {
+    return InvalidArgument(
+        "CliqueIds size must be 1 for MORI communicator initialization");
+  }
+  VLOG(1) << "Initialize MORI communicator for " << ranks.size() << " devices"
+          << "; fingerprint(id)=" << clique_ids->fingerprint();
+
+  const auto& gpu_config =
+      tsl::down_cast<const GpuCollectives::Config&>(config);
+  if (!gpu_config.blocking_communicators && !gpu_config.async_execution) {
+    return FailedPrecondition(
+        "GpuCollectives::Config blocking_communicators is false, but "
+        "async_execution is false. Non-blocking communicators require "
+        "asynchronous execution.");
+  }
+
+  // make_comm returns a new ncclComm_t.
+  auto make_comm =
+      [&, this](int i) -> absl::StatusOr<std::unique_ptr<MoriCommunicator>> {
+    VLOG(1) << "Initialize MORI communicator for rank #" << ranks[i].rank
+            << " of " << clique_key.num_devices()
+            << "; fingerprint(id)=" << clique_ids->fingerprint()
+            << "; size(id)=" << clique_ids->data().size();
+    auto* device = tsl::down_cast<GpuCollectives::Device*>(ranks[i].device);
+    // TF_RET_CHECK(device != nullptr);
+
+    // When MORI was already initialized eagerly (see InitializeTopology), we
+    // only build the communicator wrapper. Otherwise (e.g. unit tests that
+    // bypass InitializeTopology) we lazily initialize this PE here.
+    // ShmemInitAttr is idempotent, but the initialized_ gate avoids redundant
+    // uid setup.
+    auto activate_context = device->stream_executor()->Activate();
+    if (!initialized_) {
+      RETURN_IF_ERROR(InitPe(ranks[i].rank.value(), clique_key.num_devices(),
+                             clique_ids->at(0), device->stream_executor()));
+    }
+
+    // Map each collective rank to its global MORI PE. In the single-process
+    // eager-init path the MORI PE equals the global device ordinal, which is
+    // exactly clique_key.devices()[rank]. Passing this (rather than relying on
+    // ShmemNPes()/ShmemMyPe(), which describe the whole local clique) lets the
+    // collective run correctly over an arbitrary device subset.
+    std::vector<int> rank_to_pe;
+    rank_to_pe.reserve(clique_key.devices().size());
+    for (GlobalDeviceId d : clique_key.devices()) {
+      rank_to_pe.push_back(static_cast<int>(d.value()));
+    }
+    return MoriCommunicator::Create(this, cancel, ranks[i].rank.value(),
+                                    rank_to_pe);
+  };
+
+  // Create all communicators. Each communicator is created on its own thread.
+  std::vector<std::unique_ptr<Communicator>> comms(ranks.size());
+  absl::Status status;
+  absl::once_flag once;
+  {
+    tsl::thread::ThreadPool pool(tsl::Env::Default(), "CreateCommunicators",
+                                 ranks.size());
+    for (size_t i = 0; i < ranks.size(); ++i) {
+      pool.Schedule([&, i]() {
+        auto status_or_comm = make_comm(i);
+        if (!status_or_comm.ok()) {
+          absl::call_once(once, [&] { status = status_or_comm.status(); });
+          return;
+        }
+        comms[i] = std::move(status_or_comm.value());
+      });
+    }
+  }  // pool's destructor blocks until all scheduled work is done.
+  RETURN_IF_ERROR(status);
+  initialized_ = true;
+  return comms;
+}
+
+absl::StatusOr<GpuCollectives::CliqueIdCallback>
+MoriCollectives::InitializeTopology(const Topology& topology) {
+  VLOG(1) << "InitializeTopology: num_processes=" << topology.num_processes
+          << " device_count_per_process=" << topology.device_count_per_process
+          << " kv_store=" << (topology.kv_store != nullptr);
+
+  if (topology.num_processes > 1) {
+    // Multi-process eager init is not implemented yet; fall back to the lazy
+    // per-clique initialization performed in CreateCommunicatorsWithCancel
+    // (which keeps the previous hipMalloc + ShmemSymmetricRegister behavior).
+    auto mori_id_store = std::make_shared<MoriIdStore>(
+        topology.process_id, topology.device_to_process,
+        std::move(topology.kv_store));
+    return [mori_id_store, this](const CliqueKey& key) {
+      return mori_id_store->GetCliqueIds(key, *this);
+    };
+  }
+
+  // Single process: eagerly initialize MORI for every local device as a single
+  // global clique so that collective-memory allocations can use MORI's static
+  // heap (ShmemMalloc) before any executable runs.
+  const int32_t nranks =
+      static_cast<int32_t>(topology.device_count_per_process);
+  if (nranks <= 0) {
+    return nullptr;
+  }
+
+  ASSIGN_OR_RETURN(se::Platform * platform,
+                   se::PlatformManager::PlatformWithName("ROCM"));
+
+  // All local PEs share one unique id and must initialize concurrently, so
+  // ShmemInitAttr's bootstrap collective can complete.
+  ASSIGN_OR_RETURN(CliqueId clique_id, CreateUniqueCliqueId());
+
+  absl::Status status;
+  absl::once_flag once;
+  {
+    tsl::thread::ThreadPool pool(tsl::Env::Default(), "MoriEagerInit", nranks);
+    for (int32_t rank = 0; rank < nranks; ++rank) {
+      pool.Schedule([&, rank]() {
+        auto executor_or = platform->ExecutorForDevice(rank);
+        if (!executor_or.ok()) {
+          absl::call_once(once, [&] { status = executor_or.status(); });
+          return;
+        }
+        if (auto s = InitPe(rank, nranks, clique_id, *executor_or); !s.ok()) {
+          absl::call_once(once, [&] { status = s; });
+        }
+      });
+    }
+  }  // pool's destructor blocks until all scheduled work is done.
+  RETURN_IF_ERROR(status);
+
+  initialized_ = true;
+  VLOG(1) << "Eagerly initialized MORI for " << nranks << " local devices";
+  return nullptr;
+}
+
+}  // namespace xla::gpu
+
+// MoriCollectives currently does not implement GpuCollectives, so it cannot
+// be used as a host-side collectives library. Therefore, set priority to -100.
+XLA_COLLECTIVES_REGISTER("ROCM", "mori", -100,
+                         std::make_unique<xla::gpu::MoriCollectives>());

--- a/xla/backends/gpu/collectives/mori_collectives.h
+++ b/xla/backends/gpu/collectives/mori_collectives.h
@@ -1,0 +1,111 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_MORI_COLLECTIVES_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_MORI_COLLECTIVES_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xla/backends/gpu/collectives/cancellation_token.h"
+#include "xla/backends/gpu/collectives/gpu_collectives.h"
+#include "xla/core/collectives/clique_id.h"
+#include "xla/core/collectives/clique_key.h"
+#include "xla/core/collectives/collectives.h"
+#include "xla/core/collectives/communicator.h"
+#include "xla/core/collectives/rank_id.h"
+
+namespace stream_executor {
+class StreamExecutor;
+}  // namespace stream_executor
+
+namespace xla::gpu {
+
+// AMD MORI library
+class MoriCollectives : public GpuCollectives {
+ public:
+  ~MoriCollectives() override;
+
+  bool IsInitialized() { return initialized_; }
+
+  bool IsImplemented() const final { return true; }
+
+  absl::StatusOr<CliqueId> CreateUniqueCliqueId() const final;
+
+  absl::StatusOr<void*> Allocate(uint64_t bytes) final;
+
+  absl::Status Deallocate(void* buffer) final;
+
+  absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
+  CreateCommunicators(const CliqueKey& clique_key,
+                      const std::optional<CliqueIds>& clique_ids,
+                      absl::Span<const DeviceRank> ranks,
+                      const Collectives::Config& config) final {
+    return CreateCommunicatorsWithCancel(clique_key, clique_ids, ranks, config,
+                                         nullptr);
+  }
+
+  absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
+  CreateCommunicatorsWithCancel(
+      const CliqueKey& clique_key, const std::optional<CliqueIds>& clique_ids,
+      absl::Span<const DeviceRank> ranks, const Collectives::Config& config,
+      std::shared_ptr<CancellationToken> cancel) final;
+
+  absl::StatusOr<std::vector<std::unique_ptr<Communicator>>> SplitCommunicators(
+      absl::Span<const Communicator* const> comms, int32_t color,
+      absl::Span<const RankId> keys, const Collectives::Config& config,
+      absl::Span<const DeviceRank> ranks) final {
+    return SplitCommunicatorsWithCancel(comms, color, keys, config, ranks,
+                                        nullptr);
+  }
+
+  absl::StatusOr<std::vector<std::unique_ptr<Communicator>>>
+  SplitCommunicatorsWithCancel(
+      absl::Span<const Communicator* const> comms, int32_t color,
+      absl::Span<const RankId> keys, const Collectives::Config& config,
+      absl::Span<const DeviceRank> ranks,
+      std::shared_ptr<CancellationToken> cancel) final {
+    return absl::UnimplementedError("Not implemented");
+  }
+
+  absl::StatusOr<std::unique_ptr<Communicator>> CreateCommunicator() final {
+    return absl::UnimplementedError("Not implemented");
+  }
+
+  absl::StatusOr<CliqueIdCallback> InitializeTopology(
+      const Topology& topology) final;
+
+ private:
+  void Finalize();
+
+  // Initializes the MORI shmem state for a single PE (one GPU). Must be called
+  // on a thread that has `executor`'s device active. ShmemInitAttr is a
+  // collective/idempotent operation, so all participating PEs must call this
+  // concurrently with consistent (rank, nranks, uid). Shared by the eager
+  // InitializeTopology path and the lazy CreateCommunicatorsWithCancel path.
+  absl::Status InitPe(int32_t rank, int32_t nranks, const CliqueId& clique_id,
+                      stream_executor::StreamExecutor* executor);
+
+  bool initialized_ = false;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_MORI_COLLECTIVES_H_

--- a/xla/backends/gpu/collectives/mori_communicator.cc
+++ b/xla/backends/gpu/collectives/mori_communicator.cc
@@ -1,0 +1,367 @@
+/* Copyright 2026 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/mori_communicator.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/container/inlined_vector.h"
+#include "absl/functional/any_invocable.h"
+#include "absl/functional/function_ref.h"
+#include "absl/log/log.h"
+#include "absl/memory/memory.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/backends/gpu/collectives/cancellation_token.h"
+#include "xla/backends/gpu/collectives/gpu_collectives.h"
+#include "xla/backends/gpu/collectives/mori_collectives.h"
+#include "xla/backends/gpu/collectives/mori_stub.h"
+#include "xla/core/collectives/communicator.h"
+#include "xla/core/collectives/rank_id.h"
+#include "xla/core/collectives/reduction_kind.h"
+#include "xla/future.h"
+#include "xla/primitive_util.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/util.h"
+#include "xla/xla_data.pb.h"
+#include "tsl/platform/casts.h"
+
+namespace shmem = ::mori::shmem;
+namespace xla::gpu {
+
+static auto AsRocmStream(se::Stream* stream) {
+  return reinterpret_cast<std::intptr_t>(
+      stream->platform_specific_handle().stream);
+}
+
+static size_t ToMoriByteCount(PrimitiveType dtype, size_t count) {
+  if (primitive_util::IsComplexType(dtype)) {
+    count *= 2;
+  }
+  return count * primitive_util::BitWidth(dtype) / 8;
+}
+
+absl::StatusOr<std::unique_ptr<MoriCommunicator>> MoriCommunicator::Create(
+    MoriCollectives* coll, std::shared_ptr<CancellationToken> cancel, int rank,
+    absl::Span<const int> rank_to_pe) {
+  auto comm = absl::WrapUnique(new MoriCommunicator(coll, cancel));
+
+  const int num_ranks = static_cast<int>(rank_to_pe.size());
+  comm->rank_ = rank;
+  comm->num_ranks_ = num_ranks;
+  VLOG(1) << "Created " << *comm << " with participants: " << num_ranks;
+  return comm;
+}
+
+MoriCommunicator::~MoriCommunicator() {}
+
+#define CHECK_CANCELLED()                                               \
+  if (cancel_->IsCancelled()) {                                         \
+    return absl::FailedPreconditionError("MoriCommunicator cancelled"); \
+  }
+
+absl::Status MoriCommunicator::Abort() {
+  // By setting the cancellation token all pending collectives scheduled on
+  // executor_ will cancel. This will allow the aborting lambda below to run.
+  cancel_->Cancel();
+
+  VLOG(1) << "Abort MORI communicator: " << ToString();
+  if (aborted_) {
+    return FailedPrecondition("MoriCommunicator already aborted");
+  }
+  aborted_ = true;
+  // Call rocm_mori_global_exit with a non-zero return code to abort the
+  // program. rocm_mori_global_exit(1);
+  return absl::OkStatus();
+}
+
+absl::Status MoriCommunicator::Barrier(const Communicator::Executor& executor) {
+  VLOG(1) << "Barrier: " << ToString();
+  CHECK_CANCELLED()
+  ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
+  (void)stream;
+  // return xla_mori::BarrierOnStream(AsRocmStream(stream));
+  return absl::OkStatus();
+}
+
+absl::StatusOr<size_t> MoriCommunicator::NumRanks() const {
+  VLOG(5) << "Get the number of ranks in MORI communicator: " << ToString();
+  CHECK_CANCELLED()
+
+  return static_cast<size_t>(num_ranks_);
+}
+
+absl::StatusOr<size_t> MoriCommunicator::CurrentRank() {
+  VLOG(5) << "Get current rank in MORI communicator: " << ToString();
+  CHECK_CANCELLED()
+
+  return static_cast<size_t>(rank_);
+}
+
+std::string MoriCommunicator::ToString() const {
+  return absl::StrFormat("MoriCommunicator(rank=%d, num_ranks=%d, my_pe=%d)",
+                         rank_, num_ranks_, shmem::ShmemMyPe());
+}
+
+absl::StatusOr<se::Stream*> MoriCommunicator::ToStream(
+    const Executor& executor) {
+  if (auto* gpu_executor =
+          tsl::down_cast<const GpuCollectives::Executor*>(&executor)) {
+    return gpu_executor->stream();
+  }
+  return InvalidArgument("Communicator executor is not a GPU executor");
+}
+
+Future<> MoriCommunicator::AllReduce(se::DeviceAddressBase send_buffer,
+                                     se::DeviceAddressBase recv_buffer,
+                                     PrimitiveType dtype, size_t count,
+                                     ReductionKind reduction_kind,
+                                     const Executor& executor) {
+  return Execute([send_buffer, recv_buffer, dtype, count, reduction_kind,
+                  &executor, this]() -> absl::Status {
+    return LaunchAllReduce(send_buffer, recv_buffer, dtype, count,
+                           reduction_kind, executor);
+  });
+}
+
+Future<> MoriCommunicator::Broadcast(se::DeviceAddressBase send_buffer,
+                                     se::DeviceAddressBase recv_buffer,
+                                     PrimitiveType dtype, size_t count,
+                                     RankId root, const Executor& executor) {
+  return Execute(
+      [send_buffer, recv_buffer, dtype, count, root, &executor, this]() {
+        return LaunchBroadcast(send_buffer, recv_buffer, dtype, count, root,
+                               executor);
+      });
+}
+
+Future<> MoriCommunicator::ReduceScatter(se::DeviceAddressBase send_buffer,
+                                         se::DeviceAddressBase recv_buffer,
+                                         PrimitiveType dtype, size_t count,
+                                         ReductionKind reduction_kind,
+                                         const Executor& executor) {
+  return Execute([send_buffer, recv_buffer, dtype, count, reduction_kind,
+                  &executor, this]() {
+    return LaunchReduceScatter(send_buffer, recv_buffer, dtype, count,
+                               reduction_kind, executor);
+  });
+}
+
+Future<> MoriCommunicator::AllGather(se::DeviceAddressBase send_buffer,
+                                     se::DeviceAddressBase recv_buffer,
+                                     PrimitiveType dtype, size_t count,
+                                     const Executor& executor) {
+  return Execute([send_buffer, recv_buffer, dtype, count, &executor, this]() {
+    return LaunchAllGather(send_buffer, recv_buffer, dtype, count, executor);
+  });
+}
+
+Future<> MoriCommunicator::AllToAll(
+    absl::InlinedVector<se::DeviceAddressBase, 4> send_buffers,
+    absl::InlinedVector<se::DeviceAddressBase, 4> recv_buffers,
+    PrimitiveType dtype, size_t count, const Executor& executor) {
+  return Execute([send_buffers, recv_buffers, dtype, count, &executor, this]() {
+    return LaunchAllToAll(send_buffers, recv_buffers, dtype, count, executor);
+  });
+}
+
+Future<> MoriCommunicator::CollectivePermute(
+    se::DeviceAddressBase send_buffer, se::DeviceAddressBase recv_buffer,
+    PrimitiveType dtype, size_t count, std::optional<RankId> source_rank,
+    absl::Span<const RankId> target_ranks, const Executor& executor) {
+  std::vector<RankId> owned_target_ranks(target_ranks.begin(),
+                                         target_ranks.end());
+  return Execute([send_buffer, recv_buffer, dtype, count, source_rank,
+                  owned_target_ranks = std::move(owned_target_ranks), &executor,
+                  this]() {
+    return LaunchCollectivePermute(send_buffer, recv_buffer, dtype, count,
+                                   source_rank, owned_target_ranks, executor);
+  });
+}
+
+Future<> MoriCommunicator::Send(se::DeviceAddressBase recv_buffer,
+                                se::DeviceAddressBase send_buffer,
+                                PrimitiveType dtype, size_t count, RankId peer,
+                                const Executor& executor) {
+  return P2P(P2PType::Send, dtype, recv_buffer, send_buffer, count, peer,
+             executor);
+}
+
+Future<> MoriCommunicator::Recv(se::DeviceAddressBase recv_buffer,
+                                se::DeviceAddressBase send_buffer,
+                                PrimitiveType dtype, size_t count, RankId peer,
+                                const Executor& executor) {
+  return P2P(P2PType::Recv, dtype, recv_buffer, send_buffer, count, peer,
+             executor);
+}
+
+absl::Status MoriCommunicator::LaunchAllGather(
+    se::DeviceAddressBase send_buffer, se::DeviceAddressBase recv_buffer,
+    PrimitiveType dtype, size_t count, const Executor& executor) {
+  CHECK_CANCELLED()
+  ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
+  VLOG(3) << "LaunchAllGather: send_buffer=" << send_buffer.opaque()
+          << " recv_buffer=" << recv_buffer.opaque() << " count=" << count
+          << " dtype=" << primitive_util::LowercasePrimitiveTypeName(dtype)
+          << " stream=" << AsRocmStream(stream);
+  return absl::UnimplementedError("Not implemented");
+}
+
+absl::Status MoriCommunicator::LaunchAllReduce(
+    se::DeviceAddressBase send_buffer, se::DeviceAddressBase recv_buffer,
+    PrimitiveType dtype, size_t count, ReductionKind reduction_kind,
+    const Executor& executor) {
+  CHECK_CANCELLED()
+
+  ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
+  auto gpu_stream = AsRocmStream(stream);
+  (void)gpu_stream;
+  void* source_ptr = send_buffer.opaque();
+  void* dest_ptr = recv_buffer.opaque();
+  (void)source_ptr;
+  (void)dest_ptr;
+  if (primitive_util::IsComplexType(dtype)) {
+    count *= 2;
+  }
+
+  VLOG(3) << absl::StreamFormat(
+      "Launch MORI AllReduce send_buffer=%p; recv_buffer=%p; dtype=%s; "
+      "count=%d; reduction_kind=%v; device_ordinal=%d",
+      send_buffer.opaque(), recv_buffer.opaque(),
+      primitive_util::LowercasePrimitiveTypeName(dtype), count, reduction_kind,
+      stream->parent()->device_ordinal());
+  return absl::UnimplementedError("Not implemented");
+}
+
+absl::Status MoriCommunicator::LaunchReduceScatter(
+    se::DeviceAddressBase send_buffer, se::DeviceAddressBase recv_buffer,
+    PrimitiveType dtype, size_t count, ReductionKind kind,
+    const Executor& executor) {
+  CHECK_CANCELLED()
+  ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
+
+  VLOG(3) << "LaunchReduceScatter: send_buffer=" << send_buffer.opaque()
+          << " recv_buffer=" << recv_buffer.opaque() << " count=" << count
+          << " dtype=" << primitive_util::LowercasePrimitiveTypeName(dtype)
+          << " stream=" << AsRocmStream(stream);
+  return absl::UnimplementedError("Not implemented");
+}
+
+absl::Status MoriCommunicator::LaunchCollectivePermute(
+    se::DeviceAddressBase send_buffer, se::DeviceAddressBase recv_buffer,
+    PrimitiveType dtype, size_t count, std::optional<RankId> source_rank,
+    absl::Span<const RankId> target_ranks, const Executor& executor) {
+  CHECK_CANCELLED()
+  ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
+  size_t bytes = ToMoriByteCount(dtype, count);
+  (void)bytes;
+  auto rank_formatter = [](std::string* out, RankId rank) {
+    absl::StrAppendFormat(out, "%d", rank.value());
+  };
+  VLOG(3) << absl::StreamFormat(
+      "[%d] Launch MORI CollectivePermute operation; send_buffer=%p; "
+      "recv_buffer=%p; dtype=%s; source_rank=%s; target_[ranks=%s]; count=%d; "
+      "stream=%p",
+      stream->parent()->device_ordinal(), send_buffer.opaque(),
+      recv_buffer.opaque(), primitive_util::LowercasePrimitiveTypeName(dtype),
+      source_rank ? absl::StrCat(source_rank->value()) : "<empty>",
+      absl::StrJoin(target_ranks, ", ", rank_formatter), count, stream);
+
+  return absl::UnimplementedError("Not implemented");
+}
+
+// Performs point-to-point communication between two ranks using MORI.
+// Send: launches a single GPU kernel that copies data to the peer via P2P
+//       and sets a completion flag on the peer.
+// Recv: launches a single-thread GPU kernel that waits for the flag.
+absl::Status MoriCommunicator::P2P(P2PType p2p_type, PrimitiveType dtype,
+                                   se::DeviceAddressBase recv_buffer,
+                                   se::DeviceAddressBase send_buffer,
+                                   size_t count, RankId peer,
+                                   const Executor& executor) {
+  const char* stype = (p2p_type == P2PType::Send ? " Send" : " Recv");
+  VLOG(1) << CurrentRank().value() << stype << " to " << peer.value()
+          << " count " << count << " MORI communicator: " << ToString();
+  CHECK_CANCELLED()
+
+  void* source_ptr = send_buffer.opaque();
+  void* dest_ptr = recv_buffer.opaque();
+
+  ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
+  auto gpu_stream = AsRocmStream(stream);
+  size_t bytes = ToMoriByteCount(dtype, count);
+  int res = 0;
+  (void)bytes;
+  (void)res;
+  (void)gpu_stream;
+  (void)source_ptr;
+  (void)dest_ptr;
+  (void)peer;
+  (void)stream;
+  (void)dtype;
+  (void)count;
+  (void)p2p_type;
+  return absl::UnimplementedError("Not implemented");
+}
+
+Future<> MoriCommunicator::GroupExecute(
+    absl::AnyInvocable<absl::Status() &&> group) {
+  return Execute([group = std::move(group), this]() mutable {
+    return GroupLaunch([&] { return std::move(group)(); });
+  });
+}
+
+absl::Status MoriCommunicator::GroupLaunch(
+    absl::FunctionRef<absl::Status()> group) {
+  return group();
+}
+
+absl::Status MoriCommunicator::Quiet(const Executor& executor) {
+  VLOG(1) << "Quiet MORI communicator: " << ToString();
+  CHECK_CANCELLED()
+  ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
+  auto gpu_stream = AsRocmStream(stream);
+  (void)gpu_stream;
+  return absl::UnimplementedError("Not implemented");
+}
+
+absl::Status MoriCommunicator::Fence() {
+  VLOG(1) << "Fence MORI communicator: " << ToString();
+  CHECK_CANCELLED()
+  // rocm_mori_fence();
+  return absl::UnimplementedError("Not implemented");
+}
+
+absl::Status MoriCommunicator::PollUntilDone() const {
+  CHECK_CANCELLED()
+  return absl::UnimplementedError("Not implemented");
+}
+
+Future<> MoriCommunicator::Execute(
+    absl::AnyInvocable<absl::Status() &&> f) const {
+  return Future<>(std::move(f)());
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/mori_communicator.h
+++ b/xla/backends/gpu/collectives/mori_communicator.h
@@ -1,0 +1,212 @@
+/* Copyright 2026 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_MORI_COMMUNICATOR_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_MORI_COMMUNICATOR_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "absl/container/inlined_vector.h"
+#include "absl/functional/any_invocable.h"
+#include "absl/functional/function_ref.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "xla/backends/gpu/collectives/cancellation_token.h"
+#include "xla/backends/gpu/collectives/gpu_communicator.h"
+#include "xla/core/collectives/communicator.h"
+#include "xla/core/collectives/rank_id.h"
+#include "xla/core/collectives/reduction_kind.h"
+#include "xla/future.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/stream.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+
+class MoriCollectives;
+
+// XLA collectives communicator wrapping a MORI communicator.
+class MoriCommunicator : public GpuCommunicator {
+ public:
+  constexpr static uint32_t kMaxTeams = 24;
+
+  friend class MoriCollectives;
+  ~MoriCommunicator() override;
+
+  static absl::StatusOr<std::unique_ptr<MoriCommunicator>> Create(
+      MoriCollectives* coll, std::shared_ptr<CancellationToken> cancel,
+      int rank, absl::Span<const int> rank_to_pe);
+
+  // MoriCommunicator is not copyable or movable.
+  MoriCommunicator(const MoriCommunicator&) = delete;
+  MoriCommunicator(MoriCommunicator&&) = delete;
+  MoriCommunicator& operator=(const MoriCommunicator&) = delete;
+  MoriCommunicator& operator=(MoriCommunicator&&) = delete;
+
+  absl::Status Abort() final;
+  absl::StatusOr<size_t> NumRanks() const final;
+  absl::StatusOr<size_t> CurrentRank() final;
+
+  absl::Status Barrier(const Executor& executor) final;
+
+  Future<> GroupExecute(absl::AnyInvocable<absl::Status() &&> group) final;
+
+  Future<> AllReduce(se::DeviceAddressBase send_buffer,
+                     se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
+                     size_t count, ReductionKind reduction_kind,
+                     const Executor& executor) final;
+
+  Future<> Broadcast(se::DeviceAddressBase send_buffer,
+                     se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
+                     size_t count, RankId root, const Executor& executor) final;
+
+  Future<> ReduceScatter(se::DeviceAddressBase send_buffer,
+                         se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
+                         size_t count, ReductionKind reduction_kind,
+                         const Executor& executor) final;
+
+  Future<> AllGather(se::DeviceAddressBase send_buffer,
+                     se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
+                     size_t count, const Executor& executor) final;
+
+  Future<> AllToAll(absl::InlinedVector<se::DeviceAddressBase, 4> send_buffers,
+                    absl::InlinedVector<se::DeviceAddressBase, 4> recv_buffers,
+                    PrimitiveType dtype, size_t count,
+                    const Executor& executor) final;
+
+  Future<> CollectivePermute(se::DeviceAddressBase send_buffer,
+                             se::DeviceAddressBase recv_buffer,
+                             PrimitiveType dtype, size_t count,
+                             std::optional<RankId> source_rank,
+                             absl::Span<const RankId> target_ranks,
+                             const Executor& executor) final;
+
+  Future<> Send(se::DeviceAddressBase send_buffer, PrimitiveType dtype,
+                size_t count, RankId peer, const Executor& executor) final {
+    return absl::UnimplementedError("Not implemented");
+  }
+
+  Future<> Recv(se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
+                size_t count, RankId peer, const Executor& executor) final {
+    return absl::UnimplementedError("Not implemented");
+  }
+
+  Future<> Send(se::DeviceAddressBase recv_buffer,
+                se::DeviceAddressBase send_buffer, PrimitiveType dtype,
+                size_t count, RankId peer, const Executor& executor) final;
+
+  Future<> Recv(se::DeviceAddressBase recv_buffer,
+                se::DeviceAddressBase send_buffer, PrimitiveType dtype,
+                size_t count, RankId peer, const Executor& executor) final;
+
+  // Polls the communicator until any pending non-blocking operations are done
+  // or aborted.
+  absl::Status PollUntilDone() const;
+
+ private:
+  absl::Status GroupLaunch(absl::FunctionRef<absl::Status()> group);
+
+  absl::Status LaunchAllReduce(se::DeviceAddressBase send_buffer,
+                               se::DeviceAddressBase recv_buffer,
+                               PrimitiveType dtype, size_t count,
+                               ReductionKind reduction_kind,
+                               const Executor& executor) final;
+
+  absl::Status LaunchBroadcast(se::DeviceAddressBase send_buffer,
+                               se::DeviceAddressBase recv_buffer,
+                               PrimitiveType dtype, size_t count, RankId root,
+                               const Executor& executor) final {
+    return absl::UnimplementedError("Not implemented");
+  }
+
+  absl::Status LaunchReduceScatter(se::DeviceAddressBase send_buffer,
+                                   se::DeviceAddressBase recv_buffer,
+                                   PrimitiveType dtype, size_t count,
+                                   ReductionKind reduction_kind,
+                                   const Executor& executor) final;
+
+  absl::Status LaunchAllGather(se::DeviceAddressBase send_buffer,
+                               se::DeviceAddressBase recv_buffer,
+                               PrimitiveType dtype, size_t count,
+                               const Executor& executor) final;
+
+  absl::Status LaunchAllToAll(
+      absl::InlinedVector<se::DeviceAddressBase, 4> send_buffers,
+      absl::InlinedVector<se::DeviceAddressBase, 4> recv_buffers,
+      PrimitiveType dtype, size_t count, const Executor& executor) final {
+    return absl::UnimplementedError("Not implemented");
+  }
+
+  absl::Status LaunchCollectivePermute(se::DeviceAddressBase send_buffer,
+                                       se::DeviceAddressBase recv_buffer,
+                                       PrimitiveType dtype, size_t count,
+                                       std::optional<RankId> source_rank,
+                                       absl::Span<const RankId> target_ranks,
+                                       const Executor& executor) final;
+
+  absl::Status LaunchSend(se::DeviceAddressBase send_buffer,
+                          PrimitiveType dtype, size_t count, RankId peer,
+                          const Executor& executor) final {
+    return absl::UnimplementedError("Not implemented");
+  }
+
+  absl::Status LaunchRecv(se::DeviceAddressBase recv_buffer,
+                          PrimitiveType dtype, size_t count, RankId peer,
+                          const Executor& executor) final {
+    return absl::UnimplementedError("Not implemented");
+  }
+
+  absl::Status Quiet(const Executor& executor) final;
+
+  absl::Status Fence() final;
+
+  std::string ToString() const final;
+
+ private:
+  // Executes f on executor_, or calls f directly if executor_ is null.
+  Future<> Execute(absl::AnyInvocable<absl::Status() &&> f) const;
+
+  MoriCommunicator(MoriCollectives* coll,
+                   std::shared_ptr<CancellationToken> cancel)
+      : collectives_(coll), cancel_(std::move(cancel)) {}
+
+  enum class P2PType : int32_t { Send, Recv };
+
+  absl::Status P2P(P2PType p2p_type, PrimitiveType type,
+                   se::DeviceAddressBase recv_buffer,
+                   se::DeviceAddressBase send_buffer, size_t count, RankId peer,
+                   const Executor& executor);
+
+  static absl::StatusOr<se::Stream*> ToStream(const Executor& executor);
+
+  MoriCollectives* collectives_;  // Parent MoriCollectives instance
+
+  // This communicator's participant set (NOT the global MORI clique). `rank_`
+  // is this rank within the collective, `num_ranks_` the participant count, and
+  // `rank_to_pe_dev_` a device array mapping collective rank -> global MORI PE.
+  int rank_ = 0;
+  int num_ranks_ = 0;
+  // Should all pending collectives cancel?
+  std::shared_ptr<CancellationToken> cancel_;
+  bool aborted_ = false;  // Has Abort() been called?
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_MORI_COMMUNICATOR_H_

--- a/xla/backends/gpu/collectives/mori_stub.h
+++ b/xla/backends/gpu/collectives/mori_stub.h
@@ -1,0 +1,73 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_MORI_STUB_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_MORI_STUB_H_
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+// Inert stand-in for the subset of the MORI shmem host API used by the MORI
+// collectives/communicator backbone. These placeholders let the backbone
+// compile and link without depending on the MORI library. All operations are
+// no-ops. Replace by including the real "mori/shmem/shmem_api.hpp" once the
+// MORI bindings are wired up.
+
+#define MORI_SHMEM_UNIQUE_ID_BYTES 128
+
+namespace mori {
+namespace shmem {
+
+using mori_shmem_uniqueid_t = std::array<uint8_t, MORI_SHMEM_UNIQUE_ID_BYTES>;
+
+struct mori_shmem_init_attr_t {
+  int32_t rank;
+  int32_t nranks;
+  mori_shmem_uniqueid_t uid;
+  void* mpi_comm;  // Optional MPI_Comm pointer.
+};
+
+// Initialization flags.
+[[maybe_unused]] constexpr unsigned int MORI_SHMEM_INIT_WITH_MPI_COMM = 0;
+[[maybe_unused]] constexpr unsigned int MORI_SHMEM_INIT_WITH_UNIQUEID = 1;
+
+inline int ShmemGetUniqueId(mori_shmem_uniqueid_t* /*uid*/) { return 0; }
+
+inline int ShmemSetAttrUniqueIdArgs(int /*rank*/, int /*nranks*/,
+                                    mori_shmem_uniqueid_t* /*uid*/,
+                                    mori_shmem_init_attr_t* /*attr*/) {
+  return 0;
+}
+
+inline int ShmemInitAttr(unsigned int /*flags*/,
+                         mori_shmem_init_attr_t* /*attr*/) {
+  return 0;
+}
+
+inline int ShmemFinalize() { return 0; }
+
+inline int ShmemMyPe() { return 0; }
+
+inline int ShmemNPes() { return 0; }
+
+inline void* ShmemMalloc(size_t /*size*/) { return nullptr; }
+
+inline void ShmemFree(void* /*ptr*/) {}
+
+}  // namespace shmem
+}  // namespace mori
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_MORI_STUB_H_

--- a/xla/backends/gpu/runtime/collective_params.cc
+++ b/xla/backends/gpu/runtime/collective_params.cc
@@ -62,26 +62,9 @@ static absl::StatusOr<GlobalDeviceId> GetGlobalDeviceId(
   return it->second;
 }
 
-static GpuCollectives* ResolveCollectives(
-    const GpuExecutableRunOptions* gpu_options, absl::string_view platform_name,
-    const std::optional<std::string>& implementation_name) {
-  if (gpu_options && gpu_options->collectives()) {
-    return gpu_options->collectives();
-  }
-  if (implementation_name.has_value()) {
-    absl::StatusOr<Collectives*> collectives =
-        CollectivesRegistry::Get(platform_name, *implementation_name);
-    CHECK_OK(collectives) << "Failed to get GPU collectives implementation: "
-                          << *implementation_name;
-    return absl::down_cast<GpuCollectives*>(*collectives);
-  }
-  return GpuCollectives::Default(platform_name);
-}
-
 absl::StatusOr<CollectiveParams> CollectiveParams::Create(
     const ServiceExecutableRunOptions& run_options,
     absl::Span<se::Stream* const> async_streams, LocalDeviceId local_device_id,
-    std::optional<std::string> implementation_name,
     int64_t collective_max_nchannels, int64_t p2p_max_nchannels,
     bool collective_use_minimal_resource) {
   const GpuExecutableRunOptions* gpu_options =
@@ -89,8 +72,12 @@ absl::StatusOr<CollectiveParams> CollectiveParams::Create(
 
   const std::string& platform_name =
       run_options.run_options().stream()->parent()->GetPlatform()->Name();
-  auto* collectives =
-      ResolveCollectives(gpu_options, platform_name, implementation_name);
+
+  GpuCollectives* collectives =
+      gpu_options ? gpu_options->collectives() : nullptr;
+  if (collectives == nullptr) {
+    collectives = GpuCollectives::Resolve(platform_name);
+  }
 
   auto* device_id_map = gpu_options && gpu_options->gpu_global_device_ids()
                             ? &*gpu_options->gpu_global_device_ids()

--- a/xla/backends/gpu/runtime/collective_params.h
+++ b/xla/backends/gpu/runtime/collective_params.h
@@ -47,9 +47,8 @@ struct CollectiveParams {
   static absl::StatusOr<CollectiveParams> Create(
       const ServiceExecutableRunOptions& run_options,
       absl::Span<se::Stream* const> async_streams,
-      LocalDeviceId local_device_id,
-      std::optional<std::string> implementation_name = std::nullopt,
-      int64_t collective_max_nchannels = 0, int64_t p2p_max_nchannels = 0,
+      LocalDeviceId local_device_id, int64_t collective_max_nchannels = 0,
+      int64_t p2p_max_nchannels = 0,
       bool collective_use_minimal_resource = false);
 
   GpuCollectives* collectives;

--- a/xla/pjrt/gpu/BUILD
+++ b/xla/pjrt/gpu/BUILD
@@ -78,6 +78,7 @@ cc_library(
         ":gpu_metrics",
         ":se_gpu_pjrt_runtime_abi_version",
         ":se_gpu_topology_description",
+        "//xla:debug_options_flags",
         "//xla:executable_run_options",
         "//xla:future",
         "//xla:literal",
@@ -214,7 +215,6 @@ cc_library(
         "@tsl//tsl/profiler/lib:traceme",
     ] + if_cuda_or_rocm([
         # keep sorted
-        "//xla:debug_options_flags",
         "//xla/service/gpu:gpu_compiler",
         "//xla/service/gpu:gpu_executable",
         "//xla/service/gpu:gpu_executable_buffer_allocator",
@@ -231,7 +231,6 @@ cc_library(
         "@local_config_rocm//rocm:rocm_headers",
     ]) + if_sycl([
         # keep sorted
-        "//xla:debug_options_flags",
         "//xla/service/gpu:gpu_compiler",
         "//xla/service/gpu:gpu_executable",
         "//xla/service/gpu:gpu_executable_buffer_allocator",

--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -797,67 +797,69 @@ void StreamExecutorGpuClient::ScheduleTransfersOnLocalDevice(
   };
 
   // Form the closure to schedule on the device's execute thread.
-  auto execute_transfers_fn =
-      [this, local_device_state, stream,
-       transfer_dependencies = std::move(transfer_dependencies),
-       prepared_transfers = std::move(prepared_transfers),
-       launch_transfer_group = std::move(launch_transfer_group),
-       transfer_event = std::move(transfer_event)]() mutable {
-        // Wait for transfer dependencies.
-        if (auto status =
-                WaitForDeviceEventRefsOnStream(transfer_dependencies, stream);
-            !status.ok()) {
+  auto execute_transfers_fn = [this, local_device_state, stream,
+                               transfer_dependencies =
+                                   std::move(transfer_dependencies),
+                               prepared_transfers =
+                                   std::move(prepared_transfers),
+                               launch_transfer_group =
+                                   std::move(launch_transfer_group),
+                               transfer_event =
+                                   std::move(transfer_event)]() mutable {
+    // Wait for transfer dependencies.
+    if (auto status =
+            WaitForDeviceEventRefsOnStream(transfer_dependencies, stream);
+        !status.ok()) {
+      FulfillDeviceEvent(this, local_device_state, stream, transfer_event,
+                         status);
+      return;
+    }
+
+    // Group transfers by GPU clique.
+    std::vector<std::pair<gpu::GpuCliqueKey, std::vector<PreparedTransfer>>>
+        grouped_transfers =
+            GroupTransfersByCliqueKey(std::move(prepared_transfers));
+
+    // Transfers for a particular clique are executed as a group. This
+    // vector holds group futures for each clique_key in grouped_transfers.
+    std::vector<Future<>> group_futures;
+    group_futures.reserve(grouped_transfers.size());
+
+    for (auto& [clique_key, curr_transfers] : grouped_transfers) {
+      tsl::profiler::TraceMe trace([&k = clique_key] {
+        return tsl::profiler::TraceMeEncode("LaunchTransfer", {{"clique", k}});
+      });
+
+      // Get the communicator on which we will execute this group of
+      // transfers. We assume each clique key is associated with a unique
+      // communicator, so we just take the communicator of the first
+      // transfer_idx of this clique key.
+      gpu::GpuCommunicator* gpu_communicator =
+          curr_transfers[0].clique_and_communicator_.second;
+
+      // Launch the group of transfers.
+      group_futures.push_back(gpu_communicator->GroupExecute(
+          [&launch_transfer_group, &curr_transfers = curr_transfers, stream,
+           gpu_communicator]() {
+            return launch_transfer_group(
+                gpu_communicator, absl::MakeSpan(curr_transfers), stream);
+          }));
+    }
+
+    // On a separate thread pool, await group futures and fulfill buffer
+    // sequencing events and promises.
+    Future<> all_transfers_future = JoinFutures(group_futures);
+
+    all_transfers_future.OnReady(
+        *async_work_runner(),
+        [this, local_device_state, stream, transfer_event,
+         grouped_transfers =
+             std::move(grouped_transfers)](const absl::Status& status) mutable {
+          // Add transfer_event onto the stream.
           FulfillDeviceEvent(this, local_device_state, stream, transfer_event,
                              status);
-          return;
-        }
-
-        // Group transfers by GPU clique.
-        std::vector<std::pair<gpu::GpuCliqueKey, std::vector<PreparedTransfer>>>
-            grouped_transfers =
-                GroupTransfersByCliqueKey(std::move(prepared_transfers));
-
-        // Transfers for a particular clique are executed as a group. This
-        // vector holds group futures for each clique_key in grouped_transfers.
-        std::vector<Future<>> group_futures;
-        group_futures.reserve(grouped_transfers.size());
-
-        for (auto& [clique_key, curr_transfers] : grouped_transfers) {
-          tsl::profiler::TraceMe trace([&k = clique_key] {
-            return tsl::profiler::TraceMeEncode("LaunchTransfer",
-                                                {{"clique", k}});
-          });
-
-          // Get the communicator on which we will execute this group of
-          // transfers. We assume each clique key is associated with a unique
-          // communicator, so we just take the communicator of the first
-          // transfer_idx of this clique key.
-          gpu::GpuCommunicator* gpu_communicator =
-              curr_transfers[0].clique_and_communicator_.second;
-
-          // Launch the group of transfers.
-          group_futures.push_back(gpu_communicator->GroupExecute(
-              [&launch_transfer_group, &curr_transfers = curr_transfers, stream,
-               gpu_communicator]() {
-                return launch_transfer_group(
-                    gpu_communicator, absl::MakeSpan(curr_transfers), stream);
-              }));
-        }
-
-        // On a separate thread pool, await group futures and fulfill buffer
-        // sequencing events and promises.
-        Future<> all_transfers_future = JoinFutures(group_futures);
-
-        all_transfers_future.OnReady(
-            *async_work_runner(),
-            [this, local_device_state, stream, transfer_event,
-             grouped_transfers = std::move(grouped_transfers)](
-                const absl::Status& status) mutable {
-              // Add transfer_event onto the stream.
-              FulfillDeviceEvent(this, local_device_state, stream,
-                                 transfer_event, status);
-            });
-      };
+        });
+  };
 
   // Schedule transfers on the execute thread.
   local_device_state->execute_thread()->Schedule(
@@ -1647,13 +1649,9 @@ absl::StatusOr<DeviceTopologyPair> BuildDistributedDevices(
   gpu_executable_run_options->set_gpu_global_device_ids(
       std::move(gpu_device_ids));
 
-  ASSIGN_OR_RETURN(xla::Collectives * collectives,
-                   xla::CollectivesRegistry::Default("gpu"));
-  xla::gpu::GpuCollectives* gpu_collectives =
-      absl::down_cast<xla::gpu::GpuCollectives*>(collectives);
-
+  auto* gpu_collectives = gpu_executable_run_options->collectives();
   if (gpu_collectives == nullptr) {
-    return absl::InternalError("Failed to get GPU collectives");
+    gpu_collectives = gpu::GpuCollectives::Resolve(platform_name);
   }
 
   size_t num_processes = global_topology.processes().size();
@@ -1949,7 +1947,8 @@ absl::StatusOr<std::unique_ptr<PjRtClient>> GetSharedStreamExecutorGpuClient(
       VLOG(2) << "  pjrt_device " << i++ << ":"
               << pjrt_device->description().DebugString();
     } else {
-      VLOG(2) << "  pjrt_device " << i++ << ":" << "nullptr";
+      VLOG(2) << "  pjrt_device " << i++ << ":"
+              << "nullptr";
     }
   }
   ASSIGN_OR_RETURN(auto gpu_topology,

--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -180,7 +180,7 @@ class GpuExecutableThunkPassBufferAllocator : public ThunkPassBufferAllocator {
       BufferAllocation::Index start_idx)
       : next_idx_(start_idx) {}
 
-  absl::StatusOr<BufferAllocation* absl_nonnull> NewEmptyAllocation(
+  absl::StatusOr<BufferAllocation * absl_nonnull> NewEmptyAllocation(
       int64_t size) override {
     allocations_.push_back(BufferAllocation(next_idx_++, size, /*color=*/0));
     return &allocations_.back();
@@ -724,20 +724,12 @@ absl::Status GpuExecutable::ExecuteThunksImpl(
   // A state container for this execution.
   Thunk::ExecutionScopedState execution_scoped_state;
 
-  // Parameters for executing collective operations.
-  std::optional<std::string> collectives_impl_name;
-  if (debug_options &&
-      !debug_options->xla_gpu_collectives_implementation().empty()) {
-    collectives_impl_name = debug_options->xla_gpu_collectives_implementation();
-  }
-
-  ASSIGN_OR_RETURN(
-      CollectiveParams collective_params,
-      CollectiveParams::Create(
-          *run_options, communication_streams.streams,
-          LocalDeviceId(main_stream->parent()->device_ordinal()),
-          std::move(collectives_impl_name), collective_max_nchannels,
-          p2p_max_nchannels, collective_use_minimal_resource));
+  ASSIGN_OR_RETURN(CollectiveParams collective_params,
+                   CollectiveParams::Create(
+                       *run_options, communication_streams.streams,
+                       LocalDeviceId(main_stream->parent()->device_ordinal()),
+                       collective_max_nchannels, p2p_max_nchannels,
+                       collective_use_minimal_resource));
 
   CollectiveCliqueRequests collective_clique_requests;
   CollectiveMemoryRequests collective_memory_requests(buffer_allocations);

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -149,6 +149,7 @@ cc_library(
         ":rocm_stream",
         ":rocm_timer",
         ":rocm_version_parser",
+        "//xla/backends/gpu/collectives:gpu_collectives",
         ":rocm_xgmi_topology",
         "//xla/stream_executor:activate_context",
         "//xla/stream_executor:blas",

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -15,8 +15,6 @@ limitations under the License.
 
 #include "xla/stream_executor/rocm/rocm_executor.h"
 
-#include <unistd.h>
-
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -49,6 +47,8 @@ limitations under the License.
 #include "rocm/include/hip/hip_runtime.h"
 #include "rocm/include/hip/hip_version.h"
 #include "rocm/rocm_config.h"
+#include <unistd.h>
+#include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/stream_executor/activate_context.h"
 #include "xla/stream_executor/blas.h"
 #include "xla/stream_executor/command_buffer.h"
@@ -93,6 +93,8 @@ limitations under the License.
 #include "xla/tsl/platform/errors.h"
 #include "xla/tsl/platform/logging.h"
 #include "xla/tsl/platform/statusor.h"
+#include "xla/util.h"
+#include "tsl/platform/casts.h"
 #include "tsl/platform/fingerprint.h"
 #include "tsl/platform/numa.h"
 #include "tsl/platform/numbers.h"
@@ -383,12 +385,11 @@ bool GetDeviceProperties(hipDeviceProp_t* device_properties,
 }
 
 // Allocates memory on the GPU device.
-void* DeviceAllocate(Context* context, uint64_t bytes,
-                     bool is_fine_grained = false) {
+absl::StatusOr<void*> DeviceAllocate(Context* context, uint64_t bytes,
+                                     bool is_fine_grained = false) {
   if (bytes == 0) {
     return nullptr;
   }
-
   ScopedActivateContext activated(context);
   hipDeviceptr_t device_mem = nullptr;
   hipError_t res;
@@ -402,12 +403,8 @@ void* DeviceAllocate(Context* context, uint64_t bytes,
     res = hipMalloc(&device_mem, bytes);
   }
   if (res != hipSuccess) {
-    // LOG(INFO) because this isn't always important to users (e.g. BFCAllocator
-    // implements a retry if the first allocation fails).
-    LOG(INFO) << "failed to allocate "
-              << tsl::strings::HumanReadableNumBytes(bytes) << " (" << bytes
-              << " bytes) from device: " << ToString(res);
-    return nullptr;
+    return absl::InternalError(absl::StrFormat(
+        "failed to allocate %d bytes from device: %s", bytes, ToString(res)));
   }
   void* ptr = reinterpret_cast<void*>(device_mem);
   VLOG(2) << "allocated " << ptr << " for device " << context->device_ordinal()
@@ -456,6 +453,27 @@ absl::StatusOr<std::unique_ptr<MemoryAllocation>> AllocateHostMemory(
         VLOG(2) << "deallocated host memory at " << location << " for context "
                 << rocm_context;
       });
+}
+
+absl::StatusOr<void*> CollectiveMemoryAllocate(Context* context,
+                                               uint64_t bytes) {
+  if (bytes == 0) return nullptr;
+  ScopedActivateContext activation(context);
+  auto* collectives = xla::gpu::GpuCollectives::Resolve("ROCM");
+  ASSIGN_OR_RETURN(void* ptr, collectives->Allocate(bytes));
+  XLA_VLOG_DEVICE(2, context->device_ordinal())
+      << "allocated " << ptr << " of " << bytes
+      << " bytes of collective memory";
+  return ptr;
+}
+
+absl::Status CollectiveMemoryDeallocate(Context* context, void* location) {
+  ScopedActivateContext activation(context);
+  auto* collectives = xla::gpu::GpuCollectives::Resolve("ROCM");
+  RETURN_IF_ERROR(collectives->Deallocate(location));
+  XLA_VLOG_DEVICE(2, context->device_ordinal())
+      << "deallocated collective memory at " << location;
+  return absl::OkStatus();
 }
 
 }  // namespace
@@ -730,21 +748,30 @@ absl::StatusOr<ModuleHandle> RocmExecutor::LoadModuleFromHsaco(
 }
 
 DeviceAddressBase RocmExecutor::Allocate(uint64_t size, int64_t memory_space) {
+  absl::StatusOr<void*> result;
   switch (static_cast<MemorySpace>(memory_space)) {
-    case MemorySpace::kCollective:
+    // Collective memory cannot be used for this type of allocation since
+    // memory space is not passed to RocmExecutor::Deallocate().
+    /*case MemorySpace::kCollective:
+      result = CollectiveMemoryAllocate(&rocm_context_, size);
+      break; */
     case MemorySpace::kDevice:
-      return DeviceAddressBase(
-          DeviceAllocate(&rocm_context_, size, /*is_fine_grained*/ false),
-          size);
+      result = DeviceAllocate(&rocm_context_, size, /*is_fine_grained*/ false);
+      break;
     case MemorySpace::kHost:
-      if (auto result = HostAllocate(&rocm_context_, size); result.ok()) {
-        return DeviceAddressBase(*result, size);
-      }
-      return DeviceAddressBase(nullptr, 0);
+      result = HostAllocate(&rocm_context_, size);
+      break;
     default:
       LOG(FATAL) << "Unsupported memory space: " << memory_space;
   }
+  if (!result.ok()) {
+    XLA_LOG_DEVICE(ERROR, device_ordinal())
+        << "RocmExecutor::Allocate returns " << result.status().message();
+    return DeviceAddressBase(nullptr, 0);
+  }
+  return DeviceAddressBase(*result, size);
 }
+
 absl::StatusOr<std::unique_ptr<MemoryAllocation>>
 RocmExecutor::HostMemoryAllocate(uint64_t size) {
   return AllocateHostMemory(&rocm_context_, size);
@@ -788,28 +815,18 @@ RocmExecutor::CreateMemoryAllocator(MemorySpace type) {
           });
     case MemorySpace::kCollective:
       return std::make_unique<GenericMemoryAllocator>(
-          [](uint64_t size)
+          [this](uint64_t size)
               -> absl::StatusOr<std::unique_ptr<MemoryAllocation>> {
-            void* ptr = nullptr;
-            auto hipResult = hipMalloc(&ptr, size);
-            if (hipResult != hipSuccess) {
-              return absl::InternalError(absl::StrFormat(
-                  "failed to allocate %s (%llu bytes) from device collective "
-                  "memory: %s, "
-                  "Last NCCL warning(error)",
-                  tsl::strings::HumanReadableNumBytes(size), size,
-                  hipGetErrorString(hipResult)));
-            }
-            VLOG(2) << "allocated " << ptr << " of " << size
-                    << " bytes of collective memory";
+            ASSIGN_OR_RETURN(void* ptr,
+                             CollectiveMemoryAllocate(&rocm_context_, size));
             return std::make_unique<GenericMemoryAllocation>(
-                ptr, size, [](void* location, uint64_t size) {
-                  auto status = hipFree(location);
-                  if (status != hipSuccess) {
-                    LOG(ERROR) << "failed to free collective memory at "
-                               << location << "; result: " << status;
-                  } else {
-                    VLOG(2) << "deallocated collective memory at " << location;
+                ptr, size, [this](void* location, uint64_t size) {
+                  auto status =
+                      CollectiveMemoryDeallocate(&rocm_context_, location);
+                  if (!status.ok()) {
+                    XLA_LOG_DEVICE(ERROR, device_ordinal())
+                        << "failed to free collective memory at " << location
+                        << "; result: " << status;
                   }
                 });
           });


### PR DESCRIPTION
This PR introduces the backbone for an AMD **MORI** collectives backend in XLA:GPU
(ROCm only), without pulling in the real MORI library yet. It adds a new
`GpuCollectives`/`GpuCommunicator` implementation, wires collective-memory
allocation on the ROCm executor through the resolved collectives backend, and
adds a smoke test. All MORI device/host calls are routed through an inert stub
header so the code compiles and links in CI with no external MORI dependency.

The goal is to land the plumbing and interfaces so that the actual MORI bindings
can be dropped in later as a focused follow-up.

MORI wiring is done in a separate PR: https://github.com/openxla/xla/pull/44636

## What's included

### New MORI collectives backend (ROCm only)
- `xla/backends/gpu/collectives/mori_collectives.{h,cc}` - `MoriCollectives`,
  a `GpuCollectives` implementation 
  - Registered via `XLA_COLLECTIVES_REGISTER("ROCM", "mori", -100, ...)`.
- `xla/backends/gpu/collectives/mori_communicator.{h,cc}` - `MoriCommunicator`,
  a `GpuCommunicator` wrapper. The launch bodies currently return `Unimplemented` 
pending real bindings. `NumRanks`,  `CurrentRank`, `Abort`, and cancellation handling are functional.

### MORI stub (bindings-free)
- `xla/backends/gpu/collectives/mori_stub.h` - a self-contained, inert stand-in
  for the subset of the `mori::shmem` host API used by the backbone

### ROCm executor: collective memory via resolved backend
- `xla/stream_executor/rocm/rocm_executor.cc` - `kCollective` memory
  allocations now route through the resolved GPU collectives backend
  (`CollectiveMemoryAllocate`/`CollectiveMemoryDeallocate` ->
  `GpuCollectives::Allocate`/`Deallocate`) instead of a hard-coded
  `hipMalloc`/`hipFree`. Applies to both `RocmExecutor::Allocate` and the
  `kCollective` `CreateMemoryAllocator` path.
- `xla/stream_executor/rocm/BUILD` - adds the corresponding deps
  (`gpu_collectives`, `core/collectives`, `collectives_registry`, `xla:util`)
  and a `bool_flag` load.

### Collectives resolution refactor
- `xla/backends/gpu/runtime/collective_params.{h,cc}` - `ResolveCollectives` is replaced by `GpuCollectives::Resolve(..)` which now can be called from different places to unify collectives backend resolution.

## Testing
- `gpu_collectives_test` builds on ROCm and CUDA; the new MORI test self-skips
  unless run on a ROCm platform with >= 4 GPUs.
- Collective launch paths remain `Unimplemented` by design and are not
  exercised end-to-end yet.
