### PR TITLE
[XLA] Keep DotMerger concat operand last dim last to avoid non-fusible transpose

### DIFF
--- a/xla/hlo/transforms/simplifiers/dot_merger.cc
+++ b/xla/hlo/transforms/simplifiers/dot_merger.cc
@@ -416,10 +416,12 @@ struct ConcatTargetInfo {
 //   operand.
 // - Reshape non-contracting dimensions to rank 1 (as we'll going to concatenate
 // over it).
+// `contracting_is_minor` picks between [B, NonContracting, Contracting] and
+// [B, Contracting, NonContracting]; see the caller for how it is decided.
 absl::StatusOr<ConcatTargetInfo> TransformConcatDims(
     const DotOperandDims& concat_before, const DotOperandDims& shared_before,
     const DotOperandDims& shared_after, const ShapeTracker& shared_tracker,
-    PrimitiveType output_type) {
+    PrimitiveType output_type, bool contracting_is_minor) {
   // Make the transformations in the batch and contracting dimensions.
   ASSIGN_OR_RETURN(
       ShapeTracker batch_tracker,
@@ -467,6 +469,20 @@ absl::StatusOr<ConcatTargetInfo> TransformConcatDims(
             batch_rank_out + 1);
   DotOperandDims target_dims(zipped_tracker.output_shape(), target_batch_dims,
                              target_nc_dims, target_contracting_dims);
+
+  // Built [B,N,C] (contracting last) above. When a non-contracting dim is
+  // already last, swap to [B,C,N] to keep it last. This transpose folds into
+  // the alignment transpose above, staying a single fusible (loop) transpose.
+  if (!contracting_is_minor) {
+    std::vector<int64_t> to_ncminor(target_dims.shape().dimensions().size());
+    std::iota(to_ncminor.begin(), to_ncminor.end(), 0);
+    // [B, N, C] -> [B, C, N] (N is a single dim).
+    std::rotate(to_ncminor.begin() + batch_rank_out,
+                to_ncminor.begin() + batch_rank_out + 1, to_ncminor.end());
+    RETURN_IF_ERROR(zipped_tracker.AppendTranspose(to_ncminor));
+    target_dims = target_dims.GetPermuted(to_ncminor);
+  }
+
   return ConcatTargetInfo{target_dims, zipped_tracker};
 }
 
@@ -475,6 +491,18 @@ absl::StatusOr<std::vector<ConcatTargetInfo>> ComputeTargetConcatDims(
     HloInstruction* new_shared_op, const DotOperandDims& target_shared_dims) {
   std::vector<ConcatTargetInfo> target_concat_infos;
   target_concat_infos.reserve(dots_to_merge.size());
+
+  // Decide the order once for the class (operands must share an order to be
+  // concatenable; the first dot's operand is representative). Keep the last
+  // logical dimension in place to avoid a transpose. DotMerger runs before
+  // layout assignment, so the last logical dimension, not a physical minor dim,
+  // is what matters.
+  ASSIGN_OR_RETURN(
+      DotOperandDims first_concat_dims,
+      DotOperandDims::FromDotOperand(dots_to_merge[0].dot,
+                                     1 - dots_to_merge[0].shared_operand_idx));
+  const bool contracting_is_minor =
+      first_concat_dims.Categories().back() == DotOperandDims::kContracting;
 
   for (const auto& usage : dots_to_merge) {
     ASSIGN_OR_RETURN(DotOperandDims concat_dims_at_dot,
@@ -491,14 +519,16 @@ absl::StatusOr<std::vector<ConcatTargetInfo>> ComputeTargetConcatDims(
         ShapeTracker shared_dot_to_target,
         ShapeTracker::FromSiblings(old_shared_operand, new_shared_op));
 
-    // Bring the concat (non-shared) to the [B, NC, C] layout, where B and C are
-    // identical for all dots, and NC is a single dimension (that we'll
-    // concatenate over).
+    // Bring the concat (non-shared) operand to the canonical layout, where B
+    // and C are identical for all dots, and NC is a single dimension (that
+    // we'll concatenate over). The contracting dimension is placed last or
+    // second-to-last according to `contracting_is_minor`.
     ASSIGN_OR_RETURN(
         ConcatTargetInfo info,
         TransformConcatDims(concat_dims_at_dot, shared_dims_at_dot,
                             target_shared_dims, shared_dot_to_target,
-                            usage.dot->shape().element_type()));
+                            usage.dot->shape().element_type(),
+                            contracting_is_minor));
 
     // TransformConcatDims returns a old->new tracker for the concat operand.
     // What we actually want is a source->new tracker. To build it, we compose
@@ -767,9 +797,8 @@ absl::StatusOr<HloInstruction*> MergeCluster(
 
   // Get compatible pre-concat shapes for the non-shared operands. They must
   // have exactly same shapes/categories, except for one non-contracting
-  // dimension which we'll concatenate over. This function makes it by bringing
-  // it to [Batch, NonContracting, Contracting] layout with exactly one
-  // Non-Contracting dimension (and matching rest).
+  // dimension which we'll concatenate over. This function brings them to a
+  // common canonical layout with exactly one Non-Contracting dimension.
   ASSIGN_OR_RETURN(std::vector<ConcatTargetInfo> target_concat_infos,
                    ComputeTargetConcatDims(dots_to_merge, new_shared_op,
                                            target_shared_dims));

--- a/xla/hlo/transforms/simplifiers/dot_merger_test.cc
+++ b/xla/hlo/transforms/simplifiers/dot_merger_test.cc
@@ -79,8 +79,7 @@ TEST_F(DotMergerTest, MergeRHS) {
   EXPECT_THAT(dot0,
               GmockMatch(m::Dot(m::Parameter(0),
                                 m::Concatenate().WithBinaryOperandsAnyOrder(
-                                    m::Transpose(m::Parameter(1)),
-                                    m::Transpose(m::Parameter(2))))));
+                                    m::Parameter(1), m::Parameter(2)))));
   ASSERT_NE(lhs, nullptr);
   // We want a deterministic first user.
   EXPECT_EQ(lhs->users()[0], dot0);
@@ -121,12 +120,10 @@ TEST_F(DotMergerTest, MergeRHSSortedByPowerOfTwo) {
   EXPECT_EQ(dot0, dot3);
   // Expected order: RHS2 (64, TZ 6), RHS3 (24, TZ 3), RHS1 (50, TZ 1), RHS0
   // (10, TZ 1)
-  EXPECT_THAT(
-      dot0, GmockMatch(m::Dot(m::Parameter(0),
-                              m::Concatenate(m::Transpose(m::Parameter(3)),
-                                             m::Transpose(m::Parameter(4)),
-                                             m::Transpose(m::Parameter(2)),
-                                             m::Transpose(m::Parameter(1))))));
+  EXPECT_THAT(dot0, GmockMatch(m::Dot(
+                        m::Parameter(0),
+                        m::Concatenate(m::Parameter(3), m::Parameter(4),
+                                       m::Parameter(2), m::Parameter(1)))));
 }
 
 TEST_F(DotMergerTest, MergeRHSWithLHS) {
@@ -178,15 +175,14 @@ TEST_F(DotMergerTest, MergeRHSWithLayouts) {
       module->entry_computation()->root_instruction(),
       GmockMatch(m::Tuple(m::Slice(m::Op(&dot0)), m::Slice(m::Op(&dot1)))));
   EXPECT_EQ(dot0, dot1);
-  Shape expected_concat_shape =
-      ShapeUtil::MakeShapeWithDenseLayout(F32, {60, 100}, {1, 0});
-  EXPECT_THAT(dot0,
-              GmockMatch(m::Dot(
-                  m::Parameter(0),
-                  m::Concatenate()
-                      .WithBinaryOperandsAnyOrder(m::Transpose(m::Parameter(1)),
-                                                  m::Transpose(m::Parameter(2)))
-                      .WithShapeEqualTo(&expected_concat_shape))));
+  // DotMerger is layout-agnostic: operands concatenate directly, no transpose.
+  Shape expected_concat_shape = ShapeUtil::MakeShape(F32, {100, 60});
+  EXPECT_THAT(
+      dot0, GmockMatch(m::Dot(m::Parameter(0),
+                              m::Concatenate()
+                                  .WithBinaryOperandsAnyOrder(m::Parameter(1),
+                                                              m::Parameter(2))
+                                  .WithShapeEqualTo(&expected_concat_shape))));
 }
 
 TEST_F(DotMergerTest, MergeDifferentLayoutRHS) {
@@ -852,6 +848,41 @@ TEST_F(DotMergerTest, MergeMultipleNonContractingDimsInRhsSharedOperand) {
   EXPECT_EQ(s0, s1);
 }
 
+// Contracting (dim 1) sits between non-contracting dims 0 and 2, so the
+// canonical order must keep the last dim in place.
+TEST_F(DotMergerTest, MergeKeepsConcatOperandMinorDimMinor) {
+  absl::string_view module_string = R"(
+  HloModule module
+
+  ENTRY main {
+    lhs  = f32[64,2880] parameter(0)
+    rhs0 = f32[4,2880,2880] parameter(1)
+    rhs1 = f32[4,2880,2880] parameter(2)
+    dot0 = f32[64,4,2880] dot(lhs, rhs0), lhs_contracting_dims={1}, rhs_contracting_dims={1}
+    dot1 = f32[64,4,2880] dot(lhs, rhs1), lhs_contracting_dims={1}, rhs_contracting_dims={1}
+    ROOT tuple = (f32[64,4,2880], f32[64,4,2880]) tuple(dot0, dot1)
+  })";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(module_string));
+  DotMerger pass(/*max_size_to_merge=*/std::numeric_limits<int64_t>::max());
+  ASSERT_OK_AND_ASSIGN(bool changed, this->RunHloPass(&pass, module.get()));
+  EXPECT_TRUE(changed);
+  ASSERT_OK(verifier().Run(module.get()).status());
+  SCOPED_TRACE(module->ToString());
+
+  // No transpose may move the last logical dimension (last dim maps to itself).
+  for (const HloInstruction* instr :
+       module->entry_computation()->instructions()) {
+    if (instr->opcode() != HloOpcode::kTranspose) {
+      continue;
+    }
+    const auto& perm = instr->dimensions();
+    ASSERT_FALSE(perm.empty());
+    EXPECT_EQ(perm.back(), static_cast<int64_t>(perm.size()) - 1)
+        << "last-dimension-swapping transpose: " << instr->ToString();
+  }
+}
+
 TEST_F(DotMergerTest, MergeMultipleOuterDims) {
   absl::string_view module_string = R"(
   HloModule module
@@ -1043,14 +1074,13 @@ TEST_F(DotMergerTest, MergeWithTypeUpgrade) {
   EXPECT_TRUE(changed);
   const HloInstruction* d0 = nullptr;
   const HloInstruction* d1 = nullptr;
-  ASSERT_THAT(module->entry_computation()->root_instruction(),
-              GmockMatch(m::Tuple(
-                  m::Slice(m::Dot(&d0,
-                                  m::Concatenate(m::Transpose(m::Parameter(0)),
-                                                 m::Transpose(m::Parameter(1))),
-                                  m::Parameter(2))
-                               .WithShape(F32, {20, 10})),
-                  m::Slice(m::Op(&d1)))));
+  ASSERT_THAT(
+      module->entry_computation()->root_instruction(),
+      GmockMatch(m::Tuple(
+          m::Slice(m::Dot(&d0, m::Concatenate(m::Parameter(0), m::Parameter(1)),
+                          m::Parameter(2))
+                       .WithShape(F32, {20, 10})),
+          m::Slice(m::Op(&d1)))));
   EXPECT_EQ(d0, d1);
 }
 
@@ -1520,10 +1550,10 @@ TEST_F(DotMergerTest, MergeOneConcatOperandMissingNonContractingDim) {
                                   m::Reshape(m::Slice(m::Op(&dot1))))));
   EXPECT_EQ(dot0, dot1);
 
-  EXPECT_THAT(dot0,
-              GmockMatch(m::Dot(m::Parameter(0),
-                                m::Concatenate(m::Transpose(m::Parameter(1)),
-                                               m::Reshape(m::Parameter(2))))));
+  EXPECT_THAT(
+      dot0, GmockMatch(m::Dot(
+                m::Parameter(0),
+                m::Concatenate(m::Parameter(1), m::Reshape(m::Parameter(2))))));
 }
 
 TEST_F(DotMergerTest, MergeWithConsumerNormalization) {
@@ -1957,12 +1987,11 @@ TEST_F(DotMergerTest, MergeWithDegenerateNonContractingDimsInSharedOperand) {
                                   m::Reshape(m::Slice(m::Op(&dot1))))));
   EXPECT_EQ(dot0, dot1);
   // Verify the merged dot has the degenerate dimension reshaped out from LHS
-  EXPECT_THAT(
-      dot0,
-      GmockMatch(m::Dot(
-          m::Reshape(m::Parameter(0)),  // LHS is reshaped to [100]
-          m::Concatenate().WithBinaryOperandsAnyOrder(
-              m::Transpose(m::Parameter(1)), m::Transpose(m::Parameter(2))))));
+  EXPECT_THAT(dot0,
+              GmockMatch(m::Dot(
+                  m::Reshape(m::Parameter(0)),  // LHS is reshaped to [100]
+                  m::Concatenate().WithBinaryOperandsAnyOrder(
+                      m::Parameter(1), m::Parameter(2)))));
 }
 
 TEST_F(DotMergerTest, MergeWithConsecutiveContractingDims) {
@@ -1990,13 +2019,12 @@ TEST_F(DotMergerTest, MergeWithConsecutiveContractingDims) {
       module->entry_computation()->root_instruction(),
       GmockMatch(m::Tuple(m::Slice(m::Op(&dot0)), m::Slice(m::Op(&dot1)))));
   EXPECT_EQ(dot0, dot1);
-  EXPECT_THAT(dot0, GmockMatch(m::Dot(
-                        m::Reshape(m::Parameter(0)).WithShape(F32, {200, 100}),
-                        m::Concatenate().WithBinaryOperandsAnyOrder(
-                            m::Reshape(m::Transpose(m::Parameter(1)))
-                                .WithShape(F32, {10, 200}),
-                            m::Reshape(m::Transpose(m::Parameter(2)))
-                                .WithShape(F32, {50, 200})))));
+  EXPECT_THAT(dot0,
+              GmockMatch(m::Dot(
+                  m::Reshape(m::Parameter(0)).WithShape(F32, {200, 100}),
+                  m::Concatenate().WithBinaryOperandsAnyOrder(
+                      m::Reshape(m::Parameter(1)).WithShape(F32, {200, 10}),
+                      m::Reshape(m::Parameter(2)).WithShape(F32, {200, 50})))));
 }
 
 TEST_F(DotMergerTest, MergeWithConsecutiveContractingDimsAndDegenerate) {
@@ -2024,13 +2052,12 @@ TEST_F(DotMergerTest, MergeWithConsecutiveContractingDimsAndDegenerate) {
               GmockMatch(m::Tuple(m::Reshape(m::Slice(m::Op(&dot0))),
                                   m::Reshape(m::Slice(m::Op(&dot1))))));
   EXPECT_EQ(dot0, dot1);
-  EXPECT_THAT(dot0, GmockMatch(m::Dot(
-                        m::Reshape(m::Parameter(0)).WithShape(F32, {200, 100}),
-                        m::Concatenate().WithBinaryOperandsAnyOrder(
-                            m::Reshape(m::Transpose(m::Parameter(1)))
-                                .WithShape(F32, {10, 200}),
-                            m::Reshape(m::Transpose(m::Parameter(2)))
-                                .WithShape(F32, {50, 200})))));
+  EXPECT_THAT(dot0,
+              GmockMatch(m::Dot(
+                  m::Reshape(m::Parameter(0)).WithShape(F32, {200, 100}),
+                  m::Concatenate().WithBinaryOperandsAnyOrder(
+                      m::Reshape(m::Parameter(1)).WithShape(F32, {200, 10}),
+                      m::Reshape(m::Parameter(2)).WithShape(F32, {200, 50})))));
 }
 
 TEST_F(DotMergerTest, MergeRHSPreservesMetadata) {


### PR DESCRIPTION
📝 Summary of Changes
The DotMerger ShapeTracker refactor (cdbd8b766f) always canonicalized the concat operand to contracting-last, moving the last logical dimension when it was non-contracting. Now, the canonical order is chosen per equivalence class to keep the last logical dimension in place ([B, Contracting, NonContracting] vs [B, NonContracting, Contracting]), so the alignment transpose stays a fusible loop transpose.

🎯 Justification
The swapping transpose lowers to the GPU tiled-transpose emitter, which can't fuse and materializes the whole operand as a standalone kernel. On gpt-oss-20b prefill (1×MI350X) that was ~530MB bf16 transposes in the decoder loop resulting in ~7% regression.

🚀 Kind of Contribution
🐛 Bug Fix, ⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
gpt-oss-20b prefill, 1×MI350X: 76.3ms → 71.0ms

🧪 Unit Tests:
MergeKeepsConcatOperandMinorDimMinor: asserts no transpose moves the minor dim. Updated 8 existing expectations that no longer carry an inserted transpose.