### PR TITLE
[ROCm---XLA:GPU] Disable AnnotationStack on GpuTracer::DoStart() failure (ROCm)

### DIFF
--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -19,7 +19,6 @@ limitations under the License.
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
-#include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
@@ -113,8 +112,12 @@ absl::Status GpuTracer::DoStart() {
       trace_collector_options, start_walltime_ns, start_gputime_ns);
   rocm_trace_collector_->SetGpuAgents(rocm_tracer_->GpuAgents());
 
-  RETURN_IF_ERROR(
-      rocm_tracer_->Enable(tracer_options, rocm_trace_collector_.get()));
+  absl::Status status =
+      rocm_tracer_->Enable(tracer_options, rocm_trace_collector_.get());
+  if (!status.ok()) {
+    AnnotationStack::Enable(false);
+    return status;
+  }
   return absl::OkStatus();
 }
 


### PR DESCRIPTION
GpuTracer::DoStart() enables AnnotationStack before calling rocm_tracer_->Enable(). If Enable() fails, the previous RETURN_IF_ERROR returned without reversing the Enable(true). GpuTracer::Stop() only calls DoStop() — and thus AnnotationStack::Enable(false) — when profiling_state_ is kStartedOk, so a failed start left the annotation stack permanently enabled for the process lifetime, adding per-call overhead with no profiler running.

Fix: replace RETURN_IF_ERROR with an explicit status check that calls AnnotationStack::Enable(false) before propagating the error, mirroring the same fix applied to CuptiTracer::DoStart() in the preceding commit.

Remove the now-unused status_macros.h include.
