### PR TITLE
[XLA:GPU] Lower scaled-dot operand transposes in XTile-to-Triton

### DIFF
--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -2795,6 +2795,50 @@ TEST_P(TritonScaledDotTest, DISABLED_Fp4Succeeds) {
       std::move(optimized_module), ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
 }
 
+TEST_P(TritonScaledDotTest, Mxfp4KPackedRhsBlackwellLowersWithTranspose) {
+  if (!GetCudaComputeCapability().IsAtLeastBlackwell()) {
+    GTEST_SKIP() << "Requires Blackwell+.";
+  }
+  constexpr absl::string_view kHloText = R"hlo(
+HloModule m
+fusion__ {
+  parameter_0 = f4e2m1fn[128,256]{1,0:E(4)} parameter(0)
+  parameter_1 = f4e2m1fn[128,256]{1,0:E(4)} parameter(1)
+  parameter_2 = f8e8m0fnu[128,8]{1,0} parameter(2)
+  parameter_3 = f8e8m0fnu[128,8]{1,0} parameter(3)
+  ROOT _.1 = bf16[128,128] scaled-dot(parameter_0, parameter_1, parameter_2, parameter_3),
+    lhs_contracting_dims={1}, rhs_contracting_dims={1},
+    backend_config={"sizes":["64"]}
+}
+ENTRY e {
+  lhs = f4e2m1fn[128,256]{1,0:E(4)} parameter(0)
+  rhs = f4e2m1fn[128,256]{1,0:E(4)} parameter(1)
+  lhs_scale = f8e8m0fnu[128,8]{1,0} parameter(2)
+  rhs_scale = f8e8m0fnu[128,8]{1,0} parameter(3)
+  ROOT fusion = bf16[128,128] fusion(lhs, rhs, lhs_scale, rhs_scale),
+    kind=kCustom, calls=fusion__,
+    backend_config={"fusion_backend_config":{"kind":"__triton_nested_gemm_fusion",
+      "block_level_fusion_config":{
+        "output_tiles":[{"sizes":["128","128"]}],
+        "num_warps":"4","num_ctas":"1","num_stages":"1"}}}
+}
+)hlo";
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHloText));
+  HloComputation* scaled_dot_computation =
+      GetFirstComputationWithInstruction(*module, HloOpcode::kScaledDot);
+  EXPECT_THAT(CreateTritonIrAndFileCheckForDot(*scaled_dot_computation, R"(
+      CHECK: tt.trans
+      CHECK: tensor<128x32xi8> -> tensor<32x128xi8>
+      CHECK-NOT: unrealized_conversion_cast
+      CHECK: tt.dot_scaled
+      CHECK: tensor<128x32xi8>, tensor<128x2xi8> * tensor<32x128xi8>, tensor<128x2xi8>
+  )"),
+              IsOk())
+      << "We expect to see tt.trans and the follow up dot_scaled";
+  EXPECT_TRUE(RunAndCompareNoHloPasses(
+      std::move(module), ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
+}
+
 TEST_P(TritonScaledDotTest, GlobalScalerSucceeds) {
   if (!GetCudaComputeCapability().IsAtLeastHopper()) {
     GTEST_SKIP() << "Scaled dot isn't supported by Triton for pre-Hopper GPUs.";

--- a/xla/backends/gpu/codegen/triton/transforms/lowering_utils.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/lowering_utils.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
@@ -217,6 +218,15 @@ mlir::LogicalResult LowerReshape::matchAndRewrite(
   bool allow_reorder = false;
   rewriter.replaceOpWithNewOp<ttir::ReshapeOp>(op, op.getResult().getType(),
                                                op.getOperand(), allow_reorder);
+  return mlir::success();
+}
+
+mlir::LogicalResult LowerTranspose::matchAndRewrite(
+    stablehlo::TransposeOp op, mlir::PatternRewriter& rewriter) const {
+  SmallVector<int32_t> permutation =
+      llvm::to_vector_of<int32_t>(op.getPermutation());
+  rewriter.replaceOpWithNewOp<ttir::TransOp>(op, op.getResult().getType(),
+                                             op.getOperand(), permutation);
   return mlir::success();
 }
 

--- a/xla/backends/gpu/codegen/triton/transforms/lowering_utils.h
+++ b/xla/backends/gpu/codegen/triton/transforms/lowering_utils.h
@@ -39,6 +39,16 @@ class LowerReshape : public mlir::OpRewritePattern<stablehlo::ReshapeOp> {
       stablehlo::ReshapeOp op, mlir::PatternRewriter& rewriter) const override;
 };
 
+// Lowers stablehlo.transpose to ttir.trans.
+class LowerTranspose : public mlir::OpRewritePattern<stablehlo::TransposeOp> {
+ public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult matchAndRewrite(
+      stablehlo::TransposeOp op,
+      mlir::PatternRewriter& rewriter) const override;
+};
+
 // Returns the AddOp and its non-dot operand (accumulator) if the 'op' is
 // consumed by an AddOp. This is used to identify GEMM fusion units.
 mlir::LogicalResult GetFusedAddUnit(mlir::Operation* op,

--- a/xla/backends/gpu/codegen/triton/transforms/passes.td
+++ b/xla/backends/gpu/codegen/triton/transforms/passes.td
@@ -243,6 +243,7 @@ def XTileLowerToTritonPass
     : Pass<"xtile-lower-to-triton", "mlir::ModuleOp"> {
   let summary = "Lowers XTile operations to their Triton equivalent.";
   let dependentDialects = [
+    "::mlir::stablehlo::StablehloDialect",
     "::mlir::triton::TritonDialect",
     "::xla::xtile::XTileDialect",
   ];

--- a/xla/backends/gpu/codegen/triton/transforms/stablehlo_lower_to_triton.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/stablehlo_lower_to_triton.cc
@@ -74,22 +74,6 @@ namespace ttir = ::mlir::triton;
 
 namespace {
 
-class LowerTranspose : public mlir::OpRewritePattern<stablehlo::TransposeOp> {
- public:
-  using OpRewritePattern::OpRewritePattern;
-
- private:
-  mlir::LogicalResult matchAndRewrite(
-      stablehlo::TransposeOp op,
-      mlir::PatternRewriter& rewriter) const override {
-    SmallVector<int32_t> permutation =
-        llvm::to_vector_of<int32_t>(op.getPermutation());
-    rewriter.replaceOpWithNewOp<ttir::TransOp>(op, op.getResult().getType(),
-                                               op.getOperand(), permutation);
-    return mlir::success();
-  }
-};
-
 class LowerIotaToMakeRange : public mlir::OpRewritePattern<stablehlo::IotaOp> {
  public:
   using OpRewritePattern::OpRewritePattern;

--- a/xla/backends/gpu/codegen/triton/transforms/xtile_lower_to_triton.cc
+++ b/xla/backends/gpu/codegen/triton/transforms/xtile_lower_to_triton.cc
@@ -88,6 +88,19 @@ bool IsDotScaledCanonical(::xla::xtile::DotScaledOp op) {
          is_rank_2(op.getLhsScale()) && is_rank_2(op.getRhsScale());
 }
 
+// Removes unit dimensions from a dot result to produce the rank-2 canonical
+// form required by Triton. For example, tensor<1x128x256xf32> becomes
+// tensor<128x256xf32>.
+RankedTensorType CollapseUnitDims(RankedTensorType type) {
+  llvm::SmallVector<int64_t> shape;
+  for (int64_t dim : type.getShape()) {
+    if (dim != 1) {
+      shape.push_back(dim);
+    }
+  }
+  return RankedTensorType::get(shape, type.getElementType());
+}
+
 LogicalResult CanonicalDotScaled(::xla::xtile::DotScaledOp op,
                                  mlir::PatternRewriter& rewriter,
                                  ::xla::xtile::DotScaledOp& canonical_dot) {
@@ -140,10 +153,11 @@ LogicalResult CanonicalDotScaled(::xla::xtile::DotScaledOp op,
   }
 
   RankedTensorType result_type = mlir::cast<RankedTensorType>(op.getType());
-  RankedTensorType new_result_type = RankedTensorType::get(
-      {mlir::cast<ShapedType>(lhs.getType()).getShape()[0],
-       mlir::cast<ShapedType>(rhs.getType()).getShape()[1]},
-      result_type.getElementType());
+  RankedTensorType new_result_type = CollapseUnitDims(result_type);
+  if (new_result_type.getRank() != 2) {
+    return rewriter.notifyMatchFailure(op_loc,
+                                       "Failed to canonicalize result.");
+  }
 
   auto canonical_dims = mlir::stablehlo::DotDimensionNumbersAttr::get(
       rewriter.getContext(), {}, {}, {1}, {0});
@@ -404,9 +418,8 @@ class XTileLowerToTritonPass
   void runOnOperation() override {
     mlir::MLIRContext* mlir_context = &getContext();
     mlir::RewritePatternSet patterns(mlir_context);
-    patterns
-        .add<CanonicalizeDotScaled, LowerDotScaled, LowerReshape, LowerScan>(
-            mlir_context);
+    patterns.add<CanonicalizeDotScaled, LowerDotScaled, LowerReshape, LowerScan,
+                 LowerTranspose>(mlir_context);
     if (mlir::failed(
             mlir::applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();


### PR DESCRIPTION
📝 Summary of Changes
- Lower transposes created during XTile scaled-dot canonicalization to `tt.trans`. The transpose lowering is shared between the StableHLO-to-Triton and XTile-to-Triton passes.
- Canonicalize scaled-dot result shapes by collapsing unit dimensions to the 2D shape required by Triton.

This is another PR in the scaled dot fix series (part of https://github.com/openxla/xla/pull/44223).

🎯 Justification

Canonicalizing a scaled dot can create `stablehlo.transpose`. Previously, these operations can be created after the StableHLO-to-Triton pass and remain in the IR. This prevents the XTile-to-Triton pipeline from fully lowering MXFP4 scaled dots. Registering transpose lowering in the XTile-to-Triton pass produces the expected Triton IR. This mirrors the existing LowerReshape handling: operand canonicalization can create both reshapes and transposes after StableHLO-to-Triton lowering, so both rewrites must also run in the XTile-to-Triton pass.

🚀 Kind of Contribution
🐛 Bug Fix, 🧪 Tests

🧪 Unit Tests:
New test TritonScaledDotTest.Mxfp4KPackedRhsSm120Executes
Without this fix, it fails because the generated IR retains `stablehlo.transpose`.

@loislo 