### PR TITLE
[GPU] True stable pointers for collective and user-specified allocations

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -1441,7 +1441,9 @@ GetStreamExecutorGpuDeviceAllocator(
       }
       return se::gpu::CudaDeviceAddressVmmAllocator::Create(
           platform, allocator_config.memory_fraction,
-          allocator_config.gpu_system_memory_size, executor_streams);
+          allocator_config.gpu_system_memory_size, executor_streams,
+          /*reclaim_exempt_memory_space=*/
+          static_cast<int64_t>(gpu::MemorySpaceColor::kCollective));
 #elif TENSORFLOW_USE_ROCM
       std::vector<std::pair<se::StreamExecutor*, se::Stream*>> executor_streams;
       executor_streams.reserve(addressable_devices.size());
@@ -1451,7 +1453,9 @@ GetStreamExecutorGpuDeviceAllocator(
       }
       return se::gpu::RocmDeviceAddressVmmAllocator::Create(
           platform, allocator_config.memory_fraction,
-          allocator_config.gpu_system_memory_size, executor_streams);
+          allocator_config.gpu_system_memory_size, executor_streams,
+          /*reclaim_exempt_memory_space=*/
+          static_cast<int64_t>(gpu::MemorySpaceColor::kCollective));
 #else
       return absl::UnimplementedError(
           "VMM allocator is only supported with CUDA or ROCm.");

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -2793,6 +2793,76 @@ TEST_F(VmmTest, CommandBufferSkipProfiledFallsBackWithoutVmmAllocator) {
   mock_log.StopCapturingLogs();
 }
 
+// Records the result address of each invocation so tests can assert stability.
+std::vector<void*>& RecordedBufferAddresses() {
+  static auto* addresses = new std::vector<void*>();
+  return *addresses;
+}
+
+absl::Status RecordBufferAddressCustomCall(ffi::AnyBuffer,
+                                           ffi::Result<ffi::AnyBuffer> result) {
+  RecordedBufferAddresses().push_back(result->untyped_data());
+  return absl::OkStatus();
+}
+
+XLA_FFI_DEFINE_HANDLER(
+    kRecordBufferAddressCustomCall, RecordBufferAddressCustomCall,
+    ffi::Ffi::Bind().Arg<ffi::AnyBuffer>().Ret<ffi::AnyBuffer>());
+
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "RecordBufferAddress", "CUDA",
+                         kRecordBufferAddressCustomCall);
+
+// s is placed in the collective memory space by the results_memory_spaces
+// attribute alone. Run i yields 2*i*i.
+constexpr char kAttrPlacedModule[] = R"(
+  HloModule attr_placed_stable_buffer
+  ENTRY e {
+    p0 = f32[512,1024] parameter(0)
+    t = f32[512,1024] multiply(p0, p0)
+    s = f32[512,1024] custom-call(t), custom_call_target="RecordBufferAddress",
+      api_version=API_VERSION_TYPED_FFI,
+      output_to_operand_aliasing={{}: (0, {})},
+      frontend_attributes={results_memory_spaces="{0:1}"}
+    ROOT r = f32[512,1024] add(s, s)
+  })";
+
+TEST_F(VmmTest, CollectiveSpacePlacementKeepsAddressStableAcrossExecutions) {
+  RecordedBufferAddresses().clear();
+  ASSERT_OK_AND_ASSIGN(auto client,
+                       GetStreamExecutorGpuClient(VmmClientOptions()));
+  // SKIP_TEMP command buffers are enabled but the custom call is not captured
+  // so the recorder observes the address the runtime passes on every execution.
+  CompileOptions opts;
+  auto* dbg = opts.executable_build_options.mutable_debug_options();
+  dbg->set_xla_gpu_command_buffer_update_mode(DebugOptions::SKIP_TEMP);
+  dbg->set_xla_gpu_graph_min_graph_size(1);
+  dbg->add_xla_gpu_enable_command_buffer(DebugOptions::FUSION);
+  ASSERT_OK_AND_ASSIGN(auto executable,
+                       CompileExecutable(kAttrPlacedModule, *client, opts));
+  ASSERT_OK_AND_ASSIGN(
+      auto* mem, client->addressable_devices()[0]->default_memory_space());
+  // The first execution records the command buffer and the second replays it.
+  constexpr int kIters = 2;
+  for (int i = 1; i <= kIters; ++i) {
+    float v = static_cast<float>(i);
+    Literal input =
+        LiteralUtil::CreateFullWithDescendingLayout<float>({512, 1024}, v);
+    ASSERT_OK_AND_ASSIGN(auto in_buf,
+                         client->BufferFromHostLiteral(input, mem));
+    auto result = executable->Execute({{in_buf.get()}}, {});
+    ASSERT_OK_AND_ASSIGN(auto result_lit, ExtractSingleResult(result));
+    Literal expected = LiteralUtil::CreateFullWithDescendingLayout<float>(
+        {512, 1024}, 2 * v * v);
+    EXPECT_TRUE(LiteralTestUtil::Equal(expected, *result_lit))
+        << "Mismatch on run " << i;
+  }
+  ASSERT_EQ(RecordedBufferAddresses().size(), kIters);
+  for (int i = 1; i < kIters; ++i) {
+    EXPECT_EQ(RecordedBufferAddresses()[i], RecordedBufferAddresses()[0])
+        << "Address changed on run " << i + 1;
+  }
+}
+
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 TEST(StreamExecutorGpuClientTest, MemoryRegistrationDisabledByDefault) {

--- a/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client_test.cc
@@ -2812,6 +2812,9 @@ XLA_FFI_DEFINE_HANDLER(
 XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "RecordBufferAddress", "CUDA",
                          kRecordBufferAddressCustomCall);
 
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "RecordBufferAddress", "ROCM",
+                         kRecordBufferAddressCustomCall);
+
 // s is placed in the collective memory space by the results_memory_spaces
 // attribute alone. Run i yields 2*i*i.
 constexpr char kAttrPlacedModule[] = R"(

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.cc
@@ -45,8 +45,9 @@ limitations under the License.
 namespace stream_executor::gpu {
 
 CudaDeviceAddressVmmAllocator::CudaDeviceAddressVmmAllocator(
-    const Platform* platform)
-    : DeviceAddressVmmAllocator(platform) {}
+    const Platform* platform,
+    std::optional<int64_t> reclaim_exempt_memory_space)
+    : DeviceAddressVmmAllocator(platform, reclaim_exempt_memory_space) {}
 
 CudaDeviceAddressVmmAllocator::~CudaDeviceAddressVmmAllocator() {
   absl::Status status = SynchronizeAllPendingOperations();
@@ -57,26 +58,30 @@ CudaDeviceAddressVmmAllocator::~CudaDeviceAddressVmmAllocator() {
 }
 
 absl::StatusOr<std::unique_ptr<CudaDeviceAddressVmmAllocator>>
-CudaDeviceAddressVmmAllocator::Create(const Platform* platform,
-                                      absl::Span<const DeviceConfig> devices) {
-  auto allocator =
-      absl::WrapUnique(new CudaDeviceAddressVmmAllocator(platform));
+CudaDeviceAddressVmmAllocator::Create(
+    const Platform* platform, absl::Span<const DeviceConfig> devices,
+    std::optional<int64_t> reclaim_exempt_memory_space) {
+  auto allocator = absl::WrapUnique(
+      new CudaDeviceAddressVmmAllocator(platform, reclaim_exempt_memory_space));
   RETURN_IF_ERROR(PopulateDevices(allocator.get(), devices));
   return allocator;
 }
 
 absl::StatusOr<std::unique_ptr<CudaDeviceAddressVmmAllocator>>
-CudaDeviceAddressVmmAllocator::Create(StreamExecutor* executor, Stream* stream,
-                                      uint64_t pa_budget) {
+CudaDeviceAddressVmmAllocator::Create(
+    StreamExecutor* executor, Stream* stream, uint64_t pa_budget,
+    std::optional<int64_t> reclaim_exempt_memory_space) {
   return Create(executor->GetPlatform(),
-                {{DeviceConfig{executor, stream, pa_budget}}});
+                {{DeviceConfig{executor, stream, pa_budget}}},
+                reclaim_exempt_memory_space);
 }
 
 absl::StatusOr<std::unique_ptr<CudaDeviceAddressVmmAllocator>>
 CudaDeviceAddressVmmAllocator::Create(
     const Platform* platform, double memory_fraction,
     std::optional<int64_t> gpu_system_memory_size,
-    absl::Span<const std::pair<StreamExecutor*, Stream*>> devices) {
+    absl::Span<const std::pair<StreamExecutor*, Stream*>> devices,
+    std::optional<int64_t> reclaim_exempt_memory_space) {
   LOG(INFO) << "Using VMM device-address allocator.";
   std::vector<DeviceConfig> device_configs;
   device_configs.reserve(devices.size());
@@ -98,7 +103,7 @@ CudaDeviceAddressVmmAllocator::Create(
               << executor->device_ordinal() << ": " << pa_budget << " bytes.";
     device_configs.push_back({executor, stream, pa_budget});
   }
-  return Create(platform, device_configs);
+  return Create(platform, device_configs, reclaim_exempt_memory_space);
 }
 
 absl::Status CudaDeviceAddressVmmAllocator::InitializeDeviceState(

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator.h
@@ -53,7 +53,8 @@ class CudaDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
   //
   // Precondition: all entries in `devices` have distinct device ordinals.
   static absl::StatusOr<std::unique_ptr<CudaDeviceAddressVmmAllocator>> Create(
-      const Platform* platform, absl::Span<const DeviceConfig> devices);
+      const Platform* platform, absl::Span<const DeviceConfig> devices,
+      std::optional<int64_t> reclaim_exempt_memory_space = std::nullopt);
 
   // Creates an allocator supporting multiple devices, computing the pa_budget
   // for each device by querying DeviceMemoryUsage and applying memory_fraction.
@@ -63,7 +64,8 @@ class CudaDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
   static absl::StatusOr<std::unique_ptr<CudaDeviceAddressVmmAllocator>> Create(
       const Platform* platform, double memory_fraction,
       std::optional<int64_t> gpu_system_memory_size,
-      absl::Span<const std::pair<StreamExecutor*, Stream*>> devices);
+      absl::Span<const std::pair<StreamExecutor*, Stream*>> devices,
+      std::optional<int64_t> reclaim_exempt_memory_space = std::nullopt);
 
   // Creates an allocator for a single device.
   //
@@ -78,8 +80,8 @@ class CudaDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
   //   pa_budget: Maximum bytes of physical memory that may be simultaneously
   //              allocated on this device. Defaults to unlimited.
   static absl::StatusOr<std::unique_ptr<CudaDeviceAddressVmmAllocator>> Create(
-      StreamExecutor* executor, Stream* stream,
-      uint64_t pa_budget = UINT64_MAX);
+      StreamExecutor* executor, Stream* stream, uint64_t pa_budget = UINT64_MAX,
+      std::optional<int64_t> reclaim_exempt_memory_space = std::nullopt);
 
  protected:
   // Verifies compute capability >= 7.0, allocates the pinned timeline counter
@@ -101,7 +103,9 @@ class CudaDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
   absl::Status EnqueueDeferredDeallocation(PerDeviceState& state,
                                            uint64_t seqno) override;
 
-  explicit CudaDeviceAddressVmmAllocator(const Platform* platform);
+  explicit CudaDeviceAddressVmmAllocator(
+      const Platform* platform,
+      std::optional<int64_t> reclaim_exempt_memory_space = std::nullopt);
 };
 
 }  // namespace stream_executor::gpu

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -934,9 +934,16 @@ TEST_F(DeviceAddressVmmAllocatorTest,
 
 TEST_F(DeviceAddressVmmAllocatorTest, ReclaimNeverEvictsExemptPendingMappings) {
   // The helper creates the allocator with reclaim_exempt_memory_space = 1.
-  RunReclaimPressureOnPendingMapping(/*memory_space=*/0,
+  RunReclaimPressureOnPendingMapping(/*memory_space=*/2,
                                      /*expect_mapping_survives=*/false);
   RunReclaimPressureOnPendingMapping(/*memory_space=*/1,
+                                     /*expect_mapping_survives=*/true);
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest,
+       ReclaimSkipsPendingMappingsInTheRequestingSpace) {
+  // The pressure allocation in the helper requests memory space 0.
+  RunReclaimPressureOnPendingMapping(/*memory_space=*/0,
                                      /*expect_mapping_survives=*/true);
 }
 

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -41,6 +41,7 @@ namespace stream_executor {
 namespace {
 
 using ::absl_testing::IsOk;
+using ::absl_testing::StatusIs;
 
 class DeviceAddressVmmAllocatorTest : public ::testing::Test {
  protected:
@@ -71,6 +72,54 @@ class DeviceAddressVmmAllocatorTest : public ::testing::Test {
                       "(requires compute capability >= 7.0): "
                    << probe.status();
     }
+  }
+
+  // Asserts whether a pending mapping in memory_space survives reclaim.
+  void RunReclaimPressureOnPendingMapping(int64_t memory_space,
+                                          bool expect_mapping_survives) {
+    SCOPED_TRACE(memory_space);
+    ASSERT_OK_AND_ASSIGN(auto probe, gpu::CudaDeviceAddressVmmAllocator::Create(
+                                         executor_, stream_.get()));
+    const uint64_t granularity = probe->GetAllocationGranularity(executor_);
+    ASSERT_GT(granularity, 0);
+    probe.reset();
+
+    ASSERT_OK_AND_ASSIGN(auto allocator,
+                         gpu::CudaDeviceAddressVmmAllocator::Create(
+                             executor_, stream_.get(),
+                             /*pa_budget=*/2 * granularity,
+                             /*reclaim_exempt_memory_space=*/1));
+
+    const int ordinal = executor_->device_ordinal();
+    ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
+                                               executor_, granularity));
+    ASSERT_OK_AND_ASSIGN(
+        auto address,
+        allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                            memory_space, reservation.get(),
+                            /*reservation_offset=*/0, granularity));
+    auto* raw_allocation = allocator->GetRawAllocation(ordinal, address.cref());
+    ASSERT_NE(raw_allocation, nullptr);
+    ASSERT_THAT(allocator->Deallocate(ordinal, address.Release()), IsOk());
+
+    // Fits the PA budget only if the pending physical memory is reclaimed.
+    auto pressure =
+        allocator->Allocate(ordinal, 2 * granularity,
+                            /*retry_on_failure=*/true, /*memory_space=*/0);
+    if (expect_mapping_survives) {
+      EXPECT_THAT(pressure, StatusIs(absl::StatusCode::kResourceExhausted));
+      ASSERT_OK_AND_ASSIGN(
+          auto reused,
+          allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                              memory_space, reservation.get(),
+                              /*reservation_offset=*/0, granularity));
+      EXPECT_EQ(allocator->GetRawAllocation(ordinal, reused.cref()),
+                raw_allocation);
+      ASSERT_THAT(allocator->Deallocate(ordinal, reused.Release()), IsOk());
+    } else {
+      EXPECT_THAT(pressure, IsOk());
+    }
+    ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
   }
 
   Platform* platform_ = nullptr;
@@ -880,6 +929,44 @@ TEST_F(DeviceAddressVmmAllocatorTest,
   for (auto& address : addresses) {
     ASSERT_THAT(allocator->Deallocate(ordinal, address.Release()), IsOk());
   }
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
+TEST_F(DeviceAddressVmmAllocatorTest, ReclaimNeverEvictsExemptPendingMappings) {
+  // The helper creates the allocator with reclaim_exempt_memory_space = 1.
+  RunReclaimPressureOnPendingMapping(/*memory_space=*/0,
+                                     /*expect_mapping_survives=*/false);
+  RunReclaimPressureOnPendingMapping(/*memory_space=*/1,
+                                     /*expect_mapping_survives=*/true);
+}
+
+// A request never reuses a pending record from another memory space because
+// the record keeps its reclaim tag and reuse across spaces would mistag it.
+TEST_F(DeviceAddressVmmAllocatorTest, ReuseNeverCrossesMemorySpaces) {
+  ASSERT_OK_AND_ASSIGN(
+      auto allocator,
+      gpu::CudaDeviceAddressVmmAllocator::Create(executor_, stream_.get()));
+  const int ordinal = executor_->device_ordinal();
+  ASSERT_OK_AND_ASSIGN(
+      auto first, allocator->Allocate(ordinal, 1024, /*retry_on_failure=*/true,
+                                      /*memory_space=*/0));
+  void* first_va = first.cref().opaque();
+  ASSERT_THAT(allocator->Deallocate(ordinal, first.Release()), IsOk());
+
+  ASSERT_OK_AND_ASSIGN(auto second,
+                       allocator->Allocate(ordinal, 1024,
+                                           /*retry_on_failure=*/true,
+                                           /*memory_space=*/1));
+  EXPECT_NE(second.cref().opaque(), first_va);
+  void* second_va = second.cref().opaque();
+  ASSERT_THAT(allocator->Deallocate(ordinal, second.Release()), IsOk());
+
+  // As a control a request in the same space does reuse the pending record.
+  ASSERT_OK_AND_ASSIGN(
+      auto third, allocator->Allocate(ordinal, 1024, /*retry_on_failure=*/true,
+                                      /*memory_space=*/1));
+  EXPECT_EQ(third.cref().opaque(), second_va);
+  ASSERT_THAT(allocator->Deallocate(ordinal, third.Release()), IsOk());
   ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
 }
 

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -940,13 +940,6 @@ TEST_F(DeviceAddressVmmAllocatorTest, ReclaimNeverEvictsExemptPendingMappings) {
                                      /*expect_mapping_survives=*/true);
 }
 
-TEST_F(DeviceAddressVmmAllocatorTest,
-       ReclaimSkipsPendingMappingsInTheRequestingSpace) {
-  // The pressure allocation in the helper requests memory space 0.
-  RunReclaimPressureOnPendingMapping(/*memory_space=*/0,
-                                     /*expect_mapping_survives=*/true);
-}
-
 // A request never reuses a pending record from another memory space because
 // the record keeps its reclaim tag and reuse across spaces would mistag it.
 TEST_F(DeviceAddressVmmAllocatorTest, ReuseNeverCrossesMemorySpaces) {

--- a/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
+++ b/xla/stream_executor/cuda/cuda_device_address_vmm_allocator_test.cc
@@ -977,6 +977,63 @@ TEST_F(DeviceAddressVmmAllocatorTest, ReuseNeverCrossesMemorySpaces) {
   ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
 }
 
+// A mapped request never reuses a stale mapped record from another memory
+// space because the record would keep the wrong reclaim tag.
+TEST_F(DeviceAddressVmmAllocatorTest, MappedReuseNeverCrossesMemorySpaces) {
+  ASSERT_OK_AND_ASSIGN(auto probe, gpu::CudaDeviceAddressVmmAllocator::Create(
+                                       executor_, stream_.get()));
+  const uint64_t granularity = probe->GetAllocationGranularity(executor_);
+  ASSERT_GT(granularity, 0);
+  probe.reset();
+
+  ASSERT_OK_AND_ASSIGN(auto allocator,
+                       gpu::CudaDeviceAddressVmmAllocator::Create(
+                           executor_, stream_.get(),
+                           /*pa_budget=*/2 * granularity,
+                           /*reclaim_exempt_memory_space=*/0));
+  const int ordinal = executor_->device_ordinal();
+  ASSERT_OK_AND_ASSIGN(auto reservation, gpu::CudaMemoryReservation::Create(
+                                             executor_, granularity));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto first,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          /*memory_space=*/0, reservation.get(),
+                          /*reservation_offset=*/0, granularity));
+  auto* first_raw = allocator->GetRawAllocation(ordinal, first.cref());
+  ASSERT_NE(first_raw, nullptr);
+  ASSERT_THAT(allocator->Deallocate(ordinal, first.Release()), IsOk());
+
+  // As a control a request in the same space does reuse the stale mapping.
+  // The equality holds only while the record stays alive through reuse.
+  ASSERT_OK_AND_ASSIGN(
+      auto second,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          /*memory_space=*/0, reservation.get(),
+                          /*reservation_offset=*/0, granularity));
+  EXPECT_EQ(allocator->GetRawAllocation(ordinal, second.cref()), first_raw);
+  ASSERT_THAT(allocator->Deallocate(ordinal, second.Release()), IsOk());
+
+  // The request in another space must not resurrect the stale record. If it
+  // did, the record would keep the exempt space 0 tag and the reclaim below
+  // could not free it.
+  ASSERT_OK_AND_ASSIGN(
+      auto third,
+      allocator->Allocate(ordinal, granularity, /*retry_on_failure=*/true,
+                          /*memory_space=*/1, reservation.get(),
+                          /*reservation_offset=*/0, granularity));
+  ASSERT_THAT(allocator->Deallocate(ordinal, third.Release()), IsOk());
+
+  // Fits the two granularity budget only if the pending mapping is reclaimed,
+  // which requires its tag to be the space of the third request.
+  ASSERT_OK_AND_ASSIGN(
+      auto pressure,
+      allocator->Allocate(ordinal, 2 * granularity,
+                          /*retry_on_failure=*/true, /*memory_space=*/2));
+  ASSERT_THAT(allocator->Deallocate(ordinal, pressure.Release()), IsOk());
+  ASSERT_THAT(allocator->SynchronizePendingOperations(ordinal), IsOk());
+}
+
 // A request with a different size at the same reservation offset does not
 // match the stale mapping: it must be rejected as a partial overlap instead
 // of remapping underneath the pending teardown, and the stale mapping must

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -530,6 +530,7 @@ template <typename TryReuseFn, typename TryFreshFn>
 absl::StatusOr<DeviceAddressBase>
 DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
                                                  uint64_t reclaim_size,
+                                                 int64_t memory_space,
                                                  TryReuseFn try_reuse,
                                                  TryFreshFn try_fresh) {
   // First try to reactivate a compatible pending deallocation without waiting.
@@ -550,7 +551,7 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
     // deallocations first, without blocking for later pending work and without
     // destroying unrelated stale reservation mappings that may be reused.
     CompleteReadyAllocatorDeallocationsForReclaim(
-        state, LoadTimeline(state.pinned_timeline));
+        state, LoadTimeline(state.pinned_timeline), memory_space);
     result = try_fresh();
   }
 
@@ -578,7 +579,8 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
           state.records_by_allocator_address.find(pending.addr.opaque());
       CHECK(record_it != state.records_by_allocator_address.end());
       CHECK(record_it->second->allocator_stale());
-      if (record_it->second->memory_space() == reclaim_exempt_memory_space_) {
+      if (record_it->second->memory_space() == reclaim_exempt_memory_space_ ||
+          record_it->second->memory_space() == memory_space) {
         continue;
       }
       uint64_t reclaimable_bytes =
@@ -683,8 +685,9 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
     return absl::StatusOr<DeviceAddressBase>(allocator_address);
   };
 
-  ASSIGN_OR_RETURN(DeviceAddressBase result,
-                   TryWithPendingReclaim(*state, size, try_reuse, try_fresh));
+  ASSIGN_OR_RETURN(
+      DeviceAddressBase result,
+      TryWithPendingReclaim(*state, size, memory_space, try_reuse, try_fresh));
 
   VLOG(3) << absl::StreamFormat(
       "Allocated virtual address %p (%uB) on device ordinal %d",
@@ -742,9 +745,9 @@ DeviceAddressVmmAllocator::Allocate(
   // The shared retry helper handles PA-budget pressure: try reuse, try fresh,
   // complete already-finished pending work on ResourceExhausted, and finally
   // wait for enough pending deallocations only if necessary.
-  ASSIGN_OR_RETURN(
-      DeviceAddressBase result,
-      TryWithPendingReclaim(*state, allocation_size, try_reuse, try_fresh));
+  ASSIGN_OR_RETURN(DeviceAddressBase result,
+                   TryWithPendingReclaim(*state, allocation_size, memory_space,
+                                         try_reuse, try_fresh));
 
   // `result` is the reservation slice, which acts as the allocator address for
   // this allocation.
@@ -1112,7 +1115,7 @@ void DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
 }
 
 void DeviceAddressVmmAllocator::CompleteReadyAllocatorDeallocationsForReclaim(
-    PerDeviceState& state, uint64_t completed_seqno) {
+    PerDeviceState& state, uint64_t completed_seqno, int64_t memory_space) {
   std::vector<uint64_t> selected;
   for (const PendingDeallocation& pending : state.pending_deallocations) {
     if (pending.seqno > completed_seqno ||
@@ -1122,7 +1125,8 @@ void DeviceAddressVmmAllocator::CompleteReadyAllocatorDeallocationsForReclaim(
     auto record_it =
         state.records_by_allocator_address.find(pending.addr.opaque());
     if (record_it != state.records_by_allocator_address.end() &&
-        record_it->second->memory_space() == reclaim_exempt_memory_space_) {
+        (record_it->second->memory_space() == reclaim_exempt_memory_space_ ||
+         record_it->second->memory_space() == memory_space)) {
       continue;
     }
     selected.push_back(pending.seqno);

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -74,11 +74,12 @@ DeviceAddressVmmAllocator::AllocationRecord::AllocationRecord(
     std::unique_ptr<MemoryAllocation> raw_allocation,
     std::unique_ptr<MemoryReservation> allocator_address_reservation,
     MemoryReservation::ScopedMapping allocator_address_mapping,
-    bool multi_device)
+    int64_t memory_space, bool multi_device)
     : kind_(kind),
       allocator_address_(allocator_address),
       raw_allocation_(std::move(raw_allocation)),
       multi_device_(multi_device),
+      memory_space_(memory_space),
       allocator_address_reservation_(std::move(allocator_address_reservation)),
       allocator_address_mapping_(std::move(allocator_address_mapping)) {
   CHECK(raw_allocation_ != nullptr);
@@ -186,8 +187,11 @@ static bool AddressRangesOverlap(DeviceAddressBase lhs, DeviceAddressBase rhs) {
          AddressStart(rhs) < AddressEnd(lhs);
 }
 
-DeviceAddressVmmAllocator::DeviceAddressVmmAllocator(const Platform* platform)
-    : DeviceAddressAllocator(platform) {}
+DeviceAddressVmmAllocator::DeviceAddressVmmAllocator(
+    const Platform* platform,
+    std::optional<int64_t> reclaim_exempt_memory_space)
+    : DeviceAddressAllocator(platform),
+      reclaim_exempt_memory_space_(reclaim_exempt_memory_space) {}
 
 absl::Status DeviceAddressVmmAllocator::PopulateDevices(
     DeviceAddressVmmAllocator* allocator,
@@ -394,13 +398,14 @@ DeviceAddressVmmAllocator::TrackAllocatorAddressMappedAllocation(
     DeviceAddressBase allocator_address,
     std::unique_ptr<MemoryAllocation> raw_allocation,
     std::unique_ptr<MemoryReservation> reservation,
-    MemoryReservation::ScopedMapping mapping, bool multi_device) {
+    MemoryReservation::ScopedMapping mapping, int64_t memory_space,
+    bool multi_device) {
   void* va_ptr = allocator_address.opaque();
   CHECK(raw_allocation != nullptr);
   uint64_t physical_size = raw_allocation->address().size();
   auto record = std::make_unique<AllocationRecord>(
       kind, allocator_address, std::move(raw_allocation),
-      std::move(reservation), std::move(mapping), multi_device);
+      std::move(reservation), std::move(mapping), memory_space, multi_device);
   AllocationRecord* record_ptr = record.get();
   auto insert_result =
       state.records_by_allocator_address.emplace(va_ptr, std::move(record));
@@ -513,7 +518,7 @@ DeviceAddressVmmAllocator::CreateMappedAllocation(
       state, AllocationRecord::Kind::kAllocateAndMap,
       request.reservation_address, std::move(raw_alloc),
       /*reservation=*/nullptr, std::move(allocator_address_mapping),
-      request.multi_device);
+      request.memory_space, request.multi_device);
 
   return request.reservation_address;
 }
@@ -573,6 +578,9 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
           state.records_by_allocator_address.find(pending.addr.opaque());
       CHECK(record_it != state.records_by_allocator_address.end());
       CHECK(record_it->second->allocator_stale());
+      if (record_it->second->memory_space() == reclaim_exempt_memory_space_) {
+        continue;
+      }
       uint64_t reclaimable_bytes =
           record_it->second->raw_allocation()->address().size();
       CHECK_GT(reclaimable_bytes, 0);
@@ -601,7 +609,7 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
 absl::StatusOr<ScopedDeviceAddress<uint8_t>>
 DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
                                     bool /*retry_on_failure*/,
-                                    int64_t /*memory_space*/) {
+                                    int64_t memory_space) {
   if (size == 0) {
     return ScopedDeviceAddress<uint8_t>(DeviceAddressBase(), device_ordinal,
                                         this);
@@ -632,6 +640,10 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
         continue;
       }
       if (record.multi_device() != multi_device) {
+        continue;
+      }
+      // A reused record keeps its reclaim tag and must not serve another space.
+      if (record.memory_space() != memory_space) {
         continue;
       }
       if (RoundUpToGranularity(*state, record.allocator_address().size()) !=
@@ -666,7 +678,7 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
     TrackAllocatorAddressMappedAllocation(
         *state, AllocationRecord::Kind::kAllocate, allocator_address,
         std::move(raw_alloc), std::move(reservation), std::move(scoped_mapping),
-        multi_device);
+        memory_space, multi_device);
     // Return the original requested size, not the padded size.
     return absl::StatusOr<DeviceAddressBase>(allocator_address);
   };
@@ -686,7 +698,7 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
 absl::StatusOr<ScopedDeviceAddress<uint8_t>>
 DeviceAddressVmmAllocator::Allocate(
     int device_ordinal, uint64_t allocation_size, bool /*retry_on_failure*/,
-    int64_t /*memory_space*/, MemoryReservation* reservation,
+    int64_t memory_space, MemoryReservation* reservation,
     uint64_t reservation_offset, uint64_t mapping_size) {
   if (allocation_size != mapping_size) {
     return absl::InvalidArgumentError(
@@ -709,9 +721,9 @@ DeviceAddressVmmAllocator::Allocate(
       DeviceAddressBase reservation_address,
       ValidateReservationRange(reservation, reservation_offset, mapping_size));
 
-  const MappedAllocateRequest request{reservation, reservation_address,
+  const MappedAllocateRequest request{reservation,     reservation_address,
                                       allocation_size, reservation_offset,
-                                      multi_device};
+                                      memory_space,    multi_device};
 
   absl::MutexLock lock(state->mu);
   // Clang cannot propagate TryWithPendingReclaim's state.mu lock requirement
@@ -1105,6 +1117,12 @@ void DeviceAddressVmmAllocator::CompleteReadyAllocatorDeallocationsForReclaim(
   for (const PendingDeallocation& pending : state.pending_deallocations) {
     if (pending.seqno > completed_seqno ||
         pending.kind == PendingDeallocationKind::kMap) {
+      continue;
+    }
+    auto record_it =
+        state.records_by_allocator_address.find(pending.addr.opaque());
+    if (record_it != state.records_by_allocator_address.end() &&
+        record_it->second->memory_space() == reclaim_exempt_memory_space_) {
       continue;
     }
     selected.push_back(pending.seqno);

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -531,7 +531,6 @@ template <typename TryReuseFn, typename TryFreshFn>
 absl::StatusOr<DeviceAddressBase>
 DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
                                                  uint64_t reclaim_size,
-                                                 int64_t memory_space,
                                                  TryReuseFn try_reuse,
                                                  TryFreshFn try_fresh) {
   // First try to reactivate a compatible pending deallocation without waiting.
@@ -552,7 +551,7 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
     // deallocations first, without blocking for later pending work and without
     // destroying unrelated stale reservation mappings that may be reused.
     CompleteReadyAllocatorDeallocationsForReclaim(
-        state, LoadTimeline(state.pinned_timeline), memory_space);
+        state, LoadTimeline(state.pinned_timeline));
     result = try_fresh();
   }
 
@@ -580,8 +579,7 @@ DeviceAddressVmmAllocator::TryWithPendingReclaim(PerDeviceState& state,
           state.records_by_allocator_address.find(pending.addr.opaque());
       CHECK(record_it != state.records_by_allocator_address.end());
       CHECK(record_it->second->allocator_stale());
-      if (record_it->second->memory_space() == reclaim_exempt_memory_space_ ||
-          record_it->second->memory_space() == memory_space) {
+      if (record_it->second->memory_space() == reclaim_exempt_memory_space_) {
         continue;
       }
       uint64_t reclaimable_bytes =
@@ -686,9 +684,8 @@ DeviceAddressVmmAllocator::Allocate(int device_ordinal, uint64_t size,
     return absl::StatusOr<DeviceAddressBase>(allocator_address);
   };
 
-  ASSIGN_OR_RETURN(
-      DeviceAddressBase result,
-      TryWithPendingReclaim(*state, size, memory_space, try_reuse, try_fresh));
+  ASSIGN_OR_RETURN(DeviceAddressBase result,
+                   TryWithPendingReclaim(*state, size, try_reuse, try_fresh));
 
   VLOG(3) << absl::StreamFormat(
       "Allocated virtual address %p (%uB) on device ordinal %d",
@@ -746,9 +743,9 @@ DeviceAddressVmmAllocator::Allocate(
   // The shared retry helper handles PA-budget pressure: try reuse, try fresh,
   // complete already-finished pending work on ResourceExhausted, and finally
   // wait for enough pending deallocations only if necessary.
-  ASSIGN_OR_RETURN(DeviceAddressBase result,
-                   TryWithPendingReclaim(*state, allocation_size, memory_space,
-                                         try_reuse, try_fresh));
+  ASSIGN_OR_RETURN(
+      DeviceAddressBase result,
+      TryWithPendingReclaim(*state, allocation_size, try_reuse, try_fresh));
 
   // `result` is the reservation slice, which acts as the allocator address for
   // this allocation.
@@ -1116,7 +1113,7 @@ void DeviceAddressVmmAllocator::WaitUntilSeqno(PerDeviceState& state,
 }
 
 void DeviceAddressVmmAllocator::CompleteReadyAllocatorDeallocationsForReclaim(
-    PerDeviceState& state, uint64_t completed_seqno, int64_t memory_space) {
+    PerDeviceState& state, uint64_t completed_seqno) {
   std::vector<uint64_t> selected;
   for (const PendingDeallocation& pending : state.pending_deallocations) {
     if (pending.seqno > completed_seqno ||
@@ -1126,8 +1123,7 @@ void DeviceAddressVmmAllocator::CompleteReadyAllocatorDeallocationsForReclaim(
     auto record_it =
         state.records_by_allocator_address.find(pending.addr.opaque());
     if (record_it != state.records_by_allocator_address.end() &&
-        (record_it->second->memory_space() == reclaim_exempt_memory_space_ ||
-         record_it->second->memory_space() == memory_space)) {
+        record_it->second->memory_space() == reclaim_exempt_memory_space_) {
       continue;
     }
     selected.push_back(pending.seqno);

--- a/xla/stream_executor/device_address_vmm_allocator.cc
+++ b/xla/stream_executor/device_address_vmm_allocator.cc
@@ -427,6 +427,7 @@ DeviceAddressVmmAllocator::TryReuseMappedAllocation(
   if (record->kind() != AllocationRecord::Kind::kAllocateAndMap ||
       !record->allocator_stale() ||
       record->multi_device() != request.multi_device ||
+      record->memory_space() != request.memory_space ||
       !record->allocator_matches(request.reservation_address)) {
     return std::nullopt;
   }

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -537,6 +537,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   template <typename TryReuseFn, typename TryFreshFn>
   absl::StatusOr<DeviceAddressBase> TryWithPendingReclaim(PerDeviceState& state,
                                                           uint64_t reclaim_size,
+                                                          int64_t memory_space,
                                                           TryReuseFn try_reuse,
                                                           TryFreshFn try_fresh)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
@@ -621,7 +622,8 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // Completes ready allocator-address deallocations for PA reclaim while
   // leaving unrelated kMap entries stale and reusable.
   void CompleteReadyAllocatorDeallocationsForReclaim(PerDeviceState& state,
-                                                     uint64_t completed_seqno)
+                                                     uint64_t completed_seqno,
+                                                     int64_t memory_space)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Completes a pending operation whose stream sequence has passed by dropping

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -537,7 +537,6 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   template <typename TryReuseFn, typename TryFreshFn>
   absl::StatusOr<DeviceAddressBase> TryWithPendingReclaim(PerDeviceState& state,
                                                           uint64_t reclaim_size,
-                                                          int64_t memory_space,
                                                           TryReuseFn try_reuse,
                                                           TryFreshFn try_fresh)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
@@ -622,8 +621,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // Completes ready allocator-address deallocations for PA reclaim while
   // leaving unrelated kMap entries stale and reusable.
   void CompleteReadyAllocatorDeallocationsForReclaim(PerDeviceState& state,
-                                                     uint64_t completed_seqno,
-                                                     int64_t memory_space)
+                                                     uint64_t completed_seqno)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   // Completes a pending operation whose stream sequence has passed by dropping

--- a/xla/stream_executor/device_address_vmm_allocator.h
+++ b/xla/stream_executor/device_address_vmm_allocator.h
@@ -308,7 +308,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
         std::unique_ptr<MemoryAllocation> raw_allocation,
         std::unique_ptr<MemoryReservation> allocator_address_reservation,
         MemoryReservation::ScopedMapping allocator_address_mapping,
-        bool multi_device);
+        int64_t memory_space, bool multi_device);
     AllocationRecord(const AllocationRecord&) = delete;
     AllocationRecord& operator=(const AllocationRecord&) = delete;
 
@@ -322,6 +322,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     }
     uint64_t allocator_stale_seqno() const { return allocator_stale_seqno_; }
     bool multi_device() const { return multi_device_; }
+    int64_t memory_space() const { return memory_space_; }
     MemoryAllocation* raw_allocation() const { return raw_allocation_.get(); }
     MemoryReservation* allocator_address_reservation() const {
       return allocator_address_reservation_.get();
@@ -363,6 +364,7 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
     DeviceAddressBase allocator_address_;
     std::unique_ptr<MemoryAllocation> raw_allocation_;
     bool multi_device_;
+    int64_t memory_space_ = 0;
 
     // Present for Allocate(); the mapped Allocate() overload returns a
     // caller-reservation address and owns no reservation.
@@ -435,7 +437,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
         ABSL_GUARDED_BY(mu);
   };
 
-  explicit DeviceAddressVmmAllocator(const Platform* platform);
+  explicit DeviceAddressVmmAllocator(
+      const Platform* platform,
+      std::optional<int64_t> reclaim_exempt_memory_space = std::nullopt);
 
   // Validates no duplicate ordinals in `devices`, then iterates over each
   // device config, constructs a PerDeviceState (setting executor, stream,
@@ -496,14 +500,15 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
       DeviceAddressBase allocator_address,
       std::unique_ptr<MemoryAllocation> raw_allocation,
       std::unique_ptr<MemoryReservation> reservation,
-      MemoryReservation::ScopedMapping mapping, bool multi_device)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
+      MemoryReservation::ScopedMapping mapping, int64_t memory_space,
+      bool multi_device) ABSL_EXCLUSIVE_LOCKS_REQUIRED(state.mu);
 
   struct MappedAllocateRequest {
     MemoryReservation* reservation;
     DeviceAddressBase reservation_address;
     uint64_t size;
     uint64_t reservation_offset;
+    int64_t memory_space;
     bool multi_device;
   };
 
@@ -639,6 +644,9 @@ class DeviceAddressVmmAllocator : public DeviceAddressAllocator {
   // without an allocator-wide lock. Each PerDeviceState owns its own mutex for
   // mutable allocation and pending-deallocation state.
   absl::flat_hash_map<int, std::unique_ptr<PerDeviceState>> per_device_;
+
+  // This space is never reclaimed and is freed only at executable destruction.
+  const std::optional<int64_t> reclaim_exempt_memory_space_;
 };
 
 }  // namespace stream_executor

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.cc
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.cc
@@ -45,30 +45,35 @@ limitations under the License.
 namespace stream_executor::gpu {
 
 RocmDeviceAddressVmmAllocator::RocmDeviceAddressVmmAllocator(
-    const Platform* platform)
-    : DeviceAddressVmmAllocator(platform) {}
+    const Platform* platform,
+    std::optional<int64_t> reclaim_exempt_memory_space)
+    : DeviceAddressVmmAllocator(platform, reclaim_exempt_memory_space) {}
 
 absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
-RocmDeviceAddressVmmAllocator::Create(const Platform* platform,
-                                      absl::Span<const DeviceConfig> devices) {
-  auto allocator =
-      absl::WrapUnique(new RocmDeviceAddressVmmAllocator(platform));
+RocmDeviceAddressVmmAllocator::Create(
+    const Platform* platform, absl::Span<const DeviceConfig> devices,
+    std::optional<int64_t> reclaim_exempt_memory_space) {
+  auto allocator = absl::WrapUnique(
+      new RocmDeviceAddressVmmAllocator(platform, reclaim_exempt_memory_space));
   RETURN_IF_ERROR(PopulateDevices(allocator.get(), devices));
   return allocator;
 }
 
 absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
-RocmDeviceAddressVmmAllocator::Create(StreamExecutor* executor, Stream* stream,
-                                      uint64_t pa_budget) {
+RocmDeviceAddressVmmAllocator::Create(
+    StreamExecutor* executor, Stream* stream, uint64_t pa_budget,
+    std::optional<int64_t> reclaim_exempt_memory_space) {
   return Create(executor->GetPlatform(),
-                {{DeviceConfig{executor, stream, pa_budget}}});
+                {{DeviceConfig{executor, stream, pa_budget}}},
+                reclaim_exempt_memory_space);
 }
 
 absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>>
 RocmDeviceAddressVmmAllocator::Create(
     const Platform* platform, double memory_fraction,
     std::optional<int64_t> gpu_system_memory_size,
-    absl::Span<const std::pair<StreamExecutor*, Stream*>> devices) {
+    absl::Span<const std::pair<StreamExecutor*, Stream*>> devices,
+    std::optional<int64_t> reclaim_exempt_memory_space) {
   LOG(INFO) << "Using VMM (Virtual Memory Management) allocator for ROCm.";
   std::vector<DeviceConfig> device_configs;
   device_configs.reserve(devices.size());
@@ -90,7 +95,7 @@ RocmDeviceAddressVmmAllocator::Create(
               << executor->device_ordinal() << ": " << pa_budget << " bytes.";
     device_configs.push_back({executor, stream, pa_budget});
   }
-  return Create(platform, device_configs);
+  return Create(platform, device_configs, reclaim_exempt_memory_space);
 }
 
 absl::Status RocmDeviceAddressVmmAllocator::InitializeDeviceState(

--- a/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h
+++ b/xla/stream_executor/rocm/rocm_device_address_vmm_allocator.h
@@ -50,7 +50,8 @@ class RocmDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
   //
   // Precondition: all entries in `devices` have distinct device ordinals.
   static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(
-      const Platform* platform, absl::Span<const DeviceConfig> devices);
+      const Platform* platform, absl::Span<const DeviceConfig> devices,
+      std::optional<int64_t> reclaim_exempt_memory_space = std::nullopt);
 
   // Creates an allocator supporting multiple devices, computing the pa_budget
   // for each device by querying DeviceMemoryUsage and applying memory_fraction.
@@ -60,7 +61,8 @@ class RocmDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
   static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(
       const Platform* platform, double memory_fraction,
       std::optional<int64_t> gpu_system_memory_size,
-      absl::Span<const std::pair<StreamExecutor*, Stream*>> devices);
+      absl::Span<const std::pair<StreamExecutor*, Stream*>> devices,
+      std::optional<int64_t> reclaim_exempt_memory_space = std::nullopt);
 
   // Creates an allocator for a single device.
   //
@@ -71,8 +73,8 @@ class RocmDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
   //   pa_budget: Maximum bytes of physical memory that may be simultaneously
   //              allocated on this device. Defaults to unlimited.
   static absl::StatusOr<std::unique_ptr<RocmDeviceAddressVmmAllocator>> Create(
-      StreamExecutor* executor, Stream* stream,
-      uint64_t pa_budget = UINT64_MAX);
+      StreamExecutor* executor, Stream* stream, uint64_t pa_budget = UINT64_MAX,
+      std::optional<int64_t> reclaim_exempt_memory_space = std::nullopt);
 
  protected:
   // Allocates signal memory via hipExtMallocWithFlags(hipMallocSignalMemory)
@@ -94,7 +96,9 @@ class RocmDeviceAddressVmmAllocator : public DeviceAddressVmmAllocator {
                                            uint64_t seqno) override;
 
  private:
-  explicit RocmDeviceAddressVmmAllocator(const Platform* platform);
+  explicit RocmDeviceAddressVmmAllocator(
+      const Platform* platform,
+      std::optional<int64_t> reclaim_exempt_memory_space = std::nullopt);
 };
 
 }  // namespace stream_executor::gpu


### PR DESCRIPTION
📝 Summary of Changes
Exempt collective buffers from physical memory reclaiming, and allow users to annotate allocations that need stable addresses. Note that the user interface is sharing the existing frontend attributes (e.g. `frontend_attributes={results_memory_spaces="{0:1}"}`), all space 1 allocation will be exempted from reclaiming.

🎯 Justification
Collective buffers may be registered as symmetric memory windows, the registration retains its PA so reclaiming it can cause corruption. User specified stable allocations extend the same exemption to buffers registered/exported by FFI.

🚀 Kind of Contribution
✨ New Feature

📊 Benchmark (for Performance Improvements)
N/A.

🧪 Unit Tests:
Added.

🧪 Execution Tests:
Added.
