### PR TITLE
[xla:gpu] Treat explicit collective groups as GPU async collectives

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1568,11 +1568,8 @@ cc_library(
         "//xla/hlo/ir:hlo",
         "//xla/hlo/pass:hlo_pass",
         "//xla/service/gpu:backend_configs_cc",
-        "//xla/tsl/platform:errors",
         "//xla/tsl/platform:status_macros",
-        "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/container:flat_hash_set",
-        "@com_google_absl//absl/log",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
     ],
@@ -1583,14 +1580,13 @@ xla_cc_test(
     srcs = ["explicit_collectives_group_async_wrapper_test.cc"],
     deps = [
         ":explicit_collectives_group_async_wrapper",
+        "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:filecheck",
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "//xla/service/gpu:backend_configs_cc",
-        "//xla/tsl/lib/core:status_test_util",
-        "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest_main",  # fixdeps: keep
     ],
 )
 

--- a/xla/backends/gpu/transforms/explicit_collectives_group_async_wrapper.cc
+++ b/xla/backends/gpu/transforms/explicit_collectives_group_async_wrapper.cc
@@ -18,7 +18,6 @@ limitations under the License.
 #include <vector>
 
 #include "absl/container/flat_hash_set.h"
-#include "absl/log/log.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "xla/tsl/platform/status_macros.h"
@@ -29,8 +28,6 @@ limitations under the License.
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/shape.h"
 #include "xla/side_effect_util.h"
-#include "xla/tsl/platform/errors.h"
-#include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
 
@@ -63,9 +60,26 @@ absl::StatusOr<bool> CreateCollectivesGroupAsyncPair(HloInstruction* instr) {
           new_computation, "main"));
   HloInstruction* async_done = computation->AddInstruction(
       HloInstruction::CreateAsyncDone(instr->shape(), async_start));
-  // Forward frontend attributes to both async instructions.
+
+  // Forward instruction properties to both async instructions.
   async_start->set_frontend_attributes(instr->frontend_attributes());
   async_done->set_frontend_attributes(instr->frontend_attributes());
+  async_start->set_metadata(instr->metadata());
+  async_done->set_metadata(instr->metadata());
+  async_start->CopyBackendConfigFrom(instr);
+  async_done->CopyBackendConfigFrom(instr);
+
+  // Allow the scheduler to separate the done from the force-early start.
+  ASSIGN_OR_RETURN(GpuBackendConfig async_done_config,
+                   async_done->backend_config<GpuBackendConfig>());
+  async_done_config.set_force_earliest_schedule(false);
+  RETURN_IF_ERROR(async_done->set_backend_config(async_done_config));
+
+  // Relay control predecessors to the start and control successors from the
+  // done.
+  RETURN_IF_ERROR(instr->CopyAllControlDepsTo(async_start, async_done));
+  RETURN_IF_ERROR(instr->DropAllControlDeps());
+
   RETURN_IF_ERROR(computation->ReplaceInstruction(instr, async_done));
   return true;
 }

--- a/xla/backends/gpu/transforms/explicit_collectives_group_async_wrapper_test.cc
+++ b/xla/backends/gpu/transforms/explicit_collectives_group_async_wrapper_test.cc
@@ -21,11 +21,12 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/hlo/testlib/filecheck.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 #include "xla/service/gpu/backend_configs.pb.h"
-#include "xla/tsl/lib/core/status_test_util.h"
-#include "xla/tsl/platform/statusor.h"
 
 namespace xla::gpu {
 namespace {
@@ -52,7 +53,7 @@ TEST_F(ExplicitCollectivesGroupAsyncWrapperTest, AnnotatedOpIsWrapped) {
   auto module = ParseAndReturnVerifiedModule(hlo_string).value();
   ExplicitCollectivesGroupAsyncWrapper wrapper_pass;
 
-  TF_ASSERT_OK_AND_ASSIGN(bool mutated, wrapper_pass.Run(module.get()));
+  ASSERT_OK_AND_ASSIGN(bool mutated, wrapper_pass.Run(module.get()));
   absl::StatusOr<bool> filecheck_result = RunFileCheck(module->ToString({}), R"(
   // CHECK: %b = f32[1]{0} parameter(0)
   // CHECK: %tuple-start = ((f32[1]{0}), (f32[1]{0}, f32[1]{0})) async-start(%b), calls=%comms.collectives_group, frontend_attributes={_collectives_group=""}
@@ -84,7 +85,7 @@ TEST_F(ExplicitCollectivesGroupAsyncWrapperTest,
   auto module = ParseAndReturnVerifiedModule(hlo_string).value();
   ExplicitCollectivesGroupAsyncWrapper wrapper_pass;
 
-  TF_ASSERT_OK_AND_ASSIGN(bool mutated, wrapper_pass.Run(module.get()));
+  ASSERT_OK_AND_ASSIGN(bool mutated, wrapper_pass.Run(module.get()));
   // Assert that the scheduling annotation is removed within the cloned
   // computation, but remains on the async operations.
   absl::StatusOr<bool> filecheck_result = RunFileCheck(module->ToString({}), R"(
@@ -94,12 +95,74 @@ TEST_F(ExplicitCollectivesGroupAsyncWrapperTest,
   // CHECK-NEXT: %{{.*}} collective-permute({{.*}}), source_target_pairs={{[{][{]0,1[}][}]}}
   // CHECK: ENTRY %main {{.*}}
   // CHECK-NEXT: %[[P0:.*]] = {{.*}} parameter(0)
-  // CHECK-NEXT: %[[P1:.*]] = {{.*}} async-start(%[[P0]]), calls=%comms.collectives_group, frontend_attributes={_collectives_group="",_scheduling_group_id="1"}  
+  // CHECK-NEXT: %[[P1:.*]] = {{.*}} async-start(%[[P0]]), calls=%comms.collectives_group, frontend_attributes={_collectives_group="",_scheduling_group_id="1"}
   // CHECK-NEXT: ROOT %{{.*}} async-done(%[[P1]]), frontend_attributes={_collectives_group="",_scheduling_group_id="1"}
   )");
   ASSERT_OK(filecheck_result.status());
   EXPECT_TRUE(*filecheck_result);
   ASSERT_TRUE(mutated);
+}
+
+TEST_F(ExplicitCollectivesGroupAsyncWrapperTest,
+       PreservesMetadataAndControlDependencies) {
+  const absl::string_view hlo_string = R"(
+  HloModule composite
+  comms {
+    a = f32[1] parameter(0)
+    x = f32[1] all-gather(a), dimensions={0}
+    y = f32[1] collective-permute(a), source_target_pairs={{0,1}}
+    ROOT result = (f32[1], f32[1]) tuple(x, y)
+  }
+
+  ENTRY main {
+    b = f32[1] parameter(0)
+    predecessor = f32[1] negate(b)
+    group = (f32[1], f32[1]) call(b), to_apply=comms,
+      frontend_attributes={_collectives_group=""},
+      metadata={op_type="collectives" op_name="group"},
+      backend_config={"force_earliest_schedule":true},
+      control-predecessors={predecessor}
+    result = f32[1] get-tuple-element(group), index=0
+    ROOT succ = f32[1] negate(result), control-predecessors={group}
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  ExplicitCollectivesGroupAsyncWrapper wrapper_pass;
+  ASSERT_OK_AND_ASSIGN(bool mutated, wrapper_pass.Run(module.get()));
+  ASSERT_TRUE(mutated);
+
+  HloInstruction* async_start = nullptr;
+  HloInstruction* async_done = nullptr;
+  for (HloInstruction* instruction :
+       module->entry_computation()->instructions()) {
+    if (HloPredicateIsOp<HloOpcode::kAsyncStart>(instruction)) {
+      async_start = instruction;
+    } else if (HloPredicateIsOp<HloOpcode::kAsyncDone>(instruction)) {
+      async_done = instruction;
+    }
+  }
+  ASSERT_NE(async_start, nullptr);
+  ASSERT_NE(async_done, nullptr);
+
+  HloInstruction* predecessor = FindInstruction(module.get(), "predecessor");
+  HloInstruction* succ = FindInstruction(module.get(), "succ");
+  ASSERT_EQ(async_start->control_predecessors().size(), 1);
+  EXPECT_EQ(async_start->control_predecessors().front(), predecessor);
+  ASSERT_EQ(async_done->control_successors().size(), 1);
+  EXPECT_EQ(async_done->control_successors().front(), succ);
+
+  for (const HloInstruction* instruction : {async_start, async_done}) {
+    EXPECT_EQ(instruction->metadata().op_type(), "collectives");
+    EXPECT_EQ(instruction->metadata().op_name(), "group");
+  }
+
+  ASSERT_OK_AND_ASSIGN(GpuBackendConfig async_start_config,
+                       async_start->backend_config<GpuBackendConfig>());
+  EXPECT_TRUE(async_start_config.force_earliest_schedule());
+  ASSERT_OK_AND_ASSIGN(GpuBackendConfig async_done_config,
+                       async_done->backend_config<GpuBackendConfig>());
+  EXPECT_FALSE(async_done_config.force_earliest_schedule());
 }
 
 TEST_F(ExplicitCollectivesGroupAsyncWrapperTest, ManyCollectivesGroups) {
@@ -126,10 +189,10 @@ TEST_F(ExplicitCollectivesGroupAsyncWrapperTest, ManyCollectivesGroups) {
   auto module = ParseAndReturnVerifiedModule(hlo_string).value();
   ExplicitCollectivesGroupAsyncWrapper wrapper_pass;
 
-  TF_ASSERT_OK_AND_ASSIGN(bool mutated, wrapper_pass.Run(module.get()));
+  ASSERT_OK_AND_ASSIGN(bool mutated, wrapper_pass.Run(module.get()));
   absl::StatusOr<bool> filecheck_result = RunFileCheck(module->ToString({}), R"(
   // CHECK: %b = f32[1]{0} parameter(0)
-  // CHECK: %tuple-start = ((f32[1]{0}), (f32[1]{0}, f32[1]{0})) async-start(%b), calls=%comms.collectives_group, frontend_attributes={_collectives_group=""} 
+  // CHECK: %tuple-start = ((f32[1]{0}), (f32[1]{0}, f32[1]{0})) async-start(%b), calls=%comms.collectives_group, frontend_attributes={_collectives_group=""}
   // CHECK: %tuple-done = (f32[1]{0}, f32[1]{0}) async-done(%tuple-start), frontend_attributes={_collectives_group=""}
   // CHECK: %c = f32[1]{0} get-tuple-element(%tuple-done), index=0
   // CHECK: %tuple-start.1 = ((f32[1]{0}), (f32[1]{0}, f32[1]{0})) async-start(%c), calls=%comms.collectives_group.1, frontend_attributes={_collectives_group=""}

--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -1534,6 +1534,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@com_googlesource_code_re2//:re2",
     ],
@@ -6732,13 +6733,12 @@ xla_cc_test(
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "//xla/hlo/testlib:test_helpers",
         "//xla/hlo/utils:hlo_matchers",
-        "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest_main",  # fixdeps: keep
     ],
 )
 

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3631,11 +3631,10 @@ xla_cc_test(
         "//xla/backends/gpu/runtime:execution_stream_id",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
-        "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/strings:string_view",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest_main",  # fixdeps: keep
     ],
 )
 
@@ -3659,6 +3658,7 @@ cc_library(
         "//xla/service:profile_guided_latency_estimator",
         "//xla/stream_executor:stream_executor_h",
         "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
@@ -3683,10 +3683,8 @@ xla_cc_test(
         "//xla/service:profile_guided_latency_estimator",
         "//xla/stream_executor:device_description",
         "//xla/tests:xla_internal_test_main",
-        "//xla/tsl/lib/core:status_test_util",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:status_macros",
-        "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
@@ -3694,7 +3692,7 @@ xla_cc_test(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest",  # fixdeps: keep
         "@llvm-project//mlir:IR",
     ],
 )

--- a/xla/service/gpu/execution_stream_assignment.cc
+++ b/xla/service/gpu/execution_stream_assignment.cc
@@ -122,7 +122,9 @@ std::optional<ExecutionScopeKind> IsExecutionScopeStart(
     const HloInstruction* hlo) {
   // Async operation that starts a new execution scope.
   if (auto* start = DynCast<HloAsyncStartInstruction>(hlo)) {
-    return IsWrappedCollective(start) || IsCustomCollectiveOp(start)
+    return IsWrappedCollective(start) || IsCustomCollectiveOp(start) ||
+                   start->frontend_attributes().map().contains(
+                       kCollectivesGroupAttr)
                ? ExecutionScopeKind::kCommunication
                : ExecutionScopeKind::kCompute;
   }

--- a/xla/service/gpu/execution_stream_assignment_test.cc
+++ b/xla/service/gpu/execution_stream_assignment_test.cc
@@ -28,7 +28,6 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
-#include "xla/tsl/platform/statusor.h"
 
 namespace xla::gpu {
 namespace {
@@ -72,8 +71,8 @@ TEST_F(ExecutionStreamAssignmentTest, AsyncFusion) {
           custom_call_target="target"
     }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kModuleStr));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kModuleStr));
 
   ExecutionStreamAssignment assignment(
       module.get(),
@@ -112,8 +111,8 @@ TEST_F(ExecutionStreamAssignmentTest, CopyStartStreamIdTest) {
     ROOT copy-done = f32[2,3]{1,0:S(2)} copy-done(copy-start)
   }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(hlo_copy_start_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(hlo_copy_start_string));
 
   ExecutionStreamAssignment assignment(module.get());
 
@@ -145,8 +144,8 @@ TEST_F(ExecutionStreamAssignmentTest, FusionComputations) {
       ROOT done = f32[] fusion(p0), kind=kLoop, calls=fusion
     }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kModuleStr));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kModuleStr));
 
   ExecutionStreamAssignment assignment(module.get());
 
@@ -174,8 +173,8 @@ TEST_F(ExecutionStreamAssignmentTest, UnreachableComputation) {
       ROOT add = f32[2,2] add(p0, p0)
     }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kModuleStr));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kModuleStr));
 
   ExecutionStreamAssignment assignment(module.get());
 
@@ -213,8 +212,8 @@ TEST_F(ExecutionStreamAssignmentTest, ExplicitStreams) {
     ROOT %call-done-2 = f32[2048,2048]{1,0} call-done(((f32[2048,2048]{1,0}, f32[2048,2048]{1,0}), f32[2048,2048]{1,0}) %call-start.2)
 }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kModuleStr));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kModuleStr));
 
   ExecutionStreamAssignment assignment(
       module.get(),
@@ -258,8 +257,8 @@ TEST_F(ExecutionStreamAssignmentTest, AsyncCollectiveTest) {
       ROOT _ = (f32[], f32[1], f32[2]) tuple(ar-done, rs-done, add.0)
     }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(hlo_string));
 
   // With 4 compute streams and 2 collective streams, ar-start and rs-start
   // get CommunicationStreamId(0) and CommunicationStreamId(1).
@@ -292,6 +291,38 @@ TEST_F(ExecutionStreamAssignmentTest, AsyncCollectiveTest) {
   EXPECT_THAT(
       assignment.GetExecutionStreamId(FindInstruction(module.get(), "ar-done")),
       absl_testing::StatusIs(absl::StatusCode::kNotFound));
+}
+
+TEST_F(ExecutionStreamAssignmentTest,
+       ExplicitCollectivesGroupUsesCommunicationStream) {
+  const char* const hlo_string = R"(
+  HloModule m
+
+  comms {
+    p0 = f32[1] parameter(0)
+    ag = f32[1] all-gather(p0), dimensions={0}
+    cp = f32[1] collective-permute(p0), source_target_pairs={{0,1}}
+    ROOT result = (f32[1], f32[1]) tuple(ag, cp)
+  }
+
+  ENTRY main {
+    p0 = f32[1] parameter(0)
+    group-start = ((f32[1]), (f32[1], f32[1])) async-start(p0),
+      calls=comms, frontend_attributes={_collectives_group=""}
+    ROOT group-done = (f32[1], f32[1]) async-done(group-start)
+  }
+  )";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(hlo_string));
+
+  ExecutionStreamAssignment assignment(module.get());
+  EXPECT_THAT(
+      assignment.GetExecutionStreamId(
+          FindInstruction(module.get(), "group-start")),
+      absl_testing::IsOkAndHolds(ExecutionStreamId(CommunicationStreamId(0))));
+  EXPECT_THAT(assignment.GetExecutionStreamId(
+                  FindInstruction(module.get(), "group-done")),
+              absl_testing::StatusIs(absl::StatusCode::kNotFound));
 }
 
 TEST_F(ExecutionStreamAssignmentTest, PipelinedSendRecv) {
@@ -349,8 +380,8 @@ TEST_F(ExecutionStreamAssignmentTest, PipelinedSendRecv) {
       ROOT data_ = get-tuple-element(recv_done), index=0
     }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kModuleStr));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kModuleStr));
 
   ExecutionStreamAssignment assignment(
       module.get(), ExecutionStreamAssignment::Options{4, 4});

--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -18,7 +18,6 @@ limitations under the License.
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <iterator>
 #include <limits>
 #include <optional>
 #include <tuple>
@@ -26,6 +25,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/algorithm/container.h"
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -33,12 +33,14 @@ limitations under the License.
 #include "absl/strings/string_view.h"
 #include "xla/backends/gpu/transforms/collectives/collective_ops_utils.h"
 #include "xla/backends/gpu/transforms/dynamic_slice_copy.h"
+#include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/hlo/utils/hlo_query.h"
 #include "xla/service/collective_ops_utils.h"
 #include "xla/service/gpu/backend_configs.pb.h"
 #include "xla/service/gpu/cublas_cudnn.h"
+#include "xla/service/hlo_cost_analysis.h"
 #include "xla/service/latency_hiding_scheduler.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
@@ -167,9 +169,102 @@ bool IsMemcpyAsyncDoneOp(const HloInstruction& hlo) {
 }
 
 bool IsDynamicSliceCopyFusionAsyncOp(const HloInstruction& hlo) {
-  return (hlo.opcode() == HloOpcode::kAsyncStart ||
-          hlo.opcode() == HloOpcode::kAsyncDone) &&
+  return HloPredicateIsOp<HloOpcode::kAsyncStart, HloOpcode::kAsyncDone>(
+             &hlo) &&
          IsDynamicSliceCopyFusion(hlo.async_wrapped_instruction());
+}
+
+bool IsCollectivesGroupAsyncStartOp(const HloInstruction& hlo) {
+  return HloPredicateIsOp<HloOpcode::kAsyncStart>(&hlo) &&
+         hlo.frontend_attributes().map().contains(kCollectivesGroupAttr);
+}
+
+bool IsCollectivesGroupAsyncDoneOp(const HloInstruction& hlo) {
+  return HloPredicateIsOp<HloOpcode::kAsyncDone>(&hlo) &&
+         IsCollectivesGroupAsyncStartOp(*hlo.operand(0));
+}
+
+bool IsCollectivesGroupAsyncOp(const HloInstruction& hlo) {
+  return IsCollectivesGroupAsyncStartOp(hlo) ||
+         IsCollectivesGroupAsyncDoneOp(hlo);
+}
+
+using ReplicaGroups = std::vector<std::vector<int64_t>>;
+
+// Returns the replica groups used by an async collective start.
+std::optional<ReplicaGroups> GetReplicaGroups(const HloInstruction& start) {
+  const HloInstruction* collective = &start;
+  if (HloPredicateIsOp<HloOpcode::kAsyncStart>(collective)) {
+    collective = collective->async_wrapped_instruction();
+  }
+
+  if (HloPredicateIsOp<HloOpcode::kCollectivePermute,
+                       HloOpcode::kCollectivePermuteStart>(collective)) {
+    ReplicaGroups groups;
+    for (const auto& [source, target] : collective->source_target_pairs()) {
+      groups.push_back({source, target});
+    }
+    return groups;
+  }
+
+  if (!hlo_query::IsCollectiveCommunicationOp(collective->opcode())) {
+    return std::nullopt;
+  }
+
+  // An empty list represents one implicit group containing all participants.
+  return collective->device_list()->flattened_replica_groups();
+}
+
+// Returns the replica groups from every collective in a collective group.
+std::optional<ReplicaGroups> GetReplicaGroups(
+    const HloComputation& computation) {
+  std::optional<ReplicaGroups> groups;
+  for (const HloInstruction* instruction : computation.instructions()) {
+    if (!hlo_query::IsCollectiveCommunicationOp(instruction->opcode()) &&
+        !hlo_query::IsAsyncCollectiveStartOp(instruction,
+                                             /*include_send_recv=*/true)) {
+      continue;
+    }
+    auto instruction_groups = GetReplicaGroups(*instruction);
+    if (!instruction_groups) {
+      return std::nullopt;
+    }
+    // An all-participants collective overlaps every other collective.
+    if (instruction_groups->empty()) {
+      return ReplicaGroups{};
+    }
+    if (!groups) {
+      groups.emplace();
+    }
+    for (auto& group : *instruction_groups) {
+      groups->push_back(std::move(group));
+    }
+  }
+  return groups;
+}
+
+// Returns the maximum number of ranks shared by any pair of replica groups.
+size_t CountOverlappingRanks(const ReplicaGroups& groups,
+                             const ReplicaGroups& other_groups) {
+  // Scratch flat hash set to avoid allocation inside a loop.
+  absl::flat_hash_set<int64_t> replica_ids;
+  auto is_in_replica_ids = [&](int64_t replica_id) {
+    return replica_ids.contains(replica_id);
+  };
+
+  size_t overlapping_count = 0;
+  for (const auto& group : groups) {
+    replica_ids.clear();
+    for (int64_t replica_id : group) {
+      replica_ids.insert(replica_id);
+    }
+
+    for (const auto& other_group : other_groups) {
+      size_t group_overlap = absl::c_count_if(other_group, is_in_replica_ids);
+      overlapping_count = std::max(overlapping_count, group_overlap);
+    }
+  }
+  return overlapping_count;
 }
 
 // Marks async start operations to be scheduled as early as possible.
@@ -177,43 +272,32 @@ bool IsDynamicSliceCopyFusionAsyncOp(const HloInstruction& hlo) {
 // Besides async collectives, copy-start and dynamic-slice copy fusions are
 // async memcpy operations.
 bool IsGpuAsyncStart(const HloInstruction& hlo) {
-  return (hlo_query::IsAsyncCollectiveStartOp(&hlo,
-                                              /*include_send_recv=*/true) &&
-          !IsGPUSyncCollective(hlo)) ||
-         IsAsyncComputeStartOp(hlo) || IsMemcpyAsyncStartOp(hlo);
+  const bool is_collective_start =
+      hlo_query::IsAsyncCollectiveStartOp(&hlo,
+                                          /*include_send_recv=*/true) ||
+      IsCollectivesGroupAsyncStartOp(hlo);
+  if (is_collective_start && IsGPUSyncCollective(hlo)) {
+    return false;
+  }
+  return is_collective_start || IsAsyncComputeStartOp(hlo) ||
+         IsMemcpyAsyncStartOp(hlo);
 }
 
 // Marks async done operations to be scheduled as late as possible.
 bool IsGpuAsyncDone(const HloInstruction& hlo) {
-  return (hlo_query::IsAsyncCollectiveDoneOp(&hlo,
-                                             /*include_send_recv=*/true) &&
-          !IsGPUSyncCollective(*hlo.operand(0))) ||
-         IsAsyncComputeDoneOp(hlo) || IsMemcpyAsyncDoneOp(hlo);
+  const bool is_collective_done =
+      hlo_query::IsAsyncCollectiveDoneOp(&hlo,
+                                         /*include_send_recv=*/true) ||
+      IsCollectivesGroupAsyncDoneOp(hlo);
+  if (is_collective_done && IsGPUSyncCollective(*hlo.operand(0))) {
+    return false;
+  }
+  return is_collective_done || IsAsyncComputeDoneOp(hlo) ||
+         IsMemcpyAsyncDoneOp(hlo);
 }
 
 bool IsAsyncPair(const HloInstruction& from, const HloInstruction& target) {
   return IsGpuAsyncStart(from) && IsGpuAsyncDone(target);
-}
-
-// Count the maximum overlapping count in subgroups of group and other
-size_t CountOverlappingRanks(const std::vector<std::vector<int64_t>>& group,
-                             const std::vector<std::vector<int64_t>>& other) {
-  size_t overlapping_count = 0;
-  for (const std::vector<int64_t>& curr_replica_group : group) {
-    absl::flat_hash_set<int64_t> curr_replica_ids;
-    for (const int64_t curr_replica_id : curr_replica_group) {
-      curr_replica_ids.insert(curr_replica_id);
-    }
-
-    for (const std::vector<int64_t>& replica_group : other) {
-      size_t subgroup_count = 0;
-      for (const int64_t replica_id : replica_group) {
-        if (curr_replica_ids.contains(replica_id)) ++subgroup_count;
-      }
-      overlapping_count = std::max(overlapping_count, subgroup_count);
-    }
-  }
-  return overlapping_count;
 }
 
 }  // namespace
@@ -272,63 +356,68 @@ bool GpuScheduleCrossesOverlapLimit(
     }
   }
 
-  if (node->GetResources().size() == 0) {
+  if (node->GetResources().empty()) {
     return false;
   }
-  auto resource_type = node->GetResources().at(0).first;
-  // If the candidate collective has more than 1 overlapping ranks with
-  // in-flight collectives, they can form cyclic dependency and cannot be
-  // overlapped
-  if (resource_type == xla::ResourceTypeToIndex(
-                           GpuResourceType::kGpuAsyncStreamCollectives) &&
-      sched_state.resource_occupiers_in_flight.contains(resource_type) &&
-      !sched_state.resource_occupiers_in_flight.at(resource_type).empty() &&
-      !IsCustomCollectiveOp(&node->GetInstr())) {
-    const HloInstruction& curr_hlo_inst = node->GetInstr();
-    if (sched_state.async_tracker->IsSupportedAsyncDone(curr_hlo_inst)) {
-      CHECK(
-          hlo_query::IsAsyncCollectiveStartOp(curr_hlo_inst.operand(0), true));
-      const HloInstruction* curr_start_inst =
-          curr_hlo_inst.IsAsynchronous()
-              ? curr_hlo_inst.operand(0)->async_wrapped_instruction()
-              : curr_hlo_inst.operand(0);
 
-      auto get_replica_groups = [](const HloInstruction* inst) {
-        if (inst->opcode() != HloOpcode::kCollectivePermuteStart)
-          return inst->device_list()->flattened_replica_groups();
-        std::vector<std::vector<int64_t>> g;
-        absl::c_transform(inst->source_target_pairs(), std::back_inserter(g),
-                          [](auto& p) -> std::vector<int64_t> {
-                            return {p.first, p.second};
-                          });
-        return g;
-      };
+  const int64_t resource_type = node->GetResources().at(0).first;
 
-      // If candidate can be overlapped with in-flight collectives
-      bool can_overlap = true;
-      for (const auto async_occupier :
-           sched_state.resource_occupiers_in_flight.at(resource_type)) {
-        if (sched_state.async_tracker->IsSupportedAsyncStart(*async_occupier)) {
-          const HloInstruction* occupier =
-              async_occupier->opcode() == HloOpcode::kAsyncStart
-                  ? async_occupier->async_wrapped_instruction()
-                  : async_occupier;
+  // Rank-overlap constraints apply only while a collective is in flight.
+  if (resource_type != xla::ResourceTypeToIndex(
+                           GpuResourceType::kGpuAsyncStreamCollectives) ||
+      !sched_state.resource_occupiers_in_flight.contains(resource_type) ||
+      sched_state.resource_occupiers_in_flight.at(resource_type).empty()) {
+    return false;
+  }
 
-          size_t overlapping_count =
-              CountOverlappingRanks(get_replica_groups(curr_start_inst),
-                                    get_replica_groups(occupier));
-          if (overlapping_count > 1) {
-            can_overlap = false;
-            VLOG(3) << "Collectives have " << overlapping_count
-                    << "overlapping ranks and cannot be overlapped. Candidate "
-                       "collective: "
-                    << curr_start_inst->ToString()
-                    << ", in flight collective: " << occupier->ToString();
-            break;
-          }
-        }
-      }
-      if (!can_overlap) return true;
+  // Custom collectives are opaque; only async-done candidates expose a
+  // corresponding start whose replica groups can be checked.
+  const HloInstruction& curr_hlo = node->GetInstr();
+  if (IsCustomCollectiveOp(&curr_hlo) ||
+      !sched_state.async_tracker->IsSupportedAsyncDone(curr_hlo)) {
+    return false;
+  }
+
+  // A collective group contributes the replica groups of all collectives in
+  // its wrapped computation.
+  const HloInstruction* curr_start = curr_hlo.operand(0);
+  std::optional<ReplicaGroups> curr_replica_groups =
+      IsCollectivesGroupAsyncStartOp(*curr_start)
+          ? GetReplicaGroups(*curr_start->async_wrapped_computation())
+          : GetReplicaGroups(*curr_start);
+
+  // Unknown groups are unsafe to overlap; an empty list means all ranks.
+  if (!curr_replica_groups || curr_replica_groups->empty()) {
+    return true;
+  }
+
+  for (const HloInstruction* async_occupier :
+       sched_state.resource_occupiers_in_flight.at(resource_type)) {
+    if (!sched_state.async_tracker->IsSupportedAsyncStart(*async_occupier) ||
+        IsCustomCollectiveOp(async_occupier)) {
+      continue;
+    }
+
+    std::optional<ReplicaGroups> occupier_replica_groups =
+        IsCollectivesGroupAsyncStartOp(*async_occupier)
+            ? GetReplicaGroups(*async_occupier->async_wrapped_computation())
+            : GetReplicaGroups(*async_occupier);
+
+    // Unknown groups are unsafe to overlap; an empty list means all ranks.
+    if (!occupier_replica_groups || occupier_replica_groups->empty()) {
+      return true;
+    }
+
+    // More than one shared rank can create a cyclic launch dependency.
+    size_t overlapping_count =
+        CountOverlappingRanks(*curr_replica_groups, *occupier_replica_groups);
+    if (overlapping_count > 1) {
+      VLOG(3) << "Collectives have " << overlapping_count
+              << " overlapping ranks and cannot be overlapped. Candidate "
+                 "collective: "
+              << curr_start->ToString()
+              << ", in flight collective: " << async_occupier->ToString();
+      return true;
     }
   }
 
@@ -462,13 +551,33 @@ ResourcesVector GpuAsyncTracker::GetResourcesFromInstructionImpl(
                   ? ResourceUsageType::kResourceRelease
                   : ResourceUsageType::kResourceOccupy;
       resource = hlo_query::IsCollectiveCommunicationOp(op.inner) ||
-                         IsCustomCollectiveOp(&instr)
+                         IsCustomCollectiveOp(&instr) ||
+                         IsCollectivesGroupAsyncOp(instr)
                      ? GpuResourceType::kGpuAsyncStreamCollectives
                      : GpuResourceType::kGpuAsyncStreamComputes;
     }
     return {std::make_pair(ResourceTypeToIndex(resource), usage)};
   }
   return GpuAsyncTrackerBase::GetResourcesFromInstructionImpl(instr);
+}
+
+absl::flat_hash_map<int64_t, int64_t>
+GpuAsyncTracker::GetNumResourcesPerInstruction(
+    const HloInstruction& instr) const {
+  if (!IsCollectivesGroupAsyncOp(instr)) {
+    return GpuAsyncTrackerBase::GetNumResourcesPerInstruction(instr);
+  }
+
+  // An explicit collective group is one opaque launch. Do not recursively
+  // count the collectives in its wrapped computation as separate resources.
+  absl::flat_hash_map<int64_t, int64_t> resource_counts;
+  for (const auto& [resource_type, usage] :
+       GetResourcesFromInstruction(instr)) {
+    if (usage == ResourceUsageType::kResourceOccupy) {
+      ++resource_counts[resource_type];
+    }
+  }
+  return resource_counts;
 }
 
 int64_t GpuAsyncTracker::GetNumTargetDefinedResources() const {
@@ -728,15 +837,14 @@ void GPUProfileStatisticsAggregator::HandleFoundInstructionLatency(
   found_instructions_count_++;
 }
 
-// Checks if the async instruction is a custom collective call
+// Checks if the async instruction is a custom collective call.
 bool IsCustomCollectiveOp(const HloInstruction* instr) {
-  if (instr->opcode() == HloOpcode::kAsyncStart ||
-      instr->opcode() == HloOpcode::kAsyncDone ||
-      instr->opcode() == HloOpcode::kAsyncUpdate) {
-    auto& attrs = instr->frontend_attributes().map();
-    if (auto it = attrs.find(kXlaStreamAnnotationAttr); it != attrs.end()) {
-      return absl::EqualsIgnoreCase(it->second, kXlaCollectiveStreamAnnotation);
-    }
+  if (!HloPredicateIsOp<HloOpcode::kAsyncStart, HloOpcode::kAsyncDone>(instr)) {
+    return false;
+  }
+  const auto& attrs = instr->frontend_attributes().map();
+  if (auto it = attrs.find(kXlaStreamAnnotationAttr); it != attrs.end()) {
+    return absl::EqualsIgnoreCase(it->second, kXlaCollectiveStreamAnnotation);
   }
   return false;
 }

--- a/xla/service/gpu/gpu_latency_hiding_scheduler.h
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.h
@@ -17,7 +17,9 @@ limitations under the License.
 #define XLA_SERVICE_GPU_GPU_LATENCY_HIDING_SCHEDULER_H_
 
 #include <cstdint>
+#include <optional>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/strings/string_view.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/service/hlo_cost_analysis.h"
@@ -118,6 +120,10 @@ class GpuAsyncTracker : public GpuAsyncTrackerBase {
   // this instruction.
   int64_t GetNumResourcesPerInstruction(
       int64_t resource_type, const HloInstruction& instr) const override;
+
+  // Returns a map of resource counts used by this instruction.
+  absl::flat_hash_map<int64_t, int64_t> GetNumResourcesPerInstruction(
+      const HloInstruction& instr) const override;
 };
 
 // GPU approximate latency estimator. It is a set of hardcoded heuristics

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -42,9 +42,7 @@ limitations under the License.
 #include "xla/service/latency_hiding_scheduler.h"
 #include "xla/service/profile_guided_latency_estimator.h"
 #include "xla/stream_executor/device_description.h"
-#include "xla/tsl/lib/core/status_test_util.h"
 #include "xla/tsl/platform/errors.h"
-#include "xla/tsl/platform/statusor.h"
 #include "xla/xla.pb.h"
 
 namespace xla::gpu {
@@ -135,8 +133,8 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
   )";
 
   HloModuleConfig config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
   for (const HloInstruction* instr :
        module->entry_computation()->instructions()) {
@@ -173,8 +171,8 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
   )";
 
   HloModuleConfig config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
   for (const HloInstruction* instr :
        module->entry_computation()->instructions()) {
@@ -212,8 +210,8 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
   )";
 
   HloModuleConfig config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
   for (const HloInstruction* instr :
        module->entry_computation()->instructions()) {
@@ -260,8 +258,8 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
   )";
 
   HloModuleConfig config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
   for (const HloInstruction* instr :
        module->entry_computation()->instructions()) {
@@ -312,8 +310,8 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
     }
   )";
   auto config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
   EXPECT_THAT(ScheduleModule(module.get()),
               absl_testing::StatusIs(absl::StatusCode::kInvalidArgument));
@@ -333,8 +331,8 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
     }
   )";
   auto config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
   EXPECT_THAT(ScheduleModule(module.get()),
               absl_testing::StatusIs(absl::StatusCode::kInvalidArgument));
@@ -354,10 +352,10 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
     }
   )";
   auto config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
-  TF_EXPECT_OK(ScheduleModule(module.get()));
+  EXPECT_OK(ScheduleModule(module.get()));
 }
 
 TEST_F(GpuLatencyHidingSchedulerBaseTest,
@@ -392,10 +390,10 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
   )";
 
   HloModuleConfig config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
-  TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/2));
+  EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/2));
   const HloSchedule& schedule = module->schedule();
   std::vector<HloInstruction*> instruction_sequence =
       schedule.sequence(module->entry_computation()).instructions();
@@ -443,9 +441,9 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
   debug_options.set_xla_gpu_enable_latency_hiding_scheduler(true);
   debug_options.set_xla_gpu_enable_analytical_sol_latency_estimator(true);
 
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
-  TF_ASSERT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/1));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/1));
 
   const auto& sequence =
       module->schedule().sequence(module->entry_computation()).instructions();
@@ -490,13 +488,13 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
   )";
 
   HloModuleConfig config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
   module->mutable_config()
       .mutable_debug_options()
       .set_xla_gpu_experimental_enable_collective_multi_streaming(true);
 
-  TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/2));
+  EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/2));
   const HloSchedule& schedule = module->schedule();
   std::vector<HloInstruction*> instruction_sequence =
       schedule.sequence(module->entry_computation()).instructions();
@@ -587,10 +585,10 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, SchedulePipelinedSendRecvsLate) {
   HloModuleConfig config = GetModuleConfig(
       kFdoProfile, /*pipeline_parallelism_opt_level=*/DebugOptions::
           PIPELINE_PARALLELISM_OPT_LEVEL_ENABLE);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
-  TF_EXPECT_OK(
+  EXPECT_OK(
       ScheduleModule(module.get(), /*num_parallel_resources=*/2,
                      /*strictness=*/DebugOptions::PGLE_STRICTNESS_LEVEL_OFF));
   const HloSchedule& schedule = module->schedule();
@@ -668,11 +666,11 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
   HloModuleConfig config = GetModuleConfig(
       kFdoProfile, /*pipeline_parallelism_opt_level=*/DebugOptions::
           PIPELINE_PARALLELISM_OPT_LEVEL_ENABLE);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
-  TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/1,
-                              DebugOptions::PGLE_STRICTNESS_LEVEL_OFF));
+  EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/1,
+                           DebugOptions::PGLE_STRICTNESS_LEVEL_OFF));
   const HloSchedule& schedule = module->schedule();
 
   VLOG(3) << module->schedule().ToString();
@@ -762,11 +760,11 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, ScheduleP2PWithMultipliers) {
   HloModuleConfig config = GetModuleConfig(
       kFdoProfile, /*pipeline_parallelism_opt_level=*/DebugOptions::
           PIPELINE_PARALLELISM_OPT_LEVEL_ENABLE);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
-  TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/1,
-                              DebugOptions::PGLE_STRICTNESS_LEVEL_OFF));
+  EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/1,
+                           DebugOptions::PGLE_STRICTNESS_LEVEL_OFF));
   const HloSchedule& schedule = module->schedule();
 
   VLOG(3) << module->schedule().ToString();
@@ -853,11 +851,11 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
   HloModuleConfig config = GetModuleConfig(
       kFdoProfile, /*pipeline_parallelism_opt_level=*/DebugOptions::
           PIPELINE_PARALLELISM_OPT_LEVEL_ENABLE);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
-  TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/1,
-                              DebugOptions::PGLE_STRICTNESS_LEVEL_OFF));
+  EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/1,
+                           DebugOptions::PGLE_STRICTNESS_LEVEL_OFF));
   const HloSchedule& schedule = module->schedule();
 
   VLOG(3) << module->schedule().ToString();
@@ -942,11 +940,11 @@ ENTRY main {
   HloModuleConfig config = GetModuleConfig(
       kFdoProfile, /*pipeline_parallelism_opt_level=*/DebugOptions::
           PIPELINE_PARALLELISM_OPT_LEVEL_ENABLE);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
-  TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/4,
-                              DebugOptions::PGLE_STRICTNESS_LEVEL_OFF));
+  EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/4,
+                           DebugOptions::PGLE_STRICTNESS_LEVEL_OFF));
   const HloSchedule& schedule = module->schedule();
 
   HloComputation* main_computation = FindComputation(module.get(), "main");
@@ -1002,10 +1000,10 @@ ENTRY main {
 
   absl::string_view kFdoProfile = "";
   HloModuleConfig config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
-  TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/2));
+  EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/2));
   const HloSchedule& schedule = module->schedule();
   std::vector<HloInstruction*> instruction_sequence =
       schedule.sequence(module->entry_computation()).instructions();
@@ -1048,8 +1046,8 @@ ENTRY main {
 
   absl::string_view kFdoProfile = "";
   HloModuleConfig config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
   HloComputation* comp = module->entry_computation();
   SchedulerConfig sched_config;
   GpuAsyncTracker async_tracker(sched_config);
@@ -1098,6 +1096,325 @@ ENTRY main {
   ASSERT_EQ(done_resources.size(), 1);
   EXPECT_EQ(done_resources[0].first, compute_resource);
   EXPECT_EQ(done_resources[0].second, ResourceUsageType::kResourceOccupy);
+}
+
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
+       ExplicitCollectivesGroupUsesCollectiveResource) {
+  absl::string_view kHloModule = R"(
+HloModule test, is_scheduled=true
+
+comms {
+  p0 = f32[1] parameter(0)
+  ag0-start = (f32[1], f32[1]) all-gather-start(p0), dimensions={0}
+  ag1-start = (f32[1], f32[1]) all-gather-start(p0), dimensions={0}
+  ag0 = f32[1] all-gather-done(ag0-start)
+  ag1 = f32[1] all-gather-done(ag1-start)
+  ROOT result = (f32[1], f32[1]) tuple(ag0, ag1)
+}
+
+ENTRY main {
+  p0 = f32[1] parameter(0)
+  p1 = f32[1] parameter(1)
+  group-start = ((f32[1]), (f32[1], f32[1])) async-start(p0),
+    calls=comms, frontend_attributes={_collectives_group=""}
+  add = f32[1] add(p1, p1)
+  group-done = (f32[1], f32[1]) async-done(group-start)
+  ROOT result = ((f32[1], f32[1]), f32[1]) tuple(group-done, add)
+})";
+
+  HloModuleConfig config = GetModuleConfig(/*fdo_profile=*/"");
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
+  HloInstruction* group_start = FindInstruction(module.get(), "group-start");
+  HloInstruction* group_done = FindInstruction(module.get(), "group-done");
+
+  SchedulerConfig sched_config;
+  GpuAsyncTracker async_tracker(sched_config);
+  EXPECT_TRUE(async_tracker.IsSupportedAsyncStart(*group_start));
+  EXPECT_FALSE(async_tracker.IsSupportedAsyncDone(*group_start));
+  EXPECT_TRUE(async_tracker.IsSupportedAsyncDone(*group_done));
+  EXPECT_FALSE(async_tracker.IsSupportedAsyncStart(*group_done));
+
+  int64_t collective_resource =
+      ResourceTypeToIndex(GpuResourceType::kGpuAsyncStreamCollectives);
+  auto start_resources =
+      async_tracker.GetResourcesFromInstruction(*group_start);
+  ASSERT_EQ(start_resources.size(), 1);
+  EXPECT_EQ(start_resources[0].first, collective_resource);
+  EXPECT_EQ(start_resources[0].second, ResourceUsageType::kResourceRelease);
+
+  auto done_resources = async_tracker.GetResourcesFromInstruction(*group_done);
+  ASSERT_EQ(done_resources.size(), 1);
+  EXPECT_EQ(done_resources[0].first, collective_resource);
+  EXPECT_EQ(done_resources[0].second, ResourceUsageType::kResourceOccupy);
+  EXPECT_EQ(async_tracker.GetNumResourcesPerInstruction(collective_resource,
+                                                        *group_start),
+            0);
+  EXPECT_EQ(async_tracker.GetNumResourcesPerInstruction(collective_resource,
+                                                        *group_done),
+            1);
+
+  auto start_resource_counts =
+      async_tracker.GetNumResourcesPerInstruction(*group_start);
+  EXPECT_TRUE(start_resource_counts.empty());
+  auto done_resource_counts =
+      async_tracker.GetNumResourcesPerInstruction(*group_done);
+  ASSERT_EQ(done_resource_counts.size(), 1);
+  EXPECT_EQ(done_resource_counts.at(collective_resource), 1);
+}
+
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
+       NestedCollectivesGroupUsesOneResource) {
+  constexpr absl::string_view kHloModule = R"(
+HloModule test, is_scheduled=true
+
+comms {
+  p0 = f32[1] parameter(0)
+  ag0-start = (f32[1], f32[1]) all-gather-start(p0), dimensions={0}
+  ag1-start = (f32[1], f32[1]) all-gather-start(p0), dimensions={0}
+  ag0 = f32[1] all-gather-done(ag0-start)
+  ag1 = f32[1] all-gather-done(ag1-start)
+  ROOT result = (f32[1], f32[1]) tuple(ag0, ag1)
+}
+
+group {
+  p0 = f32[1] parameter(0)
+  group-start = ((f32[1]), (f32[1], f32[1])) async-start(p0),
+    calls=comms, frontend_attributes={_collectives_group=""}
+  ROOT group-done = (f32[1], f32[1]) async-done(group-start)
+}
+
+while_condition {
+  state = (f32[1], f32[1]) parameter(0)
+  ROOT keep-going = pred[] constant(false)
+}
+
+while_body {
+  state = (f32[1], f32[1]) parameter(0)
+  value = f32[1] get-tuple-element(state), index=0
+  ROOT group-call = (f32[1], f32[1]) call(value), to_apply=group
+}
+
+ENTRY main {
+  p0 = f32[1] parameter(0)
+  p1 = f32[1] parameter(1)
+  nested-call = (f32[1], f32[1]) call(p0), to_apply=group
+  init = (f32[1], f32[1]) tuple(p0, p1)
+  nested-while = (f32[1], f32[1]) while(init),
+    condition=while_condition, body=while_body
+  ROOT result = ((f32[1], f32[1]), (f32[1], f32[1])) tuple(
+    nested-call, nested-while)
+})";
+
+  HloModuleConfig config = GetModuleConfig(/*fdo_profile=*/"");
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
+  HloInstruction* nested_call = FindInstruction(module.get(), "nested-call");
+  HloInstruction* nested_while = FindInstruction(module.get(), "nested-while");
+  ASSERT_NE(nested_call, nullptr);
+  ASSERT_NE(nested_while, nullptr);
+
+  SchedulerConfig sched_config;
+  GpuAsyncTracker async_tracker(sched_config);
+  const int64_t collective_resource =
+      ResourceTypeToIndex(GpuResourceType::kGpuAsyncStreamCollectives);
+  for (const HloInstruction* instruction : {nested_call, nested_while}) {
+    EXPECT_EQ(async_tracker.GetNumResourcesPerInstruction(collective_resource,
+                                                          *instruction),
+              1);
+    auto resource_counts =
+        async_tracker.GetNumResourcesPerInstruction(*instruction);
+    ASSERT_EQ(resource_counts.size(), 1);
+    EXPECT_EQ(resource_counts.at(collective_resource), 1);
+  }
+}
+
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
+       ExplicitCollectivesGroupSerializesWithNativeCollective) {
+  absl::string_view kFdoProfile = R"pb(
+    costs { name: "add" cost_us: 100000.0 }
+  )pb";
+
+  absl::string_view kHloModule = R"(
+HloModule test, replica_count=4
+
+comms {
+  p0 = f32[1] parameter(0)
+  ag = f32[2] all-gather(p0), dimensions={0},
+    replica_groups={{0,2},{1,3}}
+  cp = f32[1] collective-permute(p0), source_target_pairs={{0,1}}
+  ROOT result = (f32[2], f32[1]) tuple(ag, cp)
+}
+
+ENTRY main {
+  p0 = f32[1] parameter(0)
+  p1 = f32[1] parameter(1)
+  group-start = ((f32[1]), (f32[2], f32[1])) async-start(p0),
+    calls=comms, frontend_attributes={_collectives_group=""}
+  native-start = (f32[1], f32[2]) all-gather-start(p0), dimensions={0},
+    replica_groups={{0,1},{2,3}}
+  add = f32[1] add(p1, p1)
+  group-done = (f32[2], f32[1]) async-done(group-start)
+  native-done = f32[2] all-gather-done(native-start)
+  ROOT result = ((f32[2], f32[1]), f32[2], f32[1])
+    tuple(group-done, native-done, add)
+})";
+
+  HloModuleConfig config = GetModuleConfig(kFdoProfile);
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
+  module->mutable_config()
+      .mutable_debug_options()
+      .set_xla_gpu_experimental_enable_collective_multi_streaming(true);
+  ASSERT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/2,
+                           DebugOptions::PGLE_STRICTNESS_LEVEL_OFF));
+
+  const HloSchedule& schedule = module->schedule();
+  std::vector<HloInstruction*> instruction_sequence =
+      schedule.sequence(module->entry_computation()).instructions();
+  const int group_start_index =
+      GetIndexByName(instruction_sequence, "group-start");
+  const int group_done_index =
+      GetIndexByName(instruction_sequence, "group-done");
+  const int native_start_index =
+      GetIndexByName(instruction_sequence, "native-start");
+  const int native_done_index =
+      GetIndexByName(instruction_sequence, "native-done");
+  const int add_index = GetIndexByName(instruction_sequence, "add");
+
+  // The second collective in the group and the native collective share ranks
+  // 0 and 1, so they must not overlap.
+  EXPECT_TRUE(group_done_index < native_start_index ||
+              native_done_index < group_start_index);
+  EXPECT_TRUE(
+      (group_start_index < add_index && add_index < group_done_index) ||
+      (native_start_index < add_index && add_index < native_done_index));
+}
+
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
+       ExplicitCollectivesGroupOverlapsNativeWithOneSharedRank) {
+  absl::string_view kFdoProfile = R"pb(
+    costs { name: "add" cost_us: 100000.0 }
+  )pb";
+
+  absl::string_view kHloModule = R"(
+HloModule test, replica_count=4
+
+cp {
+  p0 = f32[1] parameter(0)
+  ROOT cp = f32[1] collective-permute(p0), source_target_pairs={{0,1}}
+}
+
+comms {
+  p0 = f32[1] parameter(0)
+  cp-start = ((f32[1]), f32[1]) async-start(p0), calls=cp
+  ROOT cp-done = f32[1] async-done(cp-start)
+}
+
+ENTRY main {
+  p0 = f32[1] parameter(0)
+  p1 = f32[1] parameter(1)
+  group-start = ((f32[1]), f32[1]) async-start(p0),
+    calls=comms, frontend_attributes={_collectives_group=""}
+  native-start = (f32[1], f32[2]) all-gather-start(p0), dimensions={0},
+    replica_groups={{0,2},{1,3}}
+  add = f32[1] add(p1, p1)
+  group-done = f32[1] async-done(group-start)
+  native-done = f32[2] all-gather-done(native-start)
+  ROOT result = (f32[1], f32[2], f32[1])
+    tuple(group-done, native-done, add)
+})";
+
+  HloModuleConfig config = GetModuleConfig(kFdoProfile);
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
+  module->mutable_config()
+      .mutable_debug_options()
+      .set_xla_gpu_experimental_enable_collective_multi_streaming(true);
+  ASSERT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/2,
+                           DebugOptions::PGLE_STRICTNESS_LEVEL_OFF));
+
+  const HloSchedule& schedule = module->schedule();
+  std::vector<HloInstruction*> instruction_sequence =
+      schedule.sequence(module->entry_computation()).instructions();
+  const int group_start_index =
+      GetIndexByName(instruction_sequence, "group-start");
+  const int group_done_index =
+      GetIndexByName(instruction_sequence, "group-done");
+  const int native_start_index =
+      GetIndexByName(instruction_sequence, "native-start");
+  const int native_done_index =
+      GetIndexByName(instruction_sequence, "native-done");
+  const int add_index = GetIndexByName(instruction_sequence, "add");
+
+  // Every native subgroup shares at most one rank with the group's
+  // collective-permute, so the collectives can overlap.
+  EXPECT_TRUE((group_start_index < native_start_index &&
+               native_start_index < group_done_index) ||
+              (native_start_index < group_start_index &&
+               group_start_index < native_done_index));
+  EXPECT_TRUE(
+      (group_start_index < add_index && add_index < group_done_index) ||
+      (native_start_index < add_index && add_index < native_done_index));
+}
+
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
+       ExplicitCollectivesGroupWithImplicitReplicaGroupsSerializes) {
+  absl::string_view kFdoProfile = R"pb(
+    costs { name: "add" cost_us: 100000.0 }
+  )pb";
+
+  absl::string_view kHloModule = R"(
+HloModule test, replica_count=4
+
+comms {
+  p0 = f32[1] parameter(0)
+  ROOT ag = f32[4] all-gather(p0), dimensions={0}
+}
+
+ENTRY main {
+  p0 = f32[1] parameter(0)
+  p1 = f32[1] parameter(1)
+  group-start = ((f32[1]), f32[4]) async-start(p0),
+    calls=comms, frontend_attributes={_collectives_group=""}
+  native-start = (f32[1], f32[2]) all-gather-start(p0), dimensions={0},
+    replica_groups={{0,1},{2,3}}
+  add = f32[1] add(p1, p1)
+  group-done = f32[4] async-done(group-start)
+  native-done = f32[2] all-gather-done(native-start)
+  ROOT result = (f32[4], f32[2], f32[1])
+    tuple(group-done, native-done, add)
+})";
+
+  HloModuleConfig config = GetModuleConfig(kFdoProfile);
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
+  module->mutable_config()
+      .mutable_debug_options()
+      .set_xla_gpu_experimental_enable_collective_multi_streaming(true);
+  ASSERT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/2,
+                           DebugOptions::PGLE_STRICTNESS_LEVEL_OFF));
+
+  const HloSchedule& schedule = module->schedule();
+  std::vector<HloInstruction*> instruction_sequence =
+      schedule.sequence(module->entry_computation()).instructions();
+  const int group_start_index =
+      GetIndexByName(instruction_sequence, "group-start");
+  const int group_done_index =
+      GetIndexByName(instruction_sequence, "group-done");
+  const int native_start_index =
+      GetIndexByName(instruction_sequence, "native-start");
+  const int native_done_index =
+      GetIndexByName(instruction_sequence, "native-done");
+  const int add_index = GetIndexByName(instruction_sequence, "add");
+
+  // Empty replica_groups means that all replicas participate. Because that
+  // implicit group cannot be materialized here, serialize conservatively.
+  EXPECT_TRUE(group_done_index < native_start_index ||
+              native_done_index < group_start_index);
+  EXPECT_TRUE(
+      (group_start_index < add_index && add_index < group_done_index) ||
+      (native_start_index < add_index && add_index < native_done_index));
 }
 
 TEST_F(GpuLatencyHidingSchedulerBaseTest,
@@ -1195,11 +1512,11 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, ParallelThreadsShouldBeScheduled) {
 
   absl::string_view kFdoProfile = "";
   HloModuleConfig config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
   // It should compile without any issues.
-  TF_EXPECT_OK(ScheduleModule(module.get()));
+  EXPECT_OK(ScheduleModule(module.get()));
 }
 
 TEST_F(GpuLatencyHidingSchedulerBaseTest,
@@ -1241,11 +1558,11 @@ ENTRY main {
   absl::string_view kFdoProfile = "";
 
   HloModuleConfig config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
-  TF_EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/16,
-                              DebugOptions::PGLE_STRICTNESS_LEVEL_ERROR, true));
+  EXPECT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/16,
+                           DebugOptions::PGLE_STRICTNESS_LEVEL_ERROR, true));
   const HloSchedule& schedule = module->schedule();
   std::vector<HloInstruction*> instruction_sequence =
       schedule.sequence(module->entry_computation()).instructions();
@@ -1346,10 +1663,10 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, DelayMoveToHostAsyncStart) {
 
   absl::string_view kFdoProfile = "";
   xla::HloModuleConfig config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::HloModule> module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
-  TF_EXPECT_OK(ScheduleModule(module.get()));
+  EXPECT_OK(ScheduleModule(module.get()));
   const HloSchedule& schedule = module->schedule();
   const std::vector<xla::HloInstruction*>& instruction_sequence =
       schedule.sequence(module->entry_computation()).instructions();
@@ -1395,10 +1712,10 @@ ENTRY main {
   absl::string_view kFdoProfile = "";
 
   auto config = GetModuleConfig(kFdoProfile);
-  TF_ASSERT_OK_AND_ASSIGN(auto module,
-                          ParseAndReturnVerifiedModule(kHloModule, config));
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
 
-  TF_EXPECT_OK(ScheduleModule(module.get()));
+  EXPECT_OK(ScheduleModule(module.get()));
   auto schedule = module->schedule();
   std::vector<HloInstruction*> instruction_sequence =
       schedule.sequence(module->entry_computation()).instructions();

--- a/xla/service/latency_hiding_scheduler.cc
+++ b/xla/service/latency_hiding_scheduler.cc
@@ -743,13 +743,13 @@ AsyncTracker::RecursivelyComputeResourceMapForScheduledComputation(
         --inflight_resource_usage[resource.first];
       }
     }
-    for (const HloComputation* called_comp : inst->called_computations()) {
-      for (const auto& [type, usage] :
-           RecursivelyComputeResourceMap(called_comp)) {
-        int64_t current_usage = inflight_resource_usage[type] + usage;
-        int64_t& max_usage = res_map[type];
-        max_usage = std::max(max_usage, current_usage);
-      }
+    if (inst->called_computations().empty()) {
+      continue;
+    }
+    for (const auto& [type, usage] : GetNumResourcesPerInstruction(*inst)) {
+      int64_t current_usage = inflight_resource_usage[type] + usage;
+      int64_t& max_usage = res_map[type];
+      max_usage = std::max(max_usage, current_usage);
     }
   }
   return res_map;

--- a/xla/service/legalize_scheduling_annotations.cc
+++ b/xla/service/legalize_scheduling_annotations.cc
@@ -131,14 +131,22 @@ bool ContainsOnlyFormattingOps(const HloInstruction* async_op) {
   if (async_op->opcode() == HloOpcode::kAsyncDone) {
     return ContainsOnlyFormattingOps(async_op->operand(0));
   }
-  HloInstruction* call =
-      async_op->async_wrapped_computation()->root_instruction();
-  bool result = true;
-  for (HloInstruction* instr :
-       call->called_computations().front()->instructions()) {
+
+  const HloComputation* computation = async_op->async_wrapped_computation();
+
+  // Async wrappers can nest call-like instructions. Look through the root's
+  // callee so the recursive checks below continue into the nested async.
+  const HloInstruction* root = computation->root_instruction();
+  if (!root->called_computations().empty()) {
+    computation = root->called_computations().front();
+  }
+
+  for (const HloInstruction* instr : computation->instructions()) {
     if (HloPredicateIsOp<HloOpcode::kAsyncStart, HloOpcode::kAsyncDone>(
             instr)) {
-      result &= ContainsOnlyFormattingOps(instr);
+      if (!ContainsOnlyFormattingOps(instr)) {
+        return false;
+      }
     } else if (!HloPredicateIsOp<HloOpcode::kCopy, HloOpcode::kParameter>(
                    instr)) {
       return false;

--- a/xla/service/legalize_scheduling_annotations_test.cc
+++ b/xla/service/legalize_scheduling_annotations_test.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "xla/service/legalize_scheduling_annotations.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -34,7 +35,6 @@ limitations under the License.
 #include "xla/hlo/utils/hlo_matchers.h"
 #include "xla/service/scheduling_annotations_util.h"
 #include "xla/side_effect_util.h"
-#include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 
 namespace xla {
@@ -57,8 +57,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest, NonIntegerAnnotation) {
     ROOT tuple = (f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(c0, agd0)
   }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   EXPECT_IS_NOT_OK(
       LegalizeSchedulingAnnotations(config).Run(hlo_module.get()).status());
@@ -79,8 +79,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest, MultipleAnnotations) {
     ROOT tuple = (f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}, f32[1024,1024]{1,0}) tuple(c0, agd0, agd1)
   }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   EXPECT_IS_NOT_OK(
       LegalizeSchedulingAnnotations(config).Run(hlo_module.get()).status());
@@ -99,8 +99,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest, NegativeAnnotation) {
     ROOT tuple = (f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(c0, agd0)
   }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   EXPECT_IS_NOT_OK(
       LegalizeSchedulingAnnotations(config).Run(hlo_module.get()).status());
@@ -142,8 +142,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest, CrossComputationAnnotation) {
     ROOT tuple1 = (f32[16,64,256]{2,1,0}, f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(gte, c0, agd0)
   }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   EXPECT_IS_OK(
       LegalizeSchedulingAnnotations(config).Run(hlo_module.get()).status());
@@ -166,8 +166,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest, AnnotationWithGaps) {
     ROOT tuple = (f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(c0, agd0)
   }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   EXPECT_IS_NOT_OK(
       LegalizeSchedulingAnnotations(config).Run(hlo_module.get()).status());
@@ -190,8 +190,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest, AnnotationWithGaps2) {
     ROOT tuple = (f32[16,64,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(add1, agd0)
   }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   EXPECT_IS_NOT_OK(
       LegalizeSchedulingAnnotations(config).Run(hlo_module.get()).status());
@@ -213,8 +213,8 @@ ENTRY entry {
   ROOT add = f32[16]{0} add(b2, b2)
 }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.skip_opt_barriers = true;
   auto result = LegalizeSchedulingAnnotations(config).Run(hlo_module.get());
@@ -238,8 +238,8 @@ ENTRY entry {
   ROOT add = f32[16]{0} add(b2, b2)
 }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.skip_opt_barriers = true;
   auto result = LegalizeSchedulingAnnotations(config).Run(hlo_module.get());
@@ -259,8 +259,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest, MissingAnnotationInStart) {
     ROOT tuple = (f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(c0, agd0)
   }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   EXPECT_IS_NOT_OK(
       LegalizeSchedulingAnnotations(config).Run(hlo_module.get()).status());
@@ -282,8 +282,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest, MoveFusedOpAnnotationToCaller) {
     ROOT fusion0 = bf16[1024,2048]{1,0:T(8,128)(2,1)} fusion(p0, p1), kind=kOutput, calls=fused_computation.1
   }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   EXPECT_IS_OK(
       LegalizeSchedulingAnnotations(config).Run(hlo_module.get()).status());
@@ -311,8 +311,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest, FusedOpsWithDifferentAnnotationIds) {
     ROOT fusion0 = bf16[1024,2048]{1,0:T(8,128)(2,1)} fusion(p0, p1), kind=kOutput, calls=fused_computation.1
   }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   EXPECT_IS_NOT_OK(
       LegalizeSchedulingAnnotations(config).Run(hlo_module.get()).status());
@@ -330,8 +330,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest, DropAnnotationFromBitcast) {
     ROOT tuple = (f32[16,64,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(bitcast, agd0)
   }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.keep_sync_annotation = [](const HloInstruction* instr) {
     return instr->opcode() != HloOpcode::kBitcast;
@@ -364,8 +364,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest, DropAnnotationFromTrivialGroups) {
     ROOT tuple = (f32[16,64,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(bitcast3, agd0)
   }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.keep_trivial_sync_annotation = [](const HloInstruction* instr) {
     return instr->opcode() != HloOpcode::kBitcast;
@@ -418,8 +418,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest,
     ROOT tuple1 = (f32[16,64,256]{2,1,0}, f32[16,256,256]{2,1,0}) tuple(gte, c0)
   }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.keep_trivial_sync_annotation = HloPredicateFalse;
   EXPECT_IS_OK(
@@ -463,8 +463,8 @@ ENTRY entry {
     ROOT tuple.2 = (f32[16,256,256]{2,1,0}, f32[16,256,256]{2,1,0}, f32[128,2048,2048]{2,1,0}, f32[128,2048,2048]{2,1,0}) tuple(c0, c1, get-tuple-element.1, get-tuple-element.2)
   }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   EXPECT_IS_OK(
       LegalizeSchedulingAnnotations(config).Run(hlo_module.get()).status());
@@ -480,8 +480,8 @@ ENTRY entry {
   ROOT a0 = f32[16]{0} add(p0, p1), frontend_attributes={_scheduling_group_id="noop"}
 }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   EXPECT_IS_OK(
       LegalizeSchedulingAnnotations(config).Run(hlo_module.get()).status());
@@ -510,8 +510,8 @@ TEST_F(LegalizeSchedulingAnnotationsTest, ProgagateAnnotationToGap) {
     ROOT tuple = (f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(c0, agd0)
   }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.propagate_annotation = true;
   EXPECT_THAT(LegalizeSchedulingAnnotations(config).Run(hlo_module.get()),
@@ -541,8 +541,8 @@ TEST_F(SchedulingAnnotationPropagationTest, NothingToPropagate) {
     ROOT tuple = (f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(c0, agd0)
   }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.propagate_annotation = true;
   EXPECT_THAT(LegalizeSchedulingAnnotations(config).Run(hlo_module.get()),
@@ -565,8 +565,8 @@ TEST_F(SchedulingAnnotationPropagationTest, NoDataDependentGap) {
     ROOT tuple = (f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(c0, agd0)
   }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.propagate_annotation = true;
   EXPECT_THAT(LegalizeSchedulingAnnotations(config).Run(hlo_module.get()),
@@ -589,8 +589,8 @@ TEST_F(SchedulingAnnotationPropagationTest, GapDueToControlDependency) {
     ROOT tuple = (f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(c0, agd0)
   }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.propagate_annotation = true;
   EXPECT_THAT(LegalizeSchedulingAnnotations(config).Run(hlo_module.get()),
@@ -630,8 +630,8 @@ TEST_F(SchedulingAnnotationPropagationTest, GapDueToControlDependency2) {
     ROOT tuple = (f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(c0, agd0)
   }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.propagate_annotation = true;
   EXPECT_THAT(LegalizeSchedulingAnnotations(config).Run(hlo_module.get()),
@@ -674,8 +674,8 @@ TEST_F(SchedulingAnnotationPropagationTest, TwoGroups) {
     ROOT tuple = (f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}, f32[1024,1024]{1,0}) tuple(c0, agd0, ag)
   }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.propagate_annotation = true;
   EXPECT_THAT(LegalizeSchedulingAnnotations(config).Run(hlo_module.get()),
@@ -725,8 +725,8 @@ TEST_F(SchedulingAnnotationPropagationTest, CrossComputationAnnotation) {
     ROOT tuple1 = (f32[16,64,256]{2,1,0}, f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}) tuple(gte, c0, agd0)
   }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.propagate_annotation = true;
   EXPECT_THAT(LegalizeSchedulingAnnotations(config).Run(hlo_module.get()),
@@ -757,8 +757,8 @@ TEST_F(SchedulingAnnotationPropagationTest, ConflictingAnnotationGroups) {
     ROOT tuple = (f32[16,256,256]{2,1,0}, f32[1024,1024]{1,0}, f32[1024,1024]{1,0}) tuple(c0, agd0, ag)
   }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.propagate_annotation = true;
   auto result = LegalizeSchedulingAnnotations(config).Run(hlo_module.get());
@@ -787,8 +787,8 @@ ENTRY entry {
   ROOT tuple = (f32[16]{0}, f32[16]{0}, f32[16]{0}, f32[16]{0}) tuple(a3, a4, ag1, ag2)
 }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.propagate_annotation = true;
   auto result = LegalizeSchedulingAnnotations(config).Run(hlo_module.get());
@@ -872,8 +872,8 @@ ENTRY %entry (p0: bf16[5,8,128], p1: bf16[5,1,2,128]) -> bf16[5,8,128] {
   %add.5 = bf16[1,2,128]{2,1,0} add(%dynamic_slice_reshape.4, %dynamic_slice_reshape.4), control-predecessors={%c3.4}
 }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.remove_loop_iteration_annotation_only = true;
   EXPECT_IS_OK(
@@ -902,8 +902,8 @@ ENTRY entry {
   ROOT tuple = (f32[16]{0}, f32[16]{0}) tuple(a3, a4)
 }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.run_verification = true;
   config.keep_sync_annotation = HloPredicateFalse;
@@ -927,8 +927,8 @@ ENTRY entry {
   ROOT tuple = (f32[16]{0}, f32[16]{0}) tuple(a3, a4)
 }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.run_verification = true;
 
@@ -974,8 +974,8 @@ ENTRY entry {
   %sparse-core-data-format-call.47.cloned.1.call-done = bf16[2048,1,7168]{2,0,1:T(16,128)(2,1)} async-done(%sparse-core-data-format-call.47.cloned.1.call-start), frontend_attributes={_scheduling_group_id="47"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.keep_sync_annotation = HloPredicateFalse;
   EXPECT_IS_OK(
@@ -987,13 +987,15 @@ ENTRY entry {
   EXPECT_FALSE(annotation);
 }
 
-TEST_F(SchedulingAnnotationPropagationTest, ContainsFormattingOpsAndOthers) {
+TEST_F(SchedulingAnnotationPropagationTest,
+       ContainsFormattingOpsAndNestedOthers) {
   absl::string_view hlo_string = R"(
 HloModule module, is_scheduled=true
 
 %called_computation.441 (param_0.14479: bf16[2048,1,7168]) -> bf16[2048,1,7168] {
   %param_0.14479 = bf16[2048,1,7168]{0,2,1:T(8,128)(2,1)} parameter(0)
-  ROOT %copy.6583 = bf16[2048,1,7168]{2,0,1:T(16,128)(2,1)} copy(%param_0.14479), frontend_attributes={_scheduling_group_id="47"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
+  %add = bf16[2048,1,7168]{2,0,1:T(16,128)(2,1)} add(%param_0.14479, %param_0.14479)
+  ROOT %copy.6583 = bf16[2048,1,7168]{2,0,1:T(16,128)(2,1)} copy(%add), frontend_attributes={_scheduling_group_id="47"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"compute_type":"COMPUTE_TYPE_TILE","used_scoped_memory_configs":[]}
 }, execution_thread="sparsecore"
 
 %async_computation.510 (param_0.14480: bf16[2048,1,7168]) -> bf16[2048,1,7168] {
@@ -1003,8 +1005,7 @@ HloModule module, is_scheduled=true
 
 %called_computation.47 (param_0.13516: bf16[2048,1,7168]) -> bf16[2048,1,7168] {
   %param_0.13516 = bf16[2048,1,7168]{0,2,1:T(8,128)(2,1)} parameter(0)
-  %add = bf16[2048,1,7168]{2,0,1:T(16,128)(2,1)} add(%param_0.13516, %param_0.13516)
-  %copy.6584.cloned.1.call-start = ((bf16[2048,1,7168]{0,2,1:T(8,128)(2,1)}), bf16[2048,1,7168]{2,0,1:T(16,128)(2,1)}, u32[]{:S(8)}) async-start(%add), async_execution_thread="sparsecore", calls=%async_computation.510
+  %copy.6584.cloned.1.call-start = ((bf16[2048,1,7168]{0,2,1:T(8,128)(2,1)}), bf16[2048,1,7168]{2,0,1:T(16,128)(2,1)}, u32[]{:S(8)}) async-start(%param_0.13516), async_execution_thread="sparsecore", calls=%async_computation.510
   ROOT %copy.6584.cloned.1.call-done = bf16[2048,1,7168]{2,0,1:T(16,128)(2,1)} async-done(%copy.6584.cloned.1.call-start)
 }, execution_thread="sparsecore"
 
@@ -1020,8 +1021,8 @@ ENTRY entry {
   %sparse-core-data-format-call.47.cloned.1.call-done = bf16[2048,1,7168]{2,0,1:T(16,128)(2,1)} async-done(%sparse-core-data-format-call.47.cloned.1.call-start), frontend_attributes={_scheduling_group_id="47"}, backend_config={"flag_configs":[],"scoped_memory_configs":[],"used_scoped_memory_configs":[]}
 }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.keep_sync_annotation = HloPredicateFalse;
   EXPECT_IS_OK(
@@ -1031,6 +1032,43 @@ ENTRY entry {
       hlo_module.get(), "sparse-core-data-format-call.47.cloned.1.call-start");
   auto annotation = GetSchedulingAnnotation(async_start).value();
   EXPECT_TRUE(annotation);
+}
+
+TEST_F(SchedulingAnnotationPropagationTest,
+       KeepsAnnotationOnTupleRootedCollectivesGroup) {
+  absl::string_view hlo_string = R"(
+HloModule module
+
+comms {
+  p0 = f32[1] parameter(0)
+  ag = f32[1] all-gather(p0), dimensions={0}
+  cp = f32[1] collective-permute(p0), source_target_pairs={{0,1}}
+  ROOT result = (f32[1], f32[1]) tuple(ag, cp)
+}
+
+ENTRY entry {
+  p0 = f32[1] parameter(0)
+  group-start = ((f32[1]), (f32[1], f32[1])) async-start(p0),
+    calls=comms,
+    frontend_attributes={_collectives_group="",_scheduling_group_id="1"}
+  ROOT group-done = (f32[1], f32[1]) async-done(group-start),
+    frontend_attributes={_collectives_group="",_scheduling_group_id="1"}
+}
+)";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
+  LegalizeSchedulingAnnotations::Config config;
+  config.keep_sync_annotation = HloPredicateFalse;
+  EXPECT_IS_OK(
+      LegalizeSchedulingAnnotations(config).Run(hlo_module.get()).status());
+
+  for (absl::string_view name : {"group-start", "group-done"}) {
+    ASSERT_OK_AND_ASSIGN(
+        std::optional<Annotation> annotation,
+        GetSchedulingAnnotation(FindInstruction(hlo_module.get(), name)));
+    ASSERT_TRUE(annotation.has_value());
+    EXPECT_EQ(annotation->group_id, 1);
+  }
 }
 
 TEST_F(SchedulingAnnotationPropagationTest, FillSimpleGaps) {
@@ -1045,8 +1083,8 @@ ENTRY entry {
   ROOT a1 = f32[32]{0} all-gather(c1), replica_groups={{0,1},{2,3}}, dimensions={0}, frontend_attributes={_scheduling_group_id="1"}
 }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.keep_sync_annotation = [](const HloInstruction* instr) {
     return instr->opcode() == HloOpcode::kAllGather;
@@ -1072,8 +1110,8 @@ ENTRY %main.1 {
   ROOT %custom-call.3 = f32[8,128]{1,0} custom-call(%add.1), custom_call_target="tpu_custom_call", frontend_attributes={_scheduling_group_id="0"}
 }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   LegalizeSchedulingAnnotations::Config config;
   config.keep_sync_annotation = [](const HloInstruction* instr) {
     return instr->opcode() == HloOpcode::kCustomCall;


### PR DESCRIPTION
Explicit collective groups are represented as generic `async-start`/`async-done` operations annotated with `_collectives_group` attribute, but the GPU backend did not consistently recognize them as collective operations. 

####  This change:

  - Recognizes explicit collective-group start/done operations as GPU async collectives.
  - Assigns them to the collective execution stream and accounts for each group as one collective resource.
  - Preserves opaque resource accounting through nested calls and while loops instead of recursively counting every collective in the group.
  - Collects replica groups from the grouped collectives so rank-overlap scheduling constraints remain enforced.
  - Conservatively serializes groups when replica-group information is implicit or unavailable.
  - Preserves `force_earliest_schedule` on the group start while clearing it on the done operation, allowing latency hiding.
  - Extends scheduling-annotation legalization to look through nested async call-like wrappers.


This makes collective group call a proper first class collective-operation-citizen in XLA GPU runtime.

(while I'm here migrate touched tests away from `TF_ASSERT_OK_AND_ASSIGN`)