### PR TITLE
[XLA:GPU] Don't sibling-fuse a column reduction with an element-wise root

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -2145,6 +2145,8 @@ cc_library(
         "//xla/service:instruction_fusion",
         "//xla/service/gpu:alias_info",
         "//xla/service/gpu:gpu_fusible",
+        "//xla/service/gpu:ir_emission_utils",
+        "//xla/service/gpu:reduction_utils",
         "//xla/service/gpu/model:fusion_analysis_cache",
         "//xla/service/gpu/model:gpu_hlo_cost_analysis",
         "//xla/service/gpu/model:gpu_performance_model",

--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -2360,6 +2360,8 @@ cc_library(
         "//xla/service:instruction_fusion",
         "//xla/service/gpu:alias_info",
         "//xla/service/gpu:gpu_fusible",
+        "//xla/service/gpu:ir_emission_utils",
+        "//xla/service/gpu:reduction_utils",
         "//xla/service/gpu/model:fusion_analysis_cache",
         "//xla/service/gpu/model:gpu_hlo_cost_analysis",
         "//xla/service/gpu/model:gpu_performance_model",

--- a/xla/backends/gpu/transforms/multi_output_fusion.cc
+++ b/xla/backends/gpu/transforms/multi_output_fusion.cc
@@ -38,10 +38,12 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/service/gpu/alias_info.h"
 #include "xla/service/gpu/gpu_fusible.h"
+#include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/model/fusion_analysis_cache.h"
 #include "xla/service/gpu/model/gpu_hlo_cost_analysis.h"
 #include "xla/service/gpu/model/gpu_performance_model.h"
 #include "xla/service/gpu/model/gpu_performance_model_base.h"
+#include "xla/service/gpu/reduction_utils.h"
 #include "xla/service/hlo_graph_dumper.h"
 #include "xla/service/instruction_fusion.h"
 #include "xla/shape_util.h"
@@ -306,6 +308,31 @@ FusionDecision CanFuseSiblings(const HloInstruction& sibling_consumer_1,
 
   RETURN_IF_NOT_FUSIBLE(ShapesCompatibleForMultiOutputFusion(
       sibling_consumer_1, sibling_consumer_2, device_info));
+
+  // Avoid sibling-fusing a column (non-row) reduction with a plain element-wise
+  // root. The column reduction reads the shared producer with a 2D-tiled
+  // pattern that conflicts with the element-wise root's row-major loop, so the
+  // shared input is read with mismatched patterns; this is generally a net
+  // slowdown. Note this only applies to siblings: for producer-consumer fusion
+  // the reduction consumes the element-wise output (fusion avoids materializing
+  // the intermediate), and that path is separately cost-gated.
+  {
+    const HloInstruction* hero1 =
+        GetRealHeroForMultiOutputFusion(sibling_consumer_1, device_info);
+    const HloInstruction* hero2 =
+        GetRealHeroForMultiOutputFusion(sibling_consumer_2, device_info);
+    auto is_plain_root = [&](const HloInstruction* hero) {
+      return !IsReductionFromOrToContiguousDimensions(*hero, device_info) &&
+             !GetDescriptionForTiledTransposeEmitter(*hero).has_value() &&
+             hero->opcode() != HloOpcode::kTranspose;
+    };
+    if ((IsColumnReductionHero(hero1, device_info) && is_plain_root(hero2)) ||
+        (IsColumnReductionHero(hero2, device_info) && is_plain_root(hero1))) {
+      return FusionDecision::Forbid(
+          "sibling multi-output fusion of a column reduction with an "
+          "element-wise root");
+    }
+  }
 
   // Technically, this check is order-dependent (e.g. siblings A, B, C where
   // {A, B} and {B, C} overlap, but {A, C} do not. If the priority order is

--- a/xla/backends/gpu/transforms/multi_output_fusion.cc
+++ b/xla/backends/gpu/transforms/multi_output_fusion.cc
@@ -39,10 +39,12 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/service/gpu/alias_info.h"
 #include "xla/service/gpu/gpu_fusible.h"
+#include "xla/service/gpu/ir_emission_utils.h"
 #include "xla/service/gpu/model/fusion_analysis_cache.h"
 #include "xla/service/gpu/model/gpu_hlo_cost_analysis.h"
 #include "xla/service/gpu/model/gpu_performance_model.h"
 #include "xla/service/gpu/model/gpu_performance_model_base.h"
+#include "xla/service/gpu/reduction_utils.h"
 #include "xla/service/hlo_graph_dumper.h"
 #include "xla/service/instruction_fusion.h"
 #include "xla/shape_util.h"
@@ -319,6 +321,27 @@ FusionDecision CanFuseSiblings(const HloInstruction& sibling_consumer_1,
 
   RETURN_IF_NOT_FUSIBLE(ShapesCompatibleForMultiOutputFusion(
       sibling_consumer_1, sibling_consumer_2, device_info));
+
+  // Same read-pattern conflict as the nested transpose case in
+  // FusionHeroesAreCompatible: the column reduction's 2D-tiled read of the
+  // shared producer does not match the loop root's row-major one. Siblings
+  // only, as the producer-consumer path is cost-gated. This is a heuristic.
+  const HloInstruction* hero1 =
+      GetRealHeroForMultiOutputFusion(sibling_consumer_1, device_info);
+  const HloInstruction* hero2 =
+      GetRealHeroForMultiOutputFusion(sibling_consumer_2, device_info);
+  // Neither a reduction nor a transpose, i.e. emitted as a row-major loop.
+  auto is_loop_root = [&](const HloInstruction* hero) {
+    return !IsReductionFromOrToContiguousDimensions(*hero, device_info) &&
+           !GetDescriptionForTiledTransposeEmitter(*hero).has_value() &&
+           hero->opcode() != HloOpcode::kTranspose;
+  };
+  if ((IsColumnReductionHero(hero1, device_info) && is_loop_root(hero2)) ||
+      (IsColumnReductionHero(hero2, device_info) && is_loop_root(hero1))) {
+    return FusionDecision::Forbid(
+        "sibling multi-output fusion of a column reduction with an "
+        "element-wise root");
+  }
 
   // Technically, this check is order-dependent (e.g. siblings A, B, C where
   // {A, B} and {B, C} overlap, but {A, C} do not. If the priority order is

--- a/xla/backends/gpu/transforms/multi_output_fusion_test.cc
+++ b/xla/backends/gpu/transforms/multi_output_fusion_test.cc
@@ -118,6 +118,34 @@ TEST_F(MultiOutputFusionTest, MultiOutputFusionSiblingReduceAndReduceFusion) {
               GmockMatch(m::Tuple(m::Reduce(), m::Reduce())));
 }
 
+TEST_F(MultiOutputFusionTest,
+       NoSiblingFusionOfColumnReductionAndElementwise) {
+  // A column (non-row) reduction and a plain element-wise root that share an
+  // input must not be sibling-fused: their read patterns conflict, making the
+  // combined kernel slower than the two separate kernels. Reducing the major
+  // dimension of [6272,768] and keeping the minor one is a column reduction.
+  auto module = ParseAndReturnVerifiedModule(absl::StrCat(kModulePrefix, R"(
+    fused_reduce {
+      p0.1 = f32[6272,768]{1,0} parameter(0)
+      const.1 = f32[] constant(0)
+      ROOT reduce = f32[768]{0} reduce(p0.1, const.1), dimensions={0}, to_apply=scalar_add_computation
+    }
+
+    fused_elementwise {
+      p0.2 = f32[6272,768]{1,0} parameter(0)
+      ROOT sqrt = f32[6272,768]{1,0} sqrt(p0.2)
+    }
+
+    ENTRY entry {
+      p0 = f32[6272,768]{1,0} parameter(0)
+      reduce_fusion = f32[768]{0} fusion(p0), kind=kInput, calls=fused_reduce
+      elementwise_fusion = f32[6272,768]{1,0} fusion(p0), kind=kLoop, calls=fused_elementwise
+      ROOT root = (f32[768]{0}, f32[6272,768]{1,0}) tuple(reduce_fusion, elementwise_fusion)
+    })"))
+                    .value();
+  ASSERT_FALSE(mof_.Run(module.get()).value());
+}
+
 TEST_F(MultiOutputFusionTest, MultiOutputFusionDifferentReduceInputShapes) {
   auto module = ParseAndReturnVerifiedModule(absl::StrCat(kModulePrefix, R"(
     fused_computation_1 {

--- a/xla/backends/gpu/transforms/multi_output_fusion_test.cc
+++ b/xla/backends/gpu/transforms/multi_output_fusion_test.cc
@@ -118,6 +118,31 @@ TEST_F(MultiOutputFusionTest, MultiOutputFusionSiblingReduceAndReduceFusion) {
               GmockMatch(m::Tuple(m::Reduce(), m::Reduce())));
 }
 
+TEST_F(MultiOutputFusionTest, NoSiblingFusionOfColumnReductionAndElementwise) {
+  // Reducing the major dimension of [6272,768] and keeping the minor one is a
+  // column reduction.
+  auto module = ParseAndReturnVerifiedModule(absl::StrCat(kModulePrefix, R"(
+    fused_reduce {
+      p0.1 = f32[6272,768]{1,0} parameter(0)
+      const.1 = f32[] constant(0)
+      ROOT reduce = f32[768]{0} reduce(p0.1, const.1), dimensions={0}, to_apply=scalar_add_computation
+    }
+
+    fused_elementwise {
+      p0.2 = f32[6272,768]{1,0} parameter(0)
+      ROOT sqrt = f32[6272,768]{1,0} sqrt(p0.2)
+    }
+
+    ENTRY entry {
+      p0 = f32[6272,768]{1,0} parameter(0)
+      reduce_fusion = f32[768]{0} fusion(p0), kind=kInput, calls=fused_reduce
+      elementwise_fusion = f32[6272,768]{1,0} fusion(p0), kind=kLoop, calls=fused_elementwise
+      ROOT root = (f32[768]{0}, f32[6272,768]{1,0}) tuple(reduce_fusion, elementwise_fusion)
+    })"))
+                    .value();
+  ASSERT_FALSE(mof_.Run(module.get()).value());
+}
+
 TEST_F(MultiOutputFusionTest, MultiOutputFusionDifferentReduceInputShapes) {
   auto module = ParseAndReturnVerifiedModule(absl::StrCat(kModulePrefix, R"(
     fused_computation_1 {

--- a/xla/service/gpu/gpu_fusible.cc
+++ b/xla/service/gpu/gpu_fusible.cc
@@ -349,6 +349,19 @@ const HloInstruction* GetRealHeroForMultiOutputFusion(
   return fused_expression_root->operands()[0];
 }
 
+// Returns true if `hero` is a column (i.e. non-row) reduction. Column
+// reductions use a 2D-tiled read pattern that differs from the row-major
+// element-wise loop pattern; multi-output fusing them with a plain element-wise
+// root forces the shared input to be read with conflicting patterns, which is
+// usually a net slowdown.
+bool IsColumnReductionHero(const HloInstruction* hero,
+                           const se::DeviceDescription& device_info) {
+  if (!IsReductionFromOrToContiguousDimensions(*hero, device_info)) {
+    return false;
+  }
+  return !GetReductionKindAndContiguousComponents(*hero).is_row_reduction;
+}
+
 FusionDecision FusionHeroesAreCompatible(
     const HloInstruction* hero1, const HloInstruction* hero2,
     const se::DeviceDescription& device_info) {

--- a/xla/service/gpu/gpu_fusible.cc
+++ b/xla/service/gpu/gpu_fusible.cc
@@ -349,6 +349,14 @@ const HloInstruction* GetRealHeroForMultiOutputFusion(
   return fused_expression_root->operands()[0];
 }
 
+bool IsColumnReductionHero(const HloInstruction* hero,
+                           const se::DeviceDescription& device_info) {
+  if (!IsReductionFromOrToContiguousDimensions(*hero, device_info)) {
+    return false;
+  }
+  return !GetReductionKindAndContiguousComponents(*hero).is_row_reduction;
+}
+
 FusionDecision FusionHeroesAreCompatible(
     const HloInstruction* hero1, const HloInstruction* hero2,
     const se::DeviceDescription& device_info) {

--- a/xla/service/gpu/gpu_fusible.h
+++ b/xla/service/gpu/gpu_fusible.h
@@ -160,6 +160,12 @@ FusionDecision FusionHeroesAreCompatible(
     const HloInstruction* hero1, const HloInstruction* hero2,
     const se::DeviceDescription& device_info);
 
+// Whether `hero` is a column (i.e. non-row) reduction. Column reductions use a
+// 2D-tiled read pattern that differs from the row-major element-wise loop
+// pattern.
+bool IsColumnReductionHero(const HloInstruction* hero,
+                           const se::DeviceDescription& device_info);
+
 // Whether instruction shapes are compatible for multi-output fusion, i.e.
 // whether the emitters support lowering the resulting fusion.
 // This function works for both, sibling and producer-consumer multi-output

--- a/xla/service/gpu/gpu_fusible.h
+++ b/xla/service/gpu/gpu_fusible.h
@@ -166,6 +166,10 @@ FusionDecision FusionHeroesAreCompatible(
     const HloInstruction* hero1, const HloInstruction* hero2,
     const se::DeviceDescription& device_info);
 
+// Whether `hero` is a column (i.e. non-row) reduction.
+bool IsColumnReductionHero(const HloInstruction* hero,
+                           const se::DeviceDescription& device_info);
+
 // Whether instruction shapes are compatible for multi-output fusion, i.e.
 // whether the emitters support lowering the resulting fusion.
 // This function works for both, sibling and producer-consumer multi-output


### PR DESCRIPTION
📝 Summary of Changes
Add a guard in MultiOutputFusion::CanFuseSiblings that forbids sibling multi-output fusion of a column (non-row) reduction with a plain element-wise root. New exported helper IsColumnReductionHero in gpu_fusible.

🎯 Justification
The sibling MOF path gates on legality only, with no cost-model check, so it fuses a column reduction and an element-wise root that share an input despite their conflicting read patterns (2D-tiled vs row-major loop), yielding a kernel slower than the two separate ones. The guard is limited to sibling fusion, where this is unprofitable. Surfaced on ViT training after the DotMerger ShapeTracker refactor reshaped the graph around merged-dot consumers.

🚀 Kind of Contribution
🐛 Bug Fix, ⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
ViT training step, 1×MI350X (gfx950), 43.3 ms -> 38.9 ms (~10% faster)

🧪 Unit Tests:
MultiOutputFusionTest.NoSiblingFusionOfColumnReductionAndElementwise