### PR TITLE
Add CUPTI 13.3 multi-subscriber support with 13.2 fallback

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -739,6 +739,7 @@ cc_library(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/synchronization",
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cupti_headers",
         "@tsl//tsl/platform:errors",
         "@tsl//tsl/platform:platform_port",
         "@tsl//tsl/platform:thread_annotations",

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -269,6 +269,30 @@ cc_library(
     ],
 )
 
+xla_test(
+    name = "cupti_tracer_test",
+    size = "small",
+    srcs = ["cupti_tracer_test.cc"],
+    backends = ["gpu"],
+    tags = [
+        "cuda-only",
+        "no_mac",
+    ],
+    deps = [
+        ":cuda_test",
+        ":cupti_collector",
+        ":cupti_error_manager",
+        ":cupti_interface",
+        ":cupti_tracer",
+        ":cupti_wrapper",
+        ":mock_cupti",
+        "//xla/tsl/profiler/utils:time_utils",
+        "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_cuda//cuda:cupti_headers",
+    ],
+)
+
 cc_library(
     name = "cupti_tracer_options_utils",
     srcs = ["cupti_tracer_options_utils.cc"],

--- a/xla/backends/profiler/gpu/cupti_buffer_events.cc
+++ b/xla/backends/profiler/gpu/cupti_buffer_events.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "xla/backends/profiler/gpu/cupti_buffer_events.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -276,8 +277,8 @@ void AddMarkerActivityEvent(CuptiEventCollectorDelegate &collector,
   }
 }
 
-void AddMarkerDataActivityEvent(CuptiEventCollectorDelegate &collector,
-                                void *marker_data_trace) {
+void AddMarkerDataActivityEvent(CuptiEventCollectorDelegate& collector,
+                                void* marker_data_trace) {
   std::optional<std::pair<std::string, uint32_t>> result =
       ParseMarkerDataActivity(marker_data_trace);
   if (result.has_value() && !result.value().first.empty()) {
@@ -299,9 +300,9 @@ void AddMarkerDataActivityEvent(CuptiEventCollectorDelegate &collector,
   }
 }
 
-void AddEnvironmentActivityEvent(const CUpti_ActivityEnvironment *environment,
-                                 CuptiEventCollectorDelegate &collector) {
-  auto create_and_receive = [&](const char *name, uint64_t value) {
+void AddEnvironmentActivityEvent(const CUpti_ActivityEnvironment* environment,
+                                 CuptiEventCollectorDelegate& collector) {
+  auto create_and_receive = [&](const char* name, uint64_t value) {
     CuptiTracerEvent event{};
     event.type = CuptiTracerEventType::Environment;
     event.source = CuptiTracerEventSource::Activity;
@@ -586,15 +587,15 @@ static absl::Status ConvertActivityBuffer(
     const CuptiActivityBufferManager::ActivityBufferAndSize &buffer_and_size,
     const size_t max_activity_event_count, size_t &total_activity_event_count,
     size_t &dropped_activity_event_count, CuptiInterface *cupti_interface) {
+  uint8_t *buffer = buffer_and_size.buffer.get();
+  const size_t size = buffer_and_size.size;
   CUpti_Activity *record = nullptr;
   while (true) {
     CUptiResult status =
         cached_buffers.use_v2_records
             ? cupti_interface->ActivityGetNextRecordV2(
-                  cached_buffers.subscriber, buffer_and_size.buffer.get(),
-                  buffer_and_size.size, &record)
-            : cupti_interface->ActivityGetNextRecord(
-                  buffer_and_size.buffer.get(), buffer_and_size.size, &record);
+                  cached_buffers.subscriber, buffer, size, &record)
+            : cupti_interface->ActivityGetNextRecord(buffer, size, &record);
     if (status == CUPTI_SUCCESS) {
       if (total_activity_event_count >= max_activity_event_count) {
         dropped_activity_event_count++;
@@ -652,11 +653,11 @@ static absl::Status ConvertActivityBuffer(
               collector, reinterpret_cast<CuptiActivityMarkerTy *>(record));
           break;
         case CUPTI_ACTIVITY_KIND_MARKER_DATA:
-          AddMarkerDataActivityEvent(collector, static_cast<void *>(record));
+          AddMarkerDataActivityEvent(collector, static_cast<void*>(record));
           break;
         case CUPTI_ACTIVITY_KIND_ENVIRONMENT:
           AddEnvironmentActivityEvent(
-              reinterpret_cast<CUpti_ActivityEnvironment *>(record), collector);
+              reinterpret_cast<CUpti_ActivityEnvironment*>(record), collector);
           break;
         default:
           VLOG(3) << "Activity type " << record->kind << " is not supported.";
@@ -674,8 +675,7 @@ static absl::Status ConvertActivityBuffer(
                           "Parse cupti activity buffer error.");
     }
   }
-  VLOG(3) << "CUPTI tracer post-process one ACTIVITY buffer of size: "
-          << buffer_and_size.size
+  VLOG(3) << "CUPTI tracer post-process one ACTIVITY buffer of size: " << size
           << ", total events count:" << total_activity_event_count;
   return absl::OkStatus();
 }
@@ -755,7 +755,7 @@ absl::string_view AnnotationMap::Add(uint32_t device_id,
     VLOG(3) << "Add annotation: device_id: " << device_id
             << " correlation_id: " << correlation_id
             << " annotation: " << annotation;
-    auto &per_device_map = per_device_map_[device_id];
+    auto& per_device_map = per_device_map_[device_id];
     if (per_device_map.annotation_deduper.Size() < max_size_) {
       AnnotationInfo info;
       info.annotation = per_device_map.annotation_deduper.Dedup(annotation);

--- a/xla/backends/profiler/gpu/cupti_buffer_events.cc
+++ b/xla/backends/profiler/gpu/cupti_buffer_events.cc
@@ -276,8 +276,8 @@ void AddMarkerActivityEvent(CuptiEventCollectorDelegate &collector,
   }
 }
 
-void AddMarkerDataActivityEvent(CuptiEventCollectorDelegate& collector,
-                                void* marker_data_trace) {
+void AddMarkerDataActivityEvent(CuptiEventCollectorDelegate &collector,
+                                void *marker_data_trace) {
   std::optional<std::pair<std::string, uint32_t>> result =
       ParseMarkerDataActivity(marker_data_trace);
   if (result.has_value() && !result.value().first.empty()) {
@@ -299,9 +299,9 @@ void AddMarkerDataActivityEvent(CuptiEventCollectorDelegate& collector,
   }
 }
 
-void AddEnvironmentActivityEvent(const CUpti_ActivityEnvironment* environment,
-                                 CuptiEventCollectorDelegate& collector) {
-  auto create_and_receive = [&](const char* name, uint64_t value) {
+void AddEnvironmentActivityEvent(const CUpti_ActivityEnvironment *environment,
+                                 CuptiEventCollectorDelegate &collector) {
+  auto create_and_receive = [&](const char *name, uint64_t value) {
     CuptiTracerEvent event{};
     event.type = CuptiTracerEventType::Environment;
     event.source = CuptiTracerEventSource::Activity;
@@ -581,14 +581,20 @@ void AddSynchronizationActivityEvent(
 }
 
 static absl::Status ConvertActivityBuffer(
-    CuptiEventCollectorDelegate &collector, uint8_t *buffer, const size_t size,
+    CuptiEventCollectorDelegate &collector,
+    const CuptiActivityBufferManager::CachedActivityBufferBatch &cached_buffers,
+    const CuptiActivityBufferManager::ActivityBufferAndSize &buffer_and_size,
     const size_t max_activity_event_count, size_t &total_activity_event_count,
-    size_t &dropped_activity_event_count) {
-  CuptiInterface *cupti_interface = GetCuptiInterface();
+    size_t &dropped_activity_event_count, CuptiInterface *cupti_interface) {
   CUpti_Activity *record = nullptr;
   while (true) {
     CUptiResult status =
-        cupti_interface->ActivityGetNextRecord(buffer, size, &record);
+        cached_buffers.use_v2_records
+            ? cupti_interface->ActivityGetNextRecordV2(
+                  cached_buffers.subscriber, buffer_and_size.buffer.get(),
+                  buffer_and_size.size, &record)
+            : cupti_interface->ActivityGetNextRecord(
+                  buffer_and_size.buffer.get(), buffer_and_size.size, &record);
     if (status == CUPTI_SUCCESS) {
       if (total_activity_event_count >= max_activity_event_count) {
         dropped_activity_event_count++;
@@ -646,11 +652,11 @@ static absl::Status ConvertActivityBuffer(
               collector, reinterpret_cast<CuptiActivityMarkerTy *>(record));
           break;
         case CUPTI_ACTIVITY_KIND_MARKER_DATA:
-          AddMarkerDataActivityEvent(collector, static_cast<void*>(record));
+          AddMarkerDataActivityEvent(collector, static_cast<void *>(record));
           break;
         case CUPTI_ACTIVITY_KIND_ENVIRONMENT:
           AddEnvironmentActivityEvent(
-              reinterpret_cast<CUpti_ActivityEnvironment*>(record), collector);
+              reinterpret_cast<CUpti_ActivityEnvironment *>(record), collector);
           break;
         default:
           VLOG(3) << "Activity type " << record->kind << " is not supported.";
@@ -668,7 +674,8 @@ static absl::Status ConvertActivityBuffer(
                           "Parse cupti activity buffer error.");
     }
   }
-  VLOG(3) << "CUPTI tracer post-process one ACTIVITY buffer of size: " << size
+  VLOG(3) << "CUPTI tracer post-process one ACTIVITY buffer of size: "
+          << buffer_and_size.size
           << ", total events count:" << total_activity_event_count;
   return absl::OkStatus();
 }
@@ -748,7 +755,7 @@ absl::string_view AnnotationMap::Add(uint32_t device_id,
     VLOG(3) << "Add annotation: device_id: " << device_id
             << " correlation_id: " << correlation_id
             << " annotation: " << annotation;
-    auto& per_device_map = per_device_map_[device_id];
+    auto &per_device_map = per_device_map_[device_id];
     if (per_device_map.annotation_deduper.Size() < max_size_) {
       AnnotationInfo info;
       info.annotation = per_device_map.annotation_deduper.Dedup(annotation);
@@ -780,18 +787,17 @@ CuptiActivityBufferManager::ActivityBufferAndSize::ActivityBufferAndSize(
 
 void AddActivityBufferListEventsTo(
     CuptiEventCollectorDelegate &collector,
-    std::list<CuptiActivityBufferManager::ActivityBufferAndSize> &buffer_list,
+    CuptiActivityBufferManager::CachedActivityBufferBatch &cached_buffers,
     size_t max_activity_event_count, size_t &dropped_activity_event_count) {
   dropped_activity_event_count = 0;
   size_t total_activity_event_count = 0;
-  while (!buffer_list.empty()) {
+  while (!cached_buffers.buffers.empty()) {
     CuptiActivityBufferManager::ActivityBufferAndSize buffer_and_size(
-        std::move(buffer_list.front()));
-    buffer_list.pop_front();
-    ConvertActivityBuffer(collector, buffer_and_size.buffer.get(),
-                          buffer_and_size.size, max_activity_event_count,
-                          total_activity_event_count,
-                          dropped_activity_event_count)
+        std::move(cached_buffers.buffers.front()));
+    cached_buffers.buffers.pop_front();
+    ConvertActivityBuffer(collector, cached_buffers, buffer_and_size,
+                          max_activity_event_count, total_activity_event_count,
+                          dropped_activity_event_count, GetCuptiInterface())
         .IgnoreError();
   }
 }

--- a/xla/backends/profiler/gpu/cupti_buffer_events.h
+++ b/xla/backends/profiler/gpu/cupti_buffer_events.h
@@ -396,7 +396,7 @@ class CuptiActivityBufferManager {
 };
 
 void AddActivityBufferListEventsTo(
-    CuptiEventCollectorDelegate& receiver,
+    CuptiEventCollectorDelegate& collector,
     CuptiActivityBufferManager::CachedActivityBufferBatch& cached_buffers,
     size_t max_activity_event_count, size_t& dropped_activity_event_count);
 

--- a/xla/backends/profiler/gpu/cupti_buffer_events.h
+++ b/xla/backends/profiler/gpu/cupti_buffer_events.h
@@ -32,6 +32,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
 #include "xla/tsl/profiler/utils/buffer_pool.h"
 #include "xla/tsl/profiler/utils/lock_free_queue.h"
 #include "tsl/platform/thread_annotations.h"
@@ -333,16 +334,34 @@ struct CuptiEventCollectorDelegate {
 // A tree of scope range ids which map child_id ==> parent_id
 typedef absl::flat_hash_map<int64_t, int64_t> ScopeRangeIdTree;
 
+// Manages the fixed size raw buffers that CUPTI fills with activity records.
+// A tracing session can have multiple buffers in flight. The manager allocates
+// or reuses empty buffers and holds completed buffers until they are parsed.
 class CuptiActivityBufferManager {
  public:
+  // Owns one raw CUPTI buffer and records how many bytes contain valid activity
+  // records. A buffer can contain multiple records.
   struct ActivityBufferAndSize {
     std::unique_ptr<uint8_t, std::function<void(uint8_t*)>> buffer;
     size_t size;  // size in bytes for the events filled by CUPTI.
     explicit ActivityBufferAndSize(uint8_t* p = nullptr, size_t sz = 0);
   };
 
-  explicit CuptiActivityBufferManager(size_t buffer_size_in_bytes)
-      : buffer_pool_(buffer_size_in_bytes) {}
+  // A batch detached from the manager for periodic flushing or final trace
+  // shutdown. All buffers in a batch come from the same tracing session, so
+  // they share one subscriber and one activity record API version.
+  struct CachedActivityBufferBatch {
+    std::list<ActivityBufferAndSize> buffers;
+    CUpti_SubscriberHandle subscriber = nullptr;
+    bool use_v2_records = false;
+  };
+
+  explicit CuptiActivityBufferManager(
+      size_t buffer_size_in_bytes, CUpti_SubscriberHandle subscriber = nullptr,
+      bool use_v2_records = false)
+      : buffer_pool_(buffer_size_in_bytes),
+        subscriber_(subscriber),
+        use_v2_records_(use_v2_records) {}
 
   size_t GetBufferSizeInBytes() { return buffer_pool_.GetBufferSizeInBytes(); }
 
@@ -355,22 +374,30 @@ class CuptiActivityBufferManager {
     cached_buffers_.emplace_back(p, sz);
   }
 
-  std::list<ActivityBufferAndSize> PopCachedBuffers() {
-    std::list<ActivityBufferAndSize> result;
+  // Atomically removes and returns all currently cached buffers. The manager is
+  // left empty and can collect more buffers. This is used for periodic flushing
+  // and final trace shutdown.
+  CachedActivityBufferBatch PopCachedBuffers() {
+    CachedActivityBufferBatch result;
+    result.subscriber = subscriber_;
+    result.use_v2_records = use_v2_records_;
     absl::MutexLock lock(buffer_mutex_);
-    std::swap(result, cached_buffers_);
+    std::swap(result.buffers, cached_buffers_);
     return result;
   }
 
  private:
   tsl::profiler::BufferPool buffer_pool_;
+  // Fixed for the tracing session represented by this manager.
+  CUpti_SubscriberHandle subscriber_;
+  bool use_v2_records_;
   absl::Mutex buffer_mutex_;
   std::list<ActivityBufferAndSize> cached_buffers_ TF_GUARDED_BY(buffer_mutex_);
 };
 
 void AddActivityBufferListEventsTo(
     CuptiEventCollectorDelegate& receiver,
-    std::list<CuptiActivityBufferManager::ActivityBufferAndSize>& buffer_list,
+    CuptiActivityBufferManager::CachedActivityBufferBatch& cached_buffers,
     size_t max_activity_event_count, size_t& dropped_activity_event_count);
 
 class CallbackAnnotationsAndEvents {

--- a/xla/backends/profiler/gpu/cupti_collector.cc
+++ b/xla/backends/profiler/gpu/cupti_collector.cc
@@ -860,8 +860,7 @@ void CuptiTraceCollector::OnTracerCollectedCallbackData(
 }
 
 void CuptiTraceCollector::OnTracerCachedActivityBuffers(
-    std::list<CuptiActivityBufferManager::ActivityBufferAndSize>
-        activity_buffers) {
+    CuptiActivityBufferManager::CachedActivityBufferBatch activity_buffers) {
   size_t dropped_activity_event_count = 0;
   CuptiEventCollectorDelegate collector(
       *annotation_map(),

--- a/xla/backends/profiler/gpu/cupti_collector.h
+++ b/xla/backends/profiler/gpu/cupti_collector.h
@@ -108,8 +108,7 @@ class CuptiTraceCollector {
   // Default behavior is direct process those cached activity events and
   // add it into this class by calling AddEvent().
   virtual void OnTracerCachedActivityBuffers(
-      std::list<CuptiActivityBufferManager::ActivityBufferAndSize>
-          activity_buffers);
+      CuptiActivityBufferManager::CachedActivityBufferBatch activity_buffers);
 
   // Consumer side functions (i.e. called by GPU tracer);
   virtual bool Export(tensorflow::profiler::XSpace* space,

--- a/xla/backends/profiler/gpu/cupti_error_manager.cc
+++ b/xla/backends/profiler/gpu/cupti_error_manager.cc
@@ -109,6 +109,20 @@ CUptiResult CuptiErrorManager::ActivityGetNextRecord(
   return error;
 }
 
+CUptiResult CuptiErrorManager::ActivityGetNextRecordV2(
+    CUpti_SubscriberHandle subscriber, uint8_t* buffer,
+    size_t valid_buffer_size_bytes, CUpti_Activity** record) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult error = interface_->ActivityGetNextRecordV2(
+      subscriber, buffer, valid_buffer_size_bytes, record);
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_SUPPORTED);
+  ALLOW_ERROR(error, CUPTI_ERROR_UNKNOWN);
+  ALLOW_ERROR(error, CUPTI_ERROR_MAX_LIMIT_REACHED);
+  ALLOW_ERROR(error, CUPTI_ERROR_INVALID_KIND);
+  LOG_AND_DISABLE_IF_ERROR(error);
+  return error;
+}
+
 CUptiResult CuptiErrorManager::ActivityGetNumDroppedRecords(CUcontext context,
                                                             uint32_t stream_id,
                                                             size_t* dropped) {
@@ -192,6 +206,8 @@ CUptiResult CuptiErrorManager::ActivityUseSystemThreadIdV2(
     CUpti_SubscriberHandle subscriber) {
   IGNORE_CALL_IF_DISABLED;
   CUptiResult error = interface_->ActivityUseSystemThreadIdV2(subscriber);
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_SUPPORTED);
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_COMPATIBLE);
   LOG_AND_DISABLE_IF_ERROR(error);
   return error;
 }
@@ -199,6 +215,8 @@ CUptiResult CuptiErrorManager::ActivityUseSystemThreadIdV2(
 CUptiResult CuptiErrorManager::ActivityUsePerThreadBufferV2() {
   IGNORE_CALL_IF_DISABLED;
   CUptiResult error = interface_->ActivityUsePerThreadBufferV2();
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_SUPPORTED);
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_COMPATIBLE);
   LOG_AND_DISABLE_IF_ERROR(error);
   return error;
 }
@@ -229,6 +247,19 @@ CUptiResult CuptiErrorManager::GetDeviceId(CUcontext context,
 CUptiResult CuptiErrorManager::GetTimestamp(uint64_t* timestamp) {
   IGNORE_CALL_IF_DISABLED;
   CUptiResult error = interface_->GetTimestamp(timestamp);
+  LOG_AND_DISABLE_IF_ERROR(error);
+  return error;
+}
+
+CUptiResult CuptiErrorManager::GetTimestampV2(CUpti_SubscriberHandle subscriber,
+                                              uint64_t* timestamp) {
+  IGNORE_CALL_IF_DISABLED;
+  CUptiResult error = interface_->GetTimestampV2(subscriber, timestamp);
+  // Treat unavailable V2 support as nonfatal so the caller can clean up the V2
+  // subscriber and fall back to the V1 subscriber API.
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_SUPPORTED);
+  ALLOW_ERROR(error, CUPTI_ERROR_NOT_COMPATIBLE);
+  ALLOW_ERROR(error, CUPTI_ERROR_UNKNOWN);
   LOG_AND_DISABLE_IF_ERROR(error);
   return error;
 }
@@ -304,6 +335,7 @@ CUptiResult CuptiErrorManager::SubscribeV2(CUpti_SubscriberHandle* subscriber,
     auto f = std::bind(&CuptiErrorManager::Unsubscribe, this, *subscriber);
     RegisterUndoFunction(f);
   }
+  // Optional V2 subscriber path unavailable; callers can fall back to V1.
   ALLOW_ERROR(error, CUPTI_ERROR_NOT_SUPPORTED);
   ALLOW_ERROR(error, CUPTI_ERROR_UNKNOWN);
   LOG_AND_DISABLE_IF_ERROR(error);

--- a/xla/backends/profiler/gpu/cupti_error_manager.cc
+++ b/xla/backends/profiler/gpu/cupti_error_manager.cc
@@ -255,10 +255,12 @@ CUptiResult CuptiErrorManager::GetTimestampV2(CUpti_SubscriberHandle subscriber,
                                               uint64_t* timestamp) {
   IGNORE_CALL_IF_DISABLED;
   CUptiResult error = interface_->GetTimestampV2(subscriber, timestamp);
-  // Treat unavailable V2 support as nonfatal so the caller can clean up the V2
-  // subscriber and fall back to the V1 subscriber API.
+  // Treat recoverable V2 timestamp failures as nonfatal so the caller can
+  // clean up the V2 subscriber and fall back to the V1 subscriber API.
+  // NOT_SUPPORTED means subscriber-scoped timestamps are unavailable.
+  // UNKNOWN preserves fallback for an unclassified failure in the optional V2
+  // path.
   ALLOW_ERROR(error, CUPTI_ERROR_NOT_SUPPORTED);
-  ALLOW_ERROR(error, CUPTI_ERROR_NOT_COMPATIBLE);
   ALLOW_ERROR(error, CUPTI_ERROR_UNKNOWN);
   LOG_AND_DISABLE_IF_ERROR(error);
   return error;

--- a/xla/backends/profiler/gpu/cupti_error_manager.h
+++ b/xla/backends/profiler/gpu/cupti_error_manager.h
@@ -61,6 +61,11 @@ class CuptiErrorManager : public xla::profiler::CuptiInterface {
                                     size_t valid_buffer_size_bytes,
                                     CUpti_Activity** record) override;
 
+  CUptiResult ActivityGetNextRecordV2(CUpti_SubscriberHandle subscriber,
+                                      uint8_t* buffer,
+                                      size_t valid_buffer_size_bytes,
+                                      CUpti_Activity** record) override;
+
   // Reports the number of dropped activity records.
   CUptiResult ActivityGetNumDroppedRecords(CUcontext context,
                                            uint32_t stream_id,
@@ -105,6 +110,9 @@ class CuptiErrorManager : public xla::profiler::CuptiInterface {
 
   // Returns CUPTI timestamp.
   CUptiResult GetTimestamp(uint64_t* timestamp) override;
+
+  CUptiResult GetTimestampV2(CUpti_SubscriberHandle subscriber,
+                             uint64_t* timestamp) override;
 
   // Explicitly destroys and cleans up all resources associated with CUPTI in
   // the current process.

--- a/xla/backends/profiler/gpu/cupti_error_manager_test.cc
+++ b/xla/backends/profiler/gpu/cupti_error_manager_test.cc
@@ -96,143 +96,6 @@ class CuptiErrorManagerTest : public ::testing::Test {
 
   bool CuptiDisabled() const { return cupti_error_manager_->Disabled(); }
 
-  CuptiTracerOptions KernelTraceOptions() {
-    CuptiTracerOptions options;
-    options.activities_selected = {CUPTI_ACTIVITY_KIND_KERNEL};
-    options.cbids_selected = {CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel};
-    return options;
-  }
-
-  void ExpectSuccessfulV1KernelTrace(CUpti_SubscriberHandle subscriber) {
-    const int resource_cb_count = IsCudaNewEnoughForGraphTraceTest() ? 5 : 0;
-    EXPECT_CALL(*mock_,
-                EnableCallback(1, subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
-        .Times(resource_cb_count)
-        .WillRepeatedly(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_,
-                EnableCallback(1, subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
-                               CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_, SetThreadIdType(CUPTI_ACTIVITY_THREAD_ID_TYPE_SYSTEM))
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_, ActivityUsePerThreadBuffer())
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_, ActivityRegisterCallbacks(_, _))
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_, ActivityEnable(CUPTI_ACTIVITY_KIND_KERNEL))
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_,
-                EnableCallback(0, subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
-        .Times(resource_cb_count)
-        .WillRepeatedly(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_,
-                EnableCallback(0, subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
-                               CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_, Unsubscribe(subscriber))
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_, ActivityDisable(CUPTI_ACTIVITY_KIND_KERNEL))
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_, ActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED))
-        .WillOnce(Return(CUPTI_SUCCESS));
-  }
-
-  void ExpectV2ResourceCallbacks(Sequence& sequence,
-                                 CUpti_SubscriberHandle subscriber,
-                                 uint32_t enable) {
-    const int count = IsCudaNewEnoughForGraphTraceTest() ? 5 : 0;
-    if (count == 0) {
-      return;
-    }
-    EXPECT_CALL(*mock_,
-                EnableCallback(enable, subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
-        .Times(count)
-        .InSequence(sequence)
-        .WillRepeatedly(Return(CUPTI_SUCCESS));
-  }
-
-  void ExpectV2KernelCallback(Sequence& sequence,
-                              CUpti_SubscriberHandle subscriber,
-                              uint32_t enable,
-                              CUptiResult result = CUPTI_SUCCESS) {
-    EXPECT_CALL(*mock_,
-                EnableCallback(enable, subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
-                               CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
-        .InSequence(sequence)
-        .WillOnce(Return(result));
-  }
-
-  void ExpectV2KernelSession(Sequence& sequence,
-                             CUpti_SubscriberHandle subscriber,
-                             uint64_t preflight_timestamp,
-                             uint64_t fallback_stop_timestamp,
-                             uint64_t stop_timestamp,
-                             CUptiResult stop_timestamp_status = CUPTI_SUCCESS,
-                             bool expect_preflight_timestamp = true) {
-    if (expect_preflight_timestamp) {
-      EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
-          .InSequence(sequence)
-          .WillOnce(SetTimestampAndReturnSuccess(preflight_timestamp));
-    }
-    ExpectV2ResourceCallbacks(sequence, subscriber, /*enable=*/1);
-    ExpectV2KernelCallback(sequence, subscriber, /*enable=*/1);
-    EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(subscriber))
-        .InSequence(sequence)
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
-        .InSequence(sequence)
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_, ActivityRegisterCallbacksV2(subscriber, _, _))
-        .InSequence(sequence)
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_,
-                ActivityEnableV2(subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
-        .InSequence(sequence)
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
-        .InSequence(sequence)
-        .WillOnce(SetTimestampAndReturnSuccess(fallback_stop_timestamp));
-    ExpectV2ResourceCallbacks(sequence, subscriber, /*enable=*/0);
-    ExpectV2KernelCallback(sequence, subscriber, /*enable=*/0);
-    EXPECT_CALL(*mock_,
-                ActivityDisableV2(subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
-        .InSequence(sequence)
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_, ActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED))
-        .InSequence(sequence)
-        .WillOnce(Return(CUPTI_SUCCESS));
-    if (stop_timestamp_status == CUPTI_SUCCESS) {
-      EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
-          .InSequence(sequence)
-          .WillOnce(SetTimestampAndReturnSuccess(stop_timestamp));
-    } else {
-      EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
-          .InSequence(sequence)
-          .WillOnce(Return(stop_timestamp_status));
-    }
-  }
-
-  void ExpectV2KernelSessionWithFatalStopTimestamp(
-      Sequence& sequence, CUpti_SubscriberHandle subscriber,
-      uint64_t preflight_timestamp, uint64_t fallback_stop_timestamp) {
-    ExpectV2KernelSession(sequence, subscriber, preflight_timestamp,
-                          fallback_stop_timestamp,
-                          /*stop_timestamp=*/0, CUPTI_ERROR_INVALID_PARAMETER);
-    EXPECT_CALL(*mock_, GetResultString(CUPTI_ERROR_INVALID_PARAMETER, _))
-        .InSequence(sequence)
-        .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::GetResultString));
-
-    EXPECT_CALL(*mock_,
-                ActivityDisableV2(subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
-        .InSequence(sequence)
-        .WillOnce(Return(CUPTI_SUCCESS));
-    ExpectV2KernelCallback(sequence, subscriber, /*enable=*/0);
-    ExpectV2ResourceCallbacks(sequence, subscriber, /*enable=*/0);
-    EXPECT_CALL(*mock_, Unsubscribe(subscriber))
-        .InSequence(sequence)
-        .WillOnce(Return(CUPTI_SUCCESS));
-  }
-
   void RunGpuApp() {
     MemCopyH2D();
     PrintfKernel(/*iters=*/10);
@@ -255,6 +118,14 @@ class CuptiErrorManagerTest : public ::testing::Test {
 
   std::unique_ptr<xla::profiler::CuptiTraceCollector> cupti_collector_;
 };
+
+class CuptiV2ActivityConfigurationErrorTest
+    : public CuptiErrorManagerTest,
+      public ::testing::WithParamInterface<CUptiResult> {};
+
+class CuptiV2ActivityRecordErrorTest
+    : public CuptiErrorManagerTest,
+      public ::testing::WithParamInterface<CUptiResult> {};
 
 // Verifies that failed EnableProfiling() does not kill an application.
 TEST_F(CuptiErrorManagerTest, GpuTraceActivityEnableTest) {
@@ -396,180 +267,41 @@ TEST_F(CuptiErrorManagerTest, GpuTraceAutoEnableTest) {
   EXPECT_TRUE(CuptiDisabled());
 }
 
-TEST_F(CuptiErrorManagerTest, V2AvailabilityFailuresFallBackToV1) {
-  EXPECT_FALSE(CuptiDisabled());
-
-  // CuptiWrapper returns CUPTI_ERROR_NOT_SUPPORTED without calling
-  // cuptiSubscribe_v2 when either cuptiSubscribe_v2 or cuptiGetTimestamp_v2 is
-  // unavailable. CUPTI_ERROR_UNKNOWN from cuptiSubscribe_v2 is also safe to
-  // fall back from because no V2 subscriber was successfully created.
-  uintptr_t subscriber_id = 1;
-  for (CUptiResult result : {CUPTI_ERROR_NOT_SUPPORTED, CUPTI_ERROR_UNKNOWN}) {
-    auto* const v1_subscriber =
-        reinterpret_cast<CUpti_SubscriberHandle>(subscriber_id++);
-    EXPECT_CALL(*mock_, SubscribeV2(_, _, _)).WillOnce(Return(result));
-    EXPECT_CALL(*mock_, Subscribe(_, _, _))
-        .WillOnce(
-            DoAll(SetArgPointee<0>(v1_subscriber), Return(CUPTI_SUCCESS)));
-    ExpectSuccessfulV1KernelTrace(v1_subscriber);
-
-    CuptiTracerOptions options = KernelTraceOptions();
-    EnableProfiling(options);
-    DisableProfiling();
-  }
-
-  EXPECT_FALSE(CuptiDisabled());
-}
-
-TEST_F(CuptiErrorManagerTest, V2TimestampFailuresAfterSubscribeFallBackToV1) {
-  EXPECT_FALSE(CuptiDisabled());
-
-  uintptr_t subscriber_id = 10;
-  for (CUptiResult result : {CUPTI_ERROR_NOT_SUPPORTED,
-                             CUPTI_ERROR_NOT_COMPATIBLE, CUPTI_ERROR_UNKNOWN}) {
-    auto* const v2_subscriber =
-        reinterpret_cast<CUpti_SubscriberHandle>(subscriber_id++);
-    auto* const v1_subscriber =
-        reinterpret_cast<CUpti_SubscriberHandle>(subscriber_id++);
-    Sequence fallback_sequence;
-    EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
-        .InSequence(fallback_sequence)
-        .WillOnce(
-            DoAll(SetArgPointee<0>(v2_subscriber), Return(CUPTI_SUCCESS)));
-    EXPECT_CALL(*mock_, GetTimestampV2(v2_subscriber, _))
-        .InSequence(fallback_sequence)
-        .WillOnce(Return(result));
-    EXPECT_CALL(*mock_, Unsubscribe(v2_subscriber))
-        .InSequence(fallback_sequence)
-        .WillOnce(Return(CUPTI_SUCCESS));
-    EXPECT_CALL(*mock_, Subscribe(_, _, _))
-        .InSequence(fallback_sequence)
-        .WillOnce(
-            DoAll(SetArgPointee<0>(v1_subscriber), Return(CUPTI_SUCCESS)));
-    ExpectSuccessfulV1KernelTrace(v1_subscriber);
-
-    CuptiTracerOptions options = KernelTraceOptions();
-    EnableProfiling(options);
-    DisableProfiling();
-  }
-
-  EXPECT_FALSE(CuptiDisabled());
-}
-
-TEST_F(CuptiErrorManagerTest,
-       FatalTimestampV2FailureDoesNotUnsubscribeFreshSubscriberTwice) {
-  EXPECT_FALSE(CuptiDisabled());
-
-  auto* const v2_subscriber =
-      reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
-  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
-      .WillOnce(DoAll(SetArgPointee<0>(v2_subscriber), Return(CUPTI_SUCCESS)));
-  EXPECT_CALL(*mock_, GetTimestampV2(v2_subscriber, _))
-      .WillOnce(Return(CUPTI_ERROR_INVALID_PARAMETER));
-  EXPECT_CALL(*mock_, GetResultString(CUPTI_ERROR_INVALID_PARAMETER, _))
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::GetResultString));
-  // The error-manager undo stack owns this newly created subscriber and must
-  // be the only code path that unsubscribes it.
-  EXPECT_CALL(*mock_, Unsubscribe(v2_subscriber))
-      .WillOnce(Return(CUPTI_SUCCESS));
-
-  CuptiTracerOptions options;
-  EnableProfiling(options);
-
-  EXPECT_TRUE(CuptiDisabled());
-}
-
-TEST_F(CuptiErrorManagerTest,
-       PreparesFreshV2SubscriberBeforeEachSessionTimestamp) {
-  EXPECT_FALSE(CuptiDisabled());
-
-  Sequence sequence;
-  CuptiTracerOptions options = KernelTraceOptions();
-
-  for (uintptr_t session = 1; session <= 2; ++session) {
-    auto* const subscriber = reinterpret_cast<CUpti_SubscriberHandle>(session);
-    EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
-        .InSequence(sequence)
-        .WillOnce(DoAll(SetArgPointee<0>(subscriber), Return(CUPTI_SUCCESS)));
-    EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
-        .InSequence(sequence)
-        .WillOnce(SetTimestampAndReturnSuccess(session * 10));
-
-    absl::Status prepare_status =
-        cupti_tracer_->PrepareForProfilerStart(options);
-    ASSERT_TRUE(prepare_status.ok()) << prepare_status;
-
-    EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
-        .InSequence(sequence)
-        .WillOnce(SetTimestampAndReturnSuccess(session * 10 + 1));
-    EXPECT_EQ(cupti_tracer_->GetTimestampForSubscriber(), session * 10 + 1);
-
-    ExpectV2KernelSession(sequence, subscriber, /*preflight_timestamp=*/0,
-                          /*fallback_stop_timestamp=*/session * 10 + 2,
-                          /*stop_timestamp=*/session * 10 + 3, CUPTI_SUCCESS,
-                          /*expect_preflight_timestamp=*/false);
-    EXPECT_CALL(*mock_, Unsubscribe(subscriber))
-        .InSequence(sequence)
-        .WillOnce(Return(CUPTI_SUCCESS));
-
-    EnableProfiling(options);
-    DisableProfiling();
-    EXPECT_EQ(cupti_collector_->GetTracingEndTimeNs(), session * 10 + 3);
-  }
-
-  EXPECT_FALSE(CuptiDisabled());
-}
-
-TEST_F(CuptiErrorManagerTest,
-       FatalStopTimestampDoesNotUnsubscribeFreshSubscriberTwice) {
-  Sequence s1;
-  auto* const subscriber =
-      reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
-  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
-      .InSequence(s1)
-      .WillOnce(DoAll(SetArgPointee<0>(subscriber), Return(CUPTI_SUCCESS)));
-  ExpectV2KernelSessionWithFatalStopTimestamp(s1, subscriber,
-                                              /*preflight_timestamp=*/1,
-                                              /*fallback_stop_timestamp=*/2);
-
-  CuptiTracerOptions options = KernelTraceOptions();
-  EnableProfiling(options);
-  DisableProfiling();
-  EXPECT_EQ(cupti_collector_->GetTracingEndTimeNs(), 2);
-  EXPECT_TRUE(CuptiDisabled());
-  // A stale handle would make this retry issue an unexpected second
-  // Unsubscribe call through the disabled error manager.
-  EnableProfiling(options);
-}
-
-TEST_F(CuptiErrorManagerTest,
-       V2CapabilityErrorsDoNotDisableCuptiOrUseV1Parser) {
+TEST_P(CuptiV2ActivityConfigurationErrorTest, DoesNotDisableCupti) {
+  const CUptiResult result = GetParam();
   auto* const v2_subscriber =
       reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
   EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(v2_subscriber))
-      .WillOnce(Return(CUPTI_ERROR_NOT_COMPATIBLE));
-  EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
-      .WillOnce(Return(CUPTI_ERROR_NOT_COMPATIBLE));
+      .WillOnce(Return(result));
+  EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2()).WillOnce(Return(result));
 
   EXPECT_EQ(cupti_error_manager_->ActivityUseSystemThreadIdV2(v2_subscriber),
-            CUPTI_ERROR_NOT_COMPATIBLE);
-  EXPECT_EQ(cupti_error_manager_->ActivityUsePerThreadBufferV2(),
-            CUPTI_ERROR_NOT_COMPATIBLE);
+            result);
+  EXPECT_EQ(cupti_error_manager_->ActivityUsePerThreadBufferV2(), result);
+  EXPECT_FALSE(CuptiDisabled());
+}
 
+INSTANTIATE_TEST_SUITE_P(NonfatalErrors, CuptiV2ActivityConfigurationErrorTest,
+                         ::testing::Values(CUPTI_ERROR_NOT_SUPPORTED,
+                                           CUPTI_ERROR_NOT_COMPATIBLE));
+
+TEST_P(CuptiV2ActivityRecordErrorTest, DoesNotDisableCuptiOrUseV1Parser) {
+  const CUptiResult result = GetParam();
   uint8_t buffer[1] = {};
   CUpti_Activity* record = nullptr;
   EXPECT_CALL(*mock_, ActivityGetNextRecord(_, _, _)).Times(0);
-
-  for (CUptiResult result : {CUPTI_ERROR_NOT_SUPPORTED, CUPTI_ERROR_UNKNOWN}) {
-    EXPECT_CALL(*mock_, ActivityGetNextRecordV2(_, buffer, sizeof(buffer), _))
-        .WillOnce(Return(result));
-    EXPECT_EQ(cupti_error_manager_->ActivityGetNextRecordV2(
-                  /*subscriber=*/nullptr, buffer, sizeof(buffer), &record),
-              result);
-    EXPECT_EQ(record, nullptr);
-  }
+  EXPECT_CALL(*mock_, ActivityGetNextRecordV2(_, buffer, sizeof(buffer), _))
+      .WillOnce(Return(result));
+  EXPECT_EQ(cupti_error_manager_->ActivityGetNextRecordV2(
+                /*subscriber=*/nullptr, buffer, sizeof(buffer), &record),
+            result);
+  EXPECT_EQ(record, nullptr);
   EXPECT_FALSE(CuptiDisabled());
 }
+
+INSTANTIATE_TEST_SUITE_P(NonfatalErrors, CuptiV2ActivityRecordErrorTest,
+                         ::testing::Values(CUPTI_ERROR_NOT_SUPPORTED,
+                                           CUPTI_ERROR_UNKNOWN));
 
 }  // namespace test
 }  // namespace profiler

--- a/xla/backends/profiler/gpu/cupti_error_manager_test.cc
+++ b/xla/backends/profiler/gpu/cupti_error_manager_test.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_driver_cbid.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
 #include "xla/backends/profiler/gpu/cuda_test.h"
@@ -43,10 +44,16 @@ using xla::profiler::CuptiTracerOptions;
 using xla::profiler::CuptiWrapper;
 
 using ::testing::_;
+using ::testing::DoAll;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::Sequence;
+using ::testing::SetArgPointee;
 using ::testing::StrictMock;
+
+auto SetTimestampAndReturnSuccess(uint64_t timestamp) {
+  return DoAll(SetArgPointee<1>(timestamp), Return(CUPTI_SUCCESS));
+}
 
 // Needed to create different cupti tracer for each test cases.
 class TestableCuptiTracer : public CuptiTracer {
@@ -89,6 +96,143 @@ class CuptiErrorManagerTest : public ::testing::Test {
 
   bool CuptiDisabled() const { return cupti_error_manager_->Disabled(); }
 
+  CuptiTracerOptions KernelTraceOptions() {
+    CuptiTracerOptions options;
+    options.activities_selected = {CUPTI_ACTIVITY_KIND_KERNEL};
+    options.cbids_selected = {CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel};
+    return options;
+  }
+
+  void ExpectSuccessfulV1KernelTrace(CUpti_SubscriberHandle subscriber) {
+    const int resource_cb_count = IsCudaNewEnoughForGraphTraceTest() ? 5 : 0;
+    EXPECT_CALL(*mock_,
+                EnableCallback(1, subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
+        .Times(resource_cb_count)
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_,
+                EnableCallback(1, subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
+                               CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, SetThreadIdType(CUPTI_ACTIVITY_THREAD_ID_TYPE_SYSTEM))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityUsePerThreadBuffer())
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityRegisterCallbacks(_, _))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityEnable(CUPTI_ACTIVITY_KIND_KERNEL))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_,
+                EnableCallback(0, subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
+        .Times(resource_cb_count)
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_,
+                EnableCallback(0, subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
+                               CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, Unsubscribe(subscriber))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityDisable(CUPTI_ACTIVITY_KIND_KERNEL))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED))
+        .WillOnce(Return(CUPTI_SUCCESS));
+  }
+
+  void ExpectV2ResourceCallbacks(Sequence& sequence,
+                                 CUpti_SubscriberHandle subscriber,
+                                 uint32_t enable) {
+    const int count = IsCudaNewEnoughForGraphTraceTest() ? 5 : 0;
+    if (count == 0) {
+      return;
+    }
+    EXPECT_CALL(*mock_,
+                EnableCallback(enable, subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
+        .Times(count)
+        .InSequence(sequence)
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
+  }
+
+  void ExpectV2KernelCallback(Sequence& sequence,
+                              CUpti_SubscriberHandle subscriber,
+                              uint32_t enable,
+                              CUptiResult result = CUPTI_SUCCESS) {
+    EXPECT_CALL(*mock_,
+                EnableCallback(enable, subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
+                               CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
+        .InSequence(sequence)
+        .WillOnce(Return(result));
+  }
+
+  void ExpectV2KernelSession(Sequence& sequence,
+                             CUpti_SubscriberHandle subscriber,
+                             uint64_t preflight_timestamp,
+                             uint64_t fallback_stop_timestamp,
+                             uint64_t stop_timestamp,
+                             CUptiResult stop_timestamp_status = CUPTI_SUCCESS,
+                             bool expect_preflight_timestamp = true) {
+    if (expect_preflight_timestamp) {
+      EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
+          .InSequence(sequence)
+          .WillOnce(SetTimestampAndReturnSuccess(preflight_timestamp));
+    }
+    ExpectV2ResourceCallbacks(sequence, subscriber, /*enable=*/1);
+    ExpectV2KernelCallback(sequence, subscriber, /*enable=*/1);
+    EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(subscriber))
+        .InSequence(sequence)
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
+        .InSequence(sequence)
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityRegisterCallbacksV2(subscriber, _, _))
+        .InSequence(sequence)
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_,
+                ActivityEnableV2(subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
+        .InSequence(sequence)
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
+        .InSequence(sequence)
+        .WillOnce(SetTimestampAndReturnSuccess(fallback_stop_timestamp));
+    ExpectV2ResourceCallbacks(sequence, subscriber, /*enable=*/0);
+    ExpectV2KernelCallback(sequence, subscriber, /*enable=*/0);
+    EXPECT_CALL(*mock_,
+                ActivityDisableV2(subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
+        .InSequence(sequence)
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED))
+        .InSequence(sequence)
+        .WillOnce(Return(CUPTI_SUCCESS));
+    if (stop_timestamp_status == CUPTI_SUCCESS) {
+      EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
+          .InSequence(sequence)
+          .WillOnce(SetTimestampAndReturnSuccess(stop_timestamp));
+    } else {
+      EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
+          .InSequence(sequence)
+          .WillOnce(Return(stop_timestamp_status));
+    }
+  }
+
+  void ExpectV2KernelSessionWithFatalStopTimestamp(
+      Sequence& sequence, CUpti_SubscriberHandle subscriber,
+      uint64_t preflight_timestamp, uint64_t fallback_stop_timestamp) {
+    ExpectV2KernelSession(sequence, subscriber, preflight_timestamp,
+                          fallback_stop_timestamp,
+                          /*stop_timestamp=*/0, CUPTI_ERROR_INVALID_PARAMETER);
+    EXPECT_CALL(*mock_, GetResultString(CUPTI_ERROR_INVALID_PARAMETER, _))
+        .InSequence(sequence)
+        .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::GetResultString));
+
+    EXPECT_CALL(*mock_,
+                ActivityDisableV2(subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
+        .InSequence(sequence)
+        .WillOnce(Return(CUPTI_SUCCESS));
+    ExpectV2KernelCallback(sequence, subscriber, /*enable=*/0);
+    ExpectV2ResourceCallbacks(sequence, subscriber, /*enable=*/0);
+    EXPECT_CALL(*mock_, Unsubscribe(subscriber))
+        .InSequence(sequence)
+        .WillOnce(Return(CUPTI_SUCCESS));
+  }
+
   void RunGpuApp() {
     MemCopyH2D();
     PrintfKernel(/*iters=*/10);
@@ -117,27 +261,31 @@ TEST_F(CuptiErrorManagerTest, GpuTraceActivityEnableTest) {
   // Enforces the order of execution below.
   Sequence s1;
   // CuptiBase::EnableProfiling()
-  EXPECT_CALL(*mock_, Subscribe(_, _, _))
+  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::Subscribe));
+      .WillOnce([](CUpti_SubscriberHandle* subscriber,
+                   CUpti_CallbackFunc /*callback*/, void* /*userdata*/) {
+        *subscriber = reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+        return CUPTI_SUCCESS;
+      });
+  EXPECT_CALL(*mock_, GetTimestampV2(_, _))
+      .InSequence(s1)
+      .WillOnce(SetTimestampAndReturnSuccess(1));
   const int cb_enable_times = IsCudaNewEnoughForGraphTraceTest() ? 6 : 1;
   EXPECT_CALL(*mock_, EnableCallback(1, _, _, _))
       .Times(cb_enable_times)
       .InSequence(s1)
-      .WillRepeatedly(
-          Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableCallback));
-  EXPECT_CALL(*mock_, SetThreadIdType(_))
+      .WillRepeatedly(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(_))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::SetThreadIdType));
-  EXPECT_CALL(*mock_, ActivityUsePerThreadBuffer())
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(),
-                       &CuptiWrapper::ActivityUsePerThreadBuffer));
-  EXPECT_CALL(*mock_, ActivityRegisterCallbacks(_, _))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityRegisterCallbacksV2(_, _, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(),
-                       &CuptiWrapper::ActivityRegisterCallbacks));
-  EXPECT_CALL(*mock_, ActivityEnable(CUPTI_ACTIVITY_KIND_KERNEL))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityEnableV2(_, CUPTI_ACTIVITY_KIND_KERNEL, _))
       .InSequence(s1)
       .WillOnce(Return(CUPTI_ERROR_UNKNOWN));  // injected error
   // CuptiErrorManager::ResultString()
@@ -148,11 +296,10 @@ TEST_F(CuptiErrorManagerTest, GpuTraceActivityEnableTest) {
   EXPECT_CALL(*mock_, EnableCallback(0, _, _, _))
       .Times(cb_enable_times)
       .InSequence(s1)
-      .WillRepeatedly(
-          Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableCallback));
+      .WillRepeatedly(Return(CUPTI_SUCCESS));
   EXPECT_CALL(*mock_, Unsubscribe(_))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::Unsubscribe));
+      .WillOnce(Return(CUPTI_SUCCESS));
 
   EXPECT_FALSE(CuptiDisabled());
   CuptiTracerOptions options;
@@ -160,6 +307,10 @@ TEST_F(CuptiErrorManagerTest, GpuTraceActivityEnableTest) {
   options.cbids_selected.push_back(CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel);
   EnableProfiling(options);  // CUPTI call fails due to injected error
   EXPECT_TRUE(CuptiDisabled());
+  // Rollback already unsubscribed the handle and disabled CUPTI. Verify that a
+  // later profiling request makes no additional CUPTI calls, including a second
+  // unsubscribe.
+  EnableProfiling(options);
 
   RunGpuApp();  // Application code runs normally
 
@@ -173,35 +324,39 @@ TEST_F(CuptiErrorManagerTest, GpuTraceAutoEnableTest) {
   EXPECT_FALSE(CuptiDisabled());
   // Enforces the order of execution below.
   Sequence s1;
-  EXPECT_CALL(*mock_, Subscribe(_, _, _))
+  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::Subscribe));
+      .WillOnce([](CUpti_SubscriberHandle* subscriber,
+                   CUpti_CallbackFunc /*callback*/, void* /*userdata*/) {
+        *subscriber = reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+        return CUPTI_SUCCESS;
+      });
+  EXPECT_CALL(*mock_, GetTimestampV2(_, _))
+      .InSequence(s1)
+      .WillOnce(SetTimestampAndReturnSuccess(1));
   const int cb_enable_times = IsCudaNewEnoughForGraphTraceTest() ? 5 : 0;
   if (cb_enable_times > 0) {
     EXPECT_CALL(*mock_, EnableCallback(1, _, _, _))
         .Times(cb_enable_times)
         .InSequence(s1)
-        .WillRepeatedly(
-            Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableCallback));
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
   }
   EXPECT_CALL(*mock_, EnableDomain(1, _, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableDomain));
-  EXPECT_CALL(*mock_, SetThreadIdType(_))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(_))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::SetThreadIdType));
-  EXPECT_CALL(*mock_, ActivityUsePerThreadBuffer())
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(),
-                       &CuptiWrapper::ActivityUsePerThreadBuffer));
-  EXPECT_CALL(*mock_, ActivityRegisterCallbacks(_, _))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityRegisterCallbacksV2(_, _, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(),
-                       &CuptiWrapper::ActivityRegisterCallbacks));
-  EXPECT_CALL(*mock_, ActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityEnableV2(_, CUPTI_ACTIVITY_KIND_MEMCPY, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::ActivityEnable));
-  EXPECT_CALL(*mock_, ActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY2))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, ActivityEnableV2(_, CUPTI_ACTIVITY_KIND_MEMCPY2, _))
       .InSequence(s1)
       .WillOnce(Return(CUPTI_ERROR_UNKNOWN));  // injected error
   // CuptiErrorManager::ResultString()
@@ -209,22 +364,21 @@ TEST_F(CuptiErrorManagerTest, GpuTraceAutoEnableTest) {
       .InSequence(s1)
       .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::GetResultString));
   // CuptiErrorManager::UndoAndDisable()
-  EXPECT_CALL(*mock_, ActivityDisable(CUPTI_ACTIVITY_KIND_MEMCPY))
+  EXPECT_CALL(*mock_, ActivityDisableV2(_, CUPTI_ACTIVITY_KIND_MEMCPY, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::ActivityDisable));
+      .WillOnce(Return(CUPTI_SUCCESS));
   EXPECT_CALL(*mock_, EnableDomain(0, _, _))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableDomain));
+      .WillOnce(Return(CUPTI_SUCCESS));
   if (cb_enable_times > 0) {
     EXPECT_CALL(*mock_, EnableCallback(0, _, _, _))
         .Times(cb_enable_times)
         .InSequence(s1)
-        .WillRepeatedly(
-            Invoke(cupti_wrapper_.get(), &CuptiWrapper::EnableCallback));
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
   }
   EXPECT_CALL(*mock_, Unsubscribe(_))
       .InSequence(s1)
-      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::Unsubscribe));
+      .WillOnce(Return(CUPTI_SUCCESS));
 
   EXPECT_FALSE(CuptiDisabled());
   CuptiTracerOptions options;
@@ -240,6 +394,181 @@ TEST_F(CuptiErrorManagerTest, GpuTraceAutoEnableTest) {
   EXPECT_TRUE(CuptiDisabled());
   DisableProfiling();  // CUPTI calls are ignored
   EXPECT_TRUE(CuptiDisabled());
+}
+
+TEST_F(CuptiErrorManagerTest, V2AvailabilityFailuresFallBackToV1) {
+  EXPECT_FALSE(CuptiDisabled());
+
+  // CuptiWrapper returns CUPTI_ERROR_NOT_SUPPORTED without calling
+  // cuptiSubscribe_v2 when either cuptiSubscribe_v2 or cuptiGetTimestamp_v2 is
+  // unavailable. CUPTI_ERROR_UNKNOWN from cuptiSubscribe_v2 is also safe to
+  // fall back from because no V2 subscriber was successfully created.
+  uintptr_t subscriber_id = 1;
+  for (CUptiResult result : {CUPTI_ERROR_NOT_SUPPORTED, CUPTI_ERROR_UNKNOWN}) {
+    auto* const v1_subscriber =
+        reinterpret_cast<CUpti_SubscriberHandle>(subscriber_id++);
+    EXPECT_CALL(*mock_, SubscribeV2(_, _, _)).WillOnce(Return(result));
+    EXPECT_CALL(*mock_, Subscribe(_, _, _))
+        .WillOnce(
+            DoAll(SetArgPointee<0>(v1_subscriber), Return(CUPTI_SUCCESS)));
+    ExpectSuccessfulV1KernelTrace(v1_subscriber);
+
+    CuptiTracerOptions options = KernelTraceOptions();
+    EnableProfiling(options);
+    DisableProfiling();
+  }
+
+  EXPECT_FALSE(CuptiDisabled());
+}
+
+TEST_F(CuptiErrorManagerTest, V2TimestampFailuresAfterSubscribeFallBackToV1) {
+  EXPECT_FALSE(CuptiDisabled());
+
+  uintptr_t subscriber_id = 10;
+  for (CUptiResult result : {CUPTI_ERROR_NOT_SUPPORTED,
+                             CUPTI_ERROR_NOT_COMPATIBLE, CUPTI_ERROR_UNKNOWN}) {
+    auto* const v2_subscriber =
+        reinterpret_cast<CUpti_SubscriberHandle>(subscriber_id++);
+    auto* const v1_subscriber =
+        reinterpret_cast<CUpti_SubscriberHandle>(subscriber_id++);
+    Sequence fallback_sequence;
+    EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
+        .InSequence(fallback_sequence)
+        .WillOnce(
+            DoAll(SetArgPointee<0>(v2_subscriber), Return(CUPTI_SUCCESS)));
+    EXPECT_CALL(*mock_, GetTimestampV2(v2_subscriber, _))
+        .InSequence(fallback_sequence)
+        .WillOnce(Return(result));
+    EXPECT_CALL(*mock_, Unsubscribe(v2_subscriber))
+        .InSequence(fallback_sequence)
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, Subscribe(_, _, _))
+        .InSequence(fallback_sequence)
+        .WillOnce(
+            DoAll(SetArgPointee<0>(v1_subscriber), Return(CUPTI_SUCCESS)));
+    ExpectSuccessfulV1KernelTrace(v1_subscriber);
+
+    CuptiTracerOptions options = KernelTraceOptions();
+    EnableProfiling(options);
+    DisableProfiling();
+  }
+
+  EXPECT_FALSE(CuptiDisabled());
+}
+
+TEST_F(CuptiErrorManagerTest,
+       FatalTimestampV2FailureDoesNotUnsubscribeFreshSubscriberTwice) {
+  EXPECT_FALSE(CuptiDisabled());
+
+  auto* const v2_subscriber =
+      reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
+      .WillOnce(DoAll(SetArgPointee<0>(v2_subscriber), Return(CUPTI_SUCCESS)));
+  EXPECT_CALL(*mock_, GetTimestampV2(v2_subscriber, _))
+      .WillOnce(Return(CUPTI_ERROR_INVALID_PARAMETER));
+  EXPECT_CALL(*mock_, GetResultString(CUPTI_ERROR_INVALID_PARAMETER, _))
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::GetResultString));
+  // The error-manager undo stack owns this newly created subscriber and must
+  // be the only code path that unsubscribes it.
+  EXPECT_CALL(*mock_, Unsubscribe(v2_subscriber))
+      .WillOnce(Return(CUPTI_SUCCESS));
+
+  CuptiTracerOptions options;
+  EnableProfiling(options);
+
+  EXPECT_TRUE(CuptiDisabled());
+}
+
+TEST_F(CuptiErrorManagerTest,
+       PreparesFreshV2SubscriberBeforeEachSessionTimestamp) {
+  EXPECT_FALSE(CuptiDisabled());
+
+  Sequence sequence;
+  CuptiTracerOptions options = KernelTraceOptions();
+
+  for (uintptr_t session = 1; session <= 2; ++session) {
+    auto* const subscriber = reinterpret_cast<CUpti_SubscriberHandle>(session);
+    EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
+        .InSequence(sequence)
+        .WillOnce(DoAll(SetArgPointee<0>(subscriber), Return(CUPTI_SUCCESS)));
+    EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
+        .InSequence(sequence)
+        .WillOnce(SetTimestampAndReturnSuccess(session * 10));
+
+    absl::Status prepare_status =
+        cupti_tracer_->PrepareForProfilerStart(options);
+    ASSERT_TRUE(prepare_status.ok()) << prepare_status;
+
+    EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
+        .InSequence(sequence)
+        .WillOnce(SetTimestampAndReturnSuccess(session * 10 + 1));
+    EXPECT_EQ(cupti_tracer_->GetTimestampForSubscriber(), session * 10 + 1);
+
+    ExpectV2KernelSession(sequence, subscriber, /*preflight_timestamp=*/0,
+                          /*fallback_stop_timestamp=*/session * 10 + 2,
+                          /*stop_timestamp=*/session * 10 + 3, CUPTI_SUCCESS,
+                          /*expect_preflight_timestamp=*/false);
+    EXPECT_CALL(*mock_, Unsubscribe(subscriber))
+        .InSequence(sequence)
+        .WillOnce(Return(CUPTI_SUCCESS));
+
+    EnableProfiling(options);
+    DisableProfiling();
+    EXPECT_EQ(cupti_collector_->GetTracingEndTimeNs(), session * 10 + 3);
+  }
+
+  EXPECT_FALSE(CuptiDisabled());
+}
+
+TEST_F(CuptiErrorManagerTest,
+       FatalStopTimestampDoesNotUnsubscribeFreshSubscriberTwice) {
+  Sequence s1;
+  auto* const subscriber =
+      reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
+      .InSequence(s1)
+      .WillOnce(DoAll(SetArgPointee<0>(subscriber), Return(CUPTI_SUCCESS)));
+  ExpectV2KernelSessionWithFatalStopTimestamp(s1, subscriber,
+                                              /*preflight_timestamp=*/1,
+                                              /*fallback_stop_timestamp=*/2);
+
+  CuptiTracerOptions options = KernelTraceOptions();
+  EnableProfiling(options);
+  DisableProfiling();
+  EXPECT_EQ(cupti_collector_->GetTracingEndTimeNs(), 2);
+  EXPECT_TRUE(CuptiDisabled());
+  // A stale handle would make this retry issue an unexpected second
+  // Unsubscribe call through the disabled error manager.
+  EnableProfiling(options);
+}
+
+TEST_F(CuptiErrorManagerTest,
+       V2CapabilityErrorsDoNotDisableCuptiOrUseV1Parser) {
+  auto* const v2_subscriber =
+      reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+  EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(v2_subscriber))
+      .WillOnce(Return(CUPTI_ERROR_NOT_COMPATIBLE));
+  EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
+      .WillOnce(Return(CUPTI_ERROR_NOT_COMPATIBLE));
+
+  EXPECT_EQ(cupti_error_manager_->ActivityUseSystemThreadIdV2(v2_subscriber),
+            CUPTI_ERROR_NOT_COMPATIBLE);
+  EXPECT_EQ(cupti_error_manager_->ActivityUsePerThreadBufferV2(),
+            CUPTI_ERROR_NOT_COMPATIBLE);
+
+  uint8_t buffer[1] = {};
+  CUpti_Activity* record = nullptr;
+  EXPECT_CALL(*mock_, ActivityGetNextRecord(_, _, _)).Times(0);
+
+  for (CUptiResult result : {CUPTI_ERROR_NOT_SUPPORTED, CUPTI_ERROR_UNKNOWN}) {
+    EXPECT_CALL(*mock_, ActivityGetNextRecordV2(_, buffer, sizeof(buffer), _))
+        .WillOnce(Return(result));
+    EXPECT_EQ(cupti_error_manager_->ActivityGetNextRecordV2(
+                  /*subscriber=*/nullptr, buffer, sizeof(buffer), &record),
+              result);
+    EXPECT_EQ(record, nullptr);
+  }
+  EXPECT_FALSE(CuptiDisabled());
 }
 
 }  // namespace test

--- a/xla/backends/profiler/gpu/cupti_interface.h
+++ b/xla/backends/profiler/gpu/cupti_interface.h
@@ -69,11 +69,14 @@ using CuptiBuffersCallbackCompleteFuncV2 =
     void(CUPTIAPI*)(uint8_t* buffer, size_t size, size_t valid_size,
                     void* buffer_complete_info);
 
-// Provides a wrapper interface to every single CUPTI API function. This class
-// is needed to create an easy mock object for CUPTI API calls. All member
-// functions are defined in the following order: activity related APIs, callback
-// related APIs, Event APIs, and metric APIs. Within each category, we follow
-// the order in the original CUPTI documentation.
+// Provides a wrapper interface to every CUPTI API function. This class provides
+// a seam for mocking individual CUPTI calls. CuptiTracer selects V1 or weakly
+// linked V2 APIs per session at runtime; the two activity API families must not
+// be mixed within a session.
+//
+// Member functions are grouped by CUPTI API category: activity, callback,
+// event, and metric. Within each group, they follow the order in the CUPTI API
+// reference.
 class CuptiInterface {
  public:
   CuptiInterface() = default;
@@ -90,6 +93,11 @@ class CuptiInterface {
   virtual CUptiResult ActivityGetNextRecord(uint8_t* buffer,
                                             size_t valid_buffer_size_bytes,
                                             CUpti_Activity** record) = 0;
+
+  virtual CUptiResult ActivityGetNextRecordV2(CUpti_SubscriberHandle subscriber,
+                                              uint8_t* buffer,
+                                              size_t valid_buffer_size_bytes,
+                                              CUpti_Activity** record) = 0;
 
   virtual CUptiResult ActivityGetNumDroppedRecords(CUcontext context,
                                                    uint32_t stream_id,
@@ -133,6 +141,9 @@ class CuptiInterface {
   virtual CUptiResult GetDeviceId(CUcontext context, uint32_t* deviceId) = 0;
 
   virtual CUptiResult GetTimestamp(uint64_t* timestamp) = 0;
+
+  virtual CUptiResult GetTimestampV2(CUpti_SubscriberHandle subscriber,
+                                     uint64_t* timestamp) = 0;
 
   virtual CUptiResult Finalize() = 0;
 

--- a/xla/backends/profiler/gpu/cupti_tracer.cc
+++ b/xla/backends/profiler/gpu/cupti_tracer.cc
@@ -1037,15 +1037,16 @@ class CuptiDriverApiHookWithActivityApi : public CuptiDriverApiHook {
                                 CUpti_CallbackId cbid,
                                 const CUpti_CallbackData* cbdata) override {
     // Stash away the current Cupti timestamp into cbdata.
-    *cbdata->correlationData =
-        option_.required_callback_api_events ? CuptiTracer::GetTimestamp() : 0;
+    *cbdata->correlationData = option_.required_callback_api_events
+                                   ? tracer_->GetTimestampForSubscriber()
+                                   : 0;
     return absl::OkStatus();
   }
   absl::Status OnDriverApiExit(int device_id, CUpti_CallbackDomain domain,
                                CUpti_CallbackId cbid,
                                const CUpti_CallbackData* cbdata) override {
     // Grab timestamp for API exit. API entry timestamp saved in cbdata.
-    uint64_t end_tsc = CuptiTracer::GetTimestamp();
+    uint64_t end_tsc = tracer_->GetTimestampForSubscriber();
     uint64_t start_tsc = *cbdata->correlationData;
     TrackContext(cbid, cbdata->context);
     return AddDriverApiCallbackEvent(tracer_, cupti_interface_, device_id,
@@ -1170,20 +1171,38 @@ absl::Status CuptiTracer::Enable(
   cupti_driver_api_hook_ = std::make_unique<CuptiDriverApiHookWithActivityApi>(
       *option_, cupti_interface_, this);
 
+  absl::Cleanup api_tracing_cleanup = [&] {
+    if (cupti_interface_->Disabled()) {
+      api_tracing_enabled_ = false;
+      // A subscriber created by this session is owned by the error manager
+      // undo stack and has already been unsubscribed.
+      ClearSubscriberState();
+    } else {
+      DisableApiTracing(/*unsubscribe=*/true).IgnoreError();
+    }
+    using_v2_subscriber_api_ = false;
+    cupti_interface_->CleanUp();
+  };
+
   tsl::profiler::AnnotationStack::Enable(true);
-
-  absl::Status status = EnableApiTracing();
-  need_root_access_ |= status.code() == tsl::error::PERMISSION_DENIED;
-  if (!status.ok()) {
+  absl::Cleanup annotation_cleanup = [] {
     tsl::profiler::AnnotationStack::Enable(false);
-    return status;
-  }
+  };
 
-  absl::Status activity_status = EnableActivityTracing();
-  if (!activity_status.ok()) {
-    tsl::profiler::AnnotationStack::Enable(false);
-    return activity_status;
-  }
+  absl::Status api_status = EnableApiTracing();
+  need_root_access_ |= api_status.code() == tsl::error::PERMISSION_DENIED;
+  RETURN_IF_ERROR(api_status);
+
+  absl::Cleanup activity_tracing_cleanup = [&] {
+    if (cupti_interface_->Disabled()) {
+      // The error manager already disabled activity tracing; only reset the
+      // local state.
+      activity_tracing_enabled_ = false;
+    } else {
+      DisableActivityTracing().IgnoreError();
+    }
+  };
+  RETURN_IF_ERROR(EnableActivityTracing());
 
   int num_gpus_requested = xplanes.size();
   // Enable PM Sampling after CUPTI is initialized.
@@ -1209,16 +1228,21 @@ absl::Status CuptiTracer::Enable(
           samples->PopulateCounterLine(&xplane_builder,
                                        collector_->GetProfileStartTimeNs());
         };
-    // Creates PM sampler object.
     ASSIGN_OR_RETURN(
         cupti_pm_sampler_,
         CreatePmSampler(num_gpus_requested, option_->pm_sampler_options));
-
+    absl::Cleanup pm_sampler_cleanup = [&] {
+      cupti_pm_sampler_->Deinitialize().IgnoreError();
+    };
     RETURN_IF_ERROR(cupti_pm_sampler_->StartSampler());
     pm_sampling_enabled_ = true;
+    std::move(pm_sampler_cleanup).Cancel();
   }
 
-  return status;
+  std::move(annotation_cleanup).Cancel();
+  std::move(activity_tracing_cleanup).Cancel();
+  std::move(api_tracing_cleanup).Cancel();
+  return absl::OkStatus();
 }
 
 void CuptiTracer::Disable() {
@@ -1234,33 +1258,64 @@ void CuptiTracer::Disable() {
     pm_sampling_enabled_ = false;
   }
 
-  // ActivityDisableV2 needs the subscriber handle still valid; disable
-  // activities before API tracing (which calls Unsubscribe) only in the V2
-  // subscriber path.
   if (using_v2_subscriber_api_) {
+    // Preserve a best effort end timestamp in case teardown disables CUPTI
+    // before the final timestamp can be read.
+    uint64_t tracing_end_time_ns = GetTimestampForSubscriber();
+    // The subsequent ActivityDisableV2 and ActivityGetNextRecordV2 calls still
+    // need the subscriber handle.
+    DisableApiTracing(/*unsubscribe=*/false).IgnoreError();
     DisableActivityTracing().IgnoreError();
-    DisableApiTracing().IgnoreError();
+    cupti_driver_api_hook_->SyncAndFlush().IgnoreError();
+    if (!cupti_interface_->Disabled()) {
+      // Prefer the timestamp taken after synchronization.
+      uint64_t final_timestamp_ns = GetTimestampForSubscriber();
+      if (!cupti_interface_->Disabled()) {
+        tracing_end_time_ns = final_timestamp_ns;
+      }
+    }
+    collector_->SetTracingEndTimeNs(tracing_end_time_ns);
+
+    // Process callback events first because they populate AnnotationMap.
+    // Activity events then use that map to attach annotations to GPU events.
+    collector_->OnTracerCollectedCallbackData(
+        GatherCallbackAnnotationsAndEvents(/*stop_recording=*/true),
+        IsCallbackApiEventsRequired());
+
+    if (cupti_interface_->Disabled()) {
+      // A fatal teardown error runs CuptiErrorManager's undo stack, which
+      // already unsubscribed this session's subscriber.
+      api_tracing_enabled_ = false;
+      activity_tracing_enabled_ = false;
+      activity_buffers_.reset();
+      ClearSubscriberState();
+    } else {
+      if (activity_buffers_) {
+        auto cached_buffers = activity_buffers_->PopCachedBuffers();
+        activity_buffers_.reset();
+        collector_->OnTracerCachedActivityBuffers(std::move(cached_buffers));
+      }
+      DisableApiTracing(/*unsubscribe=*/true).IgnoreError();
+    }
+    cupti_interface_->CleanUp();
+    Finalize().IgnoreError();
   } else {
-    DisableApiTracing().IgnoreError();
+    DisableApiTracing(/*unsubscribe=*/true).IgnoreError();
     DisableActivityTracing().IgnoreError();
-  }
-  cupti_interface_->CleanUp();
-  Finalize().IgnoreError();
-  cupti_driver_api_hook_->SyncAndFlush().IgnoreError();
+    cupti_interface_->CleanUp();
+    Finalize().IgnoreError();
+    cupti_driver_api_hook_->SyncAndFlush().IgnoreError();
+    collector_->SetTracingEndTimeNs(GetTimestamp());
 
-  collector_->SetTracingEndTimeNs(GetTimestamp());
+    collector_->OnTracerCollectedCallbackData(
+        GatherCallbackAnnotationsAndEvents(/*stop_recording=*/true),
+        IsCallbackApiEventsRequired());
 
-  // The callback API events must be processed before activity API buffers
-  // because the AnnotationMap is populated from the callback API events and
-  // queried by the activity API events.
-  collector_->OnTracerCollectedCallbackData(
-      GatherCallbackAnnotationsAndEvents(/*stop_recording=*/true),
-      IsCallbackApiEventsRequired());
-
-  if (activity_buffers_) {
-    auto cached_buffers = activity_buffers_->PopCachedBuffers();
-    activity_buffers_.reset();
-    collector_->OnTracerCachedActivityBuffers(std::move(cached_buffers));
+    if (activity_buffers_) {
+      auto cached_buffers = activity_buffers_->PopCachedBuffers();
+      activity_buffers_.reset();
+      collector_->OnTracerCachedActivityBuffers(std::move(cached_buffers));
+    }
   }
 
   if (cupti_dropped_activity_event_count_ > 0) {
@@ -1277,6 +1332,7 @@ void CuptiTracer::Disable() {
   option_.reset();
   cupti_driver_api_hook_.reset();
   using_v2_subscriber_api_ = false;
+  subscriber_prepared_for_current_session_ = false;
   tsl::profiler::AnnotationStack::Enable(false);
 }
 
@@ -1383,7 +1439,7 @@ absl::Status CuptiTracer::FlushEventsToCollector() {
 
   // Need get the cached activity buffers first, but send to collector after
   // the callback events are processed.
-  std::list<CuptiActivityBufferManager::ActivityBufferAndSize> cached_buffers;
+  CuptiActivityBufferManager::CachedActivityBufferBatch cached_buffers;
   if (activity_tracing_enabled_) {
     cached_buffers = activity_buffers_->PopCachedBuffers();
   }
@@ -1412,32 +1468,64 @@ absl::Status CuptiTracer::FlushActivityBuffers() {
   return absl::OkStatus();
 }
 
-// Need to trace graph ids from creation and instantiation.
-absl::Status CuptiTracer::EnableApiTracing() {
-  if (api_tracing_enabled_) {
+absl::Status CuptiTracer::PrepareForProfilerStart(
+    const CuptiTracerOptions& option) {
+  return PrepareSubscriberForSession(option);
+}
+
+absl::Status CuptiTracer::PrepareSubscriberForSession(
+    const CuptiTracerOptions& option) {
+  if (subscriber_prepared_for_current_session_) {
     return absl::OkStatus();
   }
 
-  PrepareCallbackStart();
-  using_v2_subscriber_api_ = false;
-
-  VLOG(1) << "Enable subscriber";
+  VLOG(1) << "Prepare subscriber";
   // Subscribe can return CUPTI_ERROR_MAX_LIMIT_REACHED.
   // The application which calls CUPTI APIs cannot be used with Nvidia tools
   // like nvprof, Nvidia Visual Profiler, Nsight Compute, Nsight Systems.
   CUptiResult subscribe_status = CUPTI_ERROR_NOT_SUPPORTED;
-  if (option_->prefer_cupti_v2) {
+  bool use_v2_subscriber = false;
+  if (option.prefer_cupti_v2) {
     subscribe_status = cupti_interface_->SubscribeV2(
         &subscriber_, (CUpti_CallbackFunc)ApiCallback, this);
     if (subscribe_status == CUPTI_SUCCESS) {
-      using_v2_subscriber_api_ = true;
+      subscriber_is_v2_ = true;
+    }
+    if (subscribe_status == CUPTI_SUCCESS) {
+      use_v2_subscriber = true;
+      // Validate V2 timestamps before enabling subscriber-scoped tracing.
+      uint64_t unused_timestamp = 0;
+      CUptiResult timestamp_status =
+          cupti_interface_->GetTimestampV2(subscriber_, &unused_timestamp);
+      if (timestamp_status != CUPTI_SUCCESS) {
+        if (cupti_interface_->Disabled()) {
+          // Clear local state after the error manager unsubscribed V2.
+          ClearSubscriberState();
+          cupti_interface_->CleanUp();
+          return absl::InternalError(
+              "CUPTI V2 subscriber timestamp is unavailable");
+        }
+        LOG(INFO) << "CUPTI V2 subscriber timestamp is unavailable with status "
+                  << timestamp_status
+                  << "; falling back to legacy CUPTI subscriber.";
+        // Unsubscribe V2 because GetTimestampV2() is unavailable.
+        RETURN_IF_ERROR(UnsubscribeAndClearSubscriber());
+        // Remove the stale V2 unsubscribe callback from the undo stack.
+        cupti_interface_->CleanUp();
+        // Prepare to retry with the legacy V1 subscriber API.
+        use_v2_subscriber = false;
+        subscribe_status = CUPTI_ERROR_NOT_SUPPORTED;
+      }
     }
   }
-  if (!using_v2_subscriber_api_) {
+  if (!use_v2_subscriber) {
     if (subscribe_status == CUPTI_ERROR_NOT_SUPPORTED ||
         subscribe_status == CUPTI_ERROR_UNKNOWN) {
       subscribe_status = cupti_interface_->Subscribe(
           &subscriber_, (CUpti_CallbackFunc)ApiCallback, this);
+      if (subscribe_status == CUPTI_SUCCESS) {
+        subscriber_is_v2_ = false;
+      }
     }
   }
   if (ABSL_PREDICT_FALSE(subscribe_status != CUPTI_SUCCESS)) {
@@ -1449,6 +1537,20 @@ absl::Status CuptiTracer::EnableApiTracing() {
     }
     return absl::InternalError(absl::StrCat("CUPTI call error: ", errstr));
   }
+  subscriber_prepared_for_current_session_ = true;
+  return absl::OkStatus();
+}
+
+// Need to trace graph ids from creation and instantiation.
+absl::Status CuptiTracer::EnableApiTracing() {
+  if (api_tracing_enabled_) {
+    return absl::OkStatus();
+  }
+
+  PrepareCallbackStart();
+  using_v2_subscriber_api_ = false;
+  RETURN_IF_ERROR(PrepareSubscriberForSession(*option_));
+  using_v2_subscriber_api_ = subscriber_is_v2_;
   api_tracing_enabled_ = true;
 
   absl::Span<const CUpti_CallbackIdResource> res_cbids =
@@ -1475,32 +1577,31 @@ absl::Status CuptiTracer::EnableApiTracing() {
   return absl::OkStatus();
 }
 
-absl::Status CuptiTracer::DisableApiTracing() {
-  if (!api_tracing_enabled_) {
-    return absl::OkStatus();
-  }
+absl::Status CuptiTracer::DisableApiTracing(bool unsubscribe) {
+  if (api_tracing_enabled_) {
+    api_tracing_enabled_ = false;
 
-  api_tracing_enabled_ = false;
+    absl::Span<const CUpti_CallbackIdResource> res_cbids =
+        cuda_versions::GetCudaGraphTracingResourceCbids();
+    for (auto cbid : res_cbids) {
+      RETURN_IF_CUPTI_ERROR(EnableCallback(0 /* DISABLE */, subscriber_,
+                                           CUPTI_CB_DOMAIN_RESOURCE, cbid));
+    }
 
-  absl::Span<const CUpti_CallbackIdResource> res_cbids =
-      cuda_versions::GetCudaGraphTracingResourceCbids();
-  for (auto cbid : res_cbids) {
-    RETURN_IF_CUPTI_ERROR(EnableCallback(0 /* DISABLE */, subscriber_,
-                                         CUPTI_CB_DOMAIN_RESOURCE, cbid));
-  }
-
-  if (!option_->cbids_selected.empty()) {
+    if (option_->cbids_selected.empty()) {
+      RETURN_IF_CUPTI_ERROR(EnableDomain(0 /* DISABLE */, subscriber_,
+                                         CUPTI_CB_DOMAIN_DRIVER_API));
+    }
     for (auto cbid : option_->cbids_selected) {
       RETURN_IF_CUPTI_ERROR(EnableCallback(0 /* DISABLE */, subscriber_,
                                            CUPTI_CB_DOMAIN_DRIVER_API, cbid));
     }
-  } else {
-    RETURN_IF_CUPTI_ERROR(
-        EnableDomain(0 /* DISABLE */, subscriber_, CUPTI_CB_DOMAIN_DRIVER_API));
   }
 
-  VLOG(1) << "Disable subscriber";
-  RETURN_IF_CUPTI_ERROR(Unsubscribe(subscriber_));
+  if (unsubscribe) {
+    VLOG(1) << "Disable subscriber";
+    RETURN_IF_ERROR(UnsubscribeAndClearSubscriber());
+  }
   return absl::OkStatus();
 }
 
@@ -1646,6 +1747,20 @@ absl::Status CuptiTracer::Finalize() {
   return absl::OkStatus();
 }
 
+void CuptiTracer::ClearSubscriberState() {
+  subscriber_ = nullptr;
+  subscriber_is_v2_ = false;
+  subscriber_prepared_for_current_session_ = false;
+}
+
+absl::Status CuptiTracer::UnsubscribeAndClearSubscriber() {
+  if (subscriber_ != nullptr) {
+    RETURN_IF_CUPTI_ERROR(Unsubscribe(subscriber_));
+  }
+  ClearSubscriberState();
+  return absl::OkStatus();
+}
+
 /*static*/ uint64_t CuptiTracer::GetTimestamp() {
   uint64_t tsc;
   CuptiInterface* cupti_interface = GetCuptiInterface();
@@ -1654,6 +1769,26 @@ absl::Status CuptiTracer::Finalize() {
   }
   // Return 0 on error. If an activity timestamp is 0, the activity will be
   // dropped during time normalization.
+  return 0;
+}
+
+uint64_t CuptiTracer::GetTimestampForSubscriber() const {
+  if (!subscriber_is_v2_) {
+    return CuptiTracer::GetTimestamp();
+  }
+  DCHECK_NE(subscriber_, nullptr);
+  DCHECK_NE(cupti_interface_, nullptr);
+
+  uint64_t tsc;
+  CUptiResult timestamp_status =
+      cupti_interface_->GetTimestampV2(subscriber_, &tsc);
+  if (timestamp_status == CUPTI_SUCCESS) {
+    return tsc;
+  }
+  LOG_FIRST_N(WARNING, 1) << "CUPTI V2 GetTimestamp failed for the subscriber; "
+                             "returning timestamp 0.";
+  // Return 0 for an unavailable V2 timestamp; dependent events may be dropped
+  // during time normalization.
   return 0;
 }
 
@@ -1813,7 +1948,9 @@ void CuptiTracer::RequestActivityBuffer(uint8_t** buffer, size_t* size) {
   *size = activity_buffers_->GetBufferSizeInBytes();
 }
 
-static size_t CountCuptiActivityEvent(uint8_t* buffer, size_t size) {
+static size_t CountCuptiActivityEvent(uint8_t* buffer, size_t size,
+                                      CUpti_SubscriberHandle subscriber,
+                                      bool use_v2_records) {
   size_t total_event_count = 0;
   if (size == 0 || buffer == nullptr) {
     return total_event_count;
@@ -1821,8 +1958,12 @@ static size_t CountCuptiActivityEvent(uint8_t* buffer, size_t size) {
   CuptiInterface* cupti_interface = GetCuptiInterface();
   CUpti_Activity* record = nullptr;
   while (true) {
-    if (cupti_interface->ActivityGetNextRecord(buffer, size, &record) ==
-        CUPTI_SUCCESS) {
+    CUptiResult status =
+        use_v2_records
+            ? cupti_interface->ActivityGetNextRecordV2(subscriber, buffer, size,
+                                                       &record)
+            : cupti_interface->ActivityGetNextRecord(buffer, size, &record);
+    if (status == CUPTI_SUCCESS) {
       ++total_event_count;
     } else {
       break;
@@ -1861,7 +2002,8 @@ absl::Status CuptiTracer::ProcessActivityBuffer(CUcontext context,
     }
   }
 
-  size_t event_count_in_buffer = CountCuptiActivityEvent(buffer, size);
+  size_t event_count_in_buffer = CountCuptiActivityEvent(
+      buffer, size, subscriber_, using_v2_subscriber_api_);
   auto max_activity_event_count =
       collector_->GetOptions().max_activity_api_events;
   if (max_activity_event_count > 0 &&
@@ -1891,13 +2033,10 @@ absl::Status CuptiTracer::ProcessActivityBuffer(CUcontext context,
   if (CuptiTracer::NumGpus() == 0) {
     return ErrorWithHostname("No GPU detected.");
   }
-  if (CuptiTracer::GetCuptiTracerSingleton()->NeedRootAccess()) {
+  CuptiTracer* cupti_tracer = CuptiTracer::GetCuptiTracerSingleton();
+  if (cupti_tracer->NeedRootAccess()) {
     return ErrorWithHostname(
         "Insufficient privilege to run libcupti (you need root permission).");
-  }
-  if (CuptiTracer::GetTimestamp() == 0) {
-    return ErrorWithHostname(
-        "Failed to load libcupti (is it installed and accessible?)");
   }
   return "";
 }
@@ -1930,8 +2069,8 @@ void CuptiTracer::PrepareCallbackStart() {
 }
 
 void CuptiTracer::PrepareActivityStart() {
-  activity_buffers_ =
-      std::make_unique<CuptiActivityBufferManager>(kBufferSizeInBytes);
+  activity_buffers_ = std::make_unique<CuptiActivityBufferManager>(
+      kBufferSizeInBytes, subscriber_, using_v2_subscriber_api_);
   cupti_dropped_activity_event_count_ = 0;
   num_activity_events_in_cached_buffer_ = 0;
   num_activity_events_in_dropped_buffer_ = 0;

--- a/xla/backends/profiler/gpu/cupti_tracer.h
+++ b/xla/backends/profiler/gpu/cupti_tracer.h
@@ -53,7 +53,7 @@ struct CuptiTracerOptions {
   // Whether to call cuptiFinalize.
   bool cupti_finalize = false;
   // Whether to prefer CUPTI V2 multi-subscriber APIs when available.
-  bool prefer_cupti_v2 = false;
+  bool prefer_cupti_v2 = true;
   // Whether to call cuCtxSynchronize for each device before Stop().
   bool sync_devices_before_stop = false;
   // Whether to enable NVTX tracking, we need this for TensorRT tracking.
@@ -142,6 +142,10 @@ class CuptiTracer {
                                      uint8_t* buffer, size_t size);
 
   static uint64_t GetTimestamp();
+  // Selects and prepares the subscriber for the next profiling session before
+  // the profiler takes its GPU timestamp anchor.
+  absl::Status PrepareForProfilerStart(const CuptiTracerOptions& option);
+  uint64_t GetTimestampForSubscriber() const;
   static int NumGpus();
   // Returns the error (if any) when using libcupti.
   static std::string ErrorIfAny();
@@ -190,10 +194,14 @@ class CuptiTracer {
       bool stop_recording);
 
   absl::Status EnableApiTracing();
+  absl::Status PrepareSubscriberForSession(const CuptiTracerOptions& option);
   absl::Status EnableActivityTracing();
-  absl::Status DisableApiTracing();
+  absl::Status DisableApiTracing(bool unsubscribe);
   absl::Status DisableActivityTracing();
   absl::Status Finalize();
+  // Clears local bookkeeping without unsubscribing from CUPTI.
+  void ClearSubscriberState();
+  absl::Status UnsubscribeAndClearSubscriber();
   void ConfigureActivityUnifiedMemoryCounter(bool enable);
   absl::Status HandleNVTXCallback(CUpti_CallbackId cbid,
                                   const CUpti_CallbackData* cbdata);
@@ -215,8 +223,12 @@ class CuptiTracer {
   // Cupti handle for driver or runtime API callbacks. Cupti permits a single
   // subscriber to be active at any time and can be used to trace Cuda runtime
   // as and driver calls for all contexts and devices.
-  CUpti_SubscriberHandle subscriber_;  // valid when api_tracing_enabled_.
+  CUpti_SubscriberHandle subscriber_ = nullptr;
+  bool subscriber_is_v2_ = false;
   bool using_v2_subscriber_api_ = false;
+  // Whether subscriber selection and V2 timestamp preflight have completed
+  // for the current session.
+  bool subscriber_prepared_for_current_session_ = false;
 
   bool activity_tracing_enabled_ = false;
 

--- a/xla/backends/profiler/gpu/cupti_tracer_test.cc
+++ b/xla/backends/profiler/gpu/cupti_tracer_test.cc
@@ -1,0 +1,353 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/cupti_tracer.h"
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_driver_cbid.h"
+#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
+#include "xla/backends/profiler/gpu/cuda_test.h"
+#include "xla/backends/profiler/gpu/cupti_collector.h"
+#include "xla/backends/profiler/gpu/cupti_error_manager.h"
+#include "xla/backends/profiler/gpu/cupti_interface.h"
+#include "xla/backends/profiler/gpu/cupti_wrapper.h"
+#include "xla/backends/profiler/gpu/mock_cupti.h"
+#include "xla/tsl/profiler/utils/time_utils.h"
+
+namespace xla {
+namespace profiler {
+namespace test {
+namespace {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+using ::testing::StrictMock;
+
+auto SetTimestampAndReturnSuccess(uint64_t timestamp) {
+  return DoAll(SetArgPointee<1>(timestamp), Return(CUPTI_SUCCESS));
+}
+
+class TestableCuptiTracer : public CuptiTracer {
+ public:
+  explicit TestableCuptiTracer(CuptiInterface* cupti_interface)
+      : CuptiTracer(cupti_interface) {}
+};
+
+class CuptiTracerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_GT(CuptiTracer::NumGpus(), 0) << "No devices found";
+    auto mock_cupti = std::make_unique<StrictMock<MockCupti>>();
+    mock_ = mock_cupti.get();
+    cupti_error_manager_ =
+        std::make_unique<CuptiErrorManager>(std::move(mock_cupti));
+    cupti_tracer_ =
+        std::make_unique<TestableCuptiTracer>(cupti_error_manager_.get());
+    cupti_wrapper_ = std::make_unique<CuptiWrapper>();
+
+    CuptiTracerCollectorOptions collector_options;
+    collector_options.num_gpus = CuptiTracer::NumGpus();
+    uint64_t start_gputime_ns = CuptiTracer::GetTimestamp();
+    uint64_t start_walltime_ns = tsl::profiler::GetCurrentTimeNanos();
+    cupti_collector_ = CreateCuptiCollector(
+        collector_options, start_walltime_ns, start_gputime_ns);
+  }
+
+  void EnableProfiling(const CuptiTracerOptions& options) {
+    cupti_tracer_->Enable(options, cupti_collector_.get()).IgnoreError();
+  }
+
+  void DisableProfiling() { cupti_tracer_->Disable(); }
+
+  bool CuptiDisabled() const { return cupti_error_manager_->Disabled(); }
+
+  CuptiTracerOptions KernelTraceOptions() {
+    CuptiTracerOptions options;
+    options.activities_selected = {CUPTI_ACTIVITY_KIND_KERNEL};
+    options.cbids_selected = {CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel};
+    return options;
+  }
+
+  void ExpectSuccessfulV1KernelTrace(CUpti_SubscriberHandle subscriber) {
+    const int resource_cb_count = IsCudaNewEnoughForGraphTraceTest() ? 5 : 0;
+    EXPECT_CALL(*mock_,
+                EnableCallback(1, subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
+        .Times(resource_cb_count)
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_,
+                EnableCallback(1, subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
+                               CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, SetThreadIdType(CUPTI_ACTIVITY_THREAD_ID_TYPE_SYSTEM))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityUsePerThreadBuffer())
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityRegisterCallbacks(_, _))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityEnable(CUPTI_ACTIVITY_KIND_KERNEL))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_,
+                EnableCallback(0, subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
+        .Times(resource_cb_count)
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_,
+                EnableCallback(0, subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
+                               CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, Unsubscribe(subscriber))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityDisable(CUPTI_ACTIVITY_KIND_KERNEL))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED))
+        .WillOnce(Return(CUPTI_SUCCESS));
+  }
+
+  void ExpectV2ResourceCallbacks(CUpti_SubscriberHandle subscriber,
+                                 uint32_t enable) {
+    const int count = IsCudaNewEnoughForGraphTraceTest() ? 5 : 0;
+    if (count == 0) {
+      return;
+    }
+    EXPECT_CALL(*mock_,
+                EnableCallback(enable, subscriber, CUPTI_CB_DOMAIN_RESOURCE, _))
+        .Times(count)
+        .WillRepeatedly(Return(CUPTI_SUCCESS));
+  }
+
+  void ExpectV2KernelCallback(CUpti_SubscriberHandle subscriber,
+                              uint32_t enable) {
+    EXPECT_CALL(*mock_,
+                EnableCallback(enable, subscriber, CUPTI_CB_DOMAIN_DRIVER_API,
+                               CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel))
+        .WillOnce(Return(CUPTI_SUCCESS));
+  }
+
+  void ExpectV2KernelSession(CUpti_SubscriberHandle subscriber,
+                             uint64_t preflight_timestamp,
+                             uint64_t fallback_stop_timestamp,
+                             uint64_t stop_timestamp,
+                             CUptiResult stop_timestamp_status = CUPTI_SUCCESS,
+                             bool expect_preflight_timestamp = true) {
+    if (expect_preflight_timestamp) {
+      EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
+          .WillOnce(SetTimestampAndReturnSuccess(preflight_timestamp));
+    }
+    ExpectV2ResourceCallbacks(subscriber, /*enable=*/1);
+    ExpectV2KernelCallback(subscriber, /*enable=*/1);
+    EXPECT_CALL(*mock_, ActivityUseSystemThreadIdV2(subscriber))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityUsePerThreadBufferV2())
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityRegisterCallbacksV2(subscriber, _, _))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_,
+                ActivityEnableV2(subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
+        .WillOnce(SetTimestampAndReturnSuccess(fallback_stop_timestamp));
+    ExpectV2ResourceCallbacks(subscriber, /*enable=*/0);
+    ExpectV2KernelCallback(subscriber, /*enable=*/0);
+    EXPECT_CALL(*mock_,
+                ActivityDisableV2(subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    EXPECT_CALL(*mock_, ActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED))
+        .WillOnce(Return(CUPTI_SUCCESS));
+    if (stop_timestamp_status == CUPTI_SUCCESS) {
+      EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
+          .WillOnce(SetTimestampAndReturnSuccess(stop_timestamp));
+    } else {
+      EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
+          .WillOnce(Return(stop_timestamp_status));
+    }
+  }
+
+  StrictMock<MockCupti>* mock_;
+  std::unique_ptr<TestableCuptiTracer> cupti_tracer_;
+  std::unique_ptr<CuptiErrorManager> cupti_error_manager_;
+  std::unique_ptr<CuptiWrapper> cupti_wrapper_;
+  std::unique_ptr<CuptiTraceCollector> cupti_collector_;
+};
+
+class CuptiV2SubscribeFallbackTest
+    : public CuptiTracerTest,
+      public ::testing::WithParamInterface<CUptiResult> {};
+
+class CuptiV2TimestampFallbackTest
+    : public CuptiTracerTest,
+      public ::testing::WithParamInterface<CUptiResult> {};
+
+TEST_P(CuptiV2SubscribeFallbackTest, FallsBackToV1) {
+  EXPECT_FALSE(CuptiDisabled());
+
+  // CuptiWrapper returns CUPTI_ERROR_NOT_SUPPORTED without calling
+  // cuptiSubscribe_v2 when either cuptiSubscribe_v2 or cuptiGetTimestamp_v2 is
+  // unavailable. CUPTI_ERROR_UNKNOWN from cuptiSubscribe_v2 is also safe to
+  // fall back from because no V2 subscriber was successfully created.
+  const CUptiResult result = GetParam();
+  auto* const v1_subscriber =
+      reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+  EXPECT_CALL(*mock_, SubscribeV2(_, _, _)).WillOnce(Return(result));
+  EXPECT_CALL(*mock_, Subscribe(_, _, _))
+      .WillOnce(DoAll(SetArgPointee<0>(v1_subscriber), Return(CUPTI_SUCCESS)));
+  ExpectSuccessfulV1KernelTrace(v1_subscriber);
+
+  CuptiTracerOptions options = KernelTraceOptions();
+  EnableProfiling(options);
+  DisableProfiling();
+
+  EXPECT_FALSE(CuptiDisabled());
+}
+
+INSTANTIATE_TEST_SUITE_P(NonfatalErrors, CuptiV2SubscribeFallbackTest,
+                         ::testing::Values(CUPTI_ERROR_NOT_SUPPORTED,
+                                           CUPTI_ERROR_UNKNOWN));
+
+TEST_P(CuptiV2TimestampFallbackTest, FallsBackToV1) {
+  EXPECT_FALSE(CuptiDisabled());
+
+  const CUptiResult result = GetParam();
+  auto* const v2_subscriber =
+      reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+  auto* const v1_subscriber =
+      reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{2});
+  ::testing::InSequence in_sequence;
+  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
+      .WillOnce(DoAll(SetArgPointee<0>(v2_subscriber), Return(CUPTI_SUCCESS)));
+  EXPECT_CALL(*mock_, GetTimestampV2(v2_subscriber, _))
+      .WillOnce(Return(result));
+  EXPECT_CALL(*mock_, Unsubscribe(v2_subscriber))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  EXPECT_CALL(*mock_, Subscribe(_, _, _))
+      .WillOnce(DoAll(SetArgPointee<0>(v1_subscriber), Return(CUPTI_SUCCESS)));
+  ExpectSuccessfulV1KernelTrace(v1_subscriber);
+
+  CuptiTracerOptions options = KernelTraceOptions();
+  EnableProfiling(options);
+  DisableProfiling();
+
+  EXPECT_FALSE(CuptiDisabled());
+}
+
+// NOT_SUPPORTED covers an unavailable V2 timestamp capability. UNKNOWN
+// preserves fallback for an unclassified failure in the optional V2 path.
+// Both are safe to fall back from because the tracer unsubscribes V2 before
+// retrying with V1.
+INSTANTIATE_TEST_SUITE_P(NonfatalErrors, CuptiV2TimestampFallbackTest,
+                         ::testing::Values(CUPTI_ERROR_NOT_SUPPORTED,
+                                           CUPTI_ERROR_UNKNOWN));
+
+TEST_F(CuptiTracerTest,
+       FatalTimestampV2FailureDoesNotUnsubscribeFreshSubscriberTwice) {
+  EXPECT_FALSE(CuptiDisabled());
+
+  auto* const v2_subscriber =
+      reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
+      .WillOnce(DoAll(SetArgPointee<0>(v2_subscriber), Return(CUPTI_SUCCESS)));
+  EXPECT_CALL(*mock_, GetTimestampV2(v2_subscriber, _))
+      .WillOnce(Return(CUPTI_ERROR_INVALID_PARAMETER));
+  EXPECT_CALL(*mock_, GetResultString(CUPTI_ERROR_INVALID_PARAMETER, _))
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::GetResultString));
+  // The error-manager undo stack owns this newly created subscriber and must
+  // be the only code path that unsubscribes it.
+  EXPECT_CALL(*mock_, Unsubscribe(v2_subscriber))
+      .WillOnce(Return(CUPTI_SUCCESS));
+
+  CuptiTracerOptions options;
+  EnableProfiling(options);
+
+  EXPECT_TRUE(CuptiDisabled());
+}
+
+TEST_F(CuptiTracerTest, PreparesFreshV2SubscriberBeforeEachSessionTimestamp) {
+  EXPECT_FALSE(CuptiDisabled());
+
+  CuptiTracerOptions options = KernelTraceOptions();
+
+  for (uintptr_t session = 1; session <= 2; ++session) {
+    ::testing::InSequence in_sequence;
+    auto* const subscriber = reinterpret_cast<CUpti_SubscriberHandle>(session);
+    EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(subscriber), Return(CUPTI_SUCCESS)));
+    EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
+        .WillOnce(SetTimestampAndReturnSuccess(session * 10));
+
+    absl::Status prepare_status =
+        cupti_tracer_->PrepareForProfilerStart(options);
+    ASSERT_TRUE(prepare_status.ok()) << prepare_status;
+
+    EXPECT_CALL(*mock_, GetTimestampV2(subscriber, _))
+        .WillOnce(SetTimestampAndReturnSuccess(session * 10 + 1));
+    EXPECT_EQ(cupti_tracer_->GetTimestampForSubscriber(), session * 10 + 1);
+
+    ExpectV2KernelSession(subscriber, /*preflight_timestamp=*/0,
+                          /*fallback_stop_timestamp=*/session * 10 + 2,
+                          /*stop_timestamp=*/session * 10 + 3, CUPTI_SUCCESS,
+                          /*expect_preflight_timestamp=*/false);
+    EXPECT_CALL(*mock_, Unsubscribe(subscriber))
+        .WillOnce(Return(CUPTI_SUCCESS));
+
+    EnableProfiling(options);
+    DisableProfiling();
+    EXPECT_EQ(cupti_collector_->GetTracingEndTimeNs(), session * 10 + 3);
+  }
+
+  EXPECT_FALSE(CuptiDisabled());
+}
+
+TEST_F(CuptiTracerTest,
+       FatalStopTimestampDoesNotUnsubscribeFreshSubscriberTwice) {
+  ::testing::InSequence in_sequence;
+  auto* const subscriber =
+      reinterpret_cast<CUpti_SubscriberHandle>(uintptr_t{1});
+  EXPECT_CALL(*mock_, SubscribeV2(_, _, _))
+      .WillOnce(DoAll(SetArgPointee<0>(subscriber), Return(CUPTI_SUCCESS)));
+  ExpectV2KernelSession(subscriber, /*preflight_timestamp=*/1,
+                        /*fallback_stop_timestamp=*/2,
+                        /*stop_timestamp=*/0, CUPTI_ERROR_INVALID_PARAMETER);
+  EXPECT_CALL(*mock_, GetResultString(CUPTI_ERROR_INVALID_PARAMETER, _))
+      .WillOnce(Invoke(cupti_wrapper_.get(), &CuptiWrapper::GetResultString));
+  EXPECT_CALL(*mock_,
+              ActivityDisableV2(subscriber, CUPTI_ACTIVITY_KIND_KERNEL, _))
+      .WillOnce(Return(CUPTI_SUCCESS));
+  ExpectV2KernelCallback(subscriber, /*enable=*/0);
+  ExpectV2ResourceCallbacks(subscriber, /*enable=*/0);
+  EXPECT_CALL(*mock_, Unsubscribe(subscriber)).WillOnce(Return(CUPTI_SUCCESS));
+
+  CuptiTracerOptions options = KernelTraceOptions();
+  EnableProfiling(options);
+  DisableProfiling();
+  EXPECT_EQ(cupti_collector_->GetTracingEndTimeNs(), 2);
+  EXPECT_TRUE(CuptiDisabled());
+  // A stale handle would make this retry issue an unexpected second
+  // Unsubscribe call through the disabled error manager.
+  EnableProfiling(options);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/cupti_wrapper.cc
+++ b/xla/backends/profiler/gpu/cupti_wrapper.cc
@@ -92,11 +92,13 @@ bool SetAllowMultipleSubscribersIfSupported(Params* params) {
   return false;
 }
 
-// Older CUPTI headers do not define CUPTI_ACTIVITY_ATTR_THREAD_ID_TYPE. Use the
-// CUDA 13.2 enum value so this file can compile with those headers; weak V2
-// symbol checks still decide runtime availability.
-constexpr auto kCuptiActivityAttrThreadIdType =
+// Keep optional V2 paths buildable with older CUPTI headers; weak symbol checks
+// still decide runtime availability.
+constexpr CUpti_ActivityAttribute kCuptiActivityAttrPerThreadActivityBuffer =
+    static_cast<CUpti_ActivityAttribute>(9);
+constexpr CUpti_ActivityAttribute kCuptiActivityAttrThreadIdType =
     static_cast<CUpti_ActivityAttribute>(21);
+constexpr int kCuptiErrorMultipleSubscribersNotSupported = 39;
 
 }  // namespace
 
@@ -111,9 +113,14 @@ extern "C" {
 [[gnu::weak]] CUptiResult cuptiActivityDisable_v2(
     CUpti_SubscriberHandle subscriber, CUpti_ActivityKind kind,
     CuptiActivityConfigAbi* cfg);
+[[gnu::weak]] CUptiResult cuptiActivityGetNextRecord_v2(
+    CUpti_SubscriberHandle subscriber, uint8_t* buffer,
+    size_t valid_buffer_size_bytes, CUpti_Activity** record);
 [[gnu::weak]] CUptiResult cuptiActivitySetAttribute_v2(
     CUpti_SubscriberHandle subscriber, CUpti_ActivityAttribute attr,
     size_t* valueSize, void* value);
+[[gnu::weak]] CUptiResult cuptiGetTimestamp_v2(
+    CUpti_SubscriberHandle subscriber, uint64_t* timestamp);
 [[gnu::weak]] CUptiResult cuptiSubscribe_v2(CUpti_SubscriberHandle* subscriber,
                                             CUpti_CallbackFunc callback,
                                             void* userdata,
@@ -136,6 +143,16 @@ CUptiResult CuptiWrapper::ActivityGetNextRecord(uint8_t* buffer,
                                                 size_t valid_buffer_size_bytes,
                                                 CUpti_Activity** record) {
   return cuptiActivityGetNextRecord(buffer, valid_buffer_size_bytes, record);
+}
+
+CUptiResult CuptiWrapper::ActivityGetNextRecordV2(
+    CUpti_SubscriberHandle subscriber, uint8_t* buffer,
+    size_t valid_buffer_size_bytes, CUpti_Activity** record) {
+  if (cuptiActivityGetNextRecord_v2 == nullptr) {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+  return cuptiActivityGetNextRecord_v2(subscriber, buffer,
+                                       valid_buffer_size_bytes, record);
 }
 
 CUptiResult CuptiWrapper::ActivityGetNumDroppedRecords(CUcontext context,
@@ -212,8 +229,8 @@ CUptiResult CuptiWrapper::ActivityUsePerThreadBufferV2() {
   uint8_t use_per_thread = 1;
   size_t size = sizeof(use_per_thread);
   return ActivitySetAttributeV2(
-      /*subscriber=*/nullptr, CUPTI_ACTIVITY_ATTR_PER_THREAD_ACTIVITY_BUFFER,
-      &size, &use_per_thread);
+      /*subscriber=*/nullptr, kCuptiActivityAttrPerThreadActivityBuffer, &size,
+      &use_per_thread);
 }
 
 CUptiResult CuptiWrapper::ActivityUsePerThreadBuffer() {
@@ -246,6 +263,14 @@ CUptiResult CuptiWrapper::GetTimestamp(uint64_t* timestamp) {
   return cuptiGetTimestamp(timestamp);
 }
 
+CUptiResult CuptiWrapper::GetTimestampV2(CUpti_SubscriberHandle subscriber,
+                                         uint64_t* timestamp) {
+  if (cuptiGetTimestamp_v2 == nullptr) {
+    return CUPTI_ERROR_NOT_SUPPORTED;
+  }
+  return cuptiGetTimestamp_v2(subscriber, timestamp);
+}
+
 CUptiResult CuptiWrapper::Finalize() { return cuptiFinalize(); }
 
 CUptiResult CuptiWrapper::EnableCallback(uint32_t enable,
@@ -270,7 +295,9 @@ CUptiResult CuptiWrapper::Subscribe(CUpti_SubscriberHandle* subscriber,
 CUptiResult CuptiWrapper::SubscribeV2(CUpti_SubscriberHandle* subscriber,
                                       CUpti_CallbackFunc callback,
                                       void* userdata) {
-  if (cuptiSubscribe_v2 == nullptr) {
+  // Check both required V2 setup entry points before creating a subscriber.
+  // The tracer handles errors reported after subscription.
+  if (cuptiSubscribe_v2 == nullptr || cuptiGetTimestamp_v2 == nullptr) {
     return CUPTI_ERROR_NOT_SUPPORTED;
   }
   CuptiSubscriberParamsAbi params = {};
@@ -281,7 +308,7 @@ CUptiResult CuptiWrapper::SubscribeV2(CUpti_SubscriberHandle* subscriber,
   }
   CUptiResult result =
       cuptiSubscribe_v2(subscriber, callback, userdata, &params);
-  if (result == CUPTI_ERROR_MULTIPLE_SUBSCRIBERS_NOT_SUPPORTED) {
+  if (static_cast<int>(result) == kCuptiErrorMultipleSubscribersNotSupported) {
     return CUPTI_ERROR_NOT_SUPPORTED;
   }
   return result;

--- a/xla/backends/profiler/gpu/cupti_wrapper.h
+++ b/xla/backends/profiler/gpu/cupti_wrapper.h
@@ -16,15 +16,14 @@ limitations under the License.
 #ifndef XLA_BACKENDS_PROFILER_GPU_CUPTI_WRAPPER_H_
 #define XLA_BACKENDS_PROFILER_GPU_CUPTI_WRAPPER_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_profiler_target.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_target.h"
 #include "third_party/gpus/cuda/include/cuda.h"
+#include <stddef.h>
+#include <stdint.h>
 #include "xla/backends/profiler/gpu/cupti_interface.h"
 
 namespace xla {
@@ -46,6 +45,11 @@ class CuptiWrapper : public xla::profiler::CuptiInterface {
   CUptiResult ActivityGetNextRecord(uint8_t* buffer,
                                     size_t valid_buffer_size_bytes,
                                     CUpti_Activity** record) override;
+
+  CUptiResult ActivityGetNextRecordV2(CUpti_SubscriberHandle subscriber,
+                                      uint8_t* buffer,
+                                      size_t valid_buffer_size_bytes,
+                                      CUpti_Activity** record) override;
 
   CUptiResult ActivityGetNumDroppedRecords(CUcontext context,
                                            uint32_t stream_id,
@@ -86,6 +90,9 @@ class CuptiWrapper : public xla::profiler::CuptiInterface {
   CUptiResult GetDeviceId(CUcontext context, uint32_t* deviceId) override;
 
   CUptiResult GetTimestamp(uint64_t* timestamp) override;
+
+  CUptiResult GetTimestampV2(CUpti_SubscriberHandle subscriber,
+                             uint64_t* timestamp) override;
 
   // cuptiFinalize is only defined in CUDA8 and above.
   // To enable it in CUDA8, the environment variable CUPTI_ENABLE_FINALIZE must
@@ -250,6 +257,11 @@ class CuptiWrapperStub : public xla::profiler::CuptiInterface {
                                     size_t valid_buffer_size_bytes,
                                     CUpti_Activity** record) override;
 
+  CUptiResult ActivityGetNextRecordV2(CUpti_SubscriberHandle subscriber,
+                                      uint8_t* buffer,
+                                      size_t valid_buffer_size_bytes,
+                                      CUpti_Activity** record) override;
+
   CUptiResult ActivityGetNumDroppedRecords(CUcontext context,
                                            uint32_t stream_id,
                                            size_t* dropped) override;
@@ -289,6 +301,9 @@ class CuptiWrapperStub : public xla::profiler::CuptiInterface {
   CUptiResult GetDeviceId(CUcontext context, uint32_t* deviceId) override;
 
   CUptiResult GetTimestamp(uint64_t* timestamp) override;
+
+  CUptiResult GetTimestampV2(CUpti_SubscriberHandle subscriber,
+                             uint64_t* timestamp) override;
 
   // cuptiFinalize is only defined in CUDA8 and above.
   // To enable it in CUDA8, the environment variable CUPTI_ENABLE_FINALIZE must

--- a/xla/backends/profiler/gpu/cupti_wrapper_stub.cc
+++ b/xla/backends/profiler/gpu/cupti_wrapper_stub.cc
@@ -45,6 +45,12 @@ CUptiResult CuptiWrapperStub::ActivityGetNextRecord(
   return CUPTI_ERROR_MAX_LIMIT_REACHED;
 }
 
+CUptiResult CuptiWrapperStub::ActivityGetNextRecordV2(
+    CUpti_SubscriberHandle /*subscriber*/, uint8_t* /*buffer*/,
+    size_t /*valid_buffer_size_bytes*/, CUpti_Activity** /*record*/) {
+  return CUPTI_ERROR_MAX_LIMIT_REACHED;
+}
+
 CUptiResult CuptiWrapperStub::ActivityGetNumDroppedRecords(CUcontext context,
                                                            uint32_t stream_id,
                                                            size_t* dropped) {
@@ -112,6 +118,11 @@ CUptiResult CuptiWrapperStub::GetDeviceId(CUcontext context,
 
 CUptiResult CuptiWrapperStub::GetTimestamp(uint64_t* timestamp) {
   return cuptiGetTimestamp(timestamp);
+}
+
+CUptiResult CuptiWrapperStub::GetTimestampV2(
+    CUpti_SubscriberHandle /*subscriber*/, uint64_t* timestamp) {
+  return GetTimestamp(timestamp);
 }
 
 CUptiResult CuptiWrapperStub::Finalize() { return CUPTI_SUCCESS; }

--- a/xla/backends/profiler/gpu/device_tracer_cuda.cc
+++ b/xla/backends/profiler/gpu/device_tracer_cuda.cc
@@ -13,8 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include <stdlib.h>
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -27,6 +25,7 @@ limitations under the License.
 #include "xla/tsl/platform/status_macros.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
 #include "third_party/gpus/cuda/include/cuda.h"
+#include <stdlib.h>
 #include "xla/backends/profiler/gpu/cupti_collector.h"
 #include "xla/backends/profiler/gpu/cupti_tracer.h"
 #include "xla/backends/profiler/gpu/cupti_tracer_options_utils.h"
@@ -130,7 +129,9 @@ absl::Status GpuTracer::DoStart() {
     collector_options.num_gpus = num_gpus;
   }
 
-  uint64_t start_gputime_ns = CuptiTracer::GetTimestamp();
+  // A fresh V2 subscriber must exist before its timestamp API can be used.
+  RETURN_IF_ERROR(cupti_tracer_->PrepareForProfilerStart(options_));
+  uint64_t start_gputime_ns = cupti_tracer_->GetTimestampForSubscriber();
   uint64_t start_walltime_ns = tsl::profiler::GetCurrentTimeNanos();
   cupti_collector_ = CreateCuptiCollector(collector_options, start_walltime_ns,
                                           start_gputime_ns);

--- a/xla/backends/profiler/gpu/mock_cupti.h
+++ b/xla/backends/profiler/gpu/mock_cupti.h
@@ -45,8 +45,12 @@ class MockCupti : public xla::profiler::CuptiInterface {
               (override));
   MOCK_METHOD(CUptiResult, ActivityFlushAll, (uint32_t flag), (override));
   MOCK_METHOD(CUptiResult, ActivityGetNextRecord,
-              (uint8_t* buffer, size_t valid_buffer_size_bytes,
+              (uint8_t * buffer, size_t valid_buffer_size_bytes,
                CUpti_Activity** record),
+              (override));
+  MOCK_METHOD(CUptiResult, ActivityGetNextRecordV2,
+              (CUpti_SubscriberHandle subscriber, uint8_t* buffer,
+               size_t valid_buffer_size_bytes, CUpti_Activity** record),
               (override));
   MOCK_METHOD(CUptiResult, ActivityGetNumDroppedRecords,
               (CUcontext context, uint32_t stream_id, size_t* dropped),
@@ -84,7 +88,10 @@ class MockCupti : public xla::profiler::CuptiInterface {
               (override));
   MOCK_METHOD(CUptiResult, GetDeviceId, (CUcontext context, uint32_t* deviceId),
               (override));
-  MOCK_METHOD(CUptiResult, GetTimestamp, (uint64_t* timestamp), (override));
+  MOCK_METHOD(CUptiResult, GetTimestamp, (uint64_t * timestamp), (override));
+  MOCK_METHOD(CUptiResult, GetTimestampV2,
+              (CUpti_SubscriberHandle subscriber, uint64_t* timestamp),
+              (override));
   MOCK_METHOD(CUptiResult, Finalize, (), (override));
   MOCK_METHOD(CUptiResult, EnableCallback,
               (uint32_t enable, CUpti_SubscriberHandle subscriber,

--- a/xla/tsl/cuda/cupti.symbols
+++ b/xla/tsl/cuda/cupti.symbols
@@ -18,6 +18,7 @@ cuptiActivityFlushAll
 cuptiActivityFlushPeriod
 cuptiActivityGetAttribute
 cuptiActivityGetNextRecord
+cuptiActivityGetNextRecord_v2
 cuptiActivityGetNumDroppedRecords
 cuptiActivityGetNvtxExtPayloadAttr
 cuptiActivityGetNvtxExtPayloadEntryTypeInfo
@@ -91,6 +92,7 @@ cuptiGetStreamId
 cuptiGetStreamIdEx
 cuptiGetThreadIdType
 cuptiGetTimestamp
+cuptiGetTimestamp_v2
 cuptiGetVersion
 cuptiKernelReplaySubscribeUpdate
 cuptiMetricCreateEventGroupSets


### PR DESCRIPTION
📝 Summary of Changes
  - Added CUPTI V2 multi-subscriber support for CUPTI 13.3, using a fresh subscriber for each profiling
    session.
  - Used subscriber-scoped V2 APIs for timestamps and activity processing.
  - Kept each subscriber alive until its cached activity buffers were processed.
  - Preserved the legacy V1 path when V2 support is unavailable.

🎯 Justification
  This enables CUPTI V2 multi-subscriber support for CUPTI 13.3. It allows XLA to create an independent
  subscriber for each profiling session and lays the groundwork for using PGLE alongside NVIDIA Nsight Systems.

🚀 Kind of Contribution
   🐛 Bug Fix, ✨ New Feature, ♻️ Cleanup, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Not applicable. This change does not introduce a performance optimization.

🧪 Unit Tests:
  Added cupti_tracer_test coverage for:
  - V2 subscribe failures falling back to V1
  - V2 timestamp failures after subscription falling back to V1
  - Fatal initial V2 timestamp failures without duplicate unsubscribe
  - Preparing a fresh V2 subscriber for each profiling session
  - Fatal stop-timestamp failures without duplicate unsubscribe

  Expanded cupti_error_manager_test coverage for:
  - Nonfatal V2 activity-configuration errors
  - Nonfatal V2 activity-record errors without falling back to the V1 parser

  These tests cover V2 capability detection, V1 fallback, fresh subscribers across sessions, subscriber-scoped  timestamps, V2 activity-record handling, and cleanup after fatal errors.

🧪 Execution Tests:
  No new dedicated execution test was added.
  The existing end-to-end JAX GPU profiling tests passed using both the V1 path such as CUPTI 12.9 and the V2 path with
  CUPTI 13.3:
  - JAX //tests:pgle_test_gpu: passed
  - JAX //tests:profiler_test_gpu: passed