### PR TITLE
[XLA] Make selective-overlap valuableness resource-specific

### DIFF
--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -540,16 +540,16 @@ void GpuAsyncTrackerBase::PostProcessScheduleGraph(
 
     // With selective resources enabled, the async D2D memcpy resource can
     // only have its latency hidden by compute-bound kernels. Mark
-    // memory-bandwidth-bound kernels as not valuable for selective overlap so
-    // the scheduler prefers compute-bound kernels inside copy windows.
-    if (config_.enable_selective_resources) {
+    // memory-bandwidth-bound kernels as not valuable for overlapping the
+    // memcpy resource specifically, so that this D2D policy does not affect
+    // any other selective resource a target may define.
+    if (config_.enable_selective_resources && IsMemoryBoundKernel(*inst)) {
       HloGraphNode& node = schedule_graph->GetNode(inst);
-      node.SetValuableForSelectiveOverlap(!IsMemoryBoundKernel(*inst));
-      if (IsMemoryBoundKernel(*inst)) {
-        VLOG(5) << "Marking instruction as not valuable for selective "
-                   "overlap: "
-                << inst->ToString();
-      }
+      node.AddNonvaluableSelectiveResources(GetSelectiveResourceMask(
+          ResourceTypeToIndex(GpuResourceType::kGpuAsyncStreamMemcpy)));
+      VLOG(5) << "Marking instruction as not valuable for selective memcpy "
+                 "overlap: "
+              << inst->ToString();
     }
   }
 }

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -1606,6 +1606,20 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest,
   EXPECT_TRUE(schedule_graph.GetNode(comp->GetInstructionWithName("p0"))
                   .GetValuableForSelectiveOverlap());
 
+  // The D2D classification is attached to the async memcpy resource only;
+  // memory-bound kernels remain valuable for any other selective resource a
+  // target may define.
+  uint64_t memcpy_resource_mask = async_tracker->GetSelectiveResourceMask(
+      ResourceTypeToIndex(GpuResourceType::kGpuAsyncStreamMemcpy));
+  uint64_t other_resource_mask = async_tracker->GetSelectiveResourceMask(
+      ResourceTypeToIndex(GpuResourceType::kGpuAsyncStreamCollectives));
+  const HloGraphNode& transpose_node =
+      schedule_graph.GetNode(comp->GetInstructionWithName("transpose_fusion"));
+  EXPECT_FALSE(
+      transpose_node.IsValuableForSelectiveOverlap(memcpy_resource_mask));
+  EXPECT_TRUE(
+      transpose_node.IsValuableForSelectiveOverlap(other_resource_mask));
+
   // With the feature disabled, all nodes keep the default marking.
   SchedulerConfig default_config;
   auto default_tracker = std::make_shared<GpuAsyncTracker>(default_config);

--- a/xla/service/latency_hiding_scheduler.cc
+++ b/xla/service/latency_hiding_scheduler.cc
@@ -934,6 +934,39 @@ bool AsyncTracker::OccupiesSelectiveResource(const HloGraphNode* node) const {
       });
 }
 
+uint64_t AsyncTracker::GetSelectiveResourceMask(int64_t resource_type) const {
+  auto [it, inserted] = selective_resource_bit_indices_.emplace(
+      resource_type, selective_resource_bit_indices_.size());
+  CHECK_LT(it->second, 64) << "At most 64 selective resources are supported.";
+  return uint64_t{1} << it->second;
+}
+
+uint64_t AsyncTracker::GetReleasedSelectiveResourceMask(
+    const ResourcesVector& resources) const {
+  uint64_t mask = 0;
+  for (const ResourcePair& resource : resources) {
+    if (resource.second == ResourceUsageType::kResourceRelease &&
+        GetResourceHazardType(resource.first) ==
+            ResourceHazardType::kSelective) {
+      mask |= GetSelectiveResourceMask(resource.first);
+    }
+  }
+  return mask;
+}
+
+uint64_t AsyncTracker::GetOccupiedSelectiveResourceMask(
+    const ResourcesVector& resources) const {
+  uint64_t mask = 0;
+  for (const ResourcePair& resource : resources) {
+    if (resource.second == ResourceUsageType::kResourceOccupy &&
+        GetResourceHazardType(resource.first) ==
+            ResourceHazardType::kSelective) {
+      mask |= GetSelectiveResourceMask(resource.first);
+    }
+  }
+  return mask;
+}
+
 BufferInfoTracker::BufferInfoTracker(
     const HloModule* module, const HloAliasAnalysis* alias_analysis,
     const HloCostAnalysis::ShapeSizeFunction& shape_size_bytes) {
@@ -1274,23 +1307,23 @@ DefaultSchedulerCore::ScheduleCandidate InitializeCandidate(
 
 namespace {
 
-// Find the num hops to the closest selective resource overlap in ready set that
-// provided node can be scheduled in between.
-int64_t GetNumHopsToClosestSelectiveOverlap(
+// Returns the mask of the selective resources occupied within `max_distance`
+// hops of the ready set that the provided node can be scheduled in between.
+uint64_t GetNearbySelectiveResourcesMask(
     const DefaultSchedulerCore::ReadyQueueSet& ready_set,
-    const HloGraphNode* node) {
-  int64_t num_hops_to_closest_selective_resource_occupier =
-      std::numeric_limits<int64_t>::max();
+    const HloGraphNode* node, int64_t max_distance) {
+  uint64_t nearby_selective_resources_mask = 0;
   for (const HloGraphNode* n : ready_set) {
     // Skip the node itself.
     if (n == node) {
       continue;
     }
-    num_hops_to_closest_selective_resource_occupier =
-        std::min(num_hops_to_closest_selective_resource_occupier,
-                 n->GetNumHopsToClosestSelectiveResourceOccupier());
+    if (n->GetNumHopsToClosestSelectiveResourceOccupier() <= max_distance) {
+      nearby_selective_resources_mask |=
+          n->GetClosestSelectiveResourceOccupierMask();
+    }
   }
-  return num_hops_to_closest_selective_resource_occupier;
+  return nearby_selective_resources_mask;
 }
 
 }  // namespace
@@ -1398,22 +1431,21 @@ bool ReadySetLt::ShouldScheduleAsyncStart(const SchedulingState& state,
 std::optional<bool> ReadySetLt::IsValuableForSelectiveOverlap(
     const SchedulingState& sched_state, ScheduleCandidate& a,
     ScheduleCandidate& b, const char** reason) const {
-  // If a is valuable for selective overlap and there is a selective
-  // overlap in the near future a can be scheduled inside, hold off
-  // scheduling a and schedule b instead. Same logic applies in reverse.
-  int64_t distance_to_selective_overlap_for_a =
-      GetNumHopsToClosestSelectiveOverlap(sched_state.ready_set, a.node);
-  int64_t distance_to_selective_overlap_for_b =
-      GetNumHopsToClosestSelectiveOverlap(sched_state.ready_set, b.node);
+  // If a is valuable for a selective overlap that opens in the near future so
+  // that a can be scheduled inside it, hold off scheduling a and schedule b
+  // instead. Same logic applies in reverse.
   int64_t max_distance =
       sched_state.config.max_hops_to_closest_selective_overlap;
+  uint64_t nearby_selective_resources_for_a = GetNearbySelectiveResourcesMask(
+      sched_state.ready_set, a.node, max_distance);
+  uint64_t nearby_selective_resources_for_b = GetNearbySelectiveResourcesMask(
+      sched_state.ready_set, b.node, max_distance);
   // Reversal of b and a here is intentional due to comment above.
-  if (auto res =
-          CmpExplicit((b.node->GetValuableForSelectiveOverlap() &&
-                       distance_to_selective_overlap_for_b <= max_distance),
-                      (a.node->GetValuableForSelectiveOverlap() &&
-                       distance_to_selective_overlap_for_a <= max_distance),
-                      "kNotValuableForSelectiveOverlap", reason)) {
+  if (auto res = CmpExplicit(b.node->IsValuableForAnySelectiveResource(
+                                 nearby_selective_resources_for_b),
+                             a.node->IsValuableForAnySelectiveResource(
+                                 nearby_selective_resources_for_a),
+                             "kNotValuableForSelectiveOverlap", reason)) {
     return res;
   }
   return std::nullopt;
@@ -1615,8 +1647,12 @@ bool ReadySetLt::AIsBetterThanB(DefaultSchedulerCore::ScheduleCandidate& a,
         config.avoid_nonvaluable_selective_overlap &&
         !core_->top_down_scheduling_ &&
         !sched_state.selective_resource_releasers.empty()) {
-      return CmpExplicit(an->GetValuableForSelectiveOverlap(),
-                         bn->GetValuableForSelectiveOverlap(),
+      // Only the selective windows currently open matter: a node is
+      // deprioritized only if it cannot hide the latency of one of them.
+      return CmpExplicit(an->IsValuableForSelectiveOverlap(
+                             sched_state.open_selective_resources_mask),
+                         bn->IsValuableForSelectiveOverlap(
+                             sched_state.open_selective_resources_mask),
                          "kAvoidNonvaluableSelectiveOverlap", reason);
     }
     return std::nullopt;
@@ -2623,16 +2659,26 @@ absl::StatusOr<HloGraphNode::TimeCost> DefaultSchedulerCore::ScheduleNode(
                    << n->ToString();
     } else {
       sched_state->selective_resource_releasers.erase(it);
+      // Recompute the union of the open selective windows since another
+      // releaser may release the same selective resource.
+      sched_state->open_selective_resources_mask = 0;
+      for (const HloGraphNode* releaser :
+           sched_state->selective_resource_releasers) {
+        sched_state->open_selective_resources_mask |=
+            releaser->GetReleasedSelectiveResourcesMask();
+      }
     }
   }
 
-  // If scheduled node cannot overlap with nodes that hold selective
-  // resources, we increment the ready time of all nodes that release a
+  // If the scheduled node cannot cover the latency of an open selective
+  // window, we increment the ready time of the node releasing that window's
   // selective resource with the cost of the scheduled node.
-  if (sched_state->config.enable_selective_resources &&
-      !n->GetValuableForSelectiveOverlap()) {
+  if (sched_state->config.enable_selective_resources) {
     for (HloGraphNode* node : sched_state->selective_resource_releasers) {
-      node->SetReadyTime(node->GetReadyTime() + n->GetCost());
+      if (!n->IsValuableForSelectiveOverlap(
+              node->GetReleasedSelectiveResourcesMask())) {
+        node->SetReadyTime(node->GetReadyTime() + n->GetCost());
+      }
     }
   }
 
@@ -2837,6 +2883,8 @@ absl::StatusOr<HloGraphNode::TimeCost> DefaultSchedulerCore::ScheduleNode(
     if (sched_state->config.enable_selective_resources &&
         edge.Target().ReleasesSelectiveResource()) {
       sched_state->selective_resource_releasers.push_back(&edge.Target());
+      sched_state->open_selective_resources_mask |=
+          edge.Target().GetReleasedSelectiveResourcesMask();
     }
   }
   ++sched_state->scheduled_count;
@@ -2995,6 +3043,10 @@ HloScheduleGraph::HloScheduleGraph(
         async_tracker->ReleasesSelectiveResource(n);
     n->occupies_selective_resource_ =
         async_tracker->OccupiesSelectiveResource(n);
+    if (n->releases_selective_resource_) {
+      n->released_selective_resources_mask_ =
+          async_tracker->GetReleasedSelectiveResourceMask(resources);
+    }
     n->does_occupy_any_resource_ =
         absl::c_any_of(resources, [](const ResourcePair& resource) {
           return resource.second == ResourceUsageType::kResourceOccupy;
@@ -3358,10 +3410,14 @@ void HloScheduleGraph::InitializeGraphAnalysis() {
     // If a node occupies a selective resource, it is the closest selective
     // resource occupier to itself and is 0 hops away. Otherwise, the num hops
     // to closest selective resource occupier is the minimum of that of all
-    // predecessors plus 1.
+    // predecessors plus 1. Alongside the distance, track the mask of the
+    // selective resources occupied at that distance.
     if (scheduling_context_->GetAsyncTracker()->OccupiesSelectiveResource(
             node)) {
       node->num_hops_to_closest_selective_resource_occupier_ = 0;
+      node->closest_selective_resource_occupier_mask_ =
+          scheduling_context_->GetAsyncTracker()
+              ->GetOccupiedSelectiveResourceMask(node->GetResources());
     } else {
       int64_t closest_predecessor_distance =
           std::numeric_limits<int64_t>::max();
@@ -3373,6 +3429,13 @@ void HloScheduleGraph::InitializeGraphAnalysis() {
       if (closest_predecessor_distance != std::numeric_limits<int64_t>::max()) {
         node->num_hops_to_closest_selective_resource_occupier_ =
             closest_predecessor_distance + 1;
+        for (auto& pred : node->GetPredecessors()) {
+          if (pred.Target().num_hops_to_closest_selective_resource_occupier_ ==
+              closest_predecessor_distance) {
+            node->closest_selective_resource_occupier_mask_ |=
+                pred.Target().closest_selective_resource_occupier_mask_;
+          }
+        }
       }
     }
     if (node->IsSupportedAsyncDone()) {
@@ -3742,6 +3805,7 @@ void DefaultSchedulerCore::SchedulingState::Reset() {
   next_ready_stack.clear();
   shareable_resource_occupiers.clear();
   selective_resource_releasers.clear();
+  open_selective_resources_mask = 0;
   num_successors_for_annotation.clear();
   num_predecessors_for_annotation.clear();
   ready_annotations.clear();

--- a/xla/service/latency_hiding_scheduler.h
+++ b/xla/service/latency_hiding_scheduler.h
@@ -356,6 +356,22 @@ class AsyncTracker {
   // Returns whether the provided node occupies a selective resource.
   bool OccupiesSelectiveResource(const HloGraphNode* node) const;
 
+  // Selective resources are assigned compact bit indices (in order of first
+  // use) so that per-node selective overlap state can be stored in bit masks
+  // indexed by selective resource. At most 64 selective resources are
+  // supported.
+  uint64_t GetSelectiveResourceMask(int64_t resource_type) const;
+
+  // Returns the bit mask of the selective resources released by the given
+  // resources vector.
+  uint64_t GetReleasedSelectiveResourceMask(
+      const ResourcesVector& resources) const;
+
+  // Returns the bit mask of the selective resources occupied by the given
+  // resources vector.
+  uint64_t GetOccupiedSelectiveResourceMask(
+      const ResourcesVector& resources) const;
+
   inline CanonicalAsyncOp GetCanonicalAsyncOp(const HloInstruction& hlo) const {
     return get_canonical_async_op_(hlo);
   }
@@ -413,6 +429,9 @@ class AsyncTracker {
       std::unique_ptr<absl::flat_hash_map<int64_t, int64_t>>>
       async_in_computation_cache_;
   GetCanonicalAsyncOpFunc get_canonical_async_op_;
+  // Lazily assigned compact bit indices for selective resources. See
+  // GetSelectiveResourceMask().
+  mutable absl::flat_hash_map<int64_t, int> selective_resource_bit_indices_;
 
  protected:
   const SchedulerConfig config_;
@@ -774,11 +793,43 @@ class HloGraphNode {
   void SetForceDelayAfterTarget(bool force_delay_after_target) {
     force_delay_after_target_ = force_delay_after_target;
   }
-  bool GetValuableForSelectiveOverlap() const {
-    return valuable_for_selective_overlap_;
+  // Returns true if this node provides useful latency hiding for every
+  // selective resource in the given mask. Masks are assigned by
+  // AsyncTracker::GetSelectiveResourceMask().
+  bool IsValuableForSelectiveOverlap(uint64_t selective_resources_mask) const {
+    return (nonvaluable_selective_resources_mask_ & selective_resources_mask) ==
+           0;
   }
+  // Returns true if this node provides useful latency hiding for at least one
+  // selective resource in the given mask.
+  bool IsValuableForAnySelectiveResource(
+      uint64_t selective_resources_mask) const {
+    return (selective_resources_mask &
+            ~nonvaluable_selective_resources_mask_) != 0;
+  }
+  // Returns true if this node is valuable for every selective resource.
+  bool GetValuableForSelectiveOverlap() const {
+    return nonvaluable_selective_resources_mask_ == 0;
+  }
+  // Marks this node as valuable/nonvaluable for all selective resources.
   void SetValuableForSelectiveOverlap(bool valuable_for_selective_overlap) {
-    valuable_for_selective_overlap_ = valuable_for_selective_overlap;
+    nonvaluable_selective_resources_mask_ =
+        valuable_for_selective_overlap ? 0 : ~uint64_t{0};
+  }
+  // Marks this node as not valuable for the selective resources in the given
+  // mask, leaving its classification for other selective resources unchanged.
+  void AddNonvaluableSelectiveResources(uint64_t selective_resources_mask) {
+    nonvaluable_selective_resources_mask_ |= selective_resources_mask;
+  }
+  // Bit mask of the selective resources released by this node.
+  uint64_t GetReleasedSelectiveResourcesMask() const {
+    return released_selective_resources_mask_;
+  }
+  // Bit mask of the selective resources occupied by the closest selective
+  // resource occupier(s), i.e. the occupier(s)
+  // GetNumHopsToClosestSelectiveResourceOccupier() hops away.
+  uint64_t GetClosestSelectiveResourceOccupierMask() const {
+    return closest_selective_resource_occupier_mask_;
   }
   bool ReleasesSelectiveResource() const {
     return releases_selective_resource_;
@@ -989,7 +1040,6 @@ class HloGraphNode {
     has_operand_that_is_supported_async_done_ = false;
     has_user_that_is_supported_async_start_ = false;
     scheduled_ = false;
-    valuable_for_selective_overlap_ = true;
     releases_selective_resource_ = false;
     occupies_selective_resource_ = false;
     has_recursive_resources_ = false;
@@ -1063,9 +1113,6 @@ class HloGraphNode {
   bool has_user_that_is_supported_async_start_ : 1;
   // Whether this node has been scheduled or not yet.
   bool scheduled_ : 1;
-  // Whether this node can be overlapped with (can cover the latency/cost of)
-  // edges occupying selective resources.
-  bool valuable_for_selective_overlap_ : 1;
   // Whether this node releases a selective resource.
   bool releases_selective_resource_ : 1;
   // Whether this node occupies a selective resource.
@@ -1096,6 +1143,16 @@ class HloGraphNode {
 
   // Depth in latency terms of node based on distance to the entry node.
   int64_t graph_depth_ = 0;
+  // Bit mask of the selective resources (bit indices assigned by the
+  // AsyncTracker) for which this node does NOT provide useful latency hiding.
+  // The default (0) means the node is valuable for every selective resource.
+  uint64_t nonvaluable_selective_resources_mask_ = 0;
+  // Bit mask of the selective resources released by this node.
+  uint64_t released_selective_resources_mask_ = 0;
+  // Bit mask of the selective resources occupied by the closest selective
+  // resource occupier(s), num_hops_to_closest_selective_resource_occupier_
+  // hops away.
+  uint64_t closest_selective_resource_occupier_mask_ = 0;
   // Nums hops to closest selective resource occupier.
   int32_t num_hops_to_closest_selective_resource_occupier_ =
       std::numeric_limits<int32_t>::max();
@@ -1775,6 +1832,10 @@ class DefaultSchedulerCore : public SchedulerCore {
         shareable_resource_occupiers;
     // List of the graph nodes that release selective resources.
     std::vector<HloGraphNode*> selective_resource_releasers;
+    // Union of the selective resources released by the nodes in
+    // selective_resource_releasers, i.e. the selective windows currently open
+    // in a bottom-up schedule.
+    uint64_t open_selective_resources_mask = 0;
     // Similar to ready set, but only contains the no-op instructions.
     ReadyQueueSet nop_set;
     // Number of {scheduled, all} nodes that are a successor for the given

--- a/xla/service/latency_hiding_scheduler_test.cc
+++ b/xla/service/latency_hiding_scheduler_test.cc
@@ -3684,11 +3684,19 @@ ENTRY %module {
 )";
 
   // Extend AsyncTracker for a fake target where all-gather contains
-  // non-extendable and selective resources.
+  // non-extendable and selective resources. If
+  // mark_c2_nonvaluable_for_unrelated_resource is true, c2 is marked
+  // nonvaluable only for a second selective resource that no instruction in
+  // the module uses; otherwise c2 is marked nonvaluable for all selective
+  // resources.
   class SelectiveOverlapAsyncTracker : public AsyncTracker {
    public:
-    explicit SelectiveOverlapAsyncTracker(const SchedulerConfig& sched_config)
-        : AsyncTracker(sched_config) {}
+    explicit SelectiveOverlapAsyncTracker(
+        const SchedulerConfig& sched_config,
+        bool mark_c2_nonvaluable_for_unrelated_resource = false)
+        : AsyncTracker(sched_config),
+          mark_c2_nonvaluable_for_unrelated_resource_(
+              mark_c2_nonvaluable_for_unrelated_resource) {}
 
     ResourceHazardType GetResourceHazardType(
         int64_t resource_type) const override {
@@ -3699,6 +3707,12 @@ ENTRY %module {
       if (resource_type == AsyncTracker::GetTargetDefinedResourceTypeBegin()) {
         return ResourceHazardType::kNonextendable;
       }
+      // The second target defined resource is a selective resource that no
+      // instruction in the module uses.
+      if (resource_type ==
+          AsyncTracker::GetTargetDefinedResourceTypeBegin() + 1) {
+        return ResourceHazardType::kSelective;
+      }
       return AsyncTracker::GetResourceHazardType(resource_type);
     }
 
@@ -3706,7 +3720,8 @@ ENTRY %module {
         const HloInstruction& hlo) const override {
       ResourcesVector result =
           AsyncTracker::GetResourcesFromInstructionImpl(hlo);
-      // There is only one target defined resource (which is non-extendable).
+      // Only the first target defined resource (which is non-extendable) is
+      // used by instructions.
       if (hlo.opcode() == HloOpcode::kAllGatherStart) {
         result.push_back({AsyncTracker::GetTargetDefinedResourceTypeBegin(),
                           ResourceUsageType::kResourceRelease});
@@ -3716,13 +3731,14 @@ ENTRY %module {
       }
       return result;
     }
-    int64_t GetNumTargetDefinedResources() const override { return 1; }
+    int64_t GetNumTargetDefinedResources() const override { return 2; }
     void SetConcurrentResourceLimits(
         absl::flat_hash_map<int64_t, int64_t>& max_concurrent_resource)
         const override {
       max_concurrent_resource[ResourceTypeToIndex(ResourceType::kAllGather)] =
           1;
       max_concurrent_resource[GetTargetDefinedResourceTypeBegin()] = 1;
+      max_concurrent_resource[GetTargetDefinedResourceTypeBegin() + 1] = 1;
     }
     absl::InlinedVector<int64_t, 1> GetReleasedNonextendableResourcesFromVector(
         const ResourcesVector& resources) const override {
@@ -3743,10 +3759,21 @@ ENTRY %module {
       for (const HloInstruction* instr :
            schedule_graph->GetOriginalInstrList()) {
         if (instr->name() == "c2") {
-          schedule_graph->GetNode(instr).SetValuableForSelectiveOverlap(false);
+          HloGraphNode& node = schedule_graph->GetNode(instr);
+          if (mark_c2_nonvaluable_for_unrelated_resource_) {
+            // c2 remains valuable for the all-gather selective resource; it
+            // is nonvaluable only for the unused second selective resource.
+            node.AddNonvaluableSelectiveResources(GetSelectiveResourceMask(
+                AsyncTracker::GetTargetDefinedResourceTypeBegin() + 1));
+          } else {
+            node.SetValuableForSelectiveOverlap(false);
+          }
         }
       }
     }
+
+   private:
+    bool mark_c2_nonvaluable_for_unrelated_resource_;
   };
   SchedulerConfig sched_config = GetDefaultSchedConfig();
   sched_config.enable_selective_resources = true;
@@ -3808,6 +3835,33 @@ ENTRY %module {
   EXPECT_LT(avoiding_c2_index, avoiding_ag_start_index);
   EXPECT_LT(avoiding_ag_start_index, avoiding_c1_index);
   EXPECT_LT(avoiding_c1_index, avoiding_ag_done_index);
+
+  // The nonvaluable classification is indexed by selective resource: marking
+  // c2 nonvaluable only for a selective resource unrelated to the all-gather
+  // does not evict it from the all-gather window, even with
+  // avoid_nonvaluable_selective_overlap enabled. c2's cost fully covers the
+  // all-gather latency, so it is the only computation kept in the window.
+  SchedulerConfig isolated_config = GetDefaultSchedConfig();
+  isolated_config.enable_selective_resources = true;
+  isolated_config.avoid_nonvaluable_selective_overlap = true;
+  std::unique_ptr<AsyncTracker> isolated_tracker =
+      std::make_unique<SelectiveOverlapAsyncTracker>(
+          isolated_config,
+          /*mark_c2_nonvaluable_for_unrelated_resource=*/true);
+  ASSERT_OK_AND_ASSIGN(auto isolated_module, ParseHloText(hlo_string));
+  HloSchedule& isolated_schedule = isolated_module->schedule();
+  ASSERT_OK(RunScheduler(isolated_module.get(), isolated_config,
+                         std::make_unique<ApproximateLatencyEstimator>(),
+                         std::move(isolated_tracker)));
+  std::vector<HloInstruction*> isolated_sequence =
+      isolated_schedule.sequence(isolated_module->entry_computation())
+          .instructions();
+
+  int isolated_c2_index = GetIndex(isolated_sequence, "c2");
+  int isolated_ag_start_index = GetIndex(isolated_sequence, "ag-start");
+  int isolated_ag_done_index = GetIndex(isolated_sequence, "ag-done");
+  EXPECT_LT(isolated_ag_start_index, isolated_c2_index);
+  EXPECT_LT(isolated_c2_index, isolated_ag_done_index);
 }
 
 TEST_F(LatencyHidingSchedulerTest, AnnotationFirstDataIndependentConv) {


### PR DESCRIPTION
## Problem

PR #45983 classifies memory-bandwidth-bound kernels as "not valuable for selective overlap" so they stay outside async D2D memcpy windows. However, `HloGraphNode` stored this classification as a single boolean (`valuable_for_selective_overlap_`) that is not indexed by selective resource type. Any target-specific policy therefore silently applied to *every* selective resource in the scheduling graph.

Today this is safe only by coincidence: `kGpuAsyncStreamMemcpy` is the sole selective resource on GPU. If another resource (selective all-gather, async compute, ...) were later marked `kSelective`, the D2D-specific policy would incorrectly affect it — e.g. a memory-bound kernel is a perfectly reasonable overlap candidate for a network-bound collective, but the single boolean would deprioritize it there too.

## Design

Make the valuable-for-overlap classification resource-specific via per-node bit masks:

- `AsyncTracker` lazily assigns each selective resource a compact bit index and exposes `GetSelectiveResourceMask()` plus `GetReleasedSelectiveResourceMask()` / `GetOccupiedSelectiveResourceMask()` helpers (up to 64 selective resources).
- `HloGraphNode` replaces the boolean with:
  - `nonvaluable_selective_resources_mask_` — selective resources this node cannot hide (default 0 = valuable for everything);
  - `released_selective_resources_mask_` — selective windows this node opens (bottom-up);
  - `closest_selective_resource_occupier_mask_` — selective resources occupied at the node's min-hop distance, propagated alongside the existing hops analysis.
- The three consumers now evaluate valuableness against the resources actually involved:
  1. the `avoid_nonvaluable_selective_overlap` rule compares candidates against the union of the *currently open* selective windows (`SchedulingState::open_selective_resources_mask`, maintained incrementally);
  2. the ready-time punishment is applied per releaser, so a scheduled node's cost extends only the windows it genuinely cannot hide;
  3. the hold-back rule (`max_hops_to_closest_selective_overlap`) matches candidates against the selective resources occupied within range.
- The GPU tracker marks memory-bound kernels nonvaluable only for `kGpuAsyncStreamMemcpy`, so the D2D policy no longer leaks onto other (future) selective resources.

`SetValuableForSelectiveOverlap(bool)` is kept as an all-resources convenience with unchanged semantics, so existing users are unaffected.

## Testing

- `LatencyHidingSchedulerTest.AllGatherWithSelectiveOverlap` gains a third scenario with two selective resources: marking `c2` nonvaluable only for an unrelated selective resource keeps it inside the all-gather window even with `avoid_nonvaluable_selective_overlap` enabled (with the old boolean it was evicted).
- `GpuLatencyHidingSchedulerBaseTest.SelectiveMemcpyOverlapMarksMemoryBoundKernelsNotValuable` now asserts memory-bound kernels are nonvaluable for the memcpy resource mask but remain valuable for the collectives resource mask.
- Full suites pass locally: `latency_hiding_scheduler_test` (94/94) and `gpu_latency_hiding_scheduler_test` (32/32).

Stacked on #45983 (base: `shawnw/lhs_selective_memcpy_overlap`).
