### PR TITLE
SPMD: Use collective-broadcast for replicated dynamic-slice from sharded operands

### DIFF
--- a/xla/service/cpu/cpu_compiler.cc
+++ b/xla/service/cpu/cpu_compiler.cc
@@ -627,8 +627,13 @@ absl::Status CpuCompiler::RunHloPassesThroughLayoutAssn(
           module->config().allow_spmd_sharding_propagation_to_output(),
           module->config().allow_spmd_sharding_propagation_to_parameters());
     }
+    auto spmd_partitioner_options =
+        spmd::StatefulRngSpmdPartitioner::GetDefaultOptions();
+    // XLA:CPU does not support kCollectiveBroadcast.
+    spmd_partitioner_options.enable_dynamic_slice_collective_broadcast = false;
     spmd_pipeline.AddPass<spmd::StatefulRngSpmdPartitioner>(
-        num_partitions, module->config().replica_count());
+        num_partitions, module->config().replica_count(),
+        std::move(spmd_partitioner_options));
     spmd_pipeline.AddPass<ControlDepRewriter>();
     if (module->config().debug_options().xla_enable_enzyme_comms_opt()) {
       spmd_pipeline.AddPass<RecognizeReduceWindow>();

--- a/xla/service/cpu/tests/BUILD
+++ b/xla/service/cpu/tests/BUILD
@@ -265,6 +265,7 @@ xla_test(
     backends = ["cpu"],
     deps = [
         "//xla:debug_options_flags",
+        "//xla/service:computation_placer",
         "//xla/service:hlo_module_config",
         "//xla/service/cpu:cpu_compiler",
         "//xla/service/cpu:test_header_helper",

--- a/xla/service/cpu/tests/cpu_spmd_compile_test.cc
+++ b/xla/service/cpu/tests/cpu_spmd_compile_test.cc
@@ -13,12 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
 
 #include "absl/status/statusor.h"
 #include "xla/debug_options_flags.h"
+#include "xla/service/computation_placer.h"
 #include "xla/service/cpu/cpu_compiler.h"
 #include "xla/service/cpu/test_target_triple_helper.h"
 #include "xla/service/hlo_module_config.h"
@@ -54,6 +56,38 @@ ENTRY entry {
       CreateExecutable(std::move(hlo_module.value()),
                        /*run_hlo_passes=*/true);
   TF_EXPECT_OK(executable.status());
+}
+
+TEST_F(CpuSpmdCompileTest,
+       DynamicSliceCollectiveBroadcastUsesSupportedFallback) {
+  const char* const hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  %param = f32[4,8] parameter(0), sharding={devices=[4,1]<=[4]}
+  %index = s32[] parameter(1), sharding={replicated}
+  %zero = s32[] constant(0)
+  ROOT %dynamic-slice = f32[1,8] dynamic-slice(%param, %index, %zero),
+    dynamic_slice_sizes={1,8}, sharding={replicated}
+})";
+
+  HloModuleConfig config;
+  config.set_use_spmd_partitioning(true);
+  config.set_num_partitions(4);
+
+  DeviceAssignment device_assignment(/*replica_count=*/1,
+                                     /*computation_count=*/4);
+  for (int64_t partition = 0; partition < 4; ++partition) {
+    device_assignment(0, partition) = 0;
+  }
+  config.set_static_device_assignment(device_assignment);
+
+  ASSERT_OK_AND_ASSIGN(auto hlo_module,
+                       ParseAndReturnVerifiedModule(hlo_string, config));
+  ASSERT_OK_AND_ASSIGN(
+      auto executable,
+      CreateExecutable(std::move(hlo_module), /*run_hlo_passes=*/true));
+  EXPECT_NE(executable, nullptr);
 }
 
 }  // namespace

--- a/xla/service/gpu/gpu_spmd_pipeline.cc
+++ b/xla/service/gpu/gpu_spmd_pipeline.cc
@@ -124,18 +124,25 @@ void AddSPMDPasses(
             .debug_options()
             .xla_gpu_operand_bytes_threshold_for_windowed_einsum();
   }
-  spmd_pipeline.AddPass<spmd::StatefulRngSpmdPartitioner>(
-      num_partitions, hlo_module->config().replica_count(),
-      hlo_module->config()
-          .debug_options()
-          .xla_gpu_threshold_for_windowed_einsum_mib(),
-      hlo_module->config()
-          .debug_options()
-          .xla_gpu_multi_streamed_windowed_einsum(),
-      /*skip_checking_windowed_einsum_users=*/true,
-      /*disable_ag_rewrite_for_multiple_consumers=*/true,
-      /*enable_partial_windowed_einsums=*/true, oper_size_threshold,
-      max_windowed_einsum_iteration);
+  {
+    const auto& debug_options = hlo_module->config().debug_options();
+    spmd::SpmdPartitionerOptions spmd_options =
+        spmd::StatefulRngSpmdPartitioner::GetDefaultOptions();
+    spmd_options.threshold_for_windowed_einsum_mib =
+        debug_options.xla_gpu_threshold_for_windowed_einsum_mib();
+    spmd_options.unroll_windowed_einsum =
+        debug_options.xla_gpu_multi_streamed_windowed_einsum();
+    spmd_options.skip_checking_windowed_einsum_users = true;
+    spmd_options.disable_ag_rewrite_for_multiple_consumers = true;
+    spmd_options.partial_windowed_einsum = true;
+    spmd_options.total_bytes_windowed_einsum_threshold = oper_size_threshold;
+    spmd_options.max_windowed_einsum_iteration = max_windowed_einsum_iteration;
+    spmd_options.enable_dynamic_slice_collective_broadcast =
+        debug_options.xla_spmd_enable_dynamic_slice_collective_broadcast();
+    spmd_pipeline.AddPass<spmd::StatefulRngSpmdPartitioner>(
+        num_partitions, hlo_module->config().replica_count(),
+        std::move(spmd_options));
+  }
   if (hlo_module->config().debug_options().xla_enable_enzyme_comms_opt()) {
     spmd_pipeline.AddPass<RecognizeReduceWindow>();
     spmd_pipeline.AddPass<CollectivePermuteCSE>();

--- a/xla/service/spmd/spmd_partitioner.cc
+++ b/xla/service/spmd/spmd_partitioner.cc
@@ -4444,7 +4444,222 @@ absl::Status SpmdPartitioningVisitor::HandleConstant(HloInstruction* hlo) {
   return absl::OkStatus();
 }
 
+// Rewrites a replicated dynamic-slice from an operand that is tiled only along
+// a single slicing dimension into a single-slice collective broadcast.
+//
+// The targeted pattern is intentionally narrow:
+//
+//   operand: T[N, ...] sharded as {devices=[P,1,...]<=[P]}
+//   index:   s32[] replicated
+//   result = dynamic-slice(operand, index, 0, ...),
+//            dynamic_slice_sizes={1, ..., ...}, sharding={replicated}
+//
+// Without this rewrite, producing the replicated result generally reshares the
+// whole operand first, which becomes an all-gather of T[N, ...]. Instead, this
+// helper computes the clamped global index, derives the owning tile as
+// `owner = clamped_index / shard_size`, slices the local shard at
+// `local_index = clamped_index % shard_size`, and then builds:
+//
+//   conditional(owner,
+//     branch 0: collective-broadcast(local_slice),  // source is tile 0
+//     branch 1: collective-broadcast(local_slice),  // source is tile 1
+//     ...)
+//
+// Each branch's replica group lists the owning partition first. Collective
+// broadcast therefore forwards only that partition's local one-element slice to
+// every partition, yielding the same replicated result without all-gathering
+// the full operand.
+//
+// Keep the guard conditions conservative. The rewrite relies on one-to-one
+// ownership between tiles of the slicing dimension and partitions: no tuple
+// shapes, one slicing dimension of size 1, scalar S32 index, no partial
+// replication or other subgroups, no sharding on non-slicing dimensions, an
+// evenly divisible shard size, and a bounded number of owner branches.
+//
+// Collective-broadcast supports replica groups, but this lowering assigns one
+// static root partition to each slicing tile. Partial replication maps a tile
+// to multiple partitions, so supporting it would require selecting a canonical
+// root for each replicated tile instead of using the one-to-one mapping below.
+absl::StatusOr<bool>
+SpmdPartitioningVisitor::TryDynamicSliceWithCollectiveBroadcast(
+    HloInstruction* hlo) {
+  if (!options_.enable_dynamic_slice_collective_broadcast ||
+      !hlo->sharding().IsReplicated() || hlo->shape().IsTuple()) {
+    return false;
+  }
+
+  HloInstruction* input = hlo->mutable_operand(0);
+  if (input->shape().IsTuple()) {
+    return false;
+  }
+
+  const int64_t rank = input->shape().dimensions().size();
+  // Dynamic-slice also supports one rank-1 operand containing all indices.
+  // DynamicIndexSplitter runs after SPMD partitioning, so leave that form to
+  // the generic fallback instead of indexing nonexistent scalar operands.
+  if (hlo->operand_count() != rank + 1) {
+    return false;
+  }
+
+  std::optional<int64_t> sliced_dim;
+  for (int64_t dim = 0; dim < rank; ++dim) {
+    if (hlo->dynamic_slice_sizes()[dim] != input->shape().dimensions(dim)) {
+      if (sliced_dim.has_value()) {
+        return false;
+      }
+      sliced_dim = dim;
+    }
+  }
+  if (!sliced_dim.has_value() || hlo->dynamic_slice_sizes()[*sliced_dim] != 1) {
+    return false;
+  }
+
+  const Shape& index_shape = hlo->operand(*sliced_dim + 1)->shape();
+  if (!ShapeUtil::IsScalar(index_shape) || index_shape.element_type() != S32) {
+    return false;
+  }
+
+  PartitionedHlo input_partitioned = GetPartitionedHlo(input);
+  const HloSharding& input_sharding = input_partitioned.sharding();
+  if (!input_sharding.IsTiled() || input_sharding.HasPartialReplication() ||
+      input_sharding.num_devices() != num_partitions_) {
+    return false;
+  }
+
+  const int64_t input_dim_size = input->shape().dimensions(*sliced_dim);
+  if (input_dim_size > std::numeric_limits<int32_t>::max()) {
+    return false;
+  }
+
+  const int64_t num_slice_partitions = input_sharding.dimension(*sliced_dim);
+  if (num_slice_partitions <= 1 || num_slice_partitions != num_partitions_ ||
+      num_slice_partitions >
+          options_.max_dynamic_slice_collective_broadcast_partitions ||
+      input_dim_size % num_slice_partitions != 0) {
+    return false;
+  }
+  for (int64_t dim = 0; dim < rank; ++dim) {
+    if (dim == *sliced_dim) {
+      continue;
+    }
+    if (input_sharding.dimension(dim) != 1) {
+      return false;
+    }
+  }
+
+  std::vector<int64_t> owner_partition(num_slice_partitions, -1);
+  // Verified shardings have rank-consistent tile coordinates and unique,
+  // in-range device IDs. After the eligibility checks above, every slicing
+  // tile must map to exactly one partition.
+  bool valid_tile_assignment = true;
+  input_sharding.EachTile(
+      [&](absl::Span<const int64_t> indices, int64_t device) {
+        if (indices.size() <= *sliced_dim || device < 0 ||
+            device >= num_partitions_) {
+          valid_tile_assignment = false;
+          return;
+        }
+        for (int64_t dim = 0; dim < rank; ++dim) {
+          if (dim != *sliced_dim && indices[dim] != 0) {
+            valid_tile_assignment = false;
+            return;
+          }
+        }
+        const int64_t slice_index = indices[*sliced_dim];
+        if (slice_index < 0 || slice_index >= num_slice_partitions ||
+            owner_partition[slice_index] != -1) {
+          valid_tile_assignment = false;
+          return;
+        }
+        owner_partition[slice_index] = device;
+      });
+  TF_RET_CHECK(valid_tile_assignment)
+      << "Invalid tile assignment for dynamic-slice collective-broadcast: "
+      << input_sharding.ToString();
+  TF_RET_CHECK(!absl::c_any_of(owner_partition,
+                               [](int64_t device) { return device < 0; }))
+      << "Tile assignment does not contain an owner for every slicing tile: "
+      << input_sharding.ToString();
+
+  HloInstruction* index =
+      GetPartitionedHlo(hlo->operand(*sliced_dim + 1)).Replicate().hlo();
+  auto constant_s32 = [&](int32_t value) {
+    return b_.AddInstruction(
+        HloInstruction::CreateConstant(LiteralUtil::CreateR0<int32_t>(value)));
+  };
+  HloInstruction* zero = constant_s32(0);
+  HloInstruction* max_index =
+      constant_s32(static_cast<int32_t>(input_dim_size - 1));
+  HloInstruction* clamped_index =
+      b_.AddInstruction(HloInstruction::CreateTernary(
+          index_shape, HloOpcode::kClamp, zero, index, max_index));
+
+  const int64_t shard_size = input_dim_size / num_slice_partitions;
+  if (shard_size > std::numeric_limits<int32_t>::max()) {
+    return false;
+  }
+  HloInstruction* shard_size_hlo =
+      constant_s32(static_cast<int32_t>(shard_size));
+  HloInstruction* owner = b_.AddInstruction(HloInstruction::CreateBinary(
+      index_shape, HloOpcode::kDivide, clamped_index, shard_size_hlo));
+  HloInstruction* owner_offset = b_.AddInstruction(HloInstruction::CreateBinary(
+      index_shape, HloOpcode::kMultiply, owner, shard_size_hlo));
+  HloInstruction* local_index = b_.AddInstruction(HloInstruction::CreateBinary(
+      index_shape, HloOpcode::kSubtract, clamped_index, owner_offset));
+
+  std::vector<HloInstruction*> local_indices(rank, zero);
+  local_indices[*sliced_dim] = local_index;
+  HloInstruction* local_slice =
+      b_.AddInstruction(HloInstruction::CreateDynamicSlice(
+          hlo->shape(), input_partitioned.hlo(), local_indices,
+          hlo->dynamic_slice_sizes()));
+
+  std::vector<HloComputation*> branch_computations;
+  branch_computations.reserve(num_slice_partitions);
+  std::vector<HloInstruction*> branch_args(num_slice_partitions, local_slice);
+  for (int64_t branch_owner = 0; branch_owner < num_slice_partitions;
+       ++branch_owner) {
+    std::vector<ReplicaGroup> replica_groups(1);
+    replica_groups[0].add_replica_ids(owner_partition[branch_owner]);
+    for (int64_t i = 0; i < num_slice_partitions; ++i) {
+      if (i != branch_owner) {
+        replica_groups[0].add_replica_ids(owner_partition[i]);
+      }
+    }
+
+    SpmdBuilder branch_builder(
+        absl::StrCat("dynamic_slice_collective_broadcast_owner_", branch_owner),
+        hlo);
+    HloInstruction* branch_param =
+        branch_builder.AddInstruction(HloInstruction::CreateParameter(
+            /*parameter_number=*/0, local_slice->shape(), "operand"));
+    HloInstruction* broadcast =
+        branch_builder.AddInstruction(HloInstruction::CreateCollectiveBroadcast(
+            local_slice->shape(), {branch_param},
+            std::make_shared<CollectiveDeviceList>(replica_groups),
+            /*constrain_layout=*/false, NewChannel()));
+    broadcast->set_metadata(hlo->metadata());
+    broadcast->set_frontend_attributes(hlo->frontend_attributes());
+    broadcast->set_frontend_attribute(kSpmdGeneratedAttr, "true");
+    branch_computations.push_back(
+        module_->AddEmbeddedComputation(branch_builder.Build(broadcast)));
+  }
+
+  HloInstruction* conditional =
+      b_.AddInstruction(HloInstruction::CreateConditional(
+          hlo->shape(), owner, branch_computations, branch_args));
+  conditional->set_metadata(hlo->metadata());
+  conditional->set_frontend_attributes(hlo->frontend_attributes());
+  SetPartitionedHlo(hlo, conditional);
+  return true;
+}
+
 absl::Status SpmdPartitioningVisitor::HandleDynamicSlice(HloInstruction* hlo) {
+  ASSIGN_OR_RETURN(bool handled, TryDynamicSliceWithCollectiveBroadcast(hlo));
+  if (handled) {
+    return absl::OkStatus();
+  }
+
   if (hlo->sharding().IsReplicatedOrSingleDevice()) {
     return DefaultAction(hlo);
   }

--- a/xla/service/spmd/spmd_partitioner.h
+++ b/xla/service/spmd/spmd_partitioner.h
@@ -107,6 +107,16 @@ struct SpmdPartitionerOptions {
   // Enables windowed einsum for result reduce-scatter.
   bool enable_windowed_einsum_for_reduce_scatter = true;
 
+  // Enables a narrow dynamic-slice lowering that broadcasts a single slice
+  // from its sharded owner instead of all-gathering the full operand first.
+  // Controlled via xla_spmd_enable_dynamic_slice_collective_broadcast.
+  bool enable_dynamic_slice_collective_broadcast = false;
+
+  // Maximum number of partitions for the dynamic-slice collective-broadcast
+  // lowering. The lowering creates one branch with a full replica group per
+  // partition, so this limit bounds quadratic HLO growth.
+  int64_t max_dynamic_slice_collective_broadcast_partitions = 32;
+
   // Whether disable rewrite for dots that share the same
   // operand as an already rewritten windowed einsum loop.
   bool disable_ag_rewrite_for_multiple_consumers = false;
@@ -893,6 +903,9 @@ class SpmdPartitioningVisitor : public DfsHloVisitorWithDefault {
   HloInstruction* partition_id_;
 
  private:
+  absl::StatusOr<bool> TryDynamicSliceWithCollectiveBroadcast(
+      HloInstruction* hlo);
+
   PartitionedHlo::ReshardCache reshard_cache_;
 
   // Mapping from the instruction in the original computation to the new SPMD

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -90,10 +90,10 @@ void VerifyNoShardingOnCollectives(HloModule* module) {
   for (const HloComputation* c : module->computations()) {
     for (const HloInstruction* inst : c->instructions()) {
       bool is_collective = absl::c_linear_search(
-          std::vector<HloOpcode>{HloOpcode::kAllToAll, HloOpcode::kAllReduce,
-                                 HloOpcode::kAllGather,
-                                 HloOpcode::kCollectivePermute,
-                                 HloOpcode::kReduceScatter},
+          std::vector<HloOpcode>{
+              HloOpcode::kAllToAll, HloOpcode::kAllReduce,
+              HloOpcode::kAllGather, HloOpcode::kCollectiveBroadcast,
+              HloOpcode::kCollectivePermute, HloOpcode::kReduceScatter},
           inst->opcode());
       if (is_collective) {
         EXPECT_FALSE(inst->has_sharding());
@@ -171,6 +171,14 @@ class SpmdPartitioningTest
       if (inst->opcode() == opcode) {
         ++count;
       }
+    }
+    return count;
+  }
+
+  int64_t NumOfInstructions(const HloModule* module, HloOpcode opcode) {
+    int64_t count = 0;
+    for (const HloComputation* computation : module->computations()) {
+      count += NumOfInstructions(computation, opcode);
     }
     return count;
   }
@@ -2725,6 +2733,115 @@ ENTRY entry {
   EXPECT_THAT(
       module->entry_computation()->root_instruction(),
       AllOf(op::DynamicSlice(root_replicated, _), op::Shape("f32[64]")));
+}
+
+constexpr absl::string_view kReplicatedDynamicSliceHlo = R"(
+HloModule module
+
+ENTRY entry {
+  %param = f32[4,8,16] parameter(0), sharding={devices=[4,1,1]<=[4]}
+  %index = s32[] parameter(1), sharding={replicated}
+  %zero.0 = s32[] constant(0)
+  %zero.1 = s32[] constant(0)
+  ROOT %dynamic-slice = f32[1,8,16] dynamic-slice(%param, %index, %zero.0, %zero.1),
+    dynamic_slice_sizes={1,8,16}, sharding={replicated}
+})";
+
+TEST_P(SpmdPartitioningTest,
+       DynamicSliceReplicatedResultUsesCollectiveBroadcast) {
+  SpmdPartitionerOptions options;
+  EXPECT_FALSE(options.enable_dynamic_slice_collective_broadcast);
+  EXPECT_EQ(options.max_dynamic_slice_collective_broadcast_partitions, 32);
+  options.enable_dynamic_slice_collective_broadcast = true;
+
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       PartitionComputation(kReplicatedDynamicSliceHlo,
+                                            /*num_devices=*/4, options));
+
+  EXPECT_EQ(NumOfInstructions(module.get(), HloOpcode::kAllGather), 0);
+  EXPECT_EQ(NumOfInstructions(module.get(), HloOpcode::kCollectiveBroadcast),
+            4);
+
+  const HloInstruction* root = module->entry_computation()->root_instruction();
+  ASSERT_EQ(root->opcode(), HloOpcode::kConditional);
+  ASSERT_EQ(root->branch_count(), 4);
+
+  std::vector<int64_t> broadcast_roots;
+  for (int64_t branch = 0; branch < root->branch_count(); ++branch) {
+    const HloInstruction* broadcast =
+        root->branch_computation(branch)->root_instruction();
+    ASSERT_EQ(broadcast->opcode(), HloOpcode::kCollectiveBroadcast);
+    const std::vector<std::vector<int64_t>> replica_groups =
+        ReplicaGroupsToVecOfVec(broadcast->replica_groups());
+    ASSERT_EQ(replica_groups.size(), 1);
+    ASSERT_EQ(replica_groups[0].size(), 4);
+    broadcast_roots.push_back(replica_groups[0][0]);
+    EXPECT_THAT(replica_groups[0], UnorderedElementsAre(0, 1, 2, 3));
+  }
+  EXPECT_THAT(broadcast_roots, UnorderedElementsAre(0, 1, 2, 3));
+}
+
+TEST_P(SpmdPartitioningTest, DynamicSliceCollectiveBroadcastCanBeDisabled) {
+  SpmdPartitionerOptions options;
+  options.enable_dynamic_slice_collective_broadcast = false;
+
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       PartitionComputation(kReplicatedDynamicSliceHlo,
+                                            /*num_devices=*/4, options));
+
+  EXPECT_EQ(NumOfInstructions(module.get(), HloOpcode::kAllGather), 1);
+  EXPECT_EQ(NumOfInstructions(module.get(), HloOpcode::kCollectiveBroadcast),
+            0);
+  EXPECT_EQ(NumOfInstructions(module.get(), HloOpcode::kConditional), 0);
+  EXPECT_THAT(
+      module->entry_computation()->root_instruction(),
+      AllOf(op::DynamicSlice(op::AllGather(op::Parameter(0)), op::Parameter(1),
+                             op::Constant(), op::Constant()),
+            op::Shape("f32[1,8,16]")));
+}
+
+TEST_P(SpmdPartitioningTest,
+       DynamicSliceCollectiveBroadcastRespectsPartitionLimit) {
+  SpmdPartitionerOptions options;
+  options.enable_dynamic_slice_collective_broadcast = true;
+  options.max_dynamic_slice_collective_broadcast_partitions = 2;
+
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       PartitionComputation(kReplicatedDynamicSliceHlo,
+                                            /*num_devices=*/4, options));
+
+  EXPECT_EQ(NumOfInstructions(module.get(), HloOpcode::kAllGather), 1);
+  EXPECT_EQ(NumOfInstructions(module.get(), HloOpcode::kCollectiveBroadcast),
+            0);
+  EXPECT_EQ(NumOfInstructions(module.get(), HloOpcode::kConditional), 0);
+  EXPECT_THAT(
+      module->entry_computation()->root_instruction(),
+      AllOf(op::DynamicSlice(op::AllGather(op::Parameter(0)), op::Parameter(1),
+                             op::Constant(), op::Constant()),
+            op::Shape("f32[1,8,16]")));
+}
+
+TEST_P(SpmdPartitioningTest, DynamicSliceWithPackedIndicesUsesGenericFallback) {
+  constexpr absl::string_view hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  %param = f32[8,4] parameter(0), sharding={devices=[1,4]<=[4]}
+  %indices = s32[2] parameter(1), sharding={replicated}
+  ROOT %dynamic-slice = f32[8,1] dynamic-slice(%param, %indices),
+    dynamic_slice_sizes={8,1}, sharding={replicated}
+})";
+
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       PartitionComputation(hlo_string, /*num_devices=*/4));
+
+  EXPECT_EQ(NumOfInstructions(module.get(), HloOpcode::kAllGather), 1);
+  EXPECT_EQ(NumOfInstructions(module.get(), HloOpcode::kCollectiveBroadcast),
+            0);
+  EXPECT_THAT(
+      module->entry_computation()->root_instruction(),
+      AllOf(op::DynamicSlice(op::AllGather(op::Parameter(0)), op::Parameter(1)),
+            op::Shape("f32[8,1]")));
 }
 
 TEST_P(SpmdPartitioningTest, PadAlongNonPartitionedDimension) {

--- a/xla/service/spmd/stateful_rng_spmd_partitioner.h
+++ b/xla/service/spmd/stateful_rng_spmd_partitioner.h
@@ -53,6 +53,18 @@ class StatefulRngSpmdPartitioningVisitor
 
 class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
  public:
+  static spmd::SpmdPartitionerOptions GetDefaultOptions() {
+    spmd::SpmdPartitionerOptions options;
+    options.allow_module_signature_change = true;
+    options.threshold_for_windowed_einsum_mib = 100000;
+    return options;
+  }
+
+  StatefulRngSpmdPartitioner(int64_t num_partitions, int64_t num_replicas,
+                             spmd::SpmdPartitionerOptions options)
+      : spmd::SpmdPartitioner(num_partitions, num_replicas,
+                              std::move(options)) {}
+
   StatefulRngSpmdPartitioner(
       int64_t num_partitions, int64_t num_replicas,
       int64_t threshold_for_windowed_einsum_mib = 100000,
@@ -63,7 +75,7 @@ class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
       std::optional<int64_t> total_bytes_windowed_einsum_threshold =
           std::nullopt,
       int64_t max_windowed_einsum_iteration = 32)
-      : spmd::SpmdPartitioner(
+      : StatefulRngSpmdPartitioner(
             num_partitions, num_replicas,
             GetSpmdPartitionerOptions(threshold_for_windowed_einsum_mib,
                                       windowed_einsum_use_multiple_streams,
@@ -98,8 +110,7 @@ class StatefulRngSpmdPartitioner : public spmd::SpmdPartitioner {
       std::optional<int64_t> total_bytes_windowed_einsum_threshold =
           std::nullopt,
       int64_t max_windowed_einsum_iteration = 32) {
-    spmd::SpmdPartitionerOptions options;
-    options.allow_module_signature_change = true;
+    spmd::SpmdPartitionerOptions options = GetDefaultOptions();
     options.threshold_for_windowed_einsum_mib =
         threshold_for_windowed_einsum_mib;
     options.unroll_windowed_einsum = windowed_einsum_use_multiple_streams;

--- a/xla/tools/hlo_opt/cpu_opt.cc
+++ b/xla/tools/hlo_opt/cpu_opt.cc
@@ -145,8 +145,13 @@ class CpuOptProvider : public CompiledOptProvider {
         /*cse_prevention_only=*/false,
         /*sharding_helper=*/nullptr);
 
+    auto spmd_partitioner_options =
+        spmd::StatefulRngSpmdPartitioner::GetDefaultOptions();
+    // XLA:CPU does not support kCollectiveBroadcast.
+    spmd_partitioner_options.enable_dynamic_slice_collective_broadcast = false;
     RegisterPass<spmd::StatefulRngSpmdPartitioner>(
-        module_config.num_partitions(), module_config.replica_count());
+        module_config.num_partitions(), module_config.replica_count(),
+        std::move(spmd_partitioner_options));
     if (module_config.debug_options().xla_enable_enzyme_comms_opt()) {
       RegisterPass<RecognizeReduceWindow>();
     }

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1688,10 +1688,18 @@ message DebugOptions {
   // MeshAxesReplicaGroupList (RGV3).
   optional bool xla_enable_rgv3_materialization = 479;
 
+  // If true, enables the SPMD dynamic-slice collective-broadcast lowering.
+  // When a replicated dynamic-slice result is sliced from an operand tiled
+  // only along the sliced dimension, the partitioner emits a per-owner
+  // collective-broadcast inside a conditional instead of all-gathering the
+  // full operand first.  Disabled by default; GPU-only (requires
+  // kCollectiveBroadcast hardware support).
+  optional bool xla_spmd_enable_dynamic_slice_collective_broadcast = 517;
+
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 517
+  // Next id: 518
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
## Summary

Revived version of #44796, which was reverted because the behavior was unconditionally enabled and broke non-GPU platforms (e.g. TPU). This PR reintroduces the same lowering behind a new XLA flag `xla_spmd_enable_dynamic_slice_collective_broadcast` that defaults to **false**, so only callers that explicitly opt in get the new behavior.

This PR adds an SPMD lowering for a dynamic-slice pattern that appears in the Layered-FSDP forward pass for Muon workloads.

When a replicated result dynamically slices a single layer from an operand sharded along the layer dimension, XLA previously materialized the full operand with an all-gather and then sliced out the requested layer. This PR lowers that pattern to a per-owner `collective-broadcast`: each partition slices its local candidate, a conditional selects the partition that owns the requested layer, and that owner broadcasts only the selected slice.

## Changes from #44796

- `enable_dynamic_slice_collective_broadcast` defaults to **`false`** in `SpmdPartitionerOptions` instead of `true`.
- New XLA debug flag `xla_spmd_enable_dynamic_slice_collective_broadcast` (proto field 517, bool, default false).
- `gpu_spmd_pipeline.cc` reads the new flag and sets `enable_dynamic_slice_collective_broadcast` on the options struct via the new `SpmdPartitionerOptions`-based constructor, so the feature is off unless the caller explicitly sets `--xla_spmd_enable_dynamic_slice_collective_broadcast=true`.
- XLA:CPU (`cpu_compiler.cc`, `cpu_opt.cc`) keeps the explicit `false` override since `kCollectiveBroadcast` is not supported there.
- Unit tests updated: the main test now explicitly sets `enable_dynamic_slice_collective_broadcast = true` and checks that the default is `false`.

## Workload

The motivating workload is Layered-FSDP for Muon.

A representative weight layout is:

```text
logical shape: [L, K, N]
sharding:      P("lp", None, None)
```

During the forward pass, the scan body selects the current layer:

```text
W_i = dynamic-slice(W, i, 0, 0), dynamic_slice_sizes={1, K, N}
```

## Before / After

Before:

```text
all-gather W_local -> W_full   (communicates [L, K, N])
dynamic-slice W_full[i]
```

After (when flag is enabled):

```text
local dynamic-slice W_local[local_i]
conditional(owner)             (communicates [1, K, N])
  collective-broadcast from owner partition
```

## Testing

```
bazel test --test_output=errors \
  --test_filter="*DynamicSlice*CollectiveBroadcast*" \
  //xla/service/spmd:spmd_partitioner_test

bazel test --test_output=errors \
  //xla/service/cpu/tests:cpu_spmd_compile_test
```

🚀 Kind of Contribution
🐛 Bug Fix, ⚡️ Performance Improvement, 🧪 Tests