### PR TITLE
[ROCm] Fix gpu_cliques_test

### DIFF
--- a/xla/backends/gpu/collectives/gpu_cliques_test.cc
+++ b/xla/backends/gpu/collectives/gpu_cliques_test.cc
@@ -252,7 +252,7 @@ TEST(GpuCliquesTest, SplitCliquesKeepsReorderedRanksOnCorrectExecutors) {
   auto cleanup = absl::MakeCleanup([] { internal::DestroyAcquiredCliques(); });
 
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       PlatformUtil::GetPlatform("CUDA"));
+                       PlatformUtil::GetPlatform("gpu"));
 
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";


### PR DESCRIPTION
📝 Summary of Changes
Make new subtest `SplitCliquesKeepsReorderedRanksOnCorrectExecutors` platform-agnostic. 

🎯 Justification
In accordance with changes from https://github.com/openxla/xla/pull/44641

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix