### PR TITLE
[ROCm] Mark streamed-once loads/stores non-temporal on AMD.

### DIFF
--- a/xla/backends/gpu/codegen/emitters/mlir_kernel_emitter_test.cc
+++ b/xla/backends/gpu/codegen/emitters/mlir_kernel_emitter_test.cc
@@ -141,6 +141,11 @@ TEST_F(MlirKernelFusionTest, CreateMlirModule) {
     // CHECK:        return %[[RET]]
   )"));
   EXPECT_TRUE(filecheck_result);
+
+  // Emitters that route through the base MlirKernelEmitter path (reduction,
+  // transpose, scatter) do not tag the entry function as contiguous-output;
+  // only the loop/concatenate/dynamic-update-slice emitters do.
+  EXPECT_EQ(out.find("xla.contiguous_output"), std::string::npos);
 }
 
 TEST_F(MlirKernelFusionTest, CreateLLVMModule) {

--- a/xla/codegen/emitters/concatenate_kernel_emitter.cc
+++ b/xla/codegen/emitters/concatenate_kernel_emitter.cc
@@ -106,6 +106,9 @@ ConcatenateFusionKernelEmitter::EmitKernelDefinition() {
       emitters::EmitKernelApi(*module, fusion_, buffer_assignment_,
                               buffer_alignment_, entry_function_name_));
   SetBackendKind(&mlir_context_, entry_func, backend_kind_);
+  if (backend_kind_ == BackendKind::kGpu) {
+    SetContiguousOutput(&mlir_context_, entry_func);
+  }
 
   std::vector<emitters::EpilogueSpecification> epilogues =
       GetEpilogues(fusion_, &mlir_context_);

--- a/xla/codegen/emitters/dynamic_update_slice_kernel_emitter.cc
+++ b/xla/codegen/emitters/dynamic_update_slice_kernel_emitter.cc
@@ -110,6 +110,9 @@ DynamicUpdateSliceKernelEmitter::EmitKernelDefinition() {
       emitters::EmitKernelApi(*module, fusion_, buffer_assignment_,
                               buffer_alignment_, entry_function_name_));
   SetBackendKind(&mlir_context_, entry_func, backend_kind_);
+  if (backend_kind_ == BackendKind::kGpu) {
+    SetContiguousOutput(&mlir_context_, entry_func);
+  }
 
   emitters::PartitionedComputations computations(
       fusion_.fused_instructions_computation(), &mlir_context_, GetEpilogues());

--- a/xla/codegen/emitters/ir/xla_ops.cc
+++ b/xla/codegen/emitters/ir/xla_ops.cc
@@ -1139,6 +1139,17 @@ std::optional<xla::BackendKind> GetBackendKind(mlir::func::FuncOp fn) {
   return backend_attr.getValue();
 }
 
+static constexpr llvm::StringRef kContiguousOutputAttrName =
+    "xla.contiguous_output";
+
+void SetContiguousOutput(mlir::MLIRContext* context, mlir::func::FuncOp fn) {
+  fn->setAttr(kContiguousOutputAttrName, mlir::UnitAttr::get(context));
+}
+
+bool HasContiguousOutput(mlir::func::FuncOp fn) {
+  return fn->hasAttr(kContiguousOutputAttrName);
+}
+
 }  // namespace xla
 
 #define GET_OP_CLASSES

--- a/xla/codegen/emitters/ir/xla_ops.h
+++ b/xla/codegen/emitters/ir/xla_ops.h
@@ -78,6 +78,13 @@ std::optional<xla::BackendKind> GetBackendKind(mlir::func::FuncOp fn);
 void SetBackendKind(mlir::MLIRContext* context, mlir::func::FuncOp fn,
                     xla::BackendKind backend_kind);
 
+// Marks an entry function whose outputs are written contiguously (one write per
+// output element), as produced by the loop/concatenate/DUS emitters. Consumers
+// (e.g. the AMD non-temporal hint pass) use this to distinguish full-cache-line
+// stores from partial-line writes (reductions, transposes, scatters).
+void SetContiguousOutput(mlir::MLIRContext* context, mlir::func::FuncOp fn);
+bool HasContiguousOutput(mlir::func::FuncOp fn);
+
 }  // namespace xla
 
 #endif  // XLA_CODEGEN_EMITTERS_IR_XLA_OPS_H_

--- a/xla/codegen/emitters/kernel_api_builder.cc
+++ b/xla/codegen/emitters/kernel_api_builder.cc
@@ -49,10 +49,12 @@ limitations under the License.
 #include "xla/codegen/emitters/type_util.h"
 #include "xla/codegen/kernel_spec.h"
 #include "xla/frontend_attributes.h"
+#include "xla/hlo/analysis/indexing_analysis.h"
 #include "xla/hlo/analysis/indexing_map.h"
 #include "xla/hlo/analysis/symbolic_expr.h"
 #include "xla/hlo/analysis/symbolic_map.h"
 #include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/layout_util.h"
 #include "xla/runtime/work_dimensions.h"
@@ -138,6 +140,72 @@ static std::vector<IndexingMap::Variable> DimVarsFromWorkDimensions(
                              static_cast<int64_t>(num_work_groups.z)});
 }
 
+// Returns, for each operand of a fusion instruction, whether the operand is
+// read exactly once per output element with no reuse. The predicate is a
+// conservative, size-independent structural check on the operand's indexing
+// maps (unioned across all fusion roots):
+//   - exactly one indexing map (multiple maps => multi-path reuse),
+//   - the map is defined,
+//   - no range variables (reduction / windowed re-read) and no runtime
+//     variables (dynamic access),
+//   - every output dimension is used (a dropped dimension means a broadcast,
+//     i.e. many-to-one reads of the same element).
+// For non-fusion instructions the result is all-false (treated as not
+// streamed-once, which is the conservative default).
+static std::vector<bool> ComputeStreamedOnceOperands(
+    const HloInstruction& hlo_instruction, mlir::MLIRContext* mlir_context) {
+  const auto* fusion = DynCast<HloFusionInstruction>(&hlo_instruction);
+  if (fusion == nullptr) {
+    return {};
+  }
+
+  // The indexing analysis builds SymbolicExprs, which require the storage to be
+  // registered on the context. This is idempotent and normally happens when the
+  // Xla dialect is loaded, but register it here to be independent of dialect
+  // load ordering relative to this call.
+  RegisterSymbolicExprStorage(mlir_context);
+
+  const int64_t num_operands = fusion->operand_count();
+  const int64_t num_outputs = fusion->shape().IsTuple()
+                                  ? fusion->shape().tuple_shapes().size()
+                                  : 1;
+
+  // Union the per-operand indexing sets across all roots.
+  std::vector<OperandIndexingSet> combined(num_operands);
+  for (int64_t output_id = 0; output_id < num_outputs; ++output_id) {
+    HloInstructionIndexing indexing =
+        ComputeOutputToInputIndexing(fusion, output_id, mlir_context);
+    for (int64_t operand_id = 0;
+         operand_id < static_cast<int64_t>(indexing.indexing_maps.size()) &&
+         operand_id < num_operands;
+         ++operand_id) {
+      const OperandIndexingSet& operand_set = indexing.indexing_maps[operand_id];
+      combined[operand_id].insert(operand_set.begin(), operand_set.end());
+    }
+  }
+
+  std::vector<bool> streamed_once(num_operands, false);
+  for (int64_t operand_id = 0; operand_id < num_operands; ++operand_id) {
+    const OperandIndexingSet& operand_set = combined[operand_id];
+    if (operand_set.size() != 1) {
+      continue;
+    }
+    const IndexingMap& map = operand_set.begin()->map();
+    if (map.IsUndefined() || map.GetRangeVarsCount() != 0 ||
+        map.GetRTVarsCount() != 0) {
+      continue;
+    }
+    const SymbolicMap& symbolic_map = map.GetSymbolicMap();
+    const int64_t num_dims = symbolic_map.GetNumDims();
+    UsedParameters used =
+        GetUsedParameters(symbolic_map.GetResults(), num_dims);
+    if (static_cast<int64_t>(used.dimension_ids.size()) == num_dims) {
+      streamed_once[operand_id] = true;
+    }
+  }
+  return streamed_once;
+}
+
 absl::StatusOr<mlir::func::FuncOp> EmitKernelApi(
     mlir::ModuleOp module, const HloInstruction& hlo_instruction,
     const BufferAssignment* buffer_assignment,
@@ -154,6 +222,12 @@ absl::StatusOr<mlir::func::FuncOp> EmitKernelApi(
         args, KernelArguments::Create(*buffer_assignment, buffer_alignment,
                                       &hlo_instruction));
   }
+  // Per-operand reuse fact used to drive streaming (non-temporal) loads. Index
+  // into this by operand id; result args are never streamed-once.
+  const std::vector<bool> streamed_once =
+      ComputeStreamedOnceOperands(hlo_instruction, context);
+  const int64_t num_operands = hlo_instruction.operands().size();
+
   // Annotate tensors with the buffer indices. This way, the buffer propagation
   // pass can clean them up later.
   auto get_arg_attrs = [&](int index) -> mlir::Attribute {
@@ -180,6 +254,11 @@ absl::StatusOr<mlir::func::FuncOp> EmitKernelApi(
         attrs.push_back(
             builder.getNamedAttr(kXlaNotInvariantAttr, builder.getUnitAttr()));
       }
+    }
+    if (index < num_operands && index < static_cast<int>(streamed_once.size()) &&
+        streamed_once[index]) {
+      attrs.push_back(
+          builder.getNamedAttr(kXlaStreamedOnceAttr, builder.getUnitAttr()));
     }
     return builder.getDictionaryAttr(attrs);
   };

--- a/xla/codegen/emitters/kernel_api_builder.h
+++ b/xla/codegen/emitters/kernel_api_builder.h
@@ -37,6 +37,12 @@ namespace xla::emitters {
 
 inline constexpr absl::string_view kXlaNotInvariantAttr = "xla.not_invariant";
 
+// Marks an argument whose buffer is read exactly once per output element with
+// no reuse (no reduction/window re-read, no broadcast, no dynamic access).
+// Computed from indexing-map reuse analysis at emit time and consumed by the
+// AMD non-temporal hint pass to decide streaming loads.
+inline constexpr absl::string_view kXlaStreamedOnceAttr = "xla.streamed_once";
+
 // Emits and return the kernel entry function into the provided module it for
 // the given HLO instruction.
 // The function will be given the provided name and the arguments will be

--- a/xla/codegen/emitters/loop_kernel_emitter.cc
+++ b/xla/codegen/emitters/loop_kernel_emitter.cc
@@ -101,6 +101,9 @@ LoopFusionKernelEmitter::EmitKernelDefinition() {
       emitters::EmitKernelApi(*module, fusion_, buffer_assignment_,
                               buffer_alignment_, entry_function_name_));
   SetBackendKind(&mlir_context_, entry_func, backend_kind_);
+  if (backend_kind_ == BackendKind::kGpu) {
+    SetContiguousOutput(&mlir_context_, entry_func);
+  }
 
   // Loop emitters don't support epilogues.
   emitters::PartitionedComputations computations(

--- a/xla/codegen/emitters/tests/concatenate/concat_1d.hlo
+++ b/xla/codegen/emitters/tests/concatenate/concat_1d.hlo
@@ -26,6 +26,9 @@ fusion {
 // CHECK-SAME:    %[[ARG_1:[a-zA-Z0-9]*]]: {{[^,]*}},
 // CHECK-SAME:    %[[ARG_2:[a-zA-Z0-9]*]]: {{[^,]*}},
 // CHECK-SAME:    %[[OUTPUT:[a-zA-Z0-9]*]]: {{[^,]*}}
+// The GPU concatenate emitter marks the entry function as writing its output
+// contiguously.
+// CHECK-GPU-SAME: xla.contiguous_output
 
 // CHECK-GPU: %[[WORKGROUP_ID:.*]] = xla.workgroup_id x
 // CHECK-GPU: scf.forall (%[[THREAD_ID:.*]]) in (128)

--- a/xla/codegen/emitters/tests/dynamic_update_slice/simple.hlo
+++ b/xla/codegen/emitters/tests/dynamic_update_slice/simple.hlo
@@ -30,6 +30,9 @@ ENTRY main {
 // CHECK-SAME:  %arg2: tensor<i32>
 // CHECK-SAME:  %arg3: tensor<i32>
 // CHECK-SAME:  %arg4: tensor<20x30xf32>
+// The GPU dynamic-update-slice emitter marks the entry function as writing its
+// output contiguously.
+// CHECK-GPU-SAME: xla.contiguous_output
 // CHECK-DAG:   %[[C_24:.*]] = arith.constant 24
 // CHECK-DAG:   %[[C_15:.*]] = arith.constant 15
 // CHECK-DAG:   %[[C_0:.*]] = arith.constant 0

--- a/xla/codegen/emitters/tests/loop/broadcast_constant.hlo
+++ b/xla/codegen/emitters/tests/loop/broadcast_constant.hlo
@@ -12,6 +12,9 @@ bcast {
   ROOT broadcast = bf16[2,16,48]{2,1,0} broadcast(zero), dimensions={}
 }
 // CHECK: func.func @main(%[[ARG0:.*]]: tensor<2x16x48xbf16>
+// The GPU loop emitter marks the entry function as writing its output
+// contiguously.
+// CHECK-GPU-SAME: xla.contiguous_output
 // CHECK-GPU: scf.forall {{.*}} shared_outs(%[[FORALL_ARG0:.*]] = %[[ARG0]])
 // CHECK:   xla.loop ({{.*}})[{{.*}}] -> (%[[RA:.*]], %[[RB:.*]], %[[RC:.*]]) in
 // CHECK-SAME: iter_args(%[[ITER:.*]] =

--- a/xla/codegen/emitters/transforms/lower_tensors.cc
+++ b/xla/codegen/emitters/transforms/lower_tensors.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "absl/numeric/bits.h"
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -1441,8 +1442,10 @@ class LowerTensorsPass : public impl::LowerTensorsPassBase<LowerTensorsPass> {
       return;
     }
 
-    getOperation()->walk([this](ml::LoadOp load) {
-      Value addr = load.getAddr();
+    // Traces a load/store address back to the function-argument buffer it
+    // addresses. Returns a null BlockArgument for shared memory,
+    // global constants and temporaries (allocas), which must not be annotated.
+    auto global_buffer_arg = [](Value addr) -> mlir::BlockArgument {
       while (auto gep = addr.getDefiningOp<ml::GEPOp>()) {
         addr = gep.getBase();
       }
@@ -1452,19 +1455,66 @@ class LowerTensorsPass : public impl::LowerTensorsPassBase<LowerTensorsPass> {
       if (addr.getDefiningOp<ml::AddrSpaceCastOp>() ||
           addr.getDefiningOp<ml::AddressOfOp>() ||
           addr.getDefiningOp<ml::AllocaOp>()) {
-        // Shared memory, global constant or temporary - no need to annotate
-        // anything.
+        return nullptr;
+      }
+      return mlir::dyn_cast<mlir::BlockArgument>(addr);
+    };
+
+    auto arg_has_attr = [](mlir::BlockArgument arg,
+                           llvm::StringRef name) -> bool {
+      auto func =
+          mlir::dyn_cast<mlir::func::FuncOp>(arg.getOwner()->getParentOp());
+      return func && func.getArgAttr(arg.getArgNumber(), name) != nullptr;
+    };
+
+    // Count global-load sites per buffer argument.
+    // Buffers read at multiple sites are treated as reused.
+    llvm::DenseMap<Value, int> global_load_counts;
+    getOperation()->walk([&](ml::LoadOp load) {
+      mlir::BlockArgument arg = global_buffer_arg(load.getAddr());
+      if (!arg) {
+        // Shared memory, global constant or temporary - no need to annotate.
         return;
       }
-      if (auto base = mlir::dyn_cast<mlir::BlockArgument>(addr)) {
-        if (auto func = mlir::dyn_cast<mlir::func::FuncOp>(
-                base.getOwner()->getParentOp())) {
-          if (func.getArgAttr(base.getArgNumber(), "xla.invariant")) {
-            load.setInvariant(true);
-          }
-        }
+      ++global_load_counts[arg];
+      if (arg_has_attr(arg, "xla.invariant")) {
+        load.setInvariant(true);
       }
     });
+
+    // AMD-only non-temporal (streaming) cache hints.
+    if (device_spec_.IsAmdGpu()) {
+      // Streamed-once inputs: mark a read-only (xla.invariant) buffer
+      // non-temporal if read from a single global-load site (excludes
+      // reused/broadcast operands).
+      getOperation()->walk([&](ml::LoadOp load) {
+        mlir::BlockArgument arg = global_buffer_arg(load.getAddr());
+        if (!arg) {
+          return;
+        }
+        if (arg_has_attr(arg, "xla.invariant") &&
+            global_load_counts[arg] == 1) {
+          load.setNontemporal(true);
+        }
+      });
+      // Root output stores: a store to a kernel output buffer that is not also
+      // read back in the kernel is a streamed-once write; mark it non-temporal.
+      // Read-only inputs and buffers read back (e.g. in-place update) are
+      // conservatively excluded.
+      getOperation()->walk([&](ml::StoreOp store) {
+        mlir::BlockArgument arg = global_buffer_arg(store.getAddr());
+        if (!arg) {
+          return;
+        }
+        if (arg_has_attr(arg, "xla.invariant")) {
+          return;
+        }
+        if (global_load_counts.contains(arg)) {
+          return;
+        }
+        store.setNontemporal(true);
+      });
+    }
   }
 
  private:

--- a/xla/codegen/emitters/transforms/lower_tensors.cc
+++ b/xla/codegen/emitters/transforms/lower_tensors.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "absl/numeric/bits.h"
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -1461,8 +1462,10 @@ class LowerTensorsPass : public impl::LowerTensorsPassBase<LowerTensorsPass> {
       return;
     }
 
-    getOperation()->walk([this](ml::LoadOp load) {
-      Value addr = load.getAddr();
+    // Traces a load/store address back to the function-argument buffer it
+    // addresses. Returns a null BlockArgument for shared memory,
+    // global constants and temporaries (allocas), which must not be annotated.
+    auto global_buffer_arg = [](Value addr) -> mlir::BlockArgument {
       while (auto gep = addr.getDefiningOp<ml::GEPOp>()) {
         addr = gep.getBase();
       }
@@ -1472,19 +1475,106 @@ class LowerTensorsPass : public impl::LowerTensorsPassBase<LowerTensorsPass> {
       if (addr.getDefiningOp<ml::AddrSpaceCastOp>() ||
           addr.getDefiningOp<ml::AddressOfOp>() ||
           addr.getDefiningOp<ml::AllocaOp>()) {
-        // Shared memory, global constant or temporary - no need to annotate
-        // anything.
+        return nullptr;
+      }
+      return mlir::dyn_cast<mlir::BlockArgument>(addr);
+    };
+
+    auto arg_has_attr = [](mlir::BlockArgument arg,
+                           llvm::StringRef name) -> bool {
+      auto func =
+          mlir::dyn_cast<mlir::func::FuncOp>(arg.getOwner()->getParentOp());
+      return func && func.getArgAttr(arg.getArgNumber(), name) != nullptr;
+    };
+
+    // Buffer args read in the kernel; used to exclude read-back outputs
+    // (e.g. in-place updates) from non-temporal stores.
+    llvm::DenseSet<Value> loaded_args;
+    getOperation()->walk([&](ml::LoadOp load) {
+      mlir::BlockArgument arg = global_buffer_arg(load.getAddr());
+      if (!arg) {
+        // Shared memory, global constant or temporary - no need to annotate.
         return;
       }
-      if (auto base = mlir::dyn_cast<mlir::BlockArgument>(addr)) {
-        if (auto func = mlir::dyn_cast<mlir::func::FuncOp>(
-                base.getOwner()->getParentOp())) {
-          if (func.getArgAttr(base.getArgNumber(), "xla.invariant")) {
-            load.setInvariant(true);
-          }
-        }
+      loaded_args.insert(arg);
+      if (arg_has_attr(arg, "xla.invariant")) {
+        load.setInvariant(true);
       }
     });
+
+    // AMD-only non-temporal (streaming) cache hints.
+    if (device_spec_.IsAmdGpu()) {
+      // Buffer size behind an arg (llvm.dereferenceable); 0 if unknown.
+      auto arg_bytes = [](mlir::BlockArgument arg) -> int64_t {
+        auto func =
+            mlir::dyn_cast<mlir::func::FuncOp>(arg.getOwner()->getParentOp());
+        if (!func) {
+          return 0;
+        }
+        auto size = func.getArgAttrOfType<mlir::IntegerAttr>(
+            arg.getArgNumber(), ml::LLVMDialect::getDereferenceableAttrName());
+        return size ? size.getInt() : 0;
+      };
+      // Set by the loop/concat/DUS emitters when the kernel writes outputs
+      // contiguously. Reductions/transposes lack it: their partial-line stores
+      // benefit from L2 aggregation, so we don't stream them.
+      bool contiguous_output = false;
+      for (auto func : getOperation().getOps<mlir::func::FuncOp>()) {
+        if (func->hasAttr("xla.entry") &&
+            func->hasAttr("xla.contiguous_output")) {
+          contiguous_output = true;
+          break;
+        }
+      }
+      // Stream only when the buffer far exceeds L2; smaller buffers use the
+      // cache as a bandwidth buffer. Crossover on MI300X is ~16x L2 (~64 MiB);
+      // L2 = 0 disables the size path. Runtime override planned as a follow-up.
+      static constexpr int64_t kNontemporalStreamL2Multiple = 16;
+      const int64_t l2_bytes = device_spec_.gpu().l2_cache_size();
+      const int64_t stream_threshold = kNontemporalStreamL2Multiple * l2_bytes;
+      // Mark a read-only (xla.invariant) input non-temporal when the emitter
+      // proved read-once (xla.streamed_once), or - in a non-contiguous kernel -
+      // the buffer exceeds the streaming threshold.
+      bool streams_input = false;
+      getOperation()->walk([&](ml::LoadOp load) {
+        mlir::BlockArgument arg = global_buffer_arg(load.getAddr());
+        if (!arg) {
+          return;
+        }
+        if (!arg_has_attr(arg, "xla.invariant")) {
+          return;
+        }
+        const bool is_streamed_once = arg_has_attr(arg, "xla.streamed_once");
+        // Size path: non-contiguous kernel whose read-only input dwarfs L2. No
+        // load-count guard needed - reused inputs aren't xla.invariant and
+        // reductions read each element once.
+        const bool exceeds_size_threshold = !contiguous_output &&
+                                            l2_bytes > 0 &&
+                                            arg_bytes(arg) >= stream_threshold;
+        if (is_streamed_once || exceeds_size_threshold) {
+          load.setNontemporal(true);
+          streams_input = true;
+        }
+      });
+      // Root output stores: only when the kernel writes contiguously and
+      // streams an input. A store whose buffer is not read-only and not read
+      // back (e.g. in-place update) is a streamed-once write; mark it.
+      if (contiguous_output && streams_input) {
+        getOperation()->walk([&](ml::StoreOp store) {
+          mlir::BlockArgument arg = global_buffer_arg(store.getAddr());
+          if (!arg) {
+            return;
+          }
+          if (arg_has_attr(arg, "xla.invariant")) {
+            return;
+          }
+          if (loaded_args.contains(arg)) {
+            return;
+          }
+          store.setNontemporal(true);
+        });
+      }
+    }
   }
 
  private:

--- a/xla/codegen/emitters/transforms/propagate_slice_indices.cc
+++ b/xla/codegen/emitters/transforms/propagate_slice_indices.cc
@@ -62,6 +62,9 @@ void PropagateSliceIndicesPass::runOnOperation() {
         if (auto invariant = entry.getArgAttr(i, "xla.invariant")) {
           func.setArgAttr(i, "xla.invariant", invariant);
         }
+        if (auto streamed_once = entry.getArgAttr(i, "xla.streamed_once")) {
+          func.setArgAttr(i, "xla.streamed_once", streamed_once);
+        }
       } else {
         break;
       }

--- a/xla/codegen/emitters/transforms/tests/lower_tensors.mlir
+++ b/xla/codegen/emitters/transforms/tests/lower_tensors.mlir
@@ -48,6 +48,18 @@
 // RUN: -xla-lower-tensors="gpu_device_info='rocm_compute_capability {gcn_arch_name: \"gfx942:sramecc+:xnack\"}'" \
 // RUN: | FileCheck %s --check-prefix=CHECK-GFX942-MI300
 
+// RUN: emitters_opt %s --allow-unregistered-dialect -split-input-file \
+// RUN: -xla-lower-tensors="gpu_device_info='rocm_compute_capability {gcn_arch_name: \"gfx942:sramecc+:xnack\"}'" \
+// RUN: | FileCheck %s --check-prefix=CHECK-NT
+
+// RUN: emitters_opt %s --allow-unregistered-dialect -split-input-file \
+// RUN: -xla-lower-tensors="gpu_device_info='rocm_compute_capability {gcn_arch_name: \"gfx1250\"}'" \
+// RUN: | FileCheck %s --check-prefix=CHECK-NT
+
+// RUN: emitters_opt %s --allow-unregistered-dialect -split-input-file \
+// RUN: -xla-lower-tensors="gpu_device_info='cuda_compute_capability {major: 9}'" \
+// RUN: | FileCheck %s --check-prefix=CHECK-NT-CUDA
+
 module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>} {
   func.func private @add(%arg0: f32, %arg1: f32) -> f32 {
     %sum = arith.addf %arg0, %arg1 : f32
@@ -103,6 +115,54 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>
 // CHECK-NEXT:      %[[PTR2:.*]] = llvm.getelementptr inbounds %[[ARG1]][0, 23]
 // CHECK-NEXT:      llvm.store %[[CST]], %[[PTR2]]
 // CHECK-NEXT:      return
+
+// -----
+
+// AMD non-temporal hints: a streamed-once invariant input load and a
+// root output store are marked non-temporal on a supported AMD arch.
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>} {
+  func.func @nt_copy(%arg0: tensor<32xf32> {xla.invariant, xla.slice_index = 0},
+                     %arg1: tensor<32xf32> {xla.slice_index = 1}, %i: index)
+      -> tensor<32xf32> {
+    %v = tensor.extract %arg0[%i] : tensor<32xf32>
+    %out = tensor.insert %v into %arg1[%i] : tensor<32xf32>
+    func.return %out : tensor<32xf32>
+  }
+}
+
+// CHECK-NT-LABEL:  @nt_copy
+// CHECK-NT:          llvm.load {{.*}}nontemporal
+// CHECK-NT:          llvm.store {{.*}}nontemporal
+
+// Non-AMD target: no non-temporal hints on unsupported (non-AMD) targets.
+// CHECK-NT-CUDA-LABEL: @nt_copy
+// CHECK-NT-CUDA-NOT:     nontemporal
+
+// -----
+
+// AMD non-temporal hints: an input read at multiple sites is conservatively
+// treated as reused/broadcast and is NOT marked non-temporal, while the root
+// output store still is.
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>} {
+  func.func @nt_reused_input(
+      %arg0: tensor<32xf32> {xla.invariant, xla.slice_index = 0},
+      %arg1: tensor<32xf32> {xla.slice_index = 1}, %i: index, %j: index)
+      -> tensor<32xf32> {
+    %a = tensor.extract %arg0[%i] : tensor<32xf32>
+    %b = tensor.extract %arg0[%j] : tensor<32xf32>
+    %s = arith.addf %a, %b : f32
+    %out = tensor.insert %s into %arg1[%i] : tensor<32xf32>
+    func.return %out : tensor<32xf32>
+  }
+}
+
+// CHECK-NT-LABEL:  @nt_reused_input
+// CHECK-NT:          llvm.load %{{.*}} invariant :
+// CHECK-NT:          llvm.load %{{.*}} invariant :
+// CHECK-NT:          llvm.store {{.*}}nontemporal
+
+// CHECK-NT-CUDA-LABEL: @nt_reused_input
+// CHECK-NT-CUDA-NOT:     nontemporal
 
 // -----
 

--- a/xla/codegen/emitters/transforms/tests/lower_tensors.mlir
+++ b/xla/codegen/emitters/transforms/tests/lower_tensors.mlir
@@ -48,6 +48,18 @@
 // RUN: -xla-lower-tensors="gpu_device_info='rocm_compute_capability {gcn_arch_name: \"gfx942:sramecc+:xnack\"}'" \
 // RUN: | FileCheck %s --check-prefix=CHECK-GFX942-MI300
 
+// RUN: emitters_opt %s --allow-unregistered-dialect -split-input-file \
+// RUN: -xla-lower-tensors="gpu_device_info='rocm_compute_capability {gcn_arch_name: \"gfx942:sramecc+:xnack\"} l2_cache_size: 4194304'" \
+// RUN: | FileCheck %s --check-prefix=CHECK-NT
+
+// RUN: emitters_opt %s --allow-unregistered-dialect -split-input-file \
+// RUN: -xla-lower-tensors="gpu_device_info='rocm_compute_capability {gcn_arch_name: \"gfx1250\"} l2_cache_size: 4194304'" \
+// RUN: | FileCheck %s --check-prefix=CHECK-NT
+
+// RUN: emitters_opt %s --allow-unregistered-dialect -split-input-file \
+// RUN: -xla-lower-tensors="gpu_device_info='cuda_compute_capability {major: 9}'" \
+// RUN: | FileCheck %s --check-prefix=CHECK-NT-CUDA
+
 module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>} {
   func.func private @add(%arg0: f32, %arg1: f32) -> f32 {
     %sum = arith.addf %arg0, %arg1 : f32
@@ -103,6 +115,126 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>
 // CHECK-NEXT:      %[[PTR2:.*]] = llvm.getelementptr inbounds %[[ARG1]][0, 23]
 // CHECK-NEXT:      llvm.store %[[CST]], %[[PTR2]]
 // CHECK-NEXT:      return
+
+// -----
+
+// AMD non-temporal: a streamed-once invariant input in a contiguous-output
+// kernel gets both a non-temporal load and a non-temporal root store.
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>} {
+  func.func @nt_copy(
+      %arg0: tensor<1048576xf32> {xla.invariant, xla.streamed_once,
+                                  xla.slice_index = 0},
+      %arg1: tensor<1048576xf32> {xla.slice_index = 1}, %i: index)
+      -> tensor<1048576xf32> attributes {xla.contiguous_output, xla.entry} {
+    %v = tensor.extract %arg0[%i] : tensor<1048576xf32>
+    %out = tensor.insert %v into %arg1[%i] : tensor<1048576xf32>
+    func.return %out : tensor<1048576xf32>
+  }
+}
+
+// CHECK-NT-LABEL:  @nt_copy
+// CHECK-NT:          llvm.load {{.*}}nontemporal
+// CHECK-NT:          llvm.store {{.*}}nontemporal
+
+// Non-AMD target: no non-temporal hints on unsupported (non-AMD) targets.
+// CHECK-NT-CUDA-LABEL: @nt_copy
+// CHECK-NT-CUDA-NOT:     nontemporal
+
+// -----
+
+// AMD non-temporal: a streamed-once input in a non-contiguous kernel (e.g. a
+// reduction) gets a non-temporal load, but its store stays temporal.
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>} {
+  func.func @nt_streamed_not_contiguous(
+      %arg0: tensor<1048576xf32> {xla.invariant, xla.streamed_once,
+                                  xla.slice_index = 0},
+      %arg1: tensor<1048576xf32> {xla.slice_index = 1}, %i: index)
+      -> tensor<1048576xf32> attributes {xla.entry} {
+    %v = tensor.extract %arg0[%i] : tensor<1048576xf32>
+    %out = tensor.insert %v into %arg1[%i] : tensor<1048576xf32>
+    func.return %out : tensor<1048576xf32>
+  }
+}
+
+// CHECK-NT-LABEL:  @nt_streamed_not_contiguous
+// CHECK-NT:          llvm.load {{.*}}nontemporal
+// CHECK-NT-NOT:      llvm.store {{.*}}nontemporal
+
+// -----
+
+// AMD non-temporal: a contiguous-output kernel whose input is not streamed-once
+// (e.g. a broadcast) gets no non-temporal hints.
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>} {
+  func.func @nt_contiguous_not_streamed(
+      %arg0: tensor<1048576xf32> {xla.invariant, xla.slice_index = 0},
+      %arg1: tensor<1048576xf32> {xla.slice_index = 1}, %i: index, %j: index)
+      -> tensor<1048576xf32> attributes {xla.contiguous_output, xla.entry} {
+    %a = tensor.extract %arg0[%i] : tensor<1048576xf32>
+    %b = tensor.extract %arg0[%j] : tensor<1048576xf32>
+    %s = arith.addf %a, %b : f32
+    %out = tensor.insert %s into %arg1[%i] : tensor<1048576xf32>
+    func.return %out : tensor<1048576xf32>
+  }
+}
+
+// CHECK-NT-LABEL:  @nt_contiguous_not_streamed
+// CHECK-NT-NOT:      nontemporal
+
+// -----
+
+// AMD non-temporal: a kernel carrying neither fact gets no hints.
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>} {
+  func.func @nt_no_facts(
+      %arg0: tensor<1048576xf32> {xla.invariant, xla.slice_index = 0},
+      %arg1: tensor<1048576xf32> {xla.slice_index = 1}, %i: index)
+      -> tensor<1048576xf32> attributes {xla.entry} {
+    %v = tensor.extract %arg0[%i] : tensor<1048576xf32>
+    %out = tensor.insert %v into %arg1[%i] : tensor<1048576xf32>
+    func.return %out : tensor<1048576xf32>
+  }
+}
+
+// CHECK-NT-LABEL:  @nt_no_facts
+// CHECK-NT-NOT:      nontemporal
+
+// -----
+
+// AMD non-temporal (size path): a non-streamed-once invariant input in a
+// non-contiguous kernel is streamed when its buffer >= 16x L2. L2 = 4 MiB here,
+// so the 64 MiB buffer is marked non-temporal.
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>} {
+  func.func @nt_size_gate_above(
+      %arg0: tensor<16777216xf32> {llvm.dereferenceable = 67108864 : index,
+                                   xla.invariant, xla.slice_index = 0},
+      %arg1: tensor<16777216xf32> {xla.slice_index = 1}, %i: index)
+      -> tensor<16777216xf32> attributes {xla.entry} {
+    %v = tensor.extract %arg0[%i] : tensor<16777216xf32>
+    %out = tensor.insert %v into %arg1[%i] : tensor<16777216xf32>
+    func.return %out : tensor<16777216xf32>
+  }
+}
+
+// CHECK-NT-LABEL:  @nt_size_gate_above
+// CHECK-NT:          llvm.load {{.*}}nontemporal
+
+// -----
+
+// AMD non-temporal (size path): a buffer below the threshold (32 MiB < 16x4 MiB)
+// stays temporal.
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32 : i32>>} {
+  func.func @nt_size_gate_below(
+      %arg0: tensor<8388608xf32> {llvm.dereferenceable = 33554432 : index,
+                                  xla.invariant, xla.slice_index = 0},
+      %arg1: tensor<8388608xf32> {xla.slice_index = 1}, %i: index)
+      -> tensor<8388608xf32> attributes {xla.entry} {
+    %v = tensor.extract %arg0[%i] : tensor<8388608xf32>
+    %out = tensor.insert %v into %arg1[%i] : tensor<8388608xf32>
+    func.return %out : tensor<8388608xf32>
+  }
+}
+
+// CHECK-NT-LABEL:  @nt_size_gate_below
+// CHECK-NT-NOT:      nontemporal
 
 // -----
 

--- a/xla/codegen/emitters/transforms/tests/propagate_slice_indices.mlir
+++ b/xla/codegen/emitters/transforms/tests/propagate_slice_indices.mlir
@@ -32,7 +32,8 @@ module {
     func.return %call : f32
   }
 
-  func.func @stores(%arg0: tensor<17xf32> {xla.invariant, xla.slice_index = 0},
+  func.func @stores(%arg0: tensor<17xf32> {xla.invariant, xla.slice_index = 0,
+                                           xla.streamed_once},
                     %arg1: tensor<43xf32> {xla.slice_index = 1}) -> tensor<43xf32>
                     attributes { xla.entry } {
     %c17 = arith.constant 17 : index
@@ -45,6 +46,6 @@ module {
 }
 
 // CHECK-DAG: @add(%{{.*}}: f32, %{{.*}}: f32)
-// CHECK-DAG: @tensorarg(%{{.*}}: tensor<43xf32> {xla.invariant, xla.slice_index = 0 : i64}, %{{.*}}: index)
-// CHECK-DAG: @tensorcall(%{{.*}}: tensor<43xf32> {xla.invariant, xla.slice_index = 0 : i64}, %{{.*}}: index)
-// CHECK-DAG: @stores(%{{.*}}: tensor<17xf32> {xla.invariant, xla.slice_index = 0 : i64}, %{{.*}}: tensor<43xf32> {xla.slice_index = 1 : i64})
+// CHECK-DAG: @tensorarg(%{{.*}}: tensor<43xf32> {xla.invariant, xla.slice_index = 0 : i64, xla.streamed_once}, %{{.*}}: index)
+// CHECK-DAG: @tensorcall(%{{.*}}: tensor<43xf32> {xla.invariant, xla.slice_index = 0 : i64, xla.streamed_once}, %{{.*}}: index)
+// CHECK-DAG: @stores(%{{.*}}: tensor<17xf32> {xla.invariant, xla.slice_index = 0 : i64, xla.streamed_once}, %{{.*}}: tensor<43xf32> {xla.slice_index = 1 : i64})


### PR DESCRIPTION
📝 Summary of Changes
Mark streamed-once global loads/stores as non-temporal in `LowerTensorsPass` on AMD CDNA MI-series and gfx1250.

🎯 Justification
Avoids evicting reused data from L2 by streaming data that's touched exactly once (read-only inputs at a single load site, or write-only outputs) through the cache.

🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement, 🧪 Tests

🧪 Unit Tests:
FileCheck tests in `lower_tensors.mlir` covering single-load-site invariant input + root output store (non-temporal), multi-site/reused input (excluded), non-AMD target (no-op), and the cross-kernel L2-size reuse guard.
