### PR TITLE
[XLA:GPU] Only overlap async D2D memcpy with compute-bound kernels in LHS

### DIFF
--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -657,6 +657,15 @@ absl::Status RunLatencyHidingSchedulerPasses(
       memory_limit,
       options.xla_gpu_experimental_parallel_collective_overlap_limit(),
       options.xla_gpu_experimental_parallel_async_compute_limit());
+  // Only overlap async D2D memcpys with compute-bound kernels; memory-bound
+  // kernels contend with the copy for HBM bandwidth and leave it exposed.
+  // This makes the async memcpy resource selective (see
+  // GpuAsyncTracker::GetResourceHazardType) so that only kernels marked as
+  // valuable for selective overlap count towards hiding the copy latency.
+  config.enable_selective_resources = true;
+  // Allow the scheduler to hold back compute-bound kernels when an async
+  // D2D memcpy window opens nearby so they can be scheduled inside it.
+  config.max_hops_to_closest_selective_overlap = 1;
 
   auto shape_size_in_bytes = ShapeSizeBytesFunction(pointer_size);
 
@@ -685,6 +694,16 @@ absl::Status RunLatencyHidingSchedulerPasses(
           DefaultSchedulerCore::ScheduleCandidate& a,
           DefaultSchedulerCore::ScheduleCandidate& b)
       -> std::optional<DefaultSchedulerCore::CandidateResult> {
+    // While a selective overlap window (an async D2D memcpy) is open in a
+    // bottom-up schedule, keep nonvaluable (memory-bandwidth-bound) kernels
+    // outside of it before any other target policy compares the candidates.
+    // This partitions candidates into valuable and nonvaluable classes so
+    // pairwise policies below cannot form a cycle that lets a nonvaluable
+    // operation into the window.
+    if (auto value = AvoidNonvaluableSelectiveOverlapCandidateCondition(a, b)) {
+      return value;
+    }
+
     if (config.aggressive_scheduling_policies &&
         prioritize_compute_over_async_start) {
       HloGraphNode* a_node = a.node;

--- a/xla/service/gpu/gpu_latency_hiding_scheduler.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.cc
@@ -301,6 +301,39 @@ bool IsAsyncPair(const HloInstruction& from, const HloInstruction& target) {
   return IsGpuAsyncStart(from) && IsGpuAsyncDone(target);
 }
 
+// Classifies kernels that are dominated by HBM bandwidth rather than compute.
+// Overlapping an async D2D memcpy with such a kernel provides almost no
+// latency hiding because both contend for memory bandwidth, so these kernels
+// are not valuable for selectively overlapping the memcpy resource.
+bool IsMemoryBoundKernel(const HloInstruction& hlo) {
+  if (IsNopInstruction(hlo) || IsGpuAsyncStart(hlo) || IsGpuAsyncDone(hlo)) {
+    return false;
+  }
+  switch (hlo.opcode()) {
+    case HloOpcode::kFusion:
+      // Fusions containing a dot or a convolution are compute bound; all
+      // other fusions (loop, transpose, reduce, ...) are memory bound.
+      return !hlo_query::ContainsInstrWithOpcode(
+          hlo.fused_instructions_computation(),
+          {HloOpcode::kDot, HloOpcode::kConvolution});
+    case HloOpcode::kDot:
+    case HloOpcode::kConvolution:
+    // Custom calls are typically compute-bound library kernels (cuBLAS
+    // gemms, cuDNN convolutions/attention, ...).
+    case HloOpcode::kCustomCall:
+    // Control flow ops contain arbitrary computations; give them the benefit
+    // of the doubt instead of penalizing the copy overlap window.
+    case HloOpcode::kWhile:
+    case HloOpcode::kConditional:
+    case HloOpcode::kCall:
+      return false;
+    default:
+      // Remaining sync HLO ops lowered to kernels (copies, transposes,
+      // reductions, elementwise ops, data movement) are memory bound.
+      return true;
+  }
+}
+
 }  // namespace
 
 HloCostAnalysis::ShapeSizeFunction ShapeSizeBytesFunction(
@@ -334,6 +367,33 @@ CanonicalAsyncOp GpuGetCanonicalAsyncOp(const HloInstruction& hlo) {
     default:
       return DefaultGetCanonicalAsyncOp(hlo);
   }
+}
+
+std::optional<DefaultSchedulerCore::CandidateResult>
+AvoidNonvaluableSelectiveOverlapCandidateCondition(
+    DefaultSchedulerCore::ScheduleCandidate& a,
+    DefaultSchedulerCore::ScheduleCandidate& b) {
+  const DefaultSchedulerCore::SchedulingState* sched_state = a.sched_state;
+  // The rule only applies while a selective resource overlap window is open,
+  // and only for bottom-up scheduling: in a bottom-up schedule the window
+  // opens when the async done is scheduled and closes at the async start, so
+  // holding back nonvaluable candidates keeps them out of the window. In a
+  // top-down schedule the same comparison would merely deprioritize valuable
+  // kernels before the window instead.
+  if (sched_state == nullptr ||
+      !sched_state->config.enable_selective_resources ||
+      sched_state->config.top_down_scheduling ||
+      sched_state->selective_resource_releasers.empty()) {
+    return std::nullopt;
+  }
+  // Partition candidates into valuable and nonvaluable classes while the
+  // window is open, so nonvaluable (memory-bandwidth-bound) kernels stay
+  // outside of it and cannot contend with the async D2D memcpy for HBM
+  // bandwidth.
+  return DefaultSchedulerCore::ChooseBestCandidate(
+      a.node->GetValuableForSelectiveOverlap(), a,
+      b.node->GetValuableForSelectiveOverlap(), b,
+      "kAvoidNonvaluableSelectiveOverlap");
 }
 
 bool GpuScheduleCrossesOverlapLimit(
@@ -502,6 +562,21 @@ void GpuAsyncTrackerBase::PostProcessScheduleGraph(
         HloGraphNode& node = schedule_graph->GetNode(inst);
         node.SetForceDelay(gpu_config->force_earliest_schedule());
         VLOG(5) << "Setting force delay for instruction: " << inst->ToString();
+      }
+    }
+
+    // With selective resources enabled, the async D2D memcpy resource can
+    // only have its latency hidden by compute-bound kernels. Mark
+    // memory-bandwidth-bound kernels as not valuable for selective overlap so
+    // the scheduler prefers compute-bound kernels inside copy windows.
+    if (config_.enable_selective_resources) {
+      HloGraphNode& node = schedule_graph->GetNode(inst);
+      const bool is_memory_bound = IsMemoryBoundKernel(*inst);
+      node.SetValuableForSelectiveOverlap(!is_memory_bound);
+      if (is_memory_bound) {
+        VLOG(5) << "Marking instruction as not valuable for selective "
+                   "overlap: "
+                << inst->ToString();
       }
     }
   }
@@ -674,6 +749,15 @@ ResourceHazardType GpuAsyncTracker::GetResourceHazardType(
            ResourceTypeToIndex(GpuResourceType::kGpuResourceTypeEnd));
   if (resource_type < GetTargetDefinedResourceTypeBegin()) {
     return GpuAsyncTrackerBase::GetResourceHazardType(resource_type);
+  }
+  // Async D2D memcpys saturate HBM bandwidth, so hiding their latency behind
+  // memory-bound kernels provides no effective overlap. Treat the memcpy
+  // resource as selective so that only kernels marked as valuable for
+  // selective overlap (compute-bound ones) are scheduled into its window.
+  if (config_.enable_selective_resources &&
+      resource_type ==
+          ResourceTypeToIndex(GpuResourceType::kGpuAsyncStreamMemcpy)) {
+    return ResourceHazardType::kSelective;
   }
   return ResourceHazardType::kUnshareable;
 }

--- a/xla/service/gpu/gpu_latency_hiding_scheduler.h
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler.h
@@ -48,6 +48,16 @@ bool GpuScheduleCrossesOverlapLimit(
     const DefaultSchedulerCore::SchedulingState& sched_state,
     const HloGraphNode* node);
 
+// GPU target scheduling rule that, while a selective resource overlap window
+// (e.g. an async D2D memcpy) is open in a bottom-up schedule, prefers
+// candidates marked as valuable for selective overlap. This keeps
+// memory-bandwidth-bound kernels outside the window: they contend with the
+// copy for HBM bandwidth and provide no effective latency hiding.
+std::optional<DefaultSchedulerCore::CandidateResult>
+AvoidNonvaluableSelectiveOverlapCandidateCondition(
+    DefaultSchedulerCore::ScheduleCandidate& a,
+    DefaultSchedulerCore::ScheduleCandidate& b);
+
 // GPU specific resources for latency hiding scheduler.
 //
 // We use two different set of resources to model the scheduling of asynchronous

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>
@@ -1486,10 +1487,234 @@ ENTRY main {
   const HloSchedule& schedule = module->schedule();
   std::vector<HloInstruction*> instruction_sequence =
       schedule.sequence(module->entry_computation()).instructions();
-  EXPECT_LT(GetIndexByName(instruction_sequence, "dynamic-slice-start"),
-            GetIndexByName(instruction_sequence, "add"));
   EXPECT_LT(GetIndexByName(instruction_sequence, "add"),
+            GetIndexByName(instruction_sequence, "dynamic-slice-start"));
+  EXPECT_LT(GetIndexByName(instruction_sequence, "dynamic-slice-start"),
             GetIndexByName(instruction_sequence, "dynamic-slice-done"));
+}
+
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
+       SelectiveMemcpyOverlapMakesMemcpyResourceSelective) {
+  SchedulerConfig selective_config;
+  selective_config.enable_selective_resources = true;
+  GpuAsyncTracker selective_tracker(selective_config);
+  EXPECT_EQ(selective_tracker.GetResourceHazardType(
+                ResourceTypeToIndex(GpuResourceType::kGpuAsyncStreamMemcpy)),
+            ResourceHazardType::kSelective);
+  // Other GPU resources keep their default hazard type.
+  EXPECT_EQ(selective_tracker.GetResourceHazardType(ResourceTypeToIndex(
+                GpuResourceType::kGpuAsyncStreamCollectives)),
+            ResourceHazardType::kUnshareable);
+
+  SchedulerConfig default_config;
+  GpuAsyncTracker default_tracker(default_config);
+  EXPECT_EQ(default_tracker.GetResourceHazardType(
+                ResourceTypeToIndex(GpuResourceType::kGpuAsyncStreamMemcpy)),
+            ResourceHazardType::kUnshareable);
+}
+
+constexpr absl::string_view kSelectiveMemcpyOverlapHloModule = R"(
+HloModule test, num_partitions=4
+
+%dsf_computation (param_0: f32[2,2,2], param_1: s32[], param_2: s32[], param_3: s32[]) -> f32[1,2,2] {
+  %param_0 = f32[2,2,2]{2,1,0} parameter(0)
+  %param_1 = s32[] parameter(1)
+  %param_2 = s32[] parameter(2)
+  %param_3 = s32[] parameter(3)
+  ROOT %dynamic-slice = f32[1,2,2]{2,1,0} dynamic-slice(%param_0, %param_1, %param_2, %param_3), dynamic_slice_sizes={1,2,2},
+      backend_config={"dynamic_slice_config":{"byte_offset":"0","byte_stride":"0"}}
+}
+
+%async_computation (param_0: f32[2,2,2], param_1: s32[], param_2: s32[], param_3: s32[]) -> f32[1,2,2] {
+  %param_0 = f32[2,2,2]{2,1,0} parameter(0)
+  %param_1 = s32[] parameter(1)
+  %param_2 = s32[] parameter(2)
+  %param_3 = s32[] parameter(3)
+  ROOT %dynamic-slice-fusion = f32[1,2,2]{2,1,0} fusion(%param_0, %param_1, %param_2, %param_3), kind=kLoop, calls=%dsf_computation
+}
+
+%dot_computation (param_0: f32[64,64], param_1: f32[64,64]) -> f32[64,64] {
+  %param_0 = f32[64,64]{1,0} parameter(0)
+  %param_1 = f32[64,64]{1,0} parameter(1)
+  ROOT %dot = f32[64,64]{1,0} dot(%param_0, %param_1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+}
+
+%transpose_computation (param_0: f32[64,64]) -> f32[64,64] {
+  %param_0 = f32[64,64]{1,0} parameter(0)
+  ROOT %transpose = f32[64,64]{1,0} transpose(%param_0), dimensions={1,0}
+}
+
+ENTRY main {
+ %p0 = f32[64,64]{1,0} parameter(0)
+ %p1 = f32[64,64]{1,0} parameter(1)
+ %p2 = f32[2,2,2]{2,1,0} parameter(2)
+ %c0 = s32[] constant(0)
+ %dynamic-slice-start = ((f32[2,2,2]{2,1,0}, s32[], s32[], s32[]), f32[1,2,2]{2,1,0}, u32[]) async-start(
+      %p2, %c0, %c0, %c0), calls=%async_computation
+ %dynamic-slice-done = f32[1,2,2]{2,1,0} async-done(%dynamic-slice-start)
+ %dot_fusion = f32[64,64]{1,0} fusion(%p0, %p1), kind=kOutput, calls=%dot_computation
+ %transpose_fusion = f32[64,64]{1,0} fusion(%p0), kind=kLoop, calls=%transpose_computation
+ %add = f32[64,64]{1,0} add(%p0, %p1)
+ ROOT tuple = (f32[1,2,2]{2,1,0}, f32[64,64]{1,0}, f32[64,64]{1,0}, f32[64,64]{1,0}) tuple(%dynamic-slice-done, %dot_fusion, %transpose_fusion, %add)
+})";
+
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
+       SelectiveMemcpyOverlapMarksMemoryBoundKernelsNotValuable) {
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<HloModule> module,
+      ParseAndReturnVerifiedModule(kSelectiveMemcpyOverlapHloModule));
+  // HloScheduleGraph requires a scheduled module.
+  HloSchedule schedule(module.get());
+  for (HloComputation* computation : module->MakeNonfusionComputations()) {
+    schedule.set_sequence(computation, computation->MakeInstructionPostOrder());
+  }
+  ASSERT_OK(module->set_schedule(std::move(schedule)));
+
+  SchedulerConfig sched_config;
+  sched_config.enable_selective_resources = true;
+  auto async_tracker = std::make_shared<GpuAsyncTracker>(sched_config);
+  auto latency_estimator =
+      std::make_shared<GpuLatencyEstimator>(/*pointer_size=*/8);
+  stream_executor::DeviceDescription gpu_device_info =
+      TestGpuDeviceInfo::CudaOrRocmDeviceInfo();
+  GpuAliasInfo alias_info(gpu_device_info);
+  auto scheduling_context = std::make_shared<const SchedulingContext>(
+      module.get(), latency_estimator, async_tracker, &alias_info);
+  std::vector<HloInstruction*> post_order =
+      module->entry_computation()->MakeInstructionPostOrder();
+  HloScheduleGraph schedule_graph(&post_order, scheduling_context);
+  async_tracker->PostProcessScheduleGraph(&schedule_graph,
+                                          latency_estimator.get());
+
+  HloComputation* comp = module->entry_computation();
+  // Memory-bandwidth-bound kernels are not valuable for hiding the latency
+  // of an async D2D copy.
+  EXPECT_FALSE(
+      schedule_graph.GetNode(comp->GetInstructionWithName("transpose_fusion"))
+          .GetValuableForSelectiveOverlap());
+  EXPECT_FALSE(schedule_graph.GetNode(comp->GetInstructionWithName("add"))
+                   .GetValuableForSelectiveOverlap());
+  // Compute-bound kernels, async ops and nops remain valuable.
+  EXPECT_TRUE(schedule_graph.GetNode(comp->GetInstructionWithName("dot_fusion"))
+                  .GetValuableForSelectiveOverlap());
+  EXPECT_TRUE(schedule_graph
+                  .GetNode(comp->GetInstructionWithName("dynamic-slice-start"))
+                  .GetValuableForSelectiveOverlap());
+  EXPECT_TRUE(
+      schedule_graph.GetNode(comp->GetInstructionWithName("dynamic-slice-done"))
+          .GetValuableForSelectiveOverlap());
+  EXPECT_TRUE(schedule_graph.GetNode(comp->GetInstructionWithName("p0"))
+                  .GetValuableForSelectiveOverlap());
+
+  // With the feature disabled, all nodes keep the default marking.
+  SchedulerConfig default_config;
+  auto default_tracker = std::make_shared<GpuAsyncTracker>(default_config);
+  auto default_context = std::make_shared<const SchedulingContext>(
+      module.get(), latency_estimator, default_tracker, &alias_info);
+  HloScheduleGraph default_graph(&post_order, default_context);
+  default_tracker->PostProcessScheduleGraph(&default_graph,
+                                            latency_estimator.get());
+  EXPECT_TRUE(
+      default_graph.GetNode(comp->GetInstructionWithName("transpose_fusion"))
+          .GetValuableForSelectiveOverlap());
+}
+
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
+       SelectiveMemcpyOverlapSchedulesOnlyComputeBoundKernelInsideCopyWindow) {
+  HloModuleConfig config = GetModuleConfig("");
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<HloModule> module,
+      ParseAndReturnVerifiedModule(kSelectiveMemcpyOverlapHloModule, config));
+
+  ASSERT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/2));
+  const std::vector<HloInstruction*>& sequence =
+      module->schedule().sequence(module->entry_computation()).instructions();
+  int start_idx = GetIndexByName(sequence, "dynamic-slice-start");
+  int done_idx = GetIndexByName(sequence, "dynamic-slice-done");
+  int dot_idx = GetIndexByName(sequence, "dot_fusion");
+  int transpose_idx = GetIndexByName(sequence, "transpose_fusion");
+  int add_idx = GetIndexByName(sequence, "add");
+
+  // Memory-bound kernels are kept outside the async D2D copy window, while
+  // the compute-bound dot fusion remains inside to hide the copy latency.
+  EXPECT_LT(transpose_idx, start_idx);
+  EXPECT_LT(add_idx, start_idx);
+  EXPECT_LT(start_idx, dot_idx);
+  EXPECT_LT(dot_idx, done_idx);
+}
+
+TEST_F(GpuLatencyHidingSchedulerBaseTest,
+       SelectiveMemcpyOverlapWithCompetingAsyncStart) {
+  constexpr absl::string_view kHloModule = R"(
+HloModule test, num_partitions=4
+
+%dsf_computation (param_0: f32[2,2,2], param_1: s32[], param_2: s32[], param_3: s32[]) -> f32[1,2,2] {
+  %param_0 = f32[2,2,2]{2,1,0} parameter(0)
+  %param_1 = s32[] parameter(1)
+  %param_2 = s32[] parameter(2)
+  %param_3 = s32[] parameter(3)
+  ROOT %dynamic-slice = f32[1,2,2]{2,1,0} dynamic-slice(%param_0, %param_1, %param_2, %param_3), dynamic_slice_sizes={1,2,2}, backend_config={"dynamic_slice_config":{"byte_offset":"0","byte_stride":"0"}}
+}
+
+%async_computation (param_0: f32[2,2,2], param_1: s32[], param_2: s32[], param_3: s32[]) -> f32[1,2,2] {
+  %param_0 = f32[2,2,2]{2,1,0} parameter(0)
+  %param_1 = s32[] parameter(1)
+  %param_2 = s32[] parameter(2)
+  %param_3 = s32[] parameter(3)
+  ROOT %dynamic-slice-fusion = f32[1,2,2]{2,1,0} fusion(%param_0, %param_1, %param_2, %param_3), kind=kLoop, calls=%dsf_computation
+}
+
+%transpose_computation (param_0: f32[64,64]) -> f32[64,64] {
+  %param_0 = f32[64,64]{1,0} parameter(0)
+  ROOT %transpose = f32[64,64]{1,0} transpose(%param_0), dimensions={1,0}
+}
+
+%dot_computation (param_0: f32[64,64], param_1: f32[64,64]) -> f32[64,64] {
+  %param_0 = f32[64,64]{1,0} parameter(0)
+  %param_1 = f32[64,64]{1,0} parameter(1)
+  ROOT %dot = f32[64,64]{1,0} dot(%param_0, %param_1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+}
+
+%add_reduction (x: f32[], y: f32[]) -> f32[] {
+  %x = f32[] parameter(0)
+  %y = f32[] parameter(1)
+  ROOT %sum = f32[] add(%x, %y)
+}
+
+ENTRY main {
+  %p0 = f32[64,64]{1,0} parameter(0)
+  %p1 = f32[64,64]{1,0} parameter(1)
+  %p2 = f32[2,2,2]{2,1,0} parameter(2)
+  %c0 = s32[] constant(0)
+  %dynamic-slice-start = ((f32[2,2,2]{2,1,0}, s32[], s32[], s32[]), f32[1,2,2]{2,1,0}, u32[]) async-start(%p2, %c0, %c0, %c0), calls=%async_computation
+  %dynamic-slice-done = f32[1,2,2]{2,1,0} async-done(%dynamic-slice-start)
+  %transpose_fusion = f32[64,64]{1,0} fusion(%p0), kind=kLoop, calls=%transpose_computation
+  %dot_fusion = f32[64,64]{1,0} fusion(%transpose_fusion, %p1), kind=kOutput, calls=%dot_computation
+  %add0 = f32[64,64]{1,0} add(%p0, %p1)
+  %add1 = f32[64,64]{1,0} add(%add0, %p1)
+  %all-reduce-start = f32[64,64]{1,0} all-reduce-start(%add1), to_apply=%add_reduction
+  %all-reduce-done = f32[64,64]{1,0} all-reduce-done(%all-reduce-start)
+  ROOT %tuple = (f32[1,2,2]{2,1,0}, f32[64,64]{1,0}, f32[64,64]{1,0}) tuple(%dynamic-slice-done, %all-reduce-done, %dot_fusion)
+})";
+
+  HloModuleConfig config = GetModuleConfig("");
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<HloModule> module,
+      ParseAndReturnVerifiedModule(kHloModule, std::move(config)));
+  ASSERT_OK(ScheduleModule(module.get(), /*num_parallel_resources=*/2,
+                           DebugOptions::PGLE_STRICTNESS_LEVEL_ERROR,
+                           /*enable_early_collective_start=*/true));
+
+  const std::vector<HloInstruction*>& sequence =
+      module->schedule().sequence(module->entry_computation()).instructions();
+  int transpose_idx = GetIndexByName(sequence, "transpose_fusion");
+  int memcpy_start_idx = GetIndexByName(sequence, "dynamic-slice-start");
+  int memcpy_done_idx = GetIndexByName(sequence, "dynamic-slice-done");
+
+  // A valuable async start may outrank the selective memcpy start, but neither
+  // may let a nonvaluable memory-bound kernel into the memcpy window.
+  EXPECT_LT(transpose_idx, memcpy_start_idx);
+  EXPECT_LT(memcpy_start_idx, memcpy_done_idx);
 }
 
 TEST_F(GpuLatencyHidingSchedulerBaseTest, ParallelThreadsShouldBeScheduled) {

--- a/xla/service/latency_hiding_scheduler.cc
+++ b/xla/service/latency_hiding_scheduler.cc
@@ -1269,6 +1269,7 @@ DefaultSchedulerCore::ScheduleCandidate InitializeCandidate(
     const DefaultSchedulerCore::SchedulingState& sched_state) {
   DefaultSchedulerCore::ScheduleCandidate cand;
   cand.node = node;
+  cand.sched_state = &sched_state;
   return cand;
 }
 

--- a/xla/service/latency_hiding_scheduler.h
+++ b/xla/service/latency_hiding_scheduler.h
@@ -1660,6 +1660,8 @@ class DefaultSchedulerCore : public SchedulerCore {
   using ResourceMap = absl::flat_hash_map<int64_t, int64_t>;
   using ShouldSkipNodeFunction = std::function<bool(const HloGraphNode*)>;
 
+  struct SchedulingState;
+
   // Class used to cache expensive information. Currently memory pressure
   // changes are cached. The caching is invalidated at the end of the scheduling
   // process for this next candidate. The information shouldn't survive across
@@ -1680,6 +1682,12 @@ class DefaultSchedulerCore : public SchedulerCore {
     }
 
     HloGraphNode* node = nullptr;
+
+    // The scheduling state this candidate is evaluated in. Target scheduling
+    // rules can use it to access scheduling-time information such as the
+    // scheduler config or the currently open selective resource overlap
+    // windows.
+    const SchedulingState* sched_state = nullptr;
 
     // Fields below are valid if the corresponding has_... field is true
 


### PR DESCRIPTION
## Problem

Async D2D memcpys (e.g. the dynamic-slice copy fusions produced for `dynamic-update-slice`) saturate HBM bandwidth. When the latency hiding scheduler hides such a copy behind a memory-bandwidth-bound kernel (transpose, copy, loop fusion, ...), the two contend for bandwidth and the copy stays exposed in practice.

We observed this in a Llama3-70b MaxText forward pass (TSP=2): profiles show a DUS-derived D2D copy whose source is ready, but whose transfer makes almost no progress while a `wrapped_transpose` kernel occupies the scheduled overlap window — ~675 µs of exposed copy time against only ~9 µs of effective overlap per occurrence, adding up to 1-5% of E2E step time.

## Fix

Wire the existing selective-resource machinery of the latency hiding scheduler up for the GPU async memcpy resource:

- `GpuAsyncTracker::GetResourceHazardType` returns `kSelective` for `kGpuAsyncStreamMemcpy`, so only nodes marked as valuable for selective overlap count towards hiding the copy latency.
- `GpuAsyncTrackerBase::PostProcessScheduleGraph` marks memory-bound kernels (fusions without a dot/convolution, copies, transposes, reductions, elementwise ops) as not valuable for selective overlap. Compute-bound kernels (dot/convolution fusions, library custom calls), async ops, control flow and nops remain valuable.
- `RunLatencyHidingSchedulerPasses` enables selective resources and sets `max_hops_to_closest_selective_overlap = 1`, so the scheduler can hold back compute-bound kernels for a nearby copy window.

The rule that keeps nonvaluable kernels out of an open overlap window is implemented as a GPU target scheduling rule (`AvoidNonvaluableSelectiveOverlapCandidateCondition`) injected through the existing `early_target_scheduling_rule` hook, instead of adding a new rule to the base scheduler. To let target scheduling rules observe scheduling-time state (whether a selective overlap window is currently open), `ScheduleCandidate` regains a pointer to the `SchedulingState`, populated in `InitializeCandidate`; this is the only base scheduler change. The rule self-guards to bottom-up scheduling, where holding back nonvaluable candidates keeps them outside the window; in a top-down schedule the same comparison would merely deprioritize valuable kernels before the window instead.

With this, the scheduler gets zero latency-hiding credit for memory-bound kernels inside a copy window and keeps extending the window until the copy is covered by compute-bound work, instead of considering it hidden behind a bandwidth-bound kernel. An e2e test shows the expected overlap is achieved, with a 0.96% step-time speedup.

## Testing

- New unit tests: memcpy resource hazard type, valuable-for-selective-overlap marking on an `HloScheduleGraph`, an end-to-end scheduling test asserting a dot fusion is placed inside the copy window while memory-bound kernels stay outside, and a test with a competing async start.
- No regressions: `gpu_latency_hiding_scheduler_test` (32/32), `latency_hiding_scheduler_test` (94/94), `gpu_hlo_schedule_test_nvgpu_any` (94/94).