### PR TITLE
[XLA:GPU] Restore Triton TMEM scale padding workaround

### DIFF
--- a/third_party/triton/common/series.bzl
+++ b/third_party/triton/common/series.bzl
@@ -40,5 +40,6 @@ common_patch_list = [
     "//third_party/triton:common/convert_layout_heuristic.patch",
     "//third_party/triton:common/llvm_cl947230825.patch",
     "//third_party/triton:common/llvm_cl948082775.patch",
+    "//third_party/triton:common/tmem_scale_padding_second_half.patch",
     # Add new patches just above this line
 ]

--- a/third_party/triton/common/tmem_scale_padding_second_half.patch
+++ b/third_party/triton/common/tmem_scale_padding_second_half.patch
@@ -1,0 +1,48 @@
+https://github.com/triton-lang/triton/pull/10321 fixes the second-half alignment
+of unpacked 16-row TMEM scale stores. The fix is present in XLA's Triton pin,
+but tmemfix.patch reverts it because XLA uses CUDA 12.8, where ptxas fails with
+a zero second-half offset. This patch applies an alternative fix that works
+with CUDA 12.8. It can be removed once the upstream Triton fix is enabled in
+XLA.
+
+diff --git a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+index e40a1bcd2c3f..4f337df50658 100644
+--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
++++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+@@ -84,6 +84,10 @@ TMemAllocation getTmemAllocSizes(MemDescType memDescType) {
+   if (ll.getBasis(kRow, llvm::Log2_32(16)) == ArrayRef{0, 0}) {
+     nRow /= 2;
+   }
++  // Scale stores may need a padded half when lowered to 16-row TMEM messages.
++  // Unpacked store further doubles the padding requirement.
++  if (isa<TensorMemoryScalesEncodingAttr>(memDescType.getEncoding()))
++    nCol = std::max(nCol, 4);
+   // If multibuffering is present, we need to allocate more cols
+   if (memDescType.getRank() > 2) {
+     assert(memDescType.getRank() == 3);
+diff --git a/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp b/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
+index b4bf8e13c3d3..3a6d247b7dca 100644
+--- a/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
++++ b/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
+@@ -238,8 +238,10 @@ lowerTMemLdSt(const LinearLayout &cvt, int maxnreg, int bitwidth, bool isScales,
+       secondHalfOffset = (row << 16) | col;
+       if (*secondHalfOffset == 0) {
+         // Workaround for ptxas bug, we cannot use secondHalfOffset = 0 to write
+-        // only 16 elements. We use secondHalfOffset = 1 instead and we pad the
+-        // allocation.
++        // only 16 elements. For unpacked scale stores, each source register
++        // spans two TMEM columns, so place the padded half at the next
++        // two-column group. Scale TMEM allocations reserve at least four
++        // columns for this padding.
+         if (!isScales) {
+           if (emitError) {
+             emitError()
+@@ -247,7 +249,7 @@ lowerTMemLdSt(const LinearLayout &cvt, int maxnreg, int bitwidth, bool isScales,
+           }
+           return failure();
+         }
+-        secondHalfOffset = 1;
++        secondHalfOffset = unpacked ? 2 : 1;
+       }
+       // We "quotient it out", meaning we remove the last basis from reps
+       auto basis = reps.getBases();

--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -2751,6 +2751,44 @@ ENTRY e {
       std::move(optimized_module), ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
 }
 
+TEST_P(TritonScaledDotTest, Mxfp8ScaledDotSmallBlockKAndNExecutes) {
+  if (!GetCudaComputeCapability().IsAtLeastHopper()) {
+    GTEST_SKIP() << "Requires Hopper+.";
+  }
+  constexpr absl::string_view kHloText = R"hlo(
+HloModule m
+
+fusion__ {
+  parameter_0 = f8e4m3fn[128,256]{1,0} parameter(0)
+  parameter_1 = f8e4m3fn[256,128]{1,0} parameter(1)
+  parameter_2 = f8e8m0fnu[128,8]{1,0} parameter(2)
+  parameter_3 = f8e8m0fnu[8,128]{1,0} parameter(3)
+  ROOT _.1 = bf16[128,128]{1,0} scaled-dot(
+      parameter_0, parameter_1, parameter_2, parameter_3),
+    lhs_contracting_dims={1}, rhs_contracting_dims={0},
+    backend_config={"sizes":["64"]}
+}
+
+ENTRY e {
+  lhs = f8e4m3fn[128,256]{1,0} parameter(0)
+  rhs = f8e4m3fn[256,128]{1,0} parameter(1)
+  lhs_scale = f8e8m0fnu[128,8]{1,0} parameter(2)
+  rhs_scale = f8e8m0fnu[8,128]{1,0} parameter(3)
+  ROOT fusion = bf16[128,128]{1,0} fusion(
+      lhs, rhs, lhs_scale, rhs_scale),
+    kind=kCustom, calls=fusion__,
+    backend_config={"fusion_backend_config":{
+      "kind":"__triton_nested_gemm_fusion",
+      "block_level_fusion_config":{
+        "output_tiles":[{"sizes":["128","16"]}],
+        "num_warps":"4","num_ctas":"1","num_stages":"1"}}}
+}
+)hlo";
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHloText));
+  EXPECT_TRUE(RunAndCompareNoHloPasses(
+      std::move(module), ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
+}
+
 // TODO(b/522845225): After fixing random fp4 generation (before it was only 0s,
 // after it's generating uniformly from all fp4 values), we get a small amount
 // of mismatches in the output of this test (~0.2%). It is not clear if this is


### PR DESCRIPTION
📝 Summary of Changes
Backport temporary TMEM fix from Triton. 

🎯 Justification
Triton’s [upstream fix](https://github.com/triton-lang/triton/pull/10321) is currently reverted in XLA for CUDA 12.8 compatibility by [tmemfix.patch](https://github.com/openxla/xla/blob/main/third_party/triton/common/tmemfix.patch). This [alternative fix](https://github.com/triton-lang/triton/pull/10321/changes/BASE..04df539cc129008dba36555f53be41092b3891f5) provides workaround until the upstream solution can be enabled. This is a next PR in the split of scaled dot fixes https://github.com/openxla/xla/pull/44223.

🚀 Kind of Contribution
🐛 Bug Fix, 🧪 Tests

🧪 Unit Tests:
New test TritonScaledDotTest.Mxfp8ScaledDotSmallBlockKAndNExecutes fails on Blackwell (sm_100) without this fix.
