### PR TITLE
[ROCm: XLA profiler] Use real HIP stream_id instead of HSA queue handle

### DIFF
--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -369,9 +369,30 @@ void PerDeviceCollector::Export(uint64_t start_walltime_ns,
   absl::flat_hash_map<int64_t, absl::flat_hash_set<RocmTracerEventType> >
       events_types_per_line;
 
+  // Build dense stream remapping: raw HIP stream handles (64-bit pointer
+  // values) are converted to sequential indices (0, 1, 2, ...) for clean
+  // timeline lane numbering.
+  absl::flat_hash_map<uint64_t, int64_t> stream_remap;
+  int64_t next_stream_idx = 0;
+  for (const auto& event : events_) {
+    if (event.source == RocmTracerEventSource::Activity &&
+        event.stream_id != RocmTracerEvent::kInvalidStreamId &&
+        !stream_remap.contains(event.stream_id)) {
+      stream_remap[event.stream_id] = next_stream_idx++;
+    }
+  }
+
   for (const RocmTracerEvent& event : events_) {
     int64_t line_id = RocmTracerEvent::kInvalidThreadId;
     bool is_host_event = IsHostEvent(event, &line_id);
+
+    // Apply dense stream remapping for device events.
+    if (!is_host_event) {
+      auto it = stream_remap.find(static_cast<uint64_t>(line_id));
+      if (it != stream_remap.end()) {
+        line_id = it->second;
+      }
+    }
 
     if (is_host_event) {
       host_ev_cnt++;

--- a/xla/backends/profiler/gpu/rocm_collector_test.cc
+++ b/xla/backends/profiler/gpu/rocm_collector_test.cc
@@ -176,13 +176,12 @@ TEST(RocmCollectorTest, MultipleActivitiesPerCorrelationIdAllExported) {
 
   // Pre-fix (.front()-only) would emit just one event here. The fix
   // iterates the entire vector, so all three activity records must
-  // appear on the stream line.
+  // appear on the stream line. Dense stream remapping converts the raw
+  // stream_id (123) to a sequential index (0), so we look for events on
+  // any device line rather than matching a specific line ID.
   size_t total_kernel_events = 0;
   absl::flat_hash_set<std::string> seen_names;
   for (const auto& line : gpu_plane->lines()) {
-    if (line.id() != static_cast<int64_t>(kStreamId)) {
-      continue;
-    }
     total_kernel_events += line.events_size();
     for (const auto& ev : line.events()) {
       seen_names.insert(

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/base/optimization.h"
+#include "absl/container/inlined_vector.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
@@ -64,6 +65,13 @@ absl::Status RocprofilerStatusToAbslStatus(rocprofiler_status_t status) {
   return absl::InternalError(
       absl::StrCat("rocprofiler error: ", errstr ? errstr : "unknown"));
 }
+
+// Thread-local HIP stream stack. The rocprofiler-SDK fires
+// ROCPROFILER_HIP_STREAM_SET callbacks around every HIP API call that uses a
+// stream: PHASE_ENTER pushes the stream, PHASE_EXIT pops it. Between enter
+// and exit, the external correlation callback snapshots the current stream.
+// Initialized with 0 (the default HIP stream).
+thread_local absl::InlinedVector<uint64_t, 4> tls_stream_stack = {0};
 
 }  // namespace
 
@@ -279,9 +287,8 @@ void RocmTracer::MemcpyEvent(const rocprofiler_record_header_t* hdr,
   trace_event->scope_range_id =
       annotation_map()->LookUpScopeRangeId(trace_event->correlation_id);
   trace_event->thread_id = rec.thread_id;
-  // we do not know valid stream ID for memcpy
-  // rec.stream_id.handle;
-  trace_event->stream_id = RocmTracerEvent::kInvalidStreamId;
+  // HIP stream handle set by stream_external_correlation_callback().
+  trace_event->stream_id = rec.correlation_id.external.value;
   trace_event->memcpy_info = MemcpyDetails{
       .num_bytes = rec.bytes,
       .destination = static_cast<uint32_t>(dst_gpu.id.handle),
@@ -314,7 +321,9 @@ void RocmTracer::KernelEvent(const rocprofiler_record_header_t* hdr,
   trace_event->scope_range_id =
       annotation_map()->LookUpScopeRangeId(trace_event->correlation_id);
   trace_event->thread_id = rec.thread_id;
-  trace_event->stream_id = kinfo.queue_id.handle;
+  // HIP stream handle set by stream_external_correlation_callback().
+  trace_event->stream_id = rec.correlation_id.external.value;
+  trace_event->queue_id = kinfo.queue_id.handle;
   trace_event->kernel_info = KernelDetails{
       .private_segment_size = kinfo.private_segment_size,
       .group_segment_size = kinfo.group_segment_size,
@@ -423,6 +432,50 @@ static void tool_tracing_callback(rocprofiler_context_id_t context,
       context, buffer_id, headers, num_headers, drop_count);
 }
 
+// Callback for ROCPROFILER_CALLBACK_TRACING_HIP_STREAM events.
+// Maintains the thread-local stream stack so the external correlation callback
+// can snapshot the current HIP stream for each GPU operation.
+static void hip_stream_callback(rocprofiler_callback_tracing_record_t record,
+                                rocprofiler_user_data_t* /*user_data*/,
+                                void* /*callback_data*/) {
+  if (record.kind != ROCPROFILER_CALLBACK_TRACING_HIP_STREAM) return;
+
+  switch (record.operation) {
+    case ROCPROFILER_HIP_STREAM_SET:
+      if (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+        const auto* data =
+            static_cast<const rocprofiler_callback_tracing_hip_stream_data_t*>(
+                record.payload);
+        tls_stream_stack.push_back(data->stream_id.handle);
+      } else if (record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) {
+        if (tls_stream_stack.size() > 1) {
+          tls_stream_stack.pop_back();
+        }
+      }
+      break;
+    case ROCPROFILER_HIP_STREAM_CREATE:
+    case ROCPROFILER_HIP_STREAM_DESTROY:
+      break;
+    default:
+      VLOG(2) << "Unexpected HIP stream operation: " << record.operation;
+      break;
+  }
+}
+
+// External correlation ID request callback. Invoked by rocprofiler-SDK for
+// every kernel dispatch and memory copy to attach the current HIP stream_id.
+static int stream_external_correlation_callback(
+    rocprofiler_thread_id_t /*thread_id*/,
+    rocprofiler_context_id_t /*context_id*/,
+    rocprofiler_external_correlation_id_request_kind_t /*kind*/,
+    rocprofiler_tracing_operation_t /*operation*/,
+    uint64_t /*internal_corr_id_value*/,
+    rocprofiler_user_data_t* external_corr_id_value, void* /*data*/) {
+  external_corr_id_value->value =
+      tls_stream_stack.empty() ? 0 : tls_stream_stack.back();
+  return 0;
+}
+
 absl::Status RocmTracer::InitProfiling(void* tool_data) {
   name_info_ = GetCallbackTracingNames();
 
@@ -482,6 +535,39 @@ absl::Status RocmTracer::InitProfiling(void* tool_data) {
           context_, ROCPROFILER_BUFFER_TRACING_MEMORY_COPY, nullptr, 0,
           buffer_)));
 
+  // Configure external correlation ID request service on the main context.
+  // This attaches the current HIP stream_id (from tls_stream_stack) to every
+  // kernel dispatch and memory copy record via correlation_id.external.value.
+  {
+    rocprofiler_external_correlation_id_request_kind_t kinds[] = {
+        ROCPROFILER_EXTERNAL_CORRELATION_REQUEST_KERNEL_DISPATCH,
+        ROCPROFILER_EXTERNAL_CORRELATION_REQUEST_MEMORY_COPY,
+    };
+    RETURN_IF_ERROR(RocprofilerStatusToAbslStatus(
+        rocprofiler_configure_external_correlation_id_request_service(
+            context_, kinds, std::size(kinds),
+            stream_external_correlation_callback, nullptr)));
+  }
+
+  // Create a dedicated context for HIP stream tracking callbacks.
+  // This fires ROCPROFILER_HIP_STREAM_SET around every HIP API call that
+  // uses a stream, maintaining the thread-local stream stack.
+  // Intentionally process-lifetime (like utility_context_), not toggled by
+  // Enable()/Disable(): the TLS stack must stay warm so that stream IDs are
+  // correct from the very first dispatch after Enable(). The overhead when
+  // profiling is off is negligible (push/pop on a small TLS vector).
+  RETURN_IF_ERROR(RocprofilerStatusToAbslStatus(
+      rocprofiler_create_context(&hip_stream_ctx_)));
+
+  RETURN_IF_ERROR(RocprofilerStatusToAbslStatus(
+      rocprofiler_configure_callback_tracing_service(
+          hip_stream_ctx_, ROCPROFILER_CALLBACK_TRACING_HIP_STREAM, nullptr, 0,
+          hip_stream_callback, nullptr)));
+
+  RETURN_IF_ERROR(RocprofilerStatusToAbslStatus(
+      rocprofiler_start_context(hip_stream_ctx_)));
+  VLOG(1) << "rocprofiler start hip_stream_ctx";
+
   {
     const rocprofiler_tracing_operation_t* hip_ops = nullptr;
     size_t hip_ops_count = 0;
@@ -539,6 +625,8 @@ void RocmTracer::toolFinalize(void* tool_data) {
   VLOG(1) << "Calling toolFinalize!";
   rocprofiler_stop_context(obj.utility_context_);
   obj.utility_context_.handle = 0;
+  rocprofiler_stop_context(obj.hip_stream_ctx_);
+  obj.hip_stream_ctx_.handle = 0;
   rocprofiler_stop_context(obj.context_);
   obj.context_.handle = 0;
 }

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -119,6 +119,8 @@ class RocmTracer {
   // for buffered callback services
   rocprofiler_context_id_t context_{};
   rocprofiler_buffer_id_t buffer_{};
+  // for HIP stream tracking (ROCPROFILER_CALLBACK_TRACING_HIP_STREAM)
+  rocprofiler_context_id_t hip_stream_ctx_{};
 
   // Maps & misc -------------------------------------------------------
   kernel_info_map_t kernel_info_{};

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -143,6 +143,8 @@ struct RocmTracerEvent {
   uint32_t correlation_id = kInvalidCorrelationId;
   uint64_t thread_id = kInvalidThreadId;
   uint64_t stream_id = kInvalidStreamId;
+  uint64_t queue_id = 0;  // HSA queue handle, preserved for debugging/rocprof
+                          // correlation. Not exported to XEvents yet.
   int64_t scope_range_id = 0;
 
   union {


### PR DESCRIPTION
## Summary

- Fix stream_id tracking in the ROCm profiler to use real HIP stream handles
  instead of HSA queue handles (kernels) or kInvalidStreamId (memcpy — silently dropped)
- Add HIP stream tracking via `ROCPROFILER_CALLBACK_TRACING_HIP_STREAM` callback
  with external correlation ID, matching the rocprofiler-sdk reference tool (tool.cpp)
- Add dense stream remapping so trace viewer shows "Stream #0",  "Stream #1"
  instead of raw 64-bit pointer values

## Motivation

The ROCm profiler had two stream-id bugs:
1. **Kernels** used `dispatch_info.queue_id.handle` (HSA hardware queue) as `stream_id` — not the HIP stream the user created
2. **Memcpy events** used `kInvalidStreamId` (UINT64_MAX), causing them to be silently dropped from the device timeline


## Approach

Uses the SDK's purpose-built `ROCPROFILER_CALLBACK_TRACING_HIP_STREAM` kind:
- A thread-local stream stack tracks the current HIP stream via push-on-enter / pop-on-exit callbacks
- An external correlation ID request service snapshots the current stream into `correlation_id.external.value` for every `KERNEL_DISPATCH` and `MEMORY_COPY` record
- `KernelEvent()` and `MemcpyEvent()` read the real stream from the external correlation
- The HSA queue handle is preserved in a new `queue_id` field for debugging

## Changed files

| File | Lines | What |
|------|-------|------|
| `rocm_tracer.cc` | +97 −4 | TLS stream stack, callbacks, InitProfiling setup, event handler fixes |
| `rocm_tracer.h` | +2 | `hip_stream_ctx_` member |
| `rocm_tracer_utils.h` | +2 | `queue_id` field on `RocmTracerEvent` |
| `rocm_collector.cc` | +21 | Dense stream remapping in `Export()` |

## Test plan

- [x] Built with ROCm 7.2.4, gfx942 on rocm-jaxlib-v0.10.2
- [x] Ran `jax_matmul.py` (JIT bfloat16 matmul, 10 profiled iterations) — trace collected successfully
- [x] Verify in trace viewer: kernel events on clean "Stream #N" lanes, memcpy events visible on device timeline
- [x] Verify multi-stream workload produces separate timeline lanes