### PR TITLE
[XLA:GPU] Fix reversed dynamic-slice offset for offloaded scan residuals

### DIFF
--- a/xla/backends/gpu/transforms/dynamic_slice_analysis.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_analysis.cc
@@ -344,8 +344,16 @@ absl::StatusOr<std::optional<DynamicSliceDescriptor>> AnalyzeDynamicSlice(
       if (it != functional_dependency->required_parameters.end()) {
         auto param_it = absl::c_find(it->second, true);
         if (param_it != it->second.end()) {
-          local_ivar =
-              instr_comp->parameter_instruction(param_it - it->second.begin());
+          int64_t param_number = param_it - it->second.begin();
+          // required_parameters only means the parameter is needed to reach
+          // the induction variable, not that it equals it; only substitute
+          // the counter for it when the caller forwards the ivar unchanged.
+          auto callers = instr_comp->caller_instructions();
+          if (callers.size() != 1 || callers.front()->operand(param_number) !=
+                                         functional_dependency->induction_var) {
+            return std::nullopt;
+          }
+          local_ivar = instr_comp->parameter_instruction(param_number);
         }
       }
 

--- a/xla/backends/gpu/transforms/dynamic_slice_analysis_test.cc
+++ b/xla/backends/gpu/transforms/dynamic_slice_analysis_test.cc
@@ -765,5 +765,60 @@ TEST_F(DynamicSliceAnalysisTest, OverlappingTwoDus) {
   EXPECT_FALSE(*result);
 }
 
+// Caller passes a function of the induction variable (n-1-i), not the
+// induction variable itself, to a called computation.
+TEST_F(DynamicSliceAnalysisTest, ParameterIsFunctionOfInductionVariable) {
+  constexpr absl::string_view kHlo = R"(
+    async_slice {
+      p_input = s32[4,8,8] parameter(0)
+      p_index = s32[] parameter(1)
+      p_zero = s32[] parameter(2)
+      ROOT slice = s32[1,8,8] dynamic-slice(p_input, p_index, p_zero, p_zero),
+          dynamic_slice_sizes={1,8,8}
+    }
+
+    body {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      input = s32[4,8,8] get-tuple-element(p0), index=1
+      c0 = s32[] constant(0)
+      c3 = s32[] constant(3)
+      reversed = s32[] subtract(c3, ivar)
+      start = ((s32[4,8,8], s32[], s32[]), s32[1,8,8], u32[])
+          async-start(input, reversed, c0), calls=async_slice
+      done = s32[1,8,8] async-done(start)
+      c1 = s32[] constant(1)
+      next_ivar = s32[] add(ivar, c1)
+      ROOT result = (s32[], s32[4,8,8]) tuple(next_ivar, input)
+    }
+
+    condition {
+      p0 = (s32[], s32[4,8,8]) parameter(0)
+      ivar = s32[] get-tuple-element(p0), index=0
+      c4 = s32[] constant(4)
+      ROOT cmp = pred[] compare(ivar, c4), direction=LT
+    }
+
+    ENTRY main {
+      input = s32[4,8,8] parameter(0)
+      c0 = s32[] constant(0)
+      tuple = (s32[], s32[4,8,8]) tuple(c0, input)
+      ROOT while = (s32[], s32[4,8,8]) while(tuple),
+          condition=condition, body=body,
+          backend_config={"known_trip_count":{"n":"4"},
+                          "known_init_step":{"init":"0","step":"1"},
+                          "known_induction_variable":{"tuple_index":"0"}}
+    })";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  auto* slice = module->GetComputationWithName("async_slice")
+                    ->GetInstructionWithName("slice");
+  ASSERT_OK_AND_ASSIGN(auto desc, AnalyzeDynamicSlice(slice));
+  if (desc.has_value()) {
+    EXPECT_EQ(desc->byte_offset, 3 * 256);
+    EXPECT_EQ(desc->byte_stride, -256);
+  }
+}
+
 }  // namespace
 }  // namespace xla::gpu


### PR DESCRIPTION
#ai-generated

## Summary
- AnalyzeDynamicSlice substituted the loop counter into a called computation's parameter whenever `required_parameters` flagged it, but that flag only means the parameter is needed to reach the induction variable, not that it equals it.
- When the caller passes a function of the induction variable instead (e.g. `n-1-i`, which the transpose of a scan passes when reading a residual back), the slice was annotated with a forward address walk instead of a reverse one.
- This only surfaces for host offloading, since `HostMemoryTransferAsyncifier` is what moves such a slice into a called computation in the first place; device-memory slices stay inline in the while body and are analyzed correctly.
- Symptom: silently wrong gradients for a `jax.lax.scan` whose residuals are offloaded via `save_and_offload_only_these_names`, with no error and correct-looking memory figures.
- Fix: bail out (`return std::nullopt`) unless the caller forwards the induction variable unchanged.

## Test plan
- [x] Added `DynamicSliceAnalysisTest.ParameterIsFunctionOfInductionVariable` covering a called-computation parameter that receives `n-1-i` rather than the induction variable itself.
- [x] Verified against a standalone JAX repro (`jax.checkpoint` + `save_and_offload_only_these_names` over a `jax.lax.scan`): gradients matched a non-offloaded reference after the fix, and diverged (`max abs error ~770`) before it, reproduced on two different GPU architectures (Volta and Blackwell).

## Repro

Standalone JAX repro that demonstrates the bug end-to-end (`jax.checkpoint` + `save_and_offload_only_these_names` over a `jax.lax.scan`, compared against a non-offloaded reference gradient). Requires a working CUDA jaxlib on the target GPU.

Reproduced with a nonzero gradient error (`~770` max abs diff) on jax 0.11.0 on both a Volta (V100) and a Blackwell (RTX 5090) GPU; jax 0.10.2 does not reproduce it, consistent with this being a regression in a recent XLA snapshot.

```python
import jax
import jax.numpy as jnp
from jax.ad_checkpoint import checkpoint_name

jax.config.update("jax_default_matmul_precision", "highest")  # keep TF32 out of the comparison

BATCH, SEQ, WIDTH, LAYERS = 4, 256, 64, 8
MB = 2**20

OFFLOAD_CARRY = jax.checkpoint_policies.save_and_offload_only_these_names(
    names_which_can_be_saved=[],
    names_which_can_be_offloaded=["carry"],
    offload_src="device",
    offload_dst="pinned_host",
)


def layer(w, x):
    return jnp.tanh(x @ w)


def named_layer(w, x):
    # the only difference: the carry is named so the policy can act on it
    return layer(w, checkpoint_name(x, "carry"))


def stack(body):
    return lambda w, x: jax.lax.scan(lambda c, wi: (body(wi, c), None), x, w)[0]


def loss(body):
    return lambda w, x: jnp.sum(stack(body)(w, x) ** 2)


def report(name, body, w, x, reference=None):
    grad_fn = jax.jit(jax.grad(loss(body), argnums=(0, 1)))
    grads = grad_fn(w, x)
    stats = grad_fn.lower(w, x).compile().memory_analysis()
    delta = (
        None
        if reference is None
        else max(float(jnp.max(jnp.abs(a - b))) for a, b in zip(jax.tree.leaves(grads), jax.tree.leaves(reference)))
    )
    err = "--" if delta is None else f"{delta:.3e}"
    print(
        f"{name:26} device_temp={stats.temp_size_in_bytes / MB:7.1f} MB"
        f"  host_temp={stats.host_temp_size_in_bytes / MB:6.1f} MB"
        f"  max|grad - plain|={err}"
    )
    return grads, delta


def main():
    print(f"jax {jax.__version__}, device {jax.devices()[0].device_kind}")
    w = jax.random.normal(jax.random.key(0), (LAYERS, WIDTH, WIDTH)) * 0.3
    x = jax.random.normal(jax.random.key(1), (BATCH, SEQ, WIDTH))
    print(f"carry stack is {LAYERS * BATCH * SEQ * WIDTH * 4 / MB:.1f} MB\n")

    remat = lambda fn, policy: jax.checkpoint(fn, policy=policy, prevent_cse=False)

    plain, _ = report("plain scan", layer, w, x)
    report("remat nothing_saveable", remat(layer, jax.checkpoint_policies.nothing_saveable), w, x, plain)
    _, offload_err = report("remat offload 'carry'", remat(named_layer, OFFLOAD_CARRY), w, x, plain)

    if offload_err is not None and offload_err < 1e-5:
        print(
            "\nThe offload row matches plain scan, so this build is NOT affected:"
            "\neither XLA fixed it, or you are running a patched"
            "\nDynamicSliceAnnotator / AnalyzeDynamicSlice. Note the memory columns --"
            "\nthe residuals still went to host, they are just read in the right order now."
        )
    else:
        print(
            "\nExpected: the offload row matches plain scan (same math, the residual's"
            "\nmemory space is the only difference). Actual: it does not."
            "\n"
            "\nA nonzero error above is this script working as intended: it demonstrates the"
            "\nbug and deliberately uses the broken remat-policy route. Offloading a scan's"
            "\nresiduals correctly needs an explicit custom_vjp instead -- one that indexes"
            "\nthe stack by a carried value rather than the loop counter, which is what this"
            "\nrepo's learning/utils/scan.py::offload_scan does (exact to f32 rounding)."
        )


if __name__ == "__main__":
    main()
```

