### PR TITLE
[xla:ffi] Add API for matching/verifying buffers at run time

### DIFF
--- a/docs/custom_call.md
+++ b/docs/custom_call.md
@@ -129,6 +129,169 @@ auto handler = Ffi::Bind().Arg<BufferR2<F32>>().Ret<BufferR2<F32>>().To(
     });
 ```
 
+### Matching And Verifying Buffers
+
+Buffer patterns can express constraints that are more specific than the
+argument and result types in an FFI binding. They are useful for refining an
+`AnyBuffer` to a concrete buffer type, checking dimension sizes, and checking
+relationships between multiple buffer shapes.
+
+Patterns are immutable and can specify dtype and rank either directly or with
+the corresponding modifiers:
+
+```c++
+namespace m = ::xla::ffi::match;
+
+m::Buffer<F32, 2>();
+m::Buffer().WithDType<F32>().WithRank<2>();
+```
+
+The `Match` function checks a pattern and returns its maximally constrained
+buffer type. To refine an `AnyBuffer`, the pattern must specify exactly one
+data type and one rank. Matching an already typed buffer verifies any
+additional constraints and preserves its type.
+
+```c++
+namespace m = ::xla::ffi::match;
+
+auto handler = Ffi::Bind().Arg<AnyBuffer>().Ret<AnyBuffer>().To(
+    [](AnyBuffer input, Result<AnyBuffer> output) -> Error {
+      int64_t rows;
+      int64_t cols;
+
+      ErrorOr<BufferR2<F32>> typed_input =
+          Match("input", input,
+                m::Buffer<F32>().WithDims(&rows, &cols));
+      if (typed_input.has_error()) {
+        return std::move(typed_input).error();
+      }
+
+      ErrorOr<Result<BufferR2<F32>>> typed_output =
+          Match("output", output,
+                m::Buffer<F32>().WithDims(rows, cols));
+      if (typed_output.has_error()) {
+        return std::move(typed_output).error();
+      }
+
+      float* input_data = typed_input->typed_data();
+      float* output_data = (*typed_output)->typed_data();
+      return Error::Success();
+    });
+```
+
+In this example matching `input` captures its two dimension sizes, and
+matching `output` verifies that it has the same shape. Captures are committed
+only when the complete pattern matches successfully.
+
+A dimension pattern can be unconstrained, fixed, or captured. Fixed values and
+capture pointers are implicitly converted to dimension patterns:
+
+```c++
+m::Dim()       // Any dimension size.
+m::Dim(16)     // A dimension whose size is 16.
+m::Dim(&rows)  // Any dimension size, captured in `rows` on success.
+
+m::Buffer<F32>().WithDims(&rows, 16);
+```
+
+`WithDims` describes a complete shape and sets its rank from the number of
+arguments. `WithDim<I>` or `WithDim(index, ...)` constrains dimensions
+positionally without fixing the complete rank. A positional constraint requires
+the referenced dimension to exist but leaves every other dimension
+unconstrained:
+
+```c++
+ErrorOr<BufferR4<F32>> MatchActivations(AnyBuffer input) {
+  return Match(
+      "input", input,
+      m::Buffer<F32, 4>().WithDim<0>(1).WithDim<3>(128));
+}
+
+Error VerifyDimension(AnyBuffer input, size_t index, int64_t size) {
+  return Verify("input", input, m::Buffer().WithDim(index, size));
+}
+```
+
+`MatchActivations` requires a rank-4 F32 buffer with dimensions 0 and 3 equal
+to 1 and 128, respectively; dimensions 1 and 2 are unrestricted. Without an
+explicit `WithRank`, `WithDim(index, ...)` accepts any rank greater than
+`index`.
+
+Dimension captures can also express relationships between positions:
+
+```c++
+auto matrix = m::Buffer<F32>().WithDims(&rows, 128);
+
+int64_t n;
+ErrorOr<BufferR2<F32>> square =
+    Match("matrix", buffer,
+          m::Buffer<F32>().WithDims(&n, &n));
+```
+
+When the same capture pointer appears multiple times, all corresponding
+dimensions must have the same size. The `Match` call above therefore accepts
+only square matrices. Dimension captures are written only after the complete
+pattern succeeds and are unchanged on failure.
+
+Use `Verify` when the buffer should keep its existing type, or when a pattern
+accepts more than one data type or rank. For example, an index buffer can
+accept either `S32` or `S64` and dispatch on its data type after verification:
+
+```c++
+namespace m = ::xla::ffi::match;
+
+Error VerifyIndices(AnyBuffer indices) {
+  auto pattern = m::Buffer().WithDType<S32, S64>().WithRank<1, 2>();
+
+  Error error = Verify("indices", indices, pattern);
+  if (error.failure()) {
+    return error;
+  }
+
+  // Dispatch an implementation based on `indices.element_type()`.
+  return Error::Success();
+}
+```
+
+Because this pattern permits multiple concrete buffer types, it cannot refine
+an `AnyBuffer` with `Match`: there is no unique return type. It can still be
+passed to `Match` with an already typed buffer, whose return type is already
+known. An already typed buffer can also be verified; this is typically useful
+for checking shape relationships:
+
+```c++
+Error VerifySameShape(BufferR2<F32> lhs, BufferR2<F32> rhs) {
+  int64_t rows;
+  int64_t cols;
+
+  Error error = Verify(
+      "lhs", lhs,
+      m::Buffer().WithDims(&rows, &cols));
+  if (error.failure()) {
+    return error;
+  }
+
+  return Verify("rhs", rhs,
+                m::Buffer().WithDims(rows, cols));
+}
+```
+
+The name passed as the first argument to `Match` and `Verify` is required and
+is included in errors, together with a description of the failed constraint.
+
+The external FFI API in `xla/ffi/api/ffi.h` returns `Error` from `Verify` and
+`ErrorOr<T>` from `Match`, as in the examples above. The internal FFI API in
+`xla/ffi/ffi.h` provides the same matching interface using `absl::Status` and
+`absl::StatusOr<T>`:
+
+```c++
+ASSIGN_OR_RETURN(BufferR2<F32> input,
+                 Match("input", buffer, m::Buffer<F32, 2>()));
+RETURN_IF_ERROR(Verify(
+    "input", input,
+    m::Buffer().WithDims(expected_rows, m::Dim())));
+```
+
 ### Variadic Arguments And Results
 
 If the number of arguments and result can be different in different instances of

--- a/xla/ffi/BUILD
+++ b/xla/ffi/BUILD
@@ -170,6 +170,7 @@ cc_library(
         "//xla/hlo/ir:hlo",
         "//xla/stream_executor:device_address",
         "//xla/tsl/concurrency:async_value",
+        "//xla/tsl/platform:status_macros",
         "//xla/tsl/util:safe_reinterpret_cast",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base:core_headers",

--- a/xla/ffi/api/BUILD
+++ b/xla/ffi/api/BUILD
@@ -122,6 +122,7 @@ xla_cc_test(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest",
         "@eigen_archive//:eigen3",
     ],

--- a/xla/ffi/api/api.h
+++ b/xla/ffi/api/api.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include <initializer_list>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <ostream>
@@ -980,7 +981,9 @@ class Result {
  public:
   Result(T value) : value_(value) {}  // NOLINT
   T& operator*() { return value_; }
+  const T& operator*() const { return value_; }
   T* operator->() { return &value_; }
+  const T* operator->() const { return &value_; }
 
  private:
   T value_;
@@ -998,6 +1001,377 @@ class Attr {
  private:
   T value_;
 };
+
+//===----------------------------------------------------------------------===//
+// Buffers
+//===----------------------------------------------------------------------===//
+
+// Sentinel rank for buffers whose rank is not statically known; a dynamic-rank
+// buffer (or pattern) accepts any rank.
+inline constexpr size_t kDynamicRank = std::numeric_limits<size_t>::max();
+
+template <size_t rank, size_t... ranks>
+constexpr bool IsDynamicRank() {
+  return ((rank == kDynamicRank) || ... || (ranks == kDynamicRank));
+}
+
+//===----------------------------------------------------------------------===//
+// Buffer Matching
+//===----------------------------------------------------------------------===//
+
+namespace match {
+namespace internal {
+
+// Unlike std::integer_sequence, this sequence also supports enum values.
+template <typename T, T... values>
+struct ValueSequence {
+  using value_type = T;
+  static constexpr size_t size() { return sizeof...(values); }
+};
+
+}  // namespace internal
+
+// Type-level set of the unique dtype constraints on a pattern. The dtype enum
+// type is fixed per header (DataType or PrimitiveType), so the type system
+// enforces that all dtypes share one enum type.
+template <typename DType, DType... dtypes>
+using DTypeSet = internal::ValueSequence<DType, dtypes...>;
+
+// Type-level set of the unique rank constraints on a pattern.
+template <size_t... ranks>
+using RankSet = internal::ValueSequence<size_t, ranks...>;
+
+namespace internal {
+
+// Reinterprets a buffer as a concrete `Buffer<dtype, rank>` without any checks.
+// Defined by each FFI header as a friend of its buffer types, and only safe to
+// call once a successful match has confirmed the buffer's dtype and rank.
+struct BufferCast;
+
+// Prints a single constraint value into a diagnostic. The default uses
+// `operator<<`; FFI headers specialize it for dtype enums that lack a symbolic
+// `operator<<` (see `PrimitiveType` in `xla/ffi/ffi.h`).
+template <typename T>
+struct ValuePrinter {
+  friend std::ostream& operator<<(std::ostream& os, ValuePrinter printer) {
+    return os << printer.value;
+  }
+  T value;
+};
+
+// Discards diagnostics in the successful hot path. The matcher is rerun with
+// an output stream only when it fails.
+class NoOpDiagnostic {
+ public:
+  template <typename T>
+  NoOpDiagnostic& operator<<(T&&) {
+    return *this;
+  }
+};
+
+inline constexpr char kDType[] = "dtype";
+inline constexpr char kRank[] = "rank";
+
+template <const char* name, typename Values>
+class ValueSet;
+
+template <const char* name, typename T, T... values>
+class ValueSet<name, ValueSequence<T, values...>> {
+  using Values = ValueSequence<T, values...>;
+
+ public:
+  template <typename Diagnostic>
+  static bool Match(T value, Diagnostic& os) {
+    if (empty() ||
+        std::find(values_.begin(), values_.end(), value) != values_.end()) {
+      return true;
+    }
+
+    os << "expected " << name;
+    if (values_.size() == 1) {
+      os << " " << ValuePrinter<T>{values_.front()} << " but got "
+         << ValuePrinter<T>{value};
+      return false;
+    }
+
+    os << " to be one of [" << ValuePrinter<T>{values_.front()};
+    for (size_t i = 1; i < values_.size(); ++i) {
+      os << ", " << ValuePrinter<T>{values_[i]};
+    }
+    os << "] but got " << ValuePrinter<T>{value};
+    return false;
+  }
+
+  static void DescribeTo(std::ostream& os) {
+    if (values_.empty()) {
+      return;
+    }
+    os << name;
+    if (values_.size() == 1) {
+      os << " " << ValuePrinter<T>{values_.front()};
+      return;
+    }
+
+    os << " in [" << ValuePrinter<T>{values_.front()};
+    for (size_t i = 1; i < values_.size(); ++i) {
+      os << ", " << ValuePrinter<T>{values_[i]};
+    }
+    os << "]";
+  }
+
+  static constexpr bool empty() { return Values::size() == 0; }
+
+ private:
+  inline static constexpr std::array<T, Values::size()> values_ = {values...};
+};
+
+template <typename Values>
+using DTypeValues = ValueSet<kDType, Values>;  // NOLINT
+
+template <typename Values>
+using RankValues = ValueSet<kRank, Values>;  // NOLINT
+
+template <typename DTypes, typename Ranks>
+class BufferPatternBase;
+
+}  // namespace internal
+
+// Matches one buffer dimension. A dimension can be unconstrained, fixed, or
+// captured.
+class DimPattern {
+ public:
+  DimPattern() = default;
+
+  template <typename T, std::enable_if_t<std::is_integral_v<T>>* = nullptr>
+  DimPattern(T value) : value_(static_cast<int64_t>(value)) {}  // NOLINT
+
+  DimPattern(int64_t* value) : value_(value) {  // NOLINT
+    assert(value != nullptr && "dimension capture must be non-null");
+  }
+
+  template <typename Diagnostic>
+  bool Match(int64_t value, size_t index, Diagnostic& os) const {
+    const int64_t* expected = std::get_if<int64_t>(&value_);
+    if (expected == nullptr || value == *expected) {
+      return true;
+    }
+
+    os << "expected dimension " << index << " to be " << *expected
+       << " but got " << value;
+    return false;
+  }
+
+  void Capture(int64_t value) const {
+    if (auto capture = std::get_if<int64_t*>(&value_)) {
+      **capture = value;
+    }
+  }
+
+  void DescribeTo(std::ostream& os) const {
+    if (auto value = std::get_if<int64_t>(&value_)) {
+      os << *value;
+    } else if (std::holds_alternative<int64_t*>(value_)) {
+      os << "any dimension (captured)";
+    } else {
+      os << "any dimension";
+    }
+  }
+
+ private:
+  template <typename, typename>
+  friend class internal::BufferPatternBase;
+
+  int64_t* capture() const {
+    auto capture = std::get_if<int64_t*>(&value_);
+    return capture == nullptr ? nullptr : *capture;
+  }
+
+  std::variant<std::monostate, int64_t, int64_t*> value_;
+};
+
+namespace internal {
+
+// An immutable pattern for matching buffer metadata. Dtype and rank
+// constraints remain encoded in the pattern type so Match can refine an
+// AnyBuffer when both identify exactly one concrete buffer type. Patterns with
+// alternative constraints can still be used with Verify or when matching an
+// already typed Buffer.
+//
+// The concrete dtype enum (`DataType` or `PrimitiveType`) is carried by
+// `DTypes`; each FFI header exposes the pattern as its `BufferPattern` alias.
+template <typename DTypes, typename Ranks>
+class BufferPatternBase {
+  using DType = typename DTypes::value_type;
+
+ public:
+  BufferPatternBase() = default;
+
+  template <size_t rank, size_t... ranks>
+  auto WithRank() const {
+    static_assert(!IsDynamicRank<rank, ranks...>(),
+                  "dynamic rank is represented by an empty rank set");
+    using WithRankSet = RankSet<rank, ranks...>;
+    return BufferPatternBase<DTypes, WithRankSet>(*this);
+  }
+
+  template <DType dtype, DType... dtypes>
+  auto WithDType() const {
+    using WithDTypeSet = DTypeSet<DType, dtype, dtypes...>;
+    return BufferPatternBase<WithDTypeSet, Ranks>(*this);
+  }
+
+  // Constrains every dimension positionally and deduces the type-level rank
+  // from the number of arguments.
+  template <typename... Args,
+            std::enable_if_t<(std::is_convertible_v<Args, DimPattern> &&
+                              ...)>* = nullptr>
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE auto WithDims(Args&&... dimensions) const {
+    using WithRank = RankSet<sizeof...(Args)>;
+    BufferPatternBase<DTypes, WithRank> pattern(*this);
+    pattern.dimensions_ = {std::forward<Args>(dimensions)...};
+    return pattern;
+  }
+
+  // Constrains a single dimension, leaving the rest (and the rank) free.
+  BufferPatternBase WithDim(size_t index, DimPattern dimension) const {
+    BufferPatternBase pattern(*this);
+    auto& dimensions = pattern.dimensions_;
+    dimensions.resize(std::max(dimensions.size(), index + 1));
+    dimensions[index] = std::move(dimension);
+    return pattern;
+  }
+
+  template <size_t index>
+  BufferPatternBase WithDim(DimPattern dimension) const {
+    return WithDim(index, std::move(dimension));
+  }
+
+  template <typename Buffer, typename Diagnostic>
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE bool Match(Buffer buffer,
+                                             Diagnostic& os) const {
+    if (!DTypeValues<DTypes>::Match(buffer.element_type(), os)) {
+      return false;
+    }
+
+    auto dimensions = buffer.dimensions();
+    if (!RankValues<Ranks>::Match(dimensions.size(), os)) {
+      return false;
+    }
+
+    if (dimensions_.size() > dimensions.size()) {
+      os << "expected dimension " << dimensions_.size() - 1
+         << " but buffer rank is " << dimensions.size();
+      return false;
+    }
+
+    size_t count = dimensions_.size();
+    for (size_t i = 0; i < count; ++i) {
+      const DimPattern& dimension = dimensions_[i];
+      if (!dimension.Match(dimensions[i], i, os)) {
+        return false;
+      }
+
+      int64_t* capture = dimension.capture();
+      if (capture == nullptr) {
+        continue;
+      }
+      for (size_t j = 0; j < i; ++j) {
+        if (dimensions_[j].capture() != capture) {
+          continue;
+        }
+        if (dimensions[i] == dimensions[j]) {
+          break;
+        }
+        os << "expected dimension " << i << " to be " << dimensions[j]
+           << " but got " << dimensions[i];
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  template <typename Buffer>
+  void Capture(Buffer buffer) const {
+    auto dimensions = buffer.dimensions();
+    size_t count = std::min(dimensions_.size(), dimensions.size());
+    for (size_t i = 0; i < count; ++i) {
+      dimensions_[i].Capture(dimensions[i]);
+    }
+  }
+
+  void DescribeTo(std::ostream& os) const {
+    os << "a buffer";
+    if (!DTypeValues<DTypes>::empty()) {
+      os << " with ";
+      DTypeValues<DTypes>::DescribeTo(os);
+    }
+    if (!RankValues<Ranks>::empty()) {
+      os << " with ";
+      RankValues<Ranks>::DescribeTo(os);
+    }
+    if (!dimensions_.empty()) {
+      os << " with dimensions [";
+      for (size_t i = 0; i < dimensions_.size(); ++i) {
+        if (i != 0) {
+          os << ", ";
+        }
+        dimensions_[i].DescribeTo(os);
+      }
+      os << "]";
+    }
+  }
+
+ private:
+  template <typename, typename>
+  friend class BufferPatternBase;
+
+  template <typename OtherDTypes, typename OtherRanks>
+  explicit BufferPatternBase(
+      const BufferPatternBase<OtherDTypes, OtherRanks>& other)
+      : dimensions_(other.dimensions_) {}
+
+  // Positional dimension constraints. Unconstrained positions (the gaps left by
+  // WithDim) hold a catch-all DimPattern that matches any extent.
+  std::vector<DimPattern> dimensions_;
+};
+
+}  // namespace internal
+
+inline DimPattern Dim() { return DimPattern(); }
+
+template <typename T, std::enable_if_t<std::is_integral_v<T>>* = nullptr>
+inline DimPattern Dim(T value) {
+  return DimPattern(value);
+}
+inline DimPattern Dim(int64_t* value) { return DimPattern(value); }
+
+}  // namespace match
+
+namespace internal {
+
+// Matches buffer metadata and returns an error message on failure. Captures
+// are applied only after a capture-free pass succeeds.
+template <typename Buffer, typename Pattern>
+XLA_FFI_ATTRIBUTE_ALWAYS_INLINE std::optional<std::string> MatchBuffer(
+    std::string_view name, Buffer buffer, const Pattern& pattern) {
+  match::internal::NoOpDiagnostic diagnostic;
+  if (pattern.Match(buffer, diagnostic)) {
+    pattern.Capture(buffer);
+    return std::nullopt;
+  }
+
+  std::ostringstream explanation;
+  pattern.Match(buffer, explanation);
+
+  std::ostringstream error;
+  error << "Buffer '" << name << "' failed to match ";
+  pattern.DescribeTo(error);
+  error << ": " << explanation.str();
+  return error.str();
+}
+
+}  // namespace internal
 
 //===----------------------------------------------------------------------===//
 // Attributes bindings

--- a/xla/ffi/api/ffi.h
+++ b/xla/ffi/api/ffi.h
@@ -30,7 +30,6 @@ limitations under the License.
 #include <cstdlib>
 #include <functional>
 #include <iostream>
-#include <limits>
 #include <memory>
 #include <mutex>  // NOLINT
 #include <numeric>
@@ -612,6 +611,8 @@ class AnyBuffer {
   }
 
  private:
+  friend struct match::internal::BufferCast;
+
   const XLA_FFI_Buffer* buf_;
 };
 
@@ -651,8 +652,6 @@ XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::C128, std::complex<double>);
 XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::TOKEN, void);
 
 #undef XLA_FFI_REGISTER_DATATYPE_MAPPING
-
-inline constexpr size_t kDynamicRank = std::numeric_limits<size_t>::max();
 
 }  // namespace internal
 
@@ -714,7 +713,7 @@ static_assert(!IsComplexType<DataType::F32>());
 //
 // The dtype and rank are checked at decoding time. If rank is not specified,
 // any rank is accepted.
-template <DataType dtype, size_t rank = internal::kDynamicRank>
+template <DataType dtype, size_t rank = kDynamicRank>
 class Buffer {
  public:
   using Dimensions = AnyBuffer::Dimensions;
@@ -726,8 +725,7 @@ class Buffer {
   DataType element_type() const { return dtype; }
 
   Dimensions dimensions() const {
-    return Dimensions(buf_->dims,
-                      rank == internal::kDynamicRank ? buf_->rank : rank);
+    return Dimensions(buf_->dims, rank == kDynamicRank ? buf_->rank : rank);
   }
 
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE size_t size_bytes() const {
@@ -747,6 +745,8 @@ class Buffer {
   }
 
  private:
+  friend struct match::internal::BufferCast;
+
   const XLA_FFI_Buffer* buf_;
 };
 
@@ -765,7 +765,7 @@ namespace internal {
 template <DataType dtype, size_t rank>
 XLA_FFI_ATTRIBUTE_ALWAYS_INLINE bool IsaBuffer(XLA_FFI_Buffer* buf) {
   return static_cast<DataType>(buf->dtype) == dtype &&
-         (rank == internal::kDynamicRank || buf->rank == rank);
+         (rank == kDynamicRank || buf->rank == rank);
 }
 
 template <DataType dtype, size_t rank>
@@ -777,7 +777,7 @@ XLA_FFI_ATTRIBUTE_ALWAYS_INLINE std::optional<Buffer<dtype, rank>> DecodeBuffer(
            << dtype << " but got " << buf_dtype;
   }
 
-  if constexpr (rank != internal::kDynamicRank) {
+  if constexpr (rank != kDynamicRank) {
     if (XLA_FFI_PREDICT_FALSE(buf->rank != rank)) {
       return diagnostic.Emit("Wrong buffer rank: expected ")
              << rank << " but got " << buf->rank;
@@ -789,7 +789,7 @@ XLA_FFI_ATTRIBUTE_ALWAYS_INLINE std::optional<Buffer<dtype, rank>> DecodeBuffer(
 
 }  // namespace internal
 
-template <DataType dtype, size_t rank = internal::kDynamicRank>
+template <DataType dtype, size_t rank = kDynamicRank>
 using ResultBuffer = Result<Buffer<dtype, rank>>;
 
 // clang-format off
@@ -799,6 +799,89 @@ template <DataType dtype> using ResultBufferR2 = ResultBuffer<dtype, 2>;
 template <DataType dtype> using ResultBufferR3 = ResultBuffer<dtype, 3>;
 template <DataType dtype> using ResultBufferR4 = ResultBuffer<dtype, 4>;
 // clang-format on
+
+//===----------------------------------------------------------------------===//
+// Buffer Matching
+//===----------------------------------------------------------------------===//
+
+namespace match {
+namespace internal {
+
+struct BufferCast {
+  template <typename To, typename From>
+  static To Cast(const From& buffer) {
+    return To(buffer.buf_);
+  }
+};
+
+}  // namespace internal
+
+// A buffer-matching pattern specialized to the external `DataType` enum.
+template <typename DTypes = DTypeSet<DataType>, typename Ranks = RankSet<>>
+using BufferPattern = internal::BufferPatternBase<DTypes, Ranks>;
+
+template <DataType dtype, size_t rank = kDynamicRank>
+auto Buffer() {
+  if constexpr (rank == kDynamicRank) {
+    return BufferPattern<DTypeSet<DataType, dtype>>();
+  } else {
+    return BufferPattern<DTypeSet<DataType, dtype>, RankSet<rank>>();
+  }
+}
+
+inline BufferPattern<> Buffer() { return {}; }
+
+}  // namespace match
+
+template <typename BufferType, typename DTypes, typename Ranks>
+Error Verify(std::string_view name, BufferType buffer,
+             const match::BufferPattern<DTypes, Ranks>& pattern) {
+  if (auto error = internal::MatchBuffer(name, buffer, pattern)) {
+    return Error::InvalidArgument(std::move(*error));
+  }
+  return Error::Success();
+}
+
+// Matches an AnyBuffer and returns the concrete buffer type specified by a
+// pattern with exactly one dtype and one rank.
+template <DataType dtype, size_t rank>
+ErrorOr<Buffer<dtype, rank>> Match(
+    std::string_view name, AnyBuffer buffer,
+    const match::BufferPattern<match::DTypeSet<DataType, dtype>,
+                               match::RankSet<rank>>& pattern) {
+  if (auto error = internal::MatchBuffer(name, buffer, pattern)) {
+    return Unexpected(Error::InvalidArgument(std::move(*error)));
+  }
+  return match::internal::BufferCast::Cast<Buffer<dtype, rank>>(buffer);
+}
+
+template <DataType dtype, size_t rank, typename DTypes, typename Ranks>
+ErrorOr<Buffer<dtype, rank>> Match(
+    std::string_view name, Buffer<dtype, rank> buffer,
+    const match::BufferPattern<DTypes, Ranks>& pattern) {
+  if (Error error = Verify(name, buffer, pattern); error.failure()) {
+    return Unexpected(std::move(error));
+  }
+  return buffer;
+}
+
+namespace internal {
+
+template <typename Buffer>
+ErrorOr<Result<Buffer>> WrapResult(ErrorOr<Buffer> buffer) {
+  if (buffer.has_error()) {
+    return Unexpected(std::move(buffer).error());
+  }
+  return Result<Buffer>(std::move(buffer).value());
+}
+
+}  // namespace internal
+
+template <typename BufferType, typename DTypes, typename Ranks>
+auto Match(std::string_view name, Result<BufferType> buffer,
+           const match::BufferPattern<DTypes, Ranks>& pattern) {
+  return internal::WrapResult(Match(name, *buffer, pattern));
+}
 
 //===----------------------------------------------------------------------===//
 // Arguments binding

--- a/xla/ffi/api/ffi_test.cc
+++ b/xla/ffi/api/ffi_test.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/blocking_counter.h"
+#include "absl/types/span.h"
 #include "xla/executable_run_options.h"
 #include "xla/ffi/api/c_api.h"
 #include "xla/ffi/attribute_map.h"
@@ -67,6 +68,14 @@ using xla::ffi::internal::NumTagged;
 using xla::ffi::internal::RetTag;
 
 static const XLA_FFI_Api* Api() { return GetXlaFfiApi(); }
+
+template <typename T>
+static XLA_FFI_Buffer MakeBuffer(DataType dtype, absl::Span<T> storage,
+                                 absl::Span<int64_t> dims) {
+  return {XLA_FFI_Buffer_STRUCT_SIZE,           nullptr,
+          static_cast<XLA_FFI_DataType>(dtype), storage.data(),
+          static_cast<int64_t>(dims.size()),    dims.data()};
+}
 
 // Compile-time test for the template metaprograming for counting tags.
 static_assert(NumTagged<ArgTag, RetTag<int32_t>>::value == 0);
@@ -131,6 +140,7 @@ XLA_FFI_REGISTER_STRUCT_ATTR_DECODING(
 namespace xla::ffi {
 
 using ::absl_testing::StatusIs;
+using ::testing::AllOf;
 using ::testing::HasSubstr;
 
 TEST(FfiTest, DataTypeEnumValue) {
@@ -581,6 +591,206 @@ TEST(FfiTest, AnyBufferResult) {
   auto status = Invoke(Api(), *handler, call_frame);
 
   TF_ASSERT_OK(status);
+}
+
+TEST(FfiTest, BufferMatchingComposesPatterns) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> input_storage(4, 0.0f);
+  int64_t input_dims[] = {2, 2};
+  XLA_FFI_Buffer input_buffer = MakeBuffer(F32, absl::MakeSpan(input_storage),
+                                           absl::MakeSpan(input_dims));
+
+  AnyBuffer rank_two(&input_buffer);
+  Error rank_verified = Verify("rank_two", rank_two, m::Buffer().WithRank<2>());
+  EXPECT_TRUE(rank_verified.success());
+  EXPECT_EQ(rank_two.dimensions().size(), 2);
+
+  int64_t rows = -1;
+  ErrorOr<BufferR2<F32>> input = Match("input", AnyBuffer(&input_buffer),
+                                       m::Buffer<F32>().WithDims(&rows, 2));
+  ASSERT_TRUE(input.has_value());
+  EXPECT_EQ(rows, 2);
+  EXPECT_EQ(input->typed_data(), input_storage.data());
+
+  std::vector<float> output_storage(4, 0.0f);
+  int64_t output_dims[] = {1, 2, 2};
+  XLA_FFI_Buffer output_buffer = MakeBuffer(F32, absl::MakeSpan(output_storage),
+                                            absl::MakeSpan(output_dims));
+  Result<AnyBuffer> output_result{AnyBuffer(&output_buffer)};
+
+  ErrorOr<Result<BufferR3<F32>>> output =
+      Match("output", output_result,
+            m::Buffer().WithDType<F32>().WithDims(1, rows, 2));
+  ASSERT_TRUE(output.has_value());
+  EXPECT_EQ((*output)->typed_data(), output_storage.data());
+
+  Error verified =
+      Verify("typed_input", *input, m::Buffer<F32, 2>().WithDims(rows, 2));
+  EXPECT_TRUE(verified.success());
+
+  Error rejected = Verify("typed_input", *input, m::Buffer<S32, 2>());
+  ASSERT_TRUE(rejected.failure());
+  EXPECT_THAT(rejected.message(), HasSubstr("expected dtype S32 but got F32"));
+}
+
+TEST(FfiTest, BufferMatchingUnifiesDimensionCaptures) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(6, 0.0f);
+  int64_t square_dims[] = {2, 2};
+  XLA_FFI_Buffer square_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(square_dims));
+
+  int64_t n = -1;
+  auto square_pattern = m::Buffer<F32>().WithDims(&n, &n);
+
+  ErrorOr<BufferR2<F32>> square =
+      Match("square", AnyBuffer(&square_buffer), square_pattern);
+  ASSERT_TRUE(square.has_value());
+  EXPECT_EQ(n, 2);
+  EXPECT_EQ(square->typed_data(), storage.data());
+
+  n = 7;
+  int64_t nonsquare_dims[] = {2, 3};
+  XLA_FFI_Buffer nonsquare_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(nonsquare_dims));
+  ErrorOr<BufferR2<F32>> nonsquare =
+      Match("nonsquare", AnyBuffer(&nonsquare_buffer), square_pattern);
+
+  ASSERT_TRUE(nonsquare.has_error());
+  EXPECT_EQ(nonsquare.error().errc(), ErrorCode::kInvalidArgument);
+  EXPECT_THAT(nonsquare.error().message(),
+              HasSubstr("expected dimension 1 to be 2 but got 3"));
+  EXPECT_EQ(n, 7);
+}
+
+TEST(FfiTest, BufferMatchingVerifiesDTypeSet) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<int64_t> storage(4, 0);
+  int64_t dims[] = {4};
+  XLA_FFI_Buffer s32_buffer =
+      MakeBuffer(S32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+
+  auto index_pattern = m::Buffer().WithDType<S32, S64>().WithRank<1>();
+
+  Error s32_verified = Verify("indices", AnyBuffer(&s32_buffer), index_pattern);
+  EXPECT_TRUE(s32_verified.success());
+
+  XLA_FFI_Buffer s64_buffer =
+      MakeBuffer(S64, absl::MakeSpan(storage), absl::MakeSpan(dims));
+  Error s64_verified = Verify("indices", AnyBuffer(&s64_buffer), index_pattern);
+  EXPECT_TRUE(s64_verified.success());
+
+  XLA_FFI_Buffer f32_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+  Error rejected = Verify("indices", AnyBuffer(&f32_buffer), index_pattern);
+  ASSERT_TRUE(rejected.failure());
+  EXPECT_THAT(rejected.message(),
+              HasSubstr("expected dtype to be one of [S32, S64]"));
+}
+
+TEST(FfiTest, BufferMatchingVerifiesRankSet) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(4, 0.0f);
+  int64_t dims[] = {2, 2};
+  XLA_FFI_Buffer rank2_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+
+  auto rank_pattern = m::Buffer<F32>().WithRank<1, 2>();
+
+  Error verified = Verify("input", AnyBuffer(&rank2_buffer), rank_pattern);
+  EXPECT_TRUE(verified.success());
+
+  Error dimension_verified = Verify("input", AnyBuffer(&rank2_buffer),
+                                    rank_pattern.WithDim<1>(m::Dim()));
+  EXPECT_TRUE(dimension_verified.success());
+
+  int64_t rank3_dims[] = {1, 2, 2};
+  XLA_FFI_Buffer rank3_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(rank3_dims));
+  Error rejected = Verify("input", AnyBuffer(&rank3_buffer), rank_pattern);
+  ASSERT_TRUE(rejected.failure());
+  EXPECT_THAT(rejected.message(),
+              HasSubstr("expected rank to be one of [1, 2]"));
+}
+
+TEST(FfiTest, BufferMatchingCompositionIsOrderIndependent) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(7, 0.0f);
+  int64_t dims[] = {1, 1, 1, 7};
+  XLA_FFI_Buffer buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+
+  auto dim_then_rank = m::Buffer<F32, 2>().WithDim<3>(7).WithRank<4>();
+  auto rank_then_dim = m::Buffer<F32, 2>().WithRank<4>().WithDim<3>(7);
+
+  Error dim_then_rank_verified =
+      Verify("input", AnyBuffer(&buffer), dim_then_rank);
+  EXPECT_TRUE(dim_then_rank_verified.success());
+
+  Error rank_then_dim_verified =
+      Verify("input", AnyBuffer(&buffer), rank_then_dim);
+  EXPECT_TRUE(rank_then_dim_verified.success());
+}
+
+TEST(FfiTest, BufferMatchingReturnsError) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(4, 0.0f);
+  int64_t dims[] = {2, 2};
+  XLA_FFI_Buffer buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+
+  ErrorOr<BufferR2<F32>> matched =
+      Match("input", AnyBuffer(&buffer),
+            m::Buffer().WithDType<F32>().WithRank<2>().WithDim<1>(3));
+  ASSERT_TRUE(matched.has_error());
+  EXPECT_EQ(matched.error().errc(), ErrorCode::kInvalidArgument);
+  EXPECT_THAT(matched.error().message(),
+              AllOf(HasSubstr("Buffer 'input' failed to match"),
+                    HasSubstr("expected dimension 1 to be 3 but got 2")));
+
+  XLA_FFI_Buffer s32_buffer =
+      MakeBuffer(S32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+  ErrorOr<BufferR2<F32>> wrong_dtype =
+      Match("input", AnyBuffer(&s32_buffer),
+            m::Buffer().WithDType<F32>().WithRank<2>());
+  ASSERT_TRUE(wrong_dtype.has_error());
+  EXPECT_EQ(wrong_dtype.error().errc(), ErrorCode::kInvalidArgument);
+  EXPECT_THAT(wrong_dtype.error().message(),
+              HasSubstr("expected dtype F32 but got S32"));
+}
+
+TEST(FfiTest, BufferMatchingRejectsInvalidDimensions) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(4, 0.0f);
+  int64_t rank2_dims[] = {2, 2};
+  XLA_FFI_Buffer rank2_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(rank2_dims));
+
+  auto pattern = m::Buffer<F32, 2>().WithDims(m::Dim(), m::Dim(), m::Dim());
+
+  ErrorOr<BufferR3<F32>> rank2 =
+      Match("input", AnyBuffer(&rank2_buffer), pattern);
+  ASSERT_TRUE(rank2.has_error());
+  EXPECT_THAT(rank2.error().message(), HasSubstr("expected rank 3 but got 2"));
+
+  Error out_of_bounds = Verify("input", AnyBuffer(&rank2_buffer),
+                               m::Buffer<F32, 2>().WithDim<3>(m::Dim()));
+  ASSERT_TRUE(out_of_bounds.failure());
+  EXPECT_THAT(out_of_bounds.message(),
+              HasSubstr("expected dimension 3 but buffer rank is 2"));
+
+  Error out_of_order = Verify("input", AnyBuffer(&rank2_buffer),
+                              m::Buffer<F32>().WithDim<1>(3).WithDim<0>(2));
+  ASSERT_TRUE(out_of_order.failure());
+  EXPECT_THAT(out_of_order.message(),
+              HasSubstr("expected dimension 1 to be 3 but got 2"));
 }
 
 TEST(FfiTest, MissingBufferArgument) {
@@ -1904,5 +2114,53 @@ void BM_VariantAttr(benchmark::State& state) {
 }
 
 BENCHMARK(BM_VariantAttr);
+
+//===----------------------------------------------------------------------===//
+// BM_MatchPrebuiltAnyBuffer
+//===----------------------------------------------------------------------===//
+
+void BM_MatchPrebuiltAnyBuffer(benchmark::State& state) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(1, 0.0f);
+  int64_t dims[] = {1, 1, 1, 1};
+  XLA_FFI_Buffer c_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+  AnyBuffer buffer(&c_buffer);
+  auto pattern = m::Buffer<F32>().WithDims(1, 1, 1, 1);
+
+  CHECK(Match("buffer", buffer, pattern).has_value());
+  for (auto _ : state) {
+    ErrorOr<BufferR4<F32>> matched = Match("buffer", buffer, pattern);
+    benchmark::DoNotOptimize(matched);
+  }
+}
+
+BENCHMARK(BM_MatchPrebuiltAnyBuffer);
+
+//===----------------------------------------------------------------------===//
+// BM_MatchAnyBuffer
+//===----------------------------------------------------------------------===//
+
+void BM_MatchAnyBuffer(benchmark::State& state) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(1, 0.0f);
+  int64_t dims[] = {1, 1, 1, 1};
+  XLA_FFI_Buffer c_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+  AnyBuffer buffer(&c_buffer);
+
+  CHECK(Match("buffer", buffer, m::Buffer<F32>().WithDims(1, 1, 1, 1))
+            .has_value());
+  for (auto _ : state) {
+    auto pattern = m::Buffer<F32>().WithDims(1, 1, 1, 1);
+    benchmark::DoNotOptimize(pattern);
+    ErrorOr<BufferR4<F32>> matched = Match("buffer", buffer, pattern);
+    benchmark::DoNotOptimize(matched);
+  }
+}
+
+BENCHMARK(BM_MatchAnyBuffer);
 
 }  // namespace xla::ffi

--- a/xla/ffi/ffi.h
+++ b/xla/ffi/ffi.h
@@ -25,10 +25,11 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <limits>
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <string>
+#include <string_view>
 
 // IWYU pragma: begin_exports
 #include "xla/ffi/api/api.h"
@@ -44,6 +45,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/executable_run_options.h"
 #include "xla/ffi/api/c_api.h"
 #include "xla/ffi/api/c_api_internal.h"  // IWYU pragma: keep
@@ -81,8 +83,6 @@ const XLA_FFI_Api* GetXlaFfiApi();
 //===----------------------------------------------------------------------===//
 
 namespace internal {
-
-inline constexpr size_t kDynamicRank = std::numeric_limits<size_t>::max();
 
 // NativeTypeOf<dtype>::type is the native type for implementing the given dtype
 // in the FFI.
@@ -155,6 +155,8 @@ class AnyBuffer {
   }
 
  private:
+  friend struct match::internal::BufferCast;
+
   const XLA_FFI_Buffer* buf_;
 };
 
@@ -162,7 +164,7 @@ class AnyBuffer {
 //
 // The dtype and rank are checked at decoding time. If rank is not specified,
 // any rank is accepted.
-template <PrimitiveType dtype, size_t rank = internal::kDynamicRank>
+template <PrimitiveType dtype, size_t rank = kDynamicRank>
 class Buffer {
  public:
   using Dimensions = AnyBuffer::Dimensions;
@@ -174,8 +176,7 @@ class Buffer {
   PrimitiveType element_type() const { return dtype; }
 
   Dimensions dimensions() const {
-    return Dimensions(buf_->dims,
-                      rank == internal::kDynamicRank ? buf_->rank : rank);
+    return Dimensions(buf_->dims, rank == kDynamicRank ? buf_->rank : rank);
   }
 
   ABSL_ATTRIBUTE_ALWAYS_INLINE size_t size_bytes() const {
@@ -201,6 +202,8 @@ class Buffer {
   }
 
  private:
+  friend struct match::internal::BufferCast;
+
   const XLA_FFI_Buffer* buf_;
 };
 
@@ -226,7 +229,7 @@ ABSL_ATTRIBUTE_ALWAYS_INLINE std::optional<Buffer<dtype, rank>> DecodeBuffer(
            << primitive_util::LowercasePrimitiveTypeName(buf_dtype);
   }
 
-  if constexpr (rank != internal::kDynamicRank) {
+  if constexpr (rank != kDynamicRank) {
     if (ABSL_PREDICT_FALSE(buf->rank != rank)) {
       return diagnostic.Emit("Wrong buffer rank: expected ")
              << rank << " but got " << buf->rank;
@@ -266,6 +269,95 @@ TypeRegistry::TypeId GetTypeId(const XLA_FFI_Api* api) {
 }
 
 }  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Buffer Matching
+//===----------------------------------------------------------------------===//
+
+namespace match {
+namespace internal {
+
+struct BufferCast {
+  template <typename To, typename From>
+  static To Cast(const From& buffer) {
+    return To(buffer.buf_);
+  }
+};
+
+// `PrimitiveType` has no symbolic `operator<<` (it would print the integer
+// enum value), so route diagnostics through the shared spelled-out name.
+template <>
+struct ValuePrinter<PrimitiveType> {
+  friend std::ostream& operator<<(std::ostream& os, ValuePrinter printer) {
+    return os << primitive_util::LowercasePrimitiveTypeName(printer.value);
+  }
+
+  PrimitiveType value;
+};
+
+}  // namespace internal
+
+// A buffer-matching pattern specialized to the internal `PrimitiveType` enum.
+template <typename DTypes = DTypeSet<PrimitiveType>, typename Ranks = RankSet<>>
+using BufferPattern = internal::BufferPatternBase<DTypes, Ranks>;
+
+template <PrimitiveType dtype, size_t rank = kDynamicRank>
+auto Buffer() {
+  using DTypes = DTypeSet<PrimitiveType, dtype>;
+  if constexpr (rank == kDynamicRank) {
+    return BufferPattern<DTypes>();
+  } else {
+    return BufferPattern<DTypes, RankSet<rank>>();
+  }
+}
+
+inline BufferPattern<> Buffer() { return {}; }
+
+}  // namespace match
+
+template <typename BufferType, typename DTypes, typename Ranks>
+absl::Status Verify(std::string_view name, BufferType buffer,
+                    const match::BufferPattern<DTypes, Ranks>& pattern) {
+  if (auto error = internal::MatchBuffer(name, buffer, pattern)) {
+    return absl::InvalidArgumentError(std::move(*error));
+  }
+  return absl::OkStatus();
+}
+
+// Matches an AnyBuffer and returns the concrete buffer type specified by a
+// pattern with exactly one dtype and one rank.
+template <PrimitiveType dtype, size_t rank>
+absl::StatusOr<Buffer<dtype, rank>> Match(
+    std::string_view name, AnyBuffer buffer,
+    const match::BufferPattern<match::DTypeSet<PrimitiveType, dtype>,
+                               match::RankSet<rank>>& pattern) {
+  RETURN_IF_ERROR(Verify(name, buffer, pattern));
+  return match::internal::BufferCast::Cast<Buffer<dtype, rank>>(buffer);
+}
+
+template <PrimitiveType dtype, size_t rank, typename DTypes, typename Ranks>
+absl::StatusOr<Buffer<dtype, rank>> Match(
+    std::string_view name, Buffer<dtype, rank> buffer,
+    const match::BufferPattern<DTypes, Ranks>& pattern) {
+  RETURN_IF_ERROR(Verify(name, buffer, pattern));
+  return buffer;
+}
+
+namespace internal {
+
+template <typename Buffer>
+absl::StatusOr<Result<Buffer>> WrapResult(absl::StatusOr<Buffer> buffer) {
+  ASSIGN_OR_RETURN(Buffer matched, std::move(buffer));
+  return Result<Buffer>(std::move(matched));
+}
+
+}  // namespace internal
+
+template <typename BufferType, typename DTypes, typename Ranks>
+auto Match(std::string_view name, Result<BufferType> buffer,
+           const match::BufferPattern<DTypes, Ranks>& pattern) {
+  return internal::WrapResult(Match(name, *buffer, pattern));
+}
 
 //===----------------------------------------------------------------------===//
 // Arguments binding

--- a/xla/ffi/ffi_test.cc
+++ b/xla/ffi/ffi_test.cc
@@ -65,6 +65,14 @@ namespace xla::ffi {
 
 static const XLA_FFI_Api* Api() { return GetXlaFfiApi(); }
 
+template <typename T>
+static XLA_FFI_Buffer MakeBuffer(PrimitiveType dtype, absl::Span<T> storage,
+                                 absl::Span<int64_t> dims) {
+  return {XLA_FFI_Buffer_STRUCT_SIZE,           nullptr,
+          static_cast<XLA_FFI_DataType>(dtype), storage.data(),
+          static_cast<int64_t>(dims.size()),    dims.data()};
+}
+
 struct PairOfI32AndF32 {
   int32_t i32;
   float f32;
@@ -91,6 +99,7 @@ XLA_FFI_REGISTER_STRUCT_ATTR_DECODING(
 namespace xla::ffi {
 
 using ::testing::_;
+using ::testing::AllOf;
 using ::testing::HasSubstr;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
@@ -644,6 +653,196 @@ TEST(FfiTest, TypedAndRankedBufferArgument) {
     auto status = Invoke(Api(), *handler, call_frame);
     TF_ASSERT_OK(status);
   }
+}
+
+TEST(FfiTest, BufferMatchingComposesPatterns) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> input_storage(4, 0.0f);
+  int64_t input_dims[] = {2, 2};
+  XLA_FFI_Buffer input_buffer = MakeBuffer(F32, absl::MakeSpan(input_storage),
+                                           absl::MakeSpan(input_dims));
+
+  AnyBuffer rank_two(&input_buffer);
+  ASSERT_OK(Verify("rank_two", rank_two, m::Buffer().WithRank<2>()));
+  EXPECT_EQ(rank_two.dimensions().size(), 2);
+
+  int64_t rows = -1;
+  ASSERT_OK_AND_ASSIGN(BufferR2<F32> input,
+                       Match("input", AnyBuffer(&input_buffer),
+                             m::Buffer<F32>().WithDims(&rows, 2)));
+  EXPECT_EQ(rows, 2);
+  EXPECT_EQ(input.typed_data(), input_storage.data());
+
+  std::vector<float> output_storage(4, 0.0f);
+  int64_t output_dims[] = {1, 2, 2};
+  XLA_FFI_Buffer output_buffer = MakeBuffer(F32, absl::MakeSpan(output_storage),
+                                            absl::MakeSpan(output_dims));
+  Result<AnyBuffer> output_result{AnyBuffer(&output_buffer)};
+
+  ASSERT_OK_AND_ASSIGN(
+      Result<BufferR3<F32>> output,
+      Match("output", output_result,
+            m::Buffer().WithDType<F32>().WithDims(1, rows, 2)));
+  EXPECT_EQ(output->typed_data(), output_storage.data());
+
+  ASSERT_OK(
+      Verify("typed_input", input, m::Buffer<F32, 2>().WithDims(rows, 2)));
+  EXPECT_THAT(
+      Verify("typed_input", input, m::Buffer<S32, 2>()),
+      absl_testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                             HasSubstr("expected dtype s32 but got f32")));
+}
+
+TEST(FfiTest, BufferMatchingUnifiesDimensionCaptures) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(6, 0.0f);
+  int64_t square_dims[] = {2, 2};
+  XLA_FFI_Buffer square_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(square_dims));
+
+  int64_t n = -1;
+  auto square_pattern = m::Buffer<F32>().WithDims(&n, &n);
+
+  ASSERT_OK_AND_ASSIGN(
+      BufferR2<F32> square,
+      Match("square", AnyBuffer(&square_buffer), square_pattern));
+  EXPECT_EQ(n, 2);
+  EXPECT_EQ(square.typed_data(), storage.data());
+
+  n = 7;
+  int64_t nonsquare_dims[] = {2, 3};
+  XLA_FFI_Buffer nonsquare_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(nonsquare_dims));
+  absl::StatusOr<BufferR2<F32>> nonsquare =
+      Match("nonsquare", AnyBuffer(&nonsquare_buffer), square_pattern);
+
+  EXPECT_THAT(nonsquare.status(),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  HasSubstr("expected dimension 1 to be 2 but got 3")));
+  EXPECT_EQ(n, 7);
+}
+
+TEST(FfiTest, BufferMatchingVerifiesDTypeSet) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<int64_t> storage(4, 0);
+  int64_t dims[] = {4};
+  XLA_FFI_Buffer s32_buffer =
+      MakeBuffer(S32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+
+  auto index_pattern = m::Buffer().WithDType<S32, S64>().WithRank<1>();
+
+  ASSERT_OK(Verify("indices", AnyBuffer(&s32_buffer), index_pattern));
+
+  XLA_FFI_Buffer s64_buffer =
+      MakeBuffer(S64, absl::MakeSpan(storage), absl::MakeSpan(dims));
+  ASSERT_OK(Verify("indices", AnyBuffer(&s64_buffer), index_pattern));
+
+  XLA_FFI_Buffer f32_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+  EXPECT_THAT(Verify("indices", AnyBuffer(&f32_buffer), index_pattern),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  HasSubstr("expected dtype to be one of [s32, s64]")));
+}
+
+TEST(FfiTest, BufferMatchingVerifiesRankSet) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(4, 0.0f);
+  int64_t dims[] = {2, 2};
+  XLA_FFI_Buffer rank2_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+
+  auto rank_pattern = m::Buffer<F32>().WithRank<1, 2>();
+
+  ASSERT_OK(Verify("input", AnyBuffer(&rank2_buffer), rank_pattern));
+  ASSERT_OK(Verify("input", AnyBuffer(&rank2_buffer),
+                   rank_pattern.WithDim<1>(m::Dim())));
+
+  int64_t rank3_dims[] = {1, 2, 2};
+  XLA_FFI_Buffer rank3_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(rank3_dims));
+
+  EXPECT_THAT(
+      Verify("input", AnyBuffer(&rank3_buffer), rank_pattern),
+      absl_testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                             HasSubstr("expected rank to be one of [1, 2]")));
+}
+
+TEST(FfiTest, BufferMatchingCompositionIsOrderIndependent) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(7, 0.0f);
+  int64_t dims[] = {1, 1, 1, 7};
+  XLA_FFI_Buffer buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+
+  auto dim_then_rank = m::Buffer<F32, 2>().WithDim<3>(7).WithRank<4>();
+  auto rank_then_dim = m::Buffer<F32, 2>().WithRank<4>().WithDim<3>(7);
+
+  ASSERT_OK(Verify("input", AnyBuffer(&buffer), dim_then_rank));
+  ASSERT_OK(Verify("input", AnyBuffer(&buffer), rank_then_dim));
+}
+
+TEST(FfiTest, BufferMatchingReturnsError) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(4, 0.0f);
+  int64_t dims[] = {2, 2};
+  XLA_FFI_Buffer buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+
+  absl::StatusOr<BufferR2<F32>> matched =
+      Match("input", AnyBuffer(&buffer),
+            m::Buffer().WithDType<F32>().WithRank<2>().WithDim<1>(3));
+  EXPECT_THAT(matched.status(),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  AllOf(HasSubstr("Buffer 'input' failed to match"),
+                        HasSubstr("expected dimension 1 to be 3 but got 2"))));
+
+  XLA_FFI_Buffer s32_buffer =
+      MakeBuffer(S32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+  absl::StatusOr<BufferR2<F32>> wrong_dtype =
+      Match("input", AnyBuffer(&s32_buffer),
+            m::Buffer().WithDType<F32>().WithRank<2>());
+  EXPECT_THAT(
+      wrong_dtype.status(),
+      absl_testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                             HasSubstr("expected dtype f32 but got s32")));
+}
+
+TEST(FfiTest, BufferMatchingRejectsInvalidDimensions) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(4, 0.0f);
+  int64_t rank2_dims[] = {2, 2};
+  XLA_FFI_Buffer rank2_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(rank2_dims));
+
+  auto pattern = m::Buffer<F32, 2>().WithDims(m::Dim(), m::Dim(), m::Dim());
+
+  absl::StatusOr<BufferR3<F32>> rank2 =
+      Match("input", AnyBuffer(&rank2_buffer), pattern);
+  EXPECT_THAT(rank2.status(),
+              absl_testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                                     HasSubstr("expected rank 3 but got 2")));
+
+  EXPECT_THAT(Verify("input", AnyBuffer(&rank2_buffer),
+                     m::Buffer<F32, 2>().WithDim<3>(m::Dim())),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  HasSubstr("expected dimension 3 but buffer rank is 2")));
+
+  EXPECT_THAT(Verify("input", AnyBuffer(&rank2_buffer),
+                     m::Buffer<F32>().WithDim<1>(3).WithDim<0>(2)),
+              absl_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  HasSubstr("expected dimension 1 to be 3 but got 2")));
 }
 
 TEST(FfiTest, ComplexBufferArgument) {
@@ -1423,5 +1622,53 @@ void BM_TupleOfI32Attrs(benchmark::State& state) {
 }
 
 BENCHMARK(BM_TupleOfI32Attrs);
+
+//===----------------------------------------------------------------------===//
+// BM_MatchPrebuiltAnyBuffer
+//===----------------------------------------------------------------------===//
+
+void BM_MatchPrebuiltAnyBuffer(benchmark::State& state) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(1, 0.0f);
+  int64_t dims[] = {1, 1, 1, 1};
+  XLA_FFI_Buffer c_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+  AnyBuffer buffer(&c_buffer);
+  auto pattern = m::Buffer<F32>().WithDims(1, 1, 1, 1);
+
+  CHECK_OK(Match("buffer", buffer, pattern).status());
+  for (auto _ : state) {
+    absl::StatusOr<BufferR4<F32>> matched = Match("buffer", buffer, pattern);
+    benchmark::DoNotOptimize(matched);
+  }
+}
+
+BENCHMARK(BM_MatchPrebuiltAnyBuffer);
+
+//===----------------------------------------------------------------------===//
+// BM_MatchAnyBuffer
+//===----------------------------------------------------------------------===//
+
+void BM_MatchAnyBuffer(benchmark::State& state) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(1, 0.0f);
+  int64_t dims[] = {1, 1, 1, 1};
+  XLA_FFI_Buffer c_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+  AnyBuffer buffer(&c_buffer);
+
+  CHECK_OK(
+      Match("buffer", buffer, m::Buffer<F32>().WithDims(1, 1, 1, 1)).status());
+  for (auto _ : state) {
+    auto pattern = m::Buffer<F32>().WithDims(1, 1, 1, 1);
+    benchmark::DoNotOptimize(pattern);
+    absl::StatusOr<BufferR4<F32>> matched = Match("buffer", buffer, pattern);
+    benchmark::DoNotOptimize(matched);
+  }
+}
+
+BENCHMARK(BM_MatchAnyBuffer);
 
 }  // namespace xla::ffi

--- a/xla/tests/custom_call_test.cc
+++ b/xla/tests/custom_call_test.cc
@@ -240,7 +240,7 @@ namespace {
 // TODO(abanas): The following three usings are a workaround, delete when
 // ResultBuffer is implemented as its own class
 using ResultBufferBase = ffi::Result<ffi::AnyBuffer>;
-template <PrimitiveType dtype, size_t rank = xla::ffi::internal::kDynamicRank>
+template <PrimitiveType dtype, size_t rank = xla::ffi::kDynamicRank>
 using ResultBuffer = ffi::Result<ffi::Buffer<dtype, rank>>;
 template <PrimitiveType dtype>
 using ResultBufferR0 = ResultBuffer<dtype, 0>;


### PR DESCRIPTION
Adds an HLO-matcher-style API for validating and refining XLA FFI buffers.

  - Adds composable `xla::ffi::match` buffer patterns for:
    - data types and sets of accepted data types;
    - ranks and sets of accepted ranks;
    - complete shapes with `WithDims`;
    - positional dimensions with `WithDim`;
    - dimension capture and equality constraints.
  - Adds `Match` for refining an `AnyBuffer` into a concrete `Buffer<dtype, rank>`.
  - Adds `Verify` for validating buffers without changing their type.
  - Supports both internal FFI (`absl::Status`) and external FFI (`Error`) APIs.
  - Produces detailed diagnostics containing the buffer name and failed constraint.
  - Adds unit tests, documentation, and construction-inclusive microbenchmarks.

  ## Example

Checking that input and output buffers have compatible shape `f32[rows, 128]`

  ```cpp
  namespace m = ::xla::ffi::match;

  int64_t rows;

  ASSIGN_OR_RETURN(
      BufferR2<F32> input,
      Match("input", buffer,
            m::Buffer<F32>().WithDims(&rows, 128)));

  RETURN_IF_ERROR(Verify(
      "output", output,
      m::Buffer().WithRank<2>().WithDim<0>(rows).WithDim<1>(128)));
  ```