### PR TITLE
[xla:ffi] Add support for stage-dependent context decoding

### DIFF
--- a/docs/custom_call.md
+++ b/docs/custom_call.md
@@ -47,6 +47,44 @@ XLA FFI customization points implemented as template specializations, and
 users can define how to decode their custom types, i.e., it is possible
 to define custom decoding for user-defined `enum class` types.
 
+### Context Arguments
+
+Context arguments pass values supplied by the XLA runtime or backend instead of
+values present in the custom call's explicit arguments. Bind them with
+`Ctx<T>()`; for example, GPU handlers commonly bind a platform stream.
+
+Context decoding is specific to an execution stage. A context type that is
+available only while preparing a custom call can define only a prepare-stage
+decoder:
+
+```c++
+struct MyContext {};
+
+template <>
+struct CtxDecoding<ExecutionStage::kPrepare, MyContext> {
+  using Type = MyContext*;
+
+  static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    return GetMyContext(api, ctx, diagnostic);
+  }
+};
+
+auto handler = Ffi::BindPrepare()
+                   .Ctx<MyContext>()
+                   .To([](MyContext* context) {
+                     // Use the context available during preparation.
+                     return Error::Success();
+                   });
+```
+
+Specialize `CtxDecoding<stage, T>` for each stage where `T` is available. If a
+context is available at every stage, the specialization can itself be templated
+on `stage`. A catch-all `Context<stage>` is also stage typed, and its
+`context.get<T>()` method uses the same stage without allowing callers to
+override it.
+
 ### Returning Errors From Custom Calls
 
 Custom call implementations must return `xla::ffi::Error` value to signal

--- a/xla/backends/cpu/ffi.h
+++ b/xla/backends/cpu/ffi.h
@@ -38,8 +38,8 @@ struct IntraOpThreadPool {};  // binds `const Eigen::ThreadPoolDevice*`
 // Context decoding
 //===----------------------------------------------------------------------===//
 
-template <>
-struct CtxDecoding<IntraOpThreadPool> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, IntraOpThreadPool> {
   using Type = const Eigen::ThreadPoolDevice*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,

--- a/xla/backends/gpu/ffi.h
+++ b/xla/backends/gpu/ffi.h
@@ -87,8 +87,8 @@ std::optional<std::array<se::Stream*, n>> OptionalStreamsToArray(
 
 }  // namespace internal
 
-template <>
-struct CtxDecoding<Stream> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, Stream> {
   using Type = se::Stream*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -100,15 +100,16 @@ struct CtxDecoding<Stream> {
   }
 };
 
-template <typename T>
-struct CtxDecoding<PlatformStream<T>> {
+template <ExecutionStage stage, typename T>
+struct CtxDecoding<stage, PlatformStream<T>> {
   using Type = T;
   static_assert(std::is_pointer_v<T>, "platform stream type must be a pointer");
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
                                     XLA_FFI_ExecutionContext* ctx,
                                     DiagnosticEngine& diagnostic) {
-    if (auto stream = CtxDecoding<Stream>::Decode(api, ctx, diagnostic)) {
+    if (auto stream =
+            CtxDecoding<stage, Stream>::Decode(api, ctx, diagnostic)) {
       return reinterpret_cast<Type>(
           stream.value()->platform_specific_handle().stream);
     }
@@ -116,8 +117,8 @@ struct CtxDecoding<PlatformStream<T>> {
   }
 };
 
-template <size_t id>
-struct CtxDecoding<ComputationStream<id>> {
+template <ExecutionStage stage, size_t id>
+struct CtxDecoding<stage, ComputationStream<id>> {
   using Type = se::Stream*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -137,12 +138,12 @@ struct CtxDecoding<ComputationStream<id>> {
   }
 };
 
-template <size_t id0, size_t id1, size_t... ids>
-struct CtxDecoding<ComputationStream<id0, id1, ids...>> {
+template <ExecutionStage stage, size_t id0, size_t id1, size_t... ids>
+struct CtxDecoding<stage, ComputationStream<id0, id1, ids...>> {
   using Type = std::array<se::Stream*, 2 + sizeof...(ids)>;
 
   template <size_t stream_id>
-  using StreamDecoding = CtxDecoding<ComputationStream<stream_id>>;
+  using StreamDecoding = CtxDecoding<stage, ComputationStream<stream_id>>;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
                                     XLA_FFI_ExecutionContext* ctx,
@@ -155,8 +156,8 @@ struct CtxDecoding<ComputationStream<id0, id1, ids...>> {
   }
 };
 
-template <size_t id>
-struct CtxDecoding<CommunicationStream<id>> {
+template <ExecutionStage stage, size_t id>
+struct CtxDecoding<stage, CommunicationStream<id>> {
   using Type = se::Stream*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -176,12 +177,12 @@ struct CtxDecoding<CommunicationStream<id>> {
   }
 };
 
-template <size_t id0, size_t id1, size_t... ids>
-struct CtxDecoding<CommunicationStream<id0, id1, ids...>> {
+template <ExecutionStage stage, size_t id0, size_t id1, size_t... ids>
+struct CtxDecoding<stage, CommunicationStream<id0, id1, ids...>> {
   using Type = std::array<se::Stream*, 2 + sizeof...(ids)>;
 
   template <size_t stream_id>
-  using StreamDecoding = CtxDecoding<CommunicationStream<stream_id>>;
+  using StreamDecoding = CtxDecoding<stage, CommunicationStream<stream_id>>;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
                                     XLA_FFI_ExecutionContext* ctx,
@@ -194,8 +195,8 @@ struct CtxDecoding<CommunicationStream<id0, id1, ids...>> {
   }
 };
 
-template <>
-struct CtxDecoding<Allocator> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, Allocator> {
   using Type = se::DeviceAddressAllocator*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -208,8 +209,8 @@ struct CtxDecoding<Allocator> {
   }
 };
 
-template <>
-struct CtxDecoding<ScratchAllocator> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, ScratchAllocator> {
   using Type = se::OwningScratchAllocator<>;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -219,7 +220,7 @@ struct CtxDecoding<ScratchAllocator> {
         api->internal_api->XLA_FFI_INTERNAL_DeviceOrdinal_Get(ctx);
 
     auto device_allocator =
-        CtxDecoding<Allocator>::Decode(api, ctx, diagnostic);
+        CtxDecoding<stage, Allocator>::Decode(api, ctx, diagnostic);
     if (ABSL_PREDICT_FALSE(!device_allocator)) {
       return std::nullopt;
     }
@@ -228,8 +229,8 @@ struct CtxDecoding<ScratchAllocator> {
   }
 };
 
-template <>
-struct CtxDecoding<CollectiveParams> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, CollectiveParams> {
   using Type = const xla::gpu::CollectiveParams*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -242,8 +243,8 @@ struct CtxDecoding<CollectiveParams> {
   }
 };
 
-template <>
-struct CtxDecoding<CollectiveCliqueRequests> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, CollectiveCliqueRequests> {
   using Type = xla::gpu::CollectiveCliqueRequests*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -256,8 +257,8 @@ struct CtxDecoding<CollectiveCliqueRequests> {
   }
 };
 
-template <>
-struct CtxDecoding<CollectiveMemoryRequests> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, CollectiveMemoryRequests> {
   using Type = xla::gpu::CollectiveMemoryRequests*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -270,8 +271,8 @@ struct CtxDecoding<CollectiveMemoryRequests> {
   }
 };
 
-template <>
-struct CtxDecoding<CollectiveCliques> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, CollectiveCliques> {
   using Type = xla::gpu::CollectiveCliques*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -284,8 +285,8 @@ struct CtxDecoding<CollectiveCliques> {
   }
 };
 
-template <>
-struct CtxDecoding<CollectiveMemory> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, CollectiveMemory> {
   using Type = xla::gpu::CollectiveMemory*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -298,8 +299,8 @@ struct CtxDecoding<CollectiveMemory> {
   }
 };
 
-template <>
-struct CtxDecoding<TargetGpuComputeCapability> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, TargetGpuComputeCapability> {
   using Type = const se::GpuComputeCapability*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -312,8 +313,8 @@ struct CtxDecoding<TargetGpuComputeCapability> {
   }
 };
 
-template <>
-struct CtxDecoding<CpuTargetMachineOptions> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, CpuTargetMachineOptions> {
   using Type = const xla::cpu::TargetMachineOptions*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,

--- a/xla/ffi/api/api.h
+++ b/xla/ffi/api/api.h
@@ -516,6 +516,7 @@ class Dictionary;
 
 // Context gives run time access to the execution context. Concrete
 // implementation is provided by the `ffi.h` header.
+template <ExecutionStage stage = ExecutionStage::kExecute>
 class Context;
 
 namespace internal {
@@ -559,7 +560,7 @@ struct AttrTag {};
 template <typename T>
 struct AttrsTag {};
 
-// A type tag to distinguish parameter extracted from an execution context.
+// A type tag to distinguish a parameter extracted from an execution context.
 template <typename T>
 struct CtxTag {};
 
@@ -711,7 +712,7 @@ class Binding {
     return {std::move(*this)};
   }
 
-  Binding<stage, Ts..., internal::CtxTag<Context>> Ctx() && {
+  Binding<stage, Ts..., internal::CtxTag<Context<stage>>> Ctx() && {
     return {std::move(*this)};
   }
 
@@ -1468,13 +1469,15 @@ struct AttrDecoding;
 // Example: decoding for the `MyType` context
 //
 //   template <>
-//   struct CtxDecoding<MyType> {
+//   struct CtxDecoding<ExecutionStage::kExecute, MyType> {
 //    using Type = <handler argument type for context type MyType>;
 //    static std::optional<Type> Decode(const XLA_FFI_Api* api,
 //                                      XLA_FFI_ExecutionContext* ctx);
 //   }
 //
-template <typename T>
+// Context decoding is execution stage specific because some context values are
+// available only at a particular stage.
+template <ExecutionStage stage, typename T>
 struct CtxDecoding;
 
 //===----------------------------------------------------------------------===//
@@ -1596,11 +1599,11 @@ struct DecodingContext {
   const std::size_t* attrs_idx;    // not owned
 };
 
-template <typename T>
+template <ExecutionStage stage, typename T>
 struct Decode;
 
-template <typename T>
-struct Decode<ArgTag<T>> {
+template <ExecutionStage stage, typename T>
+struct Decode<stage, ArgTag<T>> {
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
   static std::optional<T> call(DecodingOffsets& offsets, DecodingContext& ctx,
                                DiagnosticEngine& diagnostic) {
@@ -1610,8 +1613,8 @@ struct Decode<ArgTag<T>> {
   }
 };
 
-template <typename T>
-struct Decode<OptionalArgTag<T>> {
+template <ExecutionStage stage, typename T>
+struct Decode<stage, OptionalArgTag<T>> {
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
   static std::optional<std::optional<T>> call(DecodingOffsets& offsets,
                                               DecodingContext& ctx,
@@ -1619,12 +1622,12 @@ struct Decode<OptionalArgTag<T>> {
     if (XLA_FFI_PREDICT_FALSE(offsets.args >= ctx.call_frame->args.size)) {
       return std::optional<T>(std::nullopt);
     }
-    return Decode<ArgTag<T>>::call(offsets, ctx, diagnostic);
+    return Decode<stage, ArgTag<T>>::call(offsets, ctx, diagnostic);
   }
 };
 
-template <typename T>
-struct Decode<RetTag<T>> {
+template <ExecutionStage stage, typename T>
+struct Decode<stage, RetTag<T>> {
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
   static std::optional<Result<T>> call(DecodingOffsets& offsets,
                                        DecodingContext& ctx,
@@ -1635,8 +1638,8 @@ struct Decode<RetTag<T>> {
   }
 };
 
-template <typename T>
-struct Decode<OptionalRetTag<T>> {
+template <ExecutionStage stage, typename T>
+struct Decode<stage, OptionalRetTag<T>> {
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
   static std::optional<std::optional<Result<T>>> call(
       DecodingOffsets& offsets, DecodingContext& ctx,
@@ -1644,12 +1647,12 @@ struct Decode<OptionalRetTag<T>> {
     if (XLA_FFI_PREDICT_FALSE(offsets.rets >= ctx.call_frame->rets.size)) {
       return std::optional<Result<T>>(std::nullopt);
     }
-    return Decode<RetTag<T>>::call(offsets, ctx, diagnostic);
+    return Decode<stage, RetTag<T>>::call(offsets, ctx, diagnostic);
   }
 };
 
-template <typename T>
-struct Decode<AttrTag<T>> {
+template <ExecutionStage stage, typename T>
+struct Decode<stage, AttrTag<T>> {
   using R = typename AttrDecoding<T>::Type;
 
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
@@ -1694,15 +1697,15 @@ struct Decode<AttrTag<T>> {
   }
 };
 
-template <typename T>
-struct Decode<CtxTag<T>> {
-  using R = typename CtxDecoding<T>::Type;
+template <ExecutionStage stage, typename T>
+struct Decode<stage, CtxTag<T>> {
+  using R = typename CtxDecoding<stage, T>::Type;
 
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
   static std::optional<R> call(DecodingOffsets& offsets, DecodingContext& ctx,
                                DiagnosticEngine& diagnostic) {
-    return CtxDecoding<T>::Decode(ctx.call_frame->api, ctx.call_frame->ctx,
-                                  diagnostic);
+    return CtxDecoding<stage, T>::Decode(ctx.call_frame->api,
+                                         ctx.call_frame->ctx, diagnostic);
   }
 };
 
@@ -1901,8 +1904,8 @@ class DictionaryBase {
 //===----------------------------------------------------------------------===//
 
 // Decode `AttrsTag` into a type `T` relying on struct decoding defined below.
-template <typename T>
-struct internal::Decode<internal::AttrsTag<T>> {
+template <ExecutionStage stage, typename T>
+struct internal::Decode<stage, internal::AttrsTag<T>> {
   static std::optional<T> call(DecodingOffsets& offsets, DecodingContext& ctx,
                                DiagnosticEngine& diagnostic) {
     return AttrDecoding<T>::Decode(XLA_FFI_AttrType_DICTIONARY,
@@ -1916,6 +1919,7 @@ struct internal::Decode<internal::AttrsTag<T>> {
 
 namespace internal {
 
+template <ExecutionStage stage>
 class ContextBase {
  public:
   ContextBase(const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx)
@@ -1926,9 +1930,9 @@ class ContextBase {
 
  protected:
   template <typename T>
-  std::optional<typename CtxDecoding<T>::Type> get(
+  std::optional<typename CtxDecoding<stage, T>::Type> get(
       DiagnosticEngine& diagnostic) const {
-    return CtxDecoding<T>::Decode(api_, ctx_, diagnostic);
+    return CtxDecoding<stage, T>::Decode(api_, ctx_, diagnostic);
   }
 
  private:
@@ -1951,52 +1955,52 @@ class RemainingRets;
 
 namespace internal {
 // A helper struct to extract the type of the handler argument.
-template <typename T>
+template <ExecutionStage stage, typename T>
 struct FnArgType;
 
-template <typename T>
-struct FnArgType<internal::ArgTag<T>> {
+template <ExecutionStage stage, typename T>
+struct FnArgType<stage, internal::ArgTag<T>> {
   using Type = T;
 };
 
-template <typename T>
-struct FnArgType<internal::OptionalArgTag<T>> {
+template <ExecutionStage stage, typename T>
+struct FnArgType<stage, internal::OptionalArgTag<T>> {
   using Type = std::optional<T>;
 };
 
-template <>
-struct FnArgType<internal::RemainingArgsTag> {
+template <ExecutionStage stage>
+struct FnArgType<stage, internal::RemainingArgsTag> {
   using Type = RemainingArgs;
 };
 
-template <typename T>
-struct FnArgType<internal::RetTag<T>> {
+template <ExecutionStage stage, typename T>
+struct FnArgType<stage, internal::RetTag<T>> {
   using Type = Result<T>;
 };
 
-template <typename T>
-struct FnArgType<internal::OptionalRetTag<T>> {
+template <ExecutionStage stage, typename T>
+struct FnArgType<stage, internal::OptionalRetTag<T>> {
   using Type = std::optional<Result<T>>;
 };
 
-template <>
-struct FnArgType<internal::RemainingRetsTag> {
+template <ExecutionStage stage>
+struct FnArgType<stage, internal::RemainingRetsTag> {
   using Type = RemainingRets;
 };
 
-template <typename T>
-struct FnArgType<internal::AttrTag<T>> {
+template <ExecutionStage stage, typename T>
+struct FnArgType<stage, internal::AttrTag<T>> {
   using Type = typename AttrDecoding<T>::Type;
 };
 
-template <typename T>
-struct FnArgType<internal::AttrsTag<T>> {
+template <ExecutionStage stage, typename T>
+struct FnArgType<stage, internal::AttrsTag<T>> {
   using Type = T;
 };
 
-template <typename T>
-struct FnArgType<internal::CtxTag<T>> {
-  using Type = typename CtxDecoding<T>::Type;
+template <ExecutionStage stage, typename T>
+struct FnArgType<stage, internal::CtxTag<T>> {
+  using Type = typename CtxDecoding<stage, T>::Type;
 };
 
 // A template to detect result encodings that are state constructors. We use
@@ -2050,7 +2054,7 @@ class Handler : public Ffi {
                 "dictionary attributes can't be mixed with regular ones");
 
   template <typename T>
-  using FnArgType = typename internal::FnArgType<T>::Type;
+  using FnArgType = typename internal::FnArgType<stage, T>::Type;
 
   static_assert(std::is_invocable_v<Fn, FnArgType<Ts>...>,
                 "FFI binding signature is not compatible with a function type");
@@ -2258,7 +2262,7 @@ class Handler : public Ffi {
     DiagnosticEngine diagnostic;
 
     std::tuple<std::optional<FnArgType<Ts>>...> args = {
-        internal::Decode<Ts>::call(offsets, ctx, diagnostic)...};
+        internal::Decode<stage, Ts>::call(offsets, ctx, diagnostic)...};
 
     if constexpr (sizeof...(Ts) > 0) {
       // We intentionally use `&`, as it generates fewer branch instructions.

--- a/xla/ffi/api/ffi.h
+++ b/xla/ffi/api/ffi.h
@@ -989,8 +989,8 @@ class RemainingArgs : public internal::RemainingArgsBase {
   }
 };
 
-template <>
-struct internal::Decode<internal::RemainingArgsTag> {
+template <ExecutionStage stage>
+struct internal::Decode<stage, internal::RemainingArgsTag> {
   static std::optional<RemainingArgs> call(DecodingOffsets& offsets,
                                            DecodingContext& ctx,
                                            DiagnosticEngine& diagnostic) {
@@ -1077,8 +1077,8 @@ class RemainingRets : public internal::RemainingRetsBase {
   }
 };
 
-template <>
-struct internal::Decode<internal::RemainingRetsTag> {
+template <ExecutionStage stage>
+struct internal::Decode<stage, internal::RemainingRetsTag> {
   static std::optional<RemainingRets> call(DecodingOffsets& offsets,
                                            DecodingContext& ctx,
                                            DiagnosticEngine& diagnostic) {
@@ -1199,8 +1199,8 @@ class Dictionary : public internal::DictionaryBase {
 };
 
 // Decode `AttrsTag` (all attributes) into a `Dictionary`.
-template <>
-struct internal::Decode<internal::AttrsTag<Dictionary>> {
+template <ExecutionStage stage>
+struct internal::Decode<stage, internal::AttrsTag<Dictionary>> {
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Dictionary> call(
       DecodingOffsets& offsets, DecodingContext& ctx,
       DiagnosticEngine& diagnostic) {
@@ -1226,14 +1226,15 @@ struct AttrDecoding<Dictionary> {
 // Type-safe wrapper for accessing context.
 //===----------------------------------------------------------------------===//
 
-class Context : public internal::ContextBase {
+template <ExecutionStage stage>
+class Context : public internal::ContextBase<stage> {
  public:
-  using internal::ContextBase::ContextBase;
+  using internal::ContextBase<stage>::ContextBase;
 
   template <typename T>
-  ErrorOr<typename CtxDecoding<T>::Type> get() const {
+  ErrorOr<typename CtxDecoding<stage, T>::Type> get() const {
     DiagnosticEngine diagnostic;
-    auto value = internal::ContextBase::get<T>(diagnostic);
+    auto value = internal::ContextBase<stage>::template get<T>(diagnostic);
     if (XLA_FFI_PREDICT_FALSE(!value.has_value())) {
       return Unexpected(Error::Internal(diagnostic.Result()));
     }
@@ -1242,15 +1243,15 @@ class Context : public internal::ContextBase {
 };
 
 // Context decoding for catch-all `Context` type.
-template <>
-struct CtxDecoding<Context> {
-  using Type = Context;
+template <ExecutionStage stage>
+struct CtxDecoding<stage, Context<stage>> {
+  using Type = Context<stage>;
 
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
-  static std::optional<Context> Decode(const XLA_FFI_Api* api,
-                                       XLA_FFI_ExecutionContext* ctx,
-                                       DiagnosticEngine&) {
-    return Context(api, ctx);
+  static std::optional<Type> Decode(const XLA_FFI_Api* api,
+                                    XLA_FFI_ExecutionContext* ctx,
+                                    DiagnosticEngine&) {
+    return Context<stage>(api, ctx);
   }
 };
 
@@ -1388,8 +1389,8 @@ struct PlatformStream {};
 //
 // Example: Ffi::Bind().Ctx<PlatformStream<cudaStream_t>()
 //                     .To([](cudaStream_t stream) { ... });
-template <typename T>
-struct CtxDecoding<PlatformStream<T>> {
+template <ExecutionStage stage, typename T>
+struct CtxDecoding<stage, PlatformStream<T>> {
   using Type = T;
 
   static_assert(std::is_pointer_v<T>, "stream type must be a pointer");
@@ -1435,7 +1436,8 @@ class ScratchAllocator {
   std::optional<void*> Allocate(size_t size, size_t alignment = 1);
 
  private:
-  friend struct CtxDecoding<ScratchAllocator>;
+  template <ExecutionStage, typename>
+  friend struct CtxDecoding;
 
   ScratchAllocator(const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
                    DiagnosticEngine& diagnostic);
@@ -1456,8 +1458,8 @@ class ScratchAllocator {
 //
 // Example: Ffi::Bind().Ctx<ScratchAllocator>()
 //                     .To([](ScratchAllocator scratch) { ... });
-template <>
-struct CtxDecoding<ScratchAllocator> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, ScratchAllocator> {
   using Type = ScratchAllocator;
 
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
@@ -1561,7 +1563,8 @@ class ThreadPool {
   }
 
  private:
-  friend struct CtxDecoding<ThreadPool>;
+  template <ExecutionStage, typename>
+  friend struct CtxDecoding;
 
   ThreadPool(const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
              DiagnosticEngine& diagnostic);
@@ -1575,8 +1578,8 @@ class ThreadPool {
 //
 // Example: Ffi::Bind().Ctx<ThreadPool>()
 //                     .To([](ThreadPool thread_pool) { ... });
-template <>
-struct CtxDecoding<ThreadPool> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, ThreadPool> {
   using Type = ThreadPool;
 
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
@@ -1634,8 +1637,8 @@ struct UserData {};
 //
 // Example: Ffi::Bind().Ctx<UserData<MyData>>()
 //                     .To([](MyData* data) { ... });
-template <typename T>
-struct CtxDecoding<UserData<T>> {
+template <ExecutionStage stage, typename T>
+struct CtxDecoding<stage, UserData<T>> {
   using Type = T*;
 
   static_assert(std::is_same_v<decltype(T::id), TypeId>,
@@ -1682,8 +1685,8 @@ using Initialized = State<T, ExecutionStage::kInitialize>;
 //
 // Example: Ffi::Bind().Ctx<State<MyState>>()
 //                     .To([](MyState* state) { ... });
-template <typename T, ExecutionStage stage>
-struct CtxDecoding<State<T, stage>> {
+template <ExecutionStage stage, typename T, ExecutionStage state_stage>
+struct CtxDecoding<stage, State<T, state_stage>> {
   using Type = T*;
 
   static_assert(std::is_same_v<decltype(T::id), TypeId>,
@@ -1695,7 +1698,7 @@ struct CtxDecoding<State<T, stage>> {
     XLA_FFI_State_Get_Args args;
     args.struct_size = XLA_FFI_State_Get_Args_STRUCT_SIZE;
     args.extension_start = nullptr;
-    args.stage = static_cast<XLA_FFI_ExecutionStage>(stage);
+    args.stage = static_cast<XLA_FFI_ExecutionStage>(state_stage);
     args.ctx = ctx;
     args.type_id = &T::id;
     args.state = nullptr;
@@ -1725,8 +1728,8 @@ struct RunId {
 //
 // Example: Ffi::Bind().Ctx<RunId>()
 //                     .To([](RunId run_id) { ... });
-template <>
-struct CtxDecoding<RunId> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, RunId> {
   using Type = RunId;
 
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
@@ -1759,8 +1762,8 @@ struct DeviceOrdinal {};
 //
 // Example: Ffi::Bind().Ctx<DeviceOrdinal>()
 //                     .To([](int32_t device_ordinal) { ... });
-template <>
-struct CtxDecoding<DeviceOrdinal> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, DeviceOrdinal> {
   using Type = int32_t;
 
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(

--- a/xla/ffi/api/ffi_test.cc
+++ b/xla/ffi/api/ffi_test.cc
@@ -493,7 +493,7 @@ TEST(FfiTest, RunIdViaContext) {
   CallFrameBuilder builder(/*num_args=*/0, /*num_rets=*/0);
   auto call_frame = builder.Build();
 
-  auto handler = Ffi::Bind().Ctx().To([&](Context ctx) {
+  auto handler = Ffi::Bind().Ctx().To([&](Context<> ctx) {
     ErrorOr<RunId> run_id = ctx.get<RunId>();
     EXPECT_TRUE(run_id.has_value());
     EXPECT_EQ(run_id->run_id, 42);
@@ -513,7 +513,7 @@ TEST(FfiTest, DeviceOrdinal) {
   auto call_frame = builder.Build();
 
   auto handler = Ffi::Bind().Ctx<DeviceOrdinal>().Ctx().To(
-      [&](int32_t device_ordinal, Context ctx) {
+      [&](int32_t device_ordinal, Context<> ctx) {
         // Get device ordinal from the argument.
         EXPECT_EQ(device_ordinal, 42);
 

--- a/xla/ffi/ffi.h
+++ b/xla/ffi/ffi.h
@@ -445,8 +445,8 @@ class RemainingArgs : public internal::RemainingArgsBase {
   }
 };
 
-template <>
-struct internal::Decode<internal::RemainingArgsTag> {
+template <ExecutionStage stage>
+struct internal::Decode<stage, internal::RemainingArgsTag> {
   static std::optional<RemainingArgs> call(DecodingOffsets& offsets,
                                            DecodingContext& ctx,
                                            DiagnosticEngine& diagnostic) {
@@ -513,8 +513,8 @@ class RemainingRets : public internal::RemainingRetsBase {
   }
 };
 
-template <>
-struct internal::Decode<internal::RemainingRetsTag> {
+template <ExecutionStage stage>
+struct internal::Decode<stage, internal::RemainingRetsTag> {
   static std::optional<RemainingRets> call(DecodingOffsets& offsets,
                                            DecodingContext& ctx,
                                            DiagnosticEngine& diagnostic) {
@@ -616,8 +616,8 @@ class Dictionary : public internal::DictionaryBase {
 };
 
 // Decode `AttrsTag` (all attributes) into a `Dictionary`.
-template <>
-struct internal::Decode<internal::AttrsTag<Dictionary>> {
+template <ExecutionStage stage>
+struct internal::Decode<stage, internal::AttrsTag<Dictionary>> {
   static std::optional<Dictionary> call(DecodingOffsets& offsets,
                                         DecodingContext& ctx,
                                         DiagnosticEngine& diagnostic) {
@@ -643,14 +643,15 @@ struct AttrDecoding<Dictionary> {
 // Type-safe wrapper for accessing context.
 //===----------------------------------------------------------------------===//
 
-class Context : public internal::ContextBase {
+template <ExecutionStage stage>
+class Context : public internal::ContextBase<stage> {
  public:
-  using internal::ContextBase::ContextBase;
+  using internal::ContextBase<stage>::ContextBase;
 
   template <typename T>
-  absl::StatusOr<typename CtxDecoding<T>::Type> get() const {
+  absl::StatusOr<typename CtxDecoding<stage, T>::Type> get() const {
     DiagnosticEngine diagnostic;
-    auto value = internal::ContextBase::get<T>(diagnostic);
+    auto value = internal::ContextBase<stage>::template get<T>(diagnostic);
     if (ABSL_PREDICT_FALSE(!value.has_value())) {
       return Internal("%s", diagnostic.Result());
     }
@@ -659,15 +660,15 @@ class Context : public internal::ContextBase {
 };
 
 // Context decoding for catch-all `Context` type.
-template <>
-struct CtxDecoding<Context> {
-  using Type = Context;
+template <ExecutionStage stage>
+struct CtxDecoding<stage, Context<stage>> {
+  using Type = Context<stage>;
 
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
-  static std::optional<Context> Decode(const XLA_FFI_Api* api,
-                                       XLA_FFI_ExecutionContext* ctx,
-                                       DiagnosticEngine&) {
-    return Context(api, ctx);
+  static std::optional<Type> Decode(const XLA_FFI_Api* api,
+                                    XLA_FFI_ExecutionContext* ctx,
+                                    DiagnosticEngine&) {
+    return Context<stage>(api, ctx);
   }
 };
 
@@ -696,8 +697,8 @@ static std::optional<T> DecodeInternalCtx(const XLA_FFI_Api* api,
 
 }  // namespace internal
 
-template <>
-struct CtxDecoding<DeviceOrdinal> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, DeviceOrdinal> {
   using Type = int32_t;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -707,8 +708,8 @@ struct CtxDecoding<DeviceOrdinal> {
   }
 };
 
-template <>
-struct CtxDecoding<CalledComputation> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, CalledComputation> {
   using Type = const HloComputation*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -719,8 +720,8 @@ struct CtxDecoding<CalledComputation> {
   }
 };
 
-template <>
-struct CtxDecoding<RunId> {
+template <ExecutionStage stage>
+struct CtxDecoding<stage, RunId> {
   using Type = RunId;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -738,8 +739,8 @@ struct CtxDecoding<RunId> {
 template <typename T>
 struct UserData {};
 
-template <typename T>
-struct CtxDecoding<UserData<T>> {
+template <ExecutionStage stage, typename T>
+struct CtxDecoding<stage, UserData<T>> {
   using Type = T*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -777,8 +778,8 @@ using Prepared = State<T, ExecutionStage::kPrepare>;
 template <typename T>
 using Initialized = State<T, ExecutionStage::kInitialize>;
 
-template <typename T, ExecutionStage stage>
-struct CtxDecoding<State<T, stage>> {
+template <ExecutionStage stage, typename T, ExecutionStage state_stage>
+struct CtxDecoding<stage, State<T, state_stage>> {
   using Type = T*;
 
   static std::optional<Type> Decode(const XLA_FFI_Api* api,
@@ -786,7 +787,7 @@ struct CtxDecoding<State<T, stage>> {
                                     DiagnosticEngine& diagnostic) {
     auto* execution_state = reinterpret_cast<const ExecutionState*>(
         api->internal_api->XLA_FFI_INTERNAL_ExecutionState_Get(
-            ctx, static_cast<XLA_FFI_ExecutionStage>(stage)));
+            ctx, static_cast<XLA_FFI_ExecutionStage>(state_stage)));
 
     if (execution_state == nullptr) {
       return diagnostic.Emit(

--- a/xla/ffi/ffi_test.cc
+++ b/xla/ffi/ffi_test.cc
@@ -253,7 +253,7 @@ TEST(FfiTest, RunId) {
   auto call_frame = builder.Build();
 
   auto handler = Ffi::Bind().Ctx<RunId>().Ctx().To(
-      [&](RunId run_id, Context context) -> absl::Status {
+      [&](RunId run_id, Context<> context) -> absl::Status {
         EXPECT_EQ(run_id.ToInt(), 42);
         ASSIGN_OR_RETURN(RunId run_id_from_context, context.get<RunId>());
         EXPECT_EQ(run_id_from_context.ToInt(), 42);


### PR DESCRIPTION
Similar to encoding results, context can be stage-dependent, i.e. collective communication "context" is available only when handler is executed!