### PR TITLE
Fix collective-permute cycle decomposer for multiple cycles

### DIFF
--- a/xla/backends/gpu/transforms/collectives/collective_permute_cycle_decomposer.cc
+++ b/xla/backends/gpu/transforms/collectives/collective_permute_cycle_decomposer.cc
@@ -227,17 +227,34 @@ absl::Status DecomposeCollectivePermuteCycle(
   //   recv-data = type[?] select(compare, cp1_done, cp2_done)
   // If the collective is across replicas, then `partition` is replaced by
   // `replica = u32[] replica-id()`.
+  //
+  // `source_target_pairs` may describe several disjoint cycles, in which case
+  // there is one back edge per cycle and the predicate has to hold for every
+  // one of their targets. A single equality would send all but one of those
+  // devices to the forward collective-permute, where they are not targets and
+  // so would read zeros instead of their permuted data. Or the comparisons
+  // together to test membership in the whole set.
   ASSIGN_OR_RETURN(HloInstruction * partition_or_replica,
                    CreatePartitionOrReplicaId(computation, mode, cp_name));
-  int64_t bwd_recv_id = back_pairs.back().second;
-  HloInstruction* constant = computation->AddInstruction(
-      HloInstruction::CreateConstant(LiteralUtil::CreateR0(U32, bwd_recv_id)),
-      absl::StrCat(cp_name, "-bwd-recv-id"));
-  HloInstruction* compare = computation->AddInstruction(
-      HloInstruction::CreateCompare(ShapeUtil::MakeShape(PRED, {}),
-                                    partition_or_replica, constant,
-                                    Comparison::Direction::kEq),
-      absl::StrCat(cp_name, "-cmp"));
+  HloInstruction* compare = nullptr;
+  for (const std::pair<int64_t, int64_t>& back_pair : back_pairs) {
+    HloInstruction* constant = computation->AddInstruction(
+        HloInstruction::CreateConstant(
+            LiteralUtil::CreateR0(U32, back_pair.second)),
+        absl::StrCat(cp_name, "-bwd-recv-id"));
+    HloInstruction* is_bwd_recv = computation->AddInstruction(
+        HloInstruction::CreateCompare(ShapeUtil::MakeShape(PRED, {}),
+                                      partition_or_replica, constant,
+                                      Comparison::Direction::kEq),
+        absl::StrCat(cp_name, "-cmp"));
+    compare = compare == nullptr
+                  ? is_bwd_recv
+                  : computation->AddInstruction(
+                        HloInstruction::CreateBinary(
+                            ShapeUtil::MakeShape(PRED, {}), HloOpcode::kOr,
+                            compare, is_bwd_recv),
+                        absl::StrCat(cp_name, "-cmp-or"));
+  }
 
   // Later in the pipeline, CollectivePermuteDecomposer uses post order
   //  to chain the send/recv instructions. It's important that the back

--- a/xla/backends/gpu/transforms/collectives/collective_permute_cycle_decomposer_test.cc
+++ b/xla/backends/gpu/transforms/collectives/collective_permute_cycle_decomposer_test.cc
@@ -172,6 +172,10 @@ TEST_F(CollectivePermuteCycleDecomposerTest, ForwardCycleMultipleCycles) {
   // For a forward cycle, this checks:
   // 1. Split collectives should not have channel-id
   // 2. Split collectives are combined based on replica-id.
+  // With two disjoint cycles there are two back edges, so the select must be
+  // driven by the disjunction of both back-edge targets: device 0 receives on
+  // {6,0} and device 1 on {7,1}, and neither is a target of the forward
+  // collective-permute.
   absl::string_view hlo = R"(
     HloModule test
     ENTRY test_computation {
@@ -186,8 +190,11 @@ TEST_F(CollectivePermuteCycleDecomposerTest, ForwardCycleMultipleCycles) {
   EXPECT_TRUE(*RunFileCheck(module->ToString(PrintOptions()), R"(
     // CHECK:     ENTRY %test_computation (p: u32[8,8]) -> u32[8,8] {
     // CHECK-DAG:   %[[replica_id:.+]] = u32[] replica-id()
+    // CHECK-DAG:   %[[c0:.+]] = u32[] constant(0)
+    // CHECK-DAG:   %[[cmp0:.+]] = pred[] compare(%[[replica_id]], %[[c0]]), direction=EQ
     // CHECK-DAG:   %[[c1:.+]] = u32[] constant(1)
-    // CHECK-DAG:   %[[compare:.+]] = pred[] compare(%[[replica_id]], %[[c1]]), direction=EQ
+    // CHECK-DAG:   %[[cmp1:.+]] = pred[] compare(%[[replica_id]], %[[c1]]), direction=EQ
+    // CHECK-DAG:   %[[compare:.+]] = pred[] or(%[[cmp0]], %[[cmp1]])
     // CHECK-DAG:   %{{.+}} = u32[8,8] parameter(0)
 
     // CHECK-DAG:   %[[cp1:.+]] = u32[8,8] collective-permute(%{{.+}}), source_target_pairs=


### PR DESCRIPTION
### Summary

`DecomposeCollectivePermuteCycle` recombines the backward and forward `collective-permute` with

```
select(compare(partition-or-replica-id, bwd_recv_id), back_cp, fwd_cp)
```

but `bwd_recv_id` was taken from a single back edge:

```c++
int64_t bwd_recv_id = back_pairs.back().second;
```

`GetCycleTypeAndIndices` returns **one back edge per cycle**, and `DecomposeCollectivePermuteCycle` accumulates all of them into `back_pairs`. When `source_target_pairs` describes several disjoint cycles there is therefore more than one back-edge target, and a scalar equality cannot express membership in that set. Every back-edge receiver except the last selects `fwd_cp`, in which it is not a target, and per collective-permute semantics a non-target outputs zeros — so those devices silently receive zeros instead of their permuted data.

Fixes #45222. Full credit to the reporter, whose analysis localised this precisely.

### The pass's own test demonstrated it

`ForwardCycleMultipleCycles` uses `{{0,2},{2,4},{4,6},{6,0},{1,3},{3,5},{5,7},{7,1}}` — two disjoint 4-cycles. The back-edge indices are `{3,7}`, so `back_pairs = {{6,0},{7,1}}` and `bwd_recv_id = 1`. Device 0 is the target of back edge `{6,0}` and must receive device 6's value, but `id == 1` is false for device 0, so it selected `fwd_cp` — whose targets are `{2,4,6,3,5,7}` — and received zero.

The test's FileCheck asserted exactly that shape (`constant(1)`, one compare), so it encoded the bug rather than catching it.

### Fix

Or the per-target comparisons together:

```c++
  HloInstruction* compare = nullptr;
  for (const std::pair<int64_t, int64_t>& back_pair : back_pairs) {
    ...
    compare = compare == nullptr ? is_bwd_recv
                                 : /* or(compare, is_bwd_recv) */;
  }
```

For a **single** cycle `back_pairs` has one element, the loop runs once, no `or` is emitted, and the generated HLO is byte-identical to before — so `ForwardCycle`, `ForwardCycleNoChannel`, `BackwardCycle`, `BackwardCycleNoChannel` and `ForwardCycleWithMatmul` are unaffected. Only the multi-cycle expectation changes.

### Verification

I could not build XLA on this machine, so this rests on CI. The reasoning above is from the source and the pass's own test vectors; the emitted-HLO claim for the single-cycle path is by construction (the loop body is the previous code, executed once).
