### PR TITLE
[ROCm] Shutdown bazel server when job is done

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -116,6 +116,10 @@ jobs:
             --bes_keywords=upstream \
             --bes_keywords=gpu \
             --bes_keywords=pull_request
+      - name: Shutdown bazel
+        timeout-minutes: 5
+        run: |
+          bazel shutdown
   xla:
     needs: rocm-config
     name: XLA Linux x86 AMD Instinct GPU
@@ -175,3 +179,7 @@ jobs:
             --bes_keywords=upstream \
             --bes_keywords=cpu \
             --bes_keywords=pull_request
+      - name: Shutdown bazel
+        timeout-minutes: 5
+        run: |
+          bazel shutdown


### PR DESCRIPTION
📝 Summary of Changes
Shutdown bazel server when the job is done
🎯 Justification
Sometimes docker termination gets stuck, we suspect 
this is due our tmpfs u-mount while bazel server is still running.

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
