### PR TITLE
[ROCm] Fix non hermetic rocm toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -45,9 +45,9 @@ bazel_dep(name = "rules_ml_toolchain")
 # echo "sha256-${HASH}"
 archive_override(
     module_name = "rules_ml_toolchain",
-    integrity = "sha256-izPVqzV2I7ox7EYzRzcRY6ogeLcHUr4LRP2xMrkWh6A=",
-    strip_prefix = "rules_ml_toolchain-236a498d8624bef88e35ce2518a833204b0db19f",
-    urls = ["https://github.com/google-ml-infra/rules_ml_toolchain/archive/236a498d8624bef88e35ce2518a833204b0db19f.tar.gz"],
+    integrity = "sha256-YXXxxgQ0/IgTbCVuXYqCtkEfiaMlgxrg0F3biUtsK+k=",
+    strip_prefix = "rules_ml_toolchain-fb28c6aca270cf05feba0602005263a5e3516c92",
+    urls = ["https://github.com/google-ml-infra/rules_ml_toolchain/archive/fb28c6aca270cf05feba0602005263a5e3516c92.tar.gz"],
 )
 
 # TODO: Upstream the patch?

--- a/third_party/gpus/crosstool/BUILD.rocm.tpl
+++ b/third_party/gpus/crosstool/BUILD.rocm.tpl
@@ -1,11 +1,15 @@
 # This file is expanded from a template by rocm_configure.bzl
 # Update rocm_configure.bzl#verify_build_defines when adding new variables.
 
-load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+load("@config_rocm_hipcc//rocm:build_defs.bzl", "hipcc_config")
 load("@local_config_clang//:clang.bzl", "local_clang")
+load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 
 # Local clang configuration for non-hermetic toolchain
 _LOCAL_CLANG = local_clang()
+
+# ROCm configuration from hermetic hipcc
+_HIPCC_CONFIG = hipcc_config()
 
 licenses(["restricted"])
 
@@ -40,9 +44,9 @@ cc_toolchain_suite(
 cc_toolchain(
     name = "cc-compiler-local",
     all_files = ":crosstool_wrapper_driver_is_not_gcc",
-    compiler_files = ":crosstool_wrapper_driver_is_not_gcc",
     ar_files = ":crosstool_wrapper_driver_is_not_gcc",
     as_files = ":crosstool_wrapper_driver_is_not_gcc",
+    compiler_files = ":crosstool_wrapper_driver_is_not_gcc",
     dwp_files = ":empty",
     linker_files = ":crosstool_wrapper_driver_is_not_gcc",
     objcopy_files = ":empty",
@@ -52,24 +56,16 @@ cc_toolchain(
     # last on the command line and contain all shared libraries to link, so all
     # regular options will be left of them.
     supports_param_files = 1,
-    toolchain_identifier = "local_linux",
     toolchain_config = ":cc-compiler-local-config",
+    toolchain_identifier = "local_linux",
 )
 
 cc_toolchain_config(
     name = "cc-compiler-local-config",
-    cpu = "local",
-    compiler = "compiler",
-    toolchain_identifier = "local_linux",
-    host_system_name = "local",
-    target_system_name = "local",
-    target_libc = "local",
-    abi_version = "local",
     abi_libc_version = "local",
-    # Include directories detected from local clang + ROCm includes
-    cxx_builtin_include_directories = _LOCAL_CLANG.include_directories + [%{cxx_builtin_include_directories}],
-    host_compiler_path = "clang/bin/crosstool_wrapper_driver_is_not_gcc",
-    host_compiler_prefix = "/usr/bin",
+    abi_version = "local",
+    # Compiler path from local_clang_info(), sets CLANG_COMPILER_PATH env var
+    clang_compiler_path = _LOCAL_CLANG.compiler_path,
     compile_flags = [
         "-U_FORTIFY_SOURCE",
         "-fstack-protector",
@@ -79,16 +75,17 @@ cc_toolchain_config(
         "-fno-omit-frame-pointer",
         "-no-canonical-prefixes",
     ],
-    opt_compile_flags = [
-        "-g0",
-        "-O2",
-        "-D_FORTIFY_SOURCE=1",
-        "-DNDEBUG",
-        "-ffunction-sections",
-        "-fdata-sections",
-    ],
-    dbg_compile_flags = ["-g"],
+    compiler = "compiler",
+    coverage_compile_flags = ["--coverage"],
+    coverage_link_flags = ["--coverage"],
+    cpu = "local",
+    # Include directories detected from local clang + ROCm includes
+    cxx_builtin_include_directories = _LOCAL_CLANG.include_directories,
     cxx_flags = ["-std=c++17"],
+    dbg_compile_flags = ["-g"],
+    host_compiler_path = "clang/bin/crosstool_wrapper_driver_is_not_gcc",
+    host_compiler_prefix = "/usr/bin",
+    host_system_name = "local",
     link_flags = [
         "-fuse-ld=lld",
         "-Wl,-no-as-needed",
@@ -99,19 +96,26 @@ cc_toolchain_config(
         "-lstdc++",
         "-lm",
     ],
+    linker_bin_path = "external/config_rocm_hipcc/rocm/" + _HIPCC_CONFIG.rocm_root + "/bin",
+    opt_compile_flags = [
+        "-g0",
+        "-O2",
+        "-D_FORTIFY_SOURCE=1",
+        "-DNDEBUG",
+        "-ffunction-sections",
+        "-fdata-sections",
+    ],
     opt_link_flags = [],
+    supports_start_end_lib = True,
+    target_libc = "local",
+    target_system_name = "local",
+    toolchain_identifier = "local_linux",
     unfiltered_compile_flags = [
         "-Wno-builtin-macro-redefined",
         "-D__DATE__=\"redacted\"",
         "-D__TIMESTAMP__=\"redacted\"",
         "-D__TIME__=\"redacted\"",
-    ] + [%{unfiltered_compile_flags}],
-    linker_bin_path = "%{linker_bin_path}",
-    coverage_compile_flags = ["--coverage"],
-    coverage_link_flags = ["--coverage"],
-    supports_start_end_lib = True,
-    # Compiler path from local_clang_info(), sets CLANG_COMPILER_PATH env var
-    clang_compiler_path = _LOCAL_CLANG.compiler_path,
+    ],
 )
 
 filegroup(
@@ -120,9 +124,9 @@ filegroup(
 )
 
 filegroup(
-  name = "crosstool_wrapper_driver_is_not_gcc",
-  srcs = [
-      ":clang/bin/crosstool_wrapper_driver_is_not_gcc", 
-      "@local_config_rocm//rocm:toolchain_data",
-  ],
+    name = "crosstool_wrapper_driver_is_not_gcc",
+    srcs = [
+        ":clang/bin/crosstool_wrapper_driver_is_not_gcc",
+        "@config_rocm_hipcc//rocm:toolchain_data",
+    ],
 )

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -22,18 +22,20 @@ import re
 import sys
 import shlex
 
-# Template values set by rocm_configure.bzl or environment
-AMDGPU_TARGETS = ('%{rocm_amdgpu_targets}')
+# Get paths from environment variables set by toolchain features
 CPU_COMPILER = os.environ.get('HOST_COMPILER', '/usr/bin/clang')
+HIPCC_PATH = os.environ.get('HIPCC_PATH', '/opt/rocm/bin/hipcc')
+ROCM_PATH = os.environ.get('ROCM_PATH', '/opt/rocm')
+AMDGPU_TARGETS = os.environ.get('AMDGPU_TARGETS', '')
+HIPCC_ENV = os.environ.get('HIPCC_ENV', '')
+ROCR_RUNTIME_LIBRARY = os.environ.get('ROCR_RUNTIME_LIBRARY', 'amdhip64')
+TMPDIR = '%{tmpdir}'
+VERBOSE = os.environ.get('CROSSTOOL_VERBOSE', '0') == '1'
 
-HIPCC_PATH = '%{rocm_root}/bin/hipcc'
-HIPCC_ENV = '%{hipcc_env}'
-HIP_RUNTIME_PATH = '%{rocm_root}/lib'
-HIP_RUNTIME_LIBRARY = '%{rocm_root}/lib'
-ROCR_RUNTIME_PATH = '%{rocm_root}/lib'
-ROCR_RUNTIME_LIBRARY = '%{rocr_runtime_library}'
-TMPDIR= '%{tmpdir}'
-VERBOSE = '%{crosstool_verbose}'=='1'
+# Derived paths
+HIP_RUNTIME_PATH = ROCM_PATH + '/lib'
+HIP_RUNTIME_LIBRARY = ROCM_PATH + '/lib'
+ROCR_RUNTIME_PATH = ROCM_PATH + '/lib'
 
 def Log(s):
   print('gpus/crosstool: {0}'.format(s))
@@ -205,7 +207,7 @@ def InvokeHipcc(argv, log=False):
   hipccopts += defines
   hipccopts += std_options
   hipccopts += m_options
-  hipccopts += ' --rocm-path="%{rocm_root}" '
+  hipccopts += ' --rocm-path="' + ROCM_PATH + '" '
 
   if depfiles:
     # Generate the dependency file

--- a/third_party/gpus/crosstool/hipcc_cc_toolchain_config.bzl.tpl
+++ b/third_party/gpus/crosstool/hipcc_cc_toolchain_config.bzl.tpl
@@ -28,6 +28,7 @@ load(
     "with_feature_set",
 )
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@config_rocm_hipcc//rocm:build_defs.bzl", "hipcc_config")
 load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfigInfo")
 
 all_compile_actions = [
@@ -266,11 +267,16 @@ def _impl(ctx):
         flag_sets = [
             flag_set(
                 actions = all_compile_actions,
-                flag_groups = ([
+                flag_groups = [
                     flag_group(
-                        flags = ctx.attr.unfiltered_compile_flags,
+                        flags = [
+                            "-DTENSORFLOW_USE_ROCM=1",
+                            "-D__HIP_PLATFORM_AMD__",
+                            "-DEIGEN_USE_HIP",
+                            "-DUSE_ROCM",
+                        ] + (ctx.attr.unfiltered_compile_flags if ctx.attr.unfiltered_compile_flags else []),
                     ),
-                ] if ctx.attr.unfiltered_compile_flags else []),
+                ],
             ),
         ],
     )
@@ -1122,6 +1128,51 @@ def _impl(ctx):
         ] if ctx.attr.clang_compiler_path else [],
     )
 
+    # ROCm HIPcc feature from hipcc_config()
+    _hipcc_config = hipcc_config()
+    # Construct full paths - config_rocm_hipcc is in external workspace
+    _workspace_prefix = "external/config_rocm_hipcc/rocm"
+    _rocm_path = _workspace_prefix + "/" + _hipcc_config.rocm_root
+
+    rocm_hipcc_feature = feature(
+        name = "rocm_hipcc",
+        enabled = True,
+        env_sets = [
+            env_set(
+                actions = all_compile_actions + all_link_actions,
+                env_entries = [
+                    env_entry(
+                        key = "HIPCC_PATH",
+                        value = _workspace_prefix + "/" + _hipcc_config.hipcc_path,
+                    ),
+                    env_entry(
+                        key = "ROCM_PATH",
+                        value = _rocm_path,
+                    ),
+                    env_entry(
+                        key = "AMDGPU_TARGETS",
+                        value = ",".join(_hipcc_config.gpu_architectures),
+                    ),
+                    env_entry(
+                        key = "HIPCC_ENV",
+                        value = _hipcc_config.hipcc_env,
+                    ),
+                ],
+            ),
+        ],
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions + all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["--rocm-path=" + _rocm_path] +
+                                ["--offload-arch=" + arch for arch in _hipcc_config.gpu_architectures],
+                    ),
+                ],
+            ),
+        ],
+    )
+
     features = [
         dependency_file_feature,
         random_seed_feature,
@@ -1152,6 +1203,7 @@ def _impl(ctx):
         supports_pic_feature,
         compiler_env_feature,
         clang_compiler_path_feature,
+        rocm_hipcc_feature,
     ] + (
         [
             supports_start_end_lib_feature,

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -3,10 +3,7 @@
 `rocm_configure` depends on the following environment variables:
 
   * `TF_NEED_ROCM`: Whether to enable building with ROCm.
-  * `TF_ROCM_CLANG`: Whether to use clang for C++ and HIPCC for ROCm compilation.
   * `TF_SYSROOT`: The sysroot to use when compiling.
-  * `CLANG_COMPILER_PATH`: The clang compiler path that will be used for
-    host code compilation if TF_ROCM_CLANG is 1.
   * `TF_ROCM_AMDGPU_TARGETS`: The AMDGPU targets.
   * `TF_ROCM_MULTIPLE_PATHS`: Colon-separated list of ROCm installation paths to merge.
   * `LLVM_PATH`: Path to LLVM installation (used with TF_ROCM_MULTIPLE_PATHS).
@@ -145,7 +142,6 @@ def verify_build_defines(params):
     missing = []
     for param in [
         "host_compiler_path",
-        "linker_bin_path",
         "unfiltered_compile_flags",
     ]:
         if ("%{" + param + "}") not in params:
@@ -155,48 +151,6 @@ def verify_build_defines(params):
         auto_configure_fail(
             "Missing template parameters: %s" % missing,
         )
-
-def _rocm_include_path(repository_ctx, rocm_config):
-    """Generates the entries for rocm inc dirs based on rocm_config.
-
-    Args:
-      repository_ctx: The repository context.
-      rocm_config: The ROCm config struct.
-
-    Returns:
-      A list of the ROCm compiler include directories.
-    """
-    inc_dirs = []
-
-    # Add HIP-Clang headers (relative to rocm root)
-    inc_dirs.append(str(repository_ctx.path(rocm_config.rocm_toolkit_path)) + "/include")
-    inc_dirs.append(str(repository_ctx.path(rocm_config.rocm_toolkit_path)) + "/lib/llvm/lib/clang/18/include")
-
-    return inc_dirs
-
-def _hipcc_env(repository_ctx):
-    """Returns the environment variable string for hipcc.
-
-    Args:
-        repository_ctx: The repository context.
-
-    Returns:
-        A string containing environment variables for hipcc.
-    """
-    hipcc_env = ""
-    for name in [
-        "HIP_CLANG_PATH",
-        "DEVICE_LIB_PATH",
-        "HIP_VDI_HOME",
-        "HIPCC_VERBOSE",
-        "HIPCC_COMPILE_FLAGS_APPEND",
-        "HIPCC_LINK_FLAGS_APPEND",
-    ]:
-        if get_host_environ(repository_ctx, name):
-            hipcc_env = (hipcc_env + " " + name + "=" +
-                         get_host_environ(repository_ctx, name))
-
-    return hipcc_env.strip()
 
 def _enable_rocm(repository_ctx):
     enable_rocm = get_host_environ(repository_ctx, "TF_NEED_ROCM")
@@ -500,31 +454,10 @@ def _create_local_rocm_repository(repository_ctx):
         repository_dict,
     )
 
-    # Set up crosstool/
-    rocm_defines = {}
-    rocm_defines["%{linker_bin_path}"] = rocm_config.rocm_toolkit_path + "/usr/bin"
-
-    rocm_defines["%{cxx_builtin_include_directories}"] = to_list_of_strings(
-        _rocm_include_path(repository_ctx, rocm_config),
-    )
-
-    rocm_defines["%{unfiltered_compile_flags}"] = to_list_of_strings([
-        "-DTENSORFLOW_USE_ROCM=1",
-        "-D__HIP_PLATFORM_AMD__",
-        "-DEIGEN_USE_HIP",
-        "-DUSE_ROCM",
-    ])
-
-    # Use wrapper as the host compiler path for the toolchain
-    rocm_defines["%{host_compiler_path}"] = "clang/bin/crosstool_wrapper_driver_is_not_gcc"
-
-    verify_build_defines(rocm_defines)
-
     # Only expand template variables in the BUILD file
     repository_ctx.template(
         "crosstool/BUILD",
         tpl_paths["crosstool:BUILD.rocm"],
-        rocm_defines,
     )
 
     # No templating of cc_toolchain_config - use attributes and templatize the
@@ -532,20 +465,12 @@ def _create_local_rocm_repository(repository_ctx):
     repository_ctx.template(
         "crosstool/cc_toolchain_config.bzl",
         tpl_paths["crosstool:hipcc_cc_toolchain_config.bzl"],
-        rocm_defines,
     )
 
     repository_ctx.template(
         "crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc",
         tpl_paths["crosstool:clang/bin/crosstool_wrapper_driver_rocm"],
         {
-            "%{rocm_root}": "external/local_config_rocm/" + str(rocm_config.rocm_toolkit_path),
-            "%{hipcc_env}": _hipcc_env(repository_ctx),
-            "%{rocr_runtime_library}": "hsa-runtime64",
-            "%{crosstool_verbose}": "0",
-            "%{rocm_amdgpu_targets}": ",".join(
-                ["%s" % c for c in rocm_config.amdgpu_targets],
-            ),
             "%{tmpdir}": get_host_environ(
                 repository_ctx,
                 _TMPDIR,

--- a/workspace3.bzl
+++ b/workspace3.bzl
@@ -76,10 +76,10 @@ def workspace():
     # Details: https://github.com/google-ml-infra/rules_ml_toolchain
     tf_http_archive(
         name = "rules_ml_toolchain",
-        sha256 = "8b33d5ab357623ba31ec463347371163aa2078b70752be0b44fdb132b91687a0",
-        strip_prefix = "rules_ml_toolchain-236a498d8624bef88e35ce2518a833204b0db19f",
+        sha256 = "6175f1c60434fc88136c256e5d8a82b6411f89a325831ae0d05ddb894b6c2be9",
+        strip_prefix = "rules_ml_toolchain-fb28c6aca270cf05feba0602005263a5e3516c92",
         urls = tf_mirror_urls(
-            "https://github.com/google-ml-infra/rules_ml_toolchain/archive/236a498d8624bef88e35ce2518a833204b0db19f.tar.gz",
+            "https://github.com/google-ml-infra/rules_ml_toolchain/archive/fb28c6aca270cf05feba0602005263a5e3516c92.tar.gz",
         ),
     )
 


### PR DESCRIPTION
📝 Summary of Changes
Use hipcc_configure to setup non hermetic llvm toolchain

🎯 Justification
Move hipcc related logic from local_config_rocm to hipcc_configure, fix
non herfmetic rocm toolchain

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup,

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI