### PR TITLE
[xla:ffi] Use FFI buffer matchers/verifiers in XLA/SE custom calls

### DIFF
--- a/docs/custom_call.md
+++ b/docs/custom_call.md
@@ -233,6 +233,29 @@ dimensions must have the same size. The `Match` call above therefore accepts
 only square matrices. Dimension captures are written only after the complete
 pattern succeeds and are unchanged on failure.
 
+Whole-buffer relationships do not require capturing every dimension.
+`WithShapeOf` matches the complete runtime shape of another buffer while
+allowing a different dtype. `Like` also requires the same dtype:
+
+```c++
+Error VerifySortBuffers(AnyBuffer keys, AnyBuffer values,
+                        Result<AnyBuffer> keys_output) {
+  Error error =
+      Verify("values", values, m::Buffer().WithShapeOf(keys));
+  if (error.failure()) {
+    return error;
+  }
+
+  return Verify("keys output", *keys_output, m::Buffer().Like(keys));
+}
+```
+
+Both modifiers copy the reference buffer's metadata when the pattern is built;
+the pattern does not retain a reference to the buffer. Because these are
+runtime constraints, they do not refine an `AnyBuffer` to a concrete return
+type. They are primarily useful with `Verify`, or with `Match` when the input
+buffer already has a concrete type.
+
 Use `Verify` when the buffer should keep its existing type, or when a pattern
 accepts more than one data type or rank. For example, an index buffer can accept
 either `S32` or `S64` and dispatch on its data type after verification:

--- a/xla/backends/gpu/runtime/runtime_intrinsics.cc
+++ b/xla/backends/gpu/runtime/runtime_intrinsics.cc
@@ -62,9 +62,9 @@ std::string GetGpuPlatformName() {
       PlatformUtil::CanonicalPlatformName("gpu").value());
 }
 
-absl::Status AssertionCustomCall(
-    se::Stream* stream, ffi::Buffer<PRED> buffer, absl::string_view error_msg,
-    xla::ffi::Result<xla::ffi::Buffer<xla::TOKEN>> res) {
+absl::Status AssertionCustomCall(se::Stream* stream, ffi::BufferR0<PRED> buffer,
+                                 absl::string_view error_msg,
+                                 ffi::Result<ffi::Token> res) {
   if (!stream) {
     return Internal("Stream is nullptr.");
   }
@@ -106,7 +106,7 @@ absl::StatusOr<Literal> ConvertToLiteral(se::Stream* stream,
 
 absl::Status DebugPrintCustomCall(se::Stream* stream, ffi::RemainingArgs args,
                                   absl::string_view format,
-                                  ffi::Result<ffi::Buffer<xla::TOKEN>> res) {
+                                  ffi::Result<ffi::Token> res) {
   if (!stream) {
     return Internal("Stream is nullptr.");
   }
@@ -151,7 +151,7 @@ std::string GetUniqueFilenameForHost() {
 absl::Status AppendToFileCustomCall(se::Stream* stream, ffi::AnyBuffer buffer,
                                     absl::string_view dir,
                                     absl::string_view metadata,
-                                    ffi::Result<ffi::Buffer<xla::TOKEN>> res) {
+                                    ffi::Result<ffi::Token> res) {
   if (!stream) {
     return Internal("Stream is nullptr.");
   }
@@ -196,7 +196,7 @@ XLA_FFI_DEFINE_HANDLER(kXlaGpuDebugPrintCustomCall, DebugPrintCustomCall,
                            .Ctx<ffi::Stream>()
                            .RemainingArgs()
                            .Attr<absl::string_view>("format")
-                           .Ret<xla::ffi::Buffer<xla::TOKEN>>());
+                           .Ret<ffi::Token>());
 
 XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), kXlaGpuDebugPrintCustomCallTag,
                          GetGpuPlatformName(), kXlaGpuDebugPrintCustomCall);
@@ -207,7 +207,7 @@ XLA_FFI_DEFINE_HANDLER(kXlaGpuAppendToFileCustomCall, AppendToFileCustomCall,
                            .Arg<ffi::AnyBuffer>()
                            .Attr<absl::string_view>("dir")
                            .Attr<absl::string_view>("metadata")
-                           .Ret<xla::ffi::Buffer<xla::TOKEN>>());
+                           .Ret<ffi::Token>());
 
 XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), kXlaGpuAppendToFileCustomCallTag,
                          GetGpuPlatformName(), kXlaGpuAppendToFileCustomCall);
@@ -215,9 +215,9 @@ XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), kXlaGpuAppendToFileCustomCallTag,
 XLA_FFI_DEFINE_HANDLER(kXlaGpuAssertCustomCall, AssertionCustomCall,
                        ffi::Ffi::Bind()
                            .Ctx<ffi::Stream>()
-                           .Arg<ffi::Buffer<xla::PRED>>()
+                           .Arg<ffi::BufferR0<xla::PRED>>()
                            .Attr<absl::string_view>("error_msg")
-                           .Ret<xla::ffi::Buffer<xla::TOKEN>>());
+                           .Ret<ffi::Token>());
 
 XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), kXlaGpuAssertCustomCallTag,
                          GetGpuPlatformName(), kXlaGpuAssertCustomCall);

--- a/xla/backends/gpu/runtime/thunk_buffer_debug_checksum.cc
+++ b/xla/backends/gpu/runtime/thunk_buffer_debug_checksum.cc
@@ -140,7 +140,7 @@ std::unique_ptr<Thunk> WrapWithChecksumThunk(
 absl::Status DumpBufferDebugChecksumLog(
     std::shared_ptr<BufferDebugLogEntryMetadataStore> metadata_store,
     se::Stream* stream, const HloComputation* absl_nonnull hlo_computation,
-    xla::ffi::Buffer<U8> log_buffer) {
+    ffi::BufferR1<U8> log_buffer) {
   VLOG(1) << "HLO computation ptr: " << hlo_computation;
   const HloModule* hlo_module = hlo_computation->parent();
   VLOG(1) << "HLO module ptr: " << hlo_module;
@@ -164,12 +164,12 @@ absl::Status DumpBufferDebugChecksumLog(
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(
     kBufferDebugChecksumLogInitHandler,
-    [](se::Stream* absl_nonnull stream, xla::ffi::Buffer<U8> log_buffer) {
+    [](se::Stream* absl_nonnull stream, ffi::BufferR1<U8> log_buffer) {
       return se::gpu::BufferDebugLog<BufferDebugLogEntry>::CreateOnDevice(
                  *stream, log_buffer.device_memory())
           .status();
     },
-    xla::ffi::Ffi::Bind().Ctx<xla::ffi::Stream>().Arg<xla::ffi::Buffer<U8>>());
+    xla::ffi::Ffi::Bind().Ctx<xla::ffi::Stream>().Arg<ffi::BufferR1<U8>>());
 
 absl::StatusOr<std::unique_ptr<CustomCallThunk>> CreateDebugInitThunk(
     BufferAllocation::Slice log_slice,
@@ -202,7 +202,7 @@ absl::StatusOr<std::unique_ptr<CustomCallThunk>> CreateBufferDebugDumpThunk(
       xla::ffi::Ffi::Bind()
           .Ctx<xla::ffi::Stream>()
           .Ctx<xla::ffi::CalledComputation>()
-          .Arg<xla::ffi::Buffer<U8>>()
+          .Arg<ffi::BufferR1<U8>>()
           .To(absl::bind_front(DumpBufferDebugChecksumLog, metadata_store));
   return CustomCallThunk::Create(
       Thunk::ThunkInfo(), "xla_gpu_buffer_debug_log_dump",

--- a/xla/backends/gpu/runtime/thunk_buffer_debug_float_check.cc
+++ b/xla/backends/gpu/runtime/thunk_buffer_debug_float_check.cc
@@ -154,14 +154,15 @@ absl::Status BackupBuffers(size_t num_buffers, se::Stream* stream,
     return absl::InternalError("Mismatch in backup buffer count");
   }
   for (size_t i = 0; i < num_buffers; ++i) {
-    ASSIGN_OR_RETURN(auto active_buf,
-                     remaining_args.get<xla::ffi::AnyBuffer>(i));
+    ASSIGN_OR_RETURN(auto active_buf, remaining_args.get<ffi::BufferR1<U8>>(i));
     ASSIGN_OR_RETURN(auto backup_buf,
-                     remaining_args.get<xla::ffi::AnyBuffer>(num_buffers + i));
+                     remaining_args.get<ffi::BufferR1<U8>>(num_buffers + i));
+
+    RETURN_IF_ERROR(
+        xla::ffi::Verify("backup", backup_buf,
+                         xla::ffi::match::Buffer().WithShapeOf(active_buf)));
+
     if (active_buf.size_bytes() == 0) continue;
-    if (active_buf.size_bytes() != backup_buf.size_bytes()) {
-      return absl::InternalError("Backup buffer size mismatch");
-    }
     se::DeviceMemoryBase active_ptr(
         const_cast<void*>(active_buf.untyped_data()), active_buf.size_bytes());
     se::DeviceMemoryBase backup_ptr(
@@ -229,7 +230,7 @@ absl::Status DumpHloSnapshot(
               size_t backup_arg_index = it->second;
               ASSIGN_OR_RETURN(
                   auto backup_buf,
-                  remaining_args.get<xla::ffi::AnyBuffer>(backup_arg_index));
+                  remaining_args.get<ffi::BufferR1<U8>>(backup_arg_index));
               if (backup_buf.size_bytes() < any_buf.size_bytes()) {
                 return absl::InternalError("Backup buffer size mismatch");
               }
@@ -299,8 +300,7 @@ absl::Status FloatCheckCrashDump(
         backup_index_map,
     const HloInstruction* absl_nonnull instr,
     std::vector<BufferAllocation::Slice> operand_slices, se::Stream* stream,
-    xla::ffi::Buffer<PrimitiveType::U8> log_buffer,
-    xla::ffi::RemainingArgs remaining_args) {
+    ffi::BufferR1<U8> log_buffer, xla::ffi::RemainingArgs remaining_args) {
   auto buffer_debug_log = se::gpu::BufferDebugLog<BufferDebugFloatCheckEntry>::
       FromDeviceAddressUnchecked(log_buffer.device_memory());
   ASSIGN_OR_RETURN(std::vector<BufferDebugFloatCheckEntry> entries,
@@ -478,7 +478,7 @@ absl::StatusOr<std::unique_ptr<Thunk>> WrapWithSyncDumpThunk(
   dump_bundle.execute =
       xla::ffi::Ffi::Bind()
           .Ctx<xla::ffi::Stream>()
-          .Arg<xla::ffi::Buffer<PrimitiveType::U8>>()
+          .Arg<ffi::BufferR1<U8>>()
           .RemainingArgs()
           .To(absl::bind_front(FloatCheckCrashDump, profile_annotation,
                                std::move(backup_index_map), instr,
@@ -682,7 +682,7 @@ EnabledChecks GetEnabledChecks(const HloModule* absl_nonnull hlo_module) {
 absl::Status BufferDebugFloatCheck(
     std::shared_ptr<BufferDebugLogEntryMetadataStore> metadata_store,
     se::Stream* stream, const HloComputation* absl_nonnull hlo_computation,
-    xla::ffi::Buffer<PrimitiveType::U8> log_buffer) {
+    ffi::BufferR1<U8> log_buffer) {
   VLOG(1) << "HLO computation ptr: " << hlo_computation;
   const HloModule* hlo_module = hlo_computation->parent();
   VLOG(1) << "HLO module ptr: " << hlo_module;
@@ -741,15 +741,12 @@ absl::Status BufferDebugFloatCheck(
 
 XLA_FFI_DEFINE_HANDLER_SYMBOL(
     kBufferDebugFloatCheckLogInitHandler,
-    [](se::Stream* absl_nonnull stream,
-       xla::ffi::Buffer<PrimitiveType::U8> log_buffer) {
+    [](se::Stream* absl_nonnull stream, ffi::BufferR1<U8> log_buffer) {
       return se::gpu::BufferDebugLog<xla::gpu::BufferDebugFloatCheckEntry>::
           CreateOnDevice(*stream, log_buffer.device_memory())
               .status();
     },
-    xla::ffi::Ffi::Bind()
-        .Ctx<xla::ffi::Stream>()
-        .Arg<xla::ffi::Buffer<PrimitiveType::U8>>());
+    xla::ffi::Ffi::Bind().Ctx<xla::ffi::Stream>().Arg<ffi::BufferR1<U8>>());
 
 absl::StatusOr<std::unique_ptr<CustomCallThunk>> CreateDebugInitThunk(
     BufferAllocation::Slice log_slice,
@@ -783,7 +780,7 @@ CreateBufferDebugFloatCheckThunk(
       xla::ffi::Ffi::Bind()
           .Ctx<xla::ffi::Stream>()
           .Ctx<xla::ffi::CalledComputation>()
-          .Arg<xla::ffi::Buffer<PrimitiveType::U8>>()
+          .Arg<ffi::BufferR1<U8>>()
           .To(absl::bind_front(BufferDebugFloatCheck, metadata_store));
   return CustomCallThunk::Create(
       Thunk::ThunkInfo(), "xla_gpu_buffer_debug_float_check",

--- a/xla/ffi/api/api.h
+++ b/xla/ffi/api/api.h
@@ -1233,6 +1233,27 @@ class BufferPatternBase {
     return BufferPatternBase<WithDTypeSet, Ranks>(*this);
   }
 
+  // Constrains the complete shape to match `buffer`.
+  template <typename Buffer>
+  auto WithShapeOf(Buffer buffer) const {
+    using Pattern = BufferPatternBase<DTypes, RankSet<>>;
+    Pattern pattern(*this);
+    auto dimensions = buffer.dimensions();
+    pattern.rank_ = dimensions.size();
+    pattern.dimensions_.assign(dimensions.begin(), dimensions.end());
+    return pattern;
+  }
+
+  // Constrains the dtype and complete shape to match `buffer`.
+  template <typename Buffer>
+  auto Like(Buffer buffer) const {
+    auto shape = WithShapeOf(buffer);
+    using Pattern = BufferPatternBase<DTypeSet<DType>, RankSet<>>;
+    Pattern pattern(shape);
+    pattern.dtype_ = buffer.element_type();
+    return pattern;
+  }
+
   // Constrains every dimension positionally and deduces the type-level rank
   // from the number of arguments.
   template <typename... Args,
@@ -1266,8 +1287,19 @@ class BufferPatternBase {
       return false;
     }
 
+    if (dtype_.has_value() && buffer.element_type() != *dtype_) {
+      os << "expected dtype " << ValuePrinter<DType>{*dtype_} << " but got "
+         << ValuePrinter<DType>{buffer.element_type()};
+      return false;
+    }
+
     auto dimensions = buffer.dimensions();
     if (!RankValues<Ranks>::Match(dimensions.size(), os)) {
+      return false;
+    }
+
+    if (rank_.has_value() && dimensions.size() != *rank_) {
+      os << "expected rank " << *rank_ << " but got " << dimensions.size();
       return false;
     }
 
@@ -1319,9 +1351,15 @@ class BufferPatternBase {
       os << " with ";
       DTypeValues<DTypes>::DescribeTo(os);
     }
+    if (dtype_.has_value()) {
+      os << " with dtype " << ValuePrinter<DType>{*dtype_};
+    }
     if (!RankValues<Ranks>::empty()) {
       os << " with ";
       RankValues<Ranks>::DescribeTo(os);
+    }
+    if (rank_.has_value()) {
+      os << " with rank " << *rank_;
     }
     if (!dimensions_.empty()) {
       os << " with dimensions [";
@@ -1342,8 +1380,23 @@ class BufferPatternBase {
   template <typename OtherDTypes, typename OtherRanks>
   explicit BufferPatternBase(
       const BufferPatternBase<OtherDTypes, OtherRanks>& other)
-      : dimensions_(other.dimensions_) {}
+      : dtype_(other.dtype_),
+        rank_(other.rank_),
+        dimensions_(other.dimensions_) {
+    // A constraint has either a type-level or runtime representation, never
+    // both. Type-changing modifiers replace the corresponding runtime value.
+    if constexpr (DTypes::size() != 0) {
+      dtype_.reset();
+    }
+    if constexpr (Ranks::size() != 0) {
+      rank_.reset();
+    }
+  }
 
+  // Runtime constraints copied from another buffer. Each is present only when
+  // the corresponding type-level set is empty.
+  std::optional<DType> dtype_;
+  std::optional<size_t> rank_;
   // Positional dimension constraints. Unconstrained positions (the gaps left by
   // WithDim) hold a catch-all DimPattern that matches any extent.
   std::vector<DimPattern> dimensions_;

--- a/xla/ffi/api/ffi_test.cc
+++ b/xla/ffi/api/ffi_test.cc
@@ -717,6 +717,79 @@ TEST(FfiTest, BufferMatchingVerifiesRankSet) {
               HasSubstr("expected rank to be one of [1, 2]"));
 }
 
+TEST(FfiTest, BufferMatchingMatchesShapeAndDTypeOfBuffer) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> reference_storage(6, 0.0f);
+  int64_t reference_dims[] = {2, 3};
+  XLA_FFI_Buffer reference_buffer = MakeBuffer(
+      F32, absl::MakeSpan(reference_storage), absl::MakeSpan(reference_dims));
+  AnyBuffer reference(&reference_buffer);
+
+  std::vector<float> matching_storage(6, 0.0f);
+  int64_t matching_dims[] = {2, 3};
+  XLA_FFI_Buffer matching_buffer = MakeBuffer(
+      F32, absl::MakeSpan(matching_storage), absl::MakeSpan(matching_dims));
+
+  auto like_reference = m::Buffer<S32, 1>().Like(reference).WithRank<2>();
+  Error matching =
+      Verify("matching", AnyBuffer(&matching_buffer), like_reference);
+  EXPECT_TRUE(matching.success());
+
+  Error static_rank_replaced =
+      Verify("static_rank_replaced", AnyBuffer(&matching_buffer),
+             m::Buffer<F32, 1>().WithShapeOf(reference));
+  EXPECT_TRUE(static_rank_replaced.success());
+
+  std::vector<int32_t> s32_storage(6, 0);
+  XLA_FFI_Buffer s32_buffer = MakeBuffer(S32, absl::MakeSpan(s32_storage),
+                                         absl::MakeSpan(matching_dims));
+  Error same_shape = Verify("same_shape", AnyBuffer(&s32_buffer),
+                            m::Buffer().WithShapeOf(reference));
+  EXPECT_TRUE(same_shape.success());
+
+  Error runtime_dtype_replaced =
+      Verify("runtime_dtype_replaced", AnyBuffer(&s32_buffer),
+             m::Buffer().Like(reference).WithDType<S32>());
+  EXPECT_TRUE(runtime_dtype_replaced.success());
+
+  int64_t rank_one_dims[] = {2};
+  XLA_FFI_Buffer rank_one_buffer = MakeBuffer(
+      F32, absl::MakeSpan(matching_storage), absl::MakeSpan(rank_one_dims));
+  Error runtime_rank_replaced = Verify(
+      "runtime_rank_replaced", AnyBuffer(&matching_buffer),
+      m::Buffer().WithShapeOf(AnyBuffer(&rank_one_buffer)).WithRank<2>());
+  EXPECT_TRUE(runtime_rank_replaced.success());
+
+  Error wrong_dtype =
+      Verify("wrong_dtype", AnyBuffer(&s32_buffer), like_reference);
+  ASSERT_TRUE(wrong_dtype.failure());
+  EXPECT_THAT(wrong_dtype.message(),
+              HasSubstr("expected dtype F32 but got S32"));
+
+  int64_t wrong_rank_dims[] = {6};
+  XLA_FFI_Buffer wrong_rank_buffer = MakeBuffer(
+      F32, absl::MakeSpan(matching_storage), absl::MakeSpan(wrong_rank_dims));
+  Error runtime_rank_replaced_by_dims =
+      Verify("runtime_rank_replaced_by_dims", AnyBuffer(&wrong_rank_buffer),
+             m::Buffer().WithShapeOf(reference).WithDims(6));
+  EXPECT_TRUE(runtime_rank_replaced_by_dims.success());
+
+  Error wrong_rank =
+      Verify("wrong_rank", AnyBuffer(&wrong_rank_buffer), like_reference);
+  ASSERT_TRUE(wrong_rank.failure());
+  EXPECT_THAT(wrong_rank.message(), HasSubstr("expected rank 2 but got 1"));
+
+  int64_t wrong_shape_dims[] = {3, 2};
+  XLA_FFI_Buffer wrong_shape_buffer = MakeBuffer(
+      F32, absl::MakeSpan(matching_storage), absl::MakeSpan(wrong_shape_dims));
+  Error wrong_shape =
+      Verify("wrong_shape", AnyBuffer(&wrong_shape_buffer), like_reference);
+  ASSERT_TRUE(wrong_shape.failure());
+  EXPECT_THAT(wrong_shape.message(),
+              HasSubstr("expected dimension 0 to be 2 but got 3"));
+}
+
 TEST(FfiTest, BufferMatchingCompositionIsOrderIndependent) {
   namespace m = ::xla::ffi::match;
 
@@ -2137,6 +2210,30 @@ void BM_MatchPrebuiltAnyBuffer(benchmark::State& state) {
 }
 
 BENCHMARK(BM_MatchPrebuiltAnyBuffer);
+
+//===----------------------------------------------------------------------===//
+// BM_VerifyLikeAnyBuffer
+//===----------------------------------------------------------------------===//
+
+void BM_VerifyLikeAnyBuffer(benchmark::State& state) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(1, 0.0f);
+  int64_t dims[] = {1, 1, 1, 1};
+  XLA_FFI_Buffer c_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+  AnyBuffer buffer(&c_buffer);
+
+  CHECK(Verify("buffer", buffer, m::Buffer().Like(buffer)).success());
+  for (auto _ : state) {
+    auto pattern = m::Buffer().Like(buffer);
+    benchmark::DoNotOptimize(pattern);
+    Error error = Verify("buffer", buffer, pattern);
+    benchmark::DoNotOptimize(error);
+  }
+}
+
+BENCHMARK(BM_VerifyLikeAnyBuffer);
 
 //===----------------------------------------------------------------------===//
 // BM_MatchAnyBuffer

--- a/xla/ffi/ffi_test.cc
+++ b/xla/ffi/ffi_test.cc
@@ -773,6 +773,69 @@ TEST(FfiTest, BufferMatchingVerifiesRankSet) {
                              HasSubstr("expected rank to be one of [1, 2]")));
 }
 
+TEST(FfiTest, BufferMatchingMatchesShapeAndDTypeOfBuffer) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> reference_storage(6, 0.0f);
+  int64_t reference_dims[] = {2, 3};
+  XLA_FFI_Buffer reference_buffer = MakeBuffer(
+      F32, absl::MakeSpan(reference_storage), absl::MakeSpan(reference_dims));
+  AnyBuffer reference(&reference_buffer);
+
+  std::vector<float> matching_storage(6, 0.0f);
+  int64_t matching_dims[] = {2, 3};
+  XLA_FFI_Buffer matching_buffer = MakeBuffer(
+      F32, absl::MakeSpan(matching_storage), absl::MakeSpan(matching_dims));
+
+  auto like_reference = m::Buffer<S32, 1>().Like(reference).WithRank<2>();
+  ASSERT_OK(Verify("matching", AnyBuffer(&matching_buffer), like_reference));
+
+  ASSERT_OK(Verify("static_rank_replaced", AnyBuffer(&matching_buffer),
+                   m::Buffer<F32, 1>().WithShapeOf(reference)));
+
+  std::vector<int32_t> s32_storage(6, 0);
+  XLA_FFI_Buffer s32_buffer = MakeBuffer(S32, absl::MakeSpan(s32_storage),
+                                         absl::MakeSpan(matching_dims));
+  ASSERT_OK(Verify("same_shape", AnyBuffer(&s32_buffer),
+                   m::Buffer().WithShapeOf(reference)));
+
+  ASSERT_OK(Verify("runtime_dtype_replaced", AnyBuffer(&s32_buffer),
+                   m::Buffer().Like(reference).WithDType<S32>()));
+
+  int64_t rank_one_dims[] = {2};
+  XLA_FFI_Buffer rank_one_buffer = MakeBuffer(
+      F32, absl::MakeSpan(matching_storage), absl::MakeSpan(rank_one_dims));
+  ASSERT_OK(Verify(
+      "runtime_rank_replaced", AnyBuffer(&matching_buffer),
+      m::Buffer().WithShapeOf(AnyBuffer(&rank_one_buffer)).WithRank<2>()));
+
+  EXPECT_THAT(
+      Verify("wrong_dtype", AnyBuffer(&s32_buffer), like_reference),
+      absl_testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                             HasSubstr("expected dtype f32 but got s32")));
+
+  int64_t wrong_rank_dims[] = {6};
+  XLA_FFI_Buffer wrong_rank_buffer = MakeBuffer(
+      F32, absl::MakeSpan(matching_storage), absl::MakeSpan(wrong_rank_dims));
+  ASSERT_OK(Verify("runtime_rank_replaced_by_dims",
+                   AnyBuffer(&wrong_rank_buffer),
+                   m::Buffer().WithShapeOf(reference).WithDims(6)));
+
+  EXPECT_THAT(
+      Verify("wrong_rank", AnyBuffer(&wrong_rank_buffer), like_reference),
+      absl_testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                             HasSubstr("expected rank 2 but got 1")));
+
+  int64_t wrong_shape_dims[] = {3, 2};
+  XLA_FFI_Buffer wrong_shape_buffer = MakeBuffer(
+      F32, absl::MakeSpan(matching_storage), absl::MakeSpan(wrong_shape_dims));
+  EXPECT_THAT(
+      Verify("wrong_shape", AnyBuffer(&wrong_shape_buffer), like_reference),
+      absl_testing::StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          HasSubstr("expected dimension 0 to be 2 but got 3")));
+}
+
 TEST(FfiTest, BufferMatchingCompositionIsOrderIndependent) {
   namespace m = ::xla::ffi::match;
 
@@ -1645,6 +1708,30 @@ void BM_MatchPrebuiltAnyBuffer(benchmark::State& state) {
 }
 
 BENCHMARK(BM_MatchPrebuiltAnyBuffer);
+
+//===----------------------------------------------------------------------===//
+// BM_VerifyLikeAnyBuffer
+//===----------------------------------------------------------------------===//
+
+void BM_VerifyLikeAnyBuffer(benchmark::State& state) {
+  namespace m = ::xla::ffi::match;
+
+  std::vector<float> storage(1, 0.0f);
+  int64_t dims[] = {1, 1, 1, 1};
+  XLA_FFI_Buffer c_buffer =
+      MakeBuffer(F32, absl::MakeSpan(storage), absl::MakeSpan(dims));
+  AnyBuffer buffer(&c_buffer);
+
+  CHECK_OK(Verify("buffer", buffer, m::Buffer().Like(buffer)));
+  for (auto _ : state) {
+    auto pattern = m::Buffer().Like(buffer);
+    benchmark::DoNotOptimize(pattern);
+    absl::Status status = Verify("buffer", buffer, pattern);
+    benchmark::DoNotOptimize(status);
+  }
+}
+
+BENCHMARK(BM_VerifyLikeAnyBuffer);
 
 //===----------------------------------------------------------------------===//
 // BM_MatchAnyBuffer

--- a/xla/stream_executor/cuda/cub_scan_kernel_cuda.cc
+++ b/xla/stream_executor/cuda/cub_scan_kernel_cuda.cc
@@ -35,11 +35,16 @@ namespace stream_executor::cuda {
 
 namespace {
 
+namespace ffi = ::xla::ffi;
+
 absl::Status CubScanLaunchKernelFfiHandler(
-    xla::ffi::AnyBuffer d_in, xla::ffi::Result<xla::ffi::AnyBuffer> d_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, int64_t vector_length,
+    ffi::AnyBuffer d_in, ffi::Result<ffi::AnyBuffer> d_out,
+    ffi::Result<ffi::BufferR1<xla::U8>> d_temp_storage, int64_t vector_length,
     int64_t row_length, int64_t column_length, CubScanKind kind,
     bool is_reverse, CUstream stream) {
+  RETURN_IF_ERROR(
+      ffi::Verify("output", *d_out, ffi::match::Buffer().Like(d_in)));
+
   return CubScanLaunchKernel(
       d_in.element_type(), d_temp_storage->untyped_data(),
       d_temp_storage->size_bytes(), d_in.untyped_data(), d_out->untyped_data(),
@@ -63,26 +68,26 @@ absl::Status CubScanDummyExecuteFfiHandler() {
 }  // namespace
 
 XLA_FFI_DEFINE_HANDLER(kCubScanExecute, CubScanLaunchKernelFfiHandler,
-                       xla::ffi::Ffi::Bind()
-                           .Arg<xla::ffi::AnyBuffer>()  // d_in
-                           .Ret<xla::ffi::AnyBuffer>()  // d_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                       ffi::Ffi::Bind()
+                           .Arg<ffi::AnyBuffer>()          // d_in
+                           .Ret<ffi::AnyBuffer>()          // d_out
+                           .Ret<ffi::BufferR1<xla::U8>>()  // d_temp_storage
                            .Attr<int64_t>("vector_length")
                            .Attr<int64_t>("row_length")
                            .Attr<int64_t>("column_length")
                            .Attr<CubScanKind>("kind")
                            .Attr<bool>("is_reverse")
-                           .Ctx<xla::ffi::PlatformStream<CUstream>>(),
-                       {xla::ffi::Traits::kCmdBufferCompatible});
+                           .Ctx<ffi::PlatformStream<CUstream>>(),
+                       {ffi::Traits::kCmdBufferCompatible});
 
-XLA_FFI_REGISTER_HANDLER(xla::ffi::GetXlaFfiApi(),
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(),
                          xla::gpu::kCubDeviceScanTarget.data(), "CUDA",
                          {/*instantiate=*/nullptr, /*prepare=*/nullptr,
                           /*initialize=*/nullptr,
                           /*.execute=*/kCubScanExecute});
 
 XLA_FFI_DEFINE_HANDLER(kCubScanInstantiate, CubScanGetScratchSizeFfiHandler,
-                       xla::ffi::Ffi::BindInstantiate()
+                       ffi::Ffi::BindInstantiate()
                            .Attr<xla::PrimitiveType>("element_type")
                            .Attr<int64_t>("vector_length")
                            .Attr<int64_t>("row_length")
@@ -91,10 +96,10 @@ XLA_FFI_DEFINE_HANDLER(kCubScanInstantiate, CubScanGetScratchSizeFfiHandler,
                            .Attr<bool>("is_reverse"));
 
 XLA_FFI_DEFINE_HANDLER(kCubScanDummyExecute, CubScanDummyExecuteFfiHandler,
-                       xla::ffi::Ffi::Bind());
+                       ffi::Ffi::Bind());
 
 XLA_FFI_REGISTER_HANDLER(
-    xla::ffi::GetXlaFfiApi(),
+    ffi::GetXlaFfiApi(),
     xla::gpu::kCubDeviceScanUnassignedScratchSizeTarget.data(), "CUDA",
     {/*.instantiate=*/kCubScanInstantiate, /*prepare=*/nullptr,
      /*initialize=*/nullptr, /*execute=*/kCubScanDummyExecute});

--- a/xla/stream_executor/cuda/cub_sort_kernel_cuda.cc
+++ b/xla/stream_executor/cuda/cub_sort_kernel_cuda.cc
@@ -42,6 +42,8 @@ namespace stream_executor {
 namespace cuda {
 namespace {
 
+namespace ffi = ::xla::ffi;
+
 using SortKeysFn = cudaError_t (*)(void* d_temp_storage, size_t& temp_bytes,
                                    const void* d_keys_in, void* d_keys_out,
                                    size_t num_items, bool descending,
@@ -123,6 +125,22 @@ absl::StatusOr<SortPairsFn> GetSortPairsFn(xla::PrimitiveType key_type,
   }
 }
 
+absl::Status VerifySortKeysBuffers(ffi::AnyBuffer keys,
+                                   ffi::Result<ffi::AnyBuffer> keys_out) {
+  return ffi::Verify("keys output", *keys_out, ffi::match::Buffer().Like(keys));
+}
+
+absl::Status VerifySortPairsBuffers(ffi::AnyBuffer keys, ffi::AnyBuffer values,
+                                    ffi::Result<ffi::AnyBuffer> keys_out,
+                                    ffi::Result<ffi::AnyBuffer> values_out) {
+  RETURN_IF_ERROR(ffi::Verify("values input", values,
+                              ffi::match::Buffer().WithShapeOf(keys)));
+  RETURN_IF_ERROR(
+      ffi::Verify("keys output", *keys_out, ffi::match::Buffer().Like(keys)));
+  return ffi::Verify("values output", *values_out,
+                     ffi::match::Buffer().Like(values));
+}
+
 // Computes the scratch buffer size needed for CUB sort, including batch
 // offsets if batch_size > 1.
 absl::StatusOr<int64_t> ComputeScratchSize(SortKeysFn fn, int64_t num_items,
@@ -178,10 +196,11 @@ absl::Status CopyOffsets(void* scratch, size_t scratch_bytes,
 //   results:  [keys_out, scratch]
 
 absl::StatusOr<std::unique_ptr<int64_t>> CubSortKeysInstantiate(
-    xla::ffi::AnyBuffer d_keys_in,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, bool descending,
+    ffi::AnyBuffer d_keys_in, ffi::Result<ffi::AnyBuffer> d_keys_out,
+    ffi::Result<ffi::BufferR1<xla::U8>> d_temp_storage, bool descending,
     int64_t batch_size) {
+  RETURN_IF_ERROR(VerifySortKeysBuffers(d_keys_in, d_keys_out));
+
   ASSIGN_OR_RETURN(auto fn, GetSortKeysFn(d_keys_in.element_type()));
   int64_t num_items = d_keys_in.element_count();
   ASSIGN_OR_RETURN(int64_t scratch_size,
@@ -190,10 +209,11 @@ absl::StatusOr<std::unique_ptr<int64_t>> CubSortKeysInstantiate(
 }
 
 absl::Status CubSortKeysExecute(
-    xla::ffi::AnyBuffer d_keys_in,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, bool descending,
+    ffi::AnyBuffer d_keys_in, ffi::Result<ffi::AnyBuffer> d_keys_out,
+    ffi::Result<ffi::BufferR1<xla::U8>> d_temp_storage, bool descending,
     int64_t batch_size, CUstream stream) {
+  RETURN_IF_ERROR(VerifySortKeysBuffers(d_keys_in, d_keys_out));
+
   ASSIGN_OR_RETURN(auto fn, GetSortKeysFn(d_keys_in.element_type()));
   size_t num_items = d_keys_in.element_count();
   size_t temp_bytes = d_temp_storage->size_bytes();
@@ -208,23 +228,23 @@ absl::Status CubSortKeysExecute(
 }
 
 XLA_FFI_DEFINE_HANDLER(kCubSortKeysInstantiate, CubSortKeysInstantiate,
-                       xla::ffi::Ffi::BindInstantiate()
-                           .Arg<xla::ffi::AnyBuffer>()  // d_keys_in
-                           .Ret<xla::ffi::AnyBuffer>()  // d_keys_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                       ffi::Ffi::BindInstantiate()
+                           .Arg<ffi::AnyBuffer>()          // d_keys_in
+                           .Ret<ffi::AnyBuffer>()          // d_keys_out
+                           .Ret<ffi::BufferR1<xla::U8>>()  // d_temp_storage
                            .Attr<bool>("descending")
                            .Attr<int64_t>("batch_size"));
 
 XLA_FFI_DEFINE_HANDLER(kCubSortKeysExecute, CubSortKeysExecute,
-                       xla::ffi::Ffi::Bind()
-                           .Arg<xla::ffi::AnyBuffer>()  // d_keys_in
-                           .Ret<xla::ffi::AnyBuffer>()  // d_keys_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                       ffi::Ffi::Bind()
+                           .Arg<ffi::AnyBuffer>()          // d_keys_in
+                           .Ret<ffi::AnyBuffer>()          // d_keys_out
+                           .Ret<ffi::BufferR1<xla::U8>>()  // d_temp_storage
                            .Attr<bool>("descending")
                            .Attr<int64_t>("batch_size")
-                           .Ctx<xla::ffi::PlatformStream<CUstream>>());
+                           .Ctx<ffi::PlatformStream<CUstream>>());
 
-XLA_FFI_REGISTER_HANDLER(xla::ffi::GetXlaFfiApi(),
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(),
                          xla::gpu::kCubDeviceRadixSortKeysTarget.data(), "CUDA",
                          {/* .instantiate = */ kCubSortKeysInstantiate,
                           /* .prepare = */ nullptr,
@@ -240,11 +260,14 @@ XLA_FFI_REGISTER_HANDLER(xla::ffi::GetXlaFfiApi(),
 //   results:  [keys_out, values_out, scratch]
 
 absl::StatusOr<std::unique_ptr<int64_t>> CubSortPairsInstantiate(
-    xla::ffi::AnyBuffer d_keys_in, xla::ffi::AnyBuffer d_values_in,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_values_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, bool descending,
+    ffi::AnyBuffer d_keys_in, ffi::AnyBuffer d_values_in,
+    ffi::Result<ffi::AnyBuffer> d_keys_out,
+    ffi::Result<ffi::AnyBuffer> d_values_out,
+    ffi::Result<ffi::BufferR1<xla::U8>> d_temp_storage, bool descending,
     int64_t batch_size) {
+  RETURN_IF_ERROR(
+      VerifySortPairsBuffers(d_keys_in, d_values_in, d_keys_out, d_values_out));
+
   ASSIGN_OR_RETURN(auto fn, GetSortPairsFn(d_keys_in.element_type(),
                                            xla::primitive_util::BitWidth(
                                                d_values_in.element_type())));
@@ -255,11 +278,14 @@ absl::StatusOr<std::unique_ptr<int64_t>> CubSortPairsInstantiate(
 }
 
 absl::Status CubSortPairsExecute(
-    xla::ffi::AnyBuffer d_keys_in, xla::ffi::AnyBuffer d_values_in,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_values_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, bool descending,
+    ffi::AnyBuffer d_keys_in, ffi::AnyBuffer d_values_in,
+    ffi::Result<ffi::AnyBuffer> d_keys_out,
+    ffi::Result<ffi::AnyBuffer> d_values_out,
+    ffi::Result<ffi::BufferR1<xla::U8>> d_temp_storage, bool descending,
     int64_t batch_size, CUstream stream) {
+  RETURN_IF_ERROR(
+      VerifySortPairsBuffers(d_keys_in, d_values_in, d_keys_out, d_values_out));
+
   ASSIGN_OR_RETURN(auto fn, GetSortPairsFn(d_keys_in.element_type(),
                                            xla::primitive_util::BitWidth(
                                                d_values_in.element_type())));
@@ -277,27 +303,27 @@ absl::Status CubSortPairsExecute(
 }
 
 XLA_FFI_DEFINE_HANDLER(kCubSortPairsInstantiate, CubSortPairsInstantiate,
-                       xla::ffi::Ffi::BindInstantiate()
-                           .Arg<xla::ffi::AnyBuffer>()  // d_keys_in
-                           .Arg<xla::ffi::AnyBuffer>()  // d_values_in
-                           .Ret<xla::ffi::AnyBuffer>()  // d_keys_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_values_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                       ffi::Ffi::BindInstantiate()
+                           .Arg<ffi::AnyBuffer>()          // d_keys_in
+                           .Arg<ffi::AnyBuffer>()          // d_values_in
+                           .Ret<ffi::AnyBuffer>()          // d_keys_out
+                           .Ret<ffi::AnyBuffer>()          // d_values_out
+                           .Ret<ffi::BufferR1<xla::U8>>()  // d_temp_storage
                            .Attr<bool>("descending")
                            .Attr<int64_t>("batch_size"));
 
 XLA_FFI_DEFINE_HANDLER(kCubSortPairsExecute, CubSortPairsExecute,
-                       xla::ffi::Ffi::Bind()
-                           .Arg<xla::ffi::AnyBuffer>()  // d_keys_in
-                           .Arg<xla::ffi::AnyBuffer>()  // d_values_in
-                           .Ret<xla::ffi::AnyBuffer>()  // d_keys_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_values_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                       ffi::Ffi::Bind()
+                           .Arg<ffi::AnyBuffer>()          // d_keys_in
+                           .Arg<ffi::AnyBuffer>()          // d_values_in
+                           .Ret<ffi::AnyBuffer>()          // d_keys_out
+                           .Ret<ffi::AnyBuffer>()          // d_values_out
+                           .Ret<ffi::BufferR1<xla::U8>>()  // d_temp_storage
                            .Attr<bool>("descending")
                            .Attr<int64_t>("batch_size")
-                           .Ctx<xla::ffi::PlatformStream<CUstream>>());
+                           .Ctx<ffi::PlatformStream<CUstream>>());
 
-XLA_FFI_REGISTER_HANDLER(xla::ffi::GetXlaFfiApi(),
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(),
                          xla::gpu::kCubDeviceRadixSortPairsTarget.data(),
                          "CUDA",
                          {/* .instantiate = */ kCubSortPairsInstantiate,

--- a/xla/stream_executor/rocm/cub_scan_kernel_rocm.cc
+++ b/xla/stream_executor/rocm/cub_scan_kernel_rocm.cc
@@ -35,11 +35,16 @@ namespace stream_executor::rocm {
 
 namespace {
 
+namespace ffi = ::xla::ffi;
+
 absl::Status CubScanLaunchKernelFfiHandler(
-    xla::ffi::AnyBuffer d_in, xla::ffi::Result<xla::ffi::AnyBuffer> d_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, int64_t vector_length,
+    ffi::AnyBuffer d_in, ffi::Result<ffi::AnyBuffer> d_out,
+    ffi::Result<ffi::BufferR1<xla::U8>> d_temp_storage, int64_t vector_length,
     int64_t row_length, int64_t column_length, CubScanKind kind,
     bool is_reverse, hipStream_t stream) {
+  RETURN_IF_ERROR(
+      ffi::Verify("output", *d_out, ffi::match::Buffer().Like(d_in)));
+
   return CubScanLaunchKernel(
       d_in.element_type(), d_temp_storage->untyped_data(),
       d_temp_storage->size_bytes(), d_in.untyped_data(), d_out->untyped_data(),
@@ -63,26 +68,26 @@ absl::Status CubScanDummyExecuteFfiHandler() {
 }  // namespace
 
 XLA_FFI_DEFINE_HANDLER(kCubScanExecute, CubScanLaunchKernelFfiHandler,
-                       xla::ffi::Ffi::Bind()
-                           .Arg<xla::ffi::AnyBuffer>()  // d_in
-                           .Ret<xla::ffi::AnyBuffer>()  // d_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                       ffi::Ffi::Bind()
+                           .Arg<ffi::AnyBuffer>()          // d_in
+                           .Ret<ffi::AnyBuffer>()          // d_out
+                           .Ret<ffi::BufferR1<xla::U8>>()  // d_temp_storage
                            .Attr<int64_t>("vector_length")
                            .Attr<int64_t>("row_length")
                            .Attr<int64_t>("column_length")
                            .Attr<CubScanKind>("kind")
                            .Attr<bool>("is_reverse")
-                           .Ctx<xla::ffi::PlatformStream<hipStream_t>>(),
-                       {xla::ffi::Traits::kCmdBufferCompatible});
+                           .Ctx<ffi::PlatformStream<hipStream_t>>(),
+                       {ffi::Traits::kCmdBufferCompatible});
 
-XLA_FFI_REGISTER_HANDLER(xla::ffi::GetXlaFfiApi(),
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(),
                          xla::gpu::kCubDeviceScanTarget.data(), "ROCM",
                          {/*instantiate=*/nullptr, /*prepare=*/nullptr,
                           /*initialize=*/nullptr,
                           /*.execute=*/kCubScanExecute});
 
 XLA_FFI_DEFINE_HANDLER(kCubScanInstantiate, CubScanGetScratchSizeFfiHandler,
-                       xla::ffi::Ffi::BindInstantiate()
+                       ffi::Ffi::BindInstantiate()
                            .Attr<xla::PrimitiveType>("element_type")
                            .Attr<int64_t>("vector_length")
                            .Attr<int64_t>("row_length")
@@ -91,10 +96,10 @@ XLA_FFI_DEFINE_HANDLER(kCubScanInstantiate, CubScanGetScratchSizeFfiHandler,
                            .Attr<bool>("is_reverse"));
 
 XLA_FFI_DEFINE_HANDLER(kCubScanDummyExecute, CubScanDummyExecuteFfiHandler,
-                       xla::ffi::Ffi::Bind());
+                       ffi::Ffi::Bind());
 
 XLA_FFI_REGISTER_HANDLER(
-    xla::ffi::GetXlaFfiApi(),
+    ffi::GetXlaFfiApi(),
     xla::gpu::kCubDeviceScanUnassignedScratchSizeTarget.data(), "ROCM",
     {/*.instantiate=*/kCubScanInstantiate, /*prepare=*/nullptr,
      /*initialize=*/nullptr, /*execute=*/kCubScanDummyExecute});

--- a/xla/stream_executor/rocm/cub_sort_kernel_rocm.cc
+++ b/xla/stream_executor/rocm/cub_sort_kernel_rocm.cc
@@ -38,6 +38,8 @@ namespace stream_executor {
 namespace rocm {
 namespace {
 
+namespace ffi = ::xla::ffi;
+
 using SortKeysFn = absl::Status (*)(void* d_temp_storage, size_t& temp_bytes,
                                     const void* d_keys_in, void* d_keys_out,
                                     size_t num_items, bool descending,
@@ -120,6 +122,22 @@ absl::StatusOr<SortPairsFn> GetSortPairsFn(xla::PrimitiveType key_type,
   }
 }
 
+absl::Status VerifySortKeysBuffers(ffi::AnyBuffer keys,
+                                   ffi::Result<ffi::AnyBuffer> keys_out) {
+  return ffi::Verify("keys output", *keys_out, ffi::match::Buffer().Like(keys));
+}
+
+absl::Status VerifySortPairsBuffers(ffi::AnyBuffer keys, ffi::AnyBuffer values,
+                                    ffi::Result<ffi::AnyBuffer> keys_out,
+                                    ffi::Result<ffi::AnyBuffer> values_out) {
+  RETURN_IF_ERROR(ffi::Verify("values input", values,
+                              ffi::match::Buffer().WithShapeOf(keys)));
+  RETURN_IF_ERROR(
+      ffi::Verify("keys output", *keys_out, ffi::match::Buffer().Like(keys)));
+  return ffi::Verify("values output", *values_out,
+                     ffi::match::Buffer().Like(values));
+}
+
 // Computes the scratch buffer size needed for CUB sort, including batch
 // offsets if batch_size > 1.
 absl::StatusOr<int64_t> ComputeScratchSize(SortKeysFn fn, int64_t num_items,
@@ -179,10 +197,11 @@ absl::Status CopyOffsets(void* scratch, size_t scratch_bytes,
 //   results:  [keys_out, scratch]
 
 absl::StatusOr<std::unique_ptr<int64_t>> CubSortKeysInstantiate(
-    xla::ffi::AnyBuffer d_keys_in,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, bool descending,
+    ffi::AnyBuffer d_keys_in, ffi::Result<ffi::AnyBuffer> d_keys_out,
+    ffi::Result<ffi::BufferR1<xla::U8>> d_temp_storage, bool descending,
     int64_t batch_size) {
+  RETURN_IF_ERROR(VerifySortKeysBuffers(d_keys_in, d_keys_out));
+
   ASSIGN_OR_RETURN(auto fn, GetSortKeysFn(d_keys_in.element_type()));
   int64_t num_items = d_keys_in.element_count();
   ASSIGN_OR_RETURN(int64_t scratch_size,
@@ -191,10 +210,11 @@ absl::StatusOr<std::unique_ptr<int64_t>> CubSortKeysInstantiate(
 }
 
 absl::Status CubSortKeysExecute(
-    xla::ffi::AnyBuffer d_keys_in,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, bool descending,
+    ffi::AnyBuffer d_keys_in, ffi::Result<ffi::AnyBuffer> d_keys_out,
+    ffi::Result<ffi::BufferR1<xla::U8>> d_temp_storage, bool descending,
     int64_t batch_size, hipStream_t stream) {
+  RETURN_IF_ERROR(VerifySortKeysBuffers(d_keys_in, d_keys_out));
+
   ASSIGN_OR_RETURN(auto fn, GetSortKeysFn(d_keys_in.element_type()));
   size_t num_items = d_keys_in.element_count();
   size_t temp_bytes = d_temp_storage->size_bytes();
@@ -209,23 +229,23 @@ absl::Status CubSortKeysExecute(
 }
 
 XLA_FFI_DEFINE_HANDLER(kCubSortKeysInstantiate, CubSortKeysInstantiate,
-                       xla::ffi::Ffi::BindInstantiate()
-                           .Arg<xla::ffi::AnyBuffer>()  // d_keys_in
-                           .Ret<xla::ffi::AnyBuffer>()  // d_keys_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                       ffi::Ffi::BindInstantiate()
+                           .Arg<ffi::AnyBuffer>()          // d_keys_in
+                           .Ret<ffi::AnyBuffer>()          // d_keys_out
+                           .Ret<ffi::BufferR1<xla::U8>>()  // d_temp_storage
                            .Attr<bool>("descending")
                            .Attr<int64_t>("batch_size"));
 
 XLA_FFI_DEFINE_HANDLER(kCubSortKeysExecute, CubSortKeysExecute,
-                       xla::ffi::Ffi::Bind()
-                           .Arg<xla::ffi::AnyBuffer>()  // d_keys_in
-                           .Ret<xla::ffi::AnyBuffer>()  // d_keys_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                       ffi::Ffi::Bind()
+                           .Arg<ffi::AnyBuffer>()          // d_keys_in
+                           .Ret<ffi::AnyBuffer>()          // d_keys_out
+                           .Ret<ffi::BufferR1<xla::U8>>()  // d_temp_storage
                            .Attr<bool>("descending")
                            .Attr<int64_t>("batch_size")
-                           .Ctx<xla::ffi::PlatformStream<hipStream_t>>());
+                           .Ctx<ffi::PlatformStream<hipStream_t>>());
 
-XLA_FFI_REGISTER_HANDLER(xla::ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_keys",
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_keys",
                          "ROCM",
                          {/* .instantiate = */ kCubSortKeysInstantiate,
                           /* .prepare = */ nullptr,
@@ -241,11 +261,14 @@ XLA_FFI_REGISTER_HANDLER(xla::ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_keys",
 //   results:  [keys_out, values_out, scratch]
 
 absl::StatusOr<std::unique_ptr<int64_t>> CubSortPairsInstantiate(
-    xla::ffi::AnyBuffer d_keys_in, xla::ffi::AnyBuffer d_values_in,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_values_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, bool descending,
+    ffi::AnyBuffer d_keys_in, ffi::AnyBuffer d_values_in,
+    ffi::Result<ffi::AnyBuffer> d_keys_out,
+    ffi::Result<ffi::AnyBuffer> d_values_out,
+    ffi::Result<ffi::BufferR1<xla::U8>> d_temp_storage, bool descending,
     int64_t batch_size) {
+  RETURN_IF_ERROR(
+      VerifySortPairsBuffers(d_keys_in, d_values_in, d_keys_out, d_values_out));
+
   ASSIGN_OR_RETURN(auto fn, GetSortPairsFn(d_keys_in.element_type(),
                                            xla::primitive_util::BitWidth(
                                                d_values_in.element_type())));
@@ -256,11 +279,14 @@ absl::StatusOr<std::unique_ptr<int64_t>> CubSortPairsInstantiate(
 }
 
 absl::Status CubSortPairsExecute(
-    xla::ffi::AnyBuffer d_keys_in, xla::ffi::AnyBuffer d_values_in,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_keys_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_values_out,
-    xla::ffi::Result<xla::ffi::AnyBuffer> d_temp_storage, bool descending,
+    ffi::AnyBuffer d_keys_in, ffi::AnyBuffer d_values_in,
+    ffi::Result<ffi::AnyBuffer> d_keys_out,
+    ffi::Result<ffi::AnyBuffer> d_values_out,
+    ffi::Result<ffi::BufferR1<xla::U8>> d_temp_storage, bool descending,
     int64_t batch_size, hipStream_t stream) {
+  RETURN_IF_ERROR(
+      VerifySortPairsBuffers(d_keys_in, d_values_in, d_keys_out, d_values_out));
+
   ASSIGN_OR_RETURN(auto fn, GetSortPairsFn(d_keys_in.element_type(),
                                            xla::primitive_util::BitWidth(
                                                d_values_in.element_type())));
@@ -278,27 +304,27 @@ absl::Status CubSortPairsExecute(
 }
 
 XLA_FFI_DEFINE_HANDLER(kCubSortPairsInstantiate, CubSortPairsInstantiate,
-                       xla::ffi::Ffi::BindInstantiate()
-                           .Arg<xla::ffi::AnyBuffer>()  // d_keys_in
-                           .Arg<xla::ffi::AnyBuffer>()  // d_values_in
-                           .Ret<xla::ffi::AnyBuffer>()  // d_keys_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_values_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                       ffi::Ffi::BindInstantiate()
+                           .Arg<ffi::AnyBuffer>()          // d_keys_in
+                           .Arg<ffi::AnyBuffer>()          // d_values_in
+                           .Ret<ffi::AnyBuffer>()          // d_keys_out
+                           .Ret<ffi::AnyBuffer>()          // d_values_out
+                           .Ret<ffi::BufferR1<xla::U8>>()  // d_temp_storage
                            .Attr<bool>("descending")
                            .Attr<int64_t>("batch_size"));
 
 XLA_FFI_DEFINE_HANDLER(kCubSortPairsExecute, CubSortPairsExecute,
-                       xla::ffi::Ffi::Bind()
-                           .Arg<xla::ffi::AnyBuffer>()  // d_keys_in
-                           .Arg<xla::ffi::AnyBuffer>()  // d_values_in
-                           .Ret<xla::ffi::AnyBuffer>()  // d_keys_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_values_out
-                           .Ret<xla::ffi::AnyBuffer>()  // d_temp_storage
+                       ffi::Ffi::Bind()
+                           .Arg<ffi::AnyBuffer>()          // d_keys_in
+                           .Arg<ffi::AnyBuffer>()          // d_values_in
+                           .Ret<ffi::AnyBuffer>()          // d_keys_out
+                           .Ret<ffi::AnyBuffer>()          // d_values_out
+                           .Ret<ffi::BufferR1<xla::U8>>()  // d_temp_storage
                            .Attr<bool>("descending")
                            .Attr<int64_t>("batch_size")
-                           .Ctx<xla::ffi::PlatformStream<hipStream_t>>());
+                           .Ctx<ffi::PlatformStream<hipStream_t>>());
 
-XLA_FFI_REGISTER_HANDLER(xla::ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_pairs",
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "xla.gpu.ext.cub_sort_pairs",
                          "ROCM",
                          {/* .instantiate = */ kCubSortPairsInstantiate,
                           /* .prepare = */ nullptr,


### PR DESCRIPTION
Add `WithShapeOf` and `Like` patterns for expressing runtime `shape` and `dtype` relationships between FFI buffers. Keep runtime and type-level dtype and rank constraints mutually exclusive when composing patterns.

Replace manual buffer validation in GPU debug thunks and CUDA/ROCm scan and sort handlers with FFI buffer verifiers. Tighten handler bindings to use concrete ranked buffer and token types where possible.

Add documentation, unit tests, and benchmarks for relational buffer matching.

Use matchers added in https://github.com/openxla/xla/pull/46234 in internal custom calls.