### PR TITLE
[XLA:GPU][oneAPI] Recognize DmaMapped host memory as pinned

### DIFF
--- a/xla/stream_executor/sycl/sycl_executor.cc
+++ b/xla/stream_executor/sycl/sycl_executor.cc
@@ -788,9 +788,15 @@ bool SyclExecutor::HostMemoryRegister(void* location, uint64_t size) {
 #if defined(SYCL_EXT_ONEAPI_COPY_OPTIMIZE)
   try {
     const sycl::context context = sycl_context_->context();
+    // TODO(intel-tf): Consider migrating to
+    // sycl_ext_oneapi_register_host_memory once the supported oneAPI toolchain
+    // provides it. At the time of writing, that extension requires the pointer
+    // and size to be host-page aligned, unlike the prepare_for_device_copy
+    // specification, and makes the registered range visible as a USM host
+    // allocation.
     sycl::ext::oneapi::experimental::prepare_for_device_copy(location, size,
                                                              context);
-    if (SyclIsHostMemoryRegistered(device_, location)) {
+    if (SyclIsHostMemoryRegistered(device_, location, size)) {
       return true;
     }
     sycl::ext::oneapi::experimental::release_from_device_copy(location,
@@ -812,7 +818,7 @@ bool SyclExecutor::HostMemoryUnregister(void* location) {
   try {
     sycl::ext::oneapi::experimental::release_from_device_copy(
         location, sycl_context_->context());
-    if (!SyclIsHostMemoryRegistered(device_, location)) {
+    if (!SyclIsHostMemoryRegistered(device_, location, 1)) {
       return true;
     }
     LOG(ERROR) << "SYCL did not unregister host memory at " << location;
@@ -824,6 +830,10 @@ bool SyclExecutor::HostMemoryUnregister(void* location) {
   LOG(ERROR) << "The SYCL toolchain does not support host memory import";
 #endif
   return false;
+}
+
+bool SyclExecutor::IsHostMemoryPinned(const void* ptr, uint64_t size) {
+  return SyclIsHostMemoryRegistered(device_, ptr, size);
 }
 
 void SyclExecutor::DeallocateStream(Stream* stream) {

--- a/xla/stream_executor/sycl/sycl_executor.h
+++ b/xla/stream_executor/sycl/sycl_executor.h
@@ -148,6 +148,7 @@ class SyclExecutor : public gpu::GpuExecutor {
 
   bool HostMemoryRegister(void* location, uint64_t size) override;
   bool HostMemoryUnregister(void* location) override;
+  bool IsHostMemoryPinned(const void* ptr, uint64_t size) override;
 
   // Deallocates the given stream.
   void DeallocateStream(Stream* stream) override;

--- a/xla/stream_executor/sycl/sycl_executor_test.cc
+++ b/xla/stream_executor/sycl/sycl_executor_test.cc
@@ -128,6 +128,25 @@ TEST_F(SyclExecutorTest, GetSyclKernel) {
               StatusIs(absl::StatusCode::kNotFound));
 }
 
+TEST_F(SyclExecutorTest, RegisteredHostMemoryIsPinned) {
+  ASSERT_OK_AND_ASSIGN(
+      Platform * platform,
+      stream_executor::PlatformManager::PlatformWithId(kSyclPlatformId));
+  ASSERT_OK_AND_ASSIGN(StreamExecutor * executor,
+                       platform->ExecutorForDevice(kDefaultDeviceOrdinal));
+
+  constexpr size_t kSize = 64 * 1024;
+  std::vector<uint8_t> buffer(kSize);
+  EXPECT_FALSE(executor->IsHostMemoryPinned(buffer.data(), buffer.size()));
+  ASSERT_TRUE(executor->HostMemoryRegister(buffer.data(), buffer.size()));
+  EXPECT_TRUE(executor->IsHostMemoryPinned(buffer.data(), buffer.size()));
+  EXPECT_TRUE(executor->IsHostMemoryPinned(buffer.data() + 1024, 4096));
+  EXPECT_FALSE(executor->IsHostMemoryPinned(buffer.data(), 0));
+  EXPECT_FALSE(executor->IsHostMemoryPinned(buffer.data() + kSize / 2, kSize));
+  ASSERT_TRUE(executor->HostMemoryUnregister(buffer.data()));
+  EXPECT_FALSE(executor->IsHostMemoryPinned(buffer.data(), buffer.size()));
+}
+
 TEST_F(SyclExecutorTest, CreateUnifiedMemoryAllocatorWorks) {
   TF_ASSERT_OK_AND_ASSIGN(Platform * platform,
                           stream_executor::PlatformManager::PlatformWithId(

--- a/xla/stream_executor/sycl/sycl_gpu_runtime.cc
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.cc
@@ -16,7 +16,10 @@ limitations under the License.
 #include "xla/stream_executor/sycl/sycl_gpu_runtime.h"
 
 #include <cassert>
+#include <cstdint>
 #include <iostream>
+#include <limits>
+#include <vector>
 
 #include "absl/base/call_once.h"
 #include "absl/synchronization/mutex.h"
@@ -136,9 +139,16 @@ absl::Status MemfillDevice(::sycl::queue* stream_handle, void* dst_device,
 // but SYCL still classifies the imported pointer as usm::alloc::unknown. Query
 // Level Zero directly so registration can be verified and copies from the
 // DmaMapped range can remain asynchronous.
+// TODO(intel-tf): Remove this helper once HostMemoryRegister uses
+// sycl_ext_oneapi_register_host_memory, which makes registered ranges visible
+// to standard SYCL USM pointer queries.
 bool SyclIsHostMemoryRegistered(const ::sycl::device& device,
-                                const void* location) {
-  if (location == nullptr) {
+                                const void* location, std::size_t size) {
+  if (location == nullptr || size == 0) {
+    return false;
+  }
+  const std::uintptr_t start = reinterpret_cast<std::uintptr_t>(location);
+  if (size - 1 > std::numeric_limits<std::uintptr_t>::max() - start) {
     return false;
   }
   try {
@@ -156,8 +166,21 @@ bool SyclIsHostMemoryRegistered(const ::sycl::device& device,
       }
       cached_driver = driver;
     }
-    return query != nullptr && query(driver, const_cast<void*>(location),
-                                     nullptr) == ZE_RESULT_SUCCESS;
+    if (query == nullptr) {
+      return false;
+    }
+    // The extension exposes range membership and the imported base, but not
+    // the range size. Imported ranges are contiguous and non-overlapping, so
+    // both endpoints resolving to the same base proves that the complete
+    // half-open range belongs to one import. This mirrors NEO's own
+    // HostPointerManager range-coverage check.
+    void* start_base = nullptr;
+    void* end_base = nullptr;
+    return query(driver, const_cast<void*>(location), &start_base) ==
+               ZE_RESULT_SUCCESS &&
+           query(driver, reinterpret_cast<void*>(start + size - 1),
+                 &end_base) == ZE_RESULT_SUCCESS &&
+           start_base == end_base;
   } catch (const ::sycl::exception&) {
     return false;
   }
@@ -567,9 +590,9 @@ absl::Status SyclMemcpyDeviceToHostAsync(::sycl::queue* stream_handle,
   }
   ::sycl::usm::alloc dst_alloc_type =
       ::sycl::get_pointer_type(dst_host, stream_handle->get_context());
-  bool async =
-      dst_alloc_type == ::sycl::usm::alloc::host ||
-      SyclIsHostMemoryRegistered(stream_handle->get_device(), dst_host);
+  bool async = dst_alloc_type == ::sycl::usm::alloc::host ||
+               SyclIsHostMemoryRegistered(stream_handle->get_device(), dst_host,
+                                          byte_count);
   return MemcpyDeviceToHost(stream_handle, dst_host, src_device, byte_count,
                             async);
 }
@@ -589,9 +612,9 @@ absl::Status SyclMemcpyHostToDeviceAsync(::sycl::queue* stream_handle,
   }
   ::sycl::usm::alloc src_alloc_type =
       ::sycl::get_pointer_type(src_host, stream_handle->get_context());
-  bool async =
-      src_alloc_type == ::sycl::usm::alloc::host ||
-      SyclIsHostMemoryRegistered(stream_handle->get_device(), src_host);
+  bool async = src_alloc_type == ::sycl::usm::alloc::host ||
+               SyclIsHostMemoryRegistered(stream_handle->get_device(), src_host,
+                                          byte_count);
   return MemcpyHostToDevice(stream_handle, dst_device, src_host, byte_count,
                             async);
 }

--- a/xla/stream_executor/sycl/sycl_gpu_runtime.h
+++ b/xla/stream_executor/sycl/sycl_gpu_runtime.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <sycl/sycl.hpp>
 // clang-format on
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -139,9 +140,10 @@ struct SyclTimerProperties {
   uint64_t timestamp_mask;
 };
 
-// Returns whether location belongs to a driver-imported host-memory range.
+// Returns whether the complete range belongs to one driver-imported host
+// allocation.
 bool SyclIsHostMemoryRegistered(const ::sycl::device& device,
-                                const void* location);
+                                const void* location, std::size_t size);
 
 // Returns the timer frequency (Hz) and valid timestamp bitmask for the given
 // device ordinal using the Level Zero backend.


### PR DESCRIPTION
📝 Summary of Changes
In https://github.com/openxla/xla/pull/45954, I added DmaMap support for Intel, but I missed `IsHostMemoryPinned` which `ShouldStageHostToDeviceTransfers` uses in https://github.com/openxla/xla/blob/main/xla/pjrt/se/pjrt_stream_executor_client.h#L359. 

Today there is no API to check for a range, so I'm doing what NEO does underneath, checking that the start and end point to the same base. https://github.com/intel/compute-runtime/blob/master/level_zero/core/source/driver/host_pointer_manager.cpp#L71

I've added a `TODO(intel-tf)`, not sure if that's a good idea or not, to consider using `sycl::ext::oneapi::experimental::register_host_memory` in the future which should provide the appropriate pointer type. However at the time of writing, it requires a page-aligned range which this implementation doesn't require, nor CUDA as far as I know.

🎯 Justification
Transfers would still go through staging buffers on Intel

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement
