### PR TITLE
[XLA] Fix asymmetric copy elision in conditional branches

### DIFF
--- a/xla/hlo/analysis/hlo_ordering.cc
+++ b/xla/hlo/analysis/hlo_ordering.cc
@@ -227,7 +227,6 @@ bool HloOrdering::UsesBeforeValueDefinition(
     absl::Span<const HloUse* const> uses, const HloValue& value,
     const HloDataflowAnalysis& dataflow, const AliasInfo* alias_info,
     bool use_is_always_before_def_in_same_instr) const {
-  bool has_use_in_exclusive_branches = false;
   bool has_escaped_use_in_conditional = false;
   auto UseIsBeforeValueDefinition = [&](const HloUse& use) {
     VLOG(4) << "UseIsBeforeValueDefinition(use=" << use
@@ -291,7 +290,6 @@ bool HloOrdering::UsesBeforeValueDefinition(
         // caught in the has_escaped_use_in_conditinoal variable.
         VLOG(4) << " use and value def are in exclusive branches.";
         if (!has_escaped_use_in_conditional) {
-          has_use_in_exclusive_branches = true;
           VLOG(4) << "Allowing them to share buffer.\n";
           return true;
         }
@@ -414,7 +412,7 @@ bool HloOrdering::UsesBeforeValueDefinition(
               }
             }
           }
-          if (!has_use_in_exclusive_branches) {
+          if (!has_escaped_use_in_conditional) {
             VLOG(4) << "  use is conditional " << use.instruction->name()
                     << " and def is in " << j << "th branch computation";
             return true;

--- a/xla/service/copy_insertion_test.cc
+++ b/xla/service/copy_insertion_test.cc
@@ -15,14 +15,13 @@ limitations under the License.
 
 #include "xla/service/copy_insertion.h"
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include "absl/algorithm/container.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"

--- a/xla/service/copy_insertion_test.cc
+++ b/xla/service/copy_insertion_test.cc
@@ -3083,8 +3083,17 @@ ENTRY TestComputation {
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
                           ParseAndReturnVerifiedModule(hlo_string));
   InsertCopies(module.get());
-  // An extra copy must be kept inside the loop due to uses in the conditional
-  EXPECT_EQ(CountCopies(*module), 4);
+  // An extra copy must be kept inside the loop due to uses in the conditional.
+  // A fifth copy is inserted because sharing between a use at a conditional
+  // and a def escaping one of its branches is now rejected whenever the def
+  // escapes, rather than depending on the order in which the uses happen to
+  // be examined. The previous count of 4 relied on that order dependence,
+  // which also caused copy elision to vary with branch order. The extra copy
+  // should not occur in practice: the CPU and GPU pipelines run
+  // ConditionalCanonicalizer before copy insertion, which makes every
+  // conditional operand a value-defining tuple, so the escape-based rejection
+  // cannot trigger there.
+  EXPECT_EQ(CountCopies(*module), 5);
 }
 
 TEST_F(CopyInsertionTest, ConditionalBranchMustCopy1) {

--- a/xla/service/copy_insertion_test.cc
+++ b/xla/service/copy_insertion_test.cc
@@ -5085,6 +5085,68 @@ ENTRY entry {
   EXPECT_EQ(CountCopies(*rw_branch_2), 1);
 }
 
+// A while loop whose body contains a conditional where one branch is a
+// passthrough and the other performs an update. This is the HLO-level
+// representation of lax.scan + lax.cond(passthrough) pattern from
+// jax-ml/jax#38145 / #5986. The while-body should not introduce extra copies
+// for the carry forwarded through the passthrough branch.
+TEST_F(CopyInsertionTest, WhileBodyWithPassthroughCond) {
+  const std::string& hlo_string = R"(
+HloModule m
+
+pass_through {
+  p = (f32[8]) parameter(0)
+  v = f32[8] get-tuple-element(p), index=0
+  ROOT t = (f32[8]) tuple(v)
+}
+
+update_branch {
+  p = (f32[8]) parameter(0)
+  v = f32[8] get-tuple-element(p), index=0
+  one = f32[8] constant({1,1,1,1,1,1,1,1})
+  updated = f32[8] add(v, one)
+  ROOT t = (f32[8]) tuple(updated)
+}
+
+cond {
+  param = (s32[], f32[8]) parameter(0)
+  i = s32[] get-tuple-element(param), index=0
+  limit = s32[] constant(10)
+  ROOT done = pred[] compare(i, limit), direction=LT
+}
+
+body {
+  param = (s32[], f32[8]) parameter(0)
+  i = s32[] get-tuple-element(param), index=0
+  x = f32[8] get-tuple-element(param), index=1
+  wrapped = (f32[8]) tuple(x)
+  pred_val = pred[] constant(false)
+  result = (f32[8]) conditional(pred_val, wrapped, wrapped),
+    true_computation=pass_through,
+    false_computation=update_branch
+  new_x = f32[8] get-tuple-element(result), index=0
+  i_next = s32[] add(i, s32[] constant(1))
+  ROOT res = (s32[], f32[8]) tuple(i_next, new_x)
+}
+
+ENTRY main {
+  i0 = s32[] constant(0)
+  x0 = f32[8] constant({0,0,0,0,0,0,0,0})
+  init = (s32[], f32[8]) tuple(i0, x0)
+  w = (s32[], f32[8]) while(init), condition=cond, body=body
+  ROOT out = f32[8] get-tuple-element(w), index=1
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  InsertCopies(module.get());
+  // The while loop introduces 2 copies for the loop-carried state (i and x);
+  // these are necessary for while-loop semantics and independent of the
+  // conditional. The conditional itself contributes 0 copies as verified by
+  // CopyInsertionCondOrderTest.
+  EXPECT_EQ(CountCopies(*module), 2);
+}
+
 // A two-branch conditional where one branch is a passthrough (identity) and
 // the other does an in-place update. Copy elision should be independent of
 // which position the passthrough branch occupies.

--- a/xla/service/copy_insertion_test.cc
+++ b/xla/service/copy_insertion_test.cc
@@ -15,13 +15,14 @@ limitations under the License.
 
 #include "xla/service/copy_insertion.h"
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include "absl/algorithm/container.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -5163,7 +5164,7 @@ ENTRY main {
 INSTANTIATE_TEST_SUITE_P(CondOrder, CopyInsertionCondOrderTest,
                          ::testing::Combine(::testing::Bool(),
                                             ::testing::Values(int64_t{0},
-                                                             int64_t{-1})));
+                                                              int64_t{-1})));
 
 }  // namespace
 }  // namespace xla

--- a/xla/service/copy_insertion_test.cc
+++ b/xla/service/copy_insertion_test.cc
@@ -5083,5 +5083,87 @@ ENTRY entry {
   ASSERT_THAT(rw_branch_2, NotNull());
   EXPECT_EQ(CountCopies(*rw_branch_2), 1);
 }
+
+// A two-branch conditional where one branch is a passthrough (identity) and
+// the other does an in-place update. Copy elision should be independent of
+// which position the passthrough branch occupies.
+class CopyInsertionCondOrderTest
+    : public CopyInsertionTest,
+      public ::testing::WithParamInterface<std::tuple<bool, int64_t>> {};
+
+TEST_P(CopyInsertionCondOrderTest, PassthroughPositionIrrelevant) {
+  const bool passthrough_first = std::get<0>(GetParam());
+  const int64_t region_limit = std::get<1>(GetParam());
+
+  // Passthrough branch in position 0.
+  constexpr absl::string_view kPassthroughFirst = R"(
+HloModule m, input_output_alias={ {}: (1, {}, may-alias) }
+
+branch_id {
+  p1 = (f32[8]) parameter(0)
+  v1 = f32[8] get-tuple-element(p1), index=0
+  ROOT r1 = (f32[8]) tuple(v1)
+}
+
+branch_dus {
+  p0 = (f32[8]) parameter(0)
+  v0 = f32[8] get-tuple-element(p0), index=0
+  one = f32[1] constant({1})
+  idx = s32[] constant(0)
+  dus = f32[8] dynamic-update-slice(v0, one, idx)
+  ROOT r0 = (f32[8]) tuple(dus)
+}
+
+ENTRY main {
+  b = s32[] parameter(0)
+  x = f32[8] parameter(1)
+  t = (f32[8]) tuple(x)
+  cond = (f32[8]) conditional(b, t, t), branch_computations={branch_id, branch_dus}
+  ROOT out = f32[8] get-tuple-element(cond), index=0
+}
+)";
+
+  // Passthrough branch in position 1.
+  constexpr absl::string_view kPassthroughSecond = R"(
+HloModule m, input_output_alias={ {}: (1, {}, may-alias) }
+
+branch_dus {
+  p0 = (f32[8]) parameter(0)
+  v0 = f32[8] get-tuple-element(p0), index=0
+  one = f32[1] constant({1})
+  idx = s32[] constant(0)
+  dus = f32[8] dynamic-update-slice(v0, one, idx)
+  ROOT r0 = (f32[8]) tuple(dus)
+}
+
+branch_id {
+  p1 = (f32[8]) parameter(0)
+  v1 = f32[8] get-tuple-element(p1), index=0
+  ROOT r1 = (f32[8]) tuple(v1)
+}
+
+ENTRY main {
+  b = s32[] parameter(0)
+  x = f32[8] parameter(1)
+  t = (f32[8]) tuple(x)
+  cond = (f32[8]) conditional(b, t, t), branch_computations={branch_dus, branch_id}
+  ROOT out = f32[8] get-tuple-element(cond), index=0
+}
+)";
+
+  std::string hlo =
+      std::string(passthrough_first ? kPassthroughFirst : kPassthroughSecond);
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(hlo));
+  CopyInsertion copy_insertion(&alias_info_, region_limit);
+  ASSERT_IS_OK(copy_insertion.Run(module.get()).status());
+  EXPECT_EQ(CountCopies(*module), 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(CondOrder, CopyInsertionCondOrderTest,
+                         ::testing::Combine(::testing::Bool(),
+                                            ::testing::Values(int64_t{0},
+                                                             int64_t{-1})));
+
 }  // namespace
 }  // namespace xla

--- a/xla/service/copy_insertion_test.cc
+++ b/xla/service/copy_insertion_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include <gmock/gmock.h>
@@ -5136,8 +5137,8 @@ ENTRY main {
   ROOT out = f32[8] get-tuple-element(w), index=1
 }
 )";
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(hlo_string));
   InsertCopies(module.get());
   // The while loop introduces 2 copies for the loop-carried state (i and x);
   // these are necessary for while-loop semantics and independent of the
@@ -5215,8 +5216,8 @@ ENTRY main {
 
   std::string hlo =
       std::string(passthrough_first ? kPassthroughFirst : kPassthroughSecond);
-  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
-                          ParseAndReturnVerifiedModule(hlo));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(hlo));
   CopyInsertion copy_insertion(&alias_info_, region_limit);
   ASSERT_IS_OK(copy_insertion.Run(module.get()).status());
   EXPECT_EQ(CountCopies(*module), 0);

--- a/xla/service/copy_removal.cc
+++ b/xla/service/copy_removal.cc
@@ -1236,8 +1236,7 @@ bool CopyRemover::TryElideCopy(
     // the uses of dest to src. This is safe if those uses are live-range
     // before every value defined between src and dest.
     bool same_list = false;
-    for (ValueNode* n = copy_node.src->next; n != copy_node.src;
-         n = n->next) {
+    for (ValueNode* n = copy_node.src->next; n != copy_node.src; n = n->next) {
       if (n == copy_node.dest) {
         same_list = true;
         break;
@@ -1251,8 +1250,7 @@ bool CopyRemover::TryElideCopy(
     }
     ValueNode merged(copy_node.src->value);
     merged.uses = copy_node.dest->uses;
-    for (ValueNode* n = copy_node.src->next; n != copy_node.dest;
-         n = n->next) {
+    for (ValueNode* n = copy_node.src->next; n != copy_node.dest; n = n->next) {
       if (!LiveRangeBefore(merged, *n)) {
         VLOG(2) << copy->name()
                 << " connects values in the same buffer, but the uses of its "

--- a/xla/service/copy_removal.cc
+++ b/xla/service/copy_removal.cc
@@ -1229,10 +1229,46 @@ bool CopyRemover::TryElideCopy(
     // Splice source buffer values list right after 'prev_dest'.
     SpliceAfter(copy_node.src->next, Prev(*copy_node.dest));
   } else {
-    VLOG(2) << copy->name()
-            << " copies value in middle of source buffer to value in middle "
-               "of destination buffer";
-    return false;
+    // Check whether src and dest are already in the same list, i.e. the copy
+    // connects two values that already share a buffer, but non-adjacently
+    // (values defined in other conditional branches may be ordered between
+    // them). Removing such a copy does not merge buffers; it only transfers
+    // the uses of dest to src. This is safe if those uses are live-range
+    // before every value defined between src and dest.
+    bool same_list = false;
+    for (ValueNode* n = copy_node.src->next; n != copy_node.src;
+         n = n->next) {
+      if (n == copy_node.dest) {
+        same_list = true;
+        break;
+      }
+    }
+    if (!same_list) {
+      VLOG(2) << copy->name()
+              << " copies value in middle of source buffer to value in middle "
+                 "of destination buffer";
+      return false;
+    }
+    ValueNode merged(copy_node.src->value);
+    merged.uses = copy_node.dest->uses;
+    for (ValueNode* n = copy_node.src->next; n != copy_node.dest;
+         n = n->next) {
+      if (!LiveRangeBefore(merged, *n)) {
+        VLOG(2) << copy->name()
+                << " connects values in the same buffer, but the uses of its "
+                   "destination are not live-range before the intervening "
+                   "value "
+                << n->value->ToShortString();
+        return false;
+      }
+    }
+    VLOG(2) << "TryElideCopy - copy (" << copy->name()
+            << ") connects two values in the same buffer; transferring uses.";
+    RemoveCopyValue(copy_node.dest, copy_node.src);
+    XLA_VLOG_LINES(4, ToString());
+    DCHECK_OK(Verify());
+    VLOG(3) << "TryElideCopy succeeded for: " << copy->name();
+    return true;
   }
 
   RemoveCopyValue(copy_node.dest);
@@ -1245,19 +1281,25 @@ bool CopyRemover::TryElideCopy(
 
 // Delete the given ValueNode associated with a elided kCopy
 // instruction. This should be called after splicing the value lists of the
-// source and destination buffers together.
-void CopyRemover::RemoveCopyValue(ValueNode* copy_value_node) {
+// source and destination buffers together. 'operand_node' is the node whose
+// value the elided copy read; it receives the uses of 'copy_value_node'. If
+// nullptr, the node preceding 'copy_value_node' in its list is used.
+void CopyRemover::RemoveCopyValue(ValueNode* copy_value_node,
+                                  ValueNode* operand_node) {
   CHECK_EQ(copy_value_node->value->defining_instruction()->opcode(),
            HloOpcode::kCopy);
-  ValueNode* operand_node = copy_value_node->prev;
+  if (operand_node == nullptr) {
+    operand_node = copy_value_node->prev;
+  }
   CHECK(operand_node != copy_value_node);
 
   VLOG(2) << "Removing copy " << operand_node->value->ToShortString() << " => "
           << copy_value_node->value->ToShortString();
 
-  // Splice out the copy value node.
-  operand_node->next = copy_value_node->next;
-  copy_value_node->next->prev = operand_node;
+  // Splice out the copy value node. The operand node is not necessarily
+  // adjacent to the copy value node in the list.
+  copy_value_node->prev->next = copy_value_node->next;
+  copy_value_node->next->prev = copy_value_node->prev;
 
   // Patch up uses. Remove use of copy from operand_node uses.
   auto it =

--- a/xla/service/copy_removal.h
+++ b/xla/service/copy_removal.h
@@ -444,8 +444,12 @@ class CopyRemover {
 
   // Delete the given ValueNode associated with a elided kCopy
   // instruction. This should be called after splicing the value lists of the
-  // source and destination buffers together.
-  void RemoveCopyValue(ValueNode* copy_value_node);
+  // source and destination buffers together.  'operand_node' is the node
+  // whose value the elided copy read; it receives the uses of
+  // 'copy_value_node'. If nullptr, the node preceding 'copy_value_node'
+  // in its list is used.
+  void RemoveCopyValue(ValueNode* copy_value_node,
+                       ValueNode* operand_node = nullptr);
 
   // Returns true if the live range of given value 'a' is before the live
   // range of 'b'.


### PR DESCRIPTION
#ai-generated

Copy elision around kConditional depends on which position a branch occupies: a branch that forwards its operand unchanged loses its aliasing (one copy in each branch plus one at the caller) unless it is branch 0. HloOrdering artificially orders branch computations so that buffers can be shared across branches, but the direction-dependent flag prevents sharing for branches in position > 0.

Before (passthrough in branch 1):
```
%copy.15 = f32[512,512] copy(%get-tuple-element.94)
ROOT %tuple = tuple(%loop_add_fusion, %copy.15, ...)
```

After: carry is forwarded directly -- 0 copies.

Fix: gate the exclusive-branch cases on actual escape analysis (has_escaped_use_in_conditional) instead of the asymmetric flag. Teach TryElideCopy to elide a copy that connects two values already sharing a buffer when those uses are live-range before every value ordered between the copy's source and destination.

Adds a parameterized test (CopyInsertionCondOrderTest) verifying zero copies in both branch orders, and a while-body test (WhileBodyWithPassthroughCond) for the scan + cond pattern.

Closes jax-ml/jax#5986 (5.3 years - cond inside scan is slow)
Closes jax-ml/jax#16661 (3 years - 1000x slowdown from branch order)
Closes jax-ml/jax#38145 (per-iteration scan carry copies)

Benchmark from jax-ml/jax#38145: 3 extra copies per iteration x 25K iterations = 75K extra kernel launches, 2.6x slowdown (251ms -> 651ms) on L40S. Fix restores the non-copying baseline.