### PR TITLE
Fixed A100 PCIe 80GB device description str field

### DIFF
--- a/xla/backends/gpu/target_config/specs/a100_pcie_80.txtpb
+++ b/xla/backends/gpu/target_config/specs/a100_pcie_80.txtpb
@@ -45,4 +45,4 @@ dnn_version_info {
   minor: 9
   patch: 4
 }
-device_description_str: "A100 80GB"
+device_description_str: "NVIDIA A100 80GB PCIe"


### PR DESCRIPTION
📝 Summary of Changes

Fixed A100 PCIe 80GB device description str field to match device_kind reported by jax:
```bash
$ python -c "import jax; print(jax.devices()[0].device_kind)"
NVIDIA A100 80GB PCIe
```

🎯 Justification

Consistency with other names

🚀 Kind of Contribution
🐛 Bug Fix
