### PR TITLE
[XLA:GPU] Run CommandBuffer in fallback mode during profile steps of SKIP_PROFILED update mode.

### DIFF
--- a/xla/backends/gpu/profiler/BUILD
+++ b/xla/backends/gpu/profiler/BUILD
@@ -121,6 +121,7 @@ xla_test(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/xla/backends/gpu/profiler/kernel_name_tracer_test.cc
+++ b/xla/backends/gpu/profiler/kernel_name_tracer_test.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/runtime/command.h"
 #include "xla/backends/gpu/runtime/command_buffer_thunk.h"
@@ -184,7 +185,9 @@ void LaunchCommandBufferThunk(stream_executor::StreamExecutor* executor,
   BufferAllocations allocations({a, b, c}, 0, &allocator);
 
   Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
-      run_options, allocations, stream, stream, nullptr, nullptr, nullptr);
+      run_options, allocations, stream, stream, nullptr, nullptr, nullptr,
+      /*additional_compute_streams=*/{}, /*execution_scoped_state=*/nullptr,
+      /*persistent_alloc_indices=*/absl::Span<const BufferAllocation::Index>());
 
   // This is where we're getting the 'AddI32' kernel from.
   TF_ASSERT_OK_AND_ASSIGN(std::vector<uint8_t> fatbin,

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -727,6 +727,8 @@ xla_test(
         "//xla/tsl/lib/core:status_test_util",
         "//xla/tsl/platform:status_macros",
         "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -63,16 +63,10 @@ CommandBufferThunk::ExecutorCommandBuffer::ExecutorCommandBuffer(
 
 bool CommandBufferThunk::ExecutorCommandBuffer::HasDynamicAllocations(
     const CommandExecutor& commands,
-    std::optional<absl::Span<const BufferAllocation::Index>>
-        persistent_alloc_indices) {
-  if (!persistent_alloc_indices.has_value()) {
-    return true;
-  }
-
+    absl::Span<const BufferAllocation::Index> persistent_alloc_indices) {
   DCHECK(absl::c_is_sorted(commands.allocs_indices()));
-  DCHECK(absl::c_is_sorted(*persistent_alloc_indices));
-  return !absl::c_includes(*persistent_alloc_indices,
-                           commands.allocs_indices());
+  DCHECK(absl::c_is_sorted(persistent_alloc_indices));
+  return !absl::c_includes(persistent_alloc_indices, commands.allocs_indices());
 }
 
 CommandBufferThunk::CommandBufferThunk(
@@ -120,13 +114,13 @@ CommandBufferThunk::ExecutorCommandBuffer::UpdateBufferAllocations(
       commands.allocs_indices();
   std::vector<BufferAllocation::Index> dynamic_alloc_indices;
 
-  if (const auto& persistent_alloc_indices = params.persistent_alloc_indices) {
-    DCHECK(absl::c_is_sorted(commands.allocs_indices()));
-    DCHECK(absl::c_is_sorted(*persistent_alloc_indices));
-    absl::c_set_difference(commands.allocs_indices(), *persistent_alloc_indices,
-                           std::back_inserter(dynamic_alloc_indices));
-    allocs_to_check = dynamic_alloc_indices;
-  }
+  DCHECK(params.persistent_alloc_indices.has_value());
+  DCHECK(absl::c_is_sorted(commands.allocs_indices()));
+  DCHECK(absl::c_is_sorted(*params.persistent_alloc_indices));
+  absl::c_set_difference(commands.allocs_indices(),
+                         *params.persistent_alloc_indices,
+                         std::back_inserter(dynamic_alloc_indices));
+  allocs_to_check = dynamic_alloc_indices;
 
   // We check only allocations referenced by commands in a cmd sequence, and
   // leave every other entry default initialized (nullptr device memory).
@@ -201,6 +195,16 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
     return absl::OkStatus();
   }
 
+  // Command buffer lowering is enabled only when persistent allocation
+  // indices are available; until then the thunk executes its fallback thunk
+  // sequence, so there is no command buffer to initialize.
+  if (!params.persistent_alloc_indices.has_value()) {
+    VLOG(1) << "Skip command buffer initialization because persistent "
+               "allocation indices are not yet available (falling back to "
+               "thunk sequence)";
+    return absl::OkStatus();
+  }
+
   ASSIGN_OR_RETURN(std::shared_ptr<ExecutorCommandBuffer> cmd_buffer,
                    GetOrCreateCommandBuffer(params.executor));
   absl::MutexLock lock(cmd_buffer->mutex);
@@ -238,28 +242,17 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
   // If commands require an update during initialization (and VA remapping is
   // not enabled), we also record them into the command buffer before execution.
   // This is required to guarantee that collective commands are recorded on all
-  // participating ranks to avoid deadlocks. We also update an existing command
-  // buffer when persistent allocation indices become available, because that
-  // changes which commands can safely retain their recorded addresses.
+  // participating ranks to avoid deadlocks.
   bool has_dynamic_allocations = cmd_buffer->HasDynamicAllocations(
-      commands_, params.persistent_alloc_indices);
+      commands_, *params.persistent_alloc_indices);
   bool is_first_record =
       cmd_buffer->command_buffer->state() == se::CommandBuffer::State::kCreate;
-  bool persistent_allocs_info_is_valid =
-      params.persistent_alloc_indices.has_value();
-  DCHECK(!cmd_buffer->persistent_allocs_info_was_valid ||
-         persistent_allocs_info_is_valid)
-      << "Persistent allocation information must remain valid once set";
   if (is_first_record ||
-      (!cmd_buffer->persistent_allocs_info_was_valid &&
-       persistent_allocs_info_is_valid) ||
       (has_dynamic_allocations && commands_.requires_update_on_initialize())) {
     VLOG(3) << "Initialize command buffer on device #"
             << params.executor->device_ordinal()
             << " by recoding command buffer cmd sequence"
-            << "; num_commands=" << commands_.size()
-            << "; persistent_allocs_info_is_valid="
-            << persistent_allocs_info_is_valid;
+            << "; num_commands=" << commands_.size();
 
     TraceMe trace([&] {
       return TraceMeEncode("command_buffer::initialize",
@@ -273,21 +266,11 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
     std::optional<std::vector<BufferAllocation::Index>> updated_allocs =
         cmd_buffer->UpdateBufferAllocations(commands_, execute_params);
 
-    // Allocations can become persistent before their new addresses are
-    // observed by UpdateBufferAllocations. Force all commands to update so
-    // none retain addresses recorded before the policy became available.
-    if (!is_first_record && !cmd_buffer->persistent_allocs_info_was_valid &&
-        persistent_allocs_info_is_valid) {
-      updated_allocs.reset();
-    }
-
     Command::RecordParams record_params = {cmd_buffer->state,
                                            std::move(updated_allocs),
                                            /*is_initialization=*/true};
     RETURN_IF_ERROR(commands_.Record(execute_params, record_params,
                                      cmd_buffer->command_buffer.get()));
-    cmd_buffer->persistent_allocs_info_was_valid =
-        persistent_allocs_info_is_valid;
 
     uint64_t end_micros = tsl::Env::Default()->NowMicros();
     VLOG(3) << "Initialized command buffer on device #"
@@ -317,6 +300,20 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
     return thunks_->ExecuteOnStream(params);
   }
 
+  // Command buffer lowering is enabled only when persistent allocation
+  // indices are available. Until then (e.g. during the VA remapping profiling
+  // window) execute the fallback thunk sequence in op-by-op mode.
+  if (!params.persistent_alloc_indices.has_value()) {
+    if (thunks_ == nullptr) {
+      return Internal(
+          "CommandBufferThunk requires either valid persistent allocation "
+          "indices or a fallback thunk sequence");
+    }
+    VLOG(2) << "Execute command buffer thunk as a regular thunk sequence "
+               "because persistent allocation indices are not yet available";
+    return thunks_->ExecuteOnStream(params);
+  }
+
   se::StreamExecutor* executor = params.stream->parent();
   ASSIGN_OR_RETURN(std::shared_ptr<ExecutorCommandBuffer> cmd_buffer,
                    GetOrCreateCommandBuffer(executor));
@@ -333,21 +330,12 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
 
   bool is_first_record =
       cmd_buffer->command_buffer->state() == se::CommandBuffer::State::kCreate;
-  // Executions initialized on opposite sides of the one-way policy transition
-  // can interleave, so the persistent allocation information recorded in the
-  // shared command buffer can have different validity from the current run.
-  bool persistent_allocs_info_is_valid =
-      params.persistent_alloc_indices.has_value();
-  bool persistent_allocs_info_is_changed =
-      !is_first_record && cmd_buffer->persistent_allocs_info_was_valid !=
-                              persistent_allocs_info_is_valid;
 
   auto updated_allocs = cmd_buffer->UpdateBufferAllocations(commands_, params);
 
   bool has_dynamic_allocations = cmd_buffer->HasDynamicAllocations(
-      commands_, params.persistent_alloc_indices);
-  bool needs_update = persistent_allocs_info_is_changed ||
-                      commands_.requires_update_on_execute() ||
+      commands_, *params.persistent_alloc_indices);
+  bool needs_update = commands_.requires_update_on_execute() ||
                       (has_dynamic_allocations && !updated_allocs.empty());
 
   if (is_first_record || needs_update) {
@@ -358,8 +346,6 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
         << "; num_commands=" << commands_.size()
         << "; updated_allocs=" << updated_allocs.size()
         << "; is_first_record=" << is_first_record
-        << "; persistent_allocs_info_is_changed="
-        << persistent_allocs_info_is_changed
         << "; needs_update=" << needs_update;
 
     TraceMe trace([&] {
@@ -372,22 +358,11 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
 
     uint64_t start_micros = tsl::Env::Default()->NowMicros();
 
-    std::optional<std::vector<BufferAllocation::Index>> allocs_to_update =
-        std::move(updated_allocs);
-    // Force all commands to update when the recorded information validity does
-    // not match this execution. A filtered update could skip a command whose
-    // allocations are all persistent in one of the interleaved executions.
-    if (persistent_allocs_info_is_changed) {
-      allocs_to_update.reset();
-    }
-
     Command::RecordParams record_params = {
-        cmd_buffer->state, std::move(allocs_to_update),
+        cmd_buffer->state, std::move(updated_allocs),
         /*is_initialization=*/is_first_record && !has_dynamic_allocations};
     RETURN_IF_ERROR(commands_.Record(params, record_params,
                                      cmd_buffer->command_buffer.get()));
-    cmd_buffer->persistent_allocs_info_was_valid =
-        persistent_allocs_info_is_valid;
 
     uint64_t end_micros = tsl::Env::Default()->NowMicros();
     XLA_VLOG_DEVICE(3, executor->device_ordinal())

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -64,7 +64,6 @@ CommandBufferThunk::ExecutorCommandBuffer::ExecutorCommandBuffer(
 bool CommandBufferThunk::ExecutorCommandBuffer::HasDynamicAllocations(
     const CommandExecutor& commands,
     absl::Span<const BufferAllocation::Index> persistent_alloc_indices) {
-  DCHECK(absl::c_is_sorted(commands.allocs_indices()));
   DCHECK(absl::c_is_sorted(persistent_alloc_indices));
   return !absl::c_includes(persistent_alloc_indices, commands.allocs_indices());
 }
@@ -107,24 +106,18 @@ CommandBufferThunk::CommandBufferThunk(
 
 std::vector<BufferAllocation::Index>
 CommandBufferThunk::ExecutorCommandBuffer::UpdateBufferAllocations(
-    const CommandExecutor& commands, const Thunk::ExecuteParams& params) {
+    const CommandExecutor& commands, const Thunk::ExecuteParams& params,
+    absl::Span<const BufferAllocation::Index> persistent_alloc_indices) {
   std::vector<BufferAllocation::Index> updated_allocs;
   const BufferAllocations* allocs = params.buffer_allocations;
-  absl::Span<const BufferAllocation::Index> allocs_to_check =
-      commands.allocs_indices();
   std::vector<BufferAllocation::Index> dynamic_alloc_indices;
 
-  DCHECK(params.persistent_alloc_indices.has_value());
-  DCHECK(absl::c_is_sorted(commands.allocs_indices()));
-  DCHECK(absl::c_is_sorted(*params.persistent_alloc_indices));
-  absl::c_set_difference(commands.allocs_indices(),
-                         *params.persistent_alloc_indices,
+  absl::c_set_difference(commands.allocs_indices(), persistent_alloc_indices,
                          std::back_inserter(dynamic_alloc_indices));
-  allocs_to_check = dynamic_alloc_indices;
 
   // We check only allocations referenced by commands in a cmd sequence, and
   // leave every other entry default initialized (nullptr device memory).
-  for (BufferAllocation::Index index : allocs_to_check) {
+  for (BufferAllocation::Index index : dynamic_alloc_indices) {
     se::DeviceAddressBase alloc = allocs->GetDeviceAddress(index);
 
     if (recorded_allocs.size() <= index) {
@@ -264,7 +257,8 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
 
     // Update recorded buffer allocations.
     std::optional<std::vector<BufferAllocation::Index>> updated_allocs =
-        cmd_buffer->UpdateBufferAllocations(commands_, execute_params);
+        cmd_buffer->UpdateBufferAllocations(commands_, execute_params,
+                                            *params.persistent_alloc_indices);
 
     Command::RecordParams record_params = {cmd_buffer->state,
                                            std::move(updated_allocs),
@@ -331,12 +325,12 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
   bool is_first_record =
       cmd_buffer->command_buffer->state() == se::CommandBuffer::State::kCreate;
 
-  auto updated_allocs = cmd_buffer->UpdateBufferAllocations(commands_, params);
-
   bool has_dynamic_allocations = cmd_buffer->HasDynamicAllocations(
       commands_, *params.persistent_alloc_indices);
-  bool needs_update = commands_.requires_update_on_execute() ||
-                      (has_dynamic_allocations && !updated_allocs.empty());
+  auto updated_allocs = cmd_buffer->UpdateBufferAllocations(
+      commands_, params, *params.persistent_alloc_indices);
+  bool needs_update =
+      commands_.requires_update_on_execute() || !updated_allocs.empty();
 
   if (is_first_record || needs_update) {
     XLA_VLOG_DEVICE(3, executor->device_ordinal())

--- a/xla/backends/gpu/runtime/command_buffer_thunk.h
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.h
@@ -18,7 +18,6 @@ limitations under the License.
 
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -96,9 +95,10 @@ class CommandBufferThunk : public Thunk {
     // Updates recorded buffer allocation for the given `commands` using the
     // buffer allocations passed in `params`. Returns buffer allocations that
     // changed since the last update. Returned buffer allocations are sorted by
-    // the buffer allocation index.
+    // the buffer allocation index. `persistent_alloc_indices` must be sorted.
     std::vector<BufferAllocation::Index> UpdateBufferAllocations(
-        const CommandExecutor& commands, const Thunk::ExecuteParams& params)
+        const CommandExecutor& commands, const Thunk::ExecuteParams& params,
+        absl::Span<const BufferAllocation::Index> persistent_alloc_indices)
         ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex);
 
     // Returns true if `commands` references any allocation whose address is not

--- a/xla/backends/gpu/runtime/command_buffer_thunk.h
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.h
@@ -102,12 +102,11 @@ class CommandBufferThunk : public Thunk {
         ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex);
 
     // Returns true if `commands` references any allocation whose address is not
-    // persistent under the current allocation address policy. If the policy is
-    // absent, conservatively returns true.
+    // persistent under the current allocation address policy.
     bool HasDynamicAllocations(
         const CommandExecutor& commands,
-        std::optional<absl::Span<const BufferAllocation::Index>>
-            persistent_alloc_indices) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex);
+        absl::Span<const BufferAllocation::Index> persistent_alloc_indices)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex);
 
     // se::CommandBuffer is not thread safe, and we guard it with a mutex to
     // guarantee that we do not mutate it concurrently.
@@ -130,12 +129,6 @@ class CommandBufferThunk : public Thunk {
     // and block sizes) captured by commands at construction time and do not
     // change.
     std::vector<se::DeviceAddressBase> recorded_allocs ABSL_GUARDED_BY(mutex);
-
-    // True if persistent allocation information was valid when the command
-    // buffer was recorded. We track only validity because the execution
-    // parameter contract guarantees that the indices remain unchanged once
-    // present.
-    bool persistent_allocs_info_was_valid ABSL_GUARDED_BY(mutex) = false;
 
     // Number of command buffer executions since last update.
     int64_t num_executions ABSL_GUARDED_BY(mutex) = 0;
@@ -183,7 +176,10 @@ class CommandBufferThunk : public Thunk {
 
   // Thunk sequence that executes the same commands as in `commands_` but using
   // thunk mechanism. We use it as a fallback mechanism to work around CUPTI
-  // bugs that lead to memory corruption when CUPTI traces CUDA graph execution.
+  // bugs that lead to memory corruption when CUPTI traces CUDA graph execution,
+  // and to execute the thunk while `persistent_alloc_indices` is not yet
+  // available (e.g. during the VA remapping profiling window), in which case
+  // command buffer lowering is disabled for the step.
   std::unique_ptr<SequentialThunk> thunks_;
 
   // When true, allows command buffers to be used while profiling active.

--- a/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
@@ -27,6 +27,8 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
 #include "absl/types/span.h"
@@ -189,6 +191,19 @@ class CountingDeviceToDeviceCopyThunk : public DeviceToDeviceCopyThunk {
   int* record_count_;
 };
 
+// Creates execute params with a valid persistent allocation indices span
+// (empty by default). Command buffer lowering is enabled only when the span
+// is valid; production code always passes a valid - possibly empty - span.
+Thunk::ExecuteParams CreateExecuteParams(
+    const ServiceExecutableRunOptions& run_options,
+    const BufferAllocations& allocations, se::Stream* stream,
+    absl::Span<const BufferAllocation::Index> persistent_alloc_indices = {}) {
+  return Thunk::ExecuteParams::Create(
+      run_options, allocations, stream, stream, nullptr, nullptr, nullptr,
+      /*additional_compute_streams=*/{}, /*execution_scoped_state=*/nullptr,
+      persistent_alloc_indices);
+}
+
 }  // namespace
 
 TEST(CommandBufferThunkTest, DeviceToDeviceCopy) {
@@ -232,8 +247,7 @@ TEST(CommandBufferThunkTest, DeviceToDeviceCopy) {
   BufferAllocations allocations({a, b}, 0, &allocator);
 
   Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+      CreateExecuteParams(run_options, allocations, stream.get());
 
   // Execute command buffer thunk and verify that it copied the memory.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -345,8 +359,7 @@ TEST(CommandBufferThunkTest, UpdatePolicyIgnoresVaRemappedAllocations) {
   ASSERT_EQ(dst, std::vector<int32_t>(4, 7));
 }
 
-TEST(CommandBufferThunkTest,
-     PersistentAllocIndicesBecomingAvailableTriggersUpdate) {
+TEST(CommandBufferThunkTest, AbsentPersistentAllocIndicesFallsBackToThunks) {
   se::StreamExecutor* stream_executor = GpuExecutor();
   ASSERT_OK_AND_ASSIGN(auto stream, stream_executor->CreateStream());
 
@@ -358,129 +371,124 @@ TEST(CommandBufferThunkTest,
       stream_executor->AllocateArray<int32_t>(kLength, 0);
   se::DeviceAddress<int32_t> b =
       stream_executor->AllocateArray<int32_t>(kLength, 0);
-  se::DeviceAddress<int32_t> c =
-      stream_executor->AllocateArray<int32_t>(kLength, 0);
-  se::DeviceAddress<int32_t> d =
-      stream_executor->AllocateArray<int32_t>(kLength, 0);
   ASSERT_OK(stream->Memset32(&a, 42, kByteLength));
   ASSERT_OK(stream->MemZero(&b, kByteLength));
-  ASSERT_OK(stream->Memset32(&c, 7, kByteLength));
-  ASSERT_OK(stream->MemZero(&d, kByteLength));
 
   BufferAllocation source(/*index=*/0, kByteLength, /*color=*/0);
   BufferAllocation destination(/*index=*/1, kByteLength, /*color=*/0);
   BufferAllocation::Slice source_slice(&source, 0, kByteLength);
   BufferAllocation::Slice destination_slice(&destination, 0, kByteLength);
 
-  auto create_thunk = [&](int* record_count)
-      -> absl::StatusOr<std::unique_ptr<CommandBufferThunk>> {
-    CommandSequence commands;
-    commands.Emplace<CountingDeviceToDeviceCopyThunk>(
-        Thunk::ThunkInfo(), ShapedSlice{source_slice, shape},
-        ShapedSlice{destination_slice, shape}, kByteLength, record_count);
-    ASSIGN_OR_RETURN(CommandExecutor executor,
-                     CommandExecutor::Create(std::move(commands), serialize));
-    return std::make_unique<CommandBufferThunk>(std::move(executor),
-                                                Thunk::ThunkInfo());
-  };
+  // Command sequence that counts how many times commands are recorded into a
+  // command buffer.
+  int record_count = 0;
+  CommandSequence commands;
+  commands.Emplace<CountingDeviceToDeviceCopyThunk>(
+      Thunk::ThunkInfo(), ShapedSlice{source_slice, shape},
+      ShapedSlice{destination_slice, shape}, kByteLength, &record_count);
+  ASSERT_OK_AND_ASSIGN(CommandExecutor executor,
+                       CommandExecutor::Create(std::move(commands), serialize));
 
-  int initialize_record_count = 0;
-  ASSERT_OK_AND_ASSIGN(auto initialize_thunk,
-                       create_thunk(&initialize_record_count));
+  // Fallback thunk sequence that executes the same copy in op-by-op mode.
+  ThunkSequence fallback_thunks;
+  fallback_thunks.push_back(std::make_unique<DeviceToDeviceCopyThunk>(
+      Thunk::ThunkInfo(), ShapedSlice{source_slice, shape},
+      ShapedSlice{destination_slice, shape}, kByteLength));
+
+  CommandBufferThunk thunk(std::move(executor), Thunk::ThunkInfo(),
+                           std::make_unique<SequentialThunk>(
+                               Thunk::ThunkInfo(), std::move(fallback_thunks)));
 
   stream_executor::StreamExecutorAddressAllocator allocator(stream_executor);
   ServiceExecutableRunOptions run_options;
-  BufferAllocations first_allocations({a, b}, /*device_ordinal=*/0, &allocator);
+  BufferAllocations allocations({a, b}, /*device_ordinal=*/0, &allocator);
 
   Thunk::InitializeParams initialize_params;
   initialize_params.executor = stream_executor;
-  initialize_params.buffer_allocations = &first_allocations;
+  initialize_params.buffer_allocations = &allocations;
   initialize_params.stream = stream.get();
-  ASSERT_OK(initialize_thunk->Initialize(initialize_params));
-  EXPECT_EQ(initialize_record_count, 1);
 
-  Thunk::ExecuteParams absent_execute_params =
-      Thunk::ExecuteParams::Create(run_options, first_allocations, stream.get(),
+  // With absent persistent allocation indices, initialization skips command
+  // buffer creation and execution falls back to the thunk sequence.
+  ASSERT_OK(thunk.Initialize(initialize_params));
+  EXPECT_EQ(record_count, 0);
+
+  Thunk::ExecuteParams absent_params =
+      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
-  ASSERT_OK(initialize_thunk->ExecuteOnStream(absent_execute_params));
-  ASSERT_OK(stream->BlockHostUntilDone());
 
   std::vector<int32_t> result(kLength, 0);
-  ASSERT_OK(stream->Memcpy(result.data(), b, kByteLength));
-  EXPECT_EQ(result, std::vector<int32_t>(kLength, 42));
-  EXPECT_EQ(initialize_record_count, 1);
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_OK(stream->MemZero(&b, kByteLength));
+    ASSERT_OK(thunk.ExecuteOnStream(absent_params));
+    ASSERT_OK(stream->BlockHostUntilDone());
 
-  // An absent policy must not trigger another initialization update.
-  ASSERT_OK(initialize_thunk->Initialize(initialize_params));
-  EXPECT_EQ(initialize_record_count, 1);
+    std::fill(result.begin(), result.end(), 0);
+    ASSERT_OK(stream->Memcpy(result.data(), b, kByteLength));
+    EXPECT_EQ(result, std::vector<int32_t>(kLength, 42));
+    EXPECT_EQ(record_count, 0);
+  }
 
-  BufferAllocations second_allocations({c, d}, /*device_ordinal=*/0,
-                                       &allocator);
-  std::vector<BufferAllocation::Index> all_persistent_alloc_indices = {0, 1};
-  initialize_params.buffer_allocations = &second_allocations;
+  // Once persistent allocation indices become available, the thunk records
+  // and executes the command buffer.
+  std::vector<BufferAllocation::Index> persistent_alloc_indices = {0, 1};
   initialize_params.persistent_alloc_indices =
-      absl::MakeConstSpan(all_persistent_alloc_indices);
-  ASSERT_OK(initialize_thunk->Initialize(initialize_params));
-  EXPECT_EQ(initialize_record_count, 2);
+      absl::MakeConstSpan(persistent_alloc_indices);
+  ASSERT_OK(thunk.Initialize(initialize_params));
+  EXPECT_EQ(record_count, 1);
 
-  // Once present, the policy remains unchanged and does not trigger another
-  // initialization update.
-  ASSERT_OK(initialize_thunk->Initialize(initialize_params));
-  EXPECT_EQ(initialize_record_count, 2);
+  Thunk::ExecuteParams present_params =
+      CreateExecuteParams(run_options, allocations, stream.get(),
+                          absl::MakeConstSpan(persistent_alloc_indices));
 
-  Thunk::ExecuteParams present_execute_params = Thunk::ExecuteParams::Create(
-      run_options, second_allocations, stream.get(), stream.get(), nullptr,
-      nullptr, nullptr, /*additional_compute_streams=*/{},
-      /*execution_scoped_state=*/nullptr,
-      absl::MakeConstSpan(all_persistent_alloc_indices));
-  ASSERT_OK(initialize_thunk->ExecuteOnStream(present_execute_params));
-  ASSERT_OK(stream->BlockHostUntilDone());
-
-  std::fill(result.begin(), result.end(), 0);
-  ASSERT_OK(stream->Memcpy(result.data(), d, kByteLength));
-  EXPECT_EQ(result, std::vector<int32_t>(kLength, 7));
-  EXPECT_EQ(initialize_record_count, 2);
-
-  // The command-buffer update in Initialize can be skipped while command
-  // buffers are disabled for profiling. Execute must still update an existing
-  // command buffer when the persistent-allocation policy becomes available.
-  int execute_record_count = 0;
-  ASSERT_OK_AND_ASSIGN(auto execute_thunk, create_thunk(&execute_record_count));
-  initialize_params.buffer_allocations = &first_allocations;
-  initialize_params.persistent_alloc_indices = std::nullopt;
-  ASSERT_OK(execute_thunk->Initialize(initialize_params));
-  EXPECT_EQ(execute_record_count, 1);
-
-  ASSERT_OK(stream->MemZero(&d, kByteLength));
-  ASSERT_OK(execute_thunk->ExecuteOnStream(present_execute_params));
-  ASSERT_OK(stream->BlockHostUntilDone());
-
-  std::fill(result.begin(), result.end(), 0);
-  ASSERT_OK(stream->Memcpy(result.data(), d, kByteLength));
-  EXPECT_EQ(result, std::vector<int32_t>(kLength, 7));
-  EXPECT_EQ(execute_record_count, 2);
-
-  // An older execution initialized before policy activation can run after the
-  // present-policy command buffer was recorded. It must restore its addresses
-  // without changing the one-way policy contract across steps.
   ASSERT_OK(stream->MemZero(&b, kByteLength));
-  ASSERT_OK(execute_thunk->ExecuteOnStream(absent_execute_params));
+  ASSERT_OK(thunk.ExecuteOnStream(present_params));
   ASSERT_OK(stream->BlockHostUntilDone());
 
   std::fill(result.begin(), result.end(), 0);
   ASSERT_OK(stream->Memcpy(result.data(), b, kByteLength));
   EXPECT_EQ(result, std::vector<int32_t>(kLength, 42));
-  EXPECT_EQ(execute_record_count, 3);
+  EXPECT_EQ(record_count, 1);
 
-  // The next present-policy execution must likewise restore its addresses.
-  ASSERT_OK(stream->MemZero(&d, kByteLength));
-  ASSERT_OK(execute_thunk->ExecuteOnStream(present_execute_params));
+  // Executing again with unchanged buffers must not trigger an update.
+  ASSERT_OK(stream->MemZero(&b, kByteLength));
+  ASSERT_OK(thunk.ExecuteOnStream(present_params));
   ASSERT_OK(stream->BlockHostUntilDone());
 
   std::fill(result.begin(), result.end(), 0);
-  ASSERT_OK(stream->Memcpy(result.data(), d, kByteLength));
-  EXPECT_EQ(result, std::vector<int32_t>(kLength, 7));
-  EXPECT_EQ(execute_record_count, 4);
+  ASSERT_OK(stream->Memcpy(result.data(), b, kByteLength));
+  EXPECT_EQ(result, std::vector<int32_t>(kLength, 42));
+  EXPECT_EQ(record_count, 1);
+}
+
+TEST(CommandBufferThunkTest,
+     AbsentPersistentAllocIndicesWithoutFallbackThunksIsError) {
+  se::StreamExecutor* stream_executor = GpuExecutor();
+  ASSERT_OK_AND_ASSIGN(auto stream, stream_executor->CreateStream());
+
+  constexpr int64_t kByteLength = sizeof(uint32_t);
+  se::DeviceAddress<uint32_t> destination =
+      stream_executor->AllocateArray<uint32_t>(1, 0);
+  BufferAllocation allocation(/*index=*/0, kByteLength, /*color=*/0);
+  BufferAllocation::Slice slice(&allocation, /*offset=*/0, kByteLength);
+
+  CommandSequence commands;
+  commands.Emplace<Memset32BitValueThunk>(Thunk::ThunkInfo(), /*value=*/42,
+                                          slice);
+  ASSERT_OK_AND_ASSIGN(CommandExecutor executor,
+                       CommandExecutor::Create(std::move(commands), serialize));
+  CommandBufferThunk thunk(std::move(executor), Thunk::ThunkInfo());
+
+  stream_executor::StreamExecutorAddressAllocator allocator(stream_executor);
+  ServiceExecutableRunOptions run_options;
+  BufferAllocations allocations({destination}, /*device_ordinal=*/0,
+                                &allocator);
+  Thunk::ExecuteParams absent_params =
+      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
+                                   stream.get(), nullptr, nullptr, nullptr);
+
+  EXPECT_THAT(thunk.ExecuteOnStream(absent_params),
+              ::absl_testing::StatusIs(absl::StatusCode::kInternal));
 }
 
 TEST(CommandBufferThunkTest,
@@ -556,8 +564,7 @@ TEST(CommandBufferThunkTest, MemzeroThunk) {
   BufferAllocations allocations({a}, 0, &allocator);
 
   Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+      CreateExecuteParams(run_options, allocations, stream.get());
 
   // Execute command buffer thunk and verify that it zeroes the memory.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -604,8 +611,7 @@ TEST(CommandBufferThunkTest, Memset32Cmd) {
   BufferAllocations allocations({a}, 0, &allocator);
 
   Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+      CreateExecuteParams(run_options, allocations, stream.get());
 
   // Execute command buffer thunk and verify that it set the memory.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -662,8 +668,7 @@ TEST(CommandBufferThunkTest, Memset32CmdCommandBuffersDisabledDuringProfiling) {
   BufferAllocations allocations({a}, 0, &allocator);
 
   Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+      CreateExecuteParams(run_options, allocations, stream.get());
 
   TF_ASSERT_OK_AND_ASSIGN(auto profiler_lock,
                           tsl::profiler::ProfilerLock::Acquire());
@@ -722,8 +727,7 @@ TEST(CommandBufferThunkTest, Memset32CmdCommandBuffersEnabledDuringProfiling) {
   BufferAllocations allocations({a}, 0, &allocator);
 
   Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+      CreateExecuteParams(run_options, allocations, stream.get());
 
   TF_ASSERT_OK_AND_ASSIGN(auto profiler_lock,
                           tsl::profiler::ProfilerLock::Acquire());
@@ -774,8 +778,7 @@ TEST(CommandBufferThunkTest, Memset32CmdOnDifferentStreams) {
   BufferAllocations allocations({a}, 0, &allocator);
 
   Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+      CreateExecuteParams(run_options, allocations, stream.get());
 
   // Execute command buffer thunk and verify that it set the memory.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -835,8 +838,7 @@ TEST(CommandBufferThunkTest, LaunchCmd) {
   BufferAllocations allocations({a, b}, 0, &allocator);
 
   Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+      CreateExecuteParams(run_options, allocations, stream.get());
 
   TF_ASSERT_OK_AND_ASSIGN(OwningExecutableSource source, ExecutableSource());
   TF_ASSERT_OK(thunk.Initialize({stream_executor,
@@ -942,8 +944,7 @@ TEST(CommandBufferThunkTest, CustomAddKernelLaunchCmd) {
   BufferAllocations allocations({a, b}, 0, &allocator);
 
   Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+      CreateExecuteParams(run_options, allocations, stream.get());
 
   TF_ASSERT_OK_AND_ASSIGN(OwningExecutableSource source, ExecutableSource());
   TF_ASSERT_OK(thunk.Initialize({stream_executor,
@@ -1073,8 +1074,7 @@ TEST(CommandBufferThunkTest, GemmCmd) {
   BufferAllocations allocations({lhs, rhs, out, workspace}, 0, &allocator);
 
   Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+      CreateExecuteParams(run_options, allocations, stream.get());
 
   Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
   TF_ASSERT_OK(thunk.Initialize(
@@ -1223,8 +1223,7 @@ TEST(CommandBufferThunkTest, CublasLtCmd) {
     BufferAllocations allocations({a, b, c, d, workspace}, 0, &allocator);
 
     Thunk::ExecuteParams params =
-        Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                     stream.get(), nullptr, nullptr, nullptr);
+        CreateExecuteParams(run_options, allocations, stream.get());
 
     Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
     TF_ASSERT_OK(thunk.Initialize(
@@ -1342,8 +1341,7 @@ TEST(CommandBufferThunkTest, MultipleLaunchCmd) {
   BufferAllocations allocations({a, b, c, d}, 0, &allocator);
 
   Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+      CreateExecuteParams(run_options, allocations, stream.get());
 
   TF_ASSERT_OK_AND_ASSIGN(OwningExecutableSource source, ExecutableSource());
   TF_ASSERT_OK(thunk.Initialize({stream_executor,
@@ -1485,8 +1483,7 @@ TEST(CommandBufferThunkTest, ConditionalThunkCaseCommand) {
   BufferAllocations allocations({index, a, b}, 0, &allocator);
 
   Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+      CreateExecuteParams(run_options, allocations, stream.get());
 
   TF_ASSERT_OK_AND_ASSIGN(OwningExecutableSource source, ExecutableSource());
   TF_ASSERT_OK(thunk.Initialize({stream_executor,
@@ -1598,8 +1595,7 @@ TEST(CommandBufferThunkTest, WhileThunk) {
                                 &allocator);
 
   Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+      CreateExecuteParams(run_options, allocations, stream.get());
 
   TF_ASSERT_OK_AND_ASSIGN(OwningExecutableSource source, ExecutableSource());
   TF_ASSERT_OK(thunk.Initialize({stream_executor,

--- a/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
@@ -223,7 +223,7 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
   initialize_params.command_buffer_trace_stream = stream.get();
   initialize_params.persistent_alloc_indices =
       absl::Span<const BufferAllocation::Index>();
-  TF_ASSERT_OK(thunk.Initialize(initialize_params));
+  ASSERT_OK(thunk.Initialize(initialize_params));
 
   // Execute command buffer thunk and verify that it executed a GEMM.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));

--- a/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
@@ -208,13 +208,22 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
   stream_executor::StreamExecutorAddressAllocator allocator(stream_executor);
   BufferAllocations allocations(operands, 0, &allocator);
 
-  Thunk::ExecuteParams params =
-      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
-                                   stream.get(), nullptr, nullptr, nullptr);
+  Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
+      run_options, allocations, stream.get(), stream.get(), nullptr, nullptr,
+      nullptr, /*additional_compute_streams=*/{},
+      /*execution_scoped_state=*/nullptr,
+      /*persistent_alloc_indices=*/absl::Span<const BufferAllocation::Index>());
 
   Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
-  TF_ASSERT_OK(thunk.Initialize(
-      {stream_executor, source, &allocations, stream.get(), stream.get()}));
+  Thunk::InitializeParams initialize_params;
+  initialize_params.executor = stream_executor;
+  initialize_params.src = source;
+  initialize_params.buffer_allocations = &allocations;
+  initialize_params.stream = stream.get();
+  initialize_params.command_buffer_trace_stream = stream.get();
+  initialize_params.persistent_alloc_indices =
+      absl::Span<const BufferAllocation::Index>();
+  TF_ASSERT_OK(thunk.Initialize(initialize_params));
 
   // Execute command buffer thunk and verify that it executed a GEMM.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));

--- a/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk_test.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk_test.cc
@@ -143,7 +143,9 @@ Thunk::ExecuteParams MakeExecuteParams(
   return Thunk::ExecuteParams::Create(
       run_options, buffer_allocations, stream,
       /*command_buffer_trace_stream=*/nullptr, /*collective_params=*/nullptr,
-      /*collective_cliques=*/nullptr, /*collective_memory=*/nullptr);
+      /*collective_cliques=*/nullptr, /*collective_memory=*/nullptr,
+      /*additional_compute_streams=*/{}, /*execution_scoped_state=*/nullptr,
+      /*persistent_alloc_indices=*/absl::Span<const BufferAllocation::Index>());
 }
 
 TEST(DynamicSliceFusionV2ThunkTest, VerifyBufferAssignment) {

--- a/xla/backends/gpu/runtime/kernel_thunk_test.cc
+++ b/xla/backends/gpu/runtime/kernel_thunk_test.cc
@@ -513,13 +513,17 @@ TEST_P(KernelThunkTmaPTXTest, TmaPTX) {
       /*memory_allocator=*/nullptr);
 
   initialize_params.buffer_allocations = &buffer_allocations;
+  initialize_params.persistent_alloc_indices.emplace();
 
   ServiceExecutableRunOptions run_options;
   run_options.mutable_run_options()->set_stream(stream.get());
 
   auto execute_params = Thunk::ExecuteParams::Create(
       run_options, buffer_allocations, stream.get(), nullptr, nullptr, nullptr,
-      nullptr, {});
+      nullptr, {},
+      /*execution_scoped_state=*/nullptr,
+      /*persistent_alloc_indices=*/
+      initialize_params.persistent_alloc_indices);
 
   const bool use_command_buffer = GetParam();
 

--- a/xla/backends/gpu/runtime/thunk.h
+++ b/xla/backends/gpu/runtime/thunk.h
@@ -266,12 +266,14 @@ class Thunk {
     ExecutionScopedState* execution_scoped_state = nullptr;
 
     // Optional allocation indices whose device addresses are stable for this
-    // execution. If absent, consumers that need address-change checks should
-    // conservatively treat allocation addresses as dynamic. Across execution
-    // steps, this may transition only from absent to present, and the
-    // transition must be passed to Initialize before ExecuteOnStream. Once
-    // present, the allocation indices must remain unchanged; consumers may
-    // rely on this invariant without revalidating the vector on each step.
+    // execution. The value is absent only while the allocation address policy
+    // is undecided (e.g. during the VA remapping profiling window); when
+    // absent, command buffer lowering is disabled for this step and
+    // CommandBufferThunk executes its fallback thunk sequence instead.
+    // Producers must pass a valid - possibly empty - span once the policy is
+    // decided. Once present, the allocation indices must remain unchanged;
+    // consumers may rely on this invariant without revalidating the vector on
+    // each step.
     std::optional<absl::Span<const BufferAllocation::Index>>
         persistent_alloc_indices = std::nullopt;
   };
@@ -348,12 +350,14 @@ class Thunk {
     uint64_t rng_seed = 0;
 
     // Optional allocation indices whose device addresses are stable for this
-    // execution. If absent, consumers that need address-change checks should
-    // conservatively treat allocation addresses as dynamic. Across execution
-    // steps, this may transition only from absent to present, and the
-    // transition must be passed to Initialize before ExecuteOnStream. Once
-    // present, the allocation indices must remain unchanged; consumers may
-    // rely on this invariant without revalidating the vector on each step.
+    // execution. The value is absent only while the allocation address policy
+    // is undecided (e.g. during the VA remapping profiling window); when
+    // absent, command buffer lowering is disabled for this step and
+    // CommandBufferThunk executes its fallback thunk sequence instead.
+    // Producers must pass a valid - possibly empty - span once the policy is
+    // decided. Once present, the allocation indices must remain unchanged;
+    // consumers may rely on this invariant without revalidating the vector on
+    // each step.
     std::optional<absl::Span<const BufferAllocation::Index>>
         persistent_alloc_indices = std::nullopt;
 

--- a/xla/service/gpu/gpu_executable.h
+++ b/xla/service/gpu/gpu_executable.h
@@ -177,7 +177,7 @@ class GpuExecutable : public Executable {
       const ServiceExecutableRunOptions* run_options,
       VariantArguments arguments);
 
-  absl::Span<const BufferAllocation* absl_nonnull const> GetAllocations()
+  absl::Span<const BufferAllocation * absl_nonnull const> GetAllocations()
       const override {
     return allocation_ptrs_;
   }
@@ -209,6 +209,11 @@ class GpuExecutable : public Executable {
     return *buffer_allocator_;
   }
 
+  // `persistent_alloc_indices` lists allocations whose device addresses are
+  // stable for this execution. Passing std::nullopt disables command buffer
+  // lowering for this step (CommandBufferThunk falls back to its thunk
+  // sequence); pass a valid - possibly empty - span once the allocation
+  // address policy is decided.
   absl::Status ExecuteThunks(
       const BufferAllocations& buffer_allocations,
       const ServiceExecutableRunOptions* run_options,


### PR DESCRIPTION
## Summary

This change only affects CommandBufferUpdateMode::SKIP_PROFILED mode for the initial 3 steps for command buffer run, and also a preparation for supporting flatterned cuda-graph.

Command buffer lowering is now enabled only when `ExecuteParams::persistent_alloc_indices` has a value. When it is absent (e.g. during the VA remapping profiling window in `SKIP_PROFILED` mode), `CommandBufferThunk` executes its embedded fallback `SequentialThunk` in op-by-op mode and skips command buffer initialization.

This removes the need for the runtime to support the one-way absent → present transition of `persistent_alloc_indices` on a live command buffer: the `persistent_allocs_info_was_valid` state, the transition detection in `Initialize`/`ExecuteOnStream`, and the forced full command updates are all deleted.


## Justification

Handling the absent → present transition on a live command buffer required validity tracking, transition detection, and conservative full command updates to stay correct under interleaved executions. Falling back to op-by-op execution while the policy is undecided means a command buffer is only ever recorded under a single stable policy, deleting all of that machinery. The cost is bounded: the fallback only runs during the 3-step `SKIP_PROFILED` profiling window (where it also serves as warmup), and the fallback `SequentialThunk` is always available in production.

## Testing

- New tests: `AbsentPersistentAllocIndicesFallsBackToThunks`, `AbsentPersistentAllocIndicesWithoutFallbackThunksIsError`.
- Passed on H100: `command_buffer_thunk_test`, `cuda_command_buffer_thunk_test`, `dynamic_slice_fusion_v2_thunk_test`, `gpu_executable_va_remap_allocator_test`, `gpu_executable_test`, `kernel_name_tracer_test`.