### PR TITLE
[GPU] Fall back until command buffer allocation policy is ready

### DIFF
--- a/xla/backends/gpu/profiler/kernel_name_tracer_test.cc
+++ b/xla/backends/gpu/profiler/kernel_name_tracer_test.cc
@@ -185,17 +185,20 @@ void LaunchCommandBufferThunk(stream_executor::StreamExecutor* executor,
 
   Thunk::ExecuteParams params = Thunk::ExecuteParams::Create(
       run_options, allocations, stream, stream, nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   // This is where we're getting the 'AddI32' kernel from.
-  TF_ASSERT_OK_AND_ASSIGN(std::vector<uint8_t> fatbin,
-                          stream_executor::gpu::GetGpuTestKernelsFatbin(
-                              executor->GetPlatform()->Name()));
-  ASSERT_THAT(
-      thunk.Initialize({executor,
-                        Thunk::ExecutableSource{/*text=*/"", fatbin,
-                                                /*dnn_compiled_graphs=*/{}},
-                        &allocations, stream}),
-      IsOk());
+  ASSERT_OK_AND_ASSIGN(std::vector<uint8_t> fatbin,
+                       stream_executor::gpu::GetGpuTestKernelsFatbin(
+                           executor->GetPlatform()->Name()));
+  Thunk::InitializeParams initialize_params;
+  initialize_params.executor = executor;
+  initialize_params.src = Thunk::ExecutableSource{/*text=*/"", fatbin,
+                                                  /*dnn_compiled_graphs=*/{}};
+  initialize_params.buffer_allocations = &allocations;
+  initialize_params.stream = stream;
+  initialize_params.persistent_alloc_indices.emplace();
+  ASSERT_THAT(thunk.Initialize(initialize_params), IsOk());
 
   // Execute command buffer thunk and verify that it added the value.
   ASSERT_THAT(thunk.ExecuteOnStream(params), IsOk());

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -19,7 +19,6 @@ limitations under the License.
 #include <cstdint>
 #include <iterator>
 #include <memory>
-#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -63,16 +62,10 @@ CommandBufferThunk::ExecutorCommandBuffer::ExecutorCommandBuffer(
 
 bool CommandBufferThunk::ExecutorCommandBuffer::HasDynamicAllocations(
     const CommandExecutor& commands,
-    std::optional<absl::Span<const BufferAllocation::Index>>
-        persistent_alloc_indices) {
-  if (!persistent_alloc_indices.has_value()) {
-    return true;
-  }
-
+    absl::Span<const BufferAllocation::Index> persistent_alloc_indices) {
   DCHECK(absl::c_is_sorted(commands.allocs_indices()));
-  DCHECK(absl::c_is_sorted(*persistent_alloc_indices));
-  return !absl::c_includes(*persistent_alloc_indices,
-                           commands.allocs_indices());
+  DCHECK(absl::c_is_sorted(persistent_alloc_indices));
+  return !absl::c_includes(persistent_alloc_indices, commands.allocs_indices());
 }
 
 CommandBufferThunk::CommandBufferThunk(
@@ -113,24 +106,19 @@ CommandBufferThunk::CommandBufferThunk(
 
 std::vector<BufferAllocation::Index>
 CommandBufferThunk::ExecutorCommandBuffer::UpdateBufferAllocations(
-    const CommandExecutor& commands, const Thunk::ExecuteParams& params) {
+    const CommandExecutor& commands, const Thunk::ExecuteParams& params,
+    absl::Span<const BufferAllocation::Index> persistent_alloc_indices) {
   std::vector<BufferAllocation::Index> updated_allocs;
   const BufferAllocations* allocs = params.buffer_allocations;
-  absl::Span<const BufferAllocation::Index> allocs_to_check =
-      commands.allocs_indices();
   std::vector<BufferAllocation::Index> dynamic_alloc_indices;
-
-  if (const auto& persistent_alloc_indices = params.persistent_alloc_indices) {
-    DCHECK(absl::c_is_sorted(commands.allocs_indices()));
-    DCHECK(absl::c_is_sorted(*persistent_alloc_indices));
-    absl::c_set_difference(commands.allocs_indices(), *persistent_alloc_indices,
-                           std::back_inserter(dynamic_alloc_indices));
-    allocs_to_check = dynamic_alloc_indices;
-  }
+  DCHECK(absl::c_is_sorted(commands.allocs_indices()));
+  DCHECK(absl::c_is_sorted(persistent_alloc_indices));
+  absl::c_set_difference(commands.allocs_indices(), persistent_alloc_indices,
+                         std::back_inserter(dynamic_alloc_indices));
 
   // We check only allocations referenced by commands in a cmd sequence, and
   // leave every other entry default initialized (nullptr device memory).
-  for (BufferAllocation::Index index : allocs_to_check) {
+  for (BufferAllocation::Index index : dynamic_alloc_indices) {
     se::DeviceAddressBase alloc = allocs->GetDeviceAddress(index);
 
     if (recorded_allocs.size() <= index) {
@@ -155,7 +143,7 @@ absl::Status CommandBufferThunk::Prepare(const PrepareParams& params) {
   }
 
   // Always prepare thunks if they are present so we are ready to fall back
-  // on them if we detect profiling activity.
+  // when profiling is active or the persistent allocation policy is not ready.
   if (thunks_) {
     RETURN_IF_ERROR(thunks_->Prepare(params));
   }
@@ -186,7 +174,7 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
   RETURN_IF_ERROR(commands_.Initialize(params));
 
   // Always initialize thunks if they are present so we are ready to fall back
-  // on them if we detect profiling activity.
+  // when profiling is active or the persistent allocation policy is not ready.
   if (thunks_) {
     RETURN_IF_ERROR(thunks_->Initialize(params));
   }
@@ -198,6 +186,17 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
     VLOG(1) << "Initialize command buffer thunk as a regular thunk sequence "
                "because we detected active profiling session";
     TraceMe trace("WARNING: CommandBuffer disabled when profiling");
+    return absl::OkStatus();
+  }
+
+  // Do not lower commands until the persistent allocation policy is finalized.
+  // SKIP_PROFILED executions use the original thunk sequence while collecting
+  // allocation address observations.
+  if (!params.persistent_alloc_indices.has_value()) {
+    TF_RET_CHECK(thunks_ != nullptr)
+        << "Command buffer fallback requires the original thunk sequence";
+    VLOG(2) << "Initialize command buffer thunk as a regular thunk sequence "
+               "because persistent allocation indices are not available";
     return absl::OkStatus();
   }
 
@@ -238,28 +237,17 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
   // If commands require an update during initialization (and VA remapping is
   // not enabled), we also record them into the command buffer before execution.
   // This is required to guarantee that collective commands are recorded on all
-  // participating ranks to avoid deadlocks. We also update an existing command
-  // buffer when persistent allocation indices become available, because that
-  // changes which commands can safely retain their recorded addresses.
+  // participating ranks to avoid deadlocks.
   bool has_dynamic_allocations = cmd_buffer->HasDynamicAllocations(
-      commands_, params.persistent_alloc_indices);
+      commands_, *params.persistent_alloc_indices);
   bool is_first_record =
       cmd_buffer->command_buffer->state() == se::CommandBuffer::State::kCreate;
-  bool persistent_allocs_info_is_valid =
-      params.persistent_alloc_indices.has_value();
-  DCHECK(!cmd_buffer->persistent_allocs_info_was_valid ||
-         persistent_allocs_info_is_valid)
-      << "Persistent allocation information must remain valid once set";
   if (is_first_record ||
-      (!cmd_buffer->persistent_allocs_info_was_valid &&
-       persistent_allocs_info_is_valid) ||
       (has_dynamic_allocations && commands_.requires_update_on_initialize())) {
     VLOG(3) << "Initialize command buffer on device #"
             << params.executor->device_ordinal()
             << " by recoding command buffer cmd sequence"
-            << "; num_commands=" << commands_.size()
-            << "; persistent_allocs_info_is_valid="
-            << persistent_allocs_info_is_valid;
+            << "; num_commands=" << commands_.size();
 
     TraceMe trace([&] {
       return TraceMeEncode("command_buffer::initialize",
@@ -270,24 +258,14 @@ absl::Status CommandBufferThunk::Initialize(const InitializeParams& params) {
     uint64_t start_micros = tsl::Env::Default()->NowMicros();
 
     // Update recorded buffer allocations.
-    std::optional<std::vector<BufferAllocation::Index>> updated_allocs =
-        cmd_buffer->UpdateBufferAllocations(commands_, execute_params);
-
-    // Allocations can become persistent before their new addresses are
-    // observed by UpdateBufferAllocations. Force all commands to update so
-    // none retain addresses recorded before the policy became available.
-    if (!is_first_record && !cmd_buffer->persistent_allocs_info_was_valid &&
-        persistent_allocs_info_is_valid) {
-      updated_allocs.reset();
-    }
+    auto updated_allocs = cmd_buffer->UpdateBufferAllocations(
+        commands_, execute_params, *params.persistent_alloc_indices);
 
     Command::RecordParams record_params = {cmd_buffer->state,
                                            std::move(updated_allocs),
                                            /*is_initialization=*/true};
     RETURN_IF_ERROR(commands_.Record(execute_params, record_params,
                                      cmd_buffer->command_buffer.get()));
-    cmd_buffer->persistent_allocs_info_was_valid =
-        persistent_allocs_info_is_valid;
 
     uint64_t end_micros = tsl::Env::Default()->NowMicros();
     VLOG(3) << "Initialized command buffer on device #"
@@ -317,6 +295,16 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
     return thunks_->ExecuteOnStream(params);
   }
 
+  if (!params.persistent_alloc_indices.has_value()) {
+    TF_RET_CHECK(thunks_ != nullptr)
+        << "Command buffer fallback requires the original thunk sequence";
+    VLOG(2) << "Execute command buffer thunk as a regular thunk sequence "
+               "because persistent allocation indices are not available";
+    TraceMe trace(
+        "CommandBuffer disabled without persistent allocation information");
+    return thunks_->ExecuteOnStream(params);
+  }
+
   se::StreamExecutor* executor = params.stream->parent();
   ASSIGN_OR_RETURN(std::shared_ptr<ExecutorCommandBuffer> cmd_buffer,
                    GetOrCreateCommandBuffer(executor));
@@ -333,21 +321,13 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
 
   bool is_first_record =
       cmd_buffer->command_buffer->state() == se::CommandBuffer::State::kCreate;
-  // Executions initialized on opposite sides of the one-way policy transition
-  // can interleave, so the persistent allocation information recorded in the
-  // shared command buffer can have different validity from the current run.
-  bool persistent_allocs_info_is_valid =
-      params.persistent_alloc_indices.has_value();
-  bool persistent_allocs_info_is_changed =
-      !is_first_record && cmd_buffer->persistent_allocs_info_was_valid !=
-                              persistent_allocs_info_is_valid;
 
-  auto updated_allocs = cmd_buffer->UpdateBufferAllocations(commands_, params);
+  auto updated_allocs = cmd_buffer->UpdateBufferAllocations(
+      commands_, params, *params.persistent_alloc_indices);
 
   bool has_dynamic_allocations = cmd_buffer->HasDynamicAllocations(
-      commands_, params.persistent_alloc_indices);
-  bool needs_update = persistent_allocs_info_is_changed ||
-                      commands_.requires_update_on_execute() ||
+      commands_, *params.persistent_alloc_indices);
+  bool needs_update = commands_.requires_update_on_execute() ||
                       (has_dynamic_allocations && !updated_allocs.empty());
 
   if (is_first_record || needs_update) {
@@ -358,8 +338,6 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
         << "; num_commands=" << commands_.size()
         << "; updated_allocs=" << updated_allocs.size()
         << "; is_first_record=" << is_first_record
-        << "; persistent_allocs_info_is_changed="
-        << persistent_allocs_info_is_changed
         << "; needs_update=" << needs_update;
 
     TraceMe trace([&] {
@@ -372,22 +350,11 @@ absl::Status CommandBufferThunk::ExecuteOnStream(const ExecuteParams& params) {
 
     uint64_t start_micros = tsl::Env::Default()->NowMicros();
 
-    std::optional<std::vector<BufferAllocation::Index>> allocs_to_update =
-        std::move(updated_allocs);
-    // Force all commands to update when the recorded information validity does
-    // not match this execution. A filtered update could skip a command whose
-    // allocations are all persistent in one of the interleaved executions.
-    if (persistent_allocs_info_is_changed) {
-      allocs_to_update.reset();
-    }
-
     Command::RecordParams record_params = {
-        cmd_buffer->state, std::move(allocs_to_update),
+        cmd_buffer->state, std::move(updated_allocs),
         /*is_initialization=*/is_first_record && !has_dynamic_allocations};
     RETURN_IF_ERROR(commands_.Record(params, record_params,
                                      cmd_buffer->command_buffer.get()));
-    cmd_buffer->persistent_allocs_info_was_valid =
-        persistent_allocs_info_is_valid;
 
     uint64_t end_micros = tsl::Env::Default()->NowMicros();
     XLA_VLOG_DEVICE(3, executor->device_ordinal())

--- a/xla/backends/gpu/runtime/command_buffer_thunk.h
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.h
@@ -18,7 +18,6 @@ limitations under the License.
 
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -44,6 +43,8 @@ namespace xla::gpu {
 
 class CommandBufferThunk : public Thunk {
  public:
+  // `thunks` retains the original execution path and is required when
+  // persistent allocation information is not available.
   CommandBufferThunk(CommandExecutor commands, ThunkInfo thunk_info,
                      std::unique_ptr<SequentialThunk> thunks = nullptr,
                      bool enable_command_buffers_during_profiling = false);
@@ -98,16 +99,16 @@ class CommandBufferThunk : public Thunk {
     // changed since the last update. Returned buffer allocations are sorted by
     // the buffer allocation index.
     std::vector<BufferAllocation::Index> UpdateBufferAllocations(
-        const CommandExecutor& commands, const Thunk::ExecuteParams& params)
+        const CommandExecutor& commands, const Thunk::ExecuteParams& params,
+        absl::Span<const BufferAllocation::Index> persistent_alloc_indices)
         ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex);
 
     // Returns true if `commands` references any allocation whose address is not
-    // persistent under the current allocation address policy. If the policy is
-    // absent, conservatively returns true.
+    // persistent under the current allocation address policy.
     bool HasDynamicAllocations(
         const CommandExecutor& commands,
-        std::optional<absl::Span<const BufferAllocation::Index>>
-            persistent_alloc_indices) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex);
+        absl::Span<const BufferAllocation::Index> persistent_alloc_indices)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex);
 
     // se::CommandBuffer is not thread safe, and we guard it with a mutex to
     // guarantee that we do not mutate it concurrently.
@@ -130,12 +131,6 @@ class CommandBufferThunk : public Thunk {
     // and block sizes) captured by commands at construction time and do not
     // change.
     std::vector<se::DeviceAddressBase> recorded_allocs ABSL_GUARDED_BY(mutex);
-
-    // True if persistent allocation information was valid when the command
-    // buffer was recorded. We track only validity because the execution
-    // parameter contract guarantees that the indices remain unchanged once
-    // present.
-    bool persistent_allocs_info_was_valid ABSL_GUARDED_BY(mutex) = false;
 
     // Number of command buffer executions since last update.
     int64_t num_executions ABSL_GUARDED_BY(mutex) = 0;

--- a/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk_test.cc
@@ -170,10 +170,18 @@ class CountingDeviceToDeviceCopyThunk : public DeviceToDeviceCopyThunk {
   CountingDeviceToDeviceCopyThunk(Thunk::ThunkInfo thunk_info,
                                   const ShapedSlice& source_buffer,
                                   const ShapedSlice& destination_buffer,
-                                  int64_t mem_size, int* record_count)
+                                  int64_t mem_size, int* execute_count,
+                                  int* record_count)
       : DeviceToDeviceCopyThunk(std::move(thunk_info), source_buffer,
                                 destination_buffer, mem_size),
+        execute_count_(execute_count),
         record_count_(record_count) {}
+
+  absl::Status ExecuteOnStream(
+      const Thunk::ExecuteParams& execute_params) override {
+    ++*execute_count_;
+    return DeviceToDeviceCopyThunk::ExecuteOnStream(execute_params);
+  }
 
   absl::StatusOr<const se::CommandBuffer::Command*> Record(
       const Thunk::ExecuteParams& execute_params,
@@ -186,6 +194,7 @@ class CountingDeviceToDeviceCopyThunk : public DeviceToDeviceCopyThunk {
   }
 
  private:
+  int* execute_count_;
   int* record_count_;
 };
 
@@ -234,6 +243,7 @@ TEST(CommandBufferThunkTest, DeviceToDeviceCopy) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   // Execute command buffer thunk and verify that it copied the memory.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -345,8 +355,7 @@ TEST(CommandBufferThunkTest, UpdatePolicyIgnoresVaRemappedAllocations) {
   ASSERT_EQ(dst, std::vector<int32_t>(4, 7));
 }
 
-TEST(CommandBufferThunkTest,
-     PersistentAllocIndicesBecomingAvailableTriggersUpdate) {
+TEST(CommandBufferThunkTest, PersistentAllocIndicesUnavailableUsesFallback) {
   se::StreamExecutor* stream_executor = GpuExecutor();
   ASSERT_OK_AND_ASSIGN(auto stream, stream_executor->CreateStream());
 
@@ -358,129 +367,92 @@ TEST(CommandBufferThunkTest,
       stream_executor->AllocateArray<int32_t>(kLength, 0);
   se::DeviceAddress<int32_t> b =
       stream_executor->AllocateArray<int32_t>(kLength, 0);
-  se::DeviceAddress<int32_t> c =
-      stream_executor->AllocateArray<int32_t>(kLength, 0);
-  se::DeviceAddress<int32_t> d =
-      stream_executor->AllocateArray<int32_t>(kLength, 0);
   ASSERT_OK(stream->Memset32(&a, 42, kByteLength));
   ASSERT_OK(stream->MemZero(&b, kByteLength));
-  ASSERT_OK(stream->Memset32(&c, 7, kByteLength));
-  ASSERT_OK(stream->MemZero(&d, kByteLength));
 
   BufferAllocation source(/*index=*/0, kByteLength, /*color=*/0);
   BufferAllocation destination(/*index=*/1, kByteLength, /*color=*/0);
   BufferAllocation::Slice source_slice(&source, 0, kByteLength);
   BufferAllocation::Slice destination_slice(&destination, 0, kByteLength);
 
-  auto create_thunk = [&](int* record_count)
-      -> absl::StatusOr<std::unique_ptr<CommandBufferThunk>> {
-    CommandSequence commands;
-    commands.Emplace<CountingDeviceToDeviceCopyThunk>(
-        Thunk::ThunkInfo(), ShapedSlice{source_slice, shape},
-        ShapedSlice{destination_slice, shape}, kByteLength, record_count);
-    ASSIGN_OR_RETURN(CommandExecutor executor,
-                     CommandExecutor::Create(std::move(commands), serialize));
-    return std::make_unique<CommandBufferThunk>(std::move(executor),
-                                                Thunk::ThunkInfo());
-  };
-
-  int initialize_record_count = 0;
-  ASSERT_OK_AND_ASSIGN(auto initialize_thunk,
-                       create_thunk(&initialize_record_count));
+  int execute_count = 0;
+  int record_count = 0;
+  auto copy_thunk = std::make_unique<CountingDeviceToDeviceCopyThunk>(
+      Thunk::ThunkInfo(), ShapedSlice{source_slice, shape},
+      ShapedSlice{destination_slice, shape}, kByteLength, &execute_count,
+      &record_count);
+  CommandSequence commands;
+  commands.Append(copy_thunk.get());
+  ASSERT_OK_AND_ASSIGN(CommandExecutor executor,
+                       CommandExecutor::Create(std::move(commands), serialize));
+  ThunkSequence fallback_thunks;
+  fallback_thunks.push_back(std::move(copy_thunk));
+  auto fallback = std::make_unique<SequentialThunk>(Thunk::ThunkInfo(),
+                                                    std::move(fallback_thunks));
+  CommandBufferThunk thunk(std::move(executor), Thunk::ThunkInfo(),
+                           std::move(fallback));
 
   stream_executor::StreamExecutorAddressAllocator allocator(stream_executor);
   ServiceExecutableRunOptions run_options;
-  BufferAllocations first_allocations({a, b}, /*device_ordinal=*/0, &allocator);
+  BufferAllocations allocations({a, b}, /*device_ordinal=*/0, &allocator);
 
   Thunk::InitializeParams initialize_params;
   initialize_params.executor = stream_executor;
-  initialize_params.buffer_allocations = &first_allocations;
+  initialize_params.buffer_allocations = &allocations;
   initialize_params.stream = stream.get();
-  ASSERT_OK(initialize_thunk->Initialize(initialize_params));
-  EXPECT_EQ(initialize_record_count, 1);
+  ASSERT_OK(thunk.Initialize(initialize_params));
+  EXPECT_EQ(record_count, 0);
 
-  Thunk::ExecuteParams absent_execute_params =
-      Thunk::ExecuteParams::Create(run_options, first_allocations, stream.get(),
+  Thunk::ExecuteParams execute_params =
+      Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
-  ASSERT_OK(initialize_thunk->ExecuteOnStream(absent_execute_params));
+  ASSERT_OK(thunk.ExecuteOnStream(execute_params));
   ASSERT_OK(stream->BlockHostUntilDone());
 
   std::vector<int32_t> result(kLength, 0);
   ASSERT_OK(stream->Memcpy(result.data(), b, kByteLength));
   EXPECT_EQ(result, std::vector<int32_t>(kLength, 42));
-  EXPECT_EQ(initialize_record_count, 1);
+  EXPECT_EQ(execute_count, 1);
+  EXPECT_EQ(record_count, 0);
 
-  // An absent policy must not trigger another initialization update.
-  ASSERT_OK(initialize_thunk->Initialize(initialize_params));
-  EXPECT_EQ(initialize_record_count, 1);
-
-  BufferAllocations second_allocations({c, d}, /*device_ordinal=*/0,
-                                       &allocator);
-  std::vector<BufferAllocation::Index> all_persistent_alloc_indices = {0, 1};
-  initialize_params.buffer_allocations = &second_allocations;
-  initialize_params.persistent_alloc_indices =
-      absl::MakeConstSpan(all_persistent_alloc_indices);
-  ASSERT_OK(initialize_thunk->Initialize(initialize_params));
-  EXPECT_EQ(initialize_record_count, 2);
-
-  // Once present, the policy remains unchanged and does not trigger another
-  // initialization update.
-  ASSERT_OK(initialize_thunk->Initialize(initialize_params));
-  EXPECT_EQ(initialize_record_count, 2);
-
-  Thunk::ExecuteParams present_execute_params = Thunk::ExecuteParams::Create(
-      run_options, second_allocations, stream.get(), stream.get(), nullptr,
-      nullptr, nullptr, /*additional_compute_streams=*/{},
-      /*execution_scoped_state=*/nullptr,
-      absl::MakeConstSpan(all_persistent_alloc_indices));
-  ASSERT_OK(initialize_thunk->ExecuteOnStream(present_execute_params));
-  ASSERT_OK(stream->BlockHostUntilDone());
-
-  std::fill(result.begin(), result.end(), 0);
-  ASSERT_OK(stream->Memcpy(result.data(), d, kByteLength));
-  EXPECT_EQ(result, std::vector<int32_t>(kLength, 7));
-  EXPECT_EQ(initialize_record_count, 2);
-
-  // The command-buffer update in Initialize can be skipped while command
-  // buffers are disabled for profiling. Execute must still update an existing
-  // command buffer when the persistent-allocation policy becomes available.
-  int execute_record_count = 0;
-  ASSERT_OK_AND_ASSIGN(auto execute_thunk, create_thunk(&execute_record_count));
-  initialize_params.buffer_allocations = &first_allocations;
-  initialize_params.persistent_alloc_indices = std::nullopt;
-  ASSERT_OK(execute_thunk->Initialize(initialize_params));
-  EXPECT_EQ(execute_record_count, 1);
-
-  ASSERT_OK(stream->MemZero(&d, kByteLength));
-  ASSERT_OK(execute_thunk->ExecuteOnStream(present_execute_params));
-  ASSERT_OK(stream->BlockHostUntilDone());
-
-  std::fill(result.begin(), result.end(), 0);
-  ASSERT_OK(stream->Memcpy(result.data(), d, kByteLength));
-  EXPECT_EQ(result, std::vector<int32_t>(kLength, 7));
-  EXPECT_EQ(execute_record_count, 2);
-
-  // An older execution initialized before policy activation can run after the
-  // present-policy command buffer was recorded. It must restore its addresses
-  // without changing the one-way policy contract across steps.
+  // A present empty span is a valid policy and enables command buffer lowering.
+  initialize_params.persistent_alloc_indices.emplace();
+  execute_params.persistent_alloc_indices.emplace();
   ASSERT_OK(stream->MemZero(&b, kByteLength));
-  ASSERT_OK(execute_thunk->ExecuteOnStream(absent_execute_params));
+  ASSERT_OK(thunk.Initialize(initialize_params));
+  ASSERT_OK(thunk.ExecuteOnStream(execute_params));
   ASSERT_OK(stream->BlockHostUntilDone());
 
   std::fill(result.begin(), result.end(), 0);
   ASSERT_OK(stream->Memcpy(result.data(), b, kByteLength));
   EXPECT_EQ(result, std::vector<int32_t>(kLength, 42));
-  EXPECT_EQ(execute_record_count, 3);
+  EXPECT_EQ(execute_count, 1);
+  EXPECT_EQ(record_count, 1);
 
-  // The next present-policy execution must likewise restore its addresses.
-  ASSERT_OK(stream->MemZero(&d, kByteLength));
-  ASSERT_OK(execute_thunk->ExecuteOnStream(present_execute_params));
+  // An execution without a policy falls back without updating the command
+  // buffer recorded by the valid execution.
+  execute_params.persistent_alloc_indices.reset();
+  ASSERT_OK(stream->MemZero(&b, kByteLength));
+  ASSERT_OK(thunk.ExecuteOnStream(execute_params));
   ASSERT_OK(stream->BlockHostUntilDone());
 
   std::fill(result.begin(), result.end(), 0);
-  ASSERT_OK(stream->Memcpy(result.data(), d, kByteLength));
-  EXPECT_EQ(result, std::vector<int32_t>(kLength, 7));
-  EXPECT_EQ(execute_record_count, 4);
+  ASSERT_OK(stream->Memcpy(result.data(), b, kByteLength));
+  EXPECT_EQ(result, std::vector<int32_t>(kLength, 42));
+  EXPECT_EQ(execute_count, 2);
+  EXPECT_EQ(record_count, 1);
+
+  // The next valid execution reuses the existing command buffer.
+  execute_params.persistent_alloc_indices.emplace();
+  ASSERT_OK(stream->MemZero(&b, kByteLength));
+  ASSERT_OK(thunk.ExecuteOnStream(execute_params));
+  ASSERT_OK(stream->BlockHostUntilDone());
+
+  std::fill(result.begin(), result.end(), 0);
+  ASSERT_OK(stream->Memcpy(result.data(), b, kByteLength));
+  EXPECT_EQ(result, std::vector<int32_t>(kLength, 42));
+  EXPECT_EQ(execute_count, 2);
+  EXPECT_EQ(record_count, 1);
 }
 
 TEST(CommandBufferThunkTest,
@@ -558,6 +530,7 @@ TEST(CommandBufferThunkTest, MemzeroThunk) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   // Execute command buffer thunk and verify that it zeroes the memory.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -606,6 +579,7 @@ TEST(CommandBufferThunkTest, Memset32Cmd) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   // Execute command buffer thunk and verify that it set the memory.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -664,6 +638,7 @@ TEST(CommandBufferThunkTest, Memset32CmdCommandBuffersDisabledDuringProfiling) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   TF_ASSERT_OK_AND_ASSIGN(auto profiler_lock,
                           tsl::profiler::ProfilerLock::Acquire());
@@ -724,6 +699,7 @@ TEST(CommandBufferThunkTest, Memset32CmdCommandBuffersEnabledDuringProfiling) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   TF_ASSERT_OK_AND_ASSIGN(auto profiler_lock,
                           tsl::profiler::ProfilerLock::Acquire());
@@ -776,6 +752,7 @@ TEST(CommandBufferThunkTest, Memset32CmdOnDifferentStreams) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   // Execute command buffer thunk and verify that it set the memory.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -837,11 +814,14 @@ TEST(CommandBufferThunkTest, LaunchCmd) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   TF_ASSERT_OK_AND_ASSIGN(OwningExecutableSource source, ExecutableSource());
-  TF_ASSERT_OK(thunk.Initialize({stream_executor,
-                                 static_cast<Thunk::ExecutableSource>(source),
-                                 &allocations, stream.get()}));
+  Thunk::InitializeParams initialize_params{
+      stream_executor, static_cast<Thunk::ExecutableSource>(source),
+      &allocations, stream.get()};
+  initialize_params.persistent_alloc_indices.emplace();
+  ASSERT_OK(thunk.Initialize(initialize_params));
 
   // Execute command buffer thunk and verify that it added the value.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -944,11 +924,14 @@ TEST(CommandBufferThunkTest, CustomAddKernelLaunchCmd) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   TF_ASSERT_OK_AND_ASSIGN(OwningExecutableSource source, ExecutableSource());
-  TF_ASSERT_OK(thunk.Initialize({stream_executor,
-                                 static_cast<Thunk::ExecutableSource>(source),
-                                 &allocations, stream.get()}));
+  Thunk::InitializeParams initialize_params{
+      stream_executor, static_cast<Thunk::ExecutableSource>(source),
+      &allocations, stream.get()};
+  initialize_params.persistent_alloc_indices.emplace();
+  ASSERT_OK(thunk.Initialize(initialize_params));
 
   // Execute command buffer thunk and verify that it added the value.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -1075,10 +1058,13 @@ TEST(CommandBufferThunkTest, GemmCmd) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
-  TF_ASSERT_OK(thunk.Initialize(
-      {stream_executor, source, &allocations, stream.get(), stream.get()}));
+  Thunk::InitializeParams initialize_params{
+      stream_executor, source, &allocations, stream.get(), stream.get()};
+  initialize_params.persistent_alloc_indices.emplace();
+  ASSERT_OK(thunk.Initialize(initialize_params));
 
   // Execute command buffer thunk and verify that it executed a GEMM.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -1225,10 +1211,13 @@ TEST(CommandBufferThunkTest, CublasLtCmd) {
     Thunk::ExecuteParams params =
         Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                      stream.get(), nullptr, nullptr, nullptr);
+    params.persistent_alloc_indices.emplace();
 
     Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
-    TF_ASSERT_OK(thunk.Initialize(
-        {stream_executor, source, &allocations, stream.get(), stream.get()}));
+    Thunk::InitializeParams initialize_params{
+        stream_executor, source, &allocations, stream.get(), stream.get()};
+    initialize_params.persistent_alloc_indices.emplace();
+    ASSERT_OK(thunk.Initialize(initialize_params));
 
     // Execute command buffer thunk and verify that it executed a GEMM.
     TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -1344,11 +1333,14 @@ TEST(CommandBufferThunkTest, MultipleLaunchCmd) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   TF_ASSERT_OK_AND_ASSIGN(OwningExecutableSource source, ExecutableSource());
-  TF_ASSERT_OK(thunk.Initialize({stream_executor,
-                                 static_cast<Thunk::ExecutableSource>(source),
-                                 &allocations, stream.get()}));
+  Thunk::InitializeParams initialize_params{
+      stream_executor, static_cast<Thunk::ExecutableSource>(source),
+      &allocations, stream.get()};
+  initialize_params.persistent_alloc_indices.emplace();
+  ASSERT_OK(thunk.Initialize(initialize_params));
 
   // Execute command buffer thunk and verify that it added the value.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -1487,11 +1479,14 @@ TEST(CommandBufferThunkTest, ConditionalThunkCaseCommand) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   TF_ASSERT_OK_AND_ASSIGN(OwningExecutableSource source, ExecutableSource());
-  TF_ASSERT_OK(thunk.Initialize({stream_executor,
-                                 static_cast<Thunk::ExecutableSource>(source),
-                                 &allocations, stream.get()}));
+  Thunk::InitializeParams initialize_params{
+      stream_executor, static_cast<Thunk::ExecutableSource>(source),
+      &allocations, stream.get()};
+  initialize_params.persistent_alloc_indices.emplace();
+  ASSERT_OK(thunk.Initialize(initialize_params));
 
   // Execute command buffer thunk and verify that it added the value.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));
@@ -1600,11 +1595,14 @@ TEST(CommandBufferThunkTest, WhileThunk) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   TF_ASSERT_OK_AND_ASSIGN(OwningExecutableSource source, ExecutableSource());
-  TF_ASSERT_OK(thunk.Initialize({stream_executor,
-                                 static_cast<Thunk::ExecutableSource>(source),
-                                 &allocations, stream.get()}));
+  Thunk::InitializeParams initialize_params{
+      stream_executor, static_cast<Thunk::ExecutableSource>(source),
+      &allocations, stream.get()};
+  initialize_params.persistent_alloc_indices.emplace();
+  ASSERT_OK(thunk.Initialize(initialize_params));
 
   // Execute command buffer thunk and verify that it added the value 10 times.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));

--- a/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
+++ b/xla/backends/gpu/runtime/cuda_command_buffer_thunk_test.cc
@@ -211,10 +211,17 @@ TEST(CommandBufferThunkTest, CuDnnCmd) {
   Thunk::ExecuteParams params =
       Thunk::ExecuteParams::Create(run_options, allocations, stream.get(),
                                    stream.get(), nullptr, nullptr, nullptr);
+  params.persistent_alloc_indices.emplace();
 
   Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
-  TF_ASSERT_OK(thunk.Initialize(
-      {stream_executor, source, &allocations, stream.get(), stream.get()}));
+  Thunk::InitializeParams initialize_params;
+  initialize_params.executor = stream_executor;
+  initialize_params.src = source;
+  initialize_params.buffer_allocations = &allocations;
+  initialize_params.stream = stream.get();
+  initialize_params.command_buffer_trace_stream = stream.get();
+  initialize_params.persistent_alloc_indices.emplace();
+  ASSERT_OK(thunk.Initialize(initialize_params));
 
   // Execute command buffer thunk and verify that it executed a GEMM.
   TF_ASSERT_OK(thunk.ExecuteOnStream(params));

--- a/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk_test.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk_test.cc
@@ -733,10 +733,17 @@ TEST(DynamicSliceFusionV2ThunkTest,
   ASSERT_OK(command_buffer_thunk.Prepare(prepare_params));
 
   Thunk::ExecutableSource source = {/*text=*/"", /*binary=*/{}};
-  ASSERT_OK(command_buffer_thunk.Initialize(
-      {executor, source, &allocations, stream.get(), stream.get()}));
+  Thunk::InitializeParams initialize_params;
+  initialize_params.executor = executor;
+  initialize_params.src = source;
+  initialize_params.buffer_allocations = &allocations;
+  initialize_params.stream = stream.get();
+  initialize_params.command_buffer_trace_stream = stream.get();
+  initialize_params.persistent_alloc_indices.emplace();
+  ASSERT_OK(command_buffer_thunk.Initialize(initialize_params));
 
   auto params = MakeExecuteParams(allocations, stream.get());
+  params.persistent_alloc_indices.emplace();
 
   ScopedWhileLoop loop("dynamic_slice_fusion_v2_command_buffer",
                        /*trip_count=*/4);

--- a/xla/backends/gpu/runtime/kernel_thunk_test.cc
+++ b/xla/backends/gpu/runtime/kernel_thunk_test.cc
@@ -538,6 +538,8 @@ TEST_P(KernelThunkTmaPTXTest, TmaPTX) {
     auto cmd_buffer_thunk = std::make_unique<CommandBufferThunk>(
         std::move(cmds), Thunk::ThunkInfo(), std::move(sequential_thunk), true);
 
+    initialize_params.persistent_alloc_indices.emplace();
+    execute_params.persistent_alloc_indices.emplace();
     ASSERT_OK(cmd_buffer_thunk->Initialize(initialize_params));
     ASSERT_OK(cmd_buffer_thunk->ExecuteOnStream(execute_params));
   } else {

--- a/xla/backends/gpu/runtime/thunk.h
+++ b/xla/backends/gpu/runtime/thunk.h
@@ -266,12 +266,12 @@ class Thunk {
     ExecutionScopedState* execution_scoped_state = nullptr;
 
     // Optional allocation indices whose device addresses are stable for this
-    // execution. If absent, consumers that need address-change checks should
-    // conservatively treat allocation addresses as dynamic. Across execution
-    // steps, this may transition only from absent to present, and the
-    // transition must be passed to Initialize before ExecuteOnStream. Once
-    // present, the allocation indices must remain unchanged; consumers may
-    // rely on this invariant without revalidating the vector on each step.
+    // execution. Command buffer thunks execute their original thunk sequence
+    // when this is absent and lower to command buffers only when it is present.
+    // A present empty span represents a finalized policy with no persistent
+    // allocations. Once present, the allocation indices must remain unchanged;
+    // consumers may rely on this invariant without revalidating the vector on
+    // each step.
     std::optional<absl::Span<const BufferAllocation::Index>>
         persistent_alloc_indices = std::nullopt;
   };
@@ -348,12 +348,12 @@ class Thunk {
     uint64_t rng_seed = 0;
 
     // Optional allocation indices whose device addresses are stable for this
-    // execution. If absent, consumers that need address-change checks should
-    // conservatively treat allocation addresses as dynamic. Across execution
-    // steps, this may transition only from absent to present, and the
-    // transition must be passed to Initialize before ExecuteOnStream. Once
-    // present, the allocation indices must remain unchanged; consumers may
-    // rely on this invariant without revalidating the vector on each step.
+    // execution. Command buffer thunks execute their original thunk sequence
+    // when this is absent and lower to command buffers only when it is present.
+    // A present empty span represents a finalized policy with no persistent
+    // allocations. Once present, the allocation indices must remain unchanged;
+    // consumers may rely on this invariant without revalidating the vector on
+    // each step.
     std::optional<absl::Span<const BufferAllocation::Index>>
         persistent_alloc_indices = std::nullopt;
 

--- a/xla/service/gpu/gpu_executable_buffer_allocator.h
+++ b/xla/service/gpu/gpu_executable_buffer_allocator.h
@@ -114,8 +114,9 @@ class GpuExecutableBufferAllocator {
         absl::FunctionRef<absl::Status(absl::Status)> allocation_error);
 
     // Runs `execute` with the allocation-address policy for this execution.
-    // The base implementation passes the command-buffer-referenced constant
-    // allocations as the persistent allocation indices.
+    // The base implementation always passes a present span containing the
+    // command-buffer-referenced constant allocations. The span is present and
+    // empty when there are no such constants.
     virtual absl::Status ExecuteWithBufferAllocations(
         const BufferAllocations& owning_buffer_allocations, int device_ordinal,
         absl::FunctionRef<absl::Status(

--- a/xla/service/gpu/gpu_executable_test.cc
+++ b/xla/service/gpu/gpu_executable_test.cc
@@ -366,6 +366,29 @@ TEST_F(GpuExecutableTest, CommandBufferAllocationPolicy) {
   EXPECT_EQ(skip_profiled_policy.command_buffer_allocation_count, 2);
   EXPECT_THAT(skip_profiled_policy.persistent_alloc_indices,
               Optional(ElementsAre(1)));
+
+  // Without VMM, constants are the only allocations with persistent
+  // addresses. Verify that every update mode passes a present, empty policy on
+  // its first execution when there are no constants.
+  allocations[1].set_constant(false);
+
+  ASSERT_OK_AND_ASSIGN(
+      auto always_update_empty_policy,
+      get_allocation_policy_without_vmm(DebugOptions::ALWAYS_UPDATE));
+  EXPECT_THAT(always_update_empty_policy.persistent_alloc_indices,
+              Optional(ElementsAre()));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto skip_temp_empty_policy,
+      get_allocation_policy_without_vmm(DebugOptions::SKIP_TEMP));
+  EXPECT_THAT(skip_temp_empty_policy.persistent_alloc_indices,
+              Optional(ElementsAre()));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto skip_profiled_empty_policy,
+      get_allocation_policy_without_vmm(DebugOptions::SKIP_PROFILED));
+  EXPECT_THAT(skip_profiled_empty_policy.persistent_alloc_indices,
+              Optional(ElementsAre()));
 }
 
 TEST_F(GpuExecutableTest, ComputeComputationLayout) {

--- a/xla/service/gpu/gpu_executable_va_remap_allocator.cc
+++ b/xla/service/gpu/gpu_executable_va_remap_allocator.cc
@@ -106,11 +106,11 @@ class GpuExecutableVaRemapAllocator::VaRemapExecutionScope
   bool va_remap_enabled() const override { return true; }
 
   // In the SKIP_PROFILED profiling phase this observes allocation addresses
-  // and passes std::nullopt as the persistent allocation indices. Otherwise it
-  // builds an execution-only address table, maps selected input/output buffers
-  // into their stable reservation addresses, and passes the persistent
-  // allocation indices to `execute`. The owning address table remains
-  // unchanged for result handling and TearDown.
+  // and passes std::nullopt so command buffer thunks execute their original
+  // thunk sequences. Otherwise it builds an execution-only address table, maps
+  // selected input/output buffers into their stable reservation addresses, and
+  // passes the persistent allocation indices to `execute`. The owning address
+  // table remains unchanged for result handling and TearDown.
   absl::Status ExecuteWithBufferAllocations(
       const BufferAllocations& owning_buffer_allocations, int device_ordinal,
       absl::FunctionRef<
@@ -388,9 +388,9 @@ absl::Status GpuExecutableVaRemapAllocator::VaRemapExecutionScope::
       owner_->update_mode_ == DebugOptions::SKIP_PROFILED;
   if (profiled_mode) {
     if (remapping_->phase == Remapping::ProfilePhase::kProfiling) {
-      // Profiling executions must pass std::nullopt: the persistent
-      // allocation indices may transition from absent to present only once,
-      // and the profiled set is not known yet.
+      // The persistent allocation policy is not known yet. Passing std::nullopt
+      // keeps command buffer thunks in their original execution mode while
+      // profiling allocation addresses.
       RETURN_IF_ERROR(execute(owning_buffer_allocations, std::nullopt));
       ObserveAllocationAddresses(owning_buffer_allocations);
       ++remapping_->profiled_steps;

--- a/xla/service/gpu/gpu_executable_va_remap_allocator.h
+++ b/xla/service/gpu/gpu_executable_va_remap_allocator.h
@@ -98,14 +98,14 @@ class GpuExecutableVaRemapAllocator : public GpuExecutableBufferAllocator {
   // execution scopes created for that executor.
   struct Remapping {
     // SKIP_PROFILED per-executor profile state machine. The phase progresses
-    // kProfiling -> (kActive | kDisabled) exactly once, which keeps the
-    // persistent allocation indices passed to thunks consistent with the
-    // one-way absent-to-present transition required by
-    // Thunk::ExecuteParams::persistent_alloc_indices.
+    // kProfiling -> (kActive | kDisabled) exactly once. Profiling executions
+    // disable command buffer lowering; the first execution after the decision
+    // receives a present persistent allocation policy.
     enum class ProfilePhase {
       // Not a SKIP_PROFILED remapping (SKIP_TEMP).
       kInactive,
-      // Observing allocation addresses; executions pass std::nullopt.
+      // Observing allocation addresses; executions pass std::nullopt and use
+      // the original thunk sequences.
       kProfiling,
       // Profile transition done; the selected allocation set is VA-remapped.
       kActive,

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -450,15 +450,18 @@ message DebugOptions {
   //     use fixed VMM reservation addresses; other dynamic allocations still
   //     trigger command updates when their addresses change.
   //
-  //   SKIP_PROFILED: For the first few executions, buffers use regular
-  //     dynamically allocated addresses. Preallocated temp buffers are
-  //     automatically selected for remapping while the runtime records which
-  //     other non-constant, non-thread-local command-buffer-referenced
-  //     allocations keep a stable address. Afterwards, the temp buffers and
-  //     stable profile candidates use fixed VMM reservation addresses during
-  //     execution. Temp buffers are allocated through the reservation;
-  //     finalized input and output addresses are aliased into it immediately
-  //     before execution.
+  //   SKIP_PROFILED: For the first few executions, command buffer thunks execute
+  //     their original thunk sequences and buffers use regular dynamically
+  //     allocated addresses. Preallocated temp buffers are automatically
+  //     selected for remapping while the runtime records which other
+  //     non-constant, non-thread-local command-buffer-referenced allocations
+  //     keep a stable address. The first execution after the profiling decision
+  //     receives a finalized persistent allocation policy, including an empty
+  //     policy when nothing is persistent, and enables command buffer lowering.
+  //     Afterwards, the temp buffers and stable profile candidates use fixed VMM
+  //     reservation addresses during execution. Temp buffers are allocated
+  //     through the reservation; finalized input and output addresses are
+  //     aliased into it immediately before execution.
   //     Remapping enforces address stability, so a mispredicted profile costs
   //     an extra VMM remap instead of correctness. Requires the VMM allocator
   //     and assumes symmetric behavior across ranks.


### PR DESCRIPTION
📝 Summary of Changes

- Run `CommandBufferThunk` through its retained thunk sequence when
  `persistent_alloc_indices` is unavailable.
- Lower and execute command buffers only after the persistent allocation policy
  is valid; a present empty vector represents a finalized policy with no
  persistent allocations.
- Remove runtime state used to handle an absent-to-present persistent allocation
  policy transition.
- Clarify the allocation-policy contract and update direct command-buffer callers
  and tests.

🎯 Justification

`SKIP_PROFILED` does not know its persistent allocation policy until profiling
has completed. Keeping `CommandBufferThunk` in normal `ExecuteOnStream` fallback
mode until that decision is available avoids requiring command-buffer runtime
state to support a policy transition. `ALWAYS_UPDATE`, `SKIP_TEMP`, and the first
post-decision `SKIP_PROFILED` execution now consistently provide a valid policy,
including an empty vector when there are no persistent allocations.

This simplifies command-buffer runtime behavior while preserving execution
during profiling and benefits GPU workloads using command-buffer allocation
update modes.

🚀 Kind of Contribution

🐛 Bug Fix, ♻️ Cleanup, 🧪 Tests

🧪 Unit Tests:

- `bazel test --test_output=errors //xla/service/gpu:gpu_executable_test
  //xla/service/gpu:gpu_executable_va_remap_allocator_test`

🧪 Execution Tests:

- `bazel test --test_output=errors --remote_upload_local_results=false
  //xla/backends/gpu/runtime:command_buffer_thunk_test_nvgpu_any
  --test_filter=CommandBufferThunkTest.PersistentAllocIndicesUnavailableUsesFallback`
