### PR TITLE
Fix DUCC's nested-parallelism check in EigenThreadPool

### DIFF
--- a/third_party/ducc/threading.h
+++ b/third_party/ducc/threading.h
@@ -38,8 +38,8 @@ class EigenThreadPool : public ducc0::detail_threading::thread_pool {
   EigenThreadPool(Eigen::ThreadPoolInterface& pool) : pool_{&pool} {}
   size_t nthreads() const override { return pool_->NumThreads(); }
   size_t adjust_nthreads(size_t nthreads_in) const override {
-    // If called by a thread in the pool, return 1
-    if (pool_->CurrentThreadId() >= 0) {
+    // Don't parallelize if this thread is already inside a parallel loop
+    if (ducc0::detail_threading::in_parallel_region) {
       return 1;
     } else if (nthreads_in == 0) {
       return pool_->NumThreads();


### PR DESCRIPTION
XLA serialises FFT operations when they're preceded by another operation. The reproducing example does FFT -> elementwise multiply -> IFFT and the IFFT runs on one core, which caused a 20x performance regression that was reported downstream in jax.

DUCC's Eigen thread pool adapter has a guard to prevent threads from recursively spawning parallel work (see: https://github.com/mreineck/ducc/commit/d3c91f2b30e8d2ac678d1fadbaa7ed189013cde6). But the check in XLA is too aggressive and treats any thread that's part of the thread pool as if it's currently doing parallel work.

This PR changes the guard to check `ducc0::detail_threading::in_parallel_region` which reports if the current thread is currently participating in parallel work.

Resolves https://github.com/openxla/xla/issues/46345 and speeds up the reproducing script by 20x

Kind of Contribution: 🐛 Bug Fix, ⚡️ Performance Improvement

<details>
<summary>Reproducer script</summary> 

```python
import statistics
import time

import jax
import jax.numpy as jnp


shape = (128, 8, 576, 576)

x = jnp.ones(shape, dtype=jnp.complex64)
kernel = jnp.ones((576, 576), dtype=jnp.complex64)


fft_only = jax.jit(
    lambda x: jnp.fft.fft2(
        x,
        axes=(-2, -1),
        norm="ortho",
    )
)


fft_mul = jax.jit(
    lambda x, kernel: (
        jnp.fft.fft2(
            x,
            axes=(-2, -1),
            norm="ortho",
        )
        * kernel
    )
)


fft_mul_ifft = jax.jit(
    lambda x, kernel: jnp.fft.ifft2(
        jnp.fft.fft2(
            x,
            axes=(-2, -1),
            norm="ortho",
        )
        * kernel,
        axes=(-2, -1),
        norm="ortho",
    )
)


def benchmark(name, fn, *args):
    # Warm-up: compile and first execution are not timed.
    fn(*args).block_until_ready()

    times = []

    for _ in range(3):
        start = time.perf_counter()
        result = fn(*args)
        result.block_until_ready()
        times.append(time.perf_counter() - start)

    print(f"{name}: {statistics.median(times):.4f} s")


benchmark("fft_only", fft_only, x)
benchmark("fft_mul", fft_mul, x, kernel)
benchmark("fft_mul_ifft", fft_mul_ifft, x, kernel)
```

</details>

Timing before patch:

```python
fft_only:       0.2077 s
fft_mul:        0.1626 s
fft_mul_ifft:   2.2228 s
```

Timing after patch:

```python
fft_only:       0.1772 s
fft_mul:        0.2004 s
fft_mul_ifft:   0.3587 s
```