### PR TITLE
[GPU][XTile] Gate replica-ids argument wrapping on the data type

### DIFF
--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -230,6 +230,7 @@ cc_library(
         ":lowering_util",
         ":triton_kernel_source",
         ":triton_wrapper_result",
+        "//xla/backends/gpu/runtime:collective_params",
         "//xla:autotuning_proto_cc",
         "//xla:frontend_attributes",
         "//xla:util",

--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_shared_dialect_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_shared_dialect_test.cc
@@ -523,6 +523,17 @@ TEST_F(XTileDialectTest, HloAllGatherDotLowering) {
   BlockLevelParameters block_level_parameters;
   block_level_parameters.output_tile_sizes = {{128, 128}};
 
+  // The AllGather input tile carries a replica_id, so the tiling infra promotes
+  // the input parameter into a replica-id pointer table (memref<2xi64>) and
+  // dereferences it via xtile.select_buffer.
+  //
+  // NOTE: This test drives the emitter directly through EmitXTileModule without
+  // an IsParamScratchBuffer runtime-contract predicate, so the data-type gating
+  // is not applied here and wrapping is honored unconditionally (the default
+  // behavior when the predicate is null). The gating itself -- which prevents
+  // this wrapping when the runtime passes the input as a plain buffer, as the
+  // AllGather collective kernel does -- is verified separately by the unit
+  // tests in xla/codegen/xtile/codegen/emitter_helpers_test.cc.
   EXPECT_OK(CreateXTileIrAndFileCheck(*module->GetComputationWithName("ag_dot"),
                                       block_level_parameters, R"(
     CHECK: xtile.entry_func @xtile_dialect_fn(%arg0: memref<2xi64>

--- a/xla/backends/gpu/codegen/triton/xtile_compiler.cc
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.cc
@@ -88,6 +88,7 @@ limitations under the License.
 #include "xla/backends/gpu/codegen/triton/transforms/passes.h"
 #include "xla/backends/gpu/codegen/triton/triton_kernel_source.h"
 #include "xla/backends/gpu/codegen/triton/triton_wrapper_result.h"
+#include "xla/backends/gpu/runtime/collective_params.h"
 #include "xla/codegen/emitters/ir/xla_dialect.h"
 #include "xla/codegen/emitters/transforms/passes.h"
 #include "xla/codegen/ir_printing.h"
@@ -279,7 +280,8 @@ absl::StatusOr<mlir::OwningOpRef<mlir::ModuleOp>> TileAndEmitXTileModule(
     const se::DeviceDescription& device_info,
     const BlockLevelParameters& block_level_parameters,
     absl::Span<mlir::Type> opaque_args_types, mlir::MLIRContext& mlir_context,
-    bool use_experimental_tiling) {
+    bool use_experimental_tiling,
+    const xtile::IsParamScratchBuffer& is_param_scratch_buffer = nullptr) {
   const HloComputation* computation = fusion.fused_instructions_computation();
 
   if (use_experimental_tiling) {
@@ -321,7 +323,7 @@ absl::StatusOr<mlir::OwningOpRef<mlir::ModuleOp>> TileAndEmitXTileModule(
         fn_name, fusion, tiled_computation, mlir_context,
         absl::MakeSpan(opaque_args_types),
         std::make_optional(device_info.gpu_compute_capability()),
-        block_level_parameters.num_tiles_per_pid);
+        block_level_parameters.num_tiles_per_pid, is_param_scratch_buffer);
   }
   SymbolicTileAnalysisOrError symbolic_tile_analysis_or =
       SymbolicTileAnalysis::AnalyzeComputation(
@@ -396,6 +398,11 @@ absl::StatusOr<TritonKernelSource> CreateTritonModule(
   // This is done after the input and output arguments but before the tile
   // index.
   int32_t num_metadata_arguments = 0;
+  // Runtime-contract predicate: whether the runtime passes a given fusion
+  // parameter as a pointer table (scratch buffer). Derived from the collective
+  // kernel spec below. A parameter whose tile carries a replica_id is only
+  // wrapped into a replica-id pointer table when this predicate returns true.
+  xtile::IsParamScratchBuffer is_param_scratch_buffer = nullptr;
   if (fusion_kind == kTritonCollectiveFusionKind) {
     auto loc = mlir::NameLoc::get(
         mlir::StringAttr::get(&mlir_context, hlo_computation->name()));
@@ -404,6 +411,49 @@ absl::StatusOr<TritonKernelSource> CreateTritonModule(
     ASSIGN_OR_RETURN(
         num_metadata_arguments,
         AddCollectiveMetadataArguments(opaque_args_types, b, hlo_computation));
+
+    // Build the runtime-contract predicate from the collective kernel spec. The
+    // argument_descriptors are independent of launch dimensions, so a default
+    // LaunchDimensions is sufficient here to obtain them. The i-th fusion
+    // parameter maps to the i-th input-buffer argument descriptor; a parameter
+    // is considered a pointer table only if that descriptor's kernel-arg type
+    // is a scratch buffer.
+    //
+    // CreateCollectiveKernelSpec is not implemented for every collective. When
+    // the spec cannot be created we leave `is_param_scratch_buffer` null, which
+    // honors replica-id wrapping unconditionally (the default, legacy
+    // behavior).
+    absl::StatusOr<CollectiveKernelSpec> kernel_spec_or =
+        CreateCollectiveKernelSpec(&fusion, LaunchDimensions());
+    if (kernel_spec_or.ok()) {
+      is_param_scratch_buffer =
+          [kernel_spec =
+               std::move(kernel_spec_or).value()](int64_t param_index) -> bool {
+        int64_t input_like_seen = 0;
+        for (const KernelArgDescriptor& desc :
+             kernel_spec.argument_descriptors) {
+          if (desc.type != KernelArgType::kInputBuffer &&
+              desc.type != KernelArgType::kScratchBuffer) {
+            continue;
+          }
+          // Only input-like descriptors participate in the parameter ordering.
+          // kScratchBuffer descriptors that back a fusion parameter (pointer
+          // table inputs) count towards the parameter index as well.
+          if (desc.type == KernelArgType::kInputBuffer) {
+            if (input_like_seen == param_index) {
+              return false;  // Plain buffer input: do not wrap.
+            }
+            ++input_like_seen;
+          }
+        }
+        return false;
+      };
+    } else {
+      VLOG(3) << "CreateCollectiveKernelSpec unavailable for "
+              << hlo_computation->name() << " ("
+              << kernel_spec_or.status().message()
+              << "); keeping default replica-id pointer-table wrapping.";
+    }
   }
 
   RETURN_IF_ERROR(ValidateF4UseInTritonFusion(*hlo_computation));
@@ -412,7 +462,7 @@ absl::StatusOr<TritonKernelSource> CreateTritonModule(
                    TileAndEmitXTileModule(
                        fn_name, fusion, device_info, block_level_parameters,
                        absl::MakeSpan(opaque_args_types), mlir_context,
-                       use_experimental_tiling));
+                       use_experimental_tiling, is_param_scratch_buffer));
 
   const auto debug_options = fusion.GetModule()->config().debug_options();
   if (DumpingEnabledForHloModule(*hlo_computation->parent()) &&

--- a/xla/codegen/xtile/codegen/BUILD
+++ b/xla/codegen/xtile/codegen/BUILD
@@ -236,6 +236,26 @@ xla_cc_test(
 )
 
 xla_cc_test(
+    name = "emitter_helpers_test",
+    srcs = ["emitter_helpers_test.cc"],
+    deps = [
+        ":emitter_helpers",
+        "//xla/codegen/xtile/ir:xtile",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service/llvm_ir:llvm_util",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest_main",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+        "@stablehlo//:stablehlo_ops",
+    ],
+)
+
+xla_cc_test(
     name = "tiled_emitter_constraints_test",
     srcs = ["tiled_emitter_constraints_test.cc"],
     deps = [

--- a/xla/codegen/xtile/codegen/emitter_helpers.cc
+++ b/xla/codegen/xtile/codegen/emitter_helpers.cc
@@ -853,7 +853,16 @@ Value Bitcast(mlir::ImplicitLocOpBuilder& b, Value value, Type type) {
       llvm::to_vector(LayoutUtil::MinorToMajor(logical_shape));
   SmallVector<Value> replica_id_offsets;
   SmallVector<Value> replica_id_bounds;
-  if (!tiled_hlo.tile().replica_ids().empty()) {
+  // A parameter's tile may carry replica_ids, but we only wrap it into a
+  // replica-id pointer table (emitting SelectBufferOp below via
+  // EmitParameterExtract) when the runtime actually passes that parameter as a
+  // pointer table (scratch buffer). Otherwise the runtime provides a plain
+  // buffer and wrapping would dereference plain data as pointers.
+  const bool param_is_scratch_buffer =
+      tiled_hlo.hlo()->opcode() == HloOpcode::kParameter &&
+      emitter_ctx.IsParamPassedAsScratchBuffer(
+          tiled_hlo.hlo()->parameter_number());
+  if (!tiled_hlo.tile().replica_ids().empty() && param_is_scratch_buffer) {
     llvm::SmallVector<SymbolicExpr> offset_exprs;
     llvm::SmallVector<SymbolicExpr> bound_exprs;
     offset_exprs.reserve(tiled_hlo.tile().replica_ids().size());
@@ -1101,7 +1110,8 @@ absl::StatusOr<SmallVector<Type>> GetFnArgTypes(
     mlir::ImplicitLocOpBuilder& b, const HloFusionInstruction& fusion,
     absl::Span<mlir::Type> opaque_args_types,
     const std::optional<GpuComputeCapability>& gpu_cc,
-    const DefaultTileRequirementsVisitor& tile_requirements_visitor) {
+    const DefaultTileRequirementsVisitor& tile_requirements_visitor,
+    const IsParamScratchBuffer& is_param_scratch_buffer) {
   SmallVector<Type> fn_arg_types;
 
   auto hlo_computation = fusion.fused_instructions_computation();
@@ -1111,7 +1121,13 @@ absl::StatusOr<SmallVector<Type>> GetFnArgTypes(
                      GetMlirType(b, p->shape().element_type(), gpu_cc));
     ASSIGN_OR_RETURN(SmallVector<int64_t> replica_id_bounds,
                      tile_requirements_visitor.RequiredReplicaIdBounds(*p));
-    if (!replica_id_bounds.empty()) {
+    // Only wrap the parameter into a replica-id pointer table when the runtime
+    // actually passes it as a pointer table (scratch buffer). When no predicate
+    // is provided, wrapping is honored unconditionally (default behavior).
+    const bool param_is_scratch_buffer =
+        is_param_scratch_buffer == nullptr ||
+        is_param_scratch_buffer(p->parameter_number());
+    if (!replica_id_bounds.empty() && param_is_scratch_buffer) {
       // Nested pointer schema for replica dimensions.
       // R x S x <type> where R is the number of replica dimensions and S is
       // the shape on the local device. In total we have R pointers to

--- a/xla/codegen/xtile/codegen/emitter_helpers.h
+++ b/xla/codegen/xtile/codegen/emitter_helpers.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define XLA_CODEGEN_XTILE_CODEGEN_EMITTER_HELPERS_H_
 
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <utility>
 
@@ -61,6 +62,16 @@ namespace xla::xtile {
 using TensorValue = mlir::TypedValue<mlir::RankedTensorType>;
 static constexpr auto kTritonDivisibilityAttr = "tt.divisibility";
 
+// Predicate describing the runtime contract for a fusion parameter: given a
+// fusion parameter index, returns whether the runtime passes that parameter as
+// a pointer table (a scratch/pointer-table kernel argument) rather than a plain
+// buffer. This is used to decide whether a parameter whose tile carries a
+// replica_id should actually be wrapped into a replica-id pointer table (with
+// an xtile::SelectBufferOp). When null, wrapping is honored unconditionally
+// (default behavior for callers without a runtime contract). Kept as a generic
+// std::function so the emitter stays agnostic to runtime-specific types.
+using IsParamScratchBuffer = std::function<bool(int64_t param_index)>;
+
 // Convenience class for holding the emitted values.
 class EmitterContext {
  public:
@@ -68,20 +79,30 @@ class EmitterContext {
       mlir::ImplicitLocOpBuilder& b, const HloFusionInstruction* fusion,
       mlir::Value pid, mlir::Value tid, gpu::experimental::Schedule schedule,
       xtile::EntryFuncOp entry_func,
-      const gpu::experimental::TiledHloComputation& tiled_computation)
+      const gpu::experimental::TiledHloComputation& tiled_computation,
+      IsParamScratchBuffer is_param_scratch_buffer = nullptr)
       : b_(b),
         pid_(pid),
         tid_(tid),
         schedule_(std::move(schedule)),
         fusion_(fusion),
         entry_func_(entry_func),
-        tiled_computation_(tiled_computation) {}
+        tiled_computation_(tiled_computation),
+        is_param_scratch_buffer_(std::move(is_param_scratch_buffer)) {}
 
   mlir::ImplicitLocOpBuilder& b() { return b_; }
   mlir::Value pid() const { return pid_; }
   mlir::Value tid() const { return tid_; }
   const HloFusionInstruction& fusion() const { return *fusion_; }
   xtile::EntryFuncOp entry_func() const { return entry_func_; }
+
+  // Returns whether the runtime passes the given fusion parameter as a pointer
+  // table (scratch buffer). When no predicate was provided, returns true so
+  // that replica-id wrapping is honored unconditionally (default behavior).
+  bool IsParamPassedAsScratchBuffer(int64_t param_index) const {
+    return is_param_scratch_buffer_ == nullptr ||
+           is_param_scratch_buffer_(param_index);
+  }
 
   TensorValue TiledHloToTensorValue(
       const gpu::experimental::TiledHloInstruction& tiled_hlo) const {
@@ -130,6 +151,9 @@ class EmitterContext {
   absl::flat_hash_map<gpu::experimental::TiledDimId,
                       std::pair<mlir::Value, Interval>>
       sequential_dim_id_to_value_;
+  // Runtime contract predicate: is a given fusion parameter passed as a pointer
+  // table (scratch buffer)? Null => treat as always true (honor wrapping).
+  IsParamScratchBuffer is_param_scratch_buffer_;
 };
 
 // Constructs and holds information needed to construct a tile. This information
@@ -420,7 +444,8 @@ absl::StatusOr<llvm::SmallVector<mlir::Type>> GetFnArgTypes(
     absl::Span<mlir::Type> opaque_args_types,
     const std::optional<stream_executor::GpuComputeCapability>& gpu_cc,
     const DefaultTileRequirementsVisitor& tile_requirements_visitor =
-        DefaultTileRequirementsVisitor());
+        DefaultTileRequirementsVisitor(),
+    const IsParamScratchBuffer& is_param_scratch_buffer = nullptr);
 
 // Function to check if the operands of a concatenation are valid for tiling.
 absl::Status CheckConcatenateOperands(

--- a/xla/codegen/xtile/codegen/emitter_helpers_test.cc
+++ b/xla/codegen/xtile/codegen/emitter_helpers_test.cc
@@ -1,0 +1,256 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/codegen/xtile/codegen/emitter_helpers.h"
+
+#include <cstdint>
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "llvm/ADT/SmallVector.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Support/LLVM.h"
+#include "stablehlo/dialect/StablehloOps.h"
+#include "xla/codegen/xtile/ir/xtile_dialect.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/service/llvm_ir/llvm_util.h"
+
+namespace xla::xtile {
+namespace {
+
+// A test-only visitor that reports a fixed replica-id bound for a chosen
+// fusion parameter. This is used to simulate a parameter whose tile carries a
+// replica_id, which is the precondition for replica-id pointer-table wrapping.
+class ReplicaIdForParamVisitor : public DefaultTileRequirementsVisitor {
+ public:
+  ReplicaIdForParamVisitor(int64_t param_number, int64_t bound)
+      : param_number_(param_number), bound_(bound) {}
+
+  absl::StatusOr<llvm::SmallVector<int64_t>> RequiredReplicaIdBounds(
+      const HloInstruction& instr) const override {
+    if (instr.opcode() == HloOpcode::kParameter &&
+        instr.parameter_number() == param_number_) {
+      return llvm::SmallVector<int64_t>({bound_});
+    }
+    return llvm::SmallVector<int64_t>();
+  }
+
+ private:
+  int64_t param_number_;
+  int64_t bound_;
+};
+
+class EmitterHelpersTest : public HloHardwareIndependentTestBase {
+ public:
+  EmitterHelpersTest() : b_(mlir::UnknownLoc::get(&ctx_), &ctx_) {
+    ctx_.loadDialect<mlir::arith::ArithDialect,
+                     mlir::stablehlo::StablehloDialect, xtile::XTileDialect>();
+    module_ = xla::llvm_ir::CreateMlirModuleOp(b_.getLoc());
+    b_.setInsertionPointToStart(module_->getBody());
+  }
+
+  // Returns the single fusion instruction from the entry computation of the
+  // given HLO text.
+  absl::StatusOr<std::unique_ptr<HloModule>> ParseFusionModule(
+      absl::string_view hlo_text) {
+    return ParseAndReturnVerifiedModule(hlo_text);
+  }
+
+  const HloFusionInstruction* GetFusion(const HloModule& module) {
+    return xla::Cast<HloFusionInstruction>(
+        module.entry_computation()->root_instruction());
+  }
+
+  mlir::MLIRContext ctx_;
+  mlir::OwningOpRef<mlir::ModuleOp> module_;
+  mlir::ImplicitLocOpBuilder b_;
+};
+
+constexpr absl::string_view kHloText = R"(
+HloModule m
+
+add_fusion {
+  p0 = f32[128,128] parameter(0)
+  p1 = f32[128,128] parameter(1)
+  ROOT add = f32[128,128] add(p0, p1)
+}
+
+ENTRY e {
+  p0 = f32[128,128] parameter(0)
+  p1 = f32[128,128] parameter(1)
+  ROOT fusion = f32[128,128] fusion(p0, p1), kind=kCustom,
+    calls=add_fusion,
+    backend_config={"fusion_backend_config": {kind: "__triton"}}
+})";
+
+// When a parameter carries a replica_id and no runtime-contract predicate is
+// provided, wrapping is honored unconditionally: the parameter is promoted to a
+// 1-D i64 pointer table of size equal to the replica-id bound.
+TEST_F(EmitterHelpersTest, WrapsReplicaIdParamWhenPredicateIsNull) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseFusionModule(kHloText));
+  const HloFusionInstruction* fusion = GetFusion(*module);
+
+  ReplicaIdForParamVisitor visitor(/*param_number=*/0, /*bound=*/2);
+  ASSERT_OK_AND_ASSIGN(
+      llvm::SmallVector<mlir::Type> arg_types,
+      GetFnArgTypes(b_, *fusion, /*opaque_args_types=*/{}, /*gpu_cc=*/{},
+                    visitor, /*is_param_scratch_buffer=*/nullptr));
+
+  // arg0 (replica-id param) -> pointer table memref<2xi64>.
+  auto arg0 = mlir::cast<mlir::MemRefType>(arg_types[0]);
+  EXPECT_EQ(arg0.getShape(), mlir::ArrayRef<int64_t>({2}));
+  EXPECT_TRUE(arg0.getElementType().isInteger(64));
+
+  // arg1 (plain param) -> plain buffer memref<128x128xf32>.
+  auto arg1 = mlir::cast<mlir::MemRefType>(arg_types[1]);
+  EXPECT_EQ(arg1.getShape(), mlir::ArrayRef<int64_t>({128, 128}));
+  EXPECT_TRUE(arg1.getElementType().isF32());
+}
+
+// When the runtime-contract predicate reports the replica-id parameter as a
+// pointer table (scratch buffer), the parameter is wrapped.
+TEST_F(EmitterHelpersTest, WrapsReplicaIdParamWhenPredicateReturnsTrue) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseFusionModule(kHloText));
+  const HloFusionInstruction* fusion = GetFusion(*module);
+
+  ReplicaIdForParamVisitor visitor(/*param_number=*/0, /*bound=*/2);
+  IsParamScratchBuffer is_param_scratch_buffer =
+      [](int64_t param_index) -> bool { return true; };
+  ASSERT_OK_AND_ASSIGN(
+      llvm::SmallVector<mlir::Type> arg_types,
+      GetFnArgTypes(b_, *fusion, /*opaque_args_types=*/{}, /*gpu_cc=*/{},
+                    visitor, is_param_scratch_buffer));
+
+  auto arg0 = mlir::cast<mlir::MemRefType>(arg_types[0]);
+  EXPECT_EQ(arg0.getShape(), mlir::ArrayRef<int64_t>({2}));
+  EXPECT_TRUE(arg0.getElementType().isInteger(64));
+}
+
+// The gating: even though the parameter's tile carries a replica_id, when the
+// runtime-contract predicate reports that the parameter is NOT passed as a
+// pointer table (scratch buffer), it must NOT be wrapped. This is the case for
+// the AllGather Triton collective kernel, which passes its input as a plain
+// buffer. Wrapping in that case would dereference plain data as pointers and
+// cause a GPU memory-access fault.
+TEST_F(EmitterHelpersTest, DoesNotWrapReplicaIdParamWhenPredicateReturnsFalse) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseFusionModule(kHloText));
+  const HloFusionInstruction* fusion = GetFusion(*module);
+
+  ReplicaIdForParamVisitor visitor(/*param_number=*/0, /*bound=*/2);
+  IsParamScratchBuffer is_param_scratch_buffer =
+      [](int64_t param_index) -> bool { return false; };
+  ASSERT_OK_AND_ASSIGN(
+      llvm::SmallVector<mlir::Type> arg_types,
+      GetFnArgTypes(b_, *fusion, /*opaque_args_types=*/{}, /*gpu_cc=*/{},
+                    visitor, is_param_scratch_buffer));
+
+  // arg0 stays a plain buffer memref<128x128xf32>, NOT a memref<2xi64> pointer
+  // table.
+  auto arg0 = mlir::cast<mlir::MemRefType>(arg_types[0]);
+  EXPECT_EQ(arg0.getShape(), mlir::ArrayRef<int64_t>({128, 128}));
+  EXPECT_TRUE(arg0.getElementType().isF32());
+}
+
+// The predicate is consulted with the correct fusion parameter number, so it
+// can wrap some replica-id parameters while leaving others as plain buffers.
+TEST_F(EmitterHelpersTest, PredicateIsGatedPerParameterIndex) {
+  constexpr absl::string_view kTwoReplicaIdParamsHlo = R"(
+HloModule m
+
+add_fusion {
+  p0 = f32[128,128] parameter(0)
+  p1 = f32[128,128] parameter(1)
+  ROOT add = f32[128,128] add(p0, p1)
+}
+
+ENTRY e {
+  p0 = f32[128,128] parameter(0)
+  p1 = f32[128,128] parameter(1)
+  ROOT fusion = f32[128,128] fusion(p0, p1), kind=kCustom,
+    calls=add_fusion,
+    backend_config={"fusion_backend_config": {kind: "__triton"}}
+})";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseFusionModule(kTwoReplicaIdParamsHlo));
+  const HloFusionInstruction* fusion = GetFusion(*module);
+
+  // Both parameters carry a replica_id.
+  class BothParamsVisitor : public DefaultTileRequirementsVisitor {
+   public:
+    absl::StatusOr<llvm::SmallVector<int64_t>> RequiredReplicaIdBounds(
+        const HloInstruction& instr) const override {
+      if (instr.opcode() == HloOpcode::kParameter) {
+        return llvm::SmallVector<int64_t>({2});
+      }
+      return llvm::SmallVector<int64_t>();
+    }
+  } visitor;
+
+  // Only parameter 1 is passed as a pointer table.
+  IsParamScratchBuffer is_param_scratch_buffer =
+      [](int64_t param_index) -> bool { return param_index == 1; };
+  ASSERT_OK_AND_ASSIGN(
+      llvm::SmallVector<mlir::Type> arg_types,
+      GetFnArgTypes(b_, *fusion, /*opaque_args_types=*/{}, /*gpu_cc=*/{},
+                    visitor, is_param_scratch_buffer));
+
+  // arg0 not wrapped (plain buffer), arg1 wrapped (pointer table).
+  auto arg0 = mlir::cast<mlir::MemRefType>(arg_types[0]);
+  EXPECT_EQ(arg0.getShape(), mlir::ArrayRef<int64_t>({128, 128}));
+  EXPECT_TRUE(arg0.getElementType().isF32());
+
+  auto arg1 = mlir::cast<mlir::MemRefType>(arg_types[1]);
+  EXPECT_EQ(arg1.getShape(), mlir::ArrayRef<int64_t>({2}));
+  EXPECT_TRUE(arg1.getElementType().isInteger(64));
+}
+
+// Sanity check: a parameter that does not carry a replica_id is never wrapped,
+// regardless of the predicate.
+TEST_F(EmitterHelpersTest, NeverWrapsNonReplicaIdParam) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseFusionModule(kHloText));
+  const HloFusionInstruction* fusion = GetFusion(*module);
+
+  // No parameter carries a replica_id.
+  DefaultTileRequirementsVisitor visitor;
+  IsParamScratchBuffer always_true = [](int64_t) -> bool { return true; };
+  ASSERT_OK_AND_ASSIGN(llvm::SmallVector<mlir::Type> arg_types,
+                       GetFnArgTypes(b_, *fusion, /*opaque_args_types=*/{},
+                                     /*gpu_cc=*/{}, visitor, always_true));
+
+  auto arg0 = mlir::cast<mlir::MemRefType>(arg_types[0]);
+  EXPECT_EQ(arg0.getShape(), mlir::ArrayRef<int64_t>({128, 128}));
+  EXPECT_TRUE(arg0.getElementType().isF32());
+}
+
+}  // namespace
+}  // namespace xla::xtile

--- a/xla/codegen/xtile/codegen/experimental_fusion_emitter.cc
+++ b/xla/codegen/xtile/codegen/experimental_fusion_emitter.cc
@@ -1327,7 +1327,8 @@ absl::Status EmitGeneric(ImplicitLocOpBuilder& b,
                          const HloFusionInstruction& fusion,
                          const ge::TiledHloComputation& tiled_computation,
                          const ge::Schedule& schedule, xtile::EntryFuncOp fn,
-                         MLIRContext* mlir_context) {
+                         MLIRContext* mlir_context,
+                         const IsParamScratchBuffer& is_param_scratch_buffer) {
   if (VLOG_IS_ON(6)) {
     VLOG(6) << "Emitting XTile IR for fusion\n"
             << ExtractInstructionIntoNewModule(fusion)->ToString();
@@ -1362,8 +1363,9 @@ absl::Status EmitGeneric(ImplicitLocOpBuilder& b,
     tile_id = for_op.getInductionVar();
     b.setInsertionPointToStart(for_op.getBody());
   }
-  EmitterContext emitter_ctx{b,        &fusion, program_id,       tile_id,
-                             schedule, fn,      tiled_computation};
+  EmitterContext emitter_ctx{
+      b,        &fusion, program_id,        tile_id,
+      schedule, fn,      tiled_computation, is_param_scratch_buffer};
 
   VLOG(2) << "EmitTiledComputation: " << tiled_computation.ToString();
   EmitFullyTiledSequentialDimensions(b, emitter_ctx, tiled_computation);
@@ -1469,7 +1471,8 @@ absl::StatusOr<mlir::OwningOpRef<mlir::ModuleOp>> EmitXTileModule(
     absl::string_view fn_name, const HloFusionInstruction& fusion,
     const ::xla::gpu::experimental::TiledHloComputation& tiled_computation,
     MLIRContext& mlir_context, absl::Span<mlir::Type> opaque_args_types,
-    const std::optional<GpuComputeCapability>& gpu_cc, int num_tiles_per_pid) {
+    const std::optional<GpuComputeCapability>& gpu_cc, int num_tiles_per_pid,
+    const IsParamScratchBuffer& is_param_scratch_buffer) {
   const HloComputation* hlo_computation =
       fusion.fused_instructions_computation();
 
@@ -1481,10 +1484,13 @@ absl::StatusOr<mlir::OwningOpRef<mlir::ModuleOp>> EmitXTileModule(
       llvm_ir::CreateMlirModuleOp(loc);
   b.setInsertionPointToEnd(xtile_module->getBody());
 
-  // Compute function argument types.
+  // Compute function argument types. A parameter carrying a replica_id is only
+  // wrapped into a replica-id pointer table when the runtime passes it as a
+  // pointer table (scratch buffer), as reported by `is_param_scratch_buffer`.
   ASSIGN_OR_RETURN(SmallVector<Type> fn_arg_types,
                    GetFnArgTypes(b, fusion, opaque_args_types, gpu_cc,
-                                 TileRequirementsVisitor(tiled_computation)));
+                                 TileRequirementsVisitor(tiled_computation),
+                                 is_param_scratch_buffer));
   // Metadata arguments are opaque to the tiling infra.
   llvm::SmallVector<mlir::NamedAttribute> named_attributes{b.getNamedAttr(
       "num_opaque_args", b.getI32IntegerAttr(opaque_args_types.size()))};
@@ -1495,8 +1501,8 @@ absl::StatusOr<mlir::OwningOpRef<mlir::ModuleOp>> EmitXTileModule(
 
   ASSIGN_OR_RETURN(auto schedule,
                    GetSchedule(tiled_computation, num_tiles_per_pid));
-  RETURN_IF_ERROR(
-      EmitGeneric(b, fusion, tiled_computation, schedule, fn, &mlir_context));
+  RETURN_IF_ERROR(EmitGeneric(b, fusion, tiled_computation, schedule, fn,
+                              &mlir_context, is_param_scratch_buffer));
   if (VLOG_IS_ON(8)) {
     std::string s;
     llvm::raw_string_ostream os(s);

--- a/xla/codegen/xtile/codegen/experimental_fusion_emitter.h
+++ b/xla/codegen/xtile/codegen/experimental_fusion_emitter.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include "mlir/Pass/PassManager.h"
 #include "xla/autotuning.pb.h"
 #include "xla/codegen/tiling/experimental/tiled_hlo.h"
+#include "xla/codegen/xtile/codegen/emitter_helpers.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/stream_executor/device_description.h"
 
@@ -42,13 +43,22 @@ namespace xla::xtile {
 // arguments for collectives in XLA:GPU.
 // gpu_cc: When set, used check for supported data types (e.g. FNUZ on ROCm),
 // Omit otherwise.
+// is_param_scratch_buffer: Optional runtime-contract predicate. Given a fusion
+// parameter index, returns whether the runtime passes that parameter as a
+// pointer table (scratch buffer). A parameter whose tile carries a replica_id
+// is only wrapped into a replica-id pointer table (arg type + SelectBufferOp)
+// when this predicate returns true for it. When null, wrapping is honored
+// unconditionally (default behavior). For collectives, the caller derives this
+// predicate from the runtime CollectiveKernelSpec, keeping this emitter
+// agnostic to runtime-specific types.
 absl::StatusOr<mlir::OwningOpRef<mlir::ModuleOp>> EmitXTileModule(
     absl::string_view fn_name, const HloFusionInstruction& fusion,
     const ::xla::gpu::experimental::TiledHloComputation& tiled_computation,
     mlir::MLIRContext& mlir_context,
     absl::Span<mlir::Type> opaque_args_types = {},
     const std::optional<stream_executor::GpuComputeCapability>& gpu_cc = {},
-    int num_tiles_per_pid = 1);
+    int num_tiles_per_pid = 1,
+    const IsParamScratchBuffer& is_param_scratch_buffer = nullptr);
 
 }  // namespace xla::xtile
 


### PR DESCRIPTION
📝 Summary of Changes
Only wrap a fusion parameter into a replica-id pointer table (`memref<Nxi64>`, via `xtile.select_buffer`) when the runtime actually passes that parameter as a pointer table (scratch buffer), rather than whenever its tile carries a `replica_id`. This is driven by a new `IsParamScratchBuffer` runtime-contract predicate threaded through `GetFnArgTypes` / `EmitXTileModule` / `EmitGeneric` and the `EmitterContext`. When the predicate is null, wrapping is honored unconditionally (default behavior). For collectives, the predicate is derived from the `CollectiveKernelSpec`.

🎯 Justification
Currently, if `replica-id` is passed to the tile, the input buffer fusion parameter is wrapped into a `replica-id` pointer table, regardless of the arg type of the operand defined by the `CollectiveKernelSpec`.
In my view, the correct behavior should be to gate this wrapping on the data type, i.e., not to wrap the parameter if the arg type explicitly indicates that the argument is a plain buffer and not a pointer table.
This PR proposes an implementation of the gating support.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

🧪 Unit Tests:
Adds emitter_helpers_test.cc verifying the gating in GetFnArgTypes: null predicate (wrap), predicate true (wrap), predicate false (no wrap, AllGather regression scenario), per-parameter gating, and the non-replica-id sanity case.
