### PR TITLE
Make slices eligible for YNNPACK fusions

### DIFF
--- a/xla/backends/cpu/transforms/ynn_matcher.h
+++ b/xla/backends/cpu/transforms/ynn_matcher.h
@@ -50,7 +50,7 @@ class YnnMatcher : public LibraryMatcher {
               HloOpcode::kConvolution,  HloOpcode::kReshape,
               HloOpcode::kBitcast,      HloOpcode::kBroadcast,
               HloOpcode::kTranspose,    HloOpcode::kPad,
-              HloOpcode::kIota};
+              HloOpcode::kIota,         HloOpcode::kSlice};
           for (const auto& [op, _] : GetYnnUnaryOpMap()) {
             supported_ops.insert(op);
           }
@@ -84,6 +84,9 @@ class YnnMatcher : public LibraryMatcher {
     }
     if (instr->opcode() == HloOpcode::kPad) {
       return IsPadOpSupportedByYnn(instr);
+    }
+    if (instr->opcode() == HloOpcode::kSlice) {
+      return IsSliceOpSupportedByYnn(instr);
     }
     if (!IsInstructionPreferredByYnn(instr)) {
       // TODO: It might make sense sometimes that even though an instruction is

--- a/xla/backends/cpu/transforms/ynn_matcher_test.cc
+++ b/xla/backends/cpu/transforms/ynn_matcher_test.cc
@@ -250,6 +250,39 @@ TEST_F(YnnReduceTest, ReduceSquared) {
   )");
 }
 
+TEST_F(YnnReduceTest, SliceSubtractSquareReduce) {
+  const char* hlo_text = R"(
+  HloModule diff_like
+
+  add {
+    lhs = f32[] parameter(0)
+    rhs = f32[] parameter(1)
+    ROOT add = f32[] add(lhs, rhs)
+  }
+
+  ENTRY main {
+    input = f32[512,512] parameter(0)
+    slice_a = f32[512,511] slice(input), slice={[0:512], [1:512]}
+    slice_b = f32[512,511] slice(input), slice={[0:512], [0:511]}
+    diff = f32[512,511] subtract(slice_a, slice_b)
+    squared = f32[512,511] multiply(diff, diff)
+    init = f32[] constant(0)
+    ROOT result = f32[512] reduce(squared, init), dimensions={1}, to_apply=add
+  }
+  )";
+
+  MatchOptimizedHlo(hlo_text, R"(
+    CHECK: fused_computation
+    CHECK: slice
+    CHECK: subtract
+    CHECK: multiply
+    CHECK-NOT: wrapped_slice_computation
+    CHECK-LABEL: ENTRY
+    CHECK: kind=kCustom
+    CHECK: "kind":"__ynn_fusion"
+  )");
+}
+
 class YnnReduceEltwiseTest : public HloTestBase {
  protected:
   DebugOptions GetDebugOptionsForTest() const override {


### PR DESCRIPTION
Reductions whose input passes through a slice don't get fused into YNNPACK kernels and each slice ends up as its own separate kernel.

Commit bf6c157f6c added support for slicing in a YNNPACK fusion but didn't enable fusion for them to preserve behaviour.

Commit 5f26078f caused a regression that made the reduction in the reproducing example eligible to be offloaded to YNNPACK. The commit message says it enables fusion support for Broadcast, Slice, Transpose, Iota, but the diff adds Pad instead of Slice.

This PR allows slice operations to be fused into YNNPACK kernels by adding `HloOpcode::kSlice` to `YnnMatcher::SupportedOps()`.

This PR also adds a regression test to check that the we fuse slices.

Resolves https://github.com/openxla/xla/issues/46351

<details> <summary>Reproducer script</summary>

```python
import jax
import jax.numpy as jnp
import timeit

@jax.jit
def reg_square(x):
    cost = 0.0
    for i in range(x.ndim):
        xd = jnp.diff(x, axis=i)
        cost += jnp.sum(jnp.square(xd))
    return cost

x = jax.random.normal(jax.random.key(0), (256, 256, 256), dtype="float32")
jax.block_until_ready(reg_square(x))

t = timeit.Timer(lambda: jax.block_until_ready(reg_square(x)))
times = t.repeat(repeat=3, number=10)
print(f"reg_square: {min(times) / 10 * 1000:.2f} ms")
```

</details>

Timing before patch: 33.66 ms
Timing after patch: 10.12 ms


<details>
<summary>HLO before patch</summary>

```llvm
%fused_computation.1 (param_0.3: f32[], param_1.5: f32[256,255,256], param_2.1: f32[256,255,256]) -> f32[] {
  %param_1.5 = f32[256,255,256]{2,1,0} parameter(1)
  %param_2.1 = f32[256,255,256]{2,1,0} parameter(2)
  %sub.7 = f32[256,255,256]{2,1,0} subtract(%param_1.5, %param_2.1)
  %square.1 = f32[256,255,256]{2,1,0} multiply(%sub.7, %sub.7)
  %param_0.3 = f32[] parameter(0)
  ROOT %reduce_sum.1 = f32[] reduce(%square.1, %param_0.3), dimensions={0,1,2}, to_apply=%region_1.4
}

%wrapped_slice_computation.4 (param_0.12: f32[256,256,256]) -> f32[256,255,256] {
  %param_0.12 = f32[256,256,256]{2,1,0} parameter(0)
  ROOT %slice.16 = f32[256,255,256]{2,1,0} slice(%param_0.12), slice={[0:256], [1:256], [0:256]}
}

%wrapped_slice_computation.5 (param_0.13: f32[256,256,256]) -> f32[256,255,256] {
  %param_0.13 = f32[256,256,256]{2,1,0} parameter(0)
  ROOT %slice.17 = f32[256,255,256]{2,1,0} slice(%param_0.13), slice={[0:256], [0:255], [0:256]}
}

ENTRY %main.7 (x.1: f32[256,256,256]) -> f32[] {
  %x.1 = f32[256,256,256]{2,1,0} parameter(0)
  %constant.1 = f32[] constant(0)
  %wrapped_slice.3 = f32[255,256,256]{2,1,0} fusion(%x.1), kind=kLoop, calls=%wrapped_slice_computation.3
  %wrapped_slice.5 = f32[256,255,256]{2,1,0} fusion(%x.1), kind=kLoop, calls=%wrapped_slice_computation.5
  %wrapped_slice.1 = f32[256,256,255]{2,1,0} fusion(%x.1), kind=kLoop, calls=%wrapped_slice_computation.1
  %wrapped_slice.2 = f32[255,256,256]{2,1,0} fusion(%x.1), kind=kLoop, calls=%wrapped_slice_computation.2
  %wrapped_slice.4 = f32[256,255,256]{2,1,0} fusion(%x.1), kind=kLoop, calls=%wrapped_slice_computation.4
  %wrapped_slice = f32[256,256,255]{2,1,0} fusion(%x.1), kind=kLoop, calls=%wrapped_slice_computation
  %ynn_fusion.2 = f32[] fusion(%constant.1, %wrapped_slice.2, %wrapped_slice.3), kind=kCustom, calls=%fused_computation.2, backend_config={"fusion_config":{"kind":"__ynn_fusion"}}
  %ynn_fusion.1 = f32[] fusion(%constant.1, %wrapped_slice.4, %wrapped_slice.5), kind=kCustom, calls=%fused_computation.1, backend_config={"fusion_config":{"kind":"__ynn_fusion"}}
  %ynn_fusion = f32[] fusion(%constant.1, %wrapped_slice, %wrapped_slice.1), kind=kCustom, calls=%fused_computation, backend_config={"fusion_config":{"kind":"__ynn_fusion"}}
  ROOT %add_add_fusion = f32[] fusion(%ynn_fusion, %ynn_fusion.2, %ynn_fusion.1), kind=kLoop, calls=%fused_computation.3
}
```

</details>

<details>
<summary>HLO after patch</summary>

```llvm
%fused_computation.1 (param_0.3: f32[], param_1.9: f32[256,256,256]) -> f32[] {
  %param_1.9 = f32[256,256,256]{2,1,0} parameter(1)
  %slice.14 = f32[256,255,256]{2,1,0} slice(%param_1.9), slice={[0:256], [1:256], [0:256]}
  %slice.15 = f32[256,255,256]{2,1,0} slice(%param_1.9), slice={[0:256], [0:255], [0:256]}
  %sub.7 = f32[256,255,256]{2,1,0} subtract(%slice.14, %slice.15)
  %square.1 = f32[256,255,256]{2,1,0} multiply(%sub.7, %sub.7)
  %param_0.3 = f32[] parameter(0)
  ROOT %reduce_sum.1 = f32[] reduce(%square.1, %param_0.3), dimensions={0,1,2}, to_apply=%region_1.4
}

ENTRY %main.7 (x.1: f32[256,256,256]) -> f32[] {
  %x.1 = f32[256,256,256]{2,1,0} parameter(0)
  %constant.1 = f32[] constant(0)
  %ynn_fusion.2 = f32[] fusion(%constant.1, %x.1), kind=kCustom, calls=%fused_computation.2, backend_config={"fusion_config":{"kind":"__ynn_fusion"}}
  %ynn_fusion.1 = f32[] fusion(%constant.1, %x.1), kind=kCustom, calls=%fused_computation.1, backend_config={"fusion_config":{"kind":"__ynn_fusion"}}
  %ynn_fusion = f32[] fusion(%constant.1, %x.1), kind=kCustom, calls=%fused_computation, backend_config={"fusion_config":{"kind":"__ynn_fusion"}}
  ROOT %add_add_fusion = f32[] fusion(%ynn_fusion, %ynn_fusion.2, %ynn_fusion.1), kind=kLoop, calls=%fused_computation.3
}
```

</details>

Kind of Contribution: 🐛 Bug Fix, ⚡️ Performance Improvement

