### PR TITLE
Fix .clang-format to sort C system headers before C++ headers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,52 +5,56 @@ AlignTrailingComments:
   Kind: Always
 IncludeBlocks: Regroup
 IncludeCategories:
-  # Priority 1: Standard C/C++ headers (angle brackets) - separated by blank line
-  - Regex:    '^<[a-z_]+>$'
+  # Priority 1: C system headers (angle brackets, .h) - separated by blank line
+  - Regex:    '^<([a-z_0-9]+|(sys|netinet|arpa|net|linux|asm|hip)/[a-z_0-9]+)\.h>$'
     Priority: 1
     SortPriority: 1
-  # Priority 2: All other headers (no blank lines between them, sorted by SortPriority)
-  # gtest/gmock headers (angle brackets, but not standard headers)
-  - Regex:    '^<g(test|mock)/.*>$'
+  # Priority 2: C++ standard headers (angle brackets) - separated by blank line
+  - Regex:    '^<[a-z_]+>$'
     Priority: 2
     SortPriority: 2
+  # Priority 3: All other headers (no blank lines between them, sorted by SortPriority)
+  # gtest/gmock headers (angle brackets, but not standard headers)
+  - Regex:    '^<g(test|mock)/.*>$'
+    Priority: 3
+    SortPriority: 3
   # absl headers
   - Regex:    '^"absl/.*"$'
-    Priority: 2
-    SortPriority: 3
+    Priority: 3
+    SortPriority: 4
   # xla/tsl/platform/status_macros.h — internally third_party/gloop, sorts after absl/
   - Regex:    '^"xla/tsl/platform/status_macros\.h"$'
-    Priority: 2
-    SortPriority: 3
+    Priority: 3
+    SortPriority: 4
   # llvm headers
   - Regex:    '^"llvm/.*"$'
-    Priority: 2
-    SortPriority: 4
+    Priority: 3
+    SortPriority: 5
   # mlir headers
   - Regex:    '^"mlir/.*"$'
-    Priority: 2
-    SortPriority: 5
+    Priority: 3
+    SortPriority: 6
   # third_party libraries
   - Regex:    '^"third_party/.*"$'
-    Priority: 2
-    SortPriority: 6
+    Priority: 3
+    SortPriority: 7
   # google (protobuf, etc.) headers
   - Regex:    '^"google/.*"$'
-    Priority: 2
-    SortPriority: 7
+    Priority: 3
+    SortPriority: 8
   # xla headers (including xla/tsl)
   - Regex:    '^"xla/.*"$'
-    Priority: 2
+    Priority: 3
     SortPriority: 100
   # tsl headers (without xla/ prefix)
   - Regex:    '^"tsl/.*"$'
-    Priority: 2
+    Priority: 3
     SortPriority: 101
   # triton headers
   - Regex:    '^"triton/.*"$'
-    Priority: 2
+    Priority: 3
     SortPriority: 102
   # Default catch-all for any other headers (IMPORTANT: ordered before XLA)
   - Regex:    '.*'
-    Priority: 2
-    SortPriority: 8
+    Priority: 3
+    SortPriority: 9


### PR DESCRIPTION
'^<[a-z_]+>$' cannot match a dot, so <unistd.h> and friends never hit Priority 1 and fell to the catch-all, sorting after <gtest/gtest.h>. Regression from #36206, which narrowed '^<.*>$' to evict <gtest/gtest.h>: excluding slashes worked, excluding dots was collateral.
