### PR TITLE
[XLA:GPU][codegen] Extend IR check patterns for LLVM-SPV vector stores

### DIFF
--- a/xla/backends/gpu/tests/gpu_pjrt_codegen_test.cc
+++ b/xla/backends/gpu/tests/gpu_pjrt_codegen_test.cc
@@ -98,8 +98,11 @@ std::string GpuPjRtCodegenTest::MakePlatformSpecificLlvm(
         IsBuiltWithRocm()
             ? "%[[LOGICAL_T2:.*]] = extractvalue { i1, i64 } %[[LOGICAL_T1]], 0"
             : "0"},
-       {"BR_CAL", IsBuiltWithRocm() ? "br i1 %[[LOGICAL_T2]],"
-                                    : "br i1 %[[LOGICAL_T0]]"}});
+       {"BR_CAL",
+        IsBuiltWithRocm() ? "br i1 %[[LOGICAL_T2]]," : "br i1 %[[LOGICAL_T0]]"},
+       {"STORE_v$0FLOAT", IsBuiltWithOneAPI()
+                              ? "@llvm.spv.store.v$0f32.p1(<$0 x float>"
+                              : "store <$0 x float>"}});
 }
 
 absl::StatusOr<std::unique_ptr<Executable>>

--- a/xla/backends/gpu/tests/gpu_unrolling_test.cc
+++ b/xla/backends/gpu/tests/gpu_unrolling_test.cc
@@ -66,14 +66,14 @@ TEST_F(GpuUnrollingTest, UnrollDefaultTimes) {
 
   EXPECT_OK(CompileAndVerifyIr(
       std::move(hlo_module),
-      absl::Substitute(R"(
+      absl::Substitute(MakePlatformSpecificLlvm(R"(
 ; CHECK-LABEL: @{{[a-z_]*}}fusion
 ; CHECK-NOT: load float
 ; CHECK-NOT: store float
 ; CHECK: load <$0 x float>
 ; CHECK: load <4 x float>
-; CHECK: store <$0 x float>
-      )",
+; CHECK: STORE_v$0FLOAT
+      )"),
                        GetExpectedUnrollFactor(device_description())),
       /*match_optimized_ir=*/true));
 }
@@ -95,14 +95,14 @@ TEST_F(GpuUnrollingTest, UnrollUnfusedAdd) {
 
   EXPECT_OK(CompileAndVerifyIr(
       std::move(hlo_module),
-      absl::Substitute(R"(
+      absl::Substitute(MakePlatformSpecificLlvm(R"(
 ; CHECK-LABEL: @wrapped_add
 ; CHECK-NOT: load float
 ; CHECK-NOT: store float
 ; CHECK: load <$0 x float>
 ; CHECK: load <4 x float>
-; CHECK: store <$0 x float>
-      )",
+; CHECK: STORE_v$0FLOAT
+  )"),
                        GetExpectedUnrollFactor(device_description())),
       /*match_optimized_ir=*/true));
 }
@@ -122,15 +122,20 @@ TEST_F(GpuUnrollingTest, UnrollUnfusedSine) {
   auto hlo_module =
       ParseAndReturnVerifiedModule(kUnfusedAddModule, config).value();
 
-  EXPECT_OK(CompileAndVerifyIr(
-      std::move(hlo_module),
-      absl::Substitute(R"(
+  const int unroll = GetExpectedUnrollFactor(device_description());
+  const std::string store_pattern =
+      IsBuiltWithOneAPI()
+          ? absl::Substitute("@llvm.spv.store.v$0f32.p1(<$0 x float>", unroll)
+          : absl::Substitute("store <$0 x {{(float|i32)}}>", unroll);
+
+  EXPECT_OK(CompileAndVerifyIr(std::move(hlo_module),
+                               absl::Substitute(R"(
 ; CHECK: load <$0 x float>
 ; CHECK-NOT: load <$0 x float>
-; CHECK: store <$0 x {{(float|i32)}}>
+; CHECK: $1
       )",
-                       GetExpectedUnrollFactor(device_description())),
-      /*match_optimized_ir=*/true));
+                                                unroll, store_pattern),
+                               /*match_optimized_ir=*/true));
 }
 
 TEST_F(GpuUnrollingTest, UnrollMultiOutputFusion) {
@@ -162,15 +167,16 @@ TEST_F(GpuUnrollingTest, UnrollMultiOutputFusion) {
       ParseAndReturnVerifiedModule(kMultiOutputFusionModule, config).value();
 
   EXPECT_OK(CompileAndVerifyIr(std::move(hlo_module),
-                               R"(
+                               absl::Substitute(MakePlatformSpecificLlvm(R"(
 ; CHECK-LABEL: @{{[a-z_]*}}fusion
 ; CHECK-NOT: load float
 ; CHECK-NOT: store float
 ; CHECK: load <4 x float>
 ; CHECK: load <4 x float>
-; CHECK: store <4 x float>
-; CHECK: store <4 x float>
-      )",
+; CHECK: STORE_v$0FLOAT
+; CHECK: STORE_v$0FLOAT
+      )"),
+                                                4),
                                /*match_optimized_ir=*/true));
 }
 


### PR DESCRIPTION
This PR updates unrolling tests to handle SPIR-V codegen differences in vector stores by adding a platform specific store pattern for float vector stores. This fixes Filecheck errors seen in all tests of `xla/backends/gpu/tests/gpu_unrolling_test.cc` for the oneAPI backend.