### PR TITLE
[XLA:GPU] Fixing Test failure due to missing registration for custom call to Callback_WithStatusFailed

### DIFF
--- a/xla/backends/gpu/runtime/legacy_custom_call_thunk_test.cc
+++ b/xla/backends/gpu/runtime/legacy_custom_call_thunk_test.cc
@@ -104,6 +104,7 @@ void Callback_WithStatusFailed(void* /*stream*/, void** /*buffers*/,
 
 XLA_REGISTER_CUSTOM_CALL_TARGET(Callback_WithStatusFailed, "CUDA");
 XLA_REGISTER_CUSTOM_CALL_TARGET(Callback_WithStatusFailed, "ROCM");
+XLA_REGISTER_CUSTOM_CALL_TARGET(Callback_WithStatusFailed, "SYCL");
 
 TEST(LegacyCustomCallThunkTest, ResolvesLegacyCustomCall) {
   ASSERT_OK_AND_ASSIGN(se::StreamExecutor * executor, GpuExecutor());


### PR DESCRIPTION
Registering the Callback_WithStatusFailed callback for the "SYCL" platform,

fixing the 2 subtest failures in //xla/backends/gpu/runtime:legacy_custom_call_thunk_test_intelgpu_any i.e.
`LegacyCustomCallRoundTrip `and `ResolvesLegacyCustomCall`.
fail with the below error:
`Actual: NOT_FOUND: No registered implementation for custom call to Callback_WithStatusFailed for platform SYCL`