### PR TITLE
[XLA:GPU] Use IEEE-754 compliant f32 division in NVPTX backend

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
@@ -215,9 +215,10 @@ std::vector<std::string> GetNVPTXBackendOptions(
   // better cost model.
   backend_llvm_opts.emplace_back("-bonus-inst-threshold=2");
 
-  // Use div.full -- it matters for some float-division heavy benchmarks.
-  // Using div.approx produces incorrect result for float32(max)/float32(max).
-  backend_llvm_opts.emplace_back("-nvptx-prec-divf32=1");
+  // Use IEEE-compliant div.rnd. Previously used div.full (value 1) which has
+  // up to 2 ULP error and violates IEEE 754 (e.g., a/a != 1.0).
+  // LLVM already defaults to IEEE754 mode; don't override it.
+  backend_llvm_opts.emplace_back("-nvptx-prec-divf32=2");
 
   // SLPVectorizer is useful (vectorizes f16x2 ops) but slow.  Most of the
   // slowness appears to be in trying to form horizontal reductions, which don't

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
@@ -28,8 +28,6 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include "xla/tsl/platform/status_macros.h"
-#include "third_party/gpus/cuda/include/cuda.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/Analysis/CGSCCPassManager.h"
 #include "llvm/Analysis/LazyCallGraph.h"
@@ -58,6 +56,9 @@ limitations under the License.
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/IPO/Internalize.h"
 #include "llvm/Transforms/Scalar.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "tsl/profiler/lib/scoped_annotation.h"
+#include "tsl/profiler/lib/traceme.h"
 #include "xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.h"
 #include "xla/service/gpu/llvm_gpu_backend/load_ir_module.h"
 #include "xla/service/gpu/llvm_gpu_backend/nvptx_libdevice_path.h"
@@ -70,10 +71,9 @@ limitations under the License.
 #include "xla/stream_executor/semantic_version.h"
 #include "xla/tsl/platform/env.h"
 #include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/status_macros.h"
 #include "xla/util.h"
 #include "xla/xla.pb.h"
-#include "tsl/profiler/lib/scoped_annotation.h"
-#include "tsl/profiler/lib/traceme.h"
 
 namespace xla::gpu::nvptx {
 
@@ -215,9 +215,10 @@ std::vector<std::string> GetNVPTXBackendOptions(
   // better cost model.
   backend_llvm_opts.emplace_back("-bonus-inst-threshold=2");
 
-  // Use div.full -- it matters for some float-division heavy benchmarks.
-  // Using div.approx produces incorrect result for float32(max)/float32(max).
-  backend_llvm_opts.emplace_back("-nvptx-prec-divf32=1");
+  // Use IEEE-compliant div.rnd. Previously used div.full (value 1) which has
+  // up to 2 ULP error and violates IEEE 754 (e.g., a/a != 1.0).
+  // LLVM already defaults to IEEE754 mode; don't override it.
+  backend_llvm_opts.emplace_back("-nvptx-prec-divf32=2");
 
   // SLPVectorizer is useful (vectorizes f16x2 ops) but slow.  Most of the
   // slowness appears to be in trying to form horizontal reductions, which don't

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -2390,6 +2390,22 @@ xla_test(
 )
 
 xla_test(
+    name = "ieee_f32_division_test",
+    srcs = ["ieee_f32_division_test.cc"],
+    deps = [
+        ":client_library_test_runner_mixin",
+        ":hlo_pjrt_interpreter_reference_mixin",
+        ":hlo_pjrt_test_base",
+        ":xla_internal_test_main",  # fixdeps: keep
+        "//xla:error_spec",
+        "//xla:literal",
+        "//xla/hlo/builder:xla_builder",
+        "//xla/service",
+        "//xla/tsl/platform:test",
+    ],
+)
+
+xla_test(
     name = "log_test",
     srcs = ["log_test.cc"],
     deps = [

--- a/xla/tests/BUILD
+++ b/xla/tests/BUILD
@@ -2391,6 +2391,22 @@ xla_test(
 )
 
 xla_test(
+    name = "ieee_f32_division_test",
+    srcs = ["ieee_f32_division_test.cc"],
+    deps = [
+        ":client_library_test_runner_mixin",
+        ":hlo_pjrt_interpreter_reference_mixin",
+        ":hlo_pjrt_test_base",
+        ":xla_internal_test_main",  # fixdeps: keep
+        "//xla:error_spec",
+        "//xla:literal",
+        "//xla/hlo/builder:xla_builder",
+        "//xla/service",
+        "//xla/tsl/platform:test",
+    ],
+)
+
+xla_test(
     name = "log_test",
     srcs = ["log_test.cc"],
     deps = [

--- a/xla/tests/ieee_f32_division_test.cc
+++ b/xla/tests/ieee_f32_division_test.cc
@@ -1,0 +1,81 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <limits>
+#include <vector>
+
+#include "xla/error_spec.h"
+#include "xla/hlo/builder/xla_builder.h"
+#include "xla/literal.h"
+#include "xla/tests/client_library_test_runner_mixin.h"
+#include "xla/tests/hlo_pjrt_interpreter_reference_mixin.h"
+#include "xla/tests/hlo_pjrt_test_base.h"
+#include "xla/tsl/platform/test.h"
+
+namespace xla {
+namespace {
+
+using IeeeF32DivisionTest =
+    ClientLibraryTestRunnerMixin<HloPjRtInterpreterReferenceMixin<HloTestBase>>;
+
+// Regression test for https://github.com/openxla/xla/issues/37181.
+//
+// The NVPTX backend used to override LLVM's IEEE-754 compliant f32 division
+// (div.rnd) with div.full, which has up to 2 ULP of error. This made e.g.
+// x / x != 1.0 for many float32 values on GPU (measured error: -5.96e-08 for
+// 3163.328613). These tests assert IEEE-754 identity properties that are
+// broken by the div.full override. They use parameters (not constants) so the
+// division is actually executed by the backend rather than folded at compile
+// time, and fast math is disabled so the property is not simplified away.
+TEST_F(IeeeF32DivisionTest, DivBySelfIsOne) {
+  SetFastMathDisabled(true);
+  XlaBuilder builder(TestName());
+  XlaOp param;
+  const Literal param_data = CreateR1Parameter<float>(
+      {3163.328613f, 1.0f, -1.0f, 3.14159f, 1e10f, 1e-10f,
+       std::numeric_limits<float>::max(), std::numeric_limits<float>::min()},
+      /*parameter_number=*/0, /*name=*/"param", /*builder=*/&builder,
+      /*data_handle=*/&param);
+  Div(param, param);
+
+  std::vector<float> expected = {1.0f, 1.0f, 1.0f, 1.0f,
+                                 1.0f, 1.0f, 1.0f, 1.0f};
+  ComputeAndCompareR1<float>(&builder, expected, {param_data}, ErrorSpec(0));
+}
+
+TEST_F(IeeeF32DivisionTest, DivByOneIsIdentity) {
+  SetFastMathDisabled(true);
+  XlaBuilder builder(TestName());
+  XlaOp param;
+  const Literal param_data = CreateR1Parameter<float>(
+      {3163.328613f, 1.0f, -1.0f, 3.14159f, 1e10f, 1e-10f,
+       std::numeric_limits<float>::max(), std::numeric_limits<float>::min()},
+      /*parameter_number=*/0, /*name=*/"param", /*builder=*/&builder,
+      /*data_handle=*/&param);
+  Div(param, ConstantR0<float>(&builder, 1.0f));
+
+  std::vector<float> expected = {3163.328613f,
+                                 1.0f,
+                                 -1.0f,
+                                 3.14159f,
+                                 1e10f,
+                                 1e-10f,
+                                 std::numeric_limits<float>::max(),
+                                 std::numeric_limits<float>::min()};
+  ComputeAndCompareR1<float>(&builder, expected, {param_data}, ErrorSpec(0));
+}
+
+}  // namespace
+}  // namespace xla


### PR DESCRIPTION
#ai-generated

**Fixes:** #37181

**Summary of Changes**
Changed `-nvptx-prec-divf32` from `1` (`div.full`, 2 ULP error) to `2` (`div.rnd`, IEEE-754 compliant) in the NVPTX backend. LLVM already defaults to `2`; XLA was overriding it.

**Justification**
GPU float32 division produces non-IEEE-754 results: `a/a` evaluates to `0.99999994` instead of `1.0` for many f32 values. This violates user expectations and breaks numerical invariants. The issue was confirmed on RTX 3090 (JAX 0.6.0) in #37181.

**Kind of Contribution**
Bug Fix

**Benchmark**
N/A — this is a correctness fix, not a performance change. The original `=1` override was added for "float-division heavy benchmarks" but `div.full` trades correctness for speed; `div.rnd` is LLVM's default and is IEEE-754 compliant with >1 ULP accuracy.

**Unit Tests**
New regression test: `xla/tests/ieee_f32_division_test.cc` (registered as `//xla/tests:ieee_f32_division_test`, runs on cpu+gpu) asserts the IEEE-754 identity properties `x / x == 1.0` and `x / 1.0 == x` that the `div.full` override broke, across values including `FLT_MAX`, `FLT_MIN`, `1e10`, `1e-10`. It uses parameters and disabled fast math so the division is actually executed by the backend rather than folded or simplified away. Existing GPU backend tests continue to pass: `nvptx_backend_test`, `load_ir_module_test`, `utils_test`, `nvptx_utils_test`.

**Execution Tests**
A standalone reproducer script is available at `repro_xla_37181.py` that verifies IEEE-754 division compliance across 5 categories (identity, inverse, overflow, underflow, NaN).
