### PR TITLE
fix(ifrt): reject dimension products that overflow int64_t in Shape::FromProto

### DIFF
--- a/xla/python/ifrt/shape.cc
+++ b/xla/python/ifrt/shape.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
+#include "xla/overflow_util.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/python/ifrt/serdes_version.h"
 #include "xla/python/ifrt/shape.pb.h"
@@ -57,9 +58,9 @@ absl::StatusOr<Shape> Shape::FromProto(const ShapeProto& proto) {
 
   Shape::Dimensions dims;
   dims.reserve(proto.dims_size());
-  // Detects a dimension product that overflows int64_t. xla::ShapeUtil (the
-  // core XLA Shape type, a separate class from this one) already validates
-  // this via ValidateDimensions/OverflowSafeMultiply; this class has its own
+  // Detects a dimension product that overflows int64_t, reusing the same
+  // OverflowSafeMultiply utility that xla::ShapeUtil::ValidateDimensions
+  // already uses for the core XLA Shape type. This class has its own
   // FromProto reachable independently (e.g. via ifrt_proxy's deserialized
   // RPC request protos) and needs the equivalent check, since num_elements()
   // below does not detect overflow itself -- an unchecked product silently
@@ -71,12 +72,10 @@ absl::StatusOr<Shape> Shape::FromProto(const ShapeProto& proto) {
       return InvalidArgument(
           "Shape expects non-negative dimension sizes, but got %d", dim);
     }
-    int64_t new_product;
-    if (__builtin_mul_overflow(product, dim, &new_product)) {
-      overflow = true;
-    } else {
-      product = new_product;
-    }
+    const auto [new_product, this_overflowed] =
+        OverflowSafeMultiply(product, dim);
+    product = new_product;
+    overflow |= this_overflowed;
     dims.push_back(dim);
   }
   if (overflow) {

--- a/xla/python/ifrt/shape.cc
+++ b/xla/python/ifrt/shape.cc
@@ -57,12 +57,31 @@ absl::StatusOr<Shape> Shape::FromProto(const ShapeProto& proto) {
 
   Shape::Dimensions dims;
   dims.reserve(proto.dims_size());
+  // Detects a dimension product that overflows int64_t. xla::ShapeUtil (the
+  // core XLA Shape type, a separate class from this one) already validates
+  // this via ValidateDimensions/OverflowSafeMultiply; this class has its own
+  // FromProto reachable independently (e.g. via ifrt_proxy's deserialized
+  // RPC request protos) and needs the equivalent check, since num_elements()
+  // below does not detect overflow itself -- an unchecked product silently
+  // wraps to a small value that undersizes any buffer computed from it.
+  int64_t product = 1;
+  bool overflow = false;
   for (int64_t dim : proto.dims()) {
     if (dim < 0) {
       return InvalidArgument(
           "Shape expects non-negative dimension sizes, but got %d", dim);
     }
+    int64_t new_product;
+    if (__builtin_mul_overflow(product, dim, &new_product)) {
+      overflow = true;
+    } else {
+      product = new_product;
+    }
     dims.push_back(dim);
+  }
+  if (overflow) {
+    return InvalidArgument(
+        "Shape dimensions overflow int64_t when multiplied together");
   }
   return Shape(std::move(dims));
 }

--- a/xla/python/ifrt/shape_test.cc
+++ b/xla/python/ifrt/shape_test.cc
@@ -120,6 +120,33 @@ INSTANTIATE_TEST_SUITE_P(
       return absl::StrCat(info.param.version_number().value());
     });
 
+TEST(ShapeTest, FromProtoRejectsDimensionProductOverflow) {
+  // Individually plausible dimensions whose product overflows int64_t.
+  // Simulates a crafted ShapeProto reaching Shape::FromProto via a
+  // deserialized RPC request (e.g. ifrt_proxy), independent of any
+  // downstream bounds check that might otherwise assume num_elements() is
+  // accurate.
+  ShapeProto proto;
+  proto.set_version_number(SerDesVersionNumber(0).value());
+  proto.add_dims(3037000500LL);
+  proto.add_dims(3037000500LL);
+  proto.add_dims(4LL);
+
+  absl::StatusOr<Shape> shape = Shape::FromProto(proto);
+  EXPECT_THAT(shape.status(),
+              absl_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(ShapeTest, FromProtoAcceptsNonOverflowingDimensions) {
+  ShapeProto proto;
+  proto.set_version_number(SerDesVersionNumber(0).value());
+  proto.add_dims(100);
+  proto.add_dims(200);
+
+  TF_ASSERT_OK_AND_ASSIGN(Shape shape, Shape::FromProto(proto));
+  EXPECT_EQ(shape, Shape({100, 200}));
+}
+
 TEST(ShapeTest, Hash) {
   EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({
       Shape({}),


### PR DESCRIPTION
`xla::ifrt::Shape::FromProto` only validated that individual dimensions were non-negative; the product of all dimensions was never checked. `xla::ShapeUtil::ValidateDimensions` already does this correctly for the core `xla::Shape` type via `OverflowSafeMultiply` -- this class is a separate type (used by the Python/IFRT layer, including `ifrt_proxy`) that didn't have the equivalent protection.

`Shape::num_elements()` computes the dimension product without overflow detection, so a crafted `ShapeProto` with individually plausible but jointly overflowing dimensions silently produces a wrapped, incorrect element count rather than being rejected.

This is reachable from `ifrt_proxy`'s deserialized RPC request protos (`ArraySpec::FromProto` -> `Shape::FromProto`), a client-server boundary distinct from IFRT's general in-process API.

Fix mirrors the existing pattern in `ValidateDimensions`: detect overflow with `__builtin_mul_overflow` while walking dimensions, reject with `InvalidArgument` instead of returning a corrupted `Shape`. Two regression tests included.
