### PR TITLE
Add pre-commit config for several easily available checks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+# Install the pre-commit hooks below with
+# 'pre-commit install'
+
+# Run the hooks on all files with
+# 'pre-commit run --all'
+
+repos:
+- repo: local
+  hooks:
+  - id: clang-format
+    name: clang-format
+    entry: build_tools/ci/run_clang_format.sh --fix
+    language: unsupported
+    files: \.(cc|h)$
+    pass_filenames: false
+  - id: clang-tidy
+    name: clang-tidy
+    entry: build_tools/ci/run_clang_tidy.sh
+    language: unsupported
+    files: \.(cc|h)$
+    pass_filenames: false
+  - id: buildifier
+    name: buildifier
+    entry: build_tools/ci/run_buildifier.sh
+    language: unsupported
+    files: ^xla/(.*/)?(BUILD(\.bazel)?|[^/]+\.bzl)$
+    pass_filenames: false


### PR DESCRIPTION
📝 Summary of Changes
Run clang-format, clang-tidy, buildifier checks scripts locally pre-commit.
As usual with pre-commit, optional - one has to enable the git hooks first and can always disable them.

🎯 Justification
Developer efficiency improvement.
