### PR TITLE
[NVIDIA GPU] Add AR DUS hoist threshold flag and fix code motion bugs

### DIFF
--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -151,7 +151,8 @@ void AbslStringify(Sink& sink, DebugOptions::CollectivePipeliningMode mode) {
 namespace {
 
 template <typename T>
-static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list, T value) {
+static auto FindRepeatedFieldValue(google::protobuf::RepeatedField<int>* list,
+                                   T value) {
   for (auto it = list->begin(); it != list->end(); ++it) {
     if (*it == value) {
       return it;
@@ -165,7 +166,8 @@ template <typename T>
 static std::function<bool(const std::string&)> SetterForRepeatedEnum(
     absl::string_view flag_name, absl::string_view enum_prefix,
     std::function<bool(absl::string_view, T*)> enum_parser,
-    std::function<google::protobuf::RepeatedField<int>*()> mutable_array_getter) {
+    std::function<google::protobuf::RepeatedField<int>*()>
+        mutable_array_getter) {
   return [flag_name, enum_prefix, enum_parser,
           mutable_array_getter](absl::string_view input) {
     auto* mutable_array = mutable_array_getter();
@@ -327,6 +329,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
       kDefaultReduceScatterCombineThreshold);
   opts.set_xla_gpu_collective_permute_combine_threshold_bytes(
       kDefaultCollectivePermuteCombineThreshold);
+  opts.set_xla_while_loop_all_reduce_dus_code_motion_max_size_bytes(10240);
   opts.set_xla_gpu_collective_combine_threshold_count(
       kDefaultCollectiveCombineThresholdCount);
   opts.set_xla_gpu_enable_all_gather_combine_by_dim(false);
@@ -2329,6 +2332,15 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "buffer it allocates. (So the buffer's total size will be increased by "
       "2x this value.)"));
   flag_list->push_back(tsl::Flag(
+      "xla_while_loop_all_reduce_dus_code_motion_max_size_bytes",
+      int64_setter_for(
+          &DebugOptions::
+              set_xla_while_loop_all_reduce_dus_code_motion_max_size_bytes),
+      debug_options->xla_while_loop_all_reduce_dus_code_motion_max_size_bytes(),
+      "Maximum size (in bytes) of an all-reduce that the while-loop all-reduce "
+      "code motion pass is allowed to hoist out of a loop for dynamic update "
+      "slice patterns."));
+  flag_list->push_back(tsl::Flag(
       "xla_gpu_shape_checks", setter_for_xla_gpu_shape_checks,
       DebugOptions::ShapeChecks_Name(debug_options->xla_gpu_shape_checks()),
       "When to perform shape checks in XLA:GPU."));
@@ -3794,16 +3806,13 @@ FlagStatus GetFlagStatus(absl::string_view flag_name) {
           "xla_gpu_all_reduce_combine_threshold_bytes",
           "xla_gpu_autotune_level",
           "xla_gpu_collective_permute_decomposer_threshold",
-          "xla_gpu_cublas_fallback",
-          "xla_gpu_dot_merger_threshold_mb",
+          "xla_gpu_cublas_fallback", "xla_gpu_dot_merger_threshold_mb",
           "xla_gpu_enable_dynamic_slice_fusion",
           "xla_gpu_enable_latency_hiding_scheduler",
           "xla_gpu_enable_triton_gemm",
           "xla_gpu_enable_while_loop_double_buffering",
-          "xla_gpu_exhaustive_tiling_search",
-          "xla_gpu_pipeline_all_gather",
-          "xla_gpu_pipeline_all_reduce",
-          "xla_gpu_pipeline_reduce_scatter",
+          "xla_gpu_exhaustive_tiling_search", "xla_gpu_pipeline_all_gather",
+          "xla_gpu_pipeline_all_reduce", "xla_gpu_pipeline_reduce_scatter",
           "xla_gpu_reduce_scatter_combine_threshold_bytes",
           // go/keep-sorted end
       });

--- a/xla/service/while_loop_all_reduce_code_motion.cc
+++ b/xla/service/while_loop_all_reduce_code_motion.cc
@@ -307,12 +307,16 @@ std::optional<MovableAllReduceContext> MatchDynamicUpdateSliceContext(
   };
 
   // Do not hoist all-reduce ops if the resulting all-reduce is too large.
-  // The threshold value is chosen arbitrarily.
-  constexpr int64_t kAllReduceMaxSizeBytes = 10240;
-  if ((*loop_bound + 1) * ShapeUtil::ArraySize(all_reduce->shape()) >
-      kAllReduceMaxSizeBytes) {
+  const int64_t all_reduce_max_size_bytes =
+      all_reduce->GetModule()
+          ->config()
+          .debug_options()
+          .xla_while_loop_all_reduce_dus_code_motion_max_size_bytes();
+  const int64_t all_reduce_size_bytes =
+      (*loop_bound + 1) * ShapeUtil::ArraySize(all_reduce->shape());
+  if (all_reduce_size_bytes > all_reduce_max_size_bytes) {
     VLOG(5) << "Resulting all-reduce exceeds the size threshold: "
-            << kAllReduceMaxSizeBytes;
+            << all_reduce_size_bytes << " > " << all_reduce_max_size_bytes;
     return std::nullopt;
   }
 
@@ -395,8 +399,9 @@ std::optional<MovableAllReduceContext> MatchDynamicUpdateSliceContext(
                "loop output at the same tuple index.";
     return std::nullopt;
   }
-  if (gte->user_count() != 1 || hlo_query::CountGteInstructionsWithIndex(
-                                    hlo->parent(), gte->tuple_index()) != 1) {
+  if (gte->user_count() != 1 ||
+      hlo_query::GetUniqueGteInstruction(gte->operand(0), gte->tuple_index()) ==
+          nullptr) {
     VLOG(5) << "DUS operand must have no users in the loop body.";
     return std::nullopt;
   }
@@ -1225,9 +1230,12 @@ absl::flat_hash_map<int, HloInstruction*> CreateSinkedAllReduces(
   return tuple_index_to_new_buffer;
 }
 
-// Creates a tuple which is equivalent to the original while instruction's
-// output.
-HloInstruction* CreateNewWhileResult(
+// Builds a tuple equivalent to the original while instruction's output,
+// replaces all uses of `old_while_instruction` with it, and then forwards any
+// GTE users of that tuple to the corresponding tuple operands. If the tuple
+// has no remaining users, it is removed.
+absl::Status InsertNewWhileResult(
+    HloInstruction* old_while_instruction,
     HloInstruction* new_while_instruction,
     const absl::flat_hash_map<int, HloInstruction*>&
         tuple_index_to_new_buffer) {
@@ -1248,7 +1256,23 @@ HloInstruction* CreateNewWhileResult(
   }
   HloInstruction* new_while_result = while_parent->AddInstruction(
       HloInstruction::CreateTuple(new_while_result_elements));
-  return new_while_result;
+  RETURN_IF_ERROR(while_parent->ReplaceInstruction(old_while_instruction,
+                                                   new_while_result));
+
+  // Forward GTE(tuple, i) to the corresponding tuple operand so nested while
+  // hoisting can see through the reconstructed packing.
+  std::vector<HloInstruction*> users(new_while_result->users().begin(),
+                                     new_while_result->users().end());
+  for (HloInstruction* user : users) {
+    if (user->opcode() != HloOpcode::kGetTupleElement) {
+      continue;
+    }
+    const int64_t index =
+        Cast<HloGetTupleElementInstruction>(user)->tuple_index();
+    RETURN_IF_ERROR(while_parent->ReplaceInstruction(
+        user, new_while_result_elements[index]));
+  }
+  return absl::OkStatus();
 }
 
 // Creates the sinked all-reduce instructions for all accumulation buffers.
@@ -1284,12 +1308,10 @@ absl::Status AddSinkedAllReducesAndReplaceWhile(
   absl::flat_hash_map<int, HloInstruction*> tuple_index_to_new_buffer =
       CreateSinkedAllReduces(new_while_instruction, all_reduce_to_accumulations,
                              new_while_init_context.tuple_index_to_old_buffer);
-  // Step 4) create the tuple and replace the old while instruction for all of
-  // its uses.
-  HloInstruction* new_while_result =
-      CreateNewWhileResult(new_while_instruction, tuple_index_to_new_buffer);
-  RETURN_IF_ERROR(while_instruction->parent()->ReplaceInstruction(
-      while_instruction, new_while_result));
+  // Step 4) create the tuple, replace the old while instruction for all of
+  // its uses, and forward GTE users of the reconstructed tuple.
+  RETURN_IF_ERROR(InsertNewWhileResult(while_instruction, new_while_instruction,
+                                       tuple_index_to_new_buffer));
   return absl::OkStatus();
 }
 
@@ -1380,11 +1402,10 @@ absl::StatusOr<HloInstruction*> AddSinkedAllReducesAndReplaceWhile(
     tuple_index_to_new_buffer[context.param_tuple_index] = update;
   }
 
-  // Replace the old while instruction with the new one.
-  HloInstruction* new_while_result =
-      CreateNewWhileResult(new_while_instruction, tuple_index_to_new_buffer);
-  RETURN_IF_ERROR(
-      while_parent->ReplaceInstruction(while_instruction, new_while_result));
+  // Replace the old while instruction with the reconstructed result and
+  // forward GTE users of the reconstructed tuple.
+  RETURN_IF_ERROR(InsertNewWhileResult(while_instruction, new_while_instruction,
+                                       tuple_index_to_new_buffer));
   return new_while_instruction;
 }
 

--- a/xla/service/while_loop_all_reduce_code_motion_test.cc
+++ b/xla/service/while_loop_all_reduce_code_motion_test.cc
@@ -408,9 +408,7 @@ TEST_F(WhileLoopAllReduceCodeMotionTest, AllReduceAccumulateUse) {
               Each(Not(op::AllReduce())));
   HloInstruction* new_root = module->entry_computation()->root_instruction();
   ASSERT_THAT(new_root, op::Multiply());
-  ASSERT_THAT(new_root->operand(0), op::GetTupleElement());
-  ASSERT_THAT(new_root->operand(0)->operand(0), op::Tuple());
-  EXPECT_THAT(new_root->operand(0)->operand(0)->operand(3), op::Add());
+  ASSERT_THAT(new_root->operand(0), op::Add());
 }
 
 TEST_F(WhileLoopAllReduceCodeMotionTest, RepeatedlyAccumulatedAllReduce) {
@@ -1616,9 +1614,7 @@ TEST_F(WhileLoopAllReduceCodeMotionTest, AllReduceConvertAccumulateUse) {
               Each(Not(op::AllReduce())));
   HloInstruction* new_root = module->entry_computation()->root_instruction();
   ASSERT_THAT(new_root, op::Multiply());
-  ASSERT_THAT(new_root->operand(0), op::GetTupleElement());
-  ASSERT_THAT(new_root->operand(0)->operand(0), op::Tuple());
-  EXPECT_THAT(new_root->operand(0)->operand(0)->operand(3), op::Add());
+  EXPECT_THAT(new_root->operand(0), op::Add());
 }
 
 // Test single all reduce and single dynamic update slice.
@@ -1855,11 +1851,9 @@ TEST_F(WhileLoopAllReduceCodeMotionTest, MultipleWhileOps) {
     CHECK: %[[while0:.+]] = ({{.+}}) while({{.+}})
     CHECK: %[[res0:.+]] = f32[16]{0} get-tuple-element(%[[while0]]), index=2
     CHECK: %[[ar0:.+]] = f32[16]{0} all-reduce(%[[res0]]){{.*}}, to_apply=%reduction
-    CHECK: tuple({{.+}}, {{.+}}, %[[ar0]])
     CHECK: %[[while1:.+]] = ({{.+}}) while({{.+}})
     CHECK: %[[res1:.+]] = f32[16]{0} get-tuple-element(%[[while1]]), index=2
     CHECK: %[[ar1:.+]] = f32[16]{0} all-reduce(%[[res1]]){{.*}}, to_apply=%reduction
-    CHECK: tuple({{.+}}, {{.+}}, %[[ar1]])
   )"),
               absl_testing::IsOkAndHolds(true));
 }
@@ -2260,14 +2254,172 @@ TEST_F(WhileLoopAllReduceCodeMotionTest, ComputationWithDUSAndAccumulation) {
               Each(Not(op::AllReduce())));
   EXPECT_THAT(RunFileCheck(entry->ToString(), R"(
     CHECK: %[[while:.+]] = ({{.+}}) while({{.+}})
+    CHECK: %[[gte2:.+]] = f32[16]{0} get-tuple-element(%[[while]]), index=2
+    CHECK: %[[ar2:.+]] = f32[16]{0} all-reduce(%[[gte2]]){{.*}}, to_apply=%reduction
     CHECK: %[[acc:.+]] = f32[256]{0} parameter(2)
     CHECK: %[[gte3:.+]] = f32[256]{0} get-tuple-element(%[[while]]), index=3
     CHECK: %[[ar3:.+]] = f32[256]{0} all-reduce(%[[gte3]]){{.*}}, to_apply=%reduction
     CHECK: %[[add:.+]] = f32[256]{0} add(%[[acc]], %[[ar3]])
-    CHECK: %[[out:.+]] = ({{.+}}) tuple({{.+}}, {{.+}}, {{.+}}, %[[add]])
-    CHECK: %[[gte2:.+]] = f32[16]{0} get-tuple-element(%[[out]]), index=2
-    CHECK: %[[ar2:.+]] = f32[16]{0} all-reduce(%[[gte2]]){{.*}}, to_apply=%reduction
-    CHECK: tuple({{.+}}, {{.+}}, %[[ar2]], {{.+}})
+    CHECK: tuple({{.+}}, {{.+}}, %[[ar2]], %[[add]])
+  )"),
+              absl_testing::IsOkAndHolds(true));
+}
+
+TEST_F(WhileLoopAllReduceCodeMotionTest,
+       DusHoistPermittedWhenUnrelatedGteSharesIndex) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule dus_with_unrelated_gte_same_index
+
+    %reduction {
+      ROOT %max = f32[] maximum(f32[] parameter(0), f32[] parameter(1))
+    }
+
+    %while_condition {
+      %param = (s32[], f32[256,256], f32[16]) parameter(0)
+      %indvar = s32[] get-tuple-element(%param), index=0
+      ROOT %result = pred[] compare(%indvar, s32[] constant(16)), direction=LT
+    }
+
+    %while_body {
+      %param = (s32[], f32[256,256], f32[16]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = f32[256,256] get-tuple-element(%param), index=1
+      %gte.2 = f32[16] get-tuple-element(%param), index=2
+      %te = (f32[], f32[], f32[16]) custom-call(), custom_call_target="te_op"
+      %decoy = f32[16] get-tuple-element(%te), index=2
+      %next = s32[] add(%gte.0, s32[] constant(1))
+      %dot = f32[256,256] dot(%gte.1, %gte.1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+      %max.local = f32[] reduce(%dot, f32[] constant(0)), dimensions={0,1}, to_apply=%reduction
+      %max.global = f32[] all-reduce(%max.local), channel_id=1, replica_groups=[1,4]<=[4], use_global_device_ids=true, to_apply=%reduction
+      %update = f32[1] reshape(%max.global)
+      %dus = f32[16] dynamic-update-slice(%gte.2, %update, %gte.0)
+      ROOT %loop_result = (s32[], f32[256,256], f32[16]) tuple(%next, %dot, %dus)
+    }
+
+    ENTRY %main {
+      %while_init = (s32[], f32[256,256], f32[16]) tuple(s32[] constant(0), f32[256,256] parameter(0), f32[16] parameter(1))
+      ROOT %while = (s32[], f32[256,256], f32[16]) while(%while_init), condition=%while_condition, body=%while_body
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloModule));
+  WhileLoopAllReduceCodeMotion pass;
+  EXPECT_THAT(pass.Run(module.get()), absl_testing::IsOkAndHolds(true));
+
+  HloComputation* entry = module->entry_computation();
+  HloInstruction* transformed_while = find_op<HloOpcode::kWhile>(entry);
+  ASSERT_THAT(transformed_while, NotNull());
+  EXPECT_THAT(transformed_while->while_body()->instructions(),
+              Each(Not(op::AllReduce())));
+  EXPECT_THAT(RunFileCheck(entry->ToString(), R"(
+    CHECK: %[[while:.+]] = ({{.+}}) while({{.+}})
+    CHECK: %[[gte:.+]] = f32[16]{0} get-tuple-element(%[[while]]), index=2
+    CHECK: %[[ar:.+]] = f32[16]{0} all-reduce(%[[gte]]){{.*}}, to_apply=%reduction
+    CHECK: tuple({{.+}}, {{.+}}, %[[ar]])
+    CHECK-NOT: all-reduce
+  )"),
+              absl_testing::IsOkAndHolds(true));
+}
+
+TEST_F(WhileLoopAllReduceCodeMotionTest, NestedAllReduceAccumulate) {
+  constexpr absl::string_view kHloModule = R"(
+    HloModule nested_all_reduce_accumulate
+
+    %reduction {
+      %x = f32[] parameter(0)
+      %y = f32[] parameter(1)
+      ROOT %add = f32[] add(f32[] %x, f32[] %y)
+    }
+
+    %inner_condition {
+      %param = (s32[], s32[], f32[64, 64], f32[64, 64]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = s32[] get-tuple-element(%param), index=1
+      ROOT result = pred[] compare(%gte.0, %gte.1), direction=LT
+    }
+
+    %inner_body {
+      %param = (s32[], s32[], f32[64, 64], f32[64, 64]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = s32[] get-tuple-element(%param), index=1
+      %gte.2 = f32[64, 64] get-tuple-element(%param), index=2
+      %gte.3 = f32[64, 64] get-tuple-element(%param), index=3
+      %all-reduce = f32[64, 64] all-reduce(f32[64, 64] %gte.2), channel_id=1, replica_groups={{0,1,2,3}}, use_global_device_ids=true, to_apply=%reduction
+      %accumulation = f32[64, 64] add(f32[64, 64] %all-reduce, f32[64, 64] %gte.3)
+      %constant = s32[] constant(1)
+      %increment_iteration = s32[] add(s32[] %gte.0, s32[] %constant)
+      ROOT %loop_result = (s32[], s32[], f32[64, 64], f32[64, 64]) tuple(%increment_iteration, %gte.1, %gte.2, %accumulation)
+    }
+
+    %outer_condition {
+      %param = (s32[], s32[], s32[], f32[64, 64], f32[64, 64]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = s32[] get-tuple-element(%param), index=1
+      ROOT result = pred[] compare(%gte.0, %gte.1), direction=LT
+    }
+
+    %outer_body {
+      %param = (s32[], s32[], s32[], f32[64, 64], f32[64, 64]) parameter(0)
+      %gte.0 = s32[] get-tuple-element(%param), index=0
+      %gte.1 = s32[] get-tuple-element(%param), index=1
+      %gte.2 = s32[] get-tuple-element(%param), index=2
+      %gte.3 = f32[64, 64] get-tuple-element(%param), index=3
+      %gte.4 = f32[64, 64] get-tuple-element(%param), index=4
+      %inner_init = (s32[], s32[], f32[64, 64], f32[64, 64]) tuple(s32[] constant(0), s32[] %gte.2, f32[64, 64] %gte.3, f32[64, 64] %gte.4)
+      %inner_while = (s32[], s32[], f32[64, 64], f32[64, 64]) while(%inner_init), condition=%inner_condition, body=%inner_body
+      %inner_result = f32[64, 64] get-tuple-element(%inner_while), index=3
+      %constant = s32[] constant(1)
+      %increment_iteration = s32[] add(s32[] %gte.0, s32[] %constant)
+      ROOT %loop_result = (s32[], s32[], s32[], f32[64, 64], f32[64, 64]) tuple(%increment_iteration, %gte.1, %gte.2, %gte.3, %inner_result)
+    }
+
+    ENTRY nested_all_reduce_accumulate {
+      %param.0 = s32[] parameter(0)
+      %param.1 = s32[] parameter(1)
+      %param.2 = f32[64, 64] parameter(2)
+      %constant.0 = s32[] constant(0)
+      %constant.1 = s32[] constant(1)
+      %accumulation_buffer_init = f32[] constant(0)
+      %accumulation_buffer = f32[64, 64] broadcast(f32[] %accumulation_buffer_init), dimensions={}
+      %while_init = (s32[], s32[], s32[], f32[64, 64], f32[64, 64]) tuple(s32[] %constant.0, s32[] %param.0, s32[] %param.1, f32[64, 64] %param.2, f32[64, 64] %accumulation_buffer)
+      ROOT %while = (s32[], s32[], s32[], f32[64, 64], f32[64, 64]) while(%while_init), condition=%outer_condition, body=%outer_body
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                          ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(bool changed,
+                          WhileLoopAllReduceCodeMotion{}.Run(module.get()));
+  ASSERT_TRUE(changed);
+  TF_ASSERT_OK(
+      HloVerifier(/*layout_sensitive=*/false, /*allow_mixed_precision=*/true)
+          .Run(module.get())
+          .status());
+
+  HloComputation* entry = module->entry_computation();
+  HloInstruction* outer_while = find_op<HloOpcode::kWhile>(entry);
+  ASSERT_THAT(outer_while, NotNull());
+  EXPECT_THAT(outer_while->while_body()->instructions(),
+              Each(Not(op::AllReduce())));
+
+  HloInstruction* inner_while =
+      find_op<HloOpcode::kWhile>(outer_while->while_body());
+  ASSERT_THAT(inner_while, NotNull());
+  EXPECT_THAT(inner_while->while_body()->instructions(),
+              Each(Not(op::AllReduce())));
+
+  std::vector<HloInstruction*> entry_all_reduces;
+  absl::c_copy_if(entry->instructions(), std::back_inserter(entry_all_reduces),
+                  HloPredicateIsOp<HloOpcode::kAllReduce>);
+  ASSERT_THAT(entry_all_reduces, SizeIs(1));
+  EXPECT_THAT(entry_all_reduces[0]->operand(0), op::GetTupleElement());
+
+  EXPECT_THAT(RunFileCheck(entry->ToString(), R"(
+    CHECK: %[[outer:.+]] = ({{.+}}) while({{.+}}), condition=%outer_condition, body=%outer_body
+    CHECK-NOT: all-reduce
+    CHECK: %[[gte:.+]] = f32[64,64]{1,0} get-tuple-element(%[[outer]]), index=4
+    CHECK: %[[ar:.+]] = f32[64,64]{1,0} all-reduce(%[[gte]])
+    CHECK: %[[add:.+]] = f32[64,64]{1,0} add({{.+}}, %[[ar]])
+    CHECK: tuple({{.+}}, {{.+}}, {{.+}}, {{.+}}, %[[add]])
   )"),
               absl_testing::IsOkAndHolds(true));
 }

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -194,6 +194,9 @@ message DebugOptions {
   // 2: recognize dot general against constants.
   // 3: recognize dot operations with additional multiplicative factors.
   optional int32 xla_recognize_reduction_optimization_level = 463;
+  // Maximum size (in bytes) of an all-reduce that the while-loop all-reduce
+  // code motion pass is allowed to hoist out of a loop.
+  optional int64 xla_while_loop_all_reduce_dus_code_motion_max_size_bytes = 528;
 
   // go/keep-sorted end
 
@@ -1773,7 +1776,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 528
+  // Next id: 529
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
📝 Summary of Changes
This MR is composed of three changes to XLA's while_loop_all_reduce_code_motion pass.
1. It adds a flag (`--xla_while_loop_all_reduce_dus_code_motion_max_size_bytes`, defualt=10240 so no default behavior change) that sets the threshold for which all-reduces are able to be hoisted when they match the DUS pattern
2. It also removes a bug in the pass. When the pass is validating that there is only one user of the loop-carried all-reduce. It would count the number of GTE of the loop parameter tuple, but it did so using `hlo_query::CountGteInstructionsWithIndex` which counts for all GTE instructions on any tuple input (not necessarily the parameter). This over-counted the number of users of an index of the parameter tuple, so we replace with `hlo_query::GetUniqueGteInstruction` which specifies the tuple we are interested in getting the number of users of.
3. It also improves opportunity for nested optimization. If the user has a `while { while { AR->add } ->add }` pattern where the all-reduce is hoistable out of both loops. When hoisting the AR out of the inner loop, the pass will re-create the while loop tuple output and format the HLO as follows `while { while { add } ->AR->tuple->gte->add }`. Because the all-reduce goes through a tuple (which the pass creates), the pattern matching of the pass no longer detects that AR is hoistable out of the nested loop. As a result, this MR adds code that forwards the tuple operands to users of their appropriate GTE, producing the following pattern `while { while { add } ->AR->add }` which is then hoistable to `while { while { add } add } ->AR`

🎯 Justification
This change is important because it allows for moving more all-reduces out of while-loop iterations reducing the amount of bytes that are communicated. This is especially helpful for data parallelism workloads when training LLM models which require all-reducing the parameters for each microbatch when performing gradient accumulation or when the user scans the layers and has a loop over the layers. This PR unlocks the ability to reduce the number of each type of AR call from `num_microbatches * num_decoder_blocks` to `1`.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement,
✨ New Feature (flag)

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
Added two tests in `while_loop_all_reduce_code_motion_test.cc`:
1. New test for validating that unrelated GTEs do not interfere with the loop-hoisting checks
2. New test that validates that nested while loop hoisting is feasible
Tests were modified to account for the new behavior that while loop reconstructed outputs may not be present anymore.

🧪 Execution Tests:
Since this wasn't a completely new optimization, no end-to-end execution tests were added, just unit tests to validate pass behavior.