### PR TITLE
[XLA:GPU][oneAPI][Bugfix] Fixing failures for sub-byte integer/float types on Intel GPU.

### DIFF
--- a/build_tools/sycl/ci_test_xla.sh
+++ b/build_tools/sycl/ci_test_xla.sh
@@ -37,8 +37,6 @@ TEST_TARGETS="${TEST_TARGETS:-\
   //xla/stream_executor/... \
   //xla/backends/gpu/codegen/emitters/tests/... \
   //xla/codegen/emitters/tests/... \
-  -//xla/backends/gpu/codegen/emitters/tests:transpose/packed_transpose_s4.hlo.test \
-  -//xla/codegen/emitters/tests:loop/s8_to_s2.hlo.test \
   -//xla/backends/gpu/codegen/emitters/tests:transpose/multiple_roots_mixed_rank.hlo.test \
   -//xla/backends/gpu/codegen/emitters/tests:transpose/multiple_roots_one_shmem_transpose.hlo.test \
   -//xla/backends/gpu/codegen/emitters/tests:transpose/packed_transpose_bf16.hlo.test \

--- a/xla/backends/gpu/codegen/emitters/transpose.cc
+++ b/xla/backends/gpu/codegen/emitters/transpose.cc
@@ -108,9 +108,9 @@ constexpr int kMaxVectorizedBytesRocm = 16;
 
 // Reads the 2D vector tile <vector_size x vector_size> from the shared memory
 // at the given indices.
-Value ReadVectorTileFromShmem(ImplicitLocOpBuilder& b, Value shmem,
-                              ValueRange shmem_indices,
-                              Value vector_tile_init) {
+Value ReadVectorTileFromShmem(
+    ImplicitLocOpBuilder& b, Value shmem, ValueRange shmem_indices,
+    Value vector_tile_init, const stream_executor::DeviceDescription& device) {
   int64_t vector_size =
       mlir::cast<VectorType>(vector_tile_init.getType()).getDimSize(0);
   Value vector_tile = vector_tile_init;
@@ -118,6 +118,36 @@ Value ReadVectorTileFromShmem(ImplicitLocOpBuilder& b, Value shmem,
                                        shmem_indices.end());
   auto elem_type =
       mlir::cast<mlir::RankedTensorType>(shmem.getType()).getElementType();
+
+  // Disable vectorization for the data types that result in sub-byte vector
+  // loads and stores in the optimized LLVM IR.
+  bool use_scalar_ops = device.gpu_compute_capability().IsOneAPI() &&
+                        elem_type.isIntOrFloat() &&
+                        elem_type.getIntOrFloatBitWidth() < 8;
+
+  if (use_scalar_ops) {
+    // Scalar path: use tensor.extract instead of vector.transfer_read
+    for (int64_t i = 0; i < vector_size; ++i) {
+      for (int64_t j = 0; j < vector_size; ++j) {
+        // Update column index for this element
+        SmallVector<Value> elem_indices = shmem_indices_vec;
+        elem_indices[1] = mlir::arith::AddIOp::create(
+            b, shmem_indices_vec[1],
+            mlir::arith::ConstantIndexOp::create(b, j));
+        // Extract scalar element
+        Value elem = mt::ExtractOp::create(b, shmem, elem_indices);
+        // Insert into vector tile
+        vector_tile = mv::InsertOp::create(b, elem, vector_tile,
+                                           SmallVector<int64_t>{j, i});
+      }
+      // Advance to next row
+      shmem_indices_vec.front() = mlir::arith::AddIOp::create(
+          b, shmem_indices_vec.front(),
+          mlir::arith::ConstantIndexOp::create(b, 1));
+    }
+    return vector_tile;
+  }
+
   auto vector_type = mlir::VectorType::get({vector_size}, elem_type);
   for (int64_t i = 0; i < vector_size; ++i) {
     Value loaded_vector = mv::TransferReadOp::create(
@@ -822,8 +852,9 @@ void PackedTranspose::EmitReadFromShMemMlir(
           ValueRange shmem_indices = map_results;
           Value vector_tile =
               elem_type_to_vector_tile[transpose->shape().element_type()];
-          vector_tile = ReadVectorTileFromShmem(nested_b, shmem, shmem_indices,
-                                                vector_tile);
+          vector_tile =
+              ReadVectorTileFromShmem(nested_b, shmem, shmem_indices,
+                                      vector_tile, analysis_.device_info());
           transpose_values[transpose] = {vector_tile};
         }
         // The inner loop writes columns of the <vector_size x vector_size>

--- a/xla/codegen/emitters/transforms/tests/vectorize_loads_stores.mlir
+++ b/xla/codegen/emitters/transforms/tests/vectorize_loads_stores.mlir
@@ -24,6 +24,10 @@
 // RUN: -xla-vectorize-loads-stores="gpu_device_info='cuda_compute_capability {major: 9}'" -cse -canonicalize \
 // RUN: | FileCheck %s --check-prefix=CHECK-HOPPER
 
+// RUN: emitters_opt %s --allow-unregistered-dialect -split-input-file \
+// RUN: -xla-vectorize-loads-stores="gpu_device_info='oneapi_compute_capability {architecture: \"bmg\"}'" -cse -canonicalize \
+// RUN: | FileCheck %s --check-prefix=CHECK-ONEAPI
+
 #map = #xla.indexing_map<"(d0)[s0] -> (d0 * 2 + s0),"
   "domain: d0 in [0, 63], s0 in [0, 1]">
 func.func @simple_read(%arg0: tensor<128xf32>) -> (f32) {
@@ -708,6 +712,12 @@ func.func @vectorize_i4_x32(%arg0: tensor<1024xi4>) -> (i4) {
 // CHECK-NEXT:      vector.extract %[[V]][%[[J]]]
 // CHECK-NEXT:      addi
 
+// Sub-byte (i4) loads are packed and cannot be vectorized on oneAPI, so the
+// loop must remain scalar with no vector.transfer_read.
+// CHECK-ONEAPI-LABEL: @vectorize_i4_x32
+// CHECK-ONEAPI-NOT:   vector.transfer_read
+// CHECK-ONEAPI:       tensor.extract
+
 // -----
 
 #map = #xla.indexing_map<"(d0)[s0] -> (d0 * 16 + s0),"
@@ -731,3 +741,36 @@ func.func @too_many_bits_for_vectorize(%arg0: tensor<1024xf32>) -> (f32) {
 }
 // CHECK-LABEL: @too_many_bits_for_vectorize
 // CHECK-NOT: vector.transfer_read
+
+// -----
+
+// Tests with an intermediate arith.andi between the extract and
+// the sub-byte trunc. InstCombine can sink the truncation through the andi, so
+// the transitive walk must still disable vectorization on oneAPI.
+#map = #xla.indexing_map<"(d0)[s0] -> (d0 * 32 + s0),"
+  "domain: d0 in [0, 31], s0 in [0, 31]">
+func.func @no_vectorize_trunc_through_intermediate_op(%arg0: tensor<1024xi8>)
+    -> (i2) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c32 = arith.constant 32 : index
+  %mask = arith.constant 3 : i8
+  %cst = arith.constant 0 : i2
+  %outer = scf.for %i = %c0 to %c32 step %c1 iter_args(%iter = %cst) -> i2 {
+    %inner = scf.for %j = %c0 to %c32 step %c1 iter_args(%iter1 = %iter) -> i2 {
+      %idx = xla.apply_indexing #map(%i)[%j]
+      %extracted = tensor.extract %arg0[%idx] : tensor<1024xi8>
+      %masked = arith.andi %extracted, %mask : i8
+      %trunc = arith.trunci %masked : i8 to i2
+      %added = arith.addi %iter1, %trunc : i2
+      scf.yield %added : i2
+    }
+    scf.yield %inner : i2
+  }
+  return %outer : i2
+}
+// CHECK-LABEL: @no_vectorize_trunc_through_intermediate_op
+// CHECK:       vector.transfer_read
+// CHECK-ONEAPI-LABEL: @no_vectorize_trunc_through_intermediate_op
+// CHECK-ONEAPI-NOT:   vector.transfer_read
+// CHECK-ONEAPI:       tensor.extract

--- a/xla/codegen/emitters/transforms/vectorize_loads_stores.cc
+++ b/xla/codegen/emitters/transforms/vectorize_loads_stores.cc
@@ -13,12 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <numeric>
 #include <optional>
 #include <string>
 #include <utility>
 
+#include "absl/algorithm/container.h"
 #include "absl/log/check.h"
 #include "absl/numeric/bits.h"
 #include "llvm/ADT/APInt.h"
@@ -258,6 +260,10 @@ std::optional<Value> GetVectorBaseIndices(Value index, scf::ForOp loop,
       ->getResult(0);
 }
 
+bool IsSubByteIntOrFloatType(mlir::Type type) {
+  return type.isIntOrFloat() && type.getIntOrFloatBitWidth() < 8;
+}
+
 bool IsConflictFree(mlir::tensor::ExtractOp op) {
   return op.getTensor().getParentRegion()->isProperAncestor(
       op->getParentRegion());
@@ -285,18 +291,29 @@ struct VectorizeLoad : mlir::OpRewritePattern<mlir::tensor::ExtractOp> {
     if (!vector_type) {
       return rewriter.notifyMatchFailure(op, "not a vectorizable loop");
     }
-
-    // Disable vectorization for sub-byte types (4/2-bit) on Intel GPUs. These
-    // types are packed (e.g., 2 int4s per byte) and are currently not
-    // supported in the LLVM SPIR-V backend as vector load operations.
+    // Prevent vectorization when a (possibly transitive) user of the extract op
+    // truncates to a sub-byte type. The LLVM's InstCombine pass folds trunc op.
+    // For example,
+    // trunc (extractelement <4 x i8> %X, i64 0) to i2 ->
+    // extractelement <16 x i2> (bitcast <4 x i8> %X to <16 x i2>), i64 0. The
+    // sub-byte vector types are not supported in the LLVM SPIR-V backend.
+    std::function<bool(mlir::Operation*)> has_sub_byte_trunc_user =
+        [&](mlir::Operation* op) {
+          return absl::c_any_of(op->getUsers(), [&](mlir::Operation* user) {
+            auto trunc = mlir::dyn_cast<mlir::arith::TruncIOp>(user);
+            if (trunc && IsSubByteIntOrFloatType(trunc.getResult().getType()))
+              return true;
+            return llvm::all_of(
+                       user->getResultTypes(),
+                       [](mlir::Type t) { return t.isIntOrFloat(); }) &&
+                   has_sub_byte_trunc_user(user);
+          });
+        };
     auto element_type = vector_type.getElementType();
-    if (device_spec_.IsIntelGpu() && element_type.isIntOrFloat()) {
-      int bit_width = element_type.getIntOrFloatBitWidth();
-      if (bit_width == 2 || bit_width == 4) {
-        return rewriter.notifyMatchFailure(
-            op,
-            "sub-byte types are not supported for vector loads on Intel GPU");
-      }
+    if (device_spec_.IsIntelGpu() && (IsSubByteIntOrFloatType(element_type) ||
+                                      has_sub_byte_trunc_user(op))) {
+      return rewriter.notifyMatchFailure(
+          op, "sub-byte types are not supported for vector loads on Intel GPU");
     }
 
     mlir::ImplicitLocOpBuilder b(op.getLoc(), rewriter);
@@ -438,17 +455,15 @@ struct VectorizeStore : mlir::OpRewritePattern<mlir::tensor::InsertOp> {
       return rewriter.notifyMatchFailure(op, "loop is not vectorizable");
     }
 
-    // Disable vectorization for sub-byte types (4/2-bit) on Intel GPUs. These
+    // Disable vectorization for the data types that result in sub-byte vector
+    // loads and stores in the optimized LLVM IR on Intel GPUs. These
     // types are packed (e.g., 2 int4s per byte) and are currently not
     // supported in the LLVM SPIR-V backend as vector store operations.
     auto element_type = vector_type.getElementType();
-    if (device_spec_.IsIntelGpu() && element_type.isIntOrFloat()) {
-      int bit_width = element_type.getIntOrFloatBitWidth();
-      if (bit_width == 2 || bit_width == 4) {
-        return rewriter.notifyMatchFailure(
-            op,
-            "sub-byte types are not supported for vector stores on Intel GPU");
-      }
+    if (device_spec_.IsIntelGpu() && IsSubByteIntOrFloatType(element_type)) {
+      return rewriter.notifyMatchFailure(
+          op,
+          "sub-byte types are not supported for vector stores on Intel GPU");
     }
 
     mlir::ImplicitLocOpBuilder b(op.getLoc(), rewriter);


### PR DESCRIPTION
Fixes failures on Intel GPUs for sub-byte integer types (i2, i4), where vector loads emit G_LOAD <16 x s2> as a packed sub-byte vector memory access that the SPIR-V backend cannot represent. This change prevents vectorization for these types and uses scalar operations instead. It also updates the test cases to expect scalar-based IR patterns.

Testcases fixed : 

//xla/backends/gpu/codegen/emitters/tests:transpose/packed_transpose_s4.hlo.test 
//xla/codegen/emitters/tests:loop/s8_to_s2.hlo.test 
//xla/backends/gpu/tests:gpu_int4_test_intelgpu_any