### PR TITLE
[xla:gpu] Group collectives by a user-defined frontend attribute key

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1784,9 +1784,9 @@ xla_cc_test(
         ":explicit_collectives_group_async_wrapper",
         ":group_collectives_by_key",
         "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:filecheck",
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
         "@com_google_absl//absl/status",
-        "@com_google_absl//absl/status:status_matchers",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest_main",  # fixdeps: keep
     ],

--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1751,6 +1751,48 @@ xla_cc_test(
 )
 
 cc_library(
+    name = "group_collectives_by_key",
+    srcs = ["group_collectives_by_key.cc"],
+    hdrs = ["group_collectives_by_key.h"],
+    deps = [
+        "//xla:shape_util",
+        "//xla:side_effect_util",
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/analysis:hlo_reachability",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/service:collective_combiner_utils",
+        "//xla/service:collective_ops_utils",
+        "//xla/tsl/platform:status_macros",
+        "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:vlog_is_on",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+xla_cc_test(
+    name = "group_collectives_by_key_test",
+    srcs = ["group_collectives_by_key_test.cc"],
+    deps = [
+        ":explicit_collectives_group_async_wrapper",
+        ":group_collectives_by_key",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest_main",  # fixdeps: keep
+    ],
+)
+
+cc_library(
     name = "explicit_stream_annotation_async_wrapper",
     srcs = ["explicit_stream_annotation_async_wrapper.cc"],
     hdrs = ["explicit_stream_annotation_async_wrapper.h"],

--- a/xla/backends/gpu/transforms/group_collectives_by_key.cc
+++ b/xla/backends/gpu/transforms/group_collectives_by_key.cc
@@ -1,0 +1,383 @@
+/* Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/group_collectives_by_key.h"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/container/btree_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/log/log.h"
+#include "absl/log/vlog_is_on.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "xla/tsl/platform/status_macros.h"
+#include "xla/hlo/analysis/hlo_reachability.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/service/collective_combiner_utils.h"
+#include "xla/service/collective_ops_utils.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+#include "xla/side_effect_util.h"
+#include "xla/util.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+namespace {
+
+// Trivial ops we drop from the printed reachability chain — they carry no
+// useful debugging signal beyond reshape/element-extract bookkeeping.
+bool IsTrivialOnPath(const HloInstruction* instr) {
+  switch (instr->opcode()) {
+    case HloOpcode::kTuple:
+    case HloOpcode::kGetTupleElement:
+    case HloOpcode::kBitcast:
+    case HloOpcode::kReshape:
+    case HloOpcode::kTranspose:
+    case HloOpcode::kCopy:
+    case HloOpcode::kBroadcast:
+    case HloOpcode::kOptimizationBarrier:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Reconstruct a dataflow path from `from` to `to` by greedy descent: at each
+// step pick any user (or control-successor) that still reaches `to`. Assumes
+// reachability.IsReachable(from, to) == true.
+std::vector<const HloInstruction*> ReconstructPath(
+    const HloInstruction* from, const HloInstruction* to,
+    const HloReachabilityMap& reachability) {
+  std::vector<const HloInstruction*> path{from};
+  const HloInstruction* cur = from;
+  while (cur != to) {
+    const HloInstruction* next = nullptr;
+    for (HloInstruction* u : cur->users()) {
+      if (reachability.IsReachable(u, to)) {
+        next = u;
+        break;
+      }
+    }
+    if (next == nullptr) {
+      for (HloInstruction* s : cur->control_successors()) {
+        if (reachability.IsReachable(s, to)) {
+          next = s;
+          break;
+        }
+      }
+    }
+    if (next == nullptr) {
+      break;  // shouldn't happen if IsReachable was true
+    }
+    path.push_back(next);
+    cur = next;
+  }
+  return path;
+}
+
+std::string FormatReachabilityChain(const HloInstruction* from,
+                                    const HloInstruction* to,
+                                    const HloReachabilityMap& reachability) {
+  std::vector<const HloInstruction*> raw =
+      ReconstructPath(from, to, reachability);
+
+  // 1. Drop trivial ops and ops with no op_name metadata (but always keep
+  // endpoints).
+  std::vector<const HloInstruction*> path;
+  path.reserve(raw.size());
+  for (size_t i = 0; i < raw.size(); ++i) {
+    bool is_endpoint = (i == 0 || i + 1 == raw.size());
+    if (is_endpoint ||
+        (!IsTrivialOnPath(raw[i]) && !raw[i]->metadata().op_name().empty())) {
+      path.push_back(raw[i]);
+    }
+  }
+
+  // 2. Common op_name prefix to elide. We only consider the two endpoints (the
+  // collectives we are reporting on); intermediate fusions / scratch ops can
+  // have unrelated op_names like "reshape.1052" that would zero the prefix and
+  // defeat the elision.
+  std::string prefix;
+  if (path.size() >= 2) {
+    prefix =
+        CommonOpNamePrefix({std::string(path.front()->metadata().op_name()),
+                            std::string(path.back()->metadata().op_name())});
+  }
+
+  std::string out;
+  for (size_t i = 0; i < path.size(); ++i) {
+    const HloInstruction* h = path[i];
+    absl::string_view op_name = h->metadata().op_name();
+    absl::string_view trimmed = op_name.size() >= prefix.size()
+                                    ? op_name.substr(prefix.size())
+                                    : op_name;
+    absl::StrAppend(&out, i == 0 ? "  " : "  -> ", h->name());
+    if (!trimmed.empty()) {
+      absl::StrAppend(&out, " op=", trimmed);
+    }
+
+    // 3. Frontend attributes.
+    if (h->has_frontend_attributes()) {
+      std::vector<std::string> kvs;
+      for (const auto& [k, v] : h->frontend_attributes().map()) {
+        kvs.push_back(absl::StrCat(k, "=", v));
+      }
+      if (!kvs.empty()) {
+        absl::StrAppend(&out, " frontend_attributes={",
+                        absl::StrJoin(kvs, ", "), "}");
+      }
+    }
+    absl::StrAppend(&out, "\n");
+  }
+  if (!prefix.empty()) {
+    absl::StrAppend(&out, "  (op_name common prefix: '", prefix, "')\n");
+  }
+  return out;
+}
+
+// Builds the embedded computation containing clones of the grouped collectives
+// operating on fresh parameters, with a tuple root over their results. The
+// computation is added with a neutral base name; AddEmbeddedComputation
+// uniquifies it against the module.
+HloComputation* BuildGroupComputation(
+    HloModule* module, absl::Span<HloInstruction* const> collectives) {
+  HloComputation::Builder builder("collectives_group");
+
+  std::vector<HloInstruction*> new_collectives;
+  new_collectives.reserve(collectives.size());
+  int param_idx = 0;
+  for (size_t k = 0; k < collectives.size(); ++k) {
+    HloInstruction* c = collectives[k];
+    std::vector<HloInstruction*> params;
+    params.reserve(c->operand_count());
+    for (int i = 0; i < c->operand_count(); ++i) {
+      params.push_back(builder.AddInstruction(HloInstruction::CreateParameter(
+          param_idx++, c->operand(i)->shape(),
+          absl::StrCat("c", k, "_operand_", i))));
+    }
+    // CloneWithNewOperands preserves channel_id, replica_groups, backend config
+    // and frontend attributes (including collective_group_key, which we keep on
+    // the clone).
+    HloInstruction* clone =
+        builder.AddInstruction(c->CloneWithNewOperands(c->shape(), params));
+
+    // The scheduling group id applies only at the outer async level; leaving it
+    // on the clones makes the latency-hiding scheduler reject the embedded
+    // computation for having multiple collective starts in one group. This is
+    // the same clone-scoped erase ExplicitCollectivesGroupAsyncWrapper
+    // performs.
+    clone->erase_frontend_attribute(kXlaSchedulingGroupIdAttr);
+
+    new_collectives.push_back(clone);
+  }
+
+  builder.AddInstruction(HloInstruction::CreateTuple(new_collectives));
+  return module->AddEmbeddedComputation(builder.Build());
+}
+
+absl::Status CreateCollectivesGroup(
+    HloComputation* computation,
+    absl::Span<HloInstruction* const> collectives) {
+  HloModule* module = computation->parent();
+  HloComputation* group_comp = BuildGroupComputation(module, collectives);
+  absl::string_view group_name = group_comp->name();
+
+  std::vector<HloInstruction*> call_operands;
+  std::vector<Shape> done_shapes;
+  done_shapes.reserve(collectives.size());
+  for (HloInstruction* c : collectives) {
+    call_operands.insert(call_operands.end(), c->operands().begin(),
+                         c->operands().end());
+    done_shapes.push_back(c->shape());
+  }
+
+  std::vector<const Shape*> param_shapes;
+  param_shapes.reserve(call_operands.size());
+  for (HloInstruction* op : call_operands) {
+    param_shapes.push_back(&op->shape());
+  }
+  Shape done_shape = ShapeUtil::MakeTupleShape(done_shapes);
+  Shape start_shape = ShapeUtil::MakeTupleShape(
+      {ShapeUtil::MakeTupleShapeWithPtrs(param_shapes), done_shape});
+
+  HloInstruction* async_start = computation->AddInstruction(
+      HloInstruction::CreateAsyncStart(start_shape, call_operands, group_comp,
+                                       HloInstruction::kMainExecutionThread));
+  async_start->SetAndSanitizeName(absl::StrCat(group_name, "-start"));
+  HloInstruction* async_done = computation->AddInstruction(
+      HloInstruction::CreateAsyncDone(done_shape, async_start));
+  async_done->SetAndSanitizeName(absl::StrCat(group_name, "-done"));
+
+  // Merge all frontend attributes of the members. Because every member shares
+  // the same collective_group_key, MergeFrontendAttributes deduplicates it to a
+  // single value; other shared attributes are preserved. Add the group marker
+  // so stream assignment and the scheduler treat this as a launch group.
+  FrontendAttributes attrs = MergeFrontendAttributes(collectives);
+  (*attrs.mutable_map())[kCollectiveGroupMarkerAttr] = "";
+  async_start->set_frontend_attributes(attrs);
+  async_done->set_frontend_attributes(attrs);
+  group_comp->root_instruction()->set_frontend_attributes(attrs);
+
+  // Preserve metadata and backend config from a representative member.
+  async_start->set_metadata(collectives.front()->metadata());
+  async_done->set_metadata(collectives.front()->metadata());
+
+  // Rewire each member's uses to a get-tuple-element of the async-done result,
+  // preserving per-output sharding, and relay external control dependencies
+  // onto the async pair.
+  for (size_t i = 0; i < collectives.size(); ++i) {
+    HloInstruction* c = collectives[i];
+    HloInstruction* replacement = computation->AddInstruction(
+        HloInstruction::CreateGetTupleElement(c->shape(), async_done, i));
+    if (c->has_sharding()) {
+      replacement->set_sharding(c->sharding());
+    }
+    // Control predecessors of the member gate the whole group's start; control
+    // successors wait on the group's done.
+    RETURN_IF_ERROR(c->CopyAllControlDepsTo(async_start, async_done));
+    RETURN_IF_ERROR(c->DropAllControlDeps());
+    RETURN_IF_ERROR(c->ReplaceAllUsesWith(replacement));
+    RETURN_IF_ERROR(computation->RemoveInstruction(c));
+  }
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<bool> GroupCollectivesInComputation(
+    HloComputation* computation, const HloPredicate& predicate) {
+  VLOG(1) << "Finding collectives to group in computation "
+          << computation->name();
+
+  // A btree_map keeps keys sorted, so groups are processed in a deterministic
+  // order without a separate ordering vector.
+  absl::btree_map<std::string, std::vector<HloInstruction*>> key_to_collectives;
+  for (HloInstruction* instr : computation->instructions()) {
+    if (!predicate(instr)) {
+      continue;
+    }
+    std::optional<absl::string_view> key = GetCollectiveGroupKey(*instr);
+    if (!key.has_value()) {
+      continue;
+    }
+    key_to_collectives[std::string(*key)].push_back(instr);
+  }
+  if (key_to_collectives.empty()) {
+    return false;
+  }
+
+  std::unique_ptr<HloReachabilityMap> reachability =
+      HloReachabilityMap::Build(computation);
+
+  // Two-phase: validate and collect every group first, then mutate. Validation
+  // reads the reachability map (and, on failure, walks live users() to
+  // reconstruct a diagnostic chain), so it must run entirely before any
+  // mutation — forming a group inserts async-start/done and GTE instructions
+  // that are absent from the map. Deferring all mutation to phase two also
+  // guarantees an invalid later key never leaves earlier keys half-transformed.
+  std::vector<std::vector<HloInstruction*>> groups_to_form;
+  groups_to_form.reserve(key_to_collectives.size());
+  for (auto& [key, collectives] : key_to_collectives) {
+    if (collectives.size() <= 1) {
+      LOG(WARNING) << "collective_group_key \"" << key << "\" ("
+                   << computation->name()
+                   << ") has only one collective, skipping";
+      continue;
+    }
+
+    // Sharing a collective_group_key is a frontend assertion that these
+    // collectives are independent. Verify it; a violation would create a cycle
+    // when we wrap them in a single async call. HloReachabilityMap::Build folds
+    // in control-predecessor edges, so this rejects data and control deps.
+    for (size_t i = 0; i < collectives.size(); ++i) {
+      for (size_t j = i + 1; j < collectives.size(); ++j) {
+        const HloInstruction* a = nullptr;
+        const HloInstruction* b = nullptr;
+        if (reachability->IsReachable(collectives[i], collectives[j])) {
+          a = collectives[i];
+          b = collectives[j];
+        } else if (reachability->IsReachable(collectives[j], collectives[i])) {
+          a = collectives[j];
+          b = collectives[i];
+        }
+        if (a != nullptr) {
+          std::string chain = FormatReachabilityChain(a, b, *reachability);
+          return FailedPrecondition(
+              "Collectives %s and %s share collective_group_key=%s but are not "
+              "independent (one is reachable from the other).\n"
+              "Computation: %s\n"
+              "Reachability chain %s -> %s:\n%s",
+              collectives[i]->name(), collectives[j]->name(), key,
+              computation->name(), a->name(), b->name(), chain);
+        }
+      }
+    }
+
+    if (VLOG_IS_ON(1)) {
+      std::vector<absl::string_view> names;
+      names.reserve(collectives.size());
+      for (HloInstruction* c : collectives) {
+        names.push_back(c->name());
+      }
+      VLOG(1) << "Grouping {" << absl::StrJoin(names, ", ")
+              << "} with collective_group_key=" << key;
+    }
+
+    groups_to_form.push_back(std::move(collectives));
+  }
+
+  // Phase two: every group validated against a consistent, mutation-free map,
+  // so it is now safe to form them.
+  bool changed = false;
+  for (const std::vector<HloInstruction*>& collectives : groups_to_form) {
+    RETURN_IF_ERROR(CreateCollectivesGroup(computation, collectives));
+    changed = true;
+  }
+  return changed;
+}
+
+}  // namespace
+
+absl::StatusOr<bool> GroupCollectivesByKey::RunImpl(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool changed = false;
+  for (HloComputation* comp :
+       module->MakeNonfusionComputations(execution_threads)) {
+    // Skip the bodies of async groups (including ones this pass already
+    // formed). Their cloned collectives keep collective_group_key, so
+    // revisiting them would re-group and break idempotence.
+    if (comp->IsAsyncComputation()) {
+      continue;
+    }
+    ASSIGN_OR_RETURN(bool comp_changed,
+                     GroupCollectivesInComputation(comp, predicate_));
+    changed |= comp_changed;
+  }
+  return changed;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/transforms/group_collectives_by_key.cc
+++ b/xla/backends/gpu/transforms/group_collectives_by_key.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "xla/backends/gpu/transforms/group_collectives_by_key.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -37,6 +38,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/ir/hlo_sharding.h"
 #include "xla/service/collective_combiner_utils.h"
 #include "xla/service/collective_ops_utils.h"
 #include "xla/shape.h"
@@ -47,6 +49,11 @@ limitations under the License.
 
 namespace xla::gpu {
 namespace {
+
+struct CollectiveGroup {
+  std::string key;
+  std::vector<HloInstruction*> collectives;
+};
 
 // Trivial ops we drop from the printed reachability chain — they carry no
 // useful debugging signal beyond reshape/element-extract bookkeeping.
@@ -164,7 +171,8 @@ std::string FormatReachabilityChain(const HloInstruction* from,
 // computation is added with a neutral base name; AddEmbeddedComputation
 // uniquifies it against the module.
 HloComputation* BuildGroupComputation(
-    HloModule* module, absl::Span<HloInstruction* const> collectives) {
+    HloModule* module, absl::Span<HloInstruction* const> collectives,
+    absl::string_view execution_thread) {
   HloComputation::Builder builder("collectives_group");
 
   std::vector<HloInstruction*> new_collectives;
@@ -196,14 +204,43 @@ HloComputation* BuildGroupComputation(
   }
 
   builder.AddInstruction(HloInstruction::CreateTuple(new_collectives));
-  return module->AddEmbeddedComputation(builder.Build());
+  HloComputation* group_computation =
+      module->AddEmbeddedComputation(builder.Build());
+  group_computation->SetExecutionThread(execution_thread);
+  return group_computation;
+}
+
+// Appends a flat sharding for every leaf of `instruction`. Unknown shardings
+// preserve partially annotated tuples without inventing a placement for an
+// unannotated member.
+void AppendShardingLeaves(const HloInstruction& instruction,
+                          std::vector<HloSharding>* shardings) {
+  int64_t leaf_count = ShapeUtil::GetLeafCount(instruction.shape());
+  if (leaf_count == 0) {
+    // Empty tuples may carry one sharding despite having no ShapeTree leaves.
+    leaf_count = 1;
+  }
+
+  if (!instruction.has_sharding()) {
+    shardings->insert(shardings->end(), leaf_count, HloSharding::Unknown());
+    return;
+  }
+
+  const HloSharding& sharding = instruction.sharding();
+  if (sharding.IsTuple()) {
+    shardings->insert(shardings->end(), sharding.tuple_elements().begin(),
+                      sharding.tuple_elements().end());
+  } else {
+    shardings->insert(shardings->end(), leaf_count, sharding);
+  }
 }
 
 absl::Status CreateCollectivesGroup(
-    HloComputation* computation,
-    absl::Span<HloInstruction* const> collectives) {
+    HloComputation* computation, absl::Span<HloInstruction* const> collectives,
+    absl::string_view execution_thread) {
   HloModule* module = computation->parent();
-  HloComputation* group_comp = BuildGroupComputation(module, collectives);
+  HloComputation* group_comp =
+      BuildGroupComputation(module, collectives, execution_thread);
   absl::string_view group_name = group_comp->name();
 
   std::vector<HloInstruction*> call_operands;
@@ -224,9 +261,9 @@ absl::Status CreateCollectivesGroup(
   Shape start_shape = ShapeUtil::MakeTupleShape(
       {ShapeUtil::MakeTupleShapeWithPtrs(param_shapes), done_shape});
 
-  HloInstruction* async_start = computation->AddInstruction(
-      HloInstruction::CreateAsyncStart(start_shape, call_operands, group_comp,
-                                       HloInstruction::kMainExecutionThread));
+  HloInstruction* async_start =
+      computation->AddInstruction(HloInstruction::CreateAsyncStart(
+          start_shape, call_operands, group_comp, execution_thread));
   async_start->SetAndSanitizeName(absl::StrCat(group_name, "-start"));
   HloInstruction* async_done = computation->AddInstruction(
       HloInstruction::CreateAsyncDone(done_shape, async_start));
@@ -245,6 +282,42 @@ absl::Status CreateCollectivesGroup(
   // Preserve metadata and backend config from a representative member.
   async_start->set_metadata(collectives.front()->metadata());
   async_done->set_metadata(collectives.front()->metadata());
+  async_start->CopyBackendConfigFrom(collectives.front());
+  async_done->CopyBackendConfigFrom(collectives.front());
+
+  bool has_operand_sharding = false;
+  for (const HloInstruction* operand : call_operands) {
+    has_operand_sharding |= operand->has_sharding();
+  }
+  bool has_output_sharding = false;
+  for (const HloInstruction* collective : collectives) {
+    has_output_sharding |= collective->has_sharding();
+  }
+
+  std::vector<HloSharding> done_shardings;
+  if (has_output_sharding) {
+    for (const HloInstruction* collective : collectives) {
+      AppendShardingLeaves(*collective, &done_shardings);
+    }
+    HloSharding done_sharding = HloSharding::Tuple(done_shape, done_shardings);
+    async_done->set_sharding(done_sharding);
+    group_comp->root_instruction()->set_sharding(std::move(done_sharding));
+  }
+
+  if (has_operand_sharding || has_output_sharding) {
+    std::vector<HloSharding> start_shardings;
+    for (const HloInstruction* operand : call_operands) {
+      AppendShardingLeaves(*operand, &start_shardings);
+    }
+    if (done_shardings.empty()) {
+      for (const HloInstruction* collective : collectives) {
+        AppendShardingLeaves(*collective, &done_shardings);
+      }
+    }
+    start_shardings.insert(start_shardings.end(), done_shardings.begin(),
+                           done_shardings.end());
+    async_start->set_sharding(HloSharding::Tuple(start_shape, start_shardings));
+  }
 
   // Rewire each member's uses to a get-tuple-element of the async-done result,
   // preserving per-output sharding, and relay external control dependencies
@@ -267,8 +340,79 @@ absl::Status CreateCollectivesGroup(
   return absl::OkStatus();
 }
 
+// Contracting every group into one async node must leave the dependency graph
+// acyclic. Pairwise independence within a group is not sufficient: two groups
+// can depend on each other through different, individually independent members.
+absl::Status ValidateGroupGraphIsAcyclic(
+    absl::Span<const CollectiveGroup> groups,
+    const HloReachabilityMap& reachability,
+    absl::string_view computation_name) {
+  std::vector<std::vector<size_t>> successors(groups.size());
+  std::vector<int64_t> in_degree(groups.size(), 0);
+
+  for (size_t i = 0; i < groups.size(); ++i) {
+    for (size_t j = 0; j < groups.size(); ++j) {
+      if (i == j) {
+        continue;
+      }
+
+      bool is_reachable = false;
+      for (const HloInstruction* from : groups[i].collectives) {
+        for (const HloInstruction* to : groups[j].collectives) {
+          if (reachability.IsReachable(from, to)) {
+            is_reachable = true;
+            break;
+          }
+        }
+        if (is_reachable) {
+          break;
+        }
+      }
+      if (is_reachable) {
+        successors[i].push_back(j);
+        ++in_degree[j];
+      }
+    }
+  }
+
+  std::vector<size_t> ready;
+  ready.reserve(groups.size());
+  for (size_t i = 0; i < groups.size(); ++i) {
+    if (in_degree[i] == 0) {
+      ready.push_back(i);
+    }
+  }
+
+  size_t visited = 0;
+  while (!ready.empty()) {
+    size_t group = ready.back();
+    ready.pop_back();
+    ++visited;
+    for (size_t successor : successors[group]) {
+      if (--in_degree[successor] == 0) {
+        ready.push_back(successor);
+      }
+    }
+  }
+
+  if (visited != groups.size()) {
+    std::vector<absl::string_view> cycle_keys;
+    for (size_t i = 0; i < groups.size(); ++i) {
+      if (in_degree[i] != 0) {
+        cycle_keys.push_back(groups[i].key);
+      }
+    }
+    return FailedPrecondition(
+        "Grouping collectives in computation %s would create a dependency "
+        "cycle among collective_group_key values {%s}",
+        computation_name, absl::StrJoin(cycle_keys, ", "));
+  }
+  return absl::OkStatus();
+}
+
 absl::StatusOr<bool> GroupCollectivesInComputation(
-    HloComputation* computation, const HloPredicate& predicate) {
+    HloComputation* computation, const HloPredicate& predicate,
+    absl::string_view execution_thread) {
   VLOG(1) << "Finding collectives to group in computation "
           << computation->name();
 
@@ -298,7 +442,7 @@ absl::StatusOr<bool> GroupCollectivesInComputation(
   // mutation — forming a group inserts async-start/done and GTE instructions
   // that are absent from the map. Deferring all mutation to phase two also
   // guarantees an invalid later key never leaves earlier keys half-transformed.
-  std::vector<std::vector<HloInstruction*>> groups_to_form;
+  std::vector<CollectiveGroup> groups_to_form;
   groups_to_form.reserve(key_to_collectives.size());
   for (auto& [key, collectives] : key_to_collectives) {
     if (collectives.size() <= 1) {
@@ -346,14 +490,18 @@ absl::StatusOr<bool> GroupCollectivesInComputation(
               << "} with collective_group_key=" << key;
     }
 
-    groups_to_form.push_back(std::move(collectives));
+    groups_to_form.push_back({key, std::move(collectives)});
   }
+
+  RETURN_IF_ERROR(ValidateGroupGraphIsAcyclic(groups_to_form, *reachability,
+                                              computation->name()));
 
   // Phase two: every group validated against a consistent, mutation-free map,
   // so it is now safe to form them.
   bool changed = false;
-  for (const std::vector<HloInstruction*>& collectives : groups_to_form) {
-    RETURN_IF_ERROR(CreateCollectivesGroup(computation, collectives));
+  for (const CollectiveGroup& group : groups_to_form) {
+    RETURN_IF_ERROR(CreateCollectivesGroup(computation, group.collectives,
+                                           execution_thread));
     changed = true;
   }
   return changed;
@@ -374,7 +522,8 @@ absl::StatusOr<bool> GroupCollectivesByKey::RunImpl(
       continue;
     }
     ASSIGN_OR_RETURN(bool comp_changed,
-                     GroupCollectivesInComputation(comp, predicate_));
+                     GroupCollectivesInComputation(comp, predicate_,
+                                                   comp->execution_thread()));
     changed |= comp_changed;
   }
   return changed;

--- a/xla/backends/gpu/transforms/group_collectives_by_key.h
+++ b/xla/backends/gpu/transforms/group_collectives_by_key.h
@@ -1,0 +1,76 @@
+/* Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_TRANSFORMS_GROUP_COLLECTIVES_BY_KEY_H_
+#define XLA_BACKENDS_GPU_TRANSFORMS_GROUP_COLLECTIVES_BY_KEY_H_
+
+#include <utility>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+#include "xla/util.h"
+
+namespace xla::gpu {
+
+// Groups independent collectives that share the same nonempty
+// `collective_group_key` frontend attribute into a single async group call.
+//
+// At run time grouped collectives are launched via the GpuCollectives
+// GroupLaunch API, which allows the collective backend to apply optimizations
+// like collective kernel fusion. However, the main reason why XLA does it is to
+// make a group of semantically related collective operations (e.g. FSDP for
+// layer_N) into a single scheduling unit.
+//
+// Which opcodes are eligible for grouping is controlled by a predicate; the
+// default predicate accepts all-gather, reduce-scatter, and all-reduce. Callers
+// (e.g. the GPU compiler pipeline) can pass a narrower or wider predicate.
+//
+// Collectives tagged with the same key must be independent (no cycles are
+// allowed), and it is the user's responsibility to tag them appropriately.
+class GroupCollectivesByKey : public HloModulePass {
+ public:
+  // Default predicate: groups all-gather, reduce-scatter, and all-reduce.
+  static HloPredicate DefaultPredicate() {
+    return HloPredicateIsOp<HloOpcode::kAllGather, HloOpcode::kReduceScatter,
+                            HloOpcode::kAllReduce>;
+  }
+
+  GroupCollectivesByKey() : predicate_(DefaultPredicate()) {}
+
+  // `predicate` selects which instructions the pass may group. Only
+  // instructions carrying a collective_group_key are ever considered, so the
+  // predicate just narrows or widens the eligible opcode set.
+  explicit GroupCollectivesByKey(HloPredicate predicate)
+      : predicate_(std::move(predicate)) {}
+
+  absl::string_view name() const override { return "group-collectives-by-key"; }
+
+ protected:
+  absl::StatusOr<bool> RunImpl(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  HloPredicate predicate_;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_TRANSFORMS_GROUP_COLLECTIVES_BY_KEY_H_

--- a/xla/backends/gpu/transforms/group_collectives_by_key_test.cc
+++ b/xla/backends/gpu/transforms/group_collectives_by_key_test.cc
@@ -15,35 +15,24 @@ limitations under the License.
 
 #include "xla/backends/gpu/transforms/group_collectives_by_key.h"
 
-#include <memory>
+#include <string>
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/status/status.h"
-#include "absl/status/status_matchers.h"
 #include "absl/strings/string_view.h"
 #include "xla/backends/gpu/transforms/explicit_collectives_group_async_wrapper.h"
-#include "xla/hlo/ir/hlo_computation.h"
-#include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/filecheck.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
 
 namespace xla::gpu {
 namespace {
 
-using ::absl_testing::StatusIs;
-
 using GroupCollectivesByKeyTest = HloHardwareIndependentTestBase;
 
-int CountOpcode(const HloModule& module, HloOpcode opcode) {
-  int count = 0;
-  for (const HloInstruction* instr :
-       module.entry_computation()->instructions()) {
-    if (instr->opcode() == opcode) {
-      ++count;
-    }
-  }
-  return count;
+void ExpectFileCheck(absl::string_view input, absl::string_view pattern) {
+  ASSERT_OK_AND_ASSIGN(bool matches, RunFileCheck(std::string(input), pattern));
+  EXPECT_TRUE(matches);
 }
 
 // Input mimics combiner output: multi-operand AG + tuple output + GTE.
@@ -77,41 +66,619 @@ TEST_F(GroupCollectivesByKeyTest, GroupsCombinedAgAndRs) {
   }
   )";
 
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: %collectives_group (
+  //       CHECK: = {{.*}} all-gather(
+  //  CHECK-SAME:   frontend_attributes={collective_group_key="g0"}
+  //       CHECK: = {{.*}} reduce-scatter(
+  //  CHECK-SAME:   frontend_attributes={collective_group_key="g0"}
+
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %[[START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   calls=%collectives_group
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //       CHECK: %[[DONE:[^ ]+]] = {{.*}} async-done(%[[START]])
+  )";
+
+  RunAndFilecheckHloRewrite(hlo_string, GroupCollectivesByKey(), expected_hlo);
+}
+
+TEST_F(GroupCollectivesByKeyTest, SkipsUnpairedKeys) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    g1 = f32[32,8] parameter(1)
+    w2 = f32[8,8] parameter(2)
+    g2 = f32[32,8] parameter(3)
+    ag1 = f32[32,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs1 = f32[8,8] reduce-scatter(g1), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g1"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}}
+    rs2 = f32[8,8] reduce-scatter(g2), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add
+    ROOT result = (f32[32,8], f32[8,8], f32[32,8], f32[8,8])
+        tuple(ag1, rs1, ag2, rs2)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_FALSE(changed);
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %ag1 = {{.*}} all-gather(
+  //       CHECK: %rs1 = {{.*}} reduce-scatter(
+  //       CHECK: %ag2 = {{.*}} all-gather(
+  //       CHECK: %rs2 = {{.*}} reduce-scatter(
+  )";
+  ExpectFileCheck(module->ToString(), expected_hlo);
+}
+
+// Unannotated collectives are never grouped.
+TEST_F(GroupCollectivesByKeyTest, UnannotatedCollectivesUnchanged) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w = f32[8,8] parameter(0)
+    g = f32[32,8] parameter(1)
+    ag = f32[32,8] all-gather(w), dimensions={0},
+        replica_groups={{0,1,2,3}}
+    rs = f32[8,8] reduce-scatter(g), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add
+    ROOT result = (f32[32,8], f32[8,8]) tuple(ag, rs)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_FALSE(changed);
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %ag = {{.*}} all-gather(
+  //       CHECK: %rs = {{.*}} reduce-scatter(
+  )";
+  ExpectFileCheck(module->ToString(), expected_hlo);
+}
+
+// AG and RS may belong to different communicators (different replica_groups).
+// NCCL's group call fuses collectives across comms, so the pass should still
+// group them when the key matches.
+TEST_F(GroupCollectivesByKeyTest, GroupsAcrossDifferentReplicaGroups) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    weights = f32[8,8] parameter(0)
+    grads = f32[32,8] parameter(1)
+    ag = f32[16,8] all-gather(weights), dimensions={0},
+        replica_groups={{0,1},{2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs = f32[8,8] reduce-scatter(grads), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[8,8]) tuple(ag, rs)
+  }
+  )";
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: %collectives_group (
+  //       CHECK: = {{.*}} all-gather(
+  //       CHECK: = {{.*}} reduce-scatter(
+
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %[[START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   calls=%collectives_group
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //       CHECK: %[[DONE:[^ ]+]] = {{.*}} async-done(%[[START]])
+  )";
+
+  RunAndFilecheckHloRewrite(hlo_string, GroupCollectivesByKey(), expected_hlo);
+}
+
+// Two AllGathers with the same key must be paired even though neither is a
+// ReduceScatter.
+TEST_F(GroupCollectivesByKeyTest, GroupsTwoAllGathers) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    w2 = f32[8,8] parameter(1)
+    ag1 = f32[16,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1},{2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[32,8]) tuple(ag1, ag2)
+  }
+  )";
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: %collectives_group (
+  //       CHECK: = {{.*}} all-gather(
+  //       CHECK: = {{.*}} all-gather(
+
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %[[START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   calls=%collectives_group
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //       CHECK: %[[DONE:[^ ]+]] = {{.*}} async-done(%[[START]])
+  )";
+
+  RunAndFilecheckHloRewrite(hlo_string, GroupCollectivesByKey(), expected_hlo);
+}
+
+// Two AllReduces with the same key group together (all-reduce support).
+TEST_F(GroupCollectivesByKeyTest, GroupsTwoAllReduces) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    x = f32[8,8] parameter(0)
+    y = f32[8,8] parameter(1)
+    ar1 = f32[8,8] all-reduce(x), replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ar2 = f32[8,8] all-reduce(y), replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[8,8], f32[8,8]) tuple(ar1, ar2)
+  }
+  )";
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: %collectives_group (
+  //       CHECK: = {{.*}} all-reduce(
+  //       CHECK: = {{.*}} all-reduce(
+
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %[[START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   calls=%collectives_group
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //       CHECK: %[[DONE:[^ ]+]] = {{.*}} async-done(%[[START]])
+  )";
+
+  RunAndFilecheckHloRewrite(hlo_string, GroupCollectivesByKey(), expected_hlo);
+}
+
+// A custom predicate narrows the eligible opcode set: here only all-gathers
+// are groupable, so a same-key AG+RS pair is left ungrouped (RS is not a
+// candidate, leaving the AG as an unpaired singleton).
+TEST_F(GroupCollectivesByKeyTest, CustomPredicateRestrictsToAllGather) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w = f32[8,8] parameter(0)
+    g = f32[32,8] parameter(1)
+    ag = f32[32,8] all-gather(w), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs = f32[8,8] reduce-scatter(g), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[32,8], f32[8,8]) tuple(ag, rs)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass(HloPredicateIsOp<HloOpcode::kAllGather>);
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_FALSE(changed);
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %ag = {{.*}} all-gather(
+  //       CHECK: %rs = {{.*}} reduce-scatter(
+  )";
+  ExpectFileCheck(module->ToString(), expected_hlo);
+}
+
+// With the same all-gather-only predicate, two same-key all-gathers still
+// group; the restriction only excludes non-matching opcodes.
+TEST_F(GroupCollectivesByKeyTest, CustomPredicateStillGroupsMatchingOpcodes) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    w2 = f32[8,8] parameter(1)
+    ag1 = f32[16,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1},{2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[32,8]) tuple(ag1, ag2)
+  }
+  )";
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: %collectives_group (
+  //       CHECK: = {{.*}} all-gather(
+  //       CHECK: = {{.*}} all-gather(
+
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %[[START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   calls=%collectives_group
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //       CHECK: %[[DONE:[^ ]+]] = {{.*}} async-done(%[[START]])
+  )";
+
+  RunAndFilecheckHloRewrite(
+      hlo_string,
+      GroupCollectivesByKey(HloPredicateIsOp<HloOpcode::kAllGather>),
+      expected_hlo);
+}
+
+// Three independent collectives sharing the same key fuse into a single group,
+// not a pair plus a singleton.
+TEST_F(GroupCollectivesByKeyTest, GroupsThreeCollectives) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    w2 = f32[8,8] parameter(1)
+    g1 = f32[32,8] parameter(2)
+    ag1 = f32[16,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1},{2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs1 = f32[8,8] reduce-scatter(g1), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[32,8], f32[8,8]) tuple(ag1, ag2, rs1)
+  }
+  )";
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: %collectives_group (
+  //       CHECK: = {{.*}} all-gather(
+  //       CHECK: = {{.*}} all-gather(
+  //       CHECK: = {{.*}} reduce-scatter(
+
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %[[START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   calls=%collectives_group
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //       CHECK: %[[DONE:[^ ]+]] = {{.*}} async-done(%[[START]])
+  )";
+
+  RunAndFilecheckHloRewrite(hlo_string, GroupCollectivesByKey(), expected_hlo);
+}
+
+TEST_F(GroupCollectivesByKeyTest, MultipleKeyPairsGroupedIndependently) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    g1 = f32[32,8] parameter(1)
+    w2 = f32[8,8] parameter(2)
+    g2 = f32[32,8] parameter(3)
+    ag1 = f32[32,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs1 = f32[8,8] reduce-scatter(g1), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g1"}
+    rs2 = f32[8,8] reduce-scatter(g2), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g1"}
+    ROOT result = (f32[32,8], f32[8,8], f32[32,8], f32[8,8])
+        tuple(ag1, rs1, ag2, rs2)
+  }
+  )";
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: %collectives_group (
+  //       CHECK: = {{.*}} all-gather(
+  //  CHECK-SAME:   frontend_attributes={collective_group_key="g0"}
+  //       CHECK: = {{.*}} reduce-scatter(
+  //  CHECK-SAME:   frontend_attributes={collective_group_key="g0"}
+
+  // CHECK-LABEL: %collectives_group.1 (
+  //       CHECK: = {{.*}} all-gather(
+  //  CHECK-SAME:   frontend_attributes={collective_group_key="g1"}
+  //       CHECK: = {{.*}} reduce-scatter(
+  //  CHECK-SAME:   frontend_attributes={collective_group_key="g1"}
+
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %[[START0:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   calls=%collectives_group
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //       CHECK: %[[DONE0:[^ ]+]] = {{.*}} async-done(%[[START0]])
+  //       CHECK: %[[START1:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   calls=%collectives_group.1
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g1"}
+  //       CHECK: %[[DONE1:[^ ]+]] = {{.*}} async-done(%[[START1]])
+  )";
+
+  RunAndFilecheckHloRewrite(hlo_string, GroupCollectivesByKey(), expected_hlo);
+}
+
+TEST_F(GroupCollectivesByKeyTest, PreservesWrapperProperties) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    x = f32[8,8] parameter(0), sharding={replicated}
+    y = f32[8,8] parameter(1), sharding={replicated}
+    ar0 = f32[8,8] all-reduce(x),
+        replica_groups={{0,1}},
+        to_apply=add,
+        frontend_attributes={collective_group_key="g0"},
+        metadata={op_name="first_collective"},
+        sharding={replicated},
+        backend_config={"collective_backend_config":{"is_pipelined":true}}
+    ar1 = f32[8,8] all-reduce(y),
+        replica_groups={{0,1}},
+        to_apply=add,
+        frontend_attributes={collective_group_key="g0"},
+        sharding={replicated}
+    ROOT result = (f32[8,8], f32[8,8]) tuple(ar0, ar1)
+  }
+  )";
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: %collectives_group (
+  //       CHECK: ROOT %{{[^ ]+}} = {{.*}} tuple
+  //  CHECK-SAME:   sharding={
+  //  CHECK-SAME:   {replicated}, {replicated}}
+
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %[[START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   calls=%collectives_group
+  //  CHECK-SAME:   sharding={
+  //  CHECK-SAME:   {replicated}, {replicated},
+  //  CHECK-SAME:   {replicated}, {replicated}}
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //  CHECK-SAME:   metadata={op_name="first_collective"}
+  //  CHECK-SAME:   backend_config={"collective_backend_config":
+  //  CHECK-SAME:   {"is_pipelined":true}}
+  //       CHECK: %[[DONE:[^ ]+]] = {{.*}} async-done(%[[START]])
+  //  CHECK-SAME:   sharding={
+  //  CHECK-SAME:   {replicated}, {replicated}}
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //  CHECK-SAME:   metadata={op_name="first_collective"}
+  //  CHECK-SAME:   backend_config={"collective_backend_config":
+  //  CHECK-SAME:   {"is_pipelined":true}}
+  )";
+
+  RunAndFilecheckHloRewrite(hlo_string, GroupCollectivesByKey(), expected_hlo);
+}
+
+TEST_F(GroupCollectivesByKeyTest, PreservesExecutionThread) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  ENTRY main {
+    x = f32[8,8] parameter(0)
+    y = f32[8,8] parameter(1)
+    ag0 = f32[16,8] all-gather(x), dimensions={0},
+        replica_groups={{0,1}},
+        frontend_attributes={collective_group_key="g0"}
+    ag1 = f32[16,8] all-gather(y), dimensions={0},
+        replica_groups={{0,1}},
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[16,8]) tuple(ag0, ag1)
+  }, execution_thread="worker"
+  )";
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: %collectives_group (
+  //       CHECK: }, execution_thread="worker"
+
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %[[START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   async_execution_thread="worker"
+  //  CHECK-SAME:   calls=%collectives_group
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //       CHECK: %[[DONE:[^ ]+]] = {{.*}} async-done(%[[START]])
+  //       CHECK: }, execution_thread="worker"
+  )";
+
+  RunAndFilecheckHloRewrite(hlo_string, GroupCollectivesByKey(), expected_hlo);
+}
+
+// External control dependencies are relayed onto the async pair.
+TEST_F(GroupCollectivesByKeyTest, PreservesExternalControlDeps) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    w2 = f32[8,8] parameter(1)
+    barrier = f32[8,8] add(w1, w1)
+    ag1 = f32[16,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1},{2,3}}, control-predecessors={barrier},
+        frontend_attributes={collective_group_key="g0"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[32,8]) tuple(ag1, ag2)
+  }
+  )";
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %barrier = {{.*}} add(
+  //       CHECK: %[[START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   calls=%collectives_group
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //  CHECK-SAME:   control-predecessors={%barrier}
+  //       CHECK: %[[DONE:[^ ]+]] = {{.*}} async-done(%[[START]])
+  )";
+
+  RunAndFilecheckHloRewrite(hlo_string, GroupCollectivesByKey(), expected_hlo);
+}
+
+// Running the pass twice is idempotent: the second run makes no change.
+TEST_F(GroupCollectivesByKeyTest, Idempotent) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    w2 = f32[8,8] parameter(1)
+    ag1 = f32[16,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1},{2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[32,8]) tuple(ag1, ag2)
+  }
+  )";
+
   ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
   GroupCollectivesByKey pass;
   ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
   EXPECT_TRUE(changed);
+  ASSERT_OK_AND_ASSIGN(bool changed_again, pass.Run(module.get()));
+  EXPECT_FALSE(changed_again);
 
-  // A single async group replaces both top-level collectives.
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 0);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kReduceScatter), 0);
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: %collectives_group (
+  //       CHECK: = {{.*}} all-gather(
+  //       CHECK: = {{.*}} all-gather(
 
-  // The async-start/done carry the marker and the preserved key.
-  const HloInstruction* async_start = nullptr;
-  for (HloInstruction* instr : module->entry_computation()->instructions()) {
-    if (instr->opcode() == HloOpcode::kAsyncStart) {
-      async_start = instr;
-    }
-  }
-  ASSERT_NE(async_start, nullptr);
-  EXPECT_EQ(async_start->get_frontend_attribute("_collectives_group"), "");
-  EXPECT_EQ(async_start->get_frontend_attribute("collective_group_key"), "g0");
-
-  // The cloned collectives inside the group computation retain the key.
-  const HloComputation* group_comp = async_start->async_wrapped_computation();
-  ASSERT_NE(group_comp, nullptr);
-  int inner_collectives = 0;
-  for (const HloInstruction* instr : group_comp->instructions()) {
-    if (instr->opcode() == HloOpcode::kAllGather ||
-        instr->opcode() == HloOpcode::kReduceScatter) {
-      ++inner_collectives;
-      EXPECT_EQ(instr->get_frontend_attribute("collective_group_key"), "g0");
-    }
-  }
-  EXPECT_EQ(inner_collectives, 2);
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %[[START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   calls=%collectives_group
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //       CHECK: %[[DONE:[^ ]+]] = {{.*}} async-done(%[[START]])
+  )";
+  ExpectFileCheck(module->ToString(), expected_hlo);
 }
 
+// The pass output is consumed cleanly: the wrapper does not re-wrap the groups
+// this pass already formed, leaving exactly the async pairs it created.
+TEST_F(GroupCollectivesByKeyTest, EndToEndWithWrapper) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w = f32[8,8] parameter(0)
+    g = f32[32,8] parameter(1)
+    ag = f32[32,8] all-gather(w), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs = f32[8,8] reduce-scatter(g), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[32,8], f32[8,8]) tuple(ag, rs)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey group_pass;
+  ASSERT_OK_AND_ASSIGN(bool grouped, group_pass.Run(module.get()));
+  EXPECT_TRUE(grouped);
+
+  ExplicitCollectivesGroupAsyncWrapper wrapper;
+  ASSERT_OK_AND_ASSIGN(bool wrapped, wrapper.Run(module.get()));
+  EXPECT_FALSE(wrapped);
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: %collectives_group (
+  //       CHECK: = {{.*}} all-gather(
+  //       CHECK: = {{.*}} reduce-scatter(
+
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %[[START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   calls=%collectives_group
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //       CHECK: %[[DONE:[^ ]+]] = {{.*}} async-done(%[[START]])
+  )";
+  ExpectFileCheck(module->ToString(), expected_hlo);
+}
+
+// Invalid collective groups fail without mutating the module.
 TEST_F(GroupCollectivesByKeyTest, ErrorsWhenDependencyExists) {
   const absl::string_view hlo_string = R"(
   HloModule test
@@ -136,11 +703,23 @@ TEST_F(GroupCollectivesByKeyTest, ErrorsWhenDependencyExists) {
 
   ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
   GroupCollectivesByKey pass;
-  EXPECT_THAT(pass.Run(module.get()).status(),
-              StatusIs(absl::StatusCode::kFailedPrecondition,
-                       ::testing::AllOf(::testing::HasSubstr("ag"),
-                                        ::testing::HasSubstr("rs"),
-                                        ::testing::HasSubstr("g0"))));
+  absl::Status status = pass.Run(module.get()).status();
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+
+  const absl::string_view expected_error = R"(
+  //       CHECK: Collectives ag and rs
+  //  CHECK-SAME:   collective_group_key=g0
+  //       CHECK: Computation: main
+  //       CHECK: Reachability chain ag -> rs:
+  )";
+  ExpectFileCheck(status.message(), expected_error);
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %ag = {{.*}} all-gather(
+  //       CHECK: %rs = {{.*}} reduce-scatter(
+  )";
+  ExpectFileCheck(module->ToString(), expected_hlo);
 }
 
 // A later key's invalid dependency path runs through an earlier key's members.
@@ -185,149 +764,27 @@ TEST_F(GroupCollectivesByKeyTest, ErrorsOnLaterKeyWithoutMutatingEarlierKey) {
 
   ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
   GroupCollectivesByKey pass;
-  EXPECT_THAT(pass.Run(module.get()).status(),
-              StatusIs(absl::StatusCode::kFailedPrecondition,
-                       ::testing::AllOf(::testing::HasSubstr("rs1"),
-                                        ::testing::HasSubstr("ag1"),
-                                        ::testing::HasSubstr("g1"))));
+  absl::Status status = pass.Run(module.get()).status();
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
 
-  // The earlier, valid key g0 must be left untouched: no async group was
-  // formed and all three all-gathers survive.
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 0);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 3);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kReduceScatter), 1);
-}
-
-TEST_F(GroupCollectivesByKeyTest, SkipsUnpairedKeys) {
-  const absl::string_view hlo_string = R"(
-  HloModule test
-
-  add {
-    a = f32[] parameter(0)
-    b = f32[] parameter(1)
-    ROOT sum = f32[] add(a, b)
-  }
-
-  ENTRY main {
-    w1 = f32[8,8] parameter(0)
-    g1 = f32[32,8] parameter(1)
-    w2 = f32[8,8] parameter(2)
-    g2 = f32[32,8] parameter(3)
-    ag1 = f32[32,8] all-gather(w1), dimensions={0},
-        replica_groups={{0,1,2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    rs1 = f32[8,8] reduce-scatter(g1), dimensions={0},
-        replica_groups={{0,1,2,3}}, to_apply=add,
-        frontend_attributes={collective_group_key="g1"}
-    ag2 = f32[32,8] all-gather(w2), dimensions={0},
-        replica_groups={{0,1,2,3}}
-    rs2 = f32[8,8] reduce-scatter(g2), dimensions={0},
-        replica_groups={{0,1,2,3}}, to_apply=add
-    ROOT result = (f32[32,8], f32[8,8], f32[32,8], f32[8,8])
-        tuple(ag1, rs1, ag2, rs2)
-  }
+  const absl::string_view expected_error = R"(
+  //       CHECK: Collectives rs1 and ag1
+  //  CHECK-SAME:   collective_group_key=g1
+  //       CHECK: Reachability chain rs1 -> ag1:
   )";
+  ExpectFileCheck(status.message(), expected_error);
 
-  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
-  GroupCollectivesByKey pass;
-  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
-  EXPECT_FALSE(changed);
-}
-
-// Unannotated collectives are never grouped.
-TEST_F(GroupCollectivesByKeyTest, UnannotatedCollectivesUnchanged) {
-  const absl::string_view hlo_string = R"(
-  HloModule test
-
-  add {
-    a = f32[] parameter(0)
-    b = f32[] parameter(1)
-    ROOT sum = f32[] add(a, b)
-  }
-
-  ENTRY main {
-    w = f32[8,8] parameter(0)
-    g = f32[32,8] parameter(1)
-    ag = f32[32,8] all-gather(w), dimensions={0},
-        replica_groups={{0,1,2,3}}
-    rs = f32[8,8] reduce-scatter(g), dimensions={0},
-        replica_groups={{0,1,2,3}}, to_apply=add
-    ROOT result = (f32[32,8], f32[8,8]) tuple(ag, rs)
-  }
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %ag0b = {{.*}} all-gather(
+  //       CHECK: %rs1 = {{.*}} reduce-scatter(
+  //       CHECK: %ag0a = {{.*}} all-gather(
+  //       CHECK: %ag1 = {{.*}} all-gather(
   )";
-
-  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
-  GroupCollectivesByKey pass;
-  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
-  EXPECT_FALSE(changed);
+  ExpectFileCheck(module->ToString(), expected_hlo);
 }
 
-// AG and RS may belong to different communicators (different replica_groups).
-// NCCL's group call fuses collectives across comms, so the pass should still
-// group them when the key matches.
-TEST_F(GroupCollectivesByKeyTest, GroupsAcrossDifferentReplicaGroups) {
-  const absl::string_view hlo_string = R"(
-  HloModule test
-
-  add {
-    a = f32[] parameter(0)
-    b = f32[] parameter(1)
-    ROOT sum = f32[] add(a, b)
-  }
-
-  ENTRY main {
-    weights = f32[8,8] parameter(0)
-    grads = f32[32,8] parameter(1)
-    ag = f32[16,8] all-gather(weights), dimensions={0},
-        replica_groups={{0,1},{2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    rs = f32[8,8] reduce-scatter(grads), dimensions={0},
-        replica_groups={{0,1,2,3}}, to_apply=add,
-        frontend_attributes={collective_group_key="g0"}
-    ROOT result = (f32[16,8], f32[8,8]) tuple(ag, rs)
-  }
-  )";
-
-  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
-  GroupCollectivesByKey pass;
-  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
-  EXPECT_TRUE(changed);
-
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 0);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kReduceScatter), 0);
-}
-
-// Two AllGathers with the same key must be paired even though neither is a
-// ReduceScatter.
-TEST_F(GroupCollectivesByKeyTest, GroupsTwoAllGathers) {
-  const absl::string_view hlo_string = R"(
-  HloModule test
-
-  ENTRY main {
-    w1 = f32[8,8] parameter(0)
-    w2 = f32[8,8] parameter(1)
-    ag1 = f32[16,8] all-gather(w1), dimensions={0},
-        replica_groups={{0,1},{2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    ag2 = f32[32,8] all-gather(w2), dimensions={0},
-        replica_groups={{0,1,2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    ROOT result = (f32[16,8], f32[32,8]) tuple(ag1, ag2)
-  }
-  )";
-
-  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
-  GroupCollectivesByKey pass;
-  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
-  EXPECT_TRUE(changed);
-
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 0);
-}
-
-// Two AllReduces with the same key group together (all-reduce support).
-TEST_F(GroupCollectivesByKeyTest, GroupsTwoAllReduces) {
+TEST_F(GroupCollectivesByKeyTest, ErrorsWhenGroupedNodeGraphHasCycle) {
   const absl::string_view hlo_string = R"(
   HloModule test
 
@@ -340,270 +797,38 @@ TEST_F(GroupCollectivesByKeyTest, GroupsTwoAllReduces) {
   ENTRY main {
     x = f32[8,8] parameter(0)
     y = f32[8,8] parameter(1)
-    ar1 = f32[8,8] all-reduce(x), replica_groups={{0,1,2,3}}, to_apply=add,
-        frontend_attributes={collective_group_key="g0"}
-    ar2 = f32[8,8] all-reduce(y), replica_groups={{0,1,2,3}}, to_apply=add,
-        frontend_attributes={collective_group_key="g0"}
-    ROOT result = (f32[8,8], f32[8,8]) tuple(ar1, ar2)
-  }
-  )";
-
-  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
-  GroupCollectivesByKey pass;
-  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
-  EXPECT_TRUE(changed);
-
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllReduce), 0);
-}
-
-// A custom predicate narrows the eligible opcode set: here only all-gathers
-// are groupable, so a same-key AG+RS pair is left ungrouped (RS is not a
-// candidate, leaving the AG as an unpaired singleton).
-TEST_F(GroupCollectivesByKeyTest, CustomPredicateRestrictsToAllGather) {
-  const absl::string_view hlo_string = R"(
-  HloModule test
-
-  add {
-    a = f32[] parameter(0)
-    b = f32[] parameter(1)
-    ROOT sum = f32[] add(a, b)
-  }
-
-  ENTRY main {
-    w = f32[8,8] parameter(0)
-    g = f32[32,8] parameter(1)
-    ag = f32[32,8] all-gather(w), dimensions={0},
-        replica_groups={{0,1,2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    rs = f32[8,8] reduce-scatter(g), dimensions={0},
-        replica_groups={{0,1,2,3}}, to_apply=add,
-        frontend_attributes={collective_group_key="g0"}
-    ROOT result = (f32[32,8], f32[8,8]) tuple(ag, rs)
-  }
-  )";
-
-  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
-  GroupCollectivesByKey pass(HloPredicateIsOp<HloOpcode::kAllGather>);
-  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
-  EXPECT_FALSE(changed);
-
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 0);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 1);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kReduceScatter), 1);
-}
-
-// With the same all-gather-only predicate, two same-key all-gathers still
-// group; the restriction only excludes non-matching opcodes.
-TEST_F(GroupCollectivesByKeyTest, CustomPredicateStillGroupsMatchingOpcodes) {
-  const absl::string_view hlo_string = R"(
-  HloModule test
-
-  ENTRY main {
-    w1 = f32[8,8] parameter(0)
-    w2 = f32[8,8] parameter(1)
-    ag1 = f32[16,8] all-gather(w1), dimensions={0},
-        replica_groups={{0,1},{2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    ag2 = f32[32,8] all-gather(w2), dimensions={0},
-        replica_groups={{0,1,2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    ROOT result = (f32[16,8], f32[32,8]) tuple(ag1, ag2)
-  }
-  )";
-
-  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
-  GroupCollectivesByKey pass(HloPredicateIsOp<HloOpcode::kAllGather>);
-  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
-  EXPECT_TRUE(changed);
-
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 0);
-}
-
-// Three independent collectives sharing the same key fuse into a single group,
-// not a pair plus a singleton.
-TEST_F(GroupCollectivesByKeyTest, GroupsThreeCollectives) {
-  const absl::string_view hlo_string = R"(
-  HloModule test
-
-  add {
-    a = f32[] parameter(0)
-    b = f32[] parameter(1)
-    ROOT sum = f32[] add(a, b)
-  }
-
-  ENTRY main {
-    w1 = f32[8,8] parameter(0)
-    w2 = f32[8,8] parameter(1)
-    g1 = f32[32,8] parameter(2)
-    ag1 = f32[16,8] all-gather(w1), dimensions={0},
-        replica_groups={{0,1},{2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    ag2 = f32[32,8] all-gather(w2), dimensions={0},
-        replica_groups={{0,1,2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    rs1 = f32[8,8] reduce-scatter(g1), dimensions={0},
-        replica_groups={{0,1,2,3}}, to_apply=add,
-        frontend_attributes={collective_group_key="g0"}
-    ROOT result = (f32[16,8], f32[32,8], f32[8,8]) tuple(ag1, ag2, rs1)
-  }
-  )";
-
-  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
-  GroupCollectivesByKey pass;
-  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
-  EXPECT_TRUE(changed);
-
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 0);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kReduceScatter), 0);
-}
-
-TEST_F(GroupCollectivesByKeyTest, MultipleKeyPairsGroupedIndependently) {
-  const absl::string_view hlo_string = R"(
-  HloModule test
-
-  add {
-    a = f32[] parameter(0)
-    b = f32[] parameter(1)
-    ROOT sum = f32[] add(a, b)
-  }
-
-  ENTRY main {
-    w1 = f32[8,8] parameter(0)
-    g1 = f32[32,8] parameter(1)
-    w2 = f32[8,8] parameter(2)
-    g2 = f32[32,8] parameter(3)
-    ag1 = f32[32,8] all-gather(w1), dimensions={0},
-        replica_groups={{0,1,2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    rs1 = f32[8,8] reduce-scatter(g1), dimensions={0},
-        replica_groups={{0,1,2,3}}, to_apply=add,
-        frontend_attributes={collective_group_key="g0"}
-    ag2 = f32[32,8] all-gather(w2), dimensions={0},
-        replica_groups={{0,1,2,3}},
-        frontend_attributes={collective_group_key="g1"}
-    rs2 = f32[8,8] reduce-scatter(g2), dimensions={0},
+    g0_first = f32[8,8] all-reduce(x), replica_groups={{0,1,2,3}},
+        to_apply=add, frontend_attributes={collective_group_key="g0"}
+    g1_first = f32[8,8] all-reduce(g0_first),
         replica_groups={{0,1,2,3}}, to_apply=add,
         frontend_attributes={collective_group_key="g1"}
-    ROOT result = (f32[32,8], f32[8,8], f32[32,8], f32[8,8])
-        tuple(ag1, rs1, ag2, rs2)
-  }
-  )";
-
-  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
-  GroupCollectivesByKey pass;
-  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
-  EXPECT_TRUE(changed);
-
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 2);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 0);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kReduceScatter), 0);
-}
-
-// External control dependencies are relayed onto the async pair.
-TEST_F(GroupCollectivesByKeyTest, PreservesExternalControlDeps) {
-  const absl::string_view hlo_string = R"(
-  HloModule test
-
-  ENTRY main {
-    w1 = f32[8,8] parameter(0)
-    w2 = f32[8,8] parameter(1)
-    barrier = f32[8,8] add(w1, w1)
-    ag1 = f32[16,8] all-gather(w1), dimensions={0},
-        replica_groups={{0,1},{2,3}}, control-predecessors={barrier},
-        frontend_attributes={collective_group_key="g0"}
-    ag2 = f32[32,8] all-gather(w2), dimensions={0},
-        replica_groups={{0,1,2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    ROOT result = (f32[16,8], f32[32,8]) tuple(ag1, ag2)
-  }
-  )";
-
-  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
-  GroupCollectivesByKey pass;
-  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
-  EXPECT_TRUE(changed);
-
-  const HloInstruction* async_start = nullptr;
-  const HloInstruction* barrier = nullptr;
-  for (HloInstruction* instr : module->entry_computation()->instructions()) {
-    if (instr->opcode() == HloOpcode::kAsyncStart) {
-      async_start = instr;
-    }
-    if (instr->name() == "barrier") {
-      barrier = instr;
-    }
-  }
-  ASSERT_NE(async_start, nullptr);
-  ASSERT_NE(barrier, nullptr);
-  EXPECT_THAT(async_start->control_predecessors(),
-              ::testing::Contains(barrier));
-}
-
-// Running the pass twice is idempotent: the second run makes no change.
-TEST_F(GroupCollectivesByKeyTest, Idempotent) {
-  const absl::string_view hlo_string = R"(
-  HloModule test
-
-  ENTRY main {
-    w1 = f32[8,8] parameter(0)
-    w2 = f32[8,8] parameter(1)
-    ag1 = f32[16,8] all-gather(w1), dimensions={0},
-        replica_groups={{0,1},{2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    ag2 = f32[32,8] all-gather(w2), dimensions={0},
-        replica_groups={{0,1,2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    ROOT result = (f32[16,8], f32[32,8]) tuple(ag1, ag2)
-  }
-  )";
-
-  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
-  GroupCollectivesByKey pass;
-  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
-  EXPECT_TRUE(changed);
-  ASSERT_OK_AND_ASSIGN(bool changed_again, pass.Run(module.get()));
-  EXPECT_FALSE(changed_again);
-}
-
-// The pass output is consumed cleanly: the wrapper does not re-wrap the groups
-// this pass already formed, leaving exactly the async pairs it created.
-TEST_F(GroupCollectivesByKeyTest, EndToEndWithWrapper) {
-  const absl::string_view hlo_string = R"(
-  HloModule test
-
-  add {
-    a = f32[] parameter(0)
-    b = f32[] parameter(1)
-    ROOT sum = f32[] add(a, b)
-  }
-
-  ENTRY main {
-    w = f32[8,8] parameter(0)
-    g = f32[32,8] parameter(1)
-    ag = f32[32,8] all-gather(w), dimensions={0},
-        replica_groups={{0,1,2,3}},
-        frontend_attributes={collective_group_key="g0"}
-    rs = f32[8,8] reduce-scatter(g), dimensions={0},
+    g1_second = f32[8,8] all-reduce(y), replica_groups={{0,1,2,3}},
+        to_apply=add, frontend_attributes={collective_group_key="g1"}
+    g0_second = f32[8,8] all-reduce(g1_second),
         replica_groups={{0,1,2,3}}, to_apply=add,
         frontend_attributes={collective_group_key="g0"}
-    ROOT result = (f32[32,8], f32[8,8]) tuple(ag, rs)
+    ROOT result = (f32[8,8], f32[8,8]) tuple(g1_first, g0_second)
   }
   )";
 
   ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
-  GroupCollectivesByKey group_pass;
-  ASSERT_OK_AND_ASSIGN(bool grouped, group_pass.Run(module.get()));
-  EXPECT_TRUE(grouped);
+  GroupCollectivesByKey pass;
+  absl::Status status = pass.Run(module.get()).status();
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
 
-  ExplicitCollectivesGroupAsyncWrapper wrapper;
-  ASSERT_OK_AND_ASSIGN(bool wrapped, wrapper.Run(module.get()));
-  // The group is already an async pair, so the wrapper (which only rewrites
-  // _collectives_group calls) has nothing to do.
-  EXPECT_FALSE(wrapped);
-  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
+  const absl::string_view expected_error = R"(
+  //       CHECK: dependency cycle among collective_group_key values {g0, g1}
+  )";
+  ExpectFileCheck(status.message(), expected_error);
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %g0_first = {{.*}} all-reduce(
+  //       CHECK: %g1_first = {{.*}} all-reduce(
+  //       CHECK: %g1_second = {{.*}} all-reduce(
+  //       CHECK: %g0_second = {{.*}} all-reduce(
+  )";
+  ExpectFileCheck(module->ToString(), expected_hlo);
 }
 
 }  // namespace

--- a/xla/backends/gpu/transforms/group_collectives_by_key_test.cc
+++ b/xla/backends/gpu/transforms/group_collectives_by_key_test.cc
@@ -1,0 +1,610 @@
+/* Copyright 2026 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/group_collectives_by_key.h"
+
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/gpu/transforms/explicit_collectives_group_async_wrapper.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+
+namespace xla::gpu {
+namespace {
+
+using ::absl_testing::StatusIs;
+
+using GroupCollectivesByKeyTest = HloHardwareIndependentTestBase;
+
+int CountOpcode(const HloModule& module, HloOpcode opcode) {
+  int count = 0;
+  for (const HloInstruction* instr :
+       module.entry_computation()->instructions()) {
+    if (instr->opcode() == opcode) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+// Input mimics combiner output: multi-operand AG + tuple output + GTE.
+TEST_F(GroupCollectivesByKeyTest, GroupsCombinedAgAndRs) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w0 = f32[8,8] parameter(0)
+    w1 = f32[8,8] parameter(1)
+    g0 = f32[32,8] parameter(2)
+    g1 = f32[32,8] parameter(3)
+    ag = (f32[32,8], f32[32,8]) all-gather(w0, w1), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ag0 = f32[32,8] get-tuple-element(ag), index=0
+    ag1 = f32[32,8] get-tuple-element(ag), index=1
+    rs = (f32[8,8], f32[8,8]) reduce-scatter(g0, g1), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    rs0 = f32[8,8] get-tuple-element(rs), index=0
+    rs1 = f32[8,8] get-tuple-element(rs), index=1
+    ROOT result = (f32[32,8], f32[32,8], f32[8,8], f32[8,8])
+        tuple(ag0, ag1, rs0, rs1)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  // A single async group replaces both top-level collectives.
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 0);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kReduceScatter), 0);
+
+  // The async-start/done carry the marker and the preserved key.
+  const HloInstruction* async_start = nullptr;
+  for (HloInstruction* instr : module->entry_computation()->instructions()) {
+    if (instr->opcode() == HloOpcode::kAsyncStart) {
+      async_start = instr;
+    }
+  }
+  ASSERT_NE(async_start, nullptr);
+  EXPECT_EQ(async_start->get_frontend_attribute("_collectives_group"), "");
+  EXPECT_EQ(async_start->get_frontend_attribute("collective_group_key"), "g0");
+
+  // The cloned collectives inside the group computation retain the key.
+  const HloComputation* group_comp = async_start->async_wrapped_computation();
+  ASSERT_NE(group_comp, nullptr);
+  int inner_collectives = 0;
+  for (const HloInstruction* instr : group_comp->instructions()) {
+    if (instr->opcode() == HloOpcode::kAllGather ||
+        instr->opcode() == HloOpcode::kReduceScatter) {
+      ++inner_collectives;
+      EXPECT_EQ(instr->get_frontend_attribute("collective_group_key"), "g0");
+    }
+  }
+  EXPECT_EQ(inner_collectives, 2);
+}
+
+TEST_F(GroupCollectivesByKeyTest, ErrorsWhenDependencyExists) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    weights = f32[8,8] parameter(0)
+    ag = f32[32,8] all-gather(weights), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs = f32[8,8] reduce-scatter(ag), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = f32[8,8] copy(rs)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  EXPECT_THAT(pass.Run(module.get()).status(),
+              StatusIs(absl::StatusCode::kFailedPrecondition,
+                       ::testing::AllOf(::testing::HasSubstr("ag"),
+                                        ::testing::HasSubstr("rs"),
+                                        ::testing::HasSubstr("g0"))));
+}
+
+// A later key's invalid dependency path runs through an earlier key's members.
+// Keys are processed in sorted order, so "g0" (valid, independent) would be
+// grouped before "g1" (invalid) is validated. Validation must therefore happen
+// for every key against a single mutation-free reachability map: otherwise the
+// "g1" diagnostic would walk users() of instructions whose "g0" neighbors have
+// already been replaced by async/GTE nodes absent from the stale map (crash),
+// and the "g0" group would be left half-transformed behind the error.
+TEST_F(GroupCollectivesByKeyTest, ErrorsOnLaterKeyWithoutMutatingEarlierKey) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    g = f32[32,8] parameter(1)
+    // g1 member; feeds an all-gather that carries key g0.
+    rs1 = f32[8,8] reduce-scatter(g), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g1"}
+    // g0 members: independent of each other, so g0 is valid on its own. But
+    // ag0a depends on rs1 and feeds ag1, so it sits on the g1 dependency path.
+    ag0a = f32[32,8] all-gather(rs1), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ag0b = f32[32,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    // g1 member reachable from rs1 through ag0a: g1 is not independent.
+    ag1 = f32[128,8] all-gather(ag0a), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g1"}
+    ROOT result = (f32[32,8], f32[128,8]) tuple(ag0b, ag1)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  EXPECT_THAT(pass.Run(module.get()).status(),
+              StatusIs(absl::StatusCode::kFailedPrecondition,
+                       ::testing::AllOf(::testing::HasSubstr("rs1"),
+                                        ::testing::HasSubstr("ag1"),
+                                        ::testing::HasSubstr("g1"))));
+
+  // The earlier, valid key g0 must be left untouched: no async group was
+  // formed and all three all-gathers survive.
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 0);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 3);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kReduceScatter), 1);
+}
+
+TEST_F(GroupCollectivesByKeyTest, SkipsUnpairedKeys) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    g1 = f32[32,8] parameter(1)
+    w2 = f32[8,8] parameter(2)
+    g2 = f32[32,8] parameter(3)
+    ag1 = f32[32,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs1 = f32[8,8] reduce-scatter(g1), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g1"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}}
+    rs2 = f32[8,8] reduce-scatter(g2), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add
+    ROOT result = (f32[32,8], f32[8,8], f32[32,8], f32[8,8])
+        tuple(ag1, rs1, ag2, rs2)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+// Unannotated collectives are never grouped.
+TEST_F(GroupCollectivesByKeyTest, UnannotatedCollectivesUnchanged) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w = f32[8,8] parameter(0)
+    g = f32[32,8] parameter(1)
+    ag = f32[32,8] all-gather(w), dimensions={0},
+        replica_groups={{0,1,2,3}}
+    rs = f32[8,8] reduce-scatter(g), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add
+    ROOT result = (f32[32,8], f32[8,8]) tuple(ag, rs)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
+// AG and RS may belong to different communicators (different replica_groups).
+// NCCL's group call fuses collectives across comms, so the pass should still
+// group them when the key matches.
+TEST_F(GroupCollectivesByKeyTest, GroupsAcrossDifferentReplicaGroups) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    weights = f32[8,8] parameter(0)
+    grads = f32[32,8] parameter(1)
+    ag = f32[16,8] all-gather(weights), dimensions={0},
+        replica_groups={{0,1},{2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs = f32[8,8] reduce-scatter(grads), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[8,8]) tuple(ag, rs)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 0);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kReduceScatter), 0);
+}
+
+// Two AllGathers with the same key must be paired even though neither is a
+// ReduceScatter.
+TEST_F(GroupCollectivesByKeyTest, GroupsTwoAllGathers) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    w2 = f32[8,8] parameter(1)
+    ag1 = f32[16,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1},{2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[32,8]) tuple(ag1, ag2)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 0);
+}
+
+// Two AllReduces with the same key group together (all-reduce support).
+TEST_F(GroupCollectivesByKeyTest, GroupsTwoAllReduces) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    x = f32[8,8] parameter(0)
+    y = f32[8,8] parameter(1)
+    ar1 = f32[8,8] all-reduce(x), replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ar2 = f32[8,8] all-reduce(y), replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[8,8], f32[8,8]) tuple(ar1, ar2)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllReduce), 0);
+}
+
+// A custom predicate narrows the eligible opcode set: here only all-gathers
+// are groupable, so a same-key AG+RS pair is left ungrouped (RS is not a
+// candidate, leaving the AG as an unpaired singleton).
+TEST_F(GroupCollectivesByKeyTest, CustomPredicateRestrictsToAllGather) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w = f32[8,8] parameter(0)
+    g = f32[32,8] parameter(1)
+    ag = f32[32,8] all-gather(w), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs = f32[8,8] reduce-scatter(g), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[32,8], f32[8,8]) tuple(ag, rs)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass(HloPredicateIsOp<HloOpcode::kAllGather>);
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_FALSE(changed);
+
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 0);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 1);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kReduceScatter), 1);
+}
+
+// With the same all-gather-only predicate, two same-key all-gathers still
+// group; the restriction only excludes non-matching opcodes.
+TEST_F(GroupCollectivesByKeyTest, CustomPredicateStillGroupsMatchingOpcodes) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    w2 = f32[8,8] parameter(1)
+    ag1 = f32[16,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1},{2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[32,8]) tuple(ag1, ag2)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass(HloPredicateIsOp<HloOpcode::kAllGather>);
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 0);
+}
+
+// Three independent collectives sharing the same key fuse into a single group,
+// not a pair plus a singleton.
+TEST_F(GroupCollectivesByKeyTest, GroupsThreeCollectives) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    w2 = f32[8,8] parameter(1)
+    g1 = f32[32,8] parameter(2)
+    ag1 = f32[16,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1},{2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs1 = f32[8,8] reduce-scatter(g1), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[32,8], f32[8,8]) tuple(ag1, ag2, rs1)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 0);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kReduceScatter), 0);
+}
+
+TEST_F(GroupCollectivesByKeyTest, MultipleKeyPairsGroupedIndependently) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    g1 = f32[32,8] parameter(1)
+    w2 = f32[8,8] parameter(2)
+    g2 = f32[32,8] parameter(3)
+    ag1 = f32[32,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs1 = f32[8,8] reduce-scatter(g1), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g1"}
+    rs2 = f32[8,8] reduce-scatter(g2), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g1"}
+    ROOT result = (f32[32,8], f32[8,8], f32[32,8], f32[8,8])
+        tuple(ag1, rs1, ag2, rs2)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 2);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAllGather), 0);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kReduceScatter), 0);
+}
+
+// External control dependencies are relayed onto the async pair.
+TEST_F(GroupCollectivesByKeyTest, PreservesExternalControlDeps) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    w2 = f32[8,8] parameter(1)
+    barrier = f32[8,8] add(w1, w1)
+    ag1 = f32[16,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1},{2,3}}, control-predecessors={barrier},
+        frontend_attributes={collective_group_key="g0"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[32,8]) tuple(ag1, ag2)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  const HloInstruction* async_start = nullptr;
+  const HloInstruction* barrier = nullptr;
+  for (HloInstruction* instr : module->entry_computation()->instructions()) {
+    if (instr->opcode() == HloOpcode::kAsyncStart) {
+      async_start = instr;
+    }
+    if (instr->name() == "barrier") {
+      barrier = instr;
+    }
+  }
+  ASSERT_NE(async_start, nullptr);
+  ASSERT_NE(barrier, nullptr);
+  EXPECT_THAT(async_start->control_predecessors(),
+              ::testing::Contains(barrier));
+}
+
+// Running the pass twice is idempotent: the second run makes no change.
+TEST_F(GroupCollectivesByKeyTest, Idempotent) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  ENTRY main {
+    w1 = f32[8,8] parameter(0)
+    w2 = f32[8,8] parameter(1)
+    ag1 = f32[16,8] all-gather(w1), dimensions={0},
+        replica_groups={{0,1},{2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ag2 = f32[32,8] all-gather(w2), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[16,8], f32[32,8]) tuple(ag1, ag2)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_TRUE(changed);
+  ASSERT_OK_AND_ASSIGN(bool changed_again, pass.Run(module.get()));
+  EXPECT_FALSE(changed_again);
+}
+
+// The pass output is consumed cleanly: the wrapper does not re-wrap the groups
+// this pass already formed, leaving exactly the async pairs it created.
+TEST_F(GroupCollectivesByKeyTest, EndToEndWithWrapper) {
+  const absl::string_view hlo_string = R"(
+  HloModule test
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w = f32[8,8] parameter(0)
+    g = f32[32,8] parameter(1)
+    ag = f32[32,8] all-gather(w), dimensions={0},
+        replica_groups={{0,1,2,3}},
+        frontend_attributes={collective_group_key="g0"}
+    rs = f32[8,8] reduce-scatter(g), dimensions={0},
+        replica_groups={{0,1,2,3}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[32,8], f32[8,8]) tuple(ag, rs)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  GroupCollectivesByKey group_pass;
+  ASSERT_OK_AND_ASSIGN(bool grouped, group_pass.Run(module.get()));
+  EXPECT_TRUE(grouped);
+
+  ExplicitCollectivesGroupAsyncWrapper wrapper;
+  ASSERT_OK_AND_ASSIGN(bool wrapped, wrapper.Run(module.get()));
+  // The group is already an async pair, so the wrapper (which only rewrites
+  // _collectives_group calls) has nothing to do.
+  EXPECT_FALSE(wrapped);
+  EXPECT_EQ(CountOpcode(*module, HloOpcode::kAsyncStart), 1);
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/service/collective_combiner_utils.cc
+++ b/xla/service/collective_combiner_utils.cc
@@ -77,10 +77,7 @@ FrontendAttributes MergeFrontendAttributes(
   return merged;
 }
 
-namespace {
-
-// Returns the longest common prefix of all strings, trimmed to the last '/'.
-std::string CommonPrefix(absl::Span<const std::string> names) {
+std::string CommonOpNamePrefix(absl::Span<const std::string> names) {
   if (names.empty()) return "";
   absl::string_view prefix = names.front();
   for (int64_t i = 1; i < names.size(); ++i) {
@@ -94,13 +91,15 @@ std::string CommonPrefix(absl::Span<const std::string> names) {
   return "";
 }
 
+namespace {
+
 // Formats op_names as "common_prefix/(suffix1:suffix2:suffix3)".
 // If all names are identical, returns the name as-is.
 std::string MergeOpNames(absl::Span<const std::string> names) {
   if (names.empty()) return "";
   if (names.size() == 1) return names.front();
 
-  std::string prefix = CommonPrefix(names);
+  std::string prefix = CommonOpNamePrefix(names);
   std::vector<std::string> suffixes;
   suffixes.reserve(names.size());
   for (const auto& name : names) {

--- a/xla/service/collective_combiner_utils.h
+++ b/xla/service/collective_combiner_utils.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
@@ -55,6 +56,12 @@ FrontendAttributes MergeFrontendAttributes(
 // as a base, then extends source_line/source_end_line to cover all instructions
 // from the same source file, and joins distinct op_names with commas.
 OpMetadata MergeMetadata(absl::Span<HloInstruction* const> to_combine);
+
+// Returns the longest common prefix shared by all `names`, trimmed back to the
+// last '/' so a path component is never split. Returns "" when the names share
+// no leading component. Used both to elide a shared op_name prefix when merging
+// collectives and when reporting on a set of related collectives.
+std::string CommonOpNamePrefix(absl::Span<const std::string> names);
 
 // Combines instructions with matching keys together.
 //

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1816,6 +1816,7 @@ cc_library(
         "//xla/backends/gpu/transforms:estimate_cub_scan_scratch_size",
         "//xla/backends/gpu/transforms:estimate_cub_sort_scratch_size",
         "//xla/backends/gpu/transforms:explicit_collectives_group_async_wrapper",
+        "//xla/backends/gpu/transforms:group_collectives_by_key",
         "//xla/backends/gpu/transforms:explicit_stream_annotation_async_wrapper",
         "//xla/backends/gpu/transforms:fusion_block_level_rewriter",
         "//xla/backends/gpu/transforms:fusion_wrapper",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -119,6 +119,7 @@ limitations under the License.
 #include "xla/backends/gpu/transforms/gemm_fusion_swap_operands.h"
 #include "xla/backends/gpu/transforms/gemm_rewriter.h"
 #include "xla/backends/gpu/transforms/gpu_copy_async_wrapper.h"
+#include "xla/backends/gpu/transforms/group_collectives_by_key.h"
 #include "xla/backends/gpu/transforms/hoist_fused_bitcasts.h"
 #include "xla/backends/gpu/transforms/layout_assignment.h"
 #include "xla/backends/gpu/transforms/move_copy_to_users.h"
@@ -1528,6 +1529,11 @@ absl::Status RunPostFusionPasses(
                               alias_info, pointer_size, options, gpu_topology,
                               mlir_context);
 
+  // Form async collective groups from collectives sharing a
+  // `collective_group_key` frontend attribute; runs after the combiner so
+  // combined collectives are grouped as a unit.
+  pipeline.AddPass<GroupCollectivesByKey>();
+
   pipeline.AddPass<AllReduceContiguous>();
 
   int32_t blueconnect_num_devices_per_host =
@@ -1571,7 +1577,11 @@ absl::Status RunPostFusionSimplificationPasses(
           .xla_gpu_experimental_stream_annotation()) {
     pipeline.AddPass<ExplicitStreamAnnotationAsyncWrapper>();
   }
+
+  // Rewrite any remaining hand-written `_collectives_group` calls into async
+  // pairs, these are non-inlineable calls in the original HLO module.
   pipeline.AddPass<ExplicitCollectivesGroupAsyncWrapper>();
+
   return pipeline.Run(hlo_module, {HloInstruction::kMainExecutionThread})
       .status();
 }

--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -593,6 +593,59 @@ TEST_F(GpuCompilerTest, CollectivePipeliningModes) {
   }
 }
 
+TEST_F(GpuCompilerTest, GroupCollectivesByKey) {
+  const absl::string_view hlo_string = R"(
+    HloModule group_collectives
+
+    add {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT sum = f32[] add(a, b)
+    }
+
+    ENTRY main {
+      p0 = f32[8,8] parameter(0)
+      p1 = f32[32,8] parameter(1)
+      ag = f32[32,8] all-gather(p0), dimensions={0},
+          replica_groups={{0,1,2,3}},
+          frontend_attributes={collective_group_key="g0"}
+      rs = f32[8,8] reduce-scatter(p1), dimensions={0},
+          replica_groups={{0,1,2,3}}, to_apply=add,
+          frontend_attributes={collective_group_key="g0"}
+      ROOT result = (f32[32,8], f32[8,8]) tuple(ag, rs)
+    }
+  )";
+
+  HloModuleConfig config = GetModuleConfigForTest(/*replica_count=*/4);
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(hlo_string, config));
+
+  // Run only the HLO optimization passes (no executable). This avoids
+  // requiring `replica_count` physical devices, which a real executable build
+  // would demand.
+  Compiler::CompileOptions compile_options;
+  compile_options.gpu_topology =
+      GetSingleDeviceGpuTopology(/*platform_version=*/"", gpu_target_config());
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<HloModule> optimized_module,
+      compiler()->RunHloPasses(std::move(module), /*executor=*/nullptr,
+                               compile_options));
+
+  // The all-gather and reduce-scatter must land in one shared group computation
+  // (proving they were grouped as a unit, not converted to async individually).
+  constexpr absl::string_view kExpected = R"(
+    // CHECK: %[[GROUP:collectives_group[a-zA-Z0-9_.-]*]] ({{.*}}) -> {{.*}} {
+    // CHECK-DAG: all-gather(
+    // CHECK-DAG: reduce-scatter(
+    // CHECK: async-start(
+    // CHECK-SAME: calls=%[[GROUP]]
+    // CHECK-SAME: _collectives_group
+  )";
+
+  EXPECT_THAT(RunFileCheck(optimized_module->ToString(), kExpected),
+              absl_testing::IsOkAndHolds(true));
+}
+
 TEST_F(GpuCompilerTest, RemovesUnnecessaryCopyAfterScheduling) {
   const absl::string_view hlo_string = R"(
 HloModule all_gather_overlapping


### PR DESCRIPTION
Add `GroupCollectivesByKey`, a GPU HLO pass that forms a single async launch group from independent collectives sharing the same nonempty `collective_group_key` frontend attribute.

  - Supports all-gather, reduce-scatter, and all-reduce operations.
  - Runs after collective combiners so combined collectives are grouped as a unit.
  - Reports a dependency path when same-key collectives are not independent.
  - Preserves frontend attributes, per-output sharding, and external control dependencies.
  - Produces groups consumed by the existing GPU grouped-collective lowering.

## Motivation

Frontends can use `collective_group_key` to associate semantically related collectives, such as the all-gather and reduce-scatter from one FSDP layer. Representing them as one scheduling and launch unit enables grouped collective execution and backend optimizations such as collective kernel fusion.