### PR TITLE
Fix C128 constants in partitioned FFT

### DIFF
--- a/xla/service/spmd/fft_handler.cc
+++ b/xla/service/spmd/fft_handler.cc
@@ -173,18 +173,21 @@ HloInstruction* GetCorrectionFactor(HloInstruction* hlo, int64_t num_partitions,
                                     SpmdBuilder* b) {
   /* n = size_per_replica
      m = num_partitions
-  factor = tf.exp(-2.0j * np.pi * tf.cast(position_index, tf.complex64) *
-                    * tf.cast(tf.range(n), dtype=tf.complex64) /
+  factor = tf.exp(-2.0j * np.pi * tf.cast(position_index, dtype) *
+                    * tf.cast(tf.range(n), dtype=dtype) /
                     (n * m))
+  where dtype matches the FFT element type.
 
   */
   auto add_hlo = [&](std::unique_ptr<HloInstruction> to_add) {
     return b->AddInstruction(std::move(to_add));
   };
   int64_t per_replica_size = hlo->shape().dimensions().back();
-  auto constant_factor =
-      add_hlo(HloInstruction::CreateConstant(LiteralUtil::CreateR0(
-          complex64(0, -2.0 * M_PI / (num_partitions * per_replica_size)))));
+  auto constant_factor = CreateR0WithType(
+      hlo->shape().element_type(),
+      complex128(0, -2.0 * M_PI /
+                        (num_partitions * per_replica_size)),
+      b);
   constant_factor = add_hlo(HloInstruction::CreateBroadcast(
       hlo->shape(), constant_factor, /*broadcast_dimensions=*/{}));
   auto converted_partition_id = add_hlo(HloInstruction::CreateConvert(
@@ -256,12 +259,14 @@ HloInstruction* GetFinalFftUsingCollectivePermute(
       HloInstruction::CreateGetTupleElement(iteration->shape(), param, 4));
   /*
     factor = tf.exp(-2.0j * np.pi  *
-                      tf.cast(dest_partiton_id, tf.complex64) *
-                      tf.cast(source_partition_id, tf.complex64) /
+                      tf.cast(dest_partition_id, dtype) *
+                      tf.cast(source_partition_id, dtype) /
     num_partitions) dest_transform += factor * source_transform
+    where dtype matches the FFT element type.
   */
-  auto constant_factor = body_b.AddInstruction(HloInstruction::CreateConstant(
-      LiteralUtil::CreateR0(complex64(0, -2.0 * M_PI / num_partitions))));
+  auto constant_factor = CreateR0WithType(
+      hlo->shape().element_type(),
+      complex128(0, -2.0 * M_PI / num_partitions), &body_b);
 
   constant_factor = body_b.AddInstruction(HloInstruction::CreateBinary(
       constant_factor->shape(), HloOpcode::kMultiply, constant_factor,

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -12867,6 +12867,25 @@ ENTRY entry {
                           op::Shape("c64[1,1,3]")));
 }
 
+TEST_P(SpmdPartitioningTest, Fft3DC128) {
+  absl::string_view hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  input = c128[1,1,6] parameter(0),
+    sharding={devices=[1,1,2]<=[2]}
+  ROOT fft = c128[1,1,6] fft(input), fft_type=FFT, fft_length={6},
+    sharding={devices=[1,1,2]<=[2]}
+}
+)";
+
+  ASSERT_OK_AND_ASSIGN(auto module,
+                       PartitionComputation(hlo_string, /*num_devices=*/2));
+  EXPECT_THAT(
+      module->entry_computation()->root_instruction(),
+      AllOf(op::GetTupleElement(op::While()), op::Shape("c128[1,1,3]")));
+}
+
 TEST_P(SpmdPartitioningTest, Fft3DSmallShardFallsBack) {
   // The last FFT dimension is sharded down to a per-shard size of 1, so halo
   // exchange (which establishes the divisibility that the per-partition shuffle


### PR DESCRIPTION
📝 Summary of Changes

Fixes #44541. Make the phase constants generated by the SPMD FFT partitioner follow the FFT element type instead of always using C64.

Updates both `GetCorrectionFactor` and `GetFinalFftUsingCollectivePermute`, and adds a C128 regression test. 


🎯 Justification
With x64 enabled, a multi-device JAX FFT uses C128 values. The SPMD FFT partitioner previously created C64 phase constants, producing invalid mixed-type operations such as `c64 * c128` and causing the post-SPMD HLO verifier to fail.

This change allows partitioned C128 FFT workloads to compile while preserving the existing C64 behavior.

🚀 Kind of Contribution
🐛 Bug Fix,
🧪 Tests

🧪 Unit Tests:
Added `SpmdPartitioningTest.Fft3DC128`, and ran with:

```shell
npx -y @bazel/bazelisk test \
  --config=macos_arm64 \
  //xla/service/spmd:spmd_partitioner_test \
  --test_sharding_strategy=disabled \
  --test_filter='*Fft3D*' \
  --test_output=errors
