### PR TITLE
[XLA:GPU][oneAPI][Bugfix] Fix FileCheck patterns for Intel GPU index tests

### DIFF
--- a/xla/backends/gpu/tests/gpu_index_test.cc
+++ b/xla/backends/gpu/tests/gpu_index_test.cc
@@ -100,12 +100,17 @@ TEST_F(GpuIndexTest, CompatibleUseLinearIndexWithReshapeAndBroadcast) {
   // the addrspace(1) attribute for the lines being checked by the following
   // patterns.
   // need to investigate why that is the case, and whether or not it is ok
+  // The GEP that consumes idx1 is emitted differently per backend:
+  //   - CUDA (NVPTX):    getelementptr ... ptr addrspace(1) ...
+  //   - ROCm (AMDGPU):   getelementptr ... ptr ...   (no addrspace(1))
+  //   - oneAPI (SPIR-V): the GEP lowers to a @llvm.spv.gep intrinsic call.
+  // MakePlatformSpecificLlvm substitutes LINEAR_GEP_IDX1 with the right form.
   EXPECT_OK(CompileAndVerifyIr(std::move(module),
-                               R"(
+                               MakePlatformSpecificLlvm(R"(
 ; CHECK: %[[urem1:.*]] = urem i{{[0-9]*}} %[[linear_index:.*]], 14
 ; CHECK: %[[idx1:.*]] = zext nneg i{{[0-9]*}} %[[urem1]] to i64
-; CHECK: getelementptr inbounds{{( nuw)?}} [4 x i8], ptr{{( addrspace\(1\))?}} %[[alloc:.*]], i64 %[[idx1]]
-      )",
+; CHECK: LINEAR_GEP_IDX1
+      )"),
                                /*match_optimized_ir=*/true));
 }
 

--- a/xla/backends/gpu/tests/gpu_pjrt_codegen_test.cc
+++ b/xla/backends/gpu/tests/gpu_pjrt_codegen_test.cc
@@ -99,7 +99,13 @@ std::string GpuPjRtCodegenTest::MakePlatformSpecificLlvm(
             ? "%[[LOGICAL_T2:.*]] = extractvalue { i1, i64 } %[[LOGICAL_T1]], 0"
             : "0"},
        {"BR_CAL", IsBuiltWithRocm() ? "br i1 %[[LOGICAL_T2]],"
-                                    : "br i1 %[[LOGICAL_T0]]"}});
+                                    : "br i1 %[[LOGICAL_T0]]"},
+       {"LINEAR_GEP_IDX1",
+        IsBuiltWithOneAPI()
+            ? "@llvm.spv.gep.{{[a-z0-9.]+}}({{.*}}ptr"
+              "{{( addrspace\\([0-9]+\\))?}} {{.*}}i64 %[[idx1]]"
+            : "getelementptr {{.*}} ptr{{( addrspace\\([0-9]+\\))?}} "
+              "{{.*}}i64 %[[idx1]]"}});
 }
 
 absl::StatusOr<std::unique_ptr<Executable>>


### PR DESCRIPTION

This PR updates index tests to handle SPIR-V codegen differences for `getelementptr`. This fixes  Filecheck errors seen in all tests of gpu_index_test for the oneAPI backend.