### PR TITLE
[XLA:GPU][SPIR-V] Limit RNG state variable to 64 bit integers for SPIR-V backend

### DIFF
--- a/xla/service/llvm_ir/llvm_util.cc
+++ b/xla/service/llvm_ir/llvm_util.cc
@@ -800,7 +800,14 @@ llvm::GlobalVariable* GetOrCreateVariableForRngState(llvm::Module* module,
   llvm::GlobalVariable* state_ptr =
       module->getNamedGlobal(kRngStateVariableName);
   if (!state_ptr) {
-    llvm::Type* state_type = b->getInt128Ty();
+    // Limit the state type to 64-bit for SPIR-V, because SPIR-V supports wider
+    // integer types only through the FPGA-specific arbitrary precision integer
+    // extension, which GPU drivers do not support.
+    // TODO(intel-tf): Remove this restriction once the LLVM SPIR-V backend adds
+    // support for arbitrary precision integers on GPU targets.
+    auto bitwidth =
+        llvm::Triple(module->getTargetTriple()).isSPIROrSPIRV() ? 64 : 128;
+    llvm::Type* state_type = b->getIntNTy(bitwidth);
     // Use a non-zero initial value as zero state can cause the result of the
     // first random number generation not passing the chi-square test. The
     // values used here are arbitrarily chosen, any non-zero values should be
@@ -810,7 +817,7 @@ llvm::GlobalVariable* GetOrCreateVariableForRngState(llvm::Module* module,
         /*Ty=*/state_type,
         /*isConstant=*/false,
         /*Linkage=*/llvm::GlobalValue::PrivateLinkage,
-        /*Initializer=*/llvm::ConstantInt::get(b->getInt128Ty(), 0x7012395ull),
+        /*Initializer=*/llvm::ConstantInt::get(state_type, 0x7012395ull),
         /*Name=*/kRngStateVariableName,
         /*InsertBefore=*/nullptr,
         /*TLMode=*/llvm::GlobalValue::NotThreadLocal,


### PR DESCRIPTION
Currently, the LLVM SPIR-V backend only supports integers wider than 64 bits via the FPGA-specific arbitrary precision integer extension, which is not available in GPU drivers. This PR adds a change to use 64 bit state type when the target triple is SPIR-V. It fixes the below error seen in many tests that use RNG with the oneAPI backend.

`LLVM ERROR: OpTypeInt type with a width other than 8, 16, 32 or 64 bits requires the following SPIR-V extension: SPV_ALTERA_arbitrary_precision_integers`