### PR TITLE
[ROCm] Fix collection of data files, use versioned files too

### DIFF
--- a/third_party/py/python_wheel.bzl
+++ b/third_party/py/python_wheel.bzl
@@ -177,8 +177,9 @@ def _collect_data_aspect_impl(_, ctx):
             for f in data.files.to_list():
                 if not f.owner.package:
                     continue
+                # Check if filename contains any of the extensions (for versioned .so files)
                 for ext in extensions:
-                    if f.extension == ext:
+                    if "." + ext in f.basename:
                         files[f] = True
                         break
 


### PR DESCRIPTION
📝 Summary of Changes
Include transitive data files in collect_data_files aspect, consider versioned so files

🎯 Justification
We need hermetic builds for rocm jax hence jax wheels shall depend on data files (rocm distro files)
and therefore we need to collect them from the rocm targets, versioned so files were missing after the initial
implementation, this change adds them too

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
