### PR TITLE
[GPU] Fix three cuDNN SDPA integration defects

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -3886,6 +3886,7 @@ cc_library(
     hdrs = ["cudnn_thunk.h"],
     deps = [
         ":command",
+        ":command_state",
         ":thunk",
         ":thunk_proto_cc",
         ":traced_command",
@@ -3901,6 +3902,7 @@ cc_library(
         "//xla/tsl/platform:status_macros",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",

--- a/xla/backends/gpu/runtime/cudnn_thunk.cc
+++ b/xla/backends/gpu/runtime/cudnn_thunk.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/base/call_once.h"
+#include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
@@ -31,6 +32,7 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/gpu/runtime/command.h"
+#include "xla/backends/gpu/runtime/command_state.h"
 #include "xla/backends/gpu/runtime/thunk.h"
 #include "xla/backends/gpu/runtime/thunk.pb.h"
 #include "xla/backends/gpu/runtime/traced_command.h"
@@ -47,6 +49,18 @@ limitations under the License.
 
 namespace xla {
 namespace gpu {
+namespace {
+
+// Zero fill commands recorded ahead of the DNN graph command. Keyed by the DNN
+// graph command they precede, because the same thunk can be recorded into one
+// command buffer several times (e.g. for an unrolled loop).
+struct MemzeroCommands : public CommandState {
+  absl::flat_hash_map<const se::CommandBuffer::Command*,
+                      std::vector<const se::CommandBuffer::Command*>>
+      commands;
+};
+
+}  // namespace
 
 CuDnnThunk::CuDnnThunk(std::string fingerprint, ThunkInfo thunk_info,
                        std::vector<ShapedSlice> args,
@@ -135,12 +149,56 @@ absl::StatusOr<const se::CommandBuffer::Command*> CuDnnThunk::Record(
   ASSIGN_OR_RETURN(const bool supports_explicit,
                    graph_->get()->SupportsExplicitCommandBufferConstruction());
   if (supports_explicit) {
+    // The DNN graph command only covers the graph launch, so the output zero
+    // fill that ExecuteOnStream applies has to be recorded separately.
+    MemzeroCommands* memzero =
+        should_memzero_ ? record_params.state.GetOrCreate<MemzeroCommands>(
+                              this, command_buffer)
+                        : nullptr;
     if (auto* create = std::get_if<RecordCreate>(&record_action)) {
-      return command_buffer->CreateDnnGraphCommand(
-          *graph_->get(), *execute_params.stream,
-          absl::Span<se::DeviceAddressBase>(operands), create->dependencies);
+      std::vector<const se::CommandBuffer::Command*> memsets;
+      std::vector<const se::CommandBuffer::Command*> dependencies(
+          create->dependencies.begin(), create->dependencies.end());
+      if (memzero != nullptr) {
+        for (int i = 0; i < operands.size(); ++i) {
+          if (!output_args_[i] || operands[i].size() == 0) {
+            continue;
+          }
+          ASSIGN_OR_RETURN(
+              const se::CommandBuffer::Command* zero_fill,
+              command_buffer->CreateMemset(&operands[i], uint8_t{0},
+                                           /*num_elements=*/operands[i].size(),
+                                           create->dependencies));
+          memsets.push_back(zero_fill);
+          dependencies.push_back(zero_fill);
+        }
+      }
+      ASSIGN_OR_RETURN(
+          const se::CommandBuffer::Command* command,
+          command_buffer->CreateDnnGraphCommand(
+              *graph_->get(), *execute_params.stream,
+              absl::Span<se::DeviceAddressBase>(operands), dependencies));
+      if (memzero != nullptr) {
+        memzero->commands[command] = std::move(memsets);
+      }
+      return command;
     }
     if (auto* update = std::get_if<RecordUpdate>(&record_action)) {
+      if (memzero != nullptr) {
+        auto it = memzero->commands.find(update->command);
+        if (it == memzero->commands.end()) {
+          return Internal("Missing cuDNN output zero fill commands");
+        }
+        int memset_index = 0;
+        for (int i = 0; i < operands.size(); ++i) {
+          if (!output_args_[i] || operands[i].size() == 0) {
+            continue;
+          }
+          RETURN_IF_ERROR(command_buffer->UpdateMemset(
+              it->second[memset_index++], &operands[i], uint8_t{0},
+              /*num_elements=*/operands[i].size()));
+        }
+      }
       RETURN_IF_ERROR(command_buffer->UpdateDnnGraphCommand(
           update->command, *graph_->get(), *execute_params.stream,
           absl::Span<se::DeviceAddressBase>(operands)));
@@ -151,6 +209,14 @@ absl::StatusOr<const se::CommandBuffer::Command*> CuDnnThunk::Record(
   return RecordTracedCommand(
       execute_params, record_params, std::move(record_action), command_buffer,
       [&](se::Stream* stream) {
+        if (should_memzero_) {
+          for (int i = 0; i < operands.size(); ++i) {
+            if (output_args_[i]) {
+              RETURN_IF_ERROR(
+                  stream->MemZero(&operands[i], operands[i].size()));
+            }
+          }
+        }
         return graph_->get()->Execute(
             *stream, absl::Span<se::DeviceAddressBase>(operands),
             execute_params.collective_params->local_device_id.value());

--- a/xla/backends/gpu/runtime/cudnn_thunk_test.cc
+++ b/xla/backends/gpu/runtime/cudnn_thunk_test.cc
@@ -149,10 +149,13 @@ bool SupportsCudaGraphTracing(const se::StreamExecutor* executor) {
 // through to RecordTracedCommand, which traces Execute() onto the trace stream.
 // Execute() memsets a 32-bit sentinel across the last operand (the output
 // buffer), giving the test a verifiable observable side effect without needing
-// a real cuDNN arithmetic kernel.
+// a real cuDNN arithmetic kernel. With `write_output` false it leaves the
+// output untouched, which models a cuDNN graph that only writes the elements
+// covered by the sequence lengths.
 class FakeDnnGraph : public se::dnn::DnnGraph {
  public:
-  explicit FakeDnnGraph(uint32_t sentinel) : sentinel_(sentinel) {}
+  explicit FakeDnnGraph(uint32_t sentinel, bool write_output = true)
+      : sentinel_(sentinel), write_output_(write_output) {}
 
   absl::Status Prepare(se::dnn::DnnSupport*, const se::DeviceDescription&,
                        const se::EngineOptions&) override {
@@ -167,6 +170,9 @@ class FakeDnnGraph : public se::dnn::DnnGraph {
                        int64_t local_device_ordinal) const override {
     if (operands.empty()) {
       return absl::InternalError("FakeDnnGraph::Execute received no operands");
+    }
+    if (!write_output_) {
+      return absl::OkStatus();
     }
     se::DeviceAddressBase& output = operands.back();
     return stream.Memset32(&output, sentinel_, output.size());
@@ -186,6 +192,7 @@ class FakeDnnGraph : public se::dnn::DnnGraph {
 
  private:
   uint32_t sentinel_;
+  bool write_output_;
 };
 
 // Fixture shared by all Record() tests.
@@ -195,10 +202,15 @@ class FakeDnnGraph : public se::dnn::DnnGraph {
 // INT32. Input is zero-filled, so the explicit-path real-matmul output is also
 // zero. The implicit-path FakeDnnGraph ignores the math and memsets the output
 // to a 32-bit sentinel instead.
+//
+// The output buffer carries kPadElements past the matmul result that the real
+// graph never writes, standing in for the padded tokens of an fMHA output.
 class CuDnnThunkCmdBufTest : public ::testing::Test {
  protected:
   static constexpr int kDimSize = 32;
   static constexpr int kTotalElements = kDimSize * kDimSize;
+  static constexpr int kPadElements = 64;
+  static constexpr int kOutputElements = kTotalElements + kPadElements;
   static constexpr uint32_t kInitialOutput = 0xdeadbeefu;
   static constexpr uint32_t kFakeSentinel = 0x12345678u;
 
@@ -215,7 +227,7 @@ class CuDnnThunkCmdBufTest : public ::testing::Test {
     TF_ASSERT_OK_AND_ASSIGN(trace_stream_, executor_->CreateStream());
 
     input_buf_ = executor_->AllocateArray<int8_t>(kTotalElements);
-    output_buf_ = executor_->AllocateArray<int32_t>(kTotalElements);
+    output_buf_ = executor_->AllocateArray<int32_t>(kOutputElements);
     TF_ASSERT_OK(stream_->MemZero(&input_buf_, input_buf_.size()));
     TF_ASSERT_OK(
         stream_->Memset32(&output_buf_, kInitialOutput, output_buf_.size()));
@@ -223,13 +235,13 @@ class CuDnnThunkCmdBufTest : public ::testing::Test {
 
     // ShapedSlice args: {input, input, output} — matmul(A, A) → D.
     Shape int8_shape = ShapeUtil::MakeShape(S8, {kTotalElements});
-    Shape int32_shape = ShapeUtil::MakeShape(S32, {kTotalElements});
+    Shape int32_shape = ShapeUtil::MakeShape(S32, {kOutputElements});
     args_.push_back({BufferAllocation::Slice(&alloc_input_, 0, kTotalElements),
                      int8_shape});
     args_.push_back({BufferAllocation::Slice(&alloc_input_, 0, kTotalElements),
                      int8_shape});
     args_.push_back({BufferAllocation::Slice(&alloc_output_, 0,
-                                             kTotalElements * sizeof(int32_t)),
+                                             kOutputElements * sizeof(int32_t)),
                      int32_shape});
 
     run_options_.mutable_run_options()->set_stream(stream_.get());
@@ -253,7 +265,7 @@ class CuDnnThunkCmdBufTest : public ::testing::Test {
 
   // Builds a real cuDNN matmul graph and wraps it in a CuDnnThunk. Skips the
   // enclosing test if cuDNN is too old or the GPU is below Ampere.
-  void BuildRealGraphThunk() {
+  void BuildRealGraphThunk(bool should_memzero = false) {
     se::dnn::DnnSupport& dnn_support = *executor_->AsDnn();
     if (dnn_support.GetVersion().value_or(se::dnn::VersionInfo{0, 0, 0}) <
         se::dnn::VersionInfo(9, 7, 0)) {
@@ -300,7 +312,8 @@ class CuDnnThunkCmdBufTest : public ::testing::Test {
     std::vector<bool> output_args(args_.size(), false);
     output_args.back() = true;
     thunk_ = std::make_unique<CuDnnThunk>(
-        /*fingerprint=*/"", Thunk::ThunkInfo(), args_, std::move(output_args));
+        /*fingerprint=*/"", Thunk::ThunkInfo(), args_, std::move(output_args),
+        should_memzero);
     se::dnn::LazyDnnGraph prebuilt(
         std::make_unique<se::gpu::CudnnGraph>(std::move(graph)));
     thunk_->graph()->swap(prebuilt);
@@ -309,13 +322,15 @@ class CuDnnThunkCmdBufTest : public ::testing::Test {
   }
 
   // Builds a CuDnnThunk backed by the FakeDnnGraph (forces the traced path).
-  void BuildFakeGraphThunk() {
+  void BuildFakeGraphThunk(bool should_memzero = false,
+                           bool write_output = true) {
     std::vector<bool> output_args(args_.size(), false);
     output_args.back() = true;
     thunk_ = std::make_unique<CuDnnThunk>(
-        /*fingerprint=*/"", Thunk::ThunkInfo(), args_, std::move(output_args));
+        /*fingerprint=*/"", Thunk::ThunkInfo(), args_, std::move(output_args),
+        should_memzero);
     se::dnn::LazyDnnGraph prebuilt(
-        std::make_unique<FakeDnnGraph>(kFakeSentinel));
+        std::make_unique<FakeDnnGraph>(kFakeSentinel, write_output));
     thunk_->graph()->swap(prebuilt);
 
     InitializeThunk();
@@ -335,6 +350,15 @@ class CuDnnThunkCmdBufTest : public ::testing::Test {
     return dst;
   }
 
+  // Reads back the tail that the real cuDNN graph never writes.
+  std::vector<int32_t> ReadOutputTail(const se::DeviceAddress<int32_t>& buf) {
+    std::vector<int32_t> dst(kOutputElements, 0);
+    TF_CHECK_OK(
+        stream_->Memcpy(dst.data(), buf, kOutputElements * sizeof(int32_t)));
+    TF_CHECK_OK(stream_->BlockHostUntilDone());
+    return std::vector<int32_t>(dst.begin() + kTotalElements, dst.end());
+  }
+
   se::StreamExecutor* executor_ = nullptr;
   std::unique_ptr<se::Stream> stream_;
   std::unique_ptr<se::Stream> trace_stream_;
@@ -345,7 +369,7 @@ class CuDnnThunkCmdBufTest : public ::testing::Test {
   // pointers into them. See the analogous comment in
   // CublasLtMatmulThunkCmdBufTest.
   BufferAllocation alloc_input_{/*index=*/0, kTotalElements, /*color=*/0};
-  BufferAllocation alloc_output_{/*index=*/1, kTotalElements * sizeof(int32_t),
+  BufferAllocation alloc_output_{/*index=*/1, kOutputElements * sizeof(int32_t),
                                  /*color=*/0};
 
   std::vector<ShapedSlice> args_;
@@ -414,7 +438,7 @@ TEST_F(CuDnnThunkCmdBufTest, RecordUpdateExplicit) {
   // UpdateDnnGraphCommand with changed arguments. Pre-fill the new buffer with
   // a non-zero sentinel so the post-submit zero fill is observable.
   se::DeviceAddress<int32_t> output1 =
-      executor_->AllocateArray<int32_t>(kTotalElements);
+      executor_->AllocateArray<int32_t>(kOutputElements);
   TF_ASSERT_OK(stream_->Memset32(&output1, kInitialOutput, output1.size()));
   BufferAllocations updated_allocations(
       std::vector<se::DeviceAddressBase>{input_buf_, output1}, 0,
@@ -495,7 +519,7 @@ TEST_F(CuDnnThunkCmdBufTest, RecordUpdateImplicit) {
   // pointer-identical to the original across backends — only assert non-null
   // and that the side effect re-occurs on the new buffer.
   se::DeviceAddress<int32_t> output1 =
-      executor_->AllocateArray<int32_t>(kTotalElements);
+      executor_->AllocateArray<int32_t>(kOutputElements);
   TF_ASSERT_OK(stream_->Memset32(&output1, kInitialOutput, output1.size()));
   BufferAllocations updated_allocations(
       std::vector<se::DeviceAddressBase>{input_buf_, output1}, 0,
@@ -516,6 +540,112 @@ TEST_F(CuDnnThunkCmdBufTest, RecordUpdateImplicit) {
   EXPECT_EQ(ReadOutput(output1),
             std::vector<int32_t>(kTotalElements,
                                  static_cast<int32_t>(kFakeSentinel)));
+}
+
+//===----------------------------------------------------------------------===//
+// should_memzero on the Record() path.
+//
+// fMHA thunks are emitted with should_memzero, because cuDNN only writes the
+// tokens covered by seq_len_q / the ragged offsets and everything else must
+// read back as zero. ExecuteOnStream honours the flag; Record() has to do the
+// same or the padded region keeps whatever the donated buffer held.
+//===----------------------------------------------------------------------===//
+
+TEST_F(CuDnnThunkCmdBufTest, RecordCreateZeroFillsOutputExplicit) {
+  BuildRealGraphThunk(/*should_memzero=*/true);
+  if (HasFatalFailure() || IsSkipped()) {
+    return;
+  }
+
+  CommandStateManager state;
+  Command::RecordParams record_params = {state};
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto command_buffer,
+      executor_->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
+  TF_ASSERT_OK_AND_ASSIGN(
+      const se::CommandBuffer::Command* cmd,
+      thunk_->Record(*params_, record_params,
+                     Command::RecordCreate{/*dependencies=*/{}},
+                     command_buffer.get()));
+  ASSERT_NE(cmd, nullptr);
+  TF_ASSERT_OK(command_buffer->Finalize());
+  TF_ASSERT_OK(command_buffer->Submit(stream_.get()));
+
+  EXPECT_EQ(ReadOutput(output_buf_), std::vector<int32_t>(kTotalElements, 0));
+  EXPECT_EQ(ReadOutputTail(output_buf_), std::vector<int32_t>(kPadElements, 0));
+}
+
+TEST_F(CuDnnThunkCmdBufTest, RecordUpdateZeroFillsOutputExplicit) {
+  BuildRealGraphThunk(/*should_memzero=*/true);
+  if (HasFatalFailure() || IsSkipped()) {
+    return;
+  }
+
+  CommandStateManager state;
+  Command::RecordParams record_params = {state};
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto command_buffer,
+      executor_->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
+  TF_ASSERT_OK_AND_ASSIGN(
+      const se::CommandBuffer::Command* cmd,
+      thunk_->Record(*params_, record_params,
+                     Command::RecordCreate{/*dependencies=*/{}},
+                     command_buffer.get()));
+  ASSERT_NE(cmd, nullptr);
+  TF_ASSERT_OK(command_buffer->Finalize());
+  TF_ASSERT_OK(command_buffer->Submit(stream_.get()));
+
+  // The zero fill commands must be rebound to the new output buffer alongside
+  // the DNN graph command.
+  se::DeviceAddress<int32_t> output1 =
+      executor_->AllocateArray<int32_t>(kOutputElements);
+  TF_ASSERT_OK(stream_->Memset32(&output1, kInitialOutput, output1.size()));
+  BufferAllocations updated_allocations(
+      std::vector<se::DeviceAddressBase>{input_buf_, output1}, 0,
+      allocator_.get());
+  Thunk::ExecuteParams updated_params = Thunk::ExecuteParams::Create(
+      run_options_, updated_allocations, stream_.get(), trace_stream_.get(),
+      &*collective_params_, /*collective_cliques=*/nullptr,
+      /*collective_memory=*/nullptr);
+
+  TF_ASSERT_OK(command_buffer->Update());
+  TF_ASSERT_OK_AND_ASSIGN(
+      const se::CommandBuffer::Command* updated_cmd,
+      thunk_->Record(updated_params, record_params, Command::RecordUpdate{cmd},
+                     command_buffer.get()));
+  EXPECT_EQ(updated_cmd, cmd);
+  TF_ASSERT_OK(command_buffer->Finalize());
+  TF_ASSERT_OK(command_buffer->Submit(stream_.get()));
+
+  EXPECT_EQ(ReadOutput(output1), std::vector<int32_t>(kTotalElements, 0));
+  EXPECT_EQ(ReadOutputTail(output1), std::vector<int32_t>(kPadElements, 0));
+}
+
+TEST_F(CuDnnThunkCmdBufTest, RecordCreateZeroFillsOutputImplicit) {
+  BuildFakeGraphThunk(/*should_memzero=*/true, /*write_output=*/false);
+  if (HasFatalFailure() || IsSkipped()) {
+    return;
+  }
+
+  CommandStateManager state;
+  Command::RecordParams record_params = {state};
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto command_buffer,
+      executor_->CreateCommandBuffer(se::CommandBuffer::Mode::kPrimary));
+  TF_ASSERT_OK_AND_ASSIGN(
+      const se::CommandBuffer::Command* cmd,
+      thunk_->Record(*params_, record_params,
+                     Command::RecordCreate{/*dependencies=*/{}},
+                     command_buffer.get()));
+  ASSERT_NE(cmd, nullptr);
+  TF_ASSERT_OK(command_buffer->Finalize());
+  TF_ASSERT_OK(command_buffer->Submit(stream_.get()));
+
+  EXPECT_EQ(ReadOutput(output_buf_), std::vector<int32_t>(kTotalElements, 0));
+  EXPECT_EQ(ReadOutputTail(output_buf_), std::vector<int32_t>(kPadElements, 0));
 }
 
 }  // namespace

--- a/xla/backends/gpu/transforms/cudnn_custom_call_compiler.cc
+++ b/xla/backends/gpu/transforms/cudnn_custom_call_compiler.cc
@@ -307,10 +307,9 @@ absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBackwardFMHA(
   // The last one is the workspace.
   TF_RET_CHECK(output_index == custom_call->shape().tuple_shapes().size() - 1);
 
-  const bool force_deterministic =
-      RequireDeterminism(custom_call->GetModule()->config());
-  config.set_force_deterministic(force_deterministic);
-  RETURN_IF_ERROR(custom_call->set_backend_config(gpu_config));
+  // Written into the backend config by SetBackwardFMHADeterminism() before the
+  // instruction is fingerprinted.
+  const bool force_deterministic = config.force_deterministic();
 
   ASSIGN_OR_RETURN(
       MatmulTensorDescriptor q,
@@ -359,6 +358,8 @@ absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBackwardFMHA(
   const HloComputation* score_mod_fwd_comp = nullptr;
   const HloComputation* score_mod_bwd_comp = nullptr;
   stream_executor::gpu::ScoreModFunc* score_mod = nullptr;
+  // Must outlive the graph build below, so it cannot live in the if-block.
+  std::optional<stream_executor::gpu::ScoreModFunc> smf;
   TF_RET_CHECK(computations.size() <= 1);
   if (computations.size() == 1) {
     score_mod_bwd_comp = computations[0];
@@ -369,9 +370,8 @@ absl::StatusOr<se::gpu::CudnnGraph> BuildGraphForCustomCallToBackwardFMHA(
       return absl::InternalError("Can't find fmha fwd custom call.");
     }
     score_mod_fwd_comp = fwd_custom_call->called_computations()[0];
-    auto smf = stream_executor::gpu::ScoreModFunc(score_mod_fwd_comp,
-                                                  score_mod_bwd_comp);
-    score_mod = &smf;
+    smf.emplace(score_mod_fwd_comp, score_mod_bwd_comp);
+    score_mod = &*smf;
     input_index += score_mod_fwd_comp->num_parameters() - 1;
   }
   TF_RET_CHECK(input_index == custom_call->operand_count());
@@ -523,6 +523,16 @@ absl::StatusOr<se::gpu::CudnnGraph> HloCustomCallToCuDnnGraph(
                                                  custom_call);
 }
 
+// Records the module-level determinism requirement in the backend config. It
+// changes the graph that gets built, so it has to be part of the instruction
+// fingerprint that keys both the workspace cache and the compilation results.
+absl::Status SetBackwardFMHADeterminism(HloInstruction* hlo) {
+  ASSIGN_OR_RETURN(auto gpu_config, hlo->backend_config<GpuBackendConfig>());
+  gpu_config.mutable_cudnn_fmha_backend_config()->set_force_deterministic(
+      RequireDeterminism(hlo->GetModule()->config()));
+  return hlo->set_backend_config(gpu_config);
+}
+
 class CuDnnCustomCallVisitor : public DfsHloRewriteVisitor {
  public:
   explicit CuDnnCustomCallVisitor(se::dnn::DnnSupport* dnn_support,
@@ -546,6 +556,10 @@ class CuDnnCustomCallVisitor : public DfsHloRewriteVisitor {
     if (!IsCustomCallTofMHA(*hlo) && !IsCustomCallTofMHAF8(*hlo) &&
         !IsCustomCallToBlockScaledDot(*hlo)) {
       return absl::OkStatus();
+    }
+
+    if (IsBwdCustomCallTofMHA(*hlo)) {
+      RETURN_IF_ERROR(SetBackwardFMHADeterminism(hlo));
     }
 
     ASSIGN_OR_RETURN(const std::string fingerprint_without_workspace,


### PR DESCRIPTION
# [GPU] Fix three cuDNN SDPA integration defects (use-after-free, missing output zero-fill under command buffers, determinism flag outside the cache key)

## Summary

Three defects in XLA's cuDNN fused-attention path, found while auditing cuDNN SDPA
consumers. The first is a use-after-free in the backward fMHA graph builder that
feeds a dangling `ScoreModFunc*` into the cuDNN frontend. The second means that
whenever an fMHA op is captured into a command buffer / CUDA graph, the output
zero-fill that XLA performs on the eager path is silently dropped, so the padded
tokens of `O` (and of `dQ`/`dK`/`dV`) return whatever the donated buffer happened
to contain. The third makes `force_deterministic` land in the backend config
*after* the instruction has been fingerprinted, so the compiled-graph lookup key
and the emitter's key can disagree under `--xla_gpu_deterministic_ops`.

### 1. Dangling `ScoreModFunc*` passed to the cuDNN frontend

`xla/backends/gpu/transforms/cudnn_custom_call_compiler.cc:361-377`
(`BuildGraphForCustomCallToBackwardFMHA`) built the score-mod functor inside an
`if` block and stored its address in a variable declared outside it:

```c++
    auto smf = stream_executor::gpu::ScoreModFunc(score_mod_fwd_comp,
                                                  score_mod_bwd_comp);
    score_mod = &smf;
```

`smf` is destroyed at the end of the `if` block, but `score_mod` is dereferenced
several statements later by
`se::gpu::GetCudnnFlashAttentionBackwardOperationGraph(..., score_mod)`, which
walks the two HLO computations to emit the score-modifier subgraph into the cuDNN
frontend graph. Every backward fMHA custom call that carries a score modifier
(any `jax.nn.dot_product_attention` / Flax attention lowered with a score-mod
computation) reads freed stack memory during compilation.

Fix: hoist the functor into a function-scope `std::optional` so it outlives the
graph build.

### 2. fMHA output zero-fill dropped on the command-buffer path

`xla/backends/gpu/runtime/cudnn_thunk.cc` — `CuDnnThunk::ExecuteOnStream` honours
`should_memzero_` and calls `stream->MemZero()` on every output buffer
(:106-108), but `CuDnnThunk::Record`, the command-buffer / CUDA-graph path, only
recorded the DNN graph launch. `should_memzero_` is set for exactly the fMHA
custom calls (`xla/service/gpu/thunk_emitter.cc:1240`,
`/*should_memzero=*/IsCustomCallTofMHA(*instr)`), so the flag exists precisely
because cuDNN does not write the whole buffer.

Why cuDNN behaves that way: the SDPA node applies a padding mask and honours the
`SEQ_LEN_Q` / `CU_SEQ_LEN_Q` / ragged-offset tensors
(`cudnn_frontend/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h`,
the `padding_mask` / ragged-offset handling around :61-129 and :757-856). Tokens
outside `seq_len_q`, and any region past the ragged offsets, are simply never
stored — cuDNN's contract is that the consumer owns those bytes. XLA reuses
(donates) buffers aggressively, so those bytes are live garbage from a previous
op, not zeros.

Failure scenario: run a variable-length / padded SDPA under
`--xla_gpu_enable_command_buffer=FUSION,CUDNN` (or any config where the fMHA
thunk is converted into a command). Both `Record` branches — the explicit
`CreateDnnGraphCommand` path and the traced `RecordTracedCommand` fallback —
launch the graph with no preceding zero-fill, so the padded rows of `O` (fwd) and
of `dQ`/`dK`/`dV` (bwd) carry the previous tenant's values into the next op. The
same class of bug was already fixed once on the eager path (NVBug 6158764,
padding leak in the backward pass); the command-buffer path never got the
treatment.

Fix (`cudnn_thunk.cc`):
* Explicit path: on `RecordCreate`, emit one `CreateMemset` per output buffer and
  make the DNN graph command depend on them; on `RecordUpdate`, rebind those
  memset nodes to the new addresses via `UpdateMemset` before updating the graph
  command. The memset nodes are kept in `CommandState` keyed by the DNN graph
  command they precede, because the same thunk can be recorded into one command
  buffer more than once (unrolled loops), so a flat vector would alias.
* Traced fallback: zero the outputs inside the traced lambda, so the memsets are
  captured into the same nested command buffer as the graph launch.

Conservative choice: if the update path cannot find the memset nodes it recorded
(state evicted or never created), it returns `Internal(...)` rather than
silently skipping the zero-fill.

### 3. `force_deterministic` written after the instruction is fingerprinted

`xla/backends/gpu/transforms/cudnn_custom_call_compiler.cc:310-313` computed
`force_deterministic` from the module config and wrote it into the backend config
*inside* `BuildGraphForCustomCallToBackwardFMHA`. But that builder is invoked
from `CuDnnCustomCallVisitor::HandleCustomCall` **after**
`fingerprint_without_workspace` has already been computed (:552), and only on a
miss in `workspace_sizes_`.

The flag does change the built graph — `se::gpu::GetCudnnFlashAttentionBackwardOperationGraph`
forwards it into `EngineOptions{force_deterministic, ...}` and into the
deterministic-engine filtering at `xla/stream_executor/cuda/cuda_dnn.cc:4886`.

Failure scenario: compile a module with determinism required (e.g.
`--xla_gpu_deterministic_ops`) that contains two structurally identical backward
fMHA custom calls — i.e. any transformer with more than one identically-shaped
layer. The first call misses the workspace cache, builds the graph, gets
`force_deterministic: true` written into its backend config, and is registered in
`compilation_results_` under a fingerprint that includes the flag. The second call
hashes to the *same* `fingerprint_without_workspace` (it is computed before the
flag is written), takes the `// Cache hit.` branch at :576, and therefore never
gets the flag written at all. At emission time
`ThunkEmitter::EmitCuDnn` fingerprints that instruction *without* the flag
(`thunk_emitter.cc:1225`), and `CuDnnThunk::Initialize` then does
`params.src.dnn_compiled_graphs.at(fingerprint_)` (`cudnn_thunk.cc:82-83`) — an
`.at()` on a key that is not there.

Fix: move the write into a small `SetBackwardFMHADeterminism()` helper called from
`HandleCustomCall` before either fingerprint is computed; the graph builder now
just reads `config.force_deterministic()`. Both the workspace cache key and the
compilation-results key now cover the flag, and the flag is written on every
backward fMHA instruction regardless of cache hits.

## Evidence

The use-after-free is a plain lifetime bug visible in the source; no runtime repro
is needed and none is claimed. Note it is latent-but-real: the freed object's
storage is usually still warm, so it passes CI and fails under a different
allocator, sanitizer build or inlining decision.

No measured reproduction is claimed for any of the three fixes — all three were
established by reading the XLA and cuDNN sources.

## Testing

Added to `xla/backends/gpu/runtime/cudnn_thunk_test.cc`:

* `CuDnnThunkCmdBufTest.RecordCreateZeroFillsOutputExplicit`
* `CuDnnThunkCmdBufTest.RecordUpdateZeroFillsOutputExplicit`
* `CuDnnThunkCmdBufTest.RecordCreateZeroFillsOutputImplicit`

The existing fixture's output allocation now carries a `kPadElements` tail past
the matmul result that the DNN graph never writes — the stand-in for the padded
tokens of an fMHA output. `SetUp()` already poisons the whole output buffer with
`0xdeadbeef`, so after recording and submitting the command buffer the tail must
read back as zero. `FakeDnnGraph` gained a `write_output` flag so the traced path
can model a graph that writes nothing at all. All three tests fail before the
`cudnn_thunk.cc` change (tail stays `0xdeadbeef`) and pass after. The existing
four `Record()` tests are unaffected: they read back only the matmul region.

**These tests were written but not built or run** — this sandbox has no XLA build.
They are `xla_test(..., backends = ["gpu"], tags = ["cuda-only"])`, so they need a
GPU with cuDNN ≥ 9.7 and CUDA graph tracing support.

There is no test target for the `cudnn_custom_call_compiler` pass in the tree, so
fix 3 has no dedicated regression test. It is exercised end-to-end by
`xla/backends/gpu/tests/gpu_fused_mha_test.cc` when the module config requires
determinism.

Found by an integration audit of cuDNN SDPA consumers by the NVIDIA cuDNN team.
