### PR TITLE
[ROCm] Allocate GPUs by ROCR_VISIBLE_DEVICES in parallel_gpu_execute

### DIFF
--- a/build_tools/rocm/parallel_gpu_execute.sh
+++ b/build_tools/rocm/parallel_gpu_execute.sh
@@ -15,11 +15,27 @@
 # ==============================================================================
 #
 #
-# A script to run multiple GPU tests in parallel controlled with an environment
-# variable.
+# A script to run GPU tests in parallel, isolating each test to the GPU(s) it
+# was allocated.
+#
+# ROCm exposes two independent visibility layers:
+#   * ROCR_VISIBLE_DEVICES selects the physical GPUs at the ROCr/HSA level.
+#   * HIP_VISIBLE_DEVICES indexes into the ROCr-visible set (so it should be a
+#     plain 0..N-1 list, NOT a physical device id).
+# We therefore allocate physical GPUs to a test via ROCR_VISIBLE_DEVICES -- only
+# ever drawing from the pool the environment already handed us (e.g. from a
+# container orchestrator such as Kubernetes) -- and expose them re-indexed to
+# 0..N-1 via HIP_VISIBLE_DEVICES.
+#
+# Multi-GPU tests (multi-process / distributed tests, identified by
+# num_processes * gpus_per_process > 1) reserve a *block* of GPUs rather than a
+# single one. The previous behavior of pinning every test to one GPU via
+# HIP_VISIBLE_DEVICES=$i made such tests impossible to run.
 #
 # Required environment variables:
 #     TF_GPU_COUNT = Number of GPUs available.
+
+set -u
 
 ROCMINFO=$(find -L "${TEST_SRCDIR:-.}" -name "rocminfo" -path "*/bin/rocminfo" | head -n 1)
 TF_GPU_COUNT=$($ROCMINFO | grep "Name: *gfx*" | wc -l)
@@ -62,31 +78,81 @@ TEST_BINARY="$(rlocation $TEST_WORKSPACE/${1#./})"
 shift
 # *******************************************************************
 
+# Determine how many GPUs this test needs. Multi-process/distributed tests pass
+# --num_processes and --gpus_per_process; everything else needs a single GPU.
+NUM_PROCESSES=1
+GPUS_PER_PROCESS=1
+for arg in "$@"; do
+  case "$arg" in
+    --num_processes=*)    NUM_PROCESSES="${arg#*=}" ;;
+    --gpus_per_process=*) GPUS_PER_PROCESS="${arg#*=}" ;;
+  esac
+done
+[[ "$NUM_PROCESSES" =~ ^[0-9]+$ ]] || NUM_PROCESSES=1
+[[ "$GPUS_PER_PROCESS" =~ ^[0-9]+$ ]] || GPUS_PER_PROCESS=1
+NEEDED_GPUS=$((NUM_PROCESSES * GPUS_PER_PROCESS))
+(( NEEDED_GPUS < 1 )) && NEEDED_GPUS=1
+
+# Physical GPU pool: honor any externally provided ROCR_VISIBLE_DEVICES
+# allocation (e.g. from the container orchestrator); otherwise use all GPUs.
+if [[ -n "${ROCR_VISIBLE_DEVICES:-}" ]]; then
+  IFS=',' read -r -a GPU_POOL <<< "$ROCR_VISIBLE_DEVICES"
+else
+  GPU_POOL=($(seq 0 $((TF_GPU_COUNT - 1))))
+fi
+POOL_SIZE=${#GPU_POOL[@]}
+
+if (( POOL_SIZE < NEEDED_GPUS )); then
+  echo "Test needs ${NEEDED_GPUS} GPU(s) but only ${POOL_SIZE} are allocated" \
+       "(ROCR_VISIBLE_DEVICES=${ROCR_VISIBLE_DEVICES:-unset}); exiting with failure..."
+  exit 1
+fi
+
 mkdir -p /var/lock
-# Try to acquire any of the TF_GPU_COUNT * TF_TESTS_PER_GPU
-# slots to run a test at.
-#
-# Prefer to allocate 1 test per GPU over 4 tests on 1 GPU.
-# So, we iterate over TF_TESTS_PER_GPU first.
-for j in `seq 0 $((TF_TESTS_PER_GPU-1))`; do
-  for i in `seq 0 $((TF_GPU_COUNT-1))`; do
-    exec {lock_fd}>/var/lock/gpulock${i}_${j} || exit 1
-    if flock -n "$lock_fd";
-    then
+# Reserve a contiguous block of NEEDED_GPUS GPUs from the pool. Prefer spreading
+# tests across GPUs (iterate the oversubscription round `j` outermost) before
+# doubling up, matching the original single-GPU behavior for NEEDED_GPUS=1.
+for j in `seq 0 $((TF_TESTS_PER_GPU - 1))`; do
+  for (( start=0; start + NEEDED_GPUS <= POOL_SIZE; start++ )); do
+    lock_fds=()
+    acquired=1
+    for (( k=0; k < NEEDED_GPUS; k++ )); do
+      gpu=${GPU_POOL[$((start + k))]}
+      exec {lock_fd}>/var/lock/gpulock${gpu}_${j} || exit 1
+      if flock -n "$lock_fd"; then
+        lock_fds+=("$lock_fd")
+      else
+        eval "exec ${lock_fd}>&-"  # close the fd we opened but failed to lock
+        acquired=0
+        break
+      fi
+    done
+    if (( acquired == 1 )); then
+      block=("${GPU_POOL[@]:start:NEEDED_GPUS}")
       (
         # This export only works within the brackets, so it is isolated to one
         # single command.
-        export CUDA_VISIBLE_DEVICES=$i
-        export HIP_VISIBLE_DEVICES=$i
-        echo "Running test $TEST_BINARY $* on GPU $CUDA_VISIBLE_DEVICES"
+        # ROCr restricts the process to the allocated physical GPUs; HIP then
+        # sees them re-indexed to 0..NEEDED_GPUS-1. Do not set
+        # CUDA_VISIBLE_DEVICES: on ROCm HIP would treat it as an additional
+        # (physical-id) filter and fight the ROCr allocation.
+        export ROCR_VISIBLE_DEVICES=$(IFS=,; echo "${block[*]}")
+        export HIP_VISIBLE_DEVICES=$(seq -s, 0 $((NEEDED_GPUS - 1)))
+        unset CUDA_VISIBLE_DEVICES
+        echo "Running test $TEST_BINARY $* on GPU(s) $ROCR_VISIBLE_DEVICES"
         "$TEST_BINARY" $@
       )
       return_code=$?
-      flock -u "$lock_fd"
+      # Releasing the locks (closing the fds) is deferred to process exit, but
+      # do it explicitly for clarity.
+      for fd in "${lock_fds[@]}"; do eval "exec ${fd}>&-"; done
       exit $return_code
+    else
+      # Release any partial locks before trying the next starting offset.
+      for fd in "${lock_fds[@]}"; do eval "exec ${fd}>&-"; done
     fi
   done
 done
 
-echo "Cannot find a free GPU to run the test $* on, exiting with failure..."
+echo "Cannot find ${NEEDED_GPUS} free GPU(s) to run the test $* on, exiting with failure..."
 exit 1


### PR DESCRIPTION
## Problem

`build_tools/rocm/parallel_gpu_execute.sh` pins every test to a single GPU by exporting `HIP_VISIBLE_DEVICES=$i` (a physical device id). This makes multi-process / distributed (multi-GPU) tests impossible to run: a worker told to use device ordinal `1` requests a GPU that isn't visible and fails with

```
hipDeviceGet HIP_ERROR_InvalidDevice
INTERNAL: no supported devices found for platform ROCM
```

It is also incorrect on ROCm even for single-GPU tests: `HIP_VISIBLE_DEVICES` is a **logical** index into the ROCr-visible set, not a physical selector. Physical device selection belongs to `ROCR_VISIBLE_DEVICES`.

## Fix

- Allocate physical GPUs via `ROCR_VISIBLE_DEVICES` and expose them re-indexed to `0..N-1` via `HIP_VISIBLE_DEVICES` (the ROCr/HSA layer sits below HIP).
- Draw only from any `ROCR_VISIBLE_DEVICES` pool the environment already provided (e.g. from a container orchestrator such as Kubernetes), so we never hand out GPUs we weren't allocated.
- Multi-GPU tests, identified from the `--num_processes` / `--gpus_per_process` flags in the test command line, reserve a **block** of GPUs instead of a single one.
- Stop setting `CUDA_VISIBLE_DEVICES` so HIP doesn't apply it as a second, physical-id filter that fights the ROCr allocation.

## Context

This is the wrapper-side counterpart to the JAX-side fix in jax-ml/jax#39602, which assigns per-worker `ROCR_VISIBLE_DEVICES` in the multi-process test harness. Either change fixes the failing multi-accelerator test on its own; together they give correct, isolated GPU allocation for both single- and multi-GPU ROCm tests.

## Testing

Verified on an 8x MI355X (gfx950) host: single-GPU tests still lock one GPU (now via ROCr) and multi-process tests receive distinct physical GPUs, each re-indexed to logical ordinal 0.