### PR TITLE
fix(gpu): make reduction group order deterministic

### DIFF
--- a/xla/backends/gpu/codegen/emitters/BUILD
+++ b/xla/backends/gpu/codegen/emitters/BUILD
@@ -331,6 +331,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/container:linked_hash_set",
         "@com_google_absl//absl/container:node_hash_map",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",

--- a/xla/backends/gpu/codegen/emitters/reduction_base.cc
+++ b/xla/backends/gpu/codegen/emitters/reduction_base.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/container/inlined_vector.h"
+#include "absl/container/linked_hash_set.h"
 #include "absl/container/node_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -125,7 +126,9 @@ ReductionGroups GroupDisjointReductions(const HloFusionAnalysis& analysis) {
     }
   }
 
-  absl::flat_hash_set<HloInstructionAdaptor> instructions;
+  // Insertion-ordered: the iteration order below decides which value survives
+  // each union-find merge, and therefore the group order.
+  absl::linked_hash_set<HloInstructionAdaptor> instructions;
   for (const HloInstruction* operand : analysis.fusion().GetParameters()) {
     instructions.insert(HloInstructionAdaptor{*operand, &analysis.fusion()});
   }


### PR DESCRIPTION
`GroupDisjointReductions` iterates an `absl::flat_hash_set` to decide which value survives each union-find merge, which sets the order of `grouped_roots` and `group_id_per_root`. That vector is written into the indexing map as a `blockIdx.z` constraint, so the same module can compile to a different group-to-block assignment.

Switches the set to `absl::linked_hash_set` so iteration follows insertion order.

Fixes #46537.