### PR TITLE
ROCm CI: add --init to container jobs to fix slow/zombie teardown

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -65,6 +65,7 @@ jobs:
         - /data/ci-cert.key:/data/ci-cert.key
         - /data:/data
       options: >-
+        --init
         --device=/dev/dri
         --device=/dev/kfd
         --ipc=host


### PR DESCRIPTION
## What

Add `--init` to the `options:` of the `container:` block used by the ROCm CI
jobs in `.github/workflows/rocm_ci.yml`:

- **JAX Linux x86 AMD Instinct GPU** (`jax` job)
- **XLA Linux x86 AMD Instinct GPU** (`xla` job)

Both jobs share one container definition via the `&rocm_container` YAML anchor /
`*rocm_container` alias, so the single-line change applies to both.

## Why

ROCm CI containers can suffer very slow shutdown (40+ minutes in some cases).
Without an init process as PID 1, orphaned/zombie child processes are never
reaped, which can hang the container on teardown. Adding `--init` to the GHA
`container:` options makes the job container run with an init (tini /
docker-init) as PID 1 that reaps zombies and forwards signals.

This was observed live on AMD's DOKS MI350X Actions runners running
openxla/xla's ROCm CI: the "XLA Linux x86 AMD Instinct GPU" and
"JAX Linux x86 AMD Instinct GPU" jobs, where container/pod teardown blocked for
tens of minutes.

## Test plan

- Confirm the ROCm CI (`CI ROCm` workflow) still starts and runs with `--init`
  in the container options (no regression to `--device`/`--kfd`/RBE flags).
- Compare container/pod teardown times before vs. after: teardown should no
  longer block for tens of minutes once an init reaps orphaned processes.

## Notes

- Only the AMD Instinct GPU container job block was modified. Unrelated
  CPU/CUDA/oneAPI/Hermetic-ROCm jobs in `ci.yml` were intentionally left
  untouched.
- YAML validated with `yaml.safe_load`; both jobs resolve to exactly one
  `--init` (no duplication).
