### PR TITLE
[XLA] Prevent partial overlap in cross-color buffer reuse

### DIFF
--- a/xla/service/buffer_assignment.cc
+++ b/xla/service/buffer_assignment.cc
@@ -2601,15 +2601,16 @@ absl::StatusOr<int64_t> BufferAssigner::ReuseCompatibleTempHeaps(
   auto candidate_interferes_with = [&](const ReuseCandidate& candidate,
                                        const HloValue* other_value) {
     const auto& other_range = live_ranges.at(other_value);
-    return absl::c_any_of(
-        candidate.hlo_buffer->values(), [&](const HloValue* value) {
-          const auto& candidate_range = live_ranges.at(value);
-          // LiveRangeInterferes allows touching operand/user ranges for exact
-          // in-place sharing. This best-fit placer does not preserve the
-          // operand's exact chunk, so touching ranges must block placement.
-          return !(candidate_range.start > other_range.end ||
-                   other_range.start > candidate_range.end);
-        });
+    return absl::c_any_of(candidate.hlo_buffer->values(),
+                          [&](const HloValue* value) {
+                            const auto& candidate_range = live_ranges.at(value);
+                            // LiveRangeInterferes allows touching operand/user
+                            // ranges for exact in-place sharing. This best-fit
+                            // placer does not preserve the operand's exact
+                            // chunk, so touching ranges must block placement.
+                            return !(candidate_range.start > other_range.end ||
+                                     other_range.start > candidate_range.end);
+                          });
   };
 
   // Finds the best-fit free gap into which `candidate` fits inside

--- a/xla/service/buffer_assignment.cc
+++ b/xla/service/buffer_assignment.cc
@@ -2600,11 +2600,15 @@ absl::StatusOr<int64_t> BufferAssigner::ReuseCompatibleTempHeaps(
   // `other_value`. If so, they cannot occupy overlapping storage.
   auto candidate_interferes_with = [&](const ReuseCandidate& candidate,
                                        const HloValue* other_value) {
-    auto& other_range = live_ranges.at(other_value);
+    const auto& other_range = live_ranges.at(other_value);
     return absl::c_any_of(
         candidate.hlo_buffer->values(), [&](const HloValue* value) {
-          return LiveRangeInterferes(value, live_ranges.at(value), other_value,
-                                     other_range, assignment);
+          const auto& candidate_range = live_ranges.at(value);
+          // LiveRangeInterferes allows touching operand/user ranges for exact
+          // in-place sharing. This best-fit placer does not preserve the
+          // operand's exact chunk, so touching ranges must block placement.
+          return !(candidate_range.start > other_range.end ||
+                   other_range.start > candidate_range.end);
         });
   };
 

--- a/xla/service/buffer_assignment_test.cc
+++ b/xla/service/buffer_assignment_test.cc
@@ -245,13 +245,18 @@ class BufferAssignmentTest : public HloHardwareIndependentTestBase {
       HloModule* module, absl::Span<HloInstruction* const> instruction_sequence,
       int64_t alignment = 1,
       BufferAssigner::CanUseAllocation can_use_allocation =
-          BufferAssigner::DefaultCanUseAllocation()) {
+          BufferAssigner::DefaultCanUseAllocation(),
+      BufferAssigner::Colorer colorer = BufferAssigner::DefaultColorer(),
+      buffer_assignment::BufferAssignmentAlgorithmProto::Value algorithm =
+          buffer_assignment::BufferAssignmentAlgorithmProto::DEFAULT) {
     HloSchedule schedule(module);
     schedule.set_sequence(module->entry_computation(), instruction_sequence);
     CHECK_OK(schedule.Update());
     BufferAssigner::Options opts;
     opts.allocate_buffers_for_constants = true;
     opts.can_use_allocation = std::move(can_use_allocation);
+    opts.colorer = std::move(colorer);
+    opts.buffer_assignment_algorithm = algorithm;
     return BufferAssigner::Run(
                module, std::make_unique<SequentialHloOrdering>(schedule),
                &BufferSizeBytes, &alias_info_,
@@ -1029,6 +1034,110 @@ ENTRY main {
               ::testing::Contains(&neg1_value));
   EXPECT_THAT(neg0_allocation.CrossColorBuffers(),
               ::testing::Not(::testing::Contains(&neg0_value)));
+}
+
+TEST_F(BufferAssignmentTest, CrossColorReuseDoesNotPartiallyOverlapOperand) {
+  // Operand/user buffer sharing is only safe when the user is assigned the
+  // operand's exact chunk. Cross-color best-fit placement cannot use that
+  // exception because it may choose a different offset.
+  const char* const hlo_text = R"(
+HloModule test
+
+add_s {
+  lhs = f32[] parameter(0)
+  rhs = f32[] parameter(1)
+  ROOT add = f32[] add(lhs, rhs)
+}
+
+ENTRY main {
+  p_d = f32[2048]{0} parameter(0)
+  p_a = f32[1024]{0} parameter(1)
+  p_k = f32[256]{0} parameter(2)
+  d = f32[2048]{0} negate(p_d)
+  zero = f32[] constant(0)
+  d_sum = f32[] reduce(d, zero), dimensions={0}, to_apply=add_s
+  a = f32[1024]{0} negate(p_a)
+  b = f32[1024]{0} abs(a)
+  k = f32[256]{0} negate(p_k)
+  k_sum = f32[] reduce(k, zero), dimensions={0}, to_apply=add_s
+  b_sum = f32[] reduce(b, zero), dimensions={0}, to_apply=add_s
+  partial = f32[] add(d_sum, k_sum)
+  ROOT out = f32[] add(partial, b_sum)
+}
+)";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_text));
+
+  HloInstruction* p_d = FindInstruction(module.get(), "p_d");
+  HloInstruction* p_a = FindInstruction(module.get(), "p_a");
+  HloInstruction* p_k = FindInstruction(module.get(), "p_k");
+  HloInstruction* d = FindInstruction(module.get(), "d");
+  HloInstruction* zero = FindInstruction(module.get(), "zero");
+  HloInstruction* d_sum = FindInstruction(module.get(), "d_sum");
+  HloInstruction* a = FindInstruction(module.get(), "a");
+  HloInstruction* b = FindInstruction(module.get(), "b");
+  HloInstruction* k = FindInstruction(module.get(), "k");
+  HloInstruction* k_sum = FindInstruction(module.get(), "k_sum");
+  HloInstruction* b_sum = FindInstruction(module.get(), "b_sum");
+  HloInstruction* partial = FindInstruction(module.get(), "partial");
+  HloInstruction* out = FindInstruction(module.get(), "out");
+
+  BufferAssigner::Colorer colorer =
+      [d, k](HloAliasAnalysis* alias_analysis, const HloOrdering&) {
+        for (HloValue* value :
+             alias_analysis->dataflow_analysis().values()) {
+          HloInstruction* instruction = value->instruction();
+          value->set_color(instruction == d || instruction == k
+                               ? BufferValue::Color(1)
+                               : BufferValue::Color(0));
+        }
+        return absl::OkStatus();
+      };
+
+  std::vector<HloInstruction*> sequence = {
+      p_d, p_a, p_k, d, zero, d_sum, a, b, k, k_sum, b_sum, partial, out};
+  auto assignment = RunBufferAssignmentWithInstructionSequence(
+      module.get(), sequence, /*alignment=*/1,
+      BufferAssigner::AllowCrossColorReuse(0, 1), std::move(colorer),
+      buffer_assignment::BufferAssignmentAlgorithmProto::TEMPORAL);
+
+  const HloValue& d_value =
+      assignment->dataflow_analysis().GetUniqueValueAt(d, {});
+  const HloValue& k_value =
+      assignment->dataflow_analysis().GetUniqueValueAt(k, {});
+  const HloValue& a_value =
+      assignment->dataflow_analysis().GetUniqueValueAt(a, {});
+  const HloValue& b_value =
+      assignment->dataflow_analysis().GetUniqueValueAt(b, {});
+  ASSERT_OK_AND_ASSIGN(BufferAllocation::Slice d_slice,
+                       assignment->GetUniqueSlice(d, {}));
+  ASSERT_OK_AND_ASSIGN(BufferAllocation::Slice k_slice,
+                       assignment->GetUniqueSlice(k, {}));
+  ASSERT_OK_AND_ASSIGN(BufferAllocation::Slice a_slice,
+                       assignment->GetUniqueSlice(a, {}));
+  ASSERT_OK_AND_ASSIGN(BufferAllocation::Slice b_slice,
+                       assignment->GetUniqueSlice(b, {}));
+
+  EXPECT_EQ(d_value.color(), 1);
+  EXPECT_EQ(k_value.color(), 1);
+  EXPECT_EQ(a_value.color(), 0);
+  EXPECT_EQ(b_value.color(), 0);
+  EXPECT_EQ(d_slice.index(), k_slice.index());
+  EXPECT_EQ(d_slice.index(), a_slice.index());
+  EXPECT_EQ(d_slice.index(), b_slice.index());
+  EXPECT_EQ(d_slice.allocation()->color(), 1);
+  EXPECT_EQ(d_slice.allocation()->size(), 8192);
+  EXPECT_EQ(d_slice.offset(), 0);
+  EXPECT_EQ(k_slice.offset(), 0);
+  EXPECT_EQ(a_slice.offset(), 0);
+  EXPECT_EQ(b_slice.offset(), 4096);
+  EXPECT_EQ(a_slice.size(), 4096);
+  EXPECT_EQ(b_slice.size(), 4096);
+  EXPECT_FALSE(a_slice.OverlapsWith(b_slice));
+  EXPECT_THAT(d_slice.allocation()->CrossColorBuffers(),
+              ::testing::Contains(&a_value));
+  EXPECT_THAT(d_slice.allocation()->CrossColorBuffers(),
+              ::testing::Contains(&b_value));
 }
 
 TEST_F(BufferAssignmentTest,

--- a/xla/service/buffer_assignment_test.cc
+++ b/xla/service/buffer_assignment_test.cc
@@ -246,7 +246,6 @@ class BufferAssignmentTest : public HloHardwareIndependentTestBase {
       int64_t alignment = 1,
       BufferAssigner::CanUseAllocation can_use_allocation =
           BufferAssigner::DefaultCanUseAllocation(),
-      BufferAssigner::Colorer colorer = BufferAssigner::DefaultColorer(),
       buffer_assignment::BufferAssignmentAlgorithmProto::Value algorithm =
           buffer_assignment::BufferAssignmentAlgorithmProto::DEFAULT) {
     HloSchedule schedule(module);
@@ -255,7 +254,6 @@ class BufferAssignmentTest : public HloHardwareIndependentTestBase {
     BufferAssigner::Options opts;
     opts.allocate_buffers_for_constants = true;
     opts.can_use_allocation = std::move(can_use_allocation);
-    opts.colorer = std::move(colorer);
     opts.buffer_assignment_algorithm = algorithm;
     return BufferAssigner::Run(
                module, std::make_unique<SequentialHloOrdering>(schedule),
@@ -1053,12 +1051,12 @@ ENTRY main {
   p_d = f32[2048]{0} parameter(0)
   p_a = f32[1024]{0} parameter(1)
   p_k = f32[256]{0} parameter(2)
-  d = f32[2048]{0} negate(p_d)
+  d = f32[2048]{0:S(1)} negate(p_d)
   zero = f32[] constant(0)
   d_sum = f32[] reduce(d, zero), dimensions={0}, to_apply=add_s
   a = f32[1024]{0} negate(p_a)
   b = f32[1024]{0} abs(a)
-  k = f32[256]{0} negate(p_k)
+  k = f32[256]{0:S(1)} negate(p_k)
   k_sum = f32[] reduce(k, zero), dimensions={0}, to_apply=add_s
   b_sum = f32[] reduce(b, zero), dimensions={0}, to_apply=add_s
   partial = f32[] add(d_sum, k_sum)
@@ -1082,23 +1080,11 @@ ENTRY main {
   HloInstruction* partial = FindInstruction(module.get(), "partial");
   HloInstruction* out = FindInstruction(module.get(), "out");
 
-  BufferAssigner::Colorer colorer =
-      [d, k](HloAliasAnalysis* alias_analysis, const HloOrdering&) {
-        for (HloValue* value :
-             alias_analysis->dataflow_analysis().values()) {
-          HloInstruction* instruction = value->instruction();
-          value->set_color(instruction == d || instruction == k
-                               ? BufferValue::Color(1)
-                               : BufferValue::Color(0));
-        }
-        return absl::OkStatus();
-      };
-
   std::vector<HloInstruction*> sequence = {
       p_d, p_a, p_k, d, zero, d_sum, a, b, k, k_sum, b_sum, partial, out};
   auto assignment = RunBufferAssignmentWithInstructionSequence(
       module.get(), sequence, /*alignment=*/1,
-      BufferAssigner::AllowCrossColorReuse(0, 1), std::move(colorer),
+      BufferAssigner::AllowCrossColorReuse(0, 1),
       buffer_assignment::BufferAssignmentAlgorithmProto::TEMPORAL);
 
   const HloValue& d_value =
@@ -1118,10 +1104,10 @@ ENTRY main {
   ASSERT_OK_AND_ASSIGN(BufferAllocation::Slice b_slice,
                        assignment->GetUniqueSlice(b, {}));
 
-  EXPECT_EQ(d_value.color(), 1);
-  EXPECT_EQ(k_value.color(), 1);
-  EXPECT_EQ(a_value.color(), 0);
-  EXPECT_EQ(b_value.color(), 0);
+  EXPECT_EQ(d_value.shape().layout().memory_space(), 1);
+  EXPECT_EQ(k_value.shape().layout().memory_space(), 1);
+  EXPECT_EQ(a_value.shape().layout().memory_space(), 0);
+  EXPECT_EQ(b_value.shape().layout().memory_space(), 0);
   EXPECT_EQ(d_slice.index(), k_slice.index());
   EXPECT_EQ(d_slice.index(), a_slice.index());
   EXPECT_EQ(d_slice.index(), b_slice.index());


### PR DESCRIPTION
📝 Summary of Changes

Update cross-color temporary-buffer reuse to treat endpoint-touching live ranges as interfering when selecting an arbitrary best-fit offset. Add focused coverage for operand/user buffers that would otherwise receive shifted, partially overlapping slices.

🎯 Justification

The operand/user endpoint exception is valid only when an allocator preserves the exact in-place slice. Cross-color best-fit placement may select a different aligned offset, so this placement phase must use closed live-range overlap when determining blocked byte ranges.

💡 Example

In the focused test’s instruction sequence, `a` is live at positions `[6, 7]` and its user `b` at `[7, 10]`, so their live ranges touch at position 7. Both buffers are 4096 bytes. Before this fix, the in-place operand/user exception caused `a` to be ignored as a blocker. Because `k` occupied bytes `[0, 1024)`, best-fit placement could put `b` at offset 1024, partially overlapping `a` at offset 0 over bytes `[1024, 4096)`. This is unsafe because the slices are not identical.

After this fix, touching ranges interfere during cross-color placement. `a` blocks `[0, 4096)`, so `b` is placed at offset 4096, occupying `[4096, 8192)` with no overlap.

🚀 Kind of Contribution

🐛 Bug Fix

📊 Benchmark (for Performance Improvements)

Not applicable. This is a correctness change.

🧪 Unit Tests:

Adds BufferAssignmentTest.CrossColorReuseDoesNotPartiallyOverlapOperand in //xla/service:buffer_assignment_test.

🧪 Execution Tests:

Not added. The cross-color placement invariant is covered by the focused buffer-assignment unit test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved buffer reuse handling to avoid incorrect overlap detection between values.
  * Fixed an edge case where reused buffers could partially overlap operands across colors.
  * Added coverage for cross-color buffer reuse behavior to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->