### PR TITLE
[XLA:GPU] Enable symmetric buffers for reduce-scatter

### DIFF
--- a/xla/backends/gpu/runtime/all_reduce_thunk.h
+++ b/xla/backends/gpu/runtime/all_reduce_thunk.h
@@ -128,6 +128,8 @@ class ReduceScatterThunk : public AllReduceReduceScatterThunkBase {
   absl::Status RunCollective(const ExecuteParams& params,
                              const GpuCliqueKey& clique_key, se::Stream& stream,
                              Communicator& comm) override;
+
+  bool CanUseSymmetricBuffer() const override { return true; }
 };
 
 // -----------------------------------------------------------------------------

--- a/xla/backends/gpu/runtime/all_reduce_thunk_test.cc
+++ b/xla/backends/gpu/runtime/all_reduce_thunk_test.cc
@@ -207,6 +207,8 @@ class NoOpReduceScatterThunk : public ReduceScatterThunk {
       : ReduceScatterThunk(std::move(thunk_info), std::move(config),
                            std::move(buffers)) {}
 
+  using ReduceScatterThunk::CanUseSymmetricBuffer;
+
   absl::Status ExecuteOnStream(const ExecuteParams& params) override {
     return absl::OkStatus();
   }
@@ -337,6 +339,15 @@ static NoOpReduceScatterThunk MakeNoOpReduceScatterThunk(
     int64_t length) {
   return NoOpReduceScatterThunk(Thunk::ThunkInfo(), MakeSumConfig(),
                                 {MakeNoOpBuffer(alloc_src, alloc_dst, length)});
+}
+
+TEST(ReduceScatterThunkTest, SupportsSymmetricBuffers) {
+  BufferAllocation alloc_src(/*index=*/0, /*size=*/16, /*color=*/0);
+  BufferAllocation alloc_dst(/*index=*/1, /*size=*/16, /*color=*/0);
+  NoOpReduceScatterThunk thunk =
+      MakeNoOpReduceScatterThunk(alloc_src, alloc_dst, /*length=*/4);
+
+  EXPECT_TRUE(thunk.CanUseSymmetricBuffer());
 }
 
 // Records AllReduceThunk into a primary command buffer (create phase) and


### PR DESCRIPTION
📝 Summary of Changes

Enable ReduceScatterThunk to report symmetric-buffer capability through CanUseSymmetricBuffer and add unit coverage for the capability.


🎯 Justification

The collective runtime queries each thunk before requesting symmetric allocation-backed source and destination buffers. Reduce-scatter supports this allocation path and should expose that capability through the same thunk interface used by other supported collectives.

🚀 Kind of Contribution

✨ New Feature

📊 Benchmark (for Performance Improvements)

Not applicable. This change enables an allocation capability rather than modifying collective performance.

🧪 Unit Tests:

Adds ReduceScatterThunkTest.SupportsSymmetricBuffers in //xla/backends/gpu/runtime:all_reduce_thunk_test.

🧪 Execution Tests:

Not added. The thunk capability is covered by the focused unit test.