### PR TITLE
[xla:gpu] Delete vestigial AsyncStreamKind enum

### DIFF
--- a/xla/service/gpu/gpu_executable.cc
+++ b/xla/service/gpu/gpu_executable.cc
@@ -232,9 +232,6 @@ absl::StatusOr<bool> ShouldCollectiveUseMinimalResource(
 
 using ::tsl::profiler::ScopedAnnotation;
 
-constexpr int kAsyncStreamTotal =
-    static_cast<int>(AsyncStreamKind::ASYNC_STREAM_KIND_MEMCPYP2P) + 1;
-
 // Returns the number of additional streams to allocate for a `GpuExecutable`.
 static GpuExecutable::NumAdditionalStreams GetNumAdditionalStreams(
     ThunkExecutor& executor, const DebugOptions& opts) {
@@ -242,9 +239,9 @@ static GpuExecutable::NumAdditionalStreams GetNumAdditionalStreams(
   int compute = opts.xla_gpu_executable_num_compute_streams();
   int comm = opts.xla_gpu_executable_num_communication_streams();
 
-  // Clamp it to minimum number of required streams.
+  // Clamp explicitly requested stream counts to non-negative values.
   compute = std::max(0, compute);
-  comm = std::max(kAsyncStreamTotal, comm);
+  comm = std::max(0, comm);
 
   // Then traverse all thunks to see if anyone requested more streams.
   for (const auto& thunk : executor.thunks()) {

--- a/xla/xla_data.proto
+++ b/xla/xla_data.proto
@@ -168,23 +168,6 @@ enum PrimitiveType {
 //   https://www.tensorflow.org/code/tensorflow/compiler/xla/tools/driver.cc
 // )
 
-// In XLA:GPU we use different streams for different kinds of collective
-// operations, and include the async stream kind into the GPU clique key.
-//
-// We carefully isolate different kinds of collectives using separate
-// communicators and guarantee that all collective operations have a total order
-// that will not create a deadlock.
-enum AsyncStreamKind {
-  // Stream for asynchronous collective ops.
-  ASYNC_STREAM_KIND_COLLECTIVE = 0;
-  // One Stream for P2P Send and Recv ops.
-  ASYNC_STREAM_KIND_P2P0 = 1;
-  // Another Stream for P2P Send and Recv ops.
-  ASYNC_STREAM_KIND_P2P1 = 2;
-  // Stream for MemCpyP2P
-  ASYNC_STREAM_KIND_MEMCPYP2P = 3;
-}
-
 // There are broadly 4 modes that collective communication ops use to describe
 // which sets of devices are participating with a given device in the operation.
 // These modes are determined by the values of channel_id (optional) and


### PR DESCRIPTION
`AsyncStreamKind` is no longer used to assign communication streams. Remove the enum and the hardcoded minimum stream count derived from it.

Allocate communication streams based on the configured count and the stream IDs actually requested by thunks.

XLA:GPU runtime has two mechanisms to assign ids to communicators:
 - `CommunicationId` - an id that allows to semantically partition communication for the same replica groups (devices)
 - `CommunicationStreamId` - index of the extra stream used for launching collective operations

Different communication strategies can combine these two ids for comm<->comm and comm<->compute overlap.