### PR TITLE
Revert "[ROCm] Fix collection of data files, use versioned files too"

### DIFF
--- a/third_party/py/python_wheel.bzl
+++ b/third_party/py/python_wheel.bzl
@@ -177,10 +177,8 @@ def _collect_data_aspect_impl(_, ctx):
             for f in data.files.to_list():
                 if not f.owner.package:
                     continue
-
-                # Check if filename contains any of the extensions (for versioned .so files)
                 for ext in extensions:
-                    if "." + ext in f.basename:
+                    if f.extension == ext:
                         files[f] = True
                         break
 


### PR DESCRIPTION
📝 Summary of Changes

Reverts c177f2b88a2eb0bd4dc24cb8564f00d7e2bf9b0e, restoring the exact extension
match in `_collect_data_aspect_impl`.

🎯 Justification

The substring match `"." + ext in f.basename` also selects versioned shared
libraries such as `librocblas.so.5`. Staging that SONAME into test runfiles makes
the ROCm plugin resolve rocBLAS from the runfiles copy rather than from the
complete system installation.

That runfiles copy is incomplete. The rocBLAS Tensile databases are `.dat`,
`.hsaco` and `.co` files, none of which are in the extension allowlist, so only
six kernel files are staged -- and those six survive only because a name like
`Kernels.so-000-gfx942.hsaco` happens to contain the substring `.so`. rocBLAS
then aborts at runtime:

```
rocBLAS error: Cannot read .../local_config_rocm/rocm/rocm_dist/lib/rocblas/library/TensileLibrary.dat: Illegal seek for GPU arch : gfx942
```



I'll reland this once I figure out correct fix.

🚀 Kind of Contribution

🐛 Bug Fix