### PR TITLE
[XLA] Simplify xor(a, a) to zero in the algebraic simplifier

### DIFF
--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <array>
 #include <cmath>
 #include <cstdint>
+#include <functional>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -5221,6 +5222,41 @@ absl::Status AlgebraicSimplifierVisitor::HandleOr(HloInstruction* logical_or) {
   // False || A => A and 0 | A => A
   VLOG(10) << "trying transform [False || A => A]: " << logical_or->ToString();
   if (IsAll(lhs, 0) && ReplaceInstructionIfCompatible(logical_or, rhs)) {
+    return absl::OkStatus();
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status AlgebraicSimplifierVisitor::HandleXor(
+    HloInstruction* logical_xor) {
+  HloInstruction *lhs, *rhs;
+  CHECK(Match(logical_xor, m::Xor(m::Op(&lhs), m::Op(&rhs))));
+
+  // A ^ A => 0. Identical() also catches operands that are distinct but
+  // equivalent instructions (e.g. two identical compares of the same inputs)
+  // before CSE has merged them; with the guards below this folds only what
+  // CSE itself would be allowed to merge: no side effects (rng and
+  // friends), and layout- and sharding-sensitive comparison.
+  VLOG(10) << "Trying transform [A ^ A => 0]: " << logical_xor->ToString();
+  if (lhs == rhs ||
+      (!lhs->HasSideEffect() &&
+       lhs->Identical(*rhs, std::equal_to<const HloInstruction*>(),
+                      std::equal_to<const HloComputation*>(),
+                      /*layout_sensitive=*/true,
+                      /*sharding_sensitive=*/true))) {
+    return ReplaceInstruction(logical_xor, MakeScalarLike(logical_xor, 0));
+  }
+
+  // A ^ False => A and A ^ 0 => A
+  VLOG(10) << "trying transform [A ^ False => A]: " << logical_xor->ToString();
+  if (IsAll(rhs, 0) && ReplaceInstructionIfCompatible(logical_xor, lhs)) {
+    return absl::OkStatus();
+  }
+
+  // False ^ A => A and 0 ^ A => A
+  VLOG(10) << "trying transform [False ^ A => A]: " << logical_xor->ToString();
+  if (IsAll(lhs, 0) && ReplaceInstructionIfCompatible(logical_xor, rhs)) {
     return absl::OkStatus();
   }
 

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.h
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.h
@@ -603,6 +603,8 @@ class AlgebraicSimplifierVisitor : public DfsHloRewriteVisitor {
 
   absl::Status HandleMap(HloInstruction* map) override;
 
+  absl::Status HandleXor(HloInstruction* logical_xor) override;
+
   // Runs the visitor on a computation.
   bool Run(HloComputation* computation,
            const AlgebraicSimplifierOptions& options,

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -6151,6 +6151,107 @@ TEST_F(AlgebraicSimplifierTest, OrFalse2) {
   EXPECT_EQ(root, param0);
 }
 
+// Test that A ^ A is simplified to 0 for predicates.
+TEST_F(AlgebraicSimplifierTest, XorSamePred) {
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule m
+    test {
+      p0 = pred[2] parameter(0)
+      ROOT xor = pred[2] xor(p0, p0)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Broadcast(m::ConstantScalar(0))));
+}
+
+// Test that A ^ A is simplified to 0 for integers.
+TEST_F(AlgebraicSimplifierTest, XorSameInt) {
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule m
+    test {
+      p0 = s32[2] parameter(0)
+      ROOT xor = s32[2] xor(p0, p0)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Broadcast(m::ConstantScalar(0))));
+}
+
+// Test that xor of two distinct but identical instructions is simplified to
+// 0 (the form CSE would produce, but before CSE has run).
+TEST_F(AlgebraicSimplifierTest, XorIdenticalOperands) {
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule m
+    test {
+      p0 = s32[2] parameter(0)
+      z = s32[] constant(0)
+      b = s32[2] broadcast(z), dimensions={}
+      ne1 = pred[2] compare(p0, b), direction=NE
+      ne2 = pred[2] compare(p0, b), direction=NE
+      ROOT xor = pred[2] xor(ne1, ne2)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Broadcast(m::ConstantScalar(0))));
+}
+
+// Test that xor of two identically-configured rng instructions is NOT
+// simplified: they produce different values.
+TEST_F(AlgebraicSimplifierTest, XorOfRngsNotSimplified) {
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule m
+    test {
+      lo = s32[] constant(0)
+      hi = s32[] constant(100)
+      rng1 = s32[2] rng(lo, hi), distribution=rng_uniform
+      rng2 = s32[2] rng(lo, hi), distribution=rng_uniform
+      ROOT xor = s32[2] xor(rng1, rng2)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  EXPECT_FALSE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+}
+
+// Test that A ^ False is simplified to A.
+TEST_F(AlgebraicSimplifierTest, XorFalse) {
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule m
+    test {
+      p0 = pred[2] parameter(0)
+      f = pred[] constant(false)
+      b = pred[2] broadcast(f), dimensions={}
+      ROOT xor = pred[2] xor(p0, b)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Parameter(0)));
+}
+
+// Test that False ^ A is simplified to A.
+TEST_F(AlgebraicSimplifierTest, XorFalse2) {
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule m
+    test {
+      p0 = s32[2] parameter(0)
+      z = s32[] constant(0)
+      b = s32[2] broadcast(z), dimensions={}
+      ROOT xor = s32[2] xor(b, p0)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Parameter(0)));
+}
+
 // Used for TEST_Ps that test merging (or not) of a kPad instruction into a
 // convolution's Window.
 struct ConvPaddingTestcase {

--- a/xla/tests/array_elementwise_ops_test.cc
+++ b/xla/tests/array_elementwise_ops_test.cc
@@ -2802,6 +2802,26 @@ TEST_F(ArrayElementwiseOpTest, Atan2C64s) {
   ComputeAndCompare(&builder, {}, error_spec_);
 }
 
+// Regression test for https://github.com/openxla/xla/issues/44705. The two
+// compares are distinct instructions (as emitted by the frontend in the
+// issue, before CSE), their xor is always false, and the converted zeros
+// only become constants during compilation; atan2(0, 0) must still be 0,
+// not NaN.
+TEST_F(ArrayElementwiseOpTest, Atan2ZerosFromXorSelf) {
+  XlaBuilder builder(TestName());
+  XlaOp a;
+  auto a_data =
+      CreateR1Parameter<int32_t>({0, 1, 2, 3, 4}, 0, "a", &builder, &a);
+  auto zero = Broadcast(ConstantR0<int32_t>(&builder, 0), {5});
+  auto ne1 = Ne(a, zero);
+  auto ne2 = Ne(a, zero);
+  auto zeros = ConvertElementType(Xor(ne1, ne2), F32);
+  Atan2(zeros, zeros);
+
+  ComputeAndCompareR1<float>(&builder, {0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+                             {&a_data}, error_spec_);
+}
+
 TEST_F(ArrayElementwiseOpTest, ErfF32s) {
   XlaBuilder builder(TestName());
   auto kInf = std::numeric_limits<float>::infinity();


### PR DESCRIPTION
Fixes #44705.

📝 Summary of Changes
Adds HandleXor to the algebraic simplifier with xor(a, a) => 0 plus the trivial xor(a, 0) => a and xor(0, a) => a identities, following the existing HandleOr structure and the A - A => 0 precedent. The xor(a, a) trigger also accepts two distinct operands that are Identical() (layout and sharding sensitive) and free of side effects, which keeps the fold within what CSE itself would merge. That covers the form the issue produces before CSE runs; without it, the pointer-equality form never appears early enough in the CPU pipeline (CSE merges the two compares only after the simplification loops, and fusion then hides the xor).

🎯 Justification
The repro in #44705 lowers to xor of two identical compares of the same operands, converted to f32 and fed to atan2. With no xor handling in the simplifier, the xor survives all HLO passes and reaches the MLIR emitters, where the arith dialect folds xori(x, x) to 0 even for non-constant x, and MLIR's math.atan2 folder then constant folds atan2(0, 0) to NaN. That folder contradicts IEEE 754 / C99 Annex F (atan2(+0, +0) is +0) and XLA's own runtime lowering, so the jitted result is NaN while eager, TPU and the interpreter all return 0. The folder bug is in LLVM (mlir/lib/Dialect/Math/IR/MathOps.cpp, since llvm/llvm-project#127947) and needs an upstream fix, but XLA should not be handing it a foldable atan2(0, 0) in the first place. With the xor folded at HLO level, constant folding evaluates atan2 with the correct semantics and the issue repro returns 0 on CPU and GPU.

One residual stays open until the LLVM folder is fixed: the identity check is shallow (operand pointers), so a frontend that duplicates the whole compare chain (two separate constants and broadcasts) would still hit the NaN on CPU. The issue's JAX trajectory shares the operands, so it is fully covered here.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
Six new cases in algebraic_simplifier_test.cc: XorSamePred and XorSameInt (xor(a, a) folds to broadcast(0)), XorIdenticalOperands (two distinct but identical compares, the pre-CSE form from the issue), XorOfRngsNotSimplified (negative test: xor of two rng instructions must not fold, guarding the side-effect check), XorFalse and XorFalse2 (xor with zero returns the other operand).

🧪 Execution Tests:
Atan2ZerosFromXorSelf in xla/tests/array_elementwise_ops_test.cc reproduces the issue shape end to end: two separate Ne ops on a parameter against one shared broadcast, xor, convert to f32, atan2, asserting the result is 0 and not NaN. It fails on both CPU and GPU without this change and passes with it. Runs on a single device (verified locally on CPU and one NVIDIA GPU).