### PR TITLE
Fix integer overflow in IFRT proxy byte-strides size check

### DIFF
--- a/xla/python/ifrt_proxy/common/BUILD
+++ b/xla/python/ifrt_proxy/common/BUILD
@@ -162,6 +162,7 @@ cc_library(
     hdrs = ["array_util.h"],
     deps = [
         ":array_util_proto_cc",
+        "//xla:overflow_util",
         "//xla/python/ifrt",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/log:check",

--- a/xla/python/ifrt_proxy/common/BUILD
+++ b/xla/python/ifrt_proxy/common/BUILD
@@ -163,6 +163,7 @@ cc_library(
     hdrs = ["array_util.h"],
     deps = [
         ":array_util_proto_cc",
+        "//xla:overflow_util",
         "//xla/python/ifrt",
         "//xla/tsl/platform:status_macros",
         "//xla/tsl/platform:statusor",

--- a/xla/python/ifrt_proxy/common/BUILD
+++ b/xla/python/ifrt_proxy/common/BUILD
@@ -162,7 +162,6 @@ cc_library(
     hdrs = ["array_util.h"],
     deps = [
         ":array_util_proto_cc",
-        "//xla:overflow_util",
         "//xla/python/ifrt",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/log:check",

--- a/xla/python/ifrt_proxy/common/array_util.cc
+++ b/xla/python/ifrt_proxy/common/array_util.cc
@@ -130,8 +130,8 @@ absl::StatusOr<ArrayMemRegion> ArrayMemRegion::FromZerothElementPointer(
           OverflowSafeMultiply(stride, shape.dims()[i] - 1);
       if (overflow) {
         return absl::InvalidArgumentError(absl::StrCat(
-            "byte_stride[", i, "] * (dim - 1) overflows: stride=", stride,
-            " dim=", shape.dims()[i]));
+            "byte_stride[", i, "] * (dim[", i, "] - 1) overflows: stride=",
+            stride, " dim[", i, "]=", shape.dims()[i]));
       }
       last_element_byte_offset += static_cast<uint64_t>(product);
     }

--- a/xla/python/ifrt_proxy/common/array_util.cc
+++ b/xla/python/ifrt_proxy/common/array_util.cc
@@ -131,7 +131,7 @@ absl::StatusOr<ArrayMemRegion> ArrayMemRegion::FromZerothElementPointer(
       if (overflow) {
         return absl::InvalidArgumentError(absl::StrCat(
             "byte_stride[", i, "] * (dim[", i, "] - 1) overflows: stride=",
-            stride, " dim[", i, "]=", shape.dims()[i]));
+            stride, " dim=", shape.dims()[i]));
       }
       last_element_byte_offset += static_cast<uint64_t>(product);
     }

--- a/xla/python/ifrt_proxy/common/array_util.cc
+++ b/xla/python/ifrt_proxy/common/array_util.cc
@@ -27,6 +27,7 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
+#include "xla/overflow_util.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/python/ifrt/dtype.h"
 #include "xla/python/ifrt/shape.h"
@@ -125,7 +126,14 @@ absl::StatusOr<ArrayMemRegion> ArrayMemRegion::FromZerothElementPointer(
       // `shape.dims()[i]` cannot be negative (we explicitly check for this
       // above) or zero (we return early for `shape.num_elements() == 0`).
       DCHECK_GT(shape.dims()[i], 0);
-      last_element_byte_offset += (stride * (shape.dims()[i] - 1));
+      auto [product, overflow] =
+          OverflowSafeMultiply(stride, shape.dims()[i] - 1);
+      if (overflow) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "byte_stride[", i, "] * (dim - 1) overflows: stride=", stride,
+            " dim=", shape.dims()[i]));
+      }
+      last_element_byte_offset += static_cast<uint64_t>(product);
     }
   }
   return ArrayMemRegion(mem_region_start, last_element_byte_offset + byte_size);

--- a/xla/python/ifrt_proxy/common/array_util.cc
+++ b/xla/python/ifrt_proxy/common/array_util.cc
@@ -28,6 +28,7 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
+#include "xla/overflow_util.h"
 #include "xla/python/ifrt/dtype.h"
 #include "xla/python/ifrt/shape.h"
 #include "xla/python/ifrt_proxy/common/array_util.pb.h"
@@ -125,7 +126,14 @@ absl::StatusOr<ArrayMemRegion> ArrayMemRegion::FromZerothElementPointer(
       // `shape.dims()[i]` cannot be negative (we explicitly check for this
       // above) or zero (we return early for `shape.num_elements() == 0`).
       DCHECK_GT(shape.dims()[i], 0);
-      last_element_byte_offset += (stride * (shape.dims()[i] - 1));
+      auto [product, overflow] =
+          OverflowSafeMultiply(stride, shape.dims()[i] - 1);
+      if (overflow) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "byte_stride[", i, "] * (dim - 1) overflows: stride=", stride,
+            " dim=", shape.dims()[i]));
+      }
+      last_element_byte_offset += static_cast<uint64_t>(product);
     }
   }
   return ArrayMemRegion(mem_region_start, last_element_byte_offset + byte_size);

--- a/xla/python/ifrt_proxy/common/array_util.cc
+++ b/xla/python/ifrt_proxy/common/array_util.cc
@@ -28,7 +28,6 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "xla/overflow_util.h"
 #include "xla/python/ifrt/dtype.h"
 #include "xla/python/ifrt/shape.h"
 #include "xla/python/ifrt_proxy/common/array_util.pb.h"
@@ -126,9 +125,8 @@ absl::StatusOr<ArrayMemRegion> ArrayMemRegion::FromZerothElementPointer(
       // `shape.dims()[i]` cannot be negative (we explicitly check for this
       // above) or zero (we return early for `shape.num_elements() == 0`).
       DCHECK_GT(shape.dims()[i], 0);
-      auto [product, overflow] =
-          OverflowSafeMultiply(stride, shape.dims()[i] - 1);
-      if (overflow) {
+      int64_t product;
+      if (__builtin_mul_overflow(stride, shape.dims()[i] - 1, &product)) {
         return absl::InvalidArgumentError(absl::StrCat(
             "byte_stride[", i, "] * (dim[", i, "] - 1) overflows: stride=",
             stride, " dim=", shape.dims()[i]));

--- a/xla/python/ifrt_proxy/common/array_util_test.cc
+++ b/xla/python/ifrt_proxy/common/array_util_test.cc
@@ -137,7 +137,13 @@ INSTANTIATE_TEST_SUITE_P(
         TC{"SmallerByteStrideThanDataType", kS32, {5, 5}, Strides({1, 1})},
         TC{"ByteStrideIndivisibleByDataType", kS32, {5, 5}, Strides({7, 7})},
         // Bad arguments
-        TC{"NegativeShapeDimension", kS32, {-5, -5}, Strides({20, 4})}),
+        TC{"NegativeShapeDimension", kS32, {-5, -5}, Strides({20, 4})},
+        // Stride * (dim - 1) overflows int64_t — must be rejected, not silently
+        // wrap to zero (which would bypass the size check in FromMinimalMemRegion).
+        TC{"ByteStrideOverflowSingleDim", kS32, {5},
+           Strides({INT64_C(4611686018427387904)})},  // 2^62 * 4 = 2^64 wraps
+        TC{"ByteStrideOverflowMultiDim", kS32, {5, 3},
+           Strides({INT64_C(4611686018427387904), 4})}),
     testing::PrintToStringParamName());
 TEST_P(ArrayMemRegionFailure, TestCase) {
   const TC tc = GetParam();


### PR DESCRIPTION
## Problem

`ArrayMemRegion::FromZerothElementPointer` in `xla/python/ifrt_proxy/common/array_util.cc` accumulates the byte span of a strided array using an unchecked `int64_t` multiplication:

```cpp
last_element_byte_offset += (stride * (shape.dims()[i] - 1));
```

When `stride * (dims[i] - 1)` overflows `int64_t` and wraps to zero (e.g. `stride = 2^62`, `dims[i] = 5`: `2^62 × 4 = 2^64 ≡ 0`), the computed memory region size equals `byte_size` regardless of the true array span. `FromMinimalMemRegion` then compares this against the caller-supplied data size, which an IFRT proxy client also controls - so the size check passes and
validation is bypassed.

This affects two gRPC handlers in `IfrtBackend`:

- **`MakeArrayFromHostBuffer`**: the PjRt backend is handed a small host buffer   declared as a multi-element strided array and reads elements at offsets up to   `(N-1) × stride` bytes beyond it (OOB read).
- **`CopyToHostBuffer`**: the server allocates a `byte_size`-byte `std::string`  for the output, then the PjRt backend writes `N` strided elements into it  (heap buffer overflow).

## Fix

Use `OverflowSafeMultiply` (already available in `xla/overflow_util.h`) before accumulating `last_element_byte_offset`, and return `InvalidArgumentError` on overflow. Add `//xla:overflow_util` to the `array_util` BUILD target.

## Changes

- `xla/python/ifrt_proxy/common/array_util.cc`: replace unchecked multiplication with `OverflowSafeMultiply`; add `#include "xla/overflow_util.h"`
- `xla/python/ifrt_proxy/common/BUILD`: add `//xla:overflow_util` dep