### PR TITLE
Fix window padding integer overflow in InferWindowOutputShape

### DIFF
--- a/xla/service/shape_inference.cc
+++ b/xla/service/shape_inference.cc
@@ -221,8 +221,18 @@ absl::StatusOr<Shape> InferWindowOutputShape(const Shape& base_shape,
     } else {
       const int64_t dilated_base = window_util::DilatedBound(
           ShapeUtil::GetDimension(base_shape, i), dim.base_dilation());
-      const int64_t padded_dilated_base =
-          dim.padding_low() + dilated_base + dim.padding_high();
+      auto padded_low = OverflowSafeAdd(dim.padding_low(), dilated_base);
+      auto padded_dilated_base_opt =
+          padded_low.has_value()
+              ? OverflowSafeAdd(*padded_low, dim.padding_high())
+              : std::optional<int64_t>{};
+      if (!padded_dilated_base_opt.has_value()) {
+        return InvalidArgument(
+            "Window padding overflows int64: padding_low=%d, dilated_base=%d, "
+            "padding_high=%d",
+            dim.padding_low(), dilated_base, dim.padding_high());
+      }
+      const int64_t padded_dilated_base = *padded_dilated_base_opt;
       const int64_t dilated_window =
           window_util::DilatedBound(dim.size(), dim.window_dilation());
 


### PR DESCRIPTION
## Problem

`InferWindowOutputShape` in `xla/service/shape_inference.cc` computes the padded dilated base size for `Convolution`, `ReduceWindow`, and `SelectAndScatter` operations using an unchecked `int64_t` addition:

```cpp
const int64_t padded_dilated_base =
    dim.padding_low() + dilated_base + dim.padding_high();
```

`padding_low` and `padding_high` are read directly from the `Window` proto sub-message with no upper bound validation. When their sum with `dilated_base` overflows `int64_t`, the result is a negative value. This is passed directly to `StridedBound` which has an unconditional `CHECK_GE(bound, 0)` that aborts the process in all build configurations:

```cpp
int64_t StridedBound(int64_t bound, ...) {
  CHECK_GE(bound, 0);  // aborts on negative input
  ...
}
```

Example trigger: `padding_low = padding_high = 2^62`, `base_dilation = 1`,
input dimension = 1 → `padded_dilated_base = 2^63 + 1` wraps to `INT64_MIN + 1` → `CHECK_GE(INT64_MIN + 1, 0)` → process abort.

## Fix

Use `OverflowSafeAdd` (already available via `xla/overflow_util.h`, already included in this file) for both additions and return `InvalidArgument` on overflow, consistent with how other overflow conditions are handled in `shape_inference.cc`.

## Changes

- `xla/service/shape_inference.cc`: replace unchecked addition with two `OverflowSafeAdd` calls; return `InvalidArgument` on overflow