### PR TITLE
[HLO] Validate iota tile assignment size in HLO parser

### DIFF
--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -4000,6 +4000,14 @@ bool HloParserImpl::ParseCollectiveDeviceListBase(
     return false;
   }
 
+  if (Product(tile_assignment_dimensions) != Product(iota_reshape_dims)) {
+    VLOG(kErrorLevel)
+        << "Iota tile assignment size " << Product(iota_reshape_dims)
+        << " does not match the tile assignment dimensions product "
+        << Product(tile_assignment_dimensions);
+    return false;
+  }
+
   *device_list = std::make_unique<IotaReplicaGroupList>(
       tile_assignment_dimensions[0], tile_assignment_dimensions[1],
       iota_reshape_dims, iota_transpose_perm);
@@ -4235,6 +4243,12 @@ bool HloParserImpl::ParseMesh(std::optional<Mesh>& mesh) {
                                         iota_transpose_perm) ||
           !ParseToken(TokKind::kRparen, "expected ')' to end device_ids")) {
         return false;
+      }
+      if (Product(axis_sizes) != Product(iota_reshape_dims)) {
+        return TokenError(absl::StrCat(
+            "mesh device_ids iota size ", Product(iota_reshape_dims),
+            " does not match the product of the mesh axis sizes ",
+            Product(axis_sizes)));
       }
       mesh.emplace(
           TileAssignment(axis_sizes, iota_reshape_dims, iota_transpose_perm),
@@ -4836,6 +4850,15 @@ bool HloParserImpl::ParseSingleSharding(std::optional<HloSharding>& sharding,
     }
     if (!iota_reshape_dims.empty()) {
       CHECK(devices.empty());
+      if (Product(tile_assignment_dimensions) != Product(iota_reshape_dims)) {
+        return Error(
+            loc,
+            absl::StrCat("iota tile assignment size ",
+                         Product(iota_reshape_dims),
+                         " does not match the tile assignment dimensions "
+                         "product ",
+                         Product(tile_assignment_dimensions)));
+      }
       sharding =
           subgroup_types.empty()
               ? HloSharding::IotaTile(tile_assignment_dimensions,

--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -4001,11 +4001,10 @@ bool HloParserImpl::ParseCollectiveDeviceListBase(
   }
 
   if (Product(tile_assignment_dimensions) != Product(iota_reshape_dims)) {
-    VLOG(kErrorLevel)
-        << "Iota tile assignment size " << Product(iota_reshape_dims)
-        << " does not match the tile assignment dimensions product "
-        << Product(tile_assignment_dimensions);
-    return false;
+    return TokenError(absl::StrCat(
+        "collective device list iota size ", Product(iota_reshape_dims),
+        " does not match the tile assignment dimensions product ",
+        Product(tile_assignment_dimensions)));
   }
 
   *device_list = std::make_unique<IotaReplicaGroupList>(

--- a/xla/hlo/parser/hlo_parser_test.cc
+++ b/xla/hlo/parser/hlo_parser_test.cc
@@ -3525,6 +3525,30 @@ ENTRY e {
               HasSubstr("does not match the tile assignment size"));
 }
 
+TEST_F(HloParserTest, ShardingIotaSizeMismatchesTileAssignment) {
+  const std::string original = R"(HloModule m
+ENTRY e {
+  p = f32[4,4] parameter(0)
+  ROOT c = f32[4,4] copy(p), sharding={devices=[2,2]<=[16]}
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(),
+              HasSubstr("does not match the tile assignment dimensions "
+                        "product"));
+}
+
+TEST_F(HloParserTest, CollectiveDeviceListIotaSizeMismatch) {
+  const std::string original = R"(HloModule m
+ENTRY e {
+  p = f32[8] parameter(0)
+  ROOT ag = f32[16] all-gather(p), dimensions={0},
+      replica_groups=[2,2]<=[16]
+})";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_FALSE(result.ok());
+}
+
 TEST_F(HloParserTest, WindowRhsReversalWrongSize) {
   const std::string original = R"(HloModule m
 ENTRY e {

--- a/xla/hlo/parser/hlo_parser_test.cc
+++ b/xla/hlo/parser/hlo_parser_test.cc
@@ -3547,6 +3547,9 @@ ENTRY e {
 })";
   auto result = ParseAndReturnUnverifiedModule(original);
   EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(),
+              HasSubstr("does not match the tile assignment dimensions "
+                        "product"));
 }
 
 TEST_F(HloParserTest, WindowRhsReversalWrongSize) {


### PR DESCRIPTION
**Summary of Changes**

Three code paths in the HLO text parser build an iota tile assignment (used by the `sharding=`, `replica_groups=`, and `mesh device_ids=` attributes) from two independent dimension lists without checking that they describe the same total number of elements. This adds that check to all three paths, matching the equivalent validation that already exists for the plain device list form of `sharding=`. Malformed input now returns a parse error instead of silently building an inconsistent tile assignment.

**Justification**

The HLO parser is the entry point for any HLO module supplied as text, including reproducers, debugging tools, and any tooling built on top of the compiler that accepts HLO as a string rather than a compiled artifact. Currently, a module with a mismatched iota tile assignment (for example `sharding={devices=[2,2]<=[16]}`, where the presented dimensions multiply to 4 but the iota reshape dimensions multiply to 16) parses successfully, but the mismatch surfaces later as an unrecoverable `CHECK` failure the first time the tile assignment array is materialized, most commonly during SPMD partitioning. That failure point is far from the actual mistake, which makes it hard to diagnose. This change catches the problem at parse time instead, with a clear error message, the same way the existing check already does for the literal device list form.

**Kind of Contribution:** Bug Fix, Tests

**Unit Tests**

Added `ShardingIotaSizeMismatchesTileAssignment` and `CollectiveDeviceListIotaSizeMismatch` in `hlo_parser_test.cc`, following the same pattern as the existing `ShardingDeviceCountExceedsTileAssignment` test. Both assert that HLO text with mismatched iota dimensions now returns a parse error instead of parsing successfully.

**Execution Tests**

Not applicable. This is a parser-level input validation fix and does not change the semantics or execution behavior of any correctly formed HLO module.