### PR TITLE
[XLA] Return an error instead of crashing on ordered comparisons of complex numbers in HloEvaluator

### DIFF
--- a/xla/hlo/evaluator/hlo_evaluator.cc
+++ b/xla/hlo/evaluator/hlo_evaluator.cc
@@ -165,8 +165,7 @@ absl::StatusOr<Literal> Compare(const Shape& shape, Comparison comparison,
       break;
   }
 
-  LOG(FATAL) << "unhandled direction for conversion to Comparison: "
-             << comparison.ToString();
+  return Unimplemented("Unsupported comparison: %s", comparison.ToString());
 }
 
 std::optional<bool> GetInstructionStaticValueAsBool(

--- a/xla/hlo/evaluator/hlo_evaluator_test.cc
+++ b/xla/hlo/evaluator/hlo_evaluator_test.cc
@@ -6850,6 +6850,24 @@ TEST_F(HloEvaluatorTest, SortC64) {
   EXPECT_TRUE(LiteralTestUtil::Equal(expected, result));
 }
 
+// Ordered comparisons are not defined for complex numbers. The evaluator
+// should return an error instead of crashing (see issue #44936).
+TEST_F(HloEvaluatorTest, OrderedCompareOnComplexReturnsError) {
+  const absl::string_view hlo_text = R"(
+  HloModule m
+
+  ENTRY main {
+    a = c128[2] constant({(1, 2), (3, 4)})
+    b = c128[2] constant({(5, 6), (7, 8)})
+    ROOT lt = pred[2] compare(a, b), direction=LT
+  }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(m_, ParseAndReturnVerifiedModule(hlo_text));
+  absl::Status status = HloEvaluator().Evaluate(*m_, {}).status();
+  EXPECT_EQ(status.code(), ::tsl::error::UNIMPLEMENTED);
+  EXPECT_THAT(status.message(), ::testing::HasSubstr("Unsupported comparison"));
+}
+
 TEST_F(HloEvaluatorTest, ConvertC128ToC64) {
   const absl::string_view hlo_text = R"(
   HloModule m


### PR DESCRIPTION
## 📝 Summary of Changes

Evaluating a `compare` with direction `LT`/`LE`/`GT`/`GE` on complex operands
made `HloEvaluator` hit `LOG(FATAL)` and abort the whole process. This
happened during normal compilation: `HloConstantFolding` calls
`TryEvaluate` on instructions with constant operands, so a constant
ordered compare on `c64`/`c128` crashed the compiler.

This change makes the evaluator return an `Unimplemented` error instead.
The surrounding code already handles this: the `Compare` helper returns
`absl::StatusOr<Literal>`, its caller propagates the status, and constant
folding treats a failed evaluation as "skip this instruction". This matches
what `ElementalIrEmitter::EmitComplexBinaryOp` does for the same case.

Repro (aborts with a check failure before this change, works after):

```
HloModule m

ENTRY main {
  a = c128[2] constant({(1,2),(3,4)})
  b = c128[2] constant({(5,6),(7,8)})
  ROOT lt = pred[2] compare(a, b), direction=LT
}
```

```
$ run_hlo_module --platform=cpu repro.hlo
F0000 ... hlo_evaluator.cc:168] unhandled direction for conversion to Comparison: .LT.C128.PARTIALORDER
*** Check failure stack trace: ***
    @ xla::HloEvaluator::HandleCompare()
    @ xla::HloEvaluator::TryEvaluate()
    @ xla::HloConstantFolding::RunImpl()
    ...
```

## 🎯 Justification

Fixes #44936. Ordered comparisons are not defined for complex numbers, but
such HLO passes shape inference and the verifier, so the evaluator can
receive it from any frontend (the issue hit it from TensorFlow's
floor_divide lowering). A compiler pass should fail with a status, not
abort the process.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

`//xla/hlo/evaluator:hlo_evaluator_test` gets a new
`OrderedCompareOnComplexReturnsError` test that checks the evaluator
returns `UNIMPLEMENTED` for an `LT` compare on `c128`. Without the fix the
test crashes with the check failure; with the fix the whole suite passes.

## 🧪 Execution Tests:

None needed; the change only turns a process abort into an error status in
the evaluator. Verified manually with `run_hlo_module --platform=cpu` on
the repro above: before the change it aborts (exit 134), after it the
module compiles and the reference interpreter reports the comparison as
unimplemented instead of crashing.