### PR TITLE
[XLA:CPU] Clamp materialized dynamic dimension sizes to their bounds

### DIFF
--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -5812,21 +5812,30 @@ absl::Status AlgebraicSimplifierVisitor::HandleConvert(
 
 absl::Status AlgebraicSimplifierVisitor::HandleCustomCall(
     HloInstruction* custom_call) {
-  // Remove redundant slice to dynamic of pad to static
+  // Remove redundant slice to dynamic of pad to static. The dynamic padder
+  // wraps the size operand in clamp(0, size, bound); looking through it is
+  // value-preserving since PadToStatic sizes are within bounds.
   HloInstruction *pad_to_static0, *pad_to_static1, *pad_to_static_operand;
-  if (Match(
-          custom_call,
-          m::CustomCall(
-              {"SliceToDynamic"},
-              m::GetTupleElement(m::CustomCall(&pad_to_static0, {"PadToStatic"},
-                                               m::Op(&pad_to_static_operand)),
-                                 0),
-              m::GetTupleElement(
-                  m::CustomCall(&pad_to_static1, {"PadToStatic"}, m::Op()),
-                  1))) &&
-      pad_to_static0 == pad_to_static1 &&
-      SameShape(custom_call->shape(), pad_to_static_operand->shape())) {
-    return ReplaceInstruction(custom_call, pad_to_static_operand);
+  if (custom_call->shape().IsArray() &&
+      custom_call->shape().dimensions().size() == 1) {
+    auto size_gte = m::GetTupleElement(
+        m::CustomCall(&pad_to_static1, {"PadToStatic"}, m::Op()), 1);
+    if (Match(custom_call,
+              m::CustomCall(
+                  {"SliceToDynamic"},
+                  m::GetTupleElement(
+                      m::CustomCall(&pad_to_static0, {"PadToStatic"},
+                                    m::Op(&pad_to_static_operand)),
+                      0),
+                  m::AnyOf<HloInstruction>(
+                      size_gte,
+                      m::Clamp(m::ConstantScalar(0), size_gte,
+                               m::ConstantScalar(
+                                   custom_call->shape().dimensions(0)))))) &&
+        pad_to_static0 == pad_to_static1 &&
+        SameShape(custom_call->shape(), pad_to_static_operand->shape())) {
+      return ReplaceInstruction(custom_call, pad_to_static_operand);
+    }
   }
   if (options_.is_layout_sensitive() &&
       custom_call->IsCustomCall("LayoutConstraint")) {

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -5879,21 +5879,30 @@ absl::Status AlgebraicSimplifierVisitor::HandleConvert(
 
 absl::Status AlgebraicSimplifierVisitor::HandleCustomCall(
     HloInstruction* custom_call) {
-  // Remove redundant slice to dynamic of pad to static
+  // Remove redundant slice to dynamic of pad to static. The dynamic padder
+  // wraps the size operand in clamp(0, size, bound); looking through it is
+  // value-preserving since PadToStatic sizes are within bounds.
   HloInstruction *pad_to_static0, *pad_to_static1, *pad_to_static_operand;
-  if (Match(
-          custom_call,
-          m::CustomCall(
-              {"SliceToDynamic"},
-              m::GetTupleElement(m::CustomCall(&pad_to_static0, {"PadToStatic"},
-                                               m::Op(&pad_to_static_operand)),
-                                 0),
-              m::GetTupleElement(
-                  m::CustomCall(&pad_to_static1, {"PadToStatic"}, m::Op()),
-                  1))) &&
-      pad_to_static0 == pad_to_static1 &&
-      SameShape(custom_call->shape(), pad_to_static_operand->shape())) {
-    return ReplaceInstruction(custom_call, pad_to_static_operand);
+  if (custom_call->shape().IsArray() &&
+      custom_call->shape().dimensions().size() == 1) {
+    auto size_gte = m::GetTupleElement(
+        m::CustomCall(&pad_to_static1, {"PadToStatic"}, m::Op()), 1);
+    if (Match(custom_call,
+              m::CustomCall(
+                  {"SliceToDynamic"},
+                  m::GetTupleElement(
+                      m::CustomCall(&pad_to_static0, {"PadToStatic"},
+                                    m::Op(&pad_to_static_operand)),
+                      0),
+                  m::AnyOf<HloInstruction>(
+                      size_gte,
+                      m::Clamp(m::ConstantScalar(0), size_gte,
+                               m::ConstantScalar(
+                                   custom_call->shape().dimensions(0)))))) &&
+        pad_to_static0 == pad_to_static1 &&
+        SameShape(custom_call->shape(), pad_to_static_operand->shape())) {
+      return ReplaceInstruction(custom_call, pad_to_static_operand);
+    }
   }
   if (options_.is_layout_sensitive() &&
       custom_call->IsCustomCall("LayoutConstraint")) {

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -5879,7 +5879,7 @@ absl::Status AlgebraicSimplifierVisitor::HandleConvert(
 
 absl::Status AlgebraicSimplifierVisitor::HandleCustomCall(
     HloInstruction* custom_call) {
-  // Remove redundant slice to dynamic of pad to static. The dynamic padder
+  // Remove redundant SliceToDynamic of PadToStatic. The dynamic padder
   // wraps the size operand in clamp(0, size, bound); looking through it is
   // value-preserving since PadToStatic sizes are within bounds.
   HloInstruction *pad_to_static0, *pad_to_static1, *pad_to_static_operand;

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -13367,6 +13367,28 @@ TEST_F(AlgebraicSimplifierTest, NoOpSliceToDynamicOfPadToStatic) {
               GmockMatch(m::Parameter(0)));
 }
 
+TEST_F(AlgebraicSimplifierTest, NoOpSliceToDynamicOfPadToStaticWithClamp) {
+  // The dynamic padder clamps the materialized size to [0, bound]; the
+  // round-trip elimination must look through the clamp.
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule m
+    test {
+      p0 = f32[<=512] parameter(0)
+      c = (f32[512], s32[]) custom-call(p0), custom_call_target="PadToStatic"
+      gte0 = f32[512] get-tuple-element(c), index=0
+      gte1 = s32[] get-tuple-element(c), index=1
+      zero = s32[] constant(0)
+      bound = s32[] constant(512)
+      clamped = s32[] clamp(zero, gte1, bound)
+      ROOT c2 = f32[<=512] custom-call(gte0, clamped), custom_call_target="SliceToDynamic"
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Parameter(0)));
+}
+
 TEST_F(AlgebraicSimplifierTest, DiffShapeSliceToDynamicOfPadToStatic) {
   constexpr absl::string_view kModuleStr = R"(
     HloModule m

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -13103,6 +13103,28 @@ TEST_F(AlgebraicSimplifierTest, NoOpSliceToDynamicOfPadToStatic) {
               GmockMatch(m::Parameter(0)));
 }
 
+TEST_F(AlgebraicSimplifierTest, NoOpSliceToDynamicOfPadToStaticWithClamp) {
+  // The dynamic padder clamps the materialized size to [0, bound]; the
+  // round-trip elimination must look through the clamp.
+  constexpr absl::string_view kModuleStr = R"(
+    HloModule m
+    test {
+      p0 = f32[<=512] parameter(0)
+      c = (f32[512], s32[]) custom-call(p0), custom_call_target="PadToStatic"
+      gte0 = f32[512] get-tuple-element(c), index=0
+      gte1 = s32[] get-tuple-element(c), index=1
+      zero = s32[] constant(0)
+      bound = s32[] constant(512)
+      clamped = s32[] clamp(zero, gte1, bound)
+      ROOT c2 = f32[<=512] custom-call(gte0, clamped), custom_call_target="SliceToDynamic"
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+  ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Parameter(0)));
+}
+
 TEST_F(AlgebraicSimplifierTest, DiffShapeSliceToDynamicOfPadToStatic) {
   constexpr absl::string_view kModuleStr = R"(
     HloModule m

--- a/xla/service/dynamic_padder.cc
+++ b/xla/service/dynamic_padder.cc
@@ -1974,6 +1974,18 @@ absl::StatusOr<HloInstruction*> DynamicShapeRemovingVisitor::ConvertToDynamic(
       if (dimension_size == nullptr) {
         dimension_size = inst->AddInstruction(HloInstruction::CreateConstant(
             LiteralUtil::CreateR0<int32_t>(subshape.dimensions(i))));
+      } else {
+        // Clamp the size to [0, bound]: nothing validates the size operand
+        // of set-dimension-size, and SliceToDynamic uses it as an unchecked
+        // copy bound.
+        HloInstruction* zero = inst->AddInstruction(
+            HloInstruction::CreateConstant(LiteralUtil::CreateR0<int32_t>(0)));
+        HloInstruction* bound =
+            inst->AddInstruction(HloInstruction::CreateConstant(
+                LiteralUtil::CreateR0<int32_t>(subshape.dimensions(i))));
+        dimension_size = inst->AddInstruction(HloInstruction::CreateTernary(
+            dimension_size->shape(), HloOpcode::kClamp, zero, dimension_size,
+            bound));
       }
       slice_operand.push_back(dimension_size);
     }

--- a/xla/service/dynamic_padder.cc
+++ b/xla/service/dynamic_padder.cc
@@ -1973,6 +1973,18 @@ absl::StatusOr<HloInstruction*> DynamicShapeRemovingVisitor::ConvertToDynamic(
       if (dimension_size == nullptr) {
         dimension_size = inst->AddInstruction(HloInstruction::CreateConstant(
             LiteralUtil::CreateR0<int32_t>(subshape.dimensions(i))));
+      } else {
+        // Clamp the size to [0, bound]: nothing validates the size operand
+        // of set-dimension-size, and SliceToDynamic uses it as an unchecked
+        // copy bound.
+        HloInstruction* zero = inst->AddInstruction(
+            HloInstruction::CreateConstant(LiteralUtil::CreateR0<int32_t>(0)));
+        HloInstruction* bound =
+            inst->AddInstruction(HloInstruction::CreateConstant(
+                LiteralUtil::CreateR0<int32_t>(subshape.dimensions(i))));
+        dimension_size = inst->AddInstruction(HloInstruction::CreateTernary(
+            dimension_size->shape(), HloOpcode::kClamp, zero, dimension_size,
+            bound));
       }
       slice_operand.push_back(dimension_size);
     }

--- a/xla/service/dynamic_padder_test.cc
+++ b/xla/service/dynamic_padder_test.cc
@@ -151,6 +151,27 @@ class DynamicPadderTest : public HloTestBase {
   const Shape scalar_shape_ = ShapeUtil::MakeShape(S32, {});
 };
 
+TEST_F(DynamicPadderTest, SliceToDynamicSizeIsClamped) {
+  // Regression test for https://github.com/openxla/xla/issues/44940: the
+  // size operand of set-dimension-size is not otherwise validated, so the
+  // materializing SliceToDynamic must clamp it to [0, bound].
+  const std::string hlo_text = R"(
+HloModule ClampSize
+
+ENTRY main {
+  data = s32[4] parameter(0)
+  size = s32[] parameter(1)
+  ROOT dyn = s32[<=4] set-dimension-size(data, size), dimensions={0}
+}
+)";
+  module_ = GetHloModule(hlo_text);
+  TF_ASSERT_OK(RunPadder(/*slice_dynamic_output=*/true).status());
+  EXPECT_THAT(module_->entry_computation()->root_instruction(),
+              op::CustomCall(
+                  {"SliceToDynamic"}, op::Parameter(0),
+                  op::Clamp(op::Constant(), op::Parameter(1), op::Constant())));
+}
+
 class MemoryAlignmentTest : public HloInterpreterReferenceMixin<HloTestBase> {};
 
 // Test that dynamic padder will not cause memory misalignment in CUDA
@@ -333,10 +354,14 @@ ENTRY main {
   //   SliceToDynamic // Root require dynamic form tensor.
 
   auto* root = module_->entry_computation()->root_instruction();
-  // The final result should use the dynamic size provided by PadToStatic.
-  EXPECT_THAT(root, op::CustomCall(
-                        {"SliceToDynamic"}, op::Negate(),
-                        op::GetTupleElement(op::CustomCall({"PadToStatic"}))));
+  // The final result should use the dynamic size provided by PadToStatic,
+  // clamped to the dimension bound.
+  EXPECT_THAT(
+      root, op::CustomCall(
+                {"SliceToDynamic"}, op::Negate(),
+                op::Clamp(op::Constant(),
+                          op::GetTupleElement(op::CustomCall({"PadToStatic"})),
+                          op::Constant())));
   HloInstruction* negate = root->mutable_operand(0);
   EXPECT_THAT(
       negate,
@@ -1159,6 +1184,36 @@ ENTRY main {
   Literal expected = LiteralUtil::CreateR1<int32_t>({2, 6, 24});
 
   EXPECT_EQ(result, expected);
+}
+
+TEST_F(ExecutionTest, OversizeDynamicDimensionSizeClamped) {
+  // Regression test for https://github.com/openxla/xla/issues/44940: a
+  // runtime size beyond the dimension bound used to become an unchecked
+  // copy bound in SliceToDynamic, corrupting memory.
+  const std::string hlo_text = R"(
+HloModule OversizeDynamicSize
+
+ENTRY main {
+  data = s32[4] parameter(0)
+  size = s32[] parameter(1)
+  ROOT dyn = s32[<=4] set-dimension-size(data, size), dimensions={0}
+}
+)";
+  Literal data = LiteralUtil::CreateR1<int32_t>({1, 2, 3, 4});
+
+  // An oversize runtime size is clamped to the bound.
+  Literal oversize = LiteralUtil::CreateR0<int32_t>(100000);
+  auto module = GetHloModule(hlo_text);
+  TF_ASSERT_OK_AND_ASSIGN(Literal result,
+                          PadAndExecute(std::move(module), {&data, &oversize}));
+  EXPECT_EQ(result.ToStatic(), LiteralUtil::CreateR1<int32_t>({1, 2, 3, 4}));
+
+  // A negative runtime size is clamped to zero.
+  Literal negative = LiteralUtil::CreateR0<int32_t>(-5);
+  module = GetHloModule(hlo_text);
+  TF_ASSERT_OK_AND_ASSIGN(Literal empty_result,
+                          PadAndExecute(std::move(module), {&data, &negative}));
+  EXPECT_EQ(empty_result.ToStatic(), LiteralUtil::CreateR1<int32_t>({}));
 }
 
 TEST_F(ExecutionTest, DynamicConcat) {

--- a/xla/service/dynamic_padder_test.cc
+++ b/xla/service/dynamic_padder_test.cc
@@ -1186,7 +1186,7 @@ ENTRY main {
   EXPECT_EQ(result, expected);
 }
 
-TEST_F(ExecutionTest, OversizeDynamicDimensionSizeClamped) {
+TEST_F(ExecutionTest, OutOfBoundsDynamicDimensionSizeClamped) {
   // Regression test for https://github.com/openxla/xla/issues/44940: a
   // runtime size beyond the dimension bound used to become an unchecked
   // copy bound in SliceToDynamic, corrupting memory.

--- a/xla/service/dynamic_padder_test.cc
+++ b/xla/service/dynamic_padder_test.cc
@@ -151,6 +151,27 @@ class DynamicPadderTest : public HloTestBase {
   const Shape scalar_shape_ = ShapeUtil::MakeShape(S32, {});
 };
 
+TEST_F(DynamicPadderTest, SliceToDynamicSizeIsClamped) {
+  // Regression test for https://github.com/openxla/xla/issues/44940: the
+  // size operand of set-dimension-size is not otherwise validated, so the
+  // materializing SliceToDynamic must clamp it to [0, bound].
+  const std::string hlo_text = R"(
+HloModule ClampSize
+
+ENTRY main {
+  data = s32[4] parameter(0)
+  size = s32[] parameter(1)
+  ROOT dyn = s32[<=4] set-dimension-size(data, size), dimensions={0}
+}
+)";
+  module_ = GetHloModule(hlo_text);
+  TF_ASSERT_OK(RunPadder(/*slice_dynamic_output=*/true).status());
+  EXPECT_THAT(module_->entry_computation()->root_instruction(),
+              op::CustomCall(
+                  {"SliceToDynamic"}, op::Parameter(0),
+                  op::Clamp(op::Constant(), op::Parameter(1), op::Constant())));
+}
+
 class MemoryAlignmentTest : public HloInterpreterReferenceMixin<HloTestBase> {};
 
 // Test that dynamic padder will not cause memory misalignment in CUDA
@@ -316,10 +337,14 @@ ENTRY main {
   //   SliceToDynamic // Root require dynamic form tensor.
 
   auto* root = module_->entry_computation()->root_instruction();
-  // The final result should use the dynamic size provided by PadToStatic.
-  EXPECT_THAT(root, op::CustomCall(
-                        {"SliceToDynamic"}, op::Negate(),
-                        op::GetTupleElement(op::CustomCall({"PadToStatic"}))));
+  // The final result should use the dynamic size provided by PadToStatic,
+  // clamped to the dimension bound.
+  EXPECT_THAT(
+      root, op::CustomCall(
+                {"SliceToDynamic"}, op::Negate(),
+                op::Clamp(op::Constant(),
+                          op::GetTupleElement(op::CustomCall({"PadToStatic"})),
+                          op::Constant())));
   HloInstruction* negate = root->mutable_operand(0);
   EXPECT_THAT(
       negate,
@@ -1106,6 +1131,36 @@ ENTRY main {
   Literal expected = LiteralUtil::CreateR0<int32_t>(6);
 
   EXPECT_EQ(result, expected);
+}
+
+TEST_F(ExecutionTest, OversizeDynamicDimensionSizeClamped) {
+  // Regression test for https://github.com/openxla/xla/issues/44940: a
+  // runtime size beyond the dimension bound used to become an unchecked
+  // copy bound in SliceToDynamic, corrupting memory.
+  const std::string hlo_text = R"(
+HloModule OversizeDynamicSize
+
+ENTRY main {
+  data = s32[4] parameter(0)
+  size = s32[] parameter(1)
+  ROOT dyn = s32[<=4] set-dimension-size(data, size), dimensions={0}
+}
+)";
+  Literal data = LiteralUtil::CreateR1<int32_t>({1, 2, 3, 4});
+
+  // An oversize runtime size is clamped to the bound.
+  Literal oversize = LiteralUtil::CreateR0<int32_t>(100000);
+  auto module = GetHloModule(hlo_text);
+  TF_ASSERT_OK_AND_ASSIGN(Literal result,
+                          PadAndExecute(std::move(module), {&data, &oversize}));
+  EXPECT_EQ(result.ToStatic(), LiteralUtil::CreateR1<int32_t>({1, 2, 3, 4}));
+
+  // A negative runtime size is clamped to zero.
+  Literal negative = LiteralUtil::CreateR0<int32_t>(-5);
+  module = GetHloModule(hlo_text);
+  TF_ASSERT_OK_AND_ASSIGN(Literal empty_result,
+                          PadAndExecute(std::move(module), {&data, &negative}));
+  EXPECT_EQ(empty_result.ToStatic(), LiteralUtil::CreateR1<int32_t>({}));
 }
 
 TEST_F(ExecutionTest, DynamicConcat) {

--- a/xla/service/dynamic_padder_test.cc
+++ b/xla/service/dynamic_padder_test.cc
@@ -288,9 +288,9 @@ ENTRY main {
   //  OpWithDynamicLowering (custom_call_2)
   //     |
   //  PadToStatic
-  //     |
-  //   Negate
-  //     |
+  //     |     \
+  //   Negate  Clamp(0, size, bound)
+  //      \     /
   //   SliceToDynamic // Root require dynamic form tensor.
   auto custom_call_1 =
       module_->entry_computation()->GetInstructionWithName("custom-call.1");
@@ -348,9 +348,9 @@ ENTRY main {
   //   GTE
   //     |
   //  PadToStatic
-  //     |
-  //   Negate
-  //     |
+  //     |     \
+  //   Negate  Clamp(0, size, bound)
+  //      \     /
   //   SliceToDynamic // Root require dynamic form tensor.
 
   auto* root = module_->entry_computation()->root_instruction();


### PR DESCRIPTION
## 📝 Summary of Changes

When the dynamic padder materializes a dynamic tensor as a `SliceToDynamic` custom-call, the inferred runtime dimension sizes become copy-loop bounds in the generated CPU kernel, completely unchecked. Nothing validates the size operand of `set-dimension-size` against the dimension's static bound: runtime shape checks are disabled on CPU (`ShapeCheckMode::kIgnore`), and size inference propagates the operand verbatim. A frontend-produced size larger than the bound therefore makes the kernel write far outside the result allocation (heap corruption or SIGSEGV), and a negative size does the same through sign extension.

This change clamps each materialized size to `[0, bound]` (an HLO `clamp` around the size operand of the created `SliceToDynamic`). For in-contract programs the clamp is a value-level no-op; out-of-contract programs now get a defined, memory-safe truncation instead of undefined behavior, consistent with the pipeline's explicit decision to skip runtime shape checks. Actually implementing runtime shape checks (erroring on invalid sizes) would be the stricter long-term answer, but the existing `ShapeCheckMode::kIgnore` TODO in the CPU pipeline notes that checks were never implemented correctly and that models depend on them being ignored, so that is left as future work.

## 🎯 Justification

Fixes #44940. XLA CPU crashes with `free(): invalid pointer` or SIGSEGV running a TF graph with `tf.raw_ops.Where` on float16: the tf2xla bridge stamps a pre-slice runtime size (up to 1024) onto a shape sliced to bound 4 via `set-dimension-size`, and the SliceToDynamic kernel then copies 1024x4 elements into a 4x4-element buffer. Reduced to a 7-line HLO module: `set-dimension-size` with an oversize size operand segfaults `run_hlo_module` on CPU at head. Eager TensorFlow rejects the original program entirely (no f16 WhereOp on CPU), so XLA is the only path that executes it and must not corrupt memory doing so.

## 🚀 Kind of Contribution

🐛 Bug Fix

The `AlgebraicSimplifier` fold that removes redundant `SliceToDynamic(PadToStatic(x))` round trips is taught to look through the new clamp (validating that the clamp is exactly `clamp(0, size, bound)`), so passthrough graphs keep folding to the original operand and no extra copies are introduced.

## 🧪 Unit Tests:

- `dynamic_padder_test.cc` `SliceToDynamicSizeIsClamped`: the size operand of the materializing `SliceToDynamic` is clamped to `[0, bound]`.
- `DynamicLoweringTestTupleInput` expectation updated for the clamp wrapper.
- `algebraic_simplifier_test.cc` `NoOpSliceToDynamicOfPadToStaticWithClamp`: the round-trip elimination still fires with the clamped size operand.

## 🧪 Execution Tests:

- `dynamic_padder_test.cc` `ExecutionTest.OversizeDynamicDimensionSizeClamped` (CPU): an oversize runtime size returns the bound-sized result and a negative size returns an empty result; both cases crashed the process before the fix. Runs on CPU, no GPUs needed.