### PR TITLE
[XLA] Fix nonnegative inference for signed integer overflow

### DIFF
--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -156,12 +156,19 @@ bool IsPositive(const HloInstruction* hlo,
       }
     }
     case HloOpcode::kPower:
+      if (primitive_util::IsSignedIntegralType(hlo->shape().element_type())) {
+        return false;
+      }
+      return IsPositive(hlo->operand(0), options);
     case HloOpcode::kAbs:
     case HloOpcode::kRsqrt:
     case HloOpcode::kSqrt:
       return IsPositive(hlo->operand(0), options);
 
     case HloOpcode::kMultiply: {
+      if (primitive_util::IsSignedIntegralType(hlo->shape().element_type())) {
+        return false;
+      }
       return hlo->operand(0) == hlo->operand(1) &&
              IsPositive(hlo->operand(0), options);
     }
@@ -534,12 +541,34 @@ bool AlgebraicSimplifierVisitor::IsNonNegative(
   }
   switch (hlo->opcode()) {
     case HloOpcode::kMultiply: {
-      return hlo->operand(0) == hlo->operand(1);
+      return hlo->operand(0) == hlo->operand(1) &&
+             !primitive_util::IsSignedIntegralType(hlo->shape().element_type());
     }
-    case HloOpcode::kAbs:
-    case HloOpcode::kExp:
-    case HloOpcode::kIota: {
+    case HloOpcode::kExp: {
       return true;
+    }
+    case HloOpcode::kIota: {
+      if (!primitive_util::IsSignedIntegralType(hlo->shape().element_type())) {
+        return true;
+      }
+      const auto* iota = Cast<HloIotaInstruction>(hlo);
+      const int64_t dim_size = iota->shape().dimensions(iota->iota_dimension());
+      const int bit_width =
+          primitive_util::BitWidth(hlo->shape().element_type());
+      if (bit_width >= 64) {
+        return true;
+      }
+      // A signed b-bit iota can represent 2^(b-1) non-negative values. The
+      // 64-bit case is handled above, so this shift is at most 62 bits.
+      const uint64_t max_nonnegative_dimension_size = uint64_t{1}
+                                                      << (bit_width - 1);
+      return static_cast<uint64_t>(dim_size) <= max_nonnegative_dimension_size;
+    }
+    case HloOpcode::kAbs: {
+      if (!primitive_util::IsSignedIntegralType(hlo->shape().element_type())) {
+        return true;
+      }
+      return IsNonNegative(hlo->operand(0), options);
     }
     case HloOpcode::kBroadcast: {
       return IsNonNegative(hlo->operand(0), options);
@@ -560,7 +589,9 @@ bool AlgebraicSimplifierVisitor::IsNonNegative(
              IsNonNegative(hlo->operand(1), options);
     }
     case HloOpcode::kPower: {
-      return IsNonNegative(hlo->operand(0), options);
+      return !primitive_util::IsSignedIntegralType(
+                 hlo->shape().element_type()) &&
+             IsNonNegative(hlo->operand(0), options);
     }
     case HloOpcode::kSelect: {
       return IsNonNegative(hlo->operand(1), options) &&

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -167,6 +167,71 @@ TEST_F(AlgebraicSimplifierTest, IsNonNegative_Op_NegativeTestCase) {
   }
 }
 
+TEST_F(AlgebraicSimplifierTest,
+       IsNonNegativeSignedIntegerOverflowNegativeTestCase) {
+  for (const auto op : {"abs(p0)", "multiply(p0, p0)"}) {
+    const auto kModuleStr = absl::StrFormat(R"(
+      HloModule m
+      test {
+        p0 = s8[] parameter(0)
+        ROOT y = s8[] %s
+      }
+    )",
+                                            op);
+    ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+    EXPECT_FALSE(AlgebraicSimplifierVisitor::IsNonNegative(
+        m->entry_computation()->root_instruction(), default_options_));
+  }
+}
+
+TEST_F(AlgebraicSimplifierTest, IsNonNegativeSignedIntegerPowerCanOverflow) {
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+    HloModule m
+    ENTRY test {
+      base = s8[] constant(7)
+      exponent = s8[] constant(7)
+      ROOT power = s8[] power(base, exponent)
+    }
+  )"));
+  EXPECT_FALSE(AlgebraicSimplifierVisitor::IsNonNegative(
+      m->entry_computation()->root_instruction(), default_options_));
+}
+
+TEST_F(AlgebraicSimplifierTest, IsNonNegativeSignedIntegerIotaCanOverflow) {
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+    HloModule m
+    ENTRY test {
+      ROOT iota = s8[129] iota(), iota_dimension=0
+    }
+  )"));
+  ASSERT_FALSE(AlgebraicSimplifierVisitor::IsNonNegative(
+      m->entry_computation()->root_instruction(), default_options_));
+}
+
+TEST_F(AlgebraicSimplifierTest, IsNonNegativeSignedIntegerIotaFitsRange) {
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+    HloModule m
+    ENTRY test {
+      ROOT iota = s8[128] iota(), iota_dimension=0
+    }
+  )"));
+  ASSERT_TRUE(AlgebraicSimplifierVisitor::IsNonNegative(
+      m->entry_computation()->root_instruction(), default_options_));
+}
+
+TEST_F(AlgebraicSimplifierTest,
+       IsNonNegativeSignedIntegerAbsOfNonNegativeOperand) {
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+    HloModule m
+    ENTRY test {
+      iota = s8[128] iota(), iota_dimension=0
+      ROOT abs = s8[128] abs(iota)
+    }
+  )"));
+  ASSERT_TRUE(AlgebraicSimplifierVisitor::IsNonNegative(
+      m->entry_computation()->root_instruction(), default_options_));
+}
+
 // Test that the result of Broadcast is non-negative if its operand is
 // non-negative
 TEST_F(AlgebraicSimplifierTest, IsNonNegative_Broadcast) {
@@ -10394,18 +10459,32 @@ TEST_F(AlgebraicSimplifierTest, CompareIota) {
 }
 
 TEST_F(AlgebraicSimplifierTest, CompareAbsLtZeroBecomesFalse) {
-  // |x| < 0  ->  false
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+  // Floating-point |x| < 0  ->  false.
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
 m {
-  p = s32[5] parameter(0)
-  a = s32[5] abs(p)
-  z = s32[] constant(0)
-  b = s32[5] broadcast(z)
+  p = f32[5] parameter(0)
+  a = f32[5] abs(p)
+  z = f32[] constant(0)
+  b = f32[5] broadcast(z)
   ROOT r = pred[5] compare(a, b), direction=LT
 })"));
   ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
   EXPECT_THAT(m->entry_computation()->root_instruction(),
               GmockMatch(m::Broadcast(m::ConstantScalar(false))));
+}
+
+TEST_F(AlgebraicSimplifierTest, DoesNotFoldSignedIntegerAbsLtZero) {
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+m {
+  p = s8[] parameter(0)
+  a = s8[] abs(p)
+  z = s8[] constant(0)
+  ROOT r = pred[] compare(a, z), direction=LT
+})"));
+  ASSERT_FALSE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Lt(m::Abs(m::Parameter(0)),
+                               m::ConstantEffectiveScalar(0))));
 }
 
 TEST_F(AlgebraicSimplifierTest, CompareLtZero) {
@@ -12142,6 +12221,30 @@ TEST_F(AlgebraicSimplifierTest, AbsEliminationIota) {
   ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
   EXPECT_THAT(m->entry_computation()->root_instruction(),
               GmockMatch(m::Iota()));
+}
+
+TEST_F(AlgebraicSimplifierTest, DoesNotFoldSignedIntegerSquareAbsSelect) {
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+    HloModule m
+    ENTRY test {
+      p0 = s8[4]{0} parameter(0)
+      mul = s8[4]{0} multiply(p0, p0)
+      zero = s8[] constant(0)
+      bcast = s8[4]{0} broadcast(zero), dimensions={}
+      cmp = pred[4]{0} compare(mul, bcast), direction=LT
+      abs = s8[4]{0} abs(mul)
+      ROOT select = s8[4]{0} select(cmp, abs, mul)
+    }
+  )"));
+  ASSERT_FALSE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+
+  HloInstruction* root = m->entry_computation()->root_instruction();
+  EXPECT_EQ(root->opcode(), HloOpcode::kSelect);
+  EXPECT_EQ(root->operand(0)->opcode(), HloOpcode::kCompare);
+  EXPECT_EQ(root->operand(1)->opcode(), HloOpcode::kAbs);
+  EXPECT_EQ(root->operand(2)->opcode(), HloOpcode::kMultiply);
+  EXPECT_EQ(root->operand(0)->operand(0), root->operand(2));
+  EXPECT_EQ(root->operand(1)->operand(0), root->operand(2));
 }
 
 TEST_F(AlgebraicSimplifierTest, SimplifyRedundantBitcastConvert) {


### PR DESCRIPTION
#ai-generated

## 📝 Summary of Changes

Prevent `IsPositive` and `IsNonNegative` from making unsound assumptions when signed integer operations can overflow.

- Treat signed integer square and power results conservatively.
- Handle signed integer `abs` conservatively unless its operand is already known to be non-negative.
- Preserve non-negative inference for signed `iota` only when its dimension fits the element type's non-negative range.
- Keep existing floating-point and safe signed-integer simplifications.
- Add regression coverage for signed `abs`, multiply, power, and iota overflow.

Fixes tensorflow/tensorflow#118178.

This ports the change from tensorflow/tensorflow#122663, which was approved and then closed because XLA changes should be submitted to this repository.

## 🎯 Justification

Signed integer operations can wrap to negative values:

- `abs(s8(-128))` remains `-128`.
- `s8(12) * s8(12)` wraps to `-112`.
- `power(s8(7), s8(7))` wraps to `-9`.
- An `s8[129]` iota exceeds the non-negative `s8` range.

Treating these results as always positive or non-negative can enable unsound algebraic simplifications and miscompile comparisons or `abs`-based expressions.

The TensorFlow issue demonstrates this with an `int8` expression containing multiply, compare, `abs`, and select operations. Eager execution produces the expected absolute values, while XLA incorrectly removes the select/abs logic after assuming that the overflowing square is non-negative.

## 🚀 Kind of Contribution

🐛 Bug Fix  
🧪 Tests

## 📊 Benchmark

Not applicable; this is a correctness fix.

## 🧪 Unit Tests

Added hardware-independent regression tests covering:

- Signed integer `abs` and square results that may be negative after overflow.
- Signed integer power overflow using `power(s8(7), s8(7))`.
- Safe and overflowing signed iota boundaries: `s8[128]` and `s8[129]`.
- Preservation of non-negative inference for signed `abs` with a proven non-negative operand.
- Prevention of unsafe folding for signed `abs < 0` and square/abs/select expressions.
- The multiply/compare/abs/select pattern reported in tensorflow/tensorflow#118178.

Validation performed on PR head `feca4c52acb64a2d841db2a8d93b4bc797d7c943`:

- `clang-format --dry-run --Werror` passes for all affected regions.
- `git diff --check` passes.
- The complete targeted test passes under WSL2 Ubuntu using Bazel 8.7.0 and the hermetic Clang 18 toolchain:

  ```sh
  bazel test //xla/hlo/transforms/simplifiers:algebraic_simplifier_test \
    --test_output=errors \
    --jobs=4 \
    --local_resources=memory=8192
  ```

  Result: `PASSED` (`1/1` Bazel test target).

## 🧪 Execution Tests

None. The change affects a hardware-independent algebraic analysis utility and is covered by the focused HLO unit tests above.