### PR TITLE
[XLA:GPU] Rubin sm107 target upstream

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
@@ -239,9 +239,9 @@ std::vector<std::string> GetNVPTXBackendOptions(
 }
 
 constexpr se::CudaComputeCapability kSupportedVersions[] = {
-    {12, 1}, {12, 0}, {11, 0}, {10, 3}, {10, 0}, {9, 0}, {8, 9}, {8, 7},
-    {8, 6},  {8, 0},  {7, 5},  {7, 2},  {7, 0},  {6, 2}, {6, 1}, {6, 0},
-    {5, 3},  {5, 2},  {5, 0},  {3, 7},  {3, 5},  {3, 2}, {3, 0}};
+    {12, 1}, {12, 0}, {11, 0}, {10, 7}, {10, 3}, {10, 0}, {9, 0}, {8, 9},
+    {8, 7},  {8, 6},  {8, 0},  {7, 5},  {7, 2},  {7, 0},  {6, 2}, {6, 1},
+    {6, 0},  {5, 3},  {5, 2},  {5, 0},  {3, 7},  {3, 5},  {3, 2}, {3, 0}};
 
 se::CudaComputeCapability ResolveSupportedComputeCapability(
     se::CudaComputeCapability compute_capability) {

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
@@ -56,10 +56,10 @@ TEST(UtilsTest, TestGetSmName) {
             "sm_121a");
   // Do not use the extension for a yet-unknown compute capability.
   // https://docs.nvidia.com/cuda/parallel-thread-execution/#release-notes-ptx-release-history
-  ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{10, 9}), "sm_103f");
+  ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{10, 9}), "sm_107f");
   ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{
                 10, 9, FeatureExtension::kAcceleratedFeatures}),
-            "sm_103f");
+            "sm_107f");
   ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{12, 9}), "sm_121f");
   ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{13, 0}), "sm_121");
 }

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
@@ -45,6 +45,13 @@ TEST(UtilsTest, TestGetSmName) {
   ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{
                 10, 3, FeatureExtension::kAcceleratedFeatures}),
             "sm_103a");
+  ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{10, 7}), "sm_107");
+  ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{
+                10, 7, FeatureExtension::kAcceleratedFeatures}),
+            "sm_107a");
+  ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{
+                10, 7, FeatureExtension::kFamilyCompatibleFeatures}),
+            "sm_107f");
   ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{
                 11, 0, FeatureExtension::kAcceleratedFeatures}),
             "sm_110a");
@@ -74,11 +81,11 @@ TEST(UtilsTest, UnknownCapabilityFallsBackToFamilyCompatible) {
   // An unknown compute capability within a known major version falls back to
   // the latest supported minor version with the family compatible extension.
   // This mirrors a yet-unreleased device (e.g. sm_1099a) where ptxas only knows
-  // about sm_103f.
+  // about sm_107f.
   EXPECT_EQ(nvptx::ResolveSupportedComputeCapability(se::CudaComputeCapability{
                 10, 99, FeatureExtension::kAcceleratedFeatures}),
             (se::CudaComputeCapability{
-                10, 3, FeatureExtension::kFamilyCompatibleFeatures}));
+                10, 7, FeatureExtension::kFamilyCompatibleFeatures}));
   // When no family-compatible extension is available, don't use any.
   EXPECT_EQ(nvptx::ResolveSupportedComputeCapability(se::CudaComputeCapability{
                 9, 99, FeatureExtension::kAcceleratedFeatures}),


### PR DESCRIPTION
📝 Summary of Changes
Add SM107 as a supported NVPTX target.

🎯 Justification
Enables NVPTX target for Rubin SM107 GPUs.

🚀 Kind of Contribution
✨ New Feature, 🧪 Tests

🧪 Unit Tests:
xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc