### PR TITLE
[XLA:GPU] Enable cuda13 and ptx9

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
@@ -116,6 +116,9 @@ INSTANTIATE_TEST_SUITE_P(VersionTest, PtxVersionFromCudaVersionTest,
                              {{12, 6, 0}, {8, 5, 0}},
                              {{12, 8, 0}, {8, 7, 0}},
                              {{12, 9, 0}, {8, 8, 0}},
+                             // CUDA 13
+                             {{13, 0, 0}, {9, 0, 0}},
+                             {{13, 1, 0}, {9, 1, 0}},
                          }),
                          [](::testing::TestParamInfo<VersionPair> data) {
                            se::SemanticVersion cuda_version = data.param.first;

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
@@ -119,6 +119,9 @@ INSTANTIATE_TEST_SUITE_P(VersionTest, PtxVersionFromCudaVersionTest,
                              // CUDA 13
                              {{13, 0, 0}, {9, 0, 0}},
                              {{13, 1, 0}, {9, 1, 0}},
+                             {{13, 2, 0}, {9, 2, 0}},
+                             {{13, 3, 0}, {9, 3, 0}},
+                             {{13, 4, 0}, {9, 4, 0}},
                          }),
                          [](::testing::TestParamInfo<VersionPair> data) {
                            se::SemanticVersion cuda_version = data.param.first;

--- a/xla/service/gpu/llvm_gpu_backend/ptx_version_util.cc
+++ b/xla/service/gpu/llvm_gpu_backend/ptx_version_util.cc
@@ -19,7 +19,7 @@ namespace xla::gpu::nvptx {
 
 namespace {
 constexpr stream_executor::SemanticVersion kFallbackPtxVersion{6, 5, 0};
-constexpr stream_executor::SemanticVersion kMaxPtxVersion{9, 1, 0};
+constexpr stream_executor::SemanticVersion kMaxPtxVersion{9, 4, 0};
 }  // namespace
 
 stream_executor::SemanticVersion
@@ -41,7 +41,7 @@ DetermineHighestSupportedPtxVersionFromCudaVersion(
     return {cuda_version.major_version() - 4, cuda_version.minor_version() - 1,
             0};
   }
-  if (cuda_version < stream_executor::SemanticVersion{13, 2, 0}) {
+  if (cuda_version < stream_executor::SemanticVersion{13, 4, 0}) {
     // Examples:
     // CUDA 11.0 -> PTX 7.0
     // CUDA 12.4 -> PTX 8.4

--- a/xla/service/gpu/llvm_gpu_backend/ptx_version_util.cc
+++ b/xla/service/gpu/llvm_gpu_backend/ptx_version_util.cc
@@ -19,7 +19,7 @@ namespace xla::gpu::nvptx {
 
 namespace {
 constexpr stream_executor::SemanticVersion kFallbackPtxVersion{6, 5, 0};
-constexpr stream_executor::SemanticVersion kMaxPtxVersion{9, 0, 0};
+constexpr stream_executor::SemanticVersion kMaxPtxVersion{9, 1, 0};
 }  // namespace
 
 stream_executor::SemanticVersion
@@ -41,7 +41,7 @@ DetermineHighestSupportedPtxVersionFromCudaVersion(
     return {cuda_version.major_version() - 4, cuda_version.minor_version() - 1,
             0};
   }
-  if (cuda_version < stream_executor::SemanticVersion{13, 1, 0}) {
+  if (cuda_version < stream_executor::SemanticVersion{13, 2, 0}) {
     // Examples:
     // CUDA 11.0 -> PTX 7.0
     // CUDA 12.4 -> PTX 8.4


### PR DESCRIPTION
📝 Summary of Changes
Map CUDA 13 to PTX 9.

🎯 Justification
Enables correct PTX selection for CUDA 13 toolchains.

🚀 Kind of Contribution
✨ New Feature, 🧪 Tests

🧪 Unit Tests:
xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc