### PR TITLE
[ROCm] Fix gpu_collectives_test

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -1152,6 +1152,32 @@ cc_library(
 )
 
 cc_library(
+    name = "rccl_registered_memory",
+    srcs = ["rccl_registered_memory.cc"],
+    hdrs = ["rccl_registered_memory.h"],
+    tags = [
+        "gpu",
+        "no-oneapi",
+        "rocm-only",
+    ],
+    visibility = [
+        "//xla/backends/gpu/runtime:__subpackages__",
+    ],
+    deps = [
+        ":rccl_errors",
+        "//xla:util",
+        "//xla/core/collectives:registered_memory",
+        "//xla/stream_executor:device_address",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@local_config_rocm//rocm:rccl",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
+cc_library(
     name = "rccl_communicator",
     srcs = ["rccl_communicator.cc"],
     hdrs = ["rccl_communicator.h"],
@@ -1167,6 +1193,7 @@ cc_library(
         ":gpu_communicator",
         ":rccl_errors",
         ":rccl_group",
+        ":rccl_registered_memory",
         ":rccl_symmetric_memory",
         ":rccl_types",
         ":single_threaded_executor",
@@ -1177,6 +1204,7 @@ cc_library(
         "//xla/core/collectives:communicator",
         "//xla/core/collectives:rank_id",
         "//xla/core/collectives:reduction_kind",
+        "//xla/core/collectives:registered_memory",
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",

--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -429,8 +429,11 @@ TEST(GpuCollectivesTest, PutAndWaitSignal) {
   if (!executors[0]->CanEnablePeerAccessTo(executors[1])) {
     GTEST_SKIP() << "Test requires peer access between devices";
   }
-  if (auto cc = executors[0]->GetDeviceDescription().gpu_compute_capability();
-      cc.IsCuda() && !cc.cuda_compute_capability()->IsAtLeastHopper()) {
+  auto cc = executors[0]->GetDeviceDescription().gpu_compute_capability();
+  if (!cc.IsCuda()) {
+    GTEST_SKIP() << "Test requires CUDA";
+  }
+  if (!cc.cuda_compute_capability()->IsAtLeastHopper()) {
     GTEST_SKIP() << "Test requires at least Hopper architecture";
   }
 

--- a/xla/backends/gpu/collectives/gpu_collectives_test.cc
+++ b/xla/backends/gpu/collectives/gpu_collectives_test.cc
@@ -429,6 +429,8 @@ TEST(GpuCollectivesTest, PutAndWaitSignal) {
   if (!executors[0]->CanEnablePeerAccessTo(executors[1])) {
     GTEST_SKIP() << "Test requires peer access between devices";
   }
+
+  // TODO(rocm): API available in RCCL 2.30, should be enabled in the future
   auto cc = executors[0]->GetDeviceDescription().gpu_compute_capability();
   if (!cc.IsCuda()) {
     GTEST_SKIP() << "Test requires CUDA";

--- a/xla/backends/gpu/collectives/rccl_collectives.cc
+++ b/xla/backends/gpu/collectives/rccl_collectives.cc
@@ -215,9 +215,13 @@ RcclCollectives::CreateCommunicatorsWithCancel(
   if (!clique_ids.has_value() || clique_ids->data().empty()) {
     return InvalidArgument("CliqueId is required to create NCCL communicators");
   }
-  if (clique_ids->data().size() != 1) {
+  int rccl_version;
+  XLA_RCCL_RETURN_IF_ERROR(ncclGetVersion(&rccl_version));
+  if (clique_ids->data().size() != 1 && rccl_version < NCCL_VERSION(2, 23, 0)) {
     return InvalidArgument(
-        "CliqueIds size must be 1 for NCCL communicator initialization");
+        "CliqueIds size must be 1 for communicator initialization for RCCL version "
+        " lower than 2.23 (the linked RCCL version is %d.%d.%d).",
+        rccl_version / 10000, (rccl_version / 100) % 100, rccl_version % 100);
   }
   VLOG(1) << "Initialize NCCL communicator for " << ranks.size() << " devices"
           << "; fingerprint(id)=" << clique_ids->fingerprint();
@@ -244,11 +248,23 @@ RcclCollectives::CreateCommunicatorsWithCancel(
     ASSIGN_OR_RETURN(ncclConfig_t comm_config,
                      AsRcclConfig(gpu_config, device->stream_executor()));
 
-    ASSIGN_OR_RETURN(auto nccl_unique_id, AsRcclUniqueId(clique_ids->at(0)));
+    std::vector<ncclUniqueId> rccl_unique_ids;
+    rccl_unique_ids.reserve(clique_ids->data().size());
+    for (const CliqueId& clique_id : clique_ids->data()) {
+      ASSIGN_OR_RETURN(rccl_unique_ids.emplace_back(),
+                       AsRcclUniqueId(clique_id));
+    }
+
     ncclComm_t comm;
-    XLA_RCCL_RETURN_IF_ERROR(
-        ncclCommInitRankConfig(&comm, clique_key.num_devices(), nccl_unique_id,
-                               ranks[i].rank.value(), &comm_config));
+    if (rccl_unique_ids.size() > 1) {
+      XLA_RCCL_RETURN_IF_ERROR(ncclCommInitRankScalable(
+          &comm, clique_key.num_devices(), ranks[i].rank.value(),
+          rccl_unique_ids.size(), rccl_unique_ids.data(), &comm_config));
+    } else {
+      XLA_RCCL_RETURN_IF_ERROR(ncclCommInitRankConfig(
+          &comm, clique_key.num_devices(), rccl_unique_ids[0],
+          ranks[i].rank.value(), &comm_config));
+    }
     return comm;
   };
 

--- a/xla/backends/gpu/collectives/rccl_collectives.cc
+++ b/xla/backends/gpu/collectives/rccl_collectives.cc
@@ -219,7 +219,8 @@ RcclCollectives::CreateCommunicatorsWithCancel(
   XLA_RCCL_RETURN_IF_ERROR(ncclGetVersion(&rccl_version));
   if (clique_ids->data().size() != 1 && rccl_version < NCCL_VERSION(2, 23, 0)) {
     return InvalidArgument(
-        "CliqueIds size must be 1 for communicator initialization for RCCL version "
+        "CliqueIds size must be 1 for communicator initialization for RCCL "
+        "version "
         " lower than 2.23 (the linked RCCL version is %d.%d.%d).",
         rccl_version / 10000, (rccl_version / 100) % 100, rccl_version % 100);
   }

--- a/xla/backends/gpu/collectives/rccl_communicator.cc
+++ b/xla/backends/gpu/collectives/rccl_communicator.cc
@@ -42,6 +42,7 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/gpu_communicator.h"
 #include "xla/backends/gpu/collectives/rccl_errors.h"
 #include "xla/backends/gpu/collectives/rccl_group.h"
+#include "xla/backends/gpu/collectives/rccl_registered_memory.h"
 #include "xla/backends/gpu/collectives/rccl_symmetric_memory.h"
 #include "xla/backends/gpu/collectives/rccl_types.h"
 #include "xla/backends/gpu/collectives/single_threaded_executor.h"
@@ -585,6 +586,11 @@ absl::Status RcclCommunicator::LaunchRecv(se::DeviceAddressBase recv_buffer,
 absl::StatusOr<std::unique_ptr<SymmetricMemory>>
 RcclCommunicator::CreateSymmetricMemory(se::DeviceAddressBase addr) {
   return RcclSymmetricMemory::Create(comm_, addr);
+}
+
+absl::StatusOr<std::unique_ptr<RegisteredMemory>>
+RcclCommunicator::CreateRegisteredMemory(se::DeviceAddressBase addr) {
+  return RcclRegisteredMemory::Create(comm_, addr);
 }
 
 std::string RcclCommunicator::ToString() const {

--- a/xla/backends/gpu/collectives/rccl_communicator.h
+++ b/xla/backends/gpu/collectives/rccl_communicator.h
@@ -114,6 +114,10 @@ class RcclCommunicator : public GpuCommunicator {
   absl::StatusOr<std::unique_ptr<SymmetricMemory>> CreateSymmetricMemory(
       se::DeviceAddressBase addr) final;
 
+  PlatformCommunicatorHandle platform_comm() const final {
+    return PlatformCommunicatorHandle{comm_};
+  }
+
   std::string ToString() const final;
 
   ncclComm_t comm() const { return comm_; }

--- a/xla/backends/gpu/collectives/rccl_communicator.h
+++ b/xla/backends/gpu/collectives/rccl_communicator.h
@@ -36,6 +36,7 @@ limitations under the License.
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
+#include "xla/core/collectives/registered_memory.h"
 #include "xla/future.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/tsl/concurrency/executor.h"
@@ -112,6 +113,9 @@ class RcclCommunicator : public GpuCommunicator {
                 size_t count, RankId peer, const Executor& executor) final;
 
   absl::StatusOr<std::unique_ptr<SymmetricMemory>> CreateSymmetricMemory(
+      se::DeviceAddressBase addr) final;
+
+  absl::StatusOr<std::unique_ptr<RegisteredMemory>> CreateRegisteredMemory(
       se::DeviceAddressBase addr) final;
 
   PlatformCommunicatorHandle platform_comm() const final {

--- a/xla/backends/gpu/collectives/rccl_registered_memory.cc
+++ b/xla/backends/gpu/collectives/rccl_registered_memory.cc
@@ -1,0 +1,65 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/collectives/rccl_registered_memory.h"
+
+#include <memory>
+#include <string>
+
+#include "absl/log/log.h"
+#include "absl/memory/memory.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "rocm/include/rccl/rccl.h"
+#include "xla/backends/gpu/collectives/rccl_errors.h"
+#include "xla/stream_executor/device_address.h"
+#include "xla/util.h"
+
+namespace xla::gpu {
+
+RcclRegisteredMemory::RcclRegisteredMemory(
+    ncclComm_t comm, void* handle, stream_executor::DeviceAddressBase addr)
+    : comm_(comm), handle_(handle), addr_(addr) {}
+
+absl::StatusOr<std::unique_ptr<RcclRegisteredMemory>>
+RcclRegisteredMemory::Create(ncclComm_t comm,
+                             stream_executor::DeviceAddressBase addr) {
+  VLOG(3) << absl::StrFormat(
+      "Create RCCL registered memory on comm=%p from: ptr=%p; size=%ld", comm,
+      addr.opaque(), addr.size());
+
+  void* handle = nullptr;
+  XLA_RCCL_RETURN_IF_ERROR(
+      ncclCommRegister(comm, addr.opaque(), addr.size(), &handle));
+
+  return absl::WrapUnique(new RcclRegisteredMemory(comm, handle, addr));
+}
+
+RcclRegisteredMemory::~RcclRegisteredMemory() {
+  VLOG(3) << absl::StrFormat("Destroy %v", *this);
+  XLA_RCCL_LOG_IF_ERROR(ncclCommDeregister(comm_, handle_));
+}
+
+stream_executor::DeviceAddressBase RcclRegisteredMemory::addr() const {
+  return addr_;
+}
+
+std::string RcclRegisteredMemory::ToString() const {
+  return absl::StrFormat(
+      "RcclRegisteredMemory(comm=%p, handle=%p, ptr=%p, size=%ld)", comm_,
+      handle_, addr_.opaque(), addr_.size());
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/collectives/rccl_registered_memory.h
+++ b/xla/backends/gpu/collectives/rccl_registered_memory.h
@@ -24,7 +24,6 @@ limitations under the License.
 #include "xla/core/collectives/registered_memory.h"
 #include "xla/stream_executor/device_address.h"
 
-
 namespace xla::gpu {
 
 // A RCCL local buffer registration handle (ncclCommRegister). Registering a

--- a/xla/backends/gpu/collectives/rccl_registered_memory.h
+++ b/xla/backends/gpu/collectives/rccl_registered_memory.h
@@ -1,0 +1,62 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_RCCL_REGISTERED_MEMORY_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_RCCL_REGISTERED_MEMORY_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "rocm/include/rccl/rccl.h"
+#include "xla/core/collectives/registered_memory.h"
+#include "xla/stream_executor/device_address.h"
+
+
+namespace xla::gpu {
+
+// A RCCL local buffer registration handle (ncclCommRegister). Registering a
+// buffer lets RCCL set up IPC / network handles for the range ahead of time so
+// that subsequent collectives over the range can run zero-copy.
+//
+// Unlike RcclSymmetricMemory this does NOT call ncclCommWindowRegister and
+// makes no symmetry assumption about the buffer across ranks: it is safe for
+// arbitrary device address ranges (e.g. slices into a larger allocation) that
+// are not symmetric across the clique. The handle is deregistered
+// (ncclCommDeregister) on destruction. Analogous to NcclRegisteredMemory for
+// the ROCm/RCCL platform.
+class RcclRegisteredMemory final : public RegisteredMemory {
+ public:
+  ~RcclRegisteredMemory() final;
+
+  static absl::StatusOr<std::unique_ptr<RcclRegisteredMemory>> Create(
+      ncclComm_t comm, stream_executor::DeviceAddressBase addr);
+
+  stream_executor::DeviceAddressBase addr() const final;
+
+  std::string ToString() const final;
+
+ private:
+  RcclRegisteredMemory(ncclComm_t comm, void* handle,
+                       stream_executor::DeviceAddressBase addr);
+
+  ncclComm_t comm_;
+  void* handle_;
+  stream_executor::DeviceAddressBase addr_;
+};
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_RCCL_REGISTERED_MEMORY_H_


### PR DESCRIPTION
📝 Summary of Changes
Several subtests were failing due to missing support on the ROCm side:
```
[  FAILED  ] GpuCollectivesTest.CreateWithMultipleIds
[  FAILED  ] GpuCollectivesTest.CreateRegisteredMemory
[  FAILED  ] GpuCollectivesTest.SplitCommunicators
[  FAILED  ] GpuCollectivesTest.CreateSymmetricMemory
[  FAILED  ] GpuCollectivesTest.PutAndWaitSignal
```

This PR:
- Skips `PutAndWaitSignal`  if the platform is not CUDA (mirroring existing `PutAndWaitSignals` test)
- Adds missing `platform_comm()`, which fixes `SplitCommunicators` and `CreateSymmetricMemory`
- Implements `rccl_registered_memory`, mirroring NCCL implementation (fixes  `CreateRegisteredMemory`)
- Adds support for multiple ids on RCCL side (fixes `CreateWithMultipleIds`)

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ✨ New Feature