### PR TITLE
[XLA:GPU] Backport Blackwell FP4 Triton fixes

### DIFF
--- a/third_party/triton/common/blackwell_fp4_mma_padding.patch
+++ b/third_party/triton/common/blackwell_fp4_mma_padding.patch
@@ -1,0 +1,32 @@
+Backport of https://github.com/triton-lang/triton/pull/11151.
+
+--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
++++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+@@ -849,16 +849,25 @@ public:
+     bool isAFP4 = dotOp.getAElemType() == ScaleDotElemType::E2M1;
+     bool isBFP4 = dotOp.getBElemType() == ScaleDotElemType::E2M1;
+ 
+     if (dotOp.getAElemType() != dotOp.getBElemType()) {
+       if (isAFP4)
+         IsAMixedPrecFp4 = true;
+       else if (isBFP4)
+         IsBMixedPrecFp4 = true;
+     }
++
++    bool isFp4MMA = isAFP4 && isBFP4;
++    // mxf4/mxf4nvf4 do not support MN-major operands, so FP4 x FP4 uses
++    // mxf8f6f4 if either operand is not K-packed. The mxf8f6f4 shared-memory
++    // packing format requires padding for every FP4 operand.
++    bool isFp4MMAUsingMxf8f6f4 =
++        isFp4MMA && (!dotOp.getLhsKPack() || !dotOp.getRhsKPack());
+     // If we use txgen05.mma.kind.mxf864 we need to padd the fp4 operands:
+     // https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-packing-formats-mxf8f6f4-smem
+-    bool isMMAv5Fp4PaddedLhs = IsAMixedPrecFp4 || !dotOp.getLhsKPack();
+-    bool isMMAv5Fp4PaddedRhs = IsBMixedPrecFp4 || !dotOp.getRhsKPack();
++    bool isMMAv5Fp4PaddedLhs =
++        IsAMixedPrecFp4 || isFp4MMAUsingMxf8f6f4;
++    bool isMMAv5Fp4PaddedRhs =
++        IsBMixedPrecFp4 || isFp4MMAUsingMxf8f6f4;
+     // For mixed-precision fp4 operands, set allowTranspose = false, to force
+     // the packed axis, K, to be contiguous in SMEM
+     a = getSharedMemoryMMAOperand(a, rewriter, 0,

--- a/third_party/triton/common/series.bzl
+++ b/third_party/triton/common/series.bzl
@@ -41,5 +41,7 @@ common_patch_list = [
     "//third_party/triton:common/convert_layout_heuristic.patch",
     "//third_party/triton:common/llvm_cl947230825.patch",
     "//third_party/triton:common/llvm_cl948082775.patch",
+    "//third_party/triton:common/sm120_fp4_non_k_fallback.patch",
+    "//third_party/triton:common/blackwell_fp4_mma_padding.patch",
     # Add new patches just above this line
 ]

--- a/third_party/triton/common/sm120_fp4_non_k_fallback.patch
+++ b/third_party/triton/common/sm120_fp4_non_k_fallback.patch
@@ -1,0 +1,23 @@
+Backport of https://github.com/triton-lang/triton/pull/10726.
+
+--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
++++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+@@ -746,12 +746,16 @@ public:
+       return elemType == ScaleDotElemType::E2M1;
+     };
+ 
++    bool isFP4xFP4 = isFP4(aElemType) && isFP4(bElemType);
+     // TODO: Enable mixed-precision mxfp for sm120
+-    if (!((isFP8(aElemType) && isFP8(bElemType)) ||
+-          (isFP4(aElemType) && isFP4(bElemType)))) {
++    if (!((isFP8(aElemType) && isFP8(bElemType)) || isFP4xFP4)) {
+       return rewriter.notifyMatchFailure(
+           dotOp, "only FP8xFP8 and FP4xFP4 are supported on sm120");
+     }
++    if (isFP4xFP4 && (!dotOp.getLhsKPack() || !dotOp.getRhsKPack())) {
++      return rewriter.notifyMatchFailure(
++          dotOp, "SM120 native FP4xFP4 requires K-packed operands");
++    }
+ 
+     auto scaleElemType = dotOp.getAScale().getType().getElementType();
+     if (scaleElemType != dotOp.getBScale().getType().getElementType()) {

--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -2789,12 +2789,7 @@ ENTRY e {
       std::move(module), ErrorSpec{/*aabs=*/1e-3, /*arel=*/1e-3}));
 }
 
-// TODO(b/522845225): After fixing random fp4 generation (before it was only 0s,
-// after it's generating uniformly from all fp4 values), we get a small amount
-// of mismatches in the output of this test (~0.2%). It is not clear if this is
-// an actual lowering bug or just a numerical stability issue. For now, we
-// disable the test.
-TEST_P(TritonScaledDotTest, DISABLED_Fp4Succeeds) {
+TEST_P(TritonScaledDotTest, Fp4Succeeds) {
   if (!GetCudaComputeCapability().IsAtLeastBlackwell()) {
     GTEST_SKIP() << "Scaled dot with FP4 isn't supported by Triton for "
                     "pre-Blackwell GPUs.";
@@ -2818,15 +2813,29 @@ TEST_P(TritonScaledDotTest, DISABLED_Fp4Succeeds) {
                        GetOptimizedModule(kHloTextTemplate));
   HloComputation* scaled_dot_computation = GetFirstComputationWithInstruction(
       *optimized_module, HloOpcode::kScaledDot);
-  constexpr absl::string_view kExpectedTritonIr = R"(
+  ASSERT_OK_AND_ASSIGN(GpuBackendConfig gpu_config,
+                       scaled_dot_computation->FusionInstruction()
+                           ->backend_config<GpuBackendConfig>());
+  const BlockLevelFusionConfig& block_level_fusion_config =
+      gpu_config.fusion_backend_config().block_level_fusion_config();
+  ASSERT_EQ(block_level_fusion_config.output_tiles_size(), 1);
+  const auto& output_tile_sizes =
+      block_level_fusion_config.output_tiles(0).sizes();
+  ASSERT_EQ(output_tile_sizes.size(), 3);
+  const int64_t output_m = output_tile_sizes.Get(1);
+  const int64_t output_n = output_tile_sizes.Get(2);
+  ASSERT_EQ(output_n % 2, 0);
+  const std::string expected_triton_ir =
+      absl::Substitute(R"(
       CHECK: tt.dot_scaled
-      CHECK: tensor<128x64xi8>, tensor<128x4xi8>
-      CHECK: tensor<128x16xi8>, tensor<32x4xi8>
-      CHECK: -> tensor<128x32xf32>
-  )";
+      CHECK: tensor<$0x64xi8>, tensor<$0x4xi8>
+      CHECK: tensor<128x$1xi8>, tensor<$2x4xi8>
+      CHECK: -> tensor<$0x$2xf32>
+  )",
+                       output_m, output_n / 2, output_n);
 
   EXPECT_THAT(CreateTritonIrAndFileCheckForDot(*scaled_dot_computation,
-                                               kExpectedTritonIr),
+                                               expected_triton_ir),
               IsOk());
 
   EXPECT_TRUE(RunAndCompareNoHloPasses(


### PR DESCRIPTION
📝 Summary of Changes
Add fixes to enable TritonScaledDotTest.Fp4Succeeds test.

🎯 Justification
- Backport two Triton patches for different support paths: one for [sm_100](https://github.com/triton-lang/triton/pull/11151) and one for [sm_120](https://github.com/triton-lang/triton/pull/10726) devices.
- Replace hardcoded test constants to fix sm_120 error caused by a different choice of tile size (a split of a larger PR https://github.com/openxla/xla/pull/44223).

🚀 Kind of Contribution
🐛 Bug Fix, 🧪 Tests

🧪 Unit Tests:
xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc TritonScaledDotTest.Fp4Succeeds
