### PR TITLE
[XLA:GPU] Drop the identity args-packing spec from custom kernels

### DIFF
--- a/xla/backends/gpu/codegen/kernels/BUILD
+++ b/xla/backends/gpu/codegen/kernels/BUILD
@@ -89,7 +89,6 @@ cc_library(
         ":custom_kernel",
         "//xla/stream_executor:kernel",
         "//xla/stream_executor:kernel_args",
-        "//xla/stream_executor:kernel_args_packing_spec",
         "//xla/stream_executor:kernel_spec",
         "//xla/stream_executor:launch_dim",
         "@com_google_absl//absl/status:statusor",

--- a/xla/backends/gpu/codegen/kernels/BUILD
+++ b/xla/backends/gpu/codegen/kernels/BUILD
@@ -74,7 +74,6 @@ cc_library(
         ":custom_kernel",
         "//xla/stream_executor:kernel",
         "//xla/stream_executor:kernel_args",
-        "//xla/stream_executor:kernel_args_packing_spec",
         "//xla/stream_executor:kernel_spec",
         "//xla/stream_executor:launch_dim",
         "@com_google_absl//absl/status:statusor",

--- a/xla/backends/gpu/codegen/kernels/ptx_custom_kernel.cc
+++ b/xla/backends/gpu/codegen/kernels/ptx_custom_kernel.cc
@@ -26,22 +26,11 @@ limitations under the License.
 #include "xla/backends/gpu/codegen/kernels/custom_kernel.h"
 #include "xla/stream_executor/kernel.h"
 #include "xla/stream_executor/kernel_args.h"
-#include "xla/stream_executor/kernel_args_packing_spec.h"
 #include "xla/stream_executor/kernel_spec.h"
 #include "xla/stream_executor/launch_dim.h"
 
 namespace xla::gpu::kernel {
 namespace se = ::stream_executor;
-
-namespace {
-se::KernelArgsPackingSpec IdentityPackingSpec(int num_args) {
-  se::KernelArgsPackingSpec packing_spec;
-  for (int i = 0; i < num_args; i++) {
-    packing_spec.AddAddressArgument(i);
-  }
-  return packing_spec;
-}
-}  // namespace
 
 // Note: Make sure that the kernel_name matches the kernel name in the ptx,
 // otherwise you will get a "CUDA_ERROR_NOT_FOUND: named symbol not found.".
@@ -53,8 +42,8 @@ absl::StatusOr<CustomKernel> GetPtxCustomKernel(std::string kernel_name,
                                                 se::ThreadDim thread_dim,
                                                 size_t shared_memory_bytes) {
   se::KernelLoaderSpec kernel_spec =
-      se::KernelLoaderSpec::CreateCudaPtxInMemorySpec(
-          ptx, kernel_name, /*arity=*/num_args, IdentityPackingSpec(num_args));
+      se::KernelLoaderSpec::CreateCudaPtxInMemorySpec(ptx, kernel_name,
+                                                      /*arity=*/num_args);
   return CustomKernel(std::move(kernel_name), kernel_spec, block_dim,
                       thread_dim, shared_memory_bytes);
 }
@@ -64,8 +53,8 @@ absl::StatusOr<CustomKernel> GetPtxCustomKernel(
     se::BlockDim block_dim, se::ThreadDim thread_dim,
     se::ClusterDim cluster_dim, size_t shared_memory_bytes) {
   se::KernelLoaderSpec kernel_spec =
-      se::KernelLoaderSpec::CreateCudaPtxInMemorySpec(
-          ptx, kernel_name, /*arity=*/num_args, IdentityPackingSpec(num_args));
+      se::KernelLoaderSpec::CreateCudaPtxInMemorySpec(ptx, kernel_name,
+                                                      /*arity=*/num_args);
   return CustomKernel(std::move(kernel_name), kernel_spec, block_dim,
                       thread_dim, cluster_dim, shared_memory_bytes);
 }
@@ -76,8 +65,7 @@ absl::StatusOr<CustomKernel> GetOwnedPtxCustomKernel(
     size_t shared_memory_bytes) {
   se::KernelLoaderSpec kernel_spec =
       se::KernelLoaderSpec::CreateOwningCudaPtxInMemorySpec(
-          std::move(ptx), kernel_name, /*arity=*/num_args,
-          IdentityPackingSpec(num_args));
+          std::move(ptx), kernel_name, /*arity=*/num_args);
   return CustomKernel(std::move(kernel_name), kernel_spec, block_dim,
                       thread_dim, shared_memory_bytes);
 }
@@ -88,8 +76,7 @@ absl::StatusOr<CustomKernel> CreateOwnedCubinCustomKernel(
     size_t shared_memory_bytes) {
   se::KernelLoaderSpec kernel_spec =
       se::KernelLoaderSpec::CreateOwningCudaCubinInMemorySpec(
-          std::move(cubin), kernel_name, /*arity=*/num_args,
-          IdentityPackingSpec(num_args));
+          std::move(cubin), kernel_name, /*arity=*/num_args);
   return CustomKernel(std::move(kernel_name), std::move(kernel_spec), block_dim,
                       thread_dim, shared_memory_bytes);
 }

--- a/xla/backends/gpu/codegen/kernels/ptx_custom_kernel_test.cc
+++ b/xla/backends/gpu/codegen/kernels/ptx_custom_kernel_test.cc
@@ -103,11 +103,11 @@ TEST(PtxCustomKernelTest, GetPtxCustomKernel) {
   CHECK_OK(stream->Memset32(&b, 2, byte_length));
   CHECK_OK(stream->MemZero(&c, byte_length));
 
-  stream_executor::KernelArgsDeviceAddressArray args(
-      std::vector<se::DeviceAddressBase>({a, b, c}),
-      custom_kernel.shared_memory_bytes());
+  std::vector<se::DeviceAddressBase> buffers = {a, b, c};
+  std::unique_ptr<se::KernelArgsPackedArray> args =
+      se::PackKernelArgs(buffers, custom_kernel.shared_memory_bytes());
   CHECK_OK(kernel->Launch(custom_kernel.thread_dims(),
-                          custom_kernel.block_dims(), stream.get(), args));
+                          custom_kernel.block_dims(), stream.get(), *args));
 
   CHECK_OK(stream->BlockHostUntilDone());
 
@@ -143,11 +143,11 @@ TEST(PtxCustomKernelTest, GetPtxCustomKernelWithClusterDim) {
   CHECK_OK(stream->Memset32(&b, 2, byte_length));
   CHECK_OK(stream->MemZero(&c, byte_length));
 
-  stream_executor::KernelArgsDeviceAddressArray args(
-      std::vector<se::DeviceAddressBase>({a, b, c}),
-      custom_kernel.shared_memory_bytes());
+  std::vector<se::DeviceAddressBase> buffers = {a, b, c};
+  std::unique_ptr<se::KernelArgsPackedArray> args =
+      se::PackKernelArgs(buffers, custom_kernel.shared_memory_bytes());
   CHECK_OK(kernel->Launch(custom_kernel.thread_dims(),
-                          custom_kernel.block_dims(), stream.get(), args));
+                          custom_kernel.block_dims(), stream.get(), *args));
 
   CHECK_OK(stream->BlockHostUntilDone());
 
@@ -222,11 +222,11 @@ TEST(PtxCustomKernelTest, GetOwnedPtxCustomKernel) {
   CHECK_OK(stream->Memset32(&b, 2, byte_length));
   CHECK_OK(stream->MemZero(&c, byte_length));
 
-  stream_executor::KernelArgsDeviceAddressArray args(
-      std::vector<se::DeviceAddressBase>({a, b, c}),
-      custom_kernel.shared_memory_bytes());
+  std::vector<se::DeviceAddressBase> buffers = {a, b, c};
+  std::unique_ptr<se::KernelArgsPackedArray> args =
+      se::PackKernelArgs(buffers, custom_kernel.shared_memory_bytes());
   CHECK_OK(kernel->Launch(custom_kernel.thread_dims(),
-                          custom_kernel.block_dims(), stream.get(), args));
+                          custom_kernel.block_dims(), stream.get(), *args));
 
   CHECK_OK(stream->BlockHostUntilDone());
 

--- a/xla/backends/gpu/runtime/custom_kernel_thunk_test.cc
+++ b/xla/backends/gpu/runtime/custom_kernel_thunk_test.cc
@@ -218,8 +218,9 @@ static absl::StatusOr<se::StreamExecutor*> GpuExecutor() {
 
 // Wraps the AddI32 PTX kernel (c[0] = a[0] + b[0]) as a CustomKernel and
 // returns a CustomKernelThunk bound to the given three allocations. The kernel
-// spec includes a custom args-packing function (required by command buffer
-// CreateLaunch/UpdateLaunch with KernelArgsDeviceAddressArray).
+// spec has no args-packing function; CustomKernelThunk::Record packs the
+// arguments itself, so command buffer CreateLaunch/UpdateLaunch never sees a
+// KernelArgsDeviceAddressArray (which would require one).
 static absl::StatusOr<std::unique_ptr<CustomKernelThunk>>
 MakeAddI32CustomKernelThunk(const std::vector<BufferAllocation>& allocs) {
   absl::string_view ptx =

--- a/xla/backends/gpu/runtime/custom_kernel_thunk_test.cc
+++ b/xla/backends/gpu/runtime/custom_kernel_thunk_test.cc
@@ -215,8 +215,9 @@ static absl::StatusOr<se::StreamExecutor*> GpuExecutor() {
 
 // Wraps the AddI32 PTX kernel (c[0] = a[0] + b[0]) as a CustomKernel and
 // returns a CustomKernelThunk bound to the given three allocations. The kernel
-// spec includes a custom args-packing function (required by command buffer
-// CreateLaunch/UpdateLaunch with KernelArgsDeviceAddressArray).
+// spec has no args-packing function; CustomKernelThunk::Record packs the
+// arguments itself, so command buffer CreateLaunch/UpdateLaunch never sees a
+// KernelArgsDeviceAddressArray (which would require one).
 static absl::StatusOr<std::unique_ptr<CustomKernelThunk>>
 MakeAddI32CustomKernelThunk(const std::vector<BufferAllocation>& allocs) {
   absl::string_view ptx =


### PR DESCRIPTION
📝 Summary of Changes

Drops `IdentityPackingSpec` from the four factories in `ptx_custom_kernel.cc`.

🎯 Justification

This allows to avoid fusion launch re-packing of arguments that are already packed

🚀 Kind of Contribution: ⚡️ Performance Improvement,♻️ Cleanup

📊 Benchmark (for Performance Improvements)
  
`ColabFold` inference on gfx950 with `--xla_gpu_enable_command_buffer=`, wall time drops from 173.1 ms to 160.2 ms per repeat (-7.5%). All of it is host-side. GPU time stay flat. It is measured by the `multihost_hlo_runner` that currently doesn't use delay kernels, so it measures not only GPU time for AMD with `--profile_execution=true`.

With command buffers enabled (default) the change is neutral: the repack is not on the graph-replay path.