### PR TITLE
[XLA] Propagate dynamic dimensions through reshapes that split a dynamic dimension in shape inference

### DIFF
--- a/xla/hlo/builder/xla_builder_test.cc
+++ b/xla/hlo/builder/xla_builder_test.cc
@@ -370,6 +370,24 @@ TEST(XlaBuilderTest, DynamicDimensionReshapeToR0) {
   ASSERT_TRUE(statusor.ok());
 }
 
+TEST(XlaBuilderTest, DynamicDimensionReshapeSplitMultipleNonDegenerate) {
+  // Regression test for https://github.com/openxla/xla/issues/44945: a
+  // dynamic dimension split into multiple non-degenerate dimensions must stay
+  // dynamic on the most-major one instead of being silently dropped.
+  XlaBuilder b(TestName());
+  auto x = Parameter(&b, 0, ShapeUtil::MakeShape(F32, {128, 128}), "x");
+  auto y = Parameter(&b, 1, ShapeUtil::MakeShape(S32, {}), "dyn_dim");
+  auto dx = SetDimensionSize(x, y, 1);
+  Reshape(dx, {64, 2, 64, 2});
+  TF_ASSERT_OK_AND_ASSIGN(const auto module, BuildHloModule(b));
+  const Shape& result_shape =
+      module->entry_computation()->root_instruction()->shape();
+  EXPECT_TRUE(ShapeUtil::Equal(
+      result_shape,
+      ShapeUtil::MakeShape(F32, {64, 2, 64, 2}, {false, false, true, false})))
+      << result_shape.ToString(/*print_layout=*/false);
+}
+
 TEST(XlaBuilderTest, ParameterAlreadyRegistered) {
   XlaBuilder b_call("add");
   Parameter(&b_call, 0, ShapeUtil::MakeShape(PRED, {}), "x");

--- a/xla/service/shape_inference.cc
+++ b/xla/service/shape_inference.cc
@@ -4079,7 +4079,12 @@ ShapeInference::InferCollectivePermuteDoneShape(const Shape& operand_shape) {
           output_non_degenerated.push_back(i);
         }
       }
-      if (output_non_degenerated.size() == 1) {
+      if (!output_non_degenerated.empty()) {
+        // Mark the most-major non-degenerate dimension as dynamic, matching
+        // how DynamicDimensionInference decomposes a split dynamic dimension
+        // (the runtime size is assumed to be a multiple of the static minor
+        // factors of the group). Dropping the dynamism here would silently
+        // bake the bound into consumers such as GetDimensionSize.
         inferred_shape.set_dynamic_dimension(output_non_degenerated[0], true);
       }
     }

--- a/xla/service/shape_inference_test.cc
+++ b/xla/service/shape_inference_test.cc
@@ -1757,6 +1757,53 @@ TEST_F(ShapeInferenceTest, InferReshapeSplit) {
   ASSERT_EQ(ShapeUtil::MakeShape(F32, {1, 10}, {true, false}), *status);
 }
 
+TEST_F(ShapeInferenceTest, InferReshapeSplitSingleNonDegenerate) {
+  // [<=5]
+  //   | reshape
+  // [1, <=5]
+  //
+  // Only one non-degenerate output dimension; it gets the dynamism without an
+  // inferred_dimension tie-break.
+  const Shape operand = ShapeUtil::MakeShape(F32, {5}, {true});
+  const auto status =
+      ShapeInference::InferReshapeShape(operand, {1, 5},
+                                        /*inferred_dimension=*/-1);
+  ASSERT_EQ(ShapeUtil::MakeShape(F32, {1, 5}, {false, true}), *status);
+}
+
+TEST_F(ShapeInferenceTest, InferReshapeSplitMultipleNonDegenerate) {
+  // [<=6]
+  //   | reshape
+  // [<=3, 2]
+  //
+  // A dynamic dimension split into multiple non-degenerate dimensions without
+  // an inferred_dimension tie-break: the most-major non-degenerate output
+  // dimension becomes dynamic. Regression test for
+  // https://github.com/openxla/xla/issues/44945 (the dynamism used to be
+  // silently dropped, so consumers saw the bound instead of the runtime size).
+  const Shape operand = ShapeUtil::MakeShape(F32, {6}, {true});
+  const auto status =
+      ShapeInference::InferReshapeShape(operand, {3, 2},
+                                        /*inferred_dimension=*/-1);
+  ASSERT_EQ(ShapeUtil::MakeShape(F32, {3, 2}, {true, false}), *status);
+}
+
+TEST_F(ShapeInferenceTest, InferReshapeSplitMultipleNonDegenerateWithMajor) {
+  // [128, <=128]
+  //   | reshape
+  // [64, 2, <=64, 2]
+  //
+  // Same as above with a static major group in front, mirroring the Diag
+  // lowering from https://github.com/openxla/xla/issues/44945.
+  const Shape operand = ShapeUtil::MakeShape(S64, {128, 128}, {false, true});
+  const auto status =
+      ShapeInference::InferReshapeShape(operand, {64, 2, 64, 2},
+                                        /*inferred_dimension=*/-1);
+  ASSERT_EQ(
+      ShapeUtil::MakeShape(S64, {64, 2, 64, 2}, {false, false, true, false}),
+      *status);
+}
+
 TEST_F(ShapeInferenceTest, InferReshapeCombine) {
   // [6, <=10]
   //   | reshape


### PR DESCRIPTION
## 📝 Summary of Changes

`ShapeInference::InferReshapeShape` propagates bounded dynamic dimensions
from the operand to the result. When a dynamic input dimension is split into
multiple output dimensions and no `inferred_dimension` tie-break is given, it
only propagated the dynamic bit if exactly one output dimension of the split
group was non-degenerate; with several non-degenerate candidates it silently
dropped the dynamism and returned a fully static result shape.

This change marks the most-major non-degenerate output dimension of the
split group as dynamic instead, matching the decomposition convention that
`DynamicDimensionInference::HandleReshape` already implements at HLO-pass
time (it divides the runtime size by the static minor factors of the group,
and it already trusts dynamic bits recorded in reshape result shapes).

## 🎯 Justification

Fixes the XLA side of #44945. There, a `tf.where` (bounded dynamic output)
-> `tf.linalg.tensor_diag` -> `tf.sparse.from_dense` pipeline compiled with
`jit_compile=True` returns `dense_shape = [64, 2, 64, 2]` (the compile-time
bounds) instead of the runtime sizes. The Diag lowering ends with a reshape
`s64[128,<=128] -> s64[64,2,64,2]` that hits the silent-drop case, so the
result shape is static and `XlaBuilder::GetDimensionSize` constant-folds the
subsequent `Shape` op's size queries to the bounds before any HLO pass runs.
With this change the reshape result is `s64[64,2,<=64,2]`, the size query
for that dimension stays live, and the dynamic padder resolves it to the
correct runtime value (0 in the reported repro).

Note this fixes dimension 2 of the repro's output. Dimensions 0 and 1 lose
their dynamism inside the TF2XLA `Diag` kernel lowering itself (a static
broadcast in `tensorflow/compiler/tf2xla/kernels/diag_op.cc`), which is
frontend-side and out of scope for this change.

Silently dropping the dynamism contradicts the intent of the change that
introduced this propagation ("Previously the reshape's shape inference
silently drop dynamic dimension, which is incorrect. This CL fixes that.")
and cannot be corrected downstream: build-time consumers of the static shape
have already baked in the bounds. It is also unrecoverable at pass time
because `DynamicDimensionInference` skips instructions whose result shape is
static.

Rollout note: programs that previously compiled with silently-wrong bound
semantics may now propagate dynamism further and can newly reach loud
`Unimplemented`/`InvalidArgument` paths at build or pass time (for example a
follow-up reshape that both splits and combines the now-dynamic dimension).
This trades silent wrong numbers for explicit errors.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

- `xla_builder_test.cc`:
  - `DynamicDimensionReshapeSplitMultipleNonDegenerate`: builder-level
    integration test - `SetDimensionSize` + `Reshape([128,<=128] ->
    [64,2,64,2])` must build a root with shape `[64,2,<=64,2]` (failed
    before this change: fully static root).
- `shape_inference_test.cc`:
  - `InferReshapeSplitMultipleNonDegenerate`: `[<=6] -> [3,2]` now infers
    `[<=3,2]` (failed before this change: static `[3,2]`).
  - `InferReshapeSplitMultipleNonDegenerateWithMajor`:
    `[128,<=128] -> [64,2,64,2]` now infers `[64,2,<=64,2]` (failed before
    this change), mirroring the #44945 Diag lowering.
  - `InferReshapeSplitSingleNonDegenerate`: `[<=5] -> [1,5]` still infers
    `[1,<=5]` (guards the previously working case).
- Also verified locally: `//xla/service:shape_inference_test`,
  `//xla/service:dynamic_dimension_inference_test`,
  `//xla/service:dynamic_padder_test`, `//xla/hlo/builder:xla_builder_test`
  all pass, and a brute-force differential comparison of the old and new
  inference over ~96k enumerated reshape cases shows the new behavior only
  ever adds the documented bit (never loses one, never changes an error
  status).

## 🧪 Execution Tests:

Reduced HLO modules mimicking the #44945 Diag pattern, run with
`run_hlo_module` on CPU: with the reshape result annotated the way this
change infers it, `get-dimension-size` on the split dimension returns the
runtime size (0 and 1 for counts 0 and 1) instead of the bound (3); the
dynamic padder handles the divide-by-minor-factors decomposition correctly.