### PR TITLE
[xla:gpu] Add a pre- and post-order traversal hooks to Thunks

### DIFF
--- a/xla/backends/cpu/runtime/conditional_thunk.cc
+++ b/xla/backends/cpu/runtime/conditional_thunk.cc
@@ -71,11 +71,12 @@ absl::StatusOr<std::unique_ptr<ConditionalThunk>> ConditionalThunk::Create(
   branch_executors.reserve(branch_sequences.size());
   for (auto& branch_sequence : branch_sequences) {
     ABSL_ASSIGN_OR_RETURN(auto branch_executor,
-                     ThunkExecutor::Create(std::move(branch_sequence)));
+                          ThunkExecutor::Create(std::move(branch_sequence)));
     branch_executors.push_back(std::move(branch_executor));
   }
 
-  ABSL_ASSIGN_OR_RETURN(Shape shape, ShapeForBranchIndexBuffer(branch_index_buffer));
+  ABSL_ASSIGN_OR_RETURN(Shape shape,
+                        ShapeForBranchIndexBuffer(branch_index_buffer));
 
   return absl::WrapUnique(
       new ConditionalThunk(std::move(info), std::move(branch_index_buffer),

--- a/xla/backends/gpu/runtime/async_thunk.cc
+++ b/xla/backends/gpu/runtime/async_thunk.cc
@@ -109,8 +109,8 @@ absl::Status AsyncStartThunk::ExecuteOnStream(const ExecuteParams& params) {
   return executor_.ExecuteOnStream(params.WithComputeStream(async_stream));
 }
 
-absl::Status AsyncStartThunk::WalkNested(Walker callback) {
-  return executor_.thunks().WalkNested(callback);
+absl::Status AsyncStartThunk::WalkNested(Walker pre_order, Walker post_order) {
+  return executor_.thunks().WalkNested(pre_order, post_order);
 }
 
 absl::Status AsyncStartThunk::TransformNested(Transformer callback) {

--- a/xla/backends/gpu/runtime/async_thunk.h
+++ b/xla/backends/gpu/runtime/async_thunk.h
@@ -81,7 +81,7 @@ class AsyncStartThunk : public Thunk {
   std::string ToString(int indent) const override;
 
  protected:
-  absl::Status WalkNested(Walker callback) override;
+  absl::Status WalkNested(Walker pre_order, Walker post_order) override;
   absl::Status TransformNested(Transformer callback) override;
 
  private:

--- a/xla/backends/gpu/runtime/collective_group_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_group_thunk.cc
@@ -104,8 +104,9 @@ absl::Status CollectiveGroupThunk::ExecuteOnStream(
       comms, [&] { return executor_.ExecuteOnStream(params); });
 }
 
-absl::Status CollectiveGroupThunk::WalkNested(Walker callback) {
-  return executor_.thunks().WalkNested(callback);
+absl::Status CollectiveGroupThunk::WalkNested(Walker pre_order,
+                                              Walker post_order) {
+  return executor_.thunks().WalkNested(pre_order, post_order);
 }
 
 absl::Status CollectiveGroupThunk::TransformNested(Transformer callback) {

--- a/xla/backends/gpu/runtime/collective_group_thunk.h
+++ b/xla/backends/gpu/runtime/collective_group_thunk.h
@@ -43,7 +43,7 @@ class CollectiveGroupThunk : public Thunk {
 
   BufferUses buffer_uses() const override { return {}; }
 
-  absl::Status WalkNested(Walker callback) override;
+  absl::Status WalkNested(Walker pre_order, Walker post_order) override;
   absl::Status TransformNested(Transformer callback) override;
 
   static absl::StatusOr<std::unique_ptr<CollectiveGroupThunk>> FromProto(

--- a/xla/backends/gpu/runtime/command.h
+++ b/xla/backends/gpu/runtime/command.h
@@ -186,10 +186,10 @@ class Command : public Thunk {
   // the user-provided callback on every command. Always starts traversal with
   // *this. These overloads accept Command*-typed callbacks and complement the
   // Thunk*-typed Walk overloads inherited from Thunk.
-  template <typename F, WalkCallback<F, Command*>* = nullptr>
-  std::invoke_result_t<F, Command*> Walk(F&& callback);
-  template <typename F, WalkCallback<F, const Command*>* = nullptr>
-  std::invoke_result_t<F, const Command*> Walk(F&& callback) const;
+  template <typename F>
+  WalkResult<Command*, F> Walk(F&& callback);
+  template <typename F>
+  WalkResult<const Command*, F> Walk(F&& callback) const;
 
  protected:
   // Walks all nested commands and calls `callback` for them. This is separate
@@ -201,7 +201,9 @@ class Command : public Thunk {
     return absl::OkStatus();
   }
 
-  absl::Status WalkNested(Walker callback) override { return absl::OkStatus(); }
+  absl::Status WalkNested(Walker pre_order, Walker post_order) override {
+    return absl::OkStatus();
+  }
 
  private:
   // The token resource is used to specify additional dependency across
@@ -218,24 +220,25 @@ class Command : public Thunk {
 // Command templates implementation.
 //===----------------------------------------------------------------------===//
 
-template <typename F, Command::WalkCallback<F, Command*>*>
-std::invoke_result_t<F, Command*> Command::Walk(F&& callback) {
-  if constexpr (std::is_void_v<std::invoke_result_t<F, Command*>>) {
-    Walk([f = std::forward<F>(callback)](Command* command) {
-      return (f(command), absl::OkStatus());
+template <typename F>
+Command::WalkResult<Command*, F> Command::Walk(F&& callback) {
+  if constexpr (std::is_void_v<WalkResult<Command*, F>>) {
+    Walk([&callback](Command* command) {
+      callback(command);
+      return absl::OkStatus();
     }).IgnoreError();  // Error can never happen here.
   } else {
     ABSL_RETURN_IF_ERROR(callback(this));
-    return WalkNestedCommands([&callback](Command* command) -> absl::Status {
-      return callback(command);
-    });
+    return WalkNestedCommands(callback);
   }
 }
 
-template <typename F, Command::WalkCallback<F, const Command*>*>
-std::invoke_result_t<F, const Command*> Command::Walk(F&& callback) const {
-  return const_cast<Command*>(this)->Walk(  // NOLINT
-      std::forward<F>(callback));
+template <typename F>
+Command::WalkResult<const Command*, F> Command::Walk(F&& callback) const {
+  Command* self = const_cast<Command*>(this);  // NOLINT
+  return self->Walk([&callback](Command* command) {
+    return callback(static_cast<const Command*>(command));
+  });
 }
 
 //===----------------------------------------------------------------------===//

--- a/xla/backends/gpu/runtime/command_buffer_thunk.cc
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.cc
@@ -457,9 +457,10 @@ void CommandBufferThunk::EvictCommandBuffers() {
   }
 }
 
-absl::Status CommandBufferThunk::WalkNested(Walker callback) {
+absl::Status CommandBufferThunk::WalkNested(Walker pre_order,
+                                            Walker post_order) {
   if (thunks_ != nullptr) {
-    ABSL_RETURN_IF_ERROR(thunks_->Walk(callback));
+    ABSL_RETURN_IF_ERROR(thunks_->Walk(pre_order, post_order));
   }
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/runtime/command_buffer_thunk.h
+++ b/xla/backends/gpu/runtime/command_buffer_thunk.h
@@ -72,7 +72,7 @@ class CommandBufferThunk : public Thunk {
 
   BufferUses buffer_uses() const override { return {}; }
 
-  absl::Status WalkNested(Walker callback) override;
+  absl::Status WalkNested(Walker pre_order, Walker post_order) override;
 
   std::string ToString(int indent) const override;
 

--- a/xla/backends/gpu/runtime/conditional_thunk.cc
+++ b/xla/backends/gpu/runtime/conditional_thunk.cc
@@ -300,9 +300,9 @@ absl::Status ConditionalThunk::ExecuteOnStream(const ExecuteParams& params) {
   return absl::OkStatus();
 }
 
-absl::Status ConditionalThunk::WalkNested(Walker callback) {
+absl::Status ConditionalThunk::WalkNested(Walker pre_order, Walker post_order) {
   for (ThunkExecutor& branch_executor : branch_executors_) {
-    ABSL_RETURN_IF_ERROR(branch_executor.thunks().WalkNested(callback));
+    ABSL_RETURN_IF_ERROR(branch_executor.thunks().WalkNested(pre_order, post_order));
   }
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/runtime/conditional_thunk.h
+++ b/xla/backends/gpu/runtime/conditional_thunk.h
@@ -81,7 +81,7 @@ class ConditionalThunk : public Command {
     return branch_index_buffer_index_;
   }
 
-  absl::Status WalkNested(Walker callback) override;
+  absl::Status WalkNested(Walker pre_order, Walker post_order) override;
   absl::Status TransformNested(Transformer callback) override;
 
   bool branch_index_is_bool() const { return branch_index_is_bool_; }

--- a/xla/backends/gpu/runtime/sequential_thunk.cc
+++ b/xla/backends/gpu/runtime/sequential_thunk.cc
@@ -54,8 +54,8 @@ absl::Status SequentialThunk::ExecuteOnStream(const ExecuteParams& params) {
   return executor_.ExecuteOnStream(params);
 }
 
-absl::Status SequentialThunk::WalkNested(Walker callback) {
-  return executor_.thunks().WalkNested(callback);
+absl::Status SequentialThunk::WalkNested(Walker pre_order, Walker post_order) {
+  return executor_.thunks().WalkNested(pre_order, post_order);
 }
 
 absl::Status SequentialThunk::TransformNested(Transformer callback) {

--- a/xla/backends/gpu/runtime/sequential_thunk.h
+++ b/xla/backends/gpu/runtime/sequential_thunk.h
@@ -47,7 +47,7 @@ class SequentialThunk : public Thunk {
 
   BufferUses buffer_uses() const override { return {}; }
 
-  absl::Status WalkNested(Walker callback) override;
+  absl::Status WalkNested(Walker pre_order, Walker post_order) override;
   absl::Status TransformNested(Transformer callback) override;
 
   absl::StatusOr<ThunkProto> ToProto() const override;

--- a/xla/backends/gpu/runtime/thunk.cc
+++ b/xla/backends/gpu/runtime/thunk.cc
@@ -449,6 +449,12 @@ bool Thunk::IsCollective() const {
   }
 }
 
+absl::Status Thunk::WalkNested(Walker, Walker) { return absl::OkStatus(); }
+
+absl::Status Thunk::WalkNested(ConstWalker, ConstWalker) const {
+  return absl::OkStatus();
+}
+
 ThunkMetadataProto Thunk::ToMetadataProto() const {
   ThunkMetadataProto metadata_proto;
   *metadata_proto.mutable_thunk_info() = thunk_info_.ToProto();
@@ -529,6 +535,22 @@ absl::Status ThunkSequence::WalkNested(Thunk::Walker callback) {
 absl::Status ThunkSequence::WalkNested(Thunk::ConstWalker callback) const {
   for (const auto& thunk : *this) {
     ABSL_RETURN_IF_ERROR(thunk->Walk(callback));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status ThunkSequence::WalkNested(Thunk::Walker pre_order,
+                                       Thunk::Walker post_order) {
+  for (auto& thunk : *this) {
+    ABSL_RETURN_IF_ERROR(thunk->Walk(pre_order, post_order));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status ThunkSequence::WalkNested(Thunk::ConstWalker pre_order,
+                                       Thunk::ConstWalker post_order) const {
+  for (const auto& thunk : *this) {
+    ABSL_RETURN_IF_ERROR(thunk->Walk(pre_order, post_order));
   }
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/runtime/thunk.h
+++ b/xla/backends/gpu/runtime/thunk.h
@@ -450,19 +450,30 @@ class Thunk {
   // Returns `true` if this thunk requires inter-GPU communication.
   bool IsCollective() const;
 
-  // Type predicate for `Walk` callback.
-  template <typename F, typename Arg>
-  using WalkCallback =
-      std::enable_if_t<std::is_invocable_v<F, Arg> ||
-                       std::is_invocable_r_v<absl::Status, F, Arg>>;
+  // Return type for `Walk` callbacks. All callbacks must return `void` or all
+  // must return `absl::Status`.
+  template <typename Arg, typename... Fs>
+  using WalkResult = std::enable_if_t<
+      (std::is_void_v<std::invoke_result_t<Fs, Arg>> && ...) ||
+          (std::is_same_v<std::invoke_result_t<Fs, Arg>, absl::Status> && ...),
+      std::common_type_t<std::invoke_result_t<Fs, Arg>...>>;
 
   // Recursively walks all the thunks nested inside *this one and calls the
   // user-provided callback on every thunk. Always starts traversal with *this,
   // and traverses thunks in DFS order.
-  template <typename F, WalkCallback<F, Thunk*>* = nullptr>
-  std::invoke_result_t<F, Thunk*> Walk(F&& callback);
-  template <typename F, WalkCallback<F, const Thunk*>* = nullptr>
-  std::invoke_result_t<F, const Thunk*> Walk(F&& callback) const;
+  template <typename F>
+  WalkResult<Thunk*, F> Walk(F&& callback);
+  template <typename F>
+  WalkResult<const Thunk*, F> Walk(F&& callback) const;
+
+  // Recursively walks all thunks in DFS order. Calls `pre_order` before
+  // visiting nested thunks and `post_order` after visiting them.
+  template <typename PreOrder, typename PostOrder>
+  WalkResult<Thunk*, PreOrder, PostOrder> Walk(PreOrder&& pre_order,
+                                               PostOrder&& post_order);
+  template <typename PreOrder, typename PostOrder>
+  WalkResult<const Thunk*, PreOrder, PostOrder> Walk(
+      PreOrder&& pre_order, PostOrder&& post_order) const;
 
   // Recursively applies transformation to all nested thunks inside *this one.
   // Transformation can be applied optionally by returning the argument back to
@@ -509,13 +520,12 @@ class Thunk {
  protected:
   friend class ThunkSequence;
 
-  // Walks all nested thunks and calls `callback` for them.
+  // Walks all nested thunks and calls `pre_order` and `post_order` for them.
   using Walker = absl::FunctionRef<absl::Status(Thunk*)>;
   using ConstWalker = absl::FunctionRef<absl::Status(const Thunk*)>;
-  virtual absl::Status WalkNested(Walker callback) { return absl::OkStatus(); }
-  virtual absl::Status WalkNested(ConstWalker callback) const {
-    return absl::OkStatus();
-  }
+  virtual absl::Status WalkNested(Walker pre_order, Walker post_order);
+  virtual absl::Status WalkNested(ConstWalker pre_order,
+                                  ConstWalker post_order) const;
 
  private:
   Kind kind_;
@@ -558,6 +568,9 @@ class ThunkSequence : public std::vector<std::unique_ptr<Thunk>> {
   // Walks/Transforms all thunks nested in *this sequence.
   absl::Status WalkNested(Thunk::Walker callback);
   absl::Status WalkNested(Thunk::ConstWalker callback) const;
+  absl::Status WalkNested(Thunk::Walker pre_order, Thunk::Walker post_order);
+  absl::Status WalkNested(Thunk::ConstWalker pre_order,
+                          Thunk::ConstWalker post_order) const;
   absl::Status TransformNested(Thunk::Transformer callback);
 
   // Creates a human-readable representation of a thunk sequence. For each thunk
@@ -582,28 +595,60 @@ ThunkMetadataListProto GetMetadataListProtoFromThunkGraph(
 // Thunk templates implementation.
 //===----------------------------------------------------------------------===//
 
-template <typename F, Thunk::WalkCallback<F, Thunk*>*>
-std::invoke_result_t<F, Thunk*> Thunk::Walk(F&& callback) {
-  if constexpr (std::is_void_v<std::invoke_result_t<F, Thunk*>>) {
-    Walk([f = std::forward<F>(callback)](Thunk* thunk) {
-      return (f(thunk), absl::OkStatus());
+template <typename F>
+Thunk::WalkResult<Thunk*, F> Thunk::Walk(F&& callback) {
+  if constexpr (std::is_void_v<WalkResult<Thunk*, F>>) {
+    Walk([&callback](Thunk* thunk) {
+      callback(thunk);
+      return absl::OkStatus();
     }).IgnoreError();  // Error can never happen here.
   } else {
     ABSL_RETURN_IF_ERROR(callback(this));
-    return WalkNested(Walker([&](Thunk* thunk) { return callback(thunk); }));
+    return WalkNested(Walker([&](Thunk* thunk) { return callback(thunk); }),
+                      Walker([](Thunk*) { return absl::OkStatus(); }));
   }
 }
 
-template <typename F, Thunk::WalkCallback<F, const Thunk*>*>
-std::invoke_result_t<F, const Thunk*> Thunk::Walk(F&& callback) const {
-  Thunk* non_const_this = const_cast<Thunk*>(this);
-  if constexpr (std::is_void_v<std::invoke_result_t<F, const Thunk*>>) {
-    non_const_this->Walk(
-        [f = std::forward<F>(callback)](Thunk* thunk) { f(thunk); });
+template <typename F>
+Thunk::WalkResult<const Thunk*, F> Thunk::Walk(F&& callback) const {
+  Thunk* self = const_cast<Thunk*>(this);  // NOLINT
+  return self->Walk([&callback](Thunk* thunk) {
+    return callback(static_cast<const Thunk*>(thunk));
+  });
+}
+
+template <typename PreOrder, typename PostOrder>
+Thunk::WalkResult<Thunk*, PreOrder, PostOrder> Thunk::Walk(
+    PreOrder&& pre_order, PostOrder&& post_order) {
+  if constexpr (std::is_void_v<WalkResult<Thunk*, PreOrder, PostOrder>>) {
+    Walk(
+        [&pre_order](Thunk* thunk) {
+          pre_order(thunk);
+          return absl::OkStatus();
+        },
+        [&post_order](Thunk* thunk) {
+          post_order(thunk);
+          return absl::OkStatus();
+        })
+        .IgnoreError();  // Error can never happen here.
   } else {
-    return non_const_this->Walk(
-        [f = std::forward<F>(callback)](Thunk* thunk) { return f(thunk); });
+    ABSL_RETURN_IF_ERROR(pre_order(this));
+    ABSL_RETURN_IF_ERROR(WalkNested(Walker(pre_order), Walker(post_order)));
+    return post_order(this);
   }
+}
+
+template <typename PreOrder, typename PostOrder>
+Thunk::WalkResult<const Thunk*, PreOrder, PostOrder> Thunk::Walk(
+    PreOrder&& pre_order, PostOrder&& post_order) const {
+  Thunk* self = const_cast<Thunk*>(this);  // NOLINT
+  return self->Walk(
+      [&pre_order](Thunk* thunk) {
+        return pre_order(static_cast<const Thunk*>(thunk));
+      },
+      [&post_order](Thunk* thunk) {
+        return post_order(static_cast<const Thunk*>(thunk));
+      });
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/runtime/thunk_test.cc
+++ b/xla/backends/gpu/runtime/thunk_test.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/thunk.h"
 
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -28,6 +29,8 @@ limitations under the License.
 
 namespace xla::gpu {
 namespace {
+
+using ::testing::ElementsAre;
 using ::tsl::proto_testing::EqualsProto;
 
 class TestThunk : public Thunk {
@@ -41,6 +44,51 @@ class TestThunk : public Thunk {
     return absl::UnimplementedError("TestThunk::ToProto is not implemented");
   }
 };
+
+class TestNestedThunk : public TestThunk {
+ public:
+  TestNestedThunk(ThunkInfo thunk_info, ThunkSequence nested)
+      : TestThunk(thunk_info), nested_(std::move(nested)) {}
+
+ protected:
+  absl::Status WalkNested(Walker pre_order, Walker post_order) override {
+    return nested_.WalkNested(pre_order, post_order);
+  }
+
+ private:
+  ThunkSequence nested_;
+};
+
+TEST(ThunkTest, WalksInPreAndPostOrder) {
+  auto make_info = [](std::string annotation) {
+    Thunk::ThunkInfo info;
+    info.profile_annotation = std::move(annotation);
+    return info;
+  };
+
+  ThunkSequence nested;
+  nested.push_back(std::make_unique<TestThunk>(make_info("grandchild")));
+
+  ThunkSequence children;
+  children.push_back(std::make_unique<TestThunk>(make_info("child")));
+  children.push_back(std::make_unique<TestNestedThunk>(make_info("nested"),
+                                                       std::move(nested)));
+
+  TestNestedThunk root(make_info("root"), std::move(children));
+  std::vector<std::string> visited;
+  root.Walk(
+      [&](const Thunk* thunk) {
+        visited.push_back("pre " + std::string(thunk->profile_annotation()));
+      },
+      [&](const Thunk* thunk) {
+        visited.push_back("post " + std::string(thunk->profile_annotation()));
+      });
+
+  EXPECT_THAT(visited,
+              ElementsAre("pre root", "pre child", "post child", "pre nested",
+                          "pre grandchild", "post grandchild", "post nested",
+                          "post root"));
+}
 
 TEST(ThunkTest, GetMetadataProto) {
   Thunk::ThunkInfo thunk_info;

--- a/xla/backends/gpu/runtime/while_thunk.cc
+++ b/xla/backends/gpu/runtime/while_thunk.cc
@@ -341,9 +341,10 @@ absl::Status WhileThunk::ExecuteOnStream(const ExecuteParams& params) {
   return absl::OkStatus();
 }
 
-absl::Status WhileThunk::WalkNested(Walker callback) {
-  ABSL_RETURN_IF_ERROR(condition_executor_.thunks().WalkNested(callback));
-  return body_executor_.thunks().WalkNested(callback);
+absl::Status WhileThunk::WalkNested(Walker pre_order, Walker post_order) {
+  ABSL_RETURN_IF_ERROR(
+      condition_executor_.thunks().WalkNested(pre_order, post_order));
+  return body_executor_.thunks().WalkNested(pre_order, post_order);
 }
 
 absl::Status WhileThunk::WalkNestedCommands(CommandWalker callback) {

--- a/xla/backends/gpu/runtime/while_thunk.h
+++ b/xla/backends/gpu/runtime/while_thunk.h
@@ -92,7 +92,7 @@ class WhileThunk : public Command {
       CommandExecutor condition_executor, CommandExecutor body_executor,
       bool enable_loop_unroll);
 
-  absl::Status WalkNested(Walker callback) override;
+  absl::Status WalkNested(Walker pre_order, Walker post_order) override;
   absl::Status TransformNested(Transformer callback) override;
 
   std::string ToString(int indent) const override;


### PR DESCRIPTION
`ThunkSequence` "tree" structure is important for some of the transformation and analysis passes. Add pre and post order traversal hooks to thunk walking API to allow users to discover thunk nesting structure inside the callback.