### PR TITLE
[XLA:GPU][oneAPI][Bugfix] Fix FileCheck patterns for Intel GPU index …

### DIFF
--- a/xla/backends/gpu/tests/gpu_index_test.cc
+++ b/xla/backends/gpu/tests/gpu_index_test.cc
@@ -105,12 +105,18 @@ TEST_F(GpuIndexTest, CompatibleUseLinearIndexWithReshapeAndBroadcast) {
   // passes only during the initial module compilation (e.g., during autotuning
   // in HLO passes). Subsequent compilations hit the cache and skip optimization
   // passes, so we wan to capture the IR during HLO pass execution.
+
+  // The GEP that consumes idx1 is emitted differently per backend:
+  //   - CUDA (NVPTX):    getelementptr ... ptr addrspace(1) ...
+  //   - ROCm (AMDGPU):   getelementptr ... ptr ...   (no addrspace(1))
+  //   - oneAPI (SPIR-V): the GEP lowers to a @llvm.spv.gep intrinsic call.
+  // MakePlatformSpecificLlvm substitutes LINEAR_GEP_IDX1 with the right form.
   EXPECT_OK(CompileAndVerifyIr(std::move(module),
-                               R"(
+                               MakePlatformSpecificLlvm(R"(
 ; CHECK: %[[urem1:.*]] = urem i{{[0-9]*}} %[[linear_index:.*]], 14
 ; CHECK: %[[idx1:.*]] = zext nneg i{{[0-9]*}} %[[urem1]] to i64
-; CHECK: getelementptr inbounds{{( nuw)?}} [4 x i8], ptr{{( addrspace\(1\))?}} %[[alloc:.*]], i64 %[[idx1]]
-      )",
+; CHECK: LINEAR_GEP_IDX1
+      )"),
                                /*match_optimized_ir=*/true,
                                /*run_optimization_passes=*/true,
                                /*match_ir_from_hlo_passes=*/true));

--- a/xla/backends/gpu/tests/gpu_pjrt_codegen_test.cc
+++ b/xla/backends/gpu/tests/gpu_pjrt_codegen_test.cc
@@ -113,7 +113,13 @@ std::string GpuPjRtCodegenTest::MakePlatformSpecificLlvm(
         IsBuiltWithRocm() ? "br i1 %[[LOGICAL_T2]]," : "br i1 %[[LOGICAL_T0]]"},
        {"STORE_v$0FLOAT", IsBuiltWithOneAPI()
                               ? "@llvm.spv.store.v$0f32.p1(<$0 x float>"
-                              : "store <$0 x float>"}});
+                              : "store <$0 x float>"},
+       {"LINEAR_GEP_IDX1",
+        IsBuiltWithOneAPI()
+            ? "@llvm.spv.gep.{{[a-z0-9.]+}}({{.*}}ptr"
+              "{{( addrspace\\([0-9]+\\))?}} {{.*}}i64 %[[idx1]]"
+            : "getelementptr {{.*}} ptr{{( addrspace\\([0-9]+\\))?}} "
+              "{{.*}}i64 %[[idx1]]"}});
 }
 
 absl::StatusOr<std::unique_ptr<Executable>>


### PR DESCRIPTION
…tests

This PR updates index tests to handle SPIR-V codegen differences for `getelementptr`. This fixes Filecheck errors seen in all tests of gpu_index_test for the oneAPI backend.