### PR TITLE
[XLA:CPU] Fix log1p approximation range

### DIFF
--- a/xla/codegen/intrinsic/log1p.cc
+++ b/xla/codegen/intrinsic/log1p.cc
@@ -80,12 +80,10 @@ absl::StatusOr<llvm::Function*> Log1p::CreateDefinition(llvm::Module* module,
   // accurate than the Taylor series.
   auto for_large_x = llvm_ir::EmitCallToIntrinsic(
       llvm::Intrinsic::log, {builder.CreateFAdd(x, one)}, {type}, &builder);
-  // When x is small, (defined to be less than sqrt(2) / 2), use a rational
-  // approximation. The approximation below is based on one from the Cephes
-  // Mathematical Library.
-  //
-  // sqrt(2) - 1.
-  const auto kAntilogarithmIsSmallThreshold = 0.41421356237309504880;
+  // The rational approximation below is based on one from the Cephes
+  // Mathematical Library. For F16 and F32, use it when
+  // abs(x) < sqrt(2) - 1. F64 uses the narrower range defined below.
+  constexpr double kApproxRangeThreshold = 0.41421356237309504880;
 
   static const std::array<double, 7> kDenominatorCoeffs{
       1.,
@@ -116,10 +114,21 @@ absl::StatusOr<llvm::Function*> Log1p::CreateDefinition(llvm::Module* module,
 
   auto abs_x = llvm_ir::EmitCallToIntrinsic(llvm::Intrinsic::fabs,
                                             {input_value}, {type}, &builder);
-  auto x_is_small = builder.CreateFCmpOLT(
-      abs_x, llvm::ConstantFP::get(type, kAntilogarithmIsSmallThreshold));
+  auto x_in_approx_range = builder.CreateFCmpOLT(
+      abs_x, llvm::ConstantFP::get(type, kApproxRangeThreshold));
+  if (intrinsic_type.element_type() == F64) {
+    // For F64, use the approximation only when
+    // 1 / sqrt(2) <= 1 + x <= sqrt(2).
+    constexpr double kF64ApproxLowerBound = -0.29289321881345247560;
+    auto x_is_above_lower_bound = builder.CreateFCmpOGE(
+        x, llvm::ConstantFP::get(type, kF64ApproxLowerBound));
+    auto x_is_below_upper_bound = builder.CreateFCmpOLE(
+        x, llvm::ConstantFP::get(type, kApproxRangeThreshold));
+    x_in_approx_range =
+        builder.CreateAnd(x_is_above_lower_bound, x_is_below_upper_bound);
+  }
   llvm::Value* result =
-      builder.CreateSelect(x_is_small, for_small_x, for_large_x);
+      builder.CreateSelect(x_in_approx_range, for_small_x, for_large_x);
 
   builder.CreateRet(result);
 

--- a/xla/codegen/intrinsic/log1p.cc
+++ b/xla/codegen/intrinsic/log1p.cc
@@ -80,12 +80,11 @@ absl::StatusOr<llvm::Function*> Log1p::CreateDefinition(llvm::Module* module,
   // accurate than the Taylor series.
   auto for_large_x = llvm_ir::EmitCallToIntrinsic(
       llvm::Intrinsic::log, {builder.CreateFAdd(x, one)}, {type}, &builder);
-  // When x is small, (defined to be less than sqrt(2) / 2), use a rational
-  // approximation. The approximation below is based on one from the Cephes
-  // Mathematical Library.
-  //
-  // sqrt(2) - 1.
-  const auto kAntilogarithmIsSmallThreshold = 0.41421356237309504880;
+  // When 1 / sqrt(2) <= 1 + x <= sqrt(2), use a rational approximation.
+  // The approximation below is based on one from the Cephes Mathematical
+  // Library.
+  constexpr double kSmallXLowerBound = -0.29289321881345247560;
+  constexpr double kSmallXUpperBound = 0.41421356237309504880;
 
   static const std::array<double, 7> kDenominatorCoeffs{
       1.,
@@ -114,12 +113,14 @@ absl::StatusOr<llvm::Function*> Log1p::CreateDefinition(llvm::Module* module,
                                    for_small_x);
   for_small_x = builder.CreateFAdd(x, for_small_x);
 
-  auto abs_x = llvm_ir::EmitCallToIntrinsic(llvm::Intrinsic::fabs,
-                                            {input_value}, {type}, &builder);
-  auto x_is_small = builder.CreateFCmpOLT(
-      abs_x, llvm::ConstantFP::get(type, kAntilogarithmIsSmallThreshold));
+  auto x_is_above_lower_bound =
+      builder.CreateFCmpOGE(x, llvm::ConstantFP::get(type, kSmallXLowerBound));
+  auto x_is_below_upper_bound =
+      builder.CreateFCmpOLE(x, llvm::ConstantFP::get(type, kSmallXUpperBound));
+  auto x_in_approx_range =
+      builder.CreateAnd(x_is_above_lower_bound, x_is_below_upper_bound);
   llvm::Value* result =
-      builder.CreateSelect(x_is_small, for_small_x, for_large_x);
+      builder.CreateSelect(x_in_approx_range, for_small_x, for_large_x);
 
   builder.CreateRet(result);
 

--- a/xla/codegen/intrinsic/log1p_test.cc
+++ b/xla/codegen/intrinsic/log1p_test.cc
@@ -76,6 +76,14 @@ std::vector<T> GetTestValues() {
           std::numeric_limits<float>::quiet_NaN()};
 }
 
+std::vector<double> GetF64TestValues() {
+  std::vector<double> test_values = GetTestValues<double>();
+  test_values.insert(
+      test_values.end(),
+      {-0.4141892, -0.35, -0.29289321881345248, 0.41421356237309505});
+  return test_values;
+}
+
 TEST(Log1pTest, F32) {
   Type type = Type::S(F32);
   JitRunner runner = CreateJitRunnerWithLog1p(type);
@@ -97,7 +105,7 @@ TEST(Log1pTest, F64) {
   JitRunner runner = CreateJitRunnerWithLog1p(type);
   auto fn = runner.GetScalarFn<double(double)>(Log1p::Name(type));
 
-  for (double x_val : GetTestValues<double>()) {
+  for (double x_val : GetF64TestValues()) {
     double expected = std::log1p(x_val);
     double result = fn(x_val);
     if (std::isnan(expected)) {


### PR DESCRIPTION
📝 Summary of Changes

Fix the range predicate used to select the rational approximation in the XLA CPU `log1p` intrinsic.

The existing implementation selects the approximation when

```text
abs(x) < sqrt(2) - 1
```

which should be

```text
1 / sqrt(2) <= 1 + x <= sqrt(2)
```

See also https://github.com/gcc-mirror/gcc/blob/36990bb0d14c4840d0250f000559d7a2a569fbc9/libphobos/src/std/math/exponential.d#L3734-L3735.

🎯 Justification

The old predicate incorrectly admits the interval

```text
(-0.414213562373095..., -0.292893218813452...)
```

On CPU this causes errors of up to 129 ULP for F64 `log1p`, including near `x = -0.4141892`.

This also affects JAX operations derived from `log1p`. In particular, `jax.numpy.atanh(0.4141892)` inherits the error from its negative `log1p` term.

See https://github.com/jax-ml/jax/issues/39707.

🚀 Kind of Contribution

Bug Fix