### PR TITLE
[ROCm] Add missing runfiles for libhsa-amd-aqlprofile64.so

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -394,7 +394,10 @@ rocm_lib_import(
 
 rocm_lib_import(
     name = "rocprofiler_sdk",
-    data = glob(["%{rocm_root}/lib/librocprofiler-sdk*.so*"]),
+    data = glob([
+        "%{rocm_root}/lib/librocprofiler-sdk*.so*",
+        "%{rocm_root}/lib/libhsa-amd-aqlprofile64.so*",
+    ]),
     interface_library = "%{rocm_root}/lib/librocprofiler-sdk.so",
     deps = [
         ":amd_comgr_libs",


### PR DESCRIPTION
📝 Summary of Changes
Added missing runfiles for libhsa-amd-aqlprofile64.so

🎯 Justification
Not a direct dep of librocprofiler-sdk.so, but it will be dlopened by libhsa-runtime64.so if former is present.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N\A

🧪 Unit Tests:
N\A

🧪 Execution Tests:
N\A
