### PR TITLE
[XLA] Simplify binary concatenate of a repeated operand to a broadcast

### DIFF
--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -2067,32 +2067,32 @@ absl::Status AlgebraicSimplifierVisitor::HandleConcatenate(
         operands[0], m::Broadcast(m::Op().WithShape(m::Shape().IsScalar())));
     bool is_effective_high_pad = Match(
         operands[1], m::Broadcast(m::Op().WithShape(m::Shape().IsScalar())));
-    if (!is_effective_low_pad && !is_effective_high_pad) {
-      return absl::OkStatus();
-    }
-    PaddingConfig padding_config;
-    for (int64_t dim = 0; dim < operands[0]->shape().dimensions().size();
-         ++dim) {
-      auto padding_config_dim = padding_config.add_dimensions();
-      padding_config_dim->set_edge_padding_high(0);
-      padding_config_dim->set_edge_padding_low(0);
-      padding_config_dim->set_interior_padding(0);
-      if (dim == concatenate_dimension) {
-        if (is_effective_low_pad) {
-          padding_config_dim->set_edge_padding_low(
-              operands[0]->shape().dimensions(dim));
-        } else {
-          padding_config_dim->set_edge_padding_high(
-              operands[1]->shape().dimensions(dim));
+    if (is_effective_low_pad || is_effective_high_pad) {
+      PaddingConfig padding_config;
+      for (int64_t dim = 0; dim < operands[0]->shape().dimensions().size();
+           ++dim) {
+        auto padding_config_dim = padding_config.add_dimensions();
+        padding_config_dim->set_edge_padding_high(0);
+        padding_config_dim->set_edge_padding_low(0);
+        padding_config_dim->set_interior_padding(0);
+        if (dim == concatenate_dimension) {
+          if (is_effective_low_pad) {
+            padding_config_dim->set_edge_padding_low(
+                operands[0]->shape().dimensions(dim));
+          } else {
+            padding_config_dim->set_edge_padding_high(
+                operands[1]->shape().dimensions(dim));
+          }
         }
       }
+      int64_t operand_to_pad = is_effective_low_pad ? 1 : 0;
+      int64_t pad_value_operand = is_effective_low_pad ? 0 : 1;
+      HloInstruction* pad =
+          concatenate->AddInstruction(HloInstruction::CreatePad(
+              concatenate->shape(), operands[operand_to_pad],
+              operands[pad_value_operand]->mutable_operand(0), padding_config));
+      return ReplaceInstruction(concatenate, pad);
     }
-    int64_t operand_to_pad = is_effective_low_pad ? 1 : 0;
-    int64_t pad_value_operand = is_effective_low_pad ? 0 : 1;
-    HloInstruction* pad = concatenate->AddInstruction(HloInstruction::CreatePad(
-        concatenate->shape(), operands[operand_to_pad],
-        operands[pad_value_operand]->mutable_operand(0), padding_config));
-    return ReplaceInstruction(concatenate, pad);
   }
 
   if (absl::c_count(operands, operands[0]) == operands.size() &&

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -2099,32 +2099,32 @@ absl::Status AlgebraicSimplifierVisitor::HandleConcatenate(
         operands[0], m::Broadcast(m::Op().WithShape(m::Shape().IsScalar())));
     bool is_effective_high_pad = Match(
         operands[1], m::Broadcast(m::Op().WithShape(m::Shape().IsScalar())));
-    if (!is_effective_low_pad && !is_effective_high_pad) {
-      return absl::OkStatus();
-    }
-    PaddingConfig padding_config;
-    for (int64_t dim = 0; dim < operands[0]->shape().dimensions().size();
-         ++dim) {
-      auto padding_config_dim = padding_config.add_dimensions();
-      padding_config_dim->set_edge_padding_high(0);
-      padding_config_dim->set_edge_padding_low(0);
-      padding_config_dim->set_interior_padding(0);
-      if (dim == concatenate_dimension) {
-        if (is_effective_low_pad) {
-          padding_config_dim->set_edge_padding_low(
-              operands[0]->shape().dimensions(dim));
-        } else {
-          padding_config_dim->set_edge_padding_high(
-              operands[1]->shape().dimensions(dim));
+    if (is_effective_low_pad || is_effective_high_pad) {
+      PaddingConfig padding_config;
+      for (int64_t dim = 0; dim < operands[0]->shape().dimensions().size();
+           ++dim) {
+        auto padding_config_dim = padding_config.add_dimensions();
+        padding_config_dim->set_edge_padding_high(0);
+        padding_config_dim->set_edge_padding_low(0);
+        padding_config_dim->set_interior_padding(0);
+        if (dim == concatenate_dimension) {
+          if (is_effective_low_pad) {
+            padding_config_dim->set_edge_padding_low(
+                operands[0]->shape().dimensions(dim));
+          } else {
+            padding_config_dim->set_edge_padding_high(
+                operands[1]->shape().dimensions(dim));
+          }
         }
       }
+      int64_t operand_to_pad = is_effective_low_pad ? 1 : 0;
+      int64_t pad_value_operand = is_effective_low_pad ? 0 : 1;
+      HloInstruction* pad =
+          concatenate->AddInstruction(HloInstruction::CreatePad(
+              concatenate->shape(), operands[operand_to_pad],
+              operands[pad_value_operand]->mutable_operand(0), padding_config));
+      return ReplaceInstruction(concatenate, pad);
     }
-    int64_t operand_to_pad = is_effective_low_pad ? 1 : 0;
-    int64_t pad_value_operand = is_effective_low_pad ? 0 : 1;
-    HloInstruction* pad = concatenate->AddInstruction(HloInstruction::CreatePad(
-        concatenate->shape(), operands[operand_to_pad],
-        operands[pad_value_operand]->mutable_operand(0), padding_config));
-    return ReplaceInstruction(concatenate, pad);
   }
 
   if (absl::c_count(operands, operands[0]) == operands.size() &&

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -8442,6 +8442,25 @@ TEST_F(AlgebraicSimplifierTest, ConcatToBroadcast) {
   EXPECT_THAT(root, GmockMatch(m::Broadcast(m::Reshape(m::Parameter(0)))));
 }
 
+TEST_F(AlgebraicSimplifierTest, BinaryConcatToBroadcast) {
+  constexpr absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY test {
+      p = f32[2,1,4] parameter(0)
+      ROOT concat = f32[2,2,4] concatenate(p,p), dimensions={1}
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  AlgebraicSimplifierOptions options = default_options_;
+  AlgebraicSimplifier simplifier(options);
+  ASSERT_THAT(simplifier.Run(module.get()), absl_testing::IsOkAndHolds(true));
+  auto root = module->entry_computation()->root_instruction();
+  EXPECT_THAT(root, GmockMatch(m::Broadcast(m::Reshape(m::Parameter(0)))));
+}
+
 TEST_F(AlgebraicSimplifierTest, NegateNegate) {
   constexpr absl::string_view hlo_string = R"(
     HloModule module

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -8217,6 +8217,25 @@ TEST_F(AlgebraicSimplifierTest, ConcatToBroadcast) {
   EXPECT_THAT(root, GmockMatch(m::Broadcast(m::Reshape(m::Parameter(0)))));
 }
 
+TEST_F(AlgebraicSimplifierTest, BinaryConcatToBroadcast) {
+  constexpr absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY test {
+      p = f32[2,1,4] parameter(0)
+      ROOT concat = f32[2,2,4] concatenate(p,p), dimensions={1}
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  AlgebraicSimplifierOptions options = default_options_;
+  AlgebraicSimplifier simplifier(options);
+  ASSERT_THAT(simplifier.Run(module.get()), absl_testing::IsOkAndHolds(true));
+  auto root = module->entry_computation()->root_instruction();
+  EXPECT_THAT(root, GmockMatch(m::Broadcast(m::Reshape(m::Parameter(0)))));
+}
+
 TEST_F(AlgebraicSimplifierTest, NegateNegate) {
   constexpr absl::string_view hlo_string = R"(
     HloModule module

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -8451,8 +8451,7 @@ TEST_F(AlgebraicSimplifierTest, BinaryConcatToBroadcast) {
       ROOT concat = f32[2,2,4] concatenate(p,p), dimensions={1}
     }
   )";
-  TF_ASSERT_OK_AND_ASSIGN(auto module,
-                          ParseAndReturnVerifiedModule(hlo_string));
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
 
   AlgebraicSimplifierOptions options = default_options_;
   AlgebraicSimplifier simplifier(options);


### PR DESCRIPTION
#ai-generated

`HandleConcatenate` returns early for a two-operand concatenate whose operands are not a broadcasted scalar. That early return sits above the `Concat(X, X, ...)` to broadcast-of-reshape rewrite, so the rewrite fires for three or more operands and never for exactly two.

This is issue #26780. The five-operand form is simplified:

```
ENTRY main {
  x = s8[2,1,4] parameter(0)
  ROOT concat = s8[2,5,4] concatenate(x, x, x, x, x), dimensions={1}
}
```

while the two-operand form is left alone:

```
ENTRY main {
  x = s8[3,1,4] parameter(0)
  ROOT concat = s8[3,2,4] concatenate(x, x), dimensions={1}
}
```

A concatenate materializes its result, a broadcast of a reshape does not and fuses into its consumer, so the two-operand case pays for a copy that the three-or-more case avoids. Doubling a degenerate dimension is a common shape after a reshape or an expand_dims, so the gap is easy to hit.

The fix guards the concat-to-pad rewrite with its scalar-broadcast condition instead of returning from the function, so the two-operand case falls through to the existing degenerate-dimension check. Precedence is unchanged: a two-operand concatenate with a broadcasted scalar operand still becomes a pad. Most of the diff is the reindentation that guard causes.

Verification: I did not build XLA for this change, so the argument is by reading. The new `BinaryConcatToBroadcast` test mirrors the existing `ConcatToBroadcast` test with two operands instead of six, and the touched lines are clang-format clean.
