### PR TITLE
[XLA] Support bit-width-changing bitcast-convert in the dynamic padder

### DIFF
--- a/xla/service/dynamic_padder.cc
+++ b/xla/service/dynamic_padder.cc
@@ -154,6 +154,10 @@ absl::StatusOr<HloInstruction*> ChooseIdentityValue(HloInstruction* inst,
     case HloOpcode::kDynamicUpdateSlice:
     case HloOpcode::kGetDimensionSize:
     case HloOpcode::kSetDimensionSize:
+    // Bit-width-changing bitcast-converts are not elementwise, but padding
+    // data reinterprets to padding data; the minor dimension they add or
+    // remove is static (shape inference rejects a dynamic one).
+    case HloOpcode::kBitcastConvert:
     case HloOpcode::kConcatenate:
     case HloOpcode::kReshape:
     case HloOpcode::kReverse:

--- a/xla/service/dynamic_padder_test.cc
+++ b/xla/service/dynamic_padder_test.cc
@@ -363,6 +363,53 @@ ENTRY main {
               op::Tuple(op::Constant(), op::CustomCall({"SliceToDynamic"})));
 }
 
+TEST_F(DynamicPadderTest, BitcastConvertWideningWithDynamicDimension) {
+  // Regression test for https://github.com/openxla/xla/issues/45967:
+  // a bit-width-changing bitcast-convert on an operand with a dynamic
+  // dimension made the dynamic padder fail with an Unimplemented error.
+  const std::string hlo_text = R"(
+HloModule BitcastConvertWidening
+
+ENTRY main {
+  param = s64[16,1] parameter(0)
+  size = s32[] parameter(1)
+  param_dynamic = s64[<=16,1] set-dimension-size(param, size), dimensions={0}
+  ROOT bitcast = f32[<=16,1,2] bitcast-convert(param_dynamic)
+}
+)";
+
+  module_ = GetHloModule(hlo_text);
+
+  TF_ASSERT_OK(RunPadder(/*slice_dynamic_output=*/true).status());
+  XLA_LOG_LINES(INFO, module_->ToString());
+
+  auto* root = module_->entry_computation()->root_instruction();
+  EXPECT_THAT(root, op::CustomCall({"SliceToDynamic"}));
+}
+
+TEST_F(DynamicPadderTest, BitcastConvertNarrowingWithDynamicDimension) {
+  // Same as above, in the narrowing direction: the major dimensions of the
+  // consumed shape may be dynamic (the contracted minor dimension is static).
+  const std::string hlo_text = R"(
+HloModule BitcastConvertNarrowing
+
+ENTRY main {
+  param = f32[16,2] parameter(0)
+  size = s32[] parameter(1)
+  param_dynamic = f32[<=16,2] set-dimension-size(param, size), dimensions={0}
+  ROOT bitcast = s64[<=16] bitcast-convert(param_dynamic)
+}
+)";
+
+  module_ = GetHloModule(hlo_text);
+
+  TF_ASSERT_OK(RunPadder(/*slice_dynamic_output=*/true).status());
+  XLA_LOG_LINES(INFO, module_->ToString());
+
+  auto* root = module_->entry_computation()->root_instruction();
+  EXPECT_THAT(root, op::CustomCall({"SliceToDynamic"}));
+}
+
 TEST_F(DynamicPadderTest, ConvolutionTest) {
   auto builder = HloComputation::Builder(TestName());
   constexpr int xdim = 3;
@@ -1141,6 +1188,53 @@ ENTRY main {
                     false));
   result.SetDynamicSize(0, 7);
   Literal expected = LiteralUtil::CreateR1<int32_t>({1, 2, 3, 4, 5, 6, 7});
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST_F(ExecutionTest, BitcastConvertWideningWithDynamicDimension) {
+  const std::string hlo_text = R"(
+HloModule BitcastConvertWidening
+
+ENTRY main {
+  param_0 = s64[3] parameter(0)
+  size = s32[] constant(2)
+  param_padded = s64[<=3] set-dimension-size(param_0, size), dimensions={0}
+  ROOT bitcast = s32[<=3,2] bitcast-convert(param_padded)
+}
+)";
+
+  Literal operand_0 = LiteralUtil::CreateR1<int64_t>({1, 2, -1});
+  auto module = GetHloModule(hlo_text);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      Literal result, PadAndExecute(std::move(module), {&operand_0}, false));
+  result.SetDynamicSize(0, 2);
+  Literal expected = LiteralUtil::CreateR2<int32_t>({{1, 0}, {2, 0}});
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST_F(ExecutionTest, BitcastConvertNarrowingWithDynamicDimension) {
+  const std::string hlo_text = R"(
+HloModule BitcastConvertNarrowing
+
+ENTRY main {
+  param_0 = s32[3,2] parameter(0)
+  size = s32[] constant(2)
+  param_padded = s32[<=3,2] set-dimension-size(param_0, size), dimensions={0}
+  ROOT bitcast = s64[<=3] bitcast-convert(param_padded)
+}
+)";
+
+  Literal operand_0 =
+      LiteralUtil::CreateR2<int32_t>({{1, 0}, {2, 0}, {-1, -1}});
+  auto module = GetHloModule(hlo_text);
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      Literal result, PadAndExecute(std::move(module), {&operand_0}, false));
+  result.SetDynamicSize(0, 2);
+  Literal expected = LiteralUtil::CreateR1<int64_t>({1, 2});
 
   EXPECT_EQ(result, expected);
 }

--- a/xla/service/shape_inference.cc
+++ b/xla/service/shape_inference.cc
@@ -656,6 +656,13 @@ absl::StatusOr<DimAndBound> InferMostSpecificDimAndBound(int64_t dim,
           ShapeUtil::HumanString(operand_shape),
           PrimitiveType_Name(new_element_type));
     }
+    if (operand_shape.is_dynamic_dimension(last_dimension_idx)) {
+      return InvalidArgument(
+          "Last dimension of input shape must be static for bitcast-convert "
+          "from %s to %s",
+          ShapeUtil::HumanString(operand_shape),
+          PrimitiveType_Name(new_element_type));
+    }
     new_shape.DeleteDimension(last_dimension_idx);
   }
   return new_shape;

--- a/xla/service/shape_inference_test.cc
+++ b/xla/service/shape_inference_test.cc
@@ -278,6 +278,28 @@ TEST_F(ShapeInferenceTest, BitcastConvertPredToF32) {
       << " expected: " << ShapeUtil::HumanString(expected);
 }
 
+TEST_F(ShapeInferenceTest, BitcastConvertWithDynamicMajorDimension) {
+  TF_ASSERT_OK_AND_ASSIGN(const Shape operand, ParseShape("f32[<=10,2]"));
+  TF_ASSERT_OK_AND_ASSIGN(
+      const Shape inferred_shape,
+      ShapeInference::InferBitcastConvertShape(operand, PrimitiveType::S64));
+  TF_ASSERT_OK_AND_ASSIGN(const Shape expected, ParseShape("s64[<=10]"));
+  EXPECT_TRUE(ShapeUtil::Equal(inferred_shape, expected))
+      << "inferred: " << ShapeUtil::HumanString(inferred_shape)
+      << " expected: " << ShapeUtil::HumanString(expected);
+}
+
+TEST_F(ShapeInferenceTest, BitcastConvertWithDynamicContractedDimension) {
+  // Narrowing to a wider element type consumes the minor dimension, which
+  // must be static: fewer than ratio valid elements cannot form an element.
+  TF_ASSERT_OK_AND_ASSIGN(const Shape operand, ParseShape("f32[10,<=2]"));
+  const absl::StatusOr<Shape> inferred_shape =
+      ShapeInference::InferBitcastConvertShape(operand, PrimitiveType::S64);
+  EXPECT_FALSE(inferred_shape.ok());
+  EXPECT_THAT(inferred_shape.status().message(),
+              HasSubstr("Last dimension of input shape must be static"));
+}
+
 TEST_F(ShapeInferenceTest, ClampAllMatrix) {
   const absl::StatusOr<Shape> inferred_shape =
       ShapeInference::InferTernaryOpShape(HloOpcode::kClamp, matrix_64_48_,


### PR DESCRIPTION
## 📝 Summary of Changes

Fixes #45967.

The dynamic padder failed with "Unimplemented padding for instruction:
bitcast-convert" whenever a bit-width-changing bitcast-convert consumed an
operand with a dynamic dimension. Same-width bitcast-converts already worked
through the elementwise early-exit in ChooseIdentityValue, but the
width-changing form is not elementwise (its shape changes), so it fell
through to the unimplemented default.

Padding data reinterprets to padding data under a bitcast, and the dimension
the op adds or removes is always the static innermost one, so no identity
value is needed. This adds kBitcastConvert to the group of ops that return
nullptr from ChooseIdentityValue. Dynamic dimension inference already
propagates the dynamic dimensions correctly for both directions (it routes
bitcast-convert through the index-preserving elementwise passthrough, and
pre-existing dimensions keep their indices in both the widening and the
narrowing form).

The repro from the issue is tf.bitcast applied to the output of tf.where:
where produces s64[<=16,1], and the int64 to float32 bitcast makes
f32[<=16,1,2], which then failed to compile.

One hole is closed on the way: shape inference checked only the bound of the
minor dimension consumed by a narrowing bitcast-convert, so a dynamic minor
dimension (for example f32[10,<=2] to s64[10]) was accepted, and with the
padder fix such an ill-defined program would have compiled and produced
garbage instead of failing. InferBitcastConvertShape now rejects a dynamic
consumed minor dimension explicitly.

## 🎯 Justification

Eager TF executes the where + bitcast graph fine; XLA refused to compile it.
The graph is well defined for any runtime size, so this is a missing case in
the dynamic padder, not a semantic limitation.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

Two pass-level regression tests in dynamic_padder_test.cc (widening
s64[<=16,1] -> f32[<=16,1,2] and narrowing f32[<=16,2] -> s64[<=16]); both
fail with the exact issue error before the fix and pass after. Two shape
inference tests cover the narrowing form: dynamic major dimension accepted,
dynamic consumed minor dimension rejected.

## 🧪 Execution Tests:

Two execution tests in the same file check the computed values end to end
with a dynamic dimension present (s64 -> s32 widening and s32 -> s64
narrowing with known bit patterns). Run on CPU.