### PR TITLE
[XLA] Handle zero-sized matrix dimensions in the SVD expansion

### DIFF
--- a/xla/hlo/builder/lib/BUILD
+++ b/xla/hlo/builder/lib/BUILD
@@ -721,6 +721,8 @@ xla_test(
         "//xla:array2d",
         "//xla:array3d",
         "//xla:error_spec",
+        "//xla:literal",
+        "//xla:literal_util",
         "//xla:shape_util",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/builder:xla_builder",

--- a/xla/hlo/builder/lib/svd.cc
+++ b/xla/hlo/builder/lib/svd.cc
@@ -851,6 +851,21 @@ SVDResult SVD(XlaOp a, int64_t max_iter, float epsilon,
   }
   int64_t m = ShapeUtil::GetDimension(a_shape, -2);
   int64_t n = ShapeUtil::GetDimension(a_shape, -1);
+
+  // A matrix with a zero-sized dimension has no singular values, and its
+  // u and v factors are identity matrices; the iteration below assumes
+  // non-empty matrices.
+  if (m == 0 || n == 0) {
+    PrimitiveType type = a_shape.element_type();
+    SVDResult result;
+    result.u = Broadcast(IdentityMatrix(builder, type, m, m), batch_dims);
+    result.v = Broadcast(IdentityMatrix(builder, type, n, n), batch_dims);
+    std::vector<int64_t> d_dims(batch_dims);
+    d_dims.push_back(0);
+    result.d = Zeros(builder, ShapeUtil::MakeShape(type, d_dims));
+    return result;
+  }
+
   bool maybe_transpose = m < n;
 
   if (maybe_transpose) {

--- a/xla/hlo/builder/lib/svd_test.cc
+++ b/xla/hlo/builder/lib/svd_test.cc
@@ -29,6 +29,8 @@ limitations under the License.
 #include "xla/hlo/builder/lib/matrix.h"
 #include "xla/hlo/builder/lib/slicing.h"
 #include "xla/hlo/builder/xla_builder.h"
+#include "xla/literal.h"
+#include "xla/literal_util.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
 #include "xla/tests/client_library_test_runner_mixin.h"
@@ -132,6 +134,61 @@ TEST_F(SVDTest, Simple2D) {
 
   ComputeAndCompareR2<float>(&builder, simple_2d_4x4_, {&a_data},
                              ErrorSpec(1e-3, 1e-3));
+}
+
+TEST_F(SVDTest, ZeroColumnMatrix) {
+  // Regression test for https://github.com/openxla/xla/issues/45972: SVD on
+  // a matrix with a zero-sized dimension failed to build with "Slice dim
+  // size 1 greater than dynamic slice dimension: 0".
+  XlaBuilder builder(TestName());
+
+  Array2D<float> a_4x0(4, 0);
+  XlaOp a;
+  auto a_data = CreateR2Parameter<float>(a_4x0, 0, "a", &builder, &a);
+  auto result = SVD(a, 100, 1e-6);
+  Tuple(&builder, {result.d, result.u, result.v});
+
+  const Literal expected = LiteralUtil::MakeTupleOwned(
+      LiteralUtil::CreateR1<float>({}),
+      LiteralUtil::CreateR2<float>(
+          {{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}),
+      LiteralUtil::CreateR2FromArray2D<float>(Array2D<float>(0, 0)));
+  ComputeAndCompareTuple(&builder, expected, {&a_data});
+}
+
+TEST_F(SVDTest, ZeroRowMatrix) {
+  // Same as ZeroColumnMatrix, with the zero-sized dimension in front.
+  XlaBuilder builder(TestName());
+
+  Array2D<float> a_0x4(0, 4);
+  XlaOp a;
+  auto a_data = CreateR2Parameter<float>(a_0x4, 0, "a", &builder, &a);
+  auto result = SVD(a, 100, 1e-6);
+  Tuple(&builder, {result.d, result.u, result.v});
+
+  const Literal expected = LiteralUtil::MakeTupleOwned(
+      LiteralUtil::CreateR1<float>({}),
+      LiteralUtil::CreateR2FromArray2D<float>(Array2D<float>(0, 0)),
+      LiteralUtil::CreateR2<float>(
+          {{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}));
+  ComputeAndCompareTuple(&builder, expected, {&a_data});
+}
+
+TEST_F(SVDTest, BatchedZeroColumnMatrix) {
+  // Batched variant of ZeroColumnMatrix.
+  XlaBuilder builder(TestName());
+
+  Array3D<float> a_2x3x0(2, 3, 0);
+  XlaOp a;
+  auto a_data = CreateR3Parameter<float>(a_2x3x0, 0, "a", &builder, &a);
+  auto result = SVD(a, 100, 1e-6);
+  Tuple(&builder, {result.d, result.u, result.v});
+
+  const Literal expected = LiteralUtil::MakeTupleOwned(
+      LiteralUtil::CreateR2FromArray2D<float>(Array2D<float>(2, 0)),
+      LiteralUtil::CreateR3FromArray3D<float>(GetUnitMatrix3D(2, 3)),
+      LiteralUtil::CreateR3FromArray3D<float>(Array3D<float>(2, 0, 0)));
+  ComputeAndCompareTuple(&builder, expected, {&a_data});
 }
 
 TEST_F(SVDTest, Test_VWVt_EQ_A_2x4x5) {


### PR DESCRIPTION
## 📝 Summary of Changes

Fixes #45972.

xla::SVD (the one-sided Jacobi expansion in xla/hlo/builder/lib/svd.cc)
assumed non-empty matrices: for an input with m == 0 or n == 0 the
Householder bidiagonalization emits a dynamic slice of size 1 along a
zero-sized dimension, and shape inference rejects the computation with
"Slice dim size 1 greater than dynamic slice dimension: 0". Eager TF
handles the same input fine and returns empty singular values.

The SVD of a matrix with a zero-sized dimension is trivial, so return it
directly: no singular values (d is [batch..., 0]) and identity u and v
factors, matching numpy and eager TF. The early return runs before the
internal transpose normalization, so both the zero-column and the zero-row
form are covered.

The repro from the issue is tf.linalg.svd applied to the output of an
Embedding layer with output_dim=0.

## 🎯 Justification

Eager TF executes the graph and returns empty singular values; XLA refused
to compile it. The degenerate case has a well-defined answer, so this is a
missing case in the expansion, not a semantic limitation.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

Three regression tests in svd_test.cc: f32[4,0], f32[0,4], and a batched
f32[2,3,0]. All three fail before the fix with the exact error from the
issue and pass after; they check the returned d, u, v values (empty
singular values, identity factors), not just successful compilation.

## 🧪 Execution Tests:

The three tests above execute on CPU via the standard client-library test
harness and compare against expected literals.