### PR TITLE
[xla:ffi] Unify FFI error handling with an ErrorPolicy abstraction

### DIFF
--- a/xla/ffi/BUILD
+++ b/xla/ffi/BUILD
@@ -160,6 +160,7 @@ cc_library(
         ":api",
         ":execution_context",
         ":execution_state",
+        ":ffi_interop",
         ":type_registry",
         "//xla:executable_run_options",
         "//xla:shape_util",

--- a/xla/ffi/api/api.h
+++ b/xla/ffi/api/api.h
@@ -1833,7 +1833,7 @@ struct HasExtensionSupport<
 //     using CExtension = XLA_FFI_MyExtension;  // C API extension type
 //     using Type = MyContext;                  // decoded C++ context type
 //
-//     static constexpr std::string_view kName = "MyExtension";
+//     static constexpr auto kName = "MyExtension";
 //     static constexpr int64_t kExtensionType = ...;
 //     static constexpr int32_t kMajorVersion = ...;
 //     static constexpr int32_t kMinorVersion = ...;
@@ -1905,11 +1905,11 @@ struct CtxDecoding<Extension<T>> {
       }
     }
 
-    return T::Create(api,
-                     // T::kExtensionType is a contract that guarantees that the
-                     // extension is of type T.
-                     reinterpret_cast<const typename T::CExtension*>(
-                         args.extension));  // NOLINT
+    return T::Create(
+        api,
+        // T::kExtensionType is a contract that guarantees that the
+        // extension is of type T. NOLINTNEXTLINE.
+        reinterpret_cast<const typename T::CExtension*>(args.extension));
   }
 };
 

--- a/xla/ffi/api/api.h
+++ b/xla/ffi/api/api.h
@@ -373,9 +373,6 @@ class Ffi {
   };
 
  protected:
-  template <typename... Args>
-  static std::string StrCat(Args... args);
-
   static XLA_FFI_Error* Success();
 
   static XLA_FFI_Error* MakeError(const XLA_FFI_Api* api,
@@ -396,6 +393,15 @@ class Ffi {
                                                    size_t expected,
                                                    size_t actual);
 };
+
+namespace internal {
+template <typename... Args>
+std::string StrCat(Args&&... args) {
+  std::stringstream ss;
+  (ss << ... << std::forward<Args>(args));
+  return ss.str();
+}
+}  // namespace internal
 
 inline XLA_FFI_Error* Ffi::RegisterStaticHandler(
     const XLA_FFI_Api* api, std::string_view name, std::string_view platform,
@@ -431,13 +437,6 @@ inline XLA_FFI_Error* Ffi::RegisterTypeId(const XLA_FFI_Api* api,
   return api->XLA_FFI_Type_Register(&args);
 }
 
-template <typename... Args>
-std::string Ffi::StrCat(Args... args) {
-  std::stringstream ss;
-  (ss << ... << args);
-  return ss.str();
-}
-
 inline XLA_FFI_Error* Ffi::Success() { return nullptr; }
 
 inline XLA_FFI_Error* Ffi::MakeError(const XLA_FFI_Api* api,
@@ -468,8 +467,9 @@ inline XLA_FFI_Error* Ffi::CheckStructSize(const XLA_FFI_Api* api,
                                            size_t expected, size_t actual) {
   if (XLA_FFI_PREDICT_FALSE(expected != actual)) {
     return InvalidArgument(
-        api, StrCat("Unexpected ", struct_name, " size: expected ", expected,
-                    " got ", actual, ". Check installed software versions."));
+        api, internal::StrCat("Unexpected ", struct_name, " size: expected ",
+                              expected, " got ", actual,
+                              ". Check installed software versions."));
   }
   return nullptr;
 }
@@ -479,9 +479,9 @@ inline XLA_FFI_Error* Ffi::StructSizeIsGreaterOrEqual(
     size_t actual) {
   if (XLA_FFI_PREDICT_FALSE(actual < expected)) {
     return InvalidArgument(
-        api, StrCat("Unexpected ", struct_name, " size: expected at least ",
-                    expected, " got ", actual,
-                    ". Check installed software versions."));
+        api, internal::StrCat("Unexpected ", struct_name,
+                              " size: expected at least ", expected, " got ",
+                              actual, ". Check installed software versions."));
   }
   return nullptr;
 }
@@ -489,6 +489,25 @@ inline XLA_FFI_Error* Ffi::StructSizeIsGreaterOrEqual(
 //===----------------------------------------------------------------------===//
 // XLA_FFI_Error helpers
 //===----------------------------------------------------------------------===//
+
+// ErrorPolicy is a compatibility layer for shared APIs that must report errors
+// using different user-facing types: Error/ErrorOr for external FFI and
+// absl::Status/absl::StatusOr for internal FFI. Concrete internal and external
+// FFI layers define an ErrorPolicy with the following interface:
+//
+//   struct ErrorPolicy {
+//     using Status = ...;
+//
+//     template <typename T>
+//     using StatusOr = ...;
+//
+//     static Status Ok();
+//     static Status FromErrorCode(XLA_FFI_Error_Code, std::string_view);
+//     static Status TakeError(const XLA_FFI_Api*, XLA_FFI_Error*);
+//   };
+//
+// TakeError takes ownership of a non-null XLA_FFI_Error. StatusOr<T> must be
+// constructible from both T and Status.
 
 namespace internal {
 
@@ -500,14 +519,26 @@ inline void DestroyError(const XLA_FFI_Api* api, XLA_FFI_Error* error) {
   api->XLA_FFI_Error_Destroy(&args);
 }
 
-inline const char* GetErrorMessage(const XLA_FFI_Api* api,
-                                   XLA_FFI_Error* error) {
-  XLA_FFI_Error_GetMessage_Args args;
-  args.struct_size = XLA_FFI_Error_GetMessage_Args_STRUCT_SIZE;
+struct ErrorDetails {
+  XLA_FFI_Error_Code errc;
+  const char* message;
+};
+
+inline ErrorDetails GetErrorDetails(const XLA_FFI_Api* api,
+                                    XLA_FFI_Error* error) {
+  XLA_FFI_Error_GetDetails_Args args;
+  args.struct_size = XLA_FFI_Error_GetDetails_Args_STRUCT_SIZE;
   args.extension_start = nullptr;
   args.error = error;
-  api->XLA_FFI_Error_GetMessage(&args);
-  return args.message;
+  args.message = nullptr;
+  args.errc = XLA_FFI_Error_Code_INTERNAL;
+  api->XLA_FFI_Error_GetDetails(&args);
+  return ErrorDetails{args.errc, args.message};
+}
+
+inline const char* GetErrorMessage(const XLA_FFI_Api* api,
+                                   XLA_FFI_Error* error) {
+  return GetErrorDetails(api, error).message;
 }
 
 }  // namespace internal
@@ -1090,7 +1121,6 @@ constexpr bool IsDynamicRank() {
 // Buffer Matching
 //===----------------------------------------------------------------------===//
 
-namespace match {
 namespace internal {
 
 // Unlike std::integer_sequence, this sequence also supports enum values.
@@ -1102,6 +1132,8 @@ struct ValueSequence {
 
 }  // namespace internal
 
+namespace match {
+
 // Type-level set of the unique dtype constraints on a pattern. The dtype enum
 // type is fixed per header (DataType or PrimitiveType), so the type system
 // enforces that all dtypes share one enum type.
@@ -1112,6 +1144,8 @@ using DTypeSet = internal::ValueSequence<DType, dtypes...>;
 template <size_t... ranks>
 using RankSet = internal::ValueSequence<size_t, ranks...>;
 
+}  // namespace match
+
 namespace internal {
 
 // Reinterprets a buffer as a concrete `Buffer<dtype, rank>` without any checks.
@@ -1119,7 +1153,7 @@ namespace internal {
 // call once a successful match has confirmed the buffer's dtype and rank.
 struct BufferCast;
 
-// Prints a single constraint value into a diagnostic. The default uses
+// Prints a single constraint value into an error message. The default uses
 // `operator<<`; FFI headers specialize it for dtype enums that lack a symbolic
 // `operator<<` (see `PrimitiveType` in `xla/ffi/ffi.h`).
 template <typename T>
@@ -1141,26 +1175,26 @@ class ValueSet<name, ValueSequence<T, values...>> {
   using Values = ValueSequence<T, values...>;
 
  public:
-  static bool Match(T value, DiagnosticEngine& diagnostic) {
-    if (empty() ||
-        std::find(kValues.begin(), kValues.end(), value) != kValues.end()) {
-      return true;
+  static std::optional<std::string> Match(T value) {
+    if (XLA_FFI_PREDICT_TRUE(empty() ||
+                             std::find(kValues.begin(), kValues.end(), value) !=
+                                 kValues.end())) {
+      return std::nullopt;
     }
 
-    InFlightDiagnostic error = diagnostic.Emit("expected ");
-    error << name;
     if (kValues.size() == 1) {
-      error << " " << ValuePrinter<T>{kValues.front()} << " but got "
-            << ValuePrinter<T>{value};
-      return false;
+      return StrCat("expected ", name, " ", ValuePrinter<T>{kValues.front()},
+                    " but got ", ValuePrinter<T>{value});
     }
 
-    error << " to be one of [" << ValuePrinter<T>{kValues.front()};
+    std::ostringstream message;
+    message << "expected " << name;
+    message << " to be one of [" << ValuePrinter<T>{kValues.front()};
     for (size_t i = 1; i < kValues.size(); ++i) {
-      error << ", " << ValuePrinter<T>{kValues[i]};
+      message << ", " << ValuePrinter<T>{kValues[i]};
     }
-    error << "] but got " << ValuePrinter<T>{value};
-    return false;
+    message << "] but got " << ValuePrinter<T>{value};
+    return message.str();
   }
 
   static std::string Describe() {
@@ -1189,19 +1223,16 @@ class ValueSet<name, ValueSequence<T, values...>> {
 };
 
 template <typename Values>
-using DTypeValues =
-    ValueSet<kDType, Values>;  // NOLINT(readability-identifier-naming): alias
-                               // for internal matcher value sets
-
+using DTypeValues = ValueSet<kDType, Values>;  // NOLINT
 template <typename Values>
-using RankValues =
-    ValueSet<kRank, Values>;  // NOLINT(readability-identifier-naming): alias
-                              // for internal matcher value sets
+using RankValues = ValueSet<kRank, Values>;  // NOLINT
 
 template <typename DTypes, typename Ranks>
 class BufferPatternBase;
 
 }  // namespace internal
+
+namespace match {
 
 // Matches one buffer dimension. A dimension can be unconstrained, fixed, or
 // captured.
@@ -1210,32 +1241,30 @@ class DimPattern {
   DimPattern() = default;
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  // NOLINTNEXTLINE(google-explicit-constructor,runtime/explicit)
-  DimPattern(T value) : value_(static_cast<int64_t>(value)) {
+  DimPattern(T value) : value_(static_cast<int64_t>(value)) {  // NOLINT
     static_assert(sizeof(T) <= sizeof(int64_t),
                   "Integral dimension value must fit in 64-bit integer.");
   }
 
   // Intentionally implicit so that capture pointers (e.g. &rows) can be passed
   // directly to WithDims and WithDim.
-  // NOLINTNEXTLINE(google-explicit-constructor,runtime/explicit)
-  DimPattern(int64_t* value) : value_(value) {
+  DimPattern(int64_t* value) : value_(value) {  // NOLINT
     assert(value != nullptr && "dimension capture must be non-null");
   }
 
-  bool Match(int64_t value, size_t index, DiagnosticEngine& diagnostic) const {
+  std::optional<std::string> Match(int64_t value, size_t index) const {
     const int64_t* expected = std::get_if<int64_t>(&value_);
-    if (expected == nullptr || value == *expected) {
-      return true;
+    if (XLA_FFI_PREDICT_TRUE(expected == nullptr || value == *expected)) {
+      return std::nullopt;
     }
 
-    diagnostic.Emit("expected dimension ")
-        << index << " to be " << *expected << " but got " << value;
-    return false;
+    return internal::StrCat("expected dimension ", index, " to be ", *expected,
+                            " but got ", value);
   }
 
   void Capture(int64_t value) const {
-    if (auto capture = std::get_if<int64_t*>(&value_)) {
+    if (auto capture = std::get_if<int64_t*>(&value_);
+        XLA_FFI_PREDICT_FALSE(capture != nullptr)) {
       **capture = value;
     }
   }
@@ -1262,6 +1291,8 @@ class DimPattern {
   std::variant<std::monostate, int64_t, int64_t*> value_;
 };
 
+}  // namespace match
+
 namespace internal {
 
 // An immutable pattern for matching buffer metadata. Dtype and rank
@@ -1283,20 +1314,20 @@ class BufferPatternBase {
   auto WithRank() const {
     static_assert(!IsDynamicRank<rank, ranks...>(),
                   "dynamic rank is represented by an empty rank set");
-    using WithRankSet = RankSet<rank, ranks...>;
+    using WithRankSet = match::RankSet<rank, ranks...>;
     return BufferPatternBase<DTypes, WithRankSet>(*this);
   }
 
   template <DType dtype, DType... dtypes>
   auto WithDType() const {
-    using WithDTypeSet = DTypeSet<DType, dtype, dtypes...>;
+    using WithDTypeSet = match::DTypeSet<DType, dtype, dtypes...>;
     return BufferPatternBase<WithDTypeSet, Ranks>(*this);
   }
 
   // Constrains the complete shape to match `buffer`.
   template <typename Buffer>
   auto WithShapeOf(Buffer buffer) const {
-    using Pattern = BufferPatternBase<DTypes, RankSet<>>;
+    using Pattern = BufferPatternBase<DTypes, match::RankSet<>>;
     Pattern pattern(*this);
     auto dimensions = buffer.dimensions();
     pattern.rank_ = dimensions.size();
@@ -1308,7 +1339,7 @@ class BufferPatternBase {
   template <typename Buffer>
   auto Like(Buffer buffer) const {
     auto shape = WithShapeOf(buffer);
-    using Pattern = BufferPatternBase<DTypeSet<DType>, RankSet<>>;
+    using Pattern = BufferPatternBase<match::DTypeSet<DType>, match::RankSet<>>;
     Pattern pattern(shape);
     pattern.dtype_ = buffer.element_type();
     return pattern;
@@ -1318,16 +1349,16 @@ class BufferPatternBase {
   // from the number of arguments.
   template <typename... Args,
             typename = std::enable_if_t<
-                (std::is_convertible_v<Args, DimPattern> && ...)>>
+                (std::is_convertible_v<Args, match::DimPattern> && ...)>>
   XLA_FFI_ATTRIBUTE_ALWAYS_INLINE auto WithDims(Args&&... dimensions) const {
-    using WithRank = RankSet<sizeof...(Args)>;
+    using WithRank = match::RankSet<sizeof...(Args)>;
     BufferPatternBase<DTypes, WithRank> pattern(*this);
     pattern.dimensions_ = {std::forward<Args>(dimensions)...};
     return pattern;
   }
 
   // Constrains a single dimension, leaving the rest (and the rank) free.
-  BufferPatternBase WithDim(size_t index, DimPattern dimension) const {
+  BufferPatternBase WithDim(size_t index, match::DimPattern dimension) const {
     BufferPatternBase pattern(*this);
     auto& dimensions = pattern.dimensions_;
     dimensions.resize(std::max(dimensions.size(), index + 1));
@@ -1336,51 +1367,50 @@ class BufferPatternBase {
   }
 
   template <size_t index>
-  BufferPatternBase WithDim(DimPattern dimension) const {
+  BufferPatternBase WithDim(match::DimPattern dimension) const {
     return WithDim(index, std::move(dimension));
   }
 
   template <typename Buffer>
-  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE bool Match(
-      Buffer buffer, DiagnosticEngine& diagnostic) const {
-    if (!DTypeValues<DTypes>::Match(buffer.element_type(), diagnostic)) {
-      return false;
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE std::optional<std::string> Match(
+      Buffer buffer) const {
+    if (auto error = DTypeValues<DTypes>::Match(buffer.element_type());
+        XLA_FFI_PREDICT_FALSE(error.has_value())) {
+      return error;
     }
 
-    if (dtype_.has_value() && buffer.element_type() != *dtype_) {
-      diagnostic.Emit("expected dtype ")
-          << ValuePrinter<DType>{*dtype_} << " but got "
-          << ValuePrinter<DType>{buffer.element_type()};
-      return false;
+    if (XLA_FFI_PREDICT_FALSE(dtype_.has_value() &&
+                              buffer.element_type() != *dtype_)) {
+      return StrCat("expected dtype ", ValuePrinter<DType>{*dtype_},
+                    " but got ", ValuePrinter<DType>{buffer.element_type()});
     }
 
     auto dimensions = buffer.dimensions();
-    if (!RankValues<Ranks>::Match(dimensions.size(), diagnostic)) {
-      return false;
+    if (auto error = RankValues<Ranks>::Match(dimensions.size());
+        XLA_FFI_PREDICT_FALSE(error.has_value())) {
+      return error;
     }
 
-    if (rank_.has_value() && dimensions.size() != *rank_) {
-      diagnostic.Emit("expected rank ")
-          << *rank_ << " but got " << dimensions.size();
-      return false;
+    if (XLA_FFI_PREDICT_FALSE(rank_.has_value() &&
+                              dimensions.size() != *rank_)) {
+      return StrCat("expected rank ", *rank_, " but got ", dimensions.size());
     }
 
-    if (dimensions_.size() > dimensions.size()) {
-      diagnostic.Emit("expected dimension ")
-          << dimensions_.size() - 1 << " but buffer rank is "
-          << dimensions.size();
-      return false;
+    if (XLA_FFI_PREDICT_FALSE(dimensions_.size() > dimensions.size())) {
+      return StrCat("expected dimension ", dimensions_.size() - 1,
+                    " but buffer rank is ", dimensions.size());
     }
 
     size_t count = dimensions_.size();
     for (size_t i = 0; i < count; ++i) {
-      const DimPattern& dimension = dimensions_[i];
-      if (!dimension.Match(dimensions[i], i, diagnostic)) {
-        return false;
+      const match::DimPattern& dimension = dimensions_[i];
+      if (auto error = dimension.Match(dimensions[i], i);
+          XLA_FFI_PREDICT_FALSE(error.has_value())) {
+        return error;
       }
 
       int64_t* capture = dimension.capture();
-      if (capture == nullptr) {
+      if (XLA_FFI_PREDICT_TRUE(capture == nullptr)) {
         continue;
       }
       for (size_t j = 0; j < i; ++j) {
@@ -1390,13 +1420,12 @@ class BufferPatternBase {
         if (dimensions[i] == dimensions[j]) {
           break;
         }
-        diagnostic.Emit("expected dimension ")
-            << i << " to be " << dimensions[j] << " but got " << dimensions[i];
-        return false;
+        return StrCat("expected dimension ", i, " to be ", dimensions[j],
+                      " but got ", dimensions[i]);
       }
     }
 
-    return true;
+    return std::nullopt;
   }
 
   template <typename Buffer>
@@ -1462,10 +1491,12 @@ class BufferPatternBase {
   std::optional<size_t> rank_;
   // Positional dimension constraints. Unconstrained positions (the gaps left by
   // WithDim) hold a catch-all DimPattern that matches any extent.
-  std::vector<DimPattern> dimensions_;
+  std::vector<match::DimPattern> dimensions_;
 };
 
 }  // namespace internal
+
+namespace match {
 
 inline DimPattern Dim() { return DimPattern(); }
 
@@ -1479,22 +1510,44 @@ inline DimPattern Dim(int64_t* value) { return DimPattern(value); }
 
 namespace internal {
 
-// Matches buffer metadata and emits a diagnostic on failure. Captures are
-// applied only after all constraints match.
+// Matches buffer metadata and returns `std::nullopt` on success or an error
+// message for the first failed constraint. Captures are applied only after all
+// constraints match.
 template <typename Buffer, typename Pattern>
-XLA_FFI_ATTRIBUTE_ALWAYS_INLINE bool MatchBuffer(std::string_view name,
-                                                 Buffer buffer,
-                                                 const Pattern& pattern,
-                                                 DiagnosticEngine& diagnostic) {
-  if (pattern.Match(buffer, diagnostic)) {
-    pattern.Capture(buffer);
-    return true;
+XLA_FFI_ATTRIBUTE_ALWAYS_INLINE std::optional<std::string> TryMatchBuffer(
+    std::string_view name, Buffer buffer, const Pattern& pattern) {
+  if (auto error = pattern.Match(buffer);
+      XLA_FFI_PREDICT_FALSE(error.has_value())) {
+    return StrCat("Buffer '", name, "' failed to match ", pattern.Describe(),
+                  ": ", *error);
   }
+  pattern.Capture(buffer);
+  return std::nullopt;
+}
 
-  std::string reason = std::move(diagnostic).Result();
-  diagnostic.Emit("Buffer '")
-      << name << "' failed to match " << pattern.Describe() << ": " << reason;
-  return false;
+template <typename ErrorPolicy, typename Buffer, typename Pattern>
+XLA_FFI_ATTRIBUTE_ALWAYS_INLINE typename ErrorPolicy::Status VerifyBuffer(
+    std::string_view name, Buffer buffer, const Pattern& pattern) {
+  if (auto error = TryMatchBuffer(name, buffer, pattern);
+      XLA_FFI_PREDICT_FALSE(error.has_value())) {
+    return ErrorPolicy::FromErrorCode(XLA_FFI_Error_Code_INVALID_ARGUMENT,
+                                      *error);
+  }
+  return ErrorPolicy::Ok();
+}
+
+template <typename ErrorPolicy, typename T, typename Buffer, typename Pattern,
+          typename OnMatch>
+XLA_FFI_ATTRIBUTE_ALWAYS_INLINE typename ErrorPolicy::template StatusOr<T>
+MatchBuffer(std::string_view name, Buffer buffer, const Pattern& pattern,
+            OnMatch&& on_match) {
+  using Result = typename ErrorPolicy::template StatusOr<T>;
+  if (auto error = TryMatchBuffer(name, buffer, pattern);
+      XLA_FFI_PREDICT_FALSE(error.has_value())) {
+    return Result(ErrorPolicy::FromErrorCode(
+        XLA_FFI_Error_Code_INVALID_ARGUMENT, *error));
+  }
+  return Result(std::forward<OnMatch>(on_match)(buffer));
 }
 
 }  // namespace internal
@@ -1773,40 +1826,32 @@ struct HasExtensionSupport<
 // Decoding for Extensions
 //===----------------------------------------------------------------------===//
 
-// Type tag for decoding an Extension.
-// The type T must define the following traits:
-// - CExtension: The C API extension type. See: struct XLA_FFI_Extension.
-// - Type: The C++ type to be decoded to. Must be constructible from CExtension*
-//         using a static method Create (see below).
-// - kName: a name for the extension used for diagnostics.
-// - kExtensionType: int64 type id to identify this extension.
-// - kMajorVersion: the major version of the extension.
-// - kMinorVersion: the minor version of the extension.
-// - Create: a static method that creates the Type from the
-//     C API extension.
-// - Support: a static method that checks given a major and minor version if
-//     the extension is supported. Optional. By default, an extension is
-//     supported if both major and minor versions match.
-//     Signature: bool Support(int32_t major_version, int32_t minor_version);
-// Example:
+// Type tag for decoding a C API extension into a C++ context. `T` must define
+// the following interface:
+//
 //   struct MyExtension {
-//     using Type = MyContext;
-//     using CExtension = XLA_FFI_MyExtension;
+//     using CExtension = XLA_FFI_MyExtension;  // C API extension type
+//     using Type = MyContext;                  // decoded C++ context type
 //
-//     static constexpr auto kName = "MyExtension";
-//     static constexpr int64_t kExtensionType = XLA_FFI_Extension_MyExtension;
-//     static constexpr int32_t kMajorVersion =
-//         XLA_FFI_Extension_MyExtension_MajorVersion;
-//     static constexpr int32_t kMinorVersion =
-//         XLA_FFI_Extension_MyExtension_MinorVersion;
+//     static constexpr std::string_view kName = "MyExtension";
+//     static constexpr int64_t kExtensionType = ...;
+//     static constexpr int32_t kMajorVersion = ...;
+//     static constexpr int32_t kMinorVersion = ...;
 //
-//     static Type Create(const CExtension* ext) {
+//     static Type Create(const XLA_FFI_Api* api, const CExtension* ext) {
 //       return MyContext(ext->some_field);
 //     }
 //   };
-// And then use it with T::Type as a value type:
-//   Ffi::Bind().Ctx<Extension<MyExtension>>()
-//                     .To([](const MyExtension::Type ext) { ... });
+//
+// `Create` receives the API used for the handler call and a pointer to the
+// extension found in the invoke context.
+//
+// By default, both version numbers must match exactly. `T` can override this
+// by defining:
+//
+//   static bool Support(int32_t major_version, int32_t minor_version);
+//
+// Bind the decoded context with `.Ctx<Extension<MyExtension>>()`.
 template <typename T>
 struct Extension {};
 
@@ -1838,12 +1883,14 @@ struct CtxDecoding<Extension<T>> {
       diagnostic.Emit("Extension ") << T::kName << " not found in context";
       return std::nullopt;
     }
+
     const auto emit_version_mismatch = [&]() {
       diagnostic.Emit("Extension version mismatch for ")
           << T::kName << ": actual(" << args.extension->id.major_version << "."
           << args.extension->id.minor_version << ") vs current("
           << T::kMajorVersion << "." << T::kMinorVersion << ")";
     };
+
     if constexpr (internal::HasExtensionSupport<T>::value) {
       if (!T::Support(args.extension->id.major_version,
                       args.extension->id.minor_version)) {
@@ -1857,11 +1904,12 @@ struct CtxDecoding<Extension<T>> {
         return std::nullopt;
       }
     }
-    return T::Create(
-        // T::kExtensionType is a contract that guarantees that the extension
-        // is of type T.
-        // NOLINTNEXTLINE
-        reinterpret_cast<const typename T::CExtension*>(args.extension));
+
+    return T::Create(api,
+                     // T::kExtensionType is a contract that guarantees that the
+                     // extension is of type T.
+                     reinterpret_cast<const typename T::CExtension*>(
+                         args.extension));  // NOLINT
   }
 };
 
@@ -2267,10 +2315,11 @@ class Handler : public Ffi {
     // Check that handler is called during correct execution stage.
     if (XLA_FFI_PREDICT_FALSE(call_frame->stage !=
                               static_cast<XLA_FFI_ExecutionStage>(stage))) {
-      return InvalidArgument(call_frame->api,
-                             StrCat("Wrong execution stage: expected `",
-                                    static_cast<XLA_FFI_ExecutionStage>(stage),
-                                    "` but got `", call_frame->stage, "`"));
+      return InvalidArgument(
+          call_frame->api,
+          internal::StrCat("Wrong execution stage: expected `",
+                           static_cast<XLA_FFI_ExecutionStage>(stage),
+                           "` but got `", call_frame->stage, "`"));
     }
 
     // Check that the number of passed arguments matches the signature. Each
@@ -2279,19 +2328,19 @@ class Handler : public Ffi {
       if (XLA_FFI_PREDICT_FALSE(call_frame->args.size < kNumArgs)) {
         return InvalidArgument(
             call_frame->api,
-            StrCat("[", call_frame->stage, "] ",
-                   "Wrong number of arguments: expected at least ",
-                   kNumArgs - kNumOptionalArgs - 1, " but got ",
-                   call_frame->args.size));
+            internal::StrCat("[", call_frame->stage, "] ",
+                             "Wrong number of arguments: expected at least ",
+                             kNumArgs - kNumOptionalArgs - 1, " but got ",
+                             call_frame->args.size));
       }
     } else if constexpr (internal::HasOptionalArgTag<Ts...>::value) {
       if (XLA_FFI_PREDICT_FALSE(call_frame->args.size < kNumArgs)) {
         return InvalidArgument(
             call_frame->api,
-            StrCat("[", call_frame->stage, "] ",
-                   "Wrong number of arguments: expected at least ",
-                   kNumArgs - kNumOptionalArgs, " but got ",
-                   call_frame->args.size));
+            internal::StrCat("[", call_frame->stage, "] ",
+                             "Wrong number of arguments: expected at least ",
+                             kNumArgs - kNumOptionalArgs, " but got ",
+                             call_frame->args.size));
       }
     } else {
       // It is safe to not check the number of arguments if we don't plan to
@@ -2301,9 +2350,9 @@ class Handler : public Ffi {
                                 kNumArgs > 0)) {
         return InvalidArgument(
             call_frame->api,
-            StrCat("[", call_frame->stage, "] ",
-                   "Wrong number of arguments: expected ", kNumArgs,
-                   " but got ", call_frame->args.size));
+            internal::StrCat("[", call_frame->stage, "] ",
+                             "Wrong number of arguments: expected ", kNumArgs,
+                             " but got ", call_frame->args.size));
       }
     }
 
@@ -2313,19 +2362,19 @@ class Handler : public Ffi {
       if (XLA_FFI_PREDICT_FALSE(call_frame->rets.size < kNumRets)) {
         return InvalidArgument(
             call_frame->api,
-            StrCat("[", call_frame->stage, "] ",
-                   "Wrong number of results: expected at least ",
-                   kNumRets - kNumOptionalRets - 1, " but got ",
-                   call_frame->rets.size));
+            internal::StrCat("[", call_frame->stage, "] ",
+                             "Wrong number of results: expected at least ",
+                             kNumRets - kNumOptionalRets - 1, " but got ",
+                             call_frame->rets.size));
       }
     } else if constexpr (internal::HasOptionalRetTag<Ts...>::value) {
       if (XLA_FFI_PREDICT_FALSE(call_frame->rets.size < kNumRets)) {
         return InvalidArgument(
             call_frame->api,
-            StrCat("[", call_frame->stage, "] ",
-                   "Wrong number of results: expected at least ",
-                   kNumRets - kNumOptionalRets, " but got ",
-                   call_frame->rets.size));
+            internal::StrCat("[", call_frame->stage, "] ",
+                             "Wrong number of results: expected at least ",
+                             kNumRets - kNumOptionalRets, " but got ",
+                             call_frame->rets.size));
       }
     } else {
       // It is safe to not check the number of results if we don't plan to
@@ -2335,9 +2384,9 @@ class Handler : public Ffi {
                                 kNumRets > 0)) {
         return InvalidArgument(
             call_frame->api,
-            StrCat("[", call_frame->stage, "] ",
-                   "Wrong number of results: expected ", kNumRets, " but got ",
-                   call_frame->rets.size));
+            internal::StrCat("[", call_frame->stage, "] ",
+                             "Wrong number of results: expected ", kNumRets,
+                             " but got ", call_frame->rets.size));
       }
     }
 

--- a/xla/ffi/api/c_api.h
+++ b/xla/ffi/api/c_api.h
@@ -135,7 +135,7 @@ XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Extension, next);
 // Minor changes include:
 // * Adding a new field to the XLA_FFI_Api or argument structs
 // * Renaming a method or argument (doesn't affect ABI)
-#define XLA_FFI_API_MINOR 3
+#define XLA_FFI_API_MINOR 4
 
 struct XLA_FFI_Api_Version {
   size_t struct_size;
@@ -202,16 +202,17 @@ XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Error_Create_Args, errc);
 
 typedef XLA_FFI_Error* XLA_FFI_Error_Create(XLA_FFI_Error_Create_Args* args);
 
-struct XLA_FFI_Error_GetMessage_Args {
+struct XLA_FFI_Error_GetDetails_Args {
   size_t struct_size;
   XLA_FFI_InternalExtension* extension_start;
   XLA_FFI_Error* error;
-  const char* message;  // out
+  const char* message;      // out
+  XLA_FFI_Error_Code errc;  // out
 };
 
-XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Error_GetMessage_Args, message);
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Error_GetDetails_Args, errc);
 
-typedef void XLA_FFI_Error_GetMessage(XLA_FFI_Error_GetMessage_Args* args);
+typedef void XLA_FFI_Error_GetDetails(XLA_FFI_Error_GetDetails_Args* args);
 
 struct XLA_FFI_Error_Destroy_Args {
   size_t struct_size;
@@ -825,7 +826,7 @@ struct XLA_FFI_Api {
   const XLA_FFI_InternalApi* internal_api;
 
   _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Error_Create);
-  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Error_GetMessage);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Error_GetDetails);
   _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Error_Destroy);
   _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Handler_Register);
   _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Stream_Get);

--- a/xla/ffi/api/ffi.h
+++ b/xla/ffi/api/ffi.h
@@ -342,7 +342,46 @@ template <typename T>
 class ErrorOr : public Expected<T, Error> {
  public:
   using Expected<T, Error>::Expected;
+
+  // Match the construction protocol of status-or types: an error status can
+  // be used directly to construct an error result.
+  ErrorOr(Error error)  // NOLINT
+      : Expected<T, Error>(Unexpected<Error>(std::move(error))) {
+    assert(this->error().failure() &&
+           "ErrorOr cannot be constructed from a successful Error");
+  }
 };
+
+//===----------------------------------------------------------------------===//
+// Error policy
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+// Error policy for external, header-only FFI handlers.
+struct ErrorPolicy {
+  using Status = xla::ffi::Error;
+
+  template <typename T>
+  using StatusOr = xla::ffi::ErrorOr<T>;
+
+  static Status Ok() { return Status::Success(); }
+
+  static Status FromErrorCode(XLA_FFI_Error_Code errc,
+                              std::string_view message) {
+    return Status(errc, std::string(message));
+  }
+
+  static Status TakeError(const XLA_FFI_Api* api, XLA_FFI_Error* error) {
+    assert(error != nullptr);
+    ErrorDetails details = GetErrorDetails(api, error);
+    std::string message = details.message;
+    DestroyError(api, error);
+    return Status(details.errc, std::move(message));
+  }
+};
+
+}  // namespace internal
 
 //===----------------------------------------------------------------------===//
 // Future
@@ -611,7 +650,7 @@ class AnyBuffer {
   }
 
  private:
-  friend struct match::internal::BufferCast;
+  friend struct internal::BufferCast;
 
   const XLA_FFI_Buffer* buf_;
 };
@@ -745,7 +784,7 @@ class Buffer {
   }
 
  private:
-  friend struct match::internal::BufferCast;
+  friend struct internal::BufferCast;
 
   const XLA_FFI_Buffer* buf_;
 };
@@ -804,7 +843,6 @@ template <DataType dtype> using ResultBufferR4 = ResultBuffer<dtype, 4>;
 // Buffer Matching
 //===----------------------------------------------------------------------===//
 
-namespace match {
 namespace internal {
 
 struct BufferCast {
@@ -815,6 +853,8 @@ struct BufferCast {
 };
 
 }  // namespace internal
+
+namespace match {
 
 // A buffer-matching pattern specialized to the external `DataType` enum.
 template <typename DTypes = DTypeSet<DataType>, typename Ranks = RankSet<>>
@@ -836,11 +876,7 @@ inline BufferPattern<> Buffer() { return {}; }
 template <typename BufferType, typename DTypes, typename Ranks>
 Error Verify(std::string_view name, BufferType buffer,
              const match::BufferPattern<DTypes, Ranks>& pattern) {
-  DiagnosticEngine diagnostic;
-  if (!internal::MatchBuffer(name, buffer, pattern, diagnostic)) {
-    return Error::InvalidArgument(diagnostic.Result());
-  }
-  return Error::Success();
+  return internal::VerifyBuffer<internal::ErrorPolicy>(name, buffer, pattern);
 }
 
 // Matches an AnyBuffer and returns the concrete buffer type specified by a
@@ -850,20 +886,18 @@ ErrorOr<Buffer<dtype, rank>> Match(
     std::string_view name, AnyBuffer buffer,
     const match::BufferPattern<match::DTypeSet<DataType, dtype>,
                                match::RankSet<rank>>& pattern) {
-  if (Error error = Verify(name, buffer, pattern); error.failure()) {
-    return Unexpected(std::move(error));
-  }
-  return match::internal::BufferCast::Cast<Buffer<dtype, rank>>(buffer);
+  return internal::MatchBuffer<internal::ErrorPolicy, Buffer<dtype, rank>>(
+      name, buffer, pattern, [](AnyBuffer buffer) {
+        return internal::BufferCast::Cast<Buffer<dtype, rank>>(buffer);
+      });
 }
 
 template <DataType dtype, size_t rank, typename DTypes, typename Ranks>
 ErrorOr<Buffer<dtype, rank>> Match(
     std::string_view name, Buffer<dtype, rank> buffer,
     const match::BufferPattern<DTypes, Ranks>& pattern) {
-  if (Error error = Verify(name, buffer, pattern); error.failure()) {
-    return Unexpected(std::move(error));
-  }
-  return buffer;
+  return internal::MatchBuffer<internal::ErrorPolicy, Buffer<dtype, rank>>(
+      name, buffer, pattern, [](Buffer<dtype, rank> buffer) { return buffer; });
 }
 
 namespace internal {

--- a/xla/ffi/api/record_api.h
+++ b/xla/ffi/api/record_api.h
@@ -162,7 +162,7 @@ class RecordContextBase {
     return static_cast<RecordAction>(frame_->action);
   }
 
-  // Instantiate a used facing command wrapper for convenience.
+  // Instantiate a user-facing command wrapper for convenience.
   BoundedCommandVector commands() const {
     return BoundedCommandVector(frame_->commands, frame_->num_commands,
                                 frame_->max_commands);

--- a/xla/ffi/api/record_api.h
+++ b/xla/ffi/api/record_api.h
@@ -59,7 +59,7 @@ enum class RecordAction {
 };
 
 namespace internal {
-template <typename Converter>
+template <typename ErrorPolicy>
 class RecordContextBase;
 }  // namespace internal
 
@@ -116,7 +116,7 @@ Overload(Ts...) -> Overload<Ts...>;
 // C++ wrapper for the XLA FFI Record extension API.
 // Unified implementation for statically linked and dynamically linked FFI
 // modules.
-template <typename Converter>
+template <typename ErrorPolicy>
 class RecordContextBase {
  private:
   // Converts a span of `KernelArg` or `void*` to a vector of
@@ -151,20 +151,18 @@ class RecordContextBase {
   }
 
  public:
-  using StatusOrT = decltype(Converter::ToStatusOr(
-      std::declval<const XLA_FFI_Command*>(), std::declval<XLA_FFI_Error*>()));
-  using StatusT = decltype(Converter::ToStatus(std::declval<XLA_FFI_Error*>()));
-  // The constructor takes the main API and the frame directly. (The main API
-  // is passed by CtxDecoding but can be ignored since the frame provides the
-  // RecordContext).
-  explicit RecordContextBase(const XLA_FFI_RecordFrame* frame)
-      : frame_(frame) {}
+  using Status = typename ErrorPolicy::Status;
+  template <typename T>
+  using StatusOr = typename ErrorPolicy::template StatusOr<T>;
+
+  RecordContextBase(const XLA_FFI_Api* api, const XLA_FFI_RecordFrame* frame)
+      : api_(api), frame_(frame) {}
 
   RecordAction action() const {
     return static_cast<RecordAction>(frame_->action);
   }
 
-  // Instantiate a used facing comamnd wrapper for convenience.
+  // Instantiate a used facing command wrapper for convenience.
   BoundedCommandVector commands() const {
     return BoundedCommandVector(frame_->commands, frame_->num_commands,
                                 frame_->max_commands);
@@ -174,11 +172,11 @@ class RecordContextBase {
   // void* const> for args)
   template <typename KernelArgSpan,
             typename DepSpan = std::initializer_list<const XLA_FFI_Command*>>
-  StatusOrT CreateLaunch(const char* kernel_name, const void* kernel_data,
-                         size_t kernel_size, SourceFormat format,
-                         XLA_FFI_LaunchDims launch_dims,
-                         uint32_t shared_mem_bytes, KernelArgSpan args,
-                         DepSpan dependencies = {}) {
+  StatusOr<const XLA_FFI_Command*> CreateLaunch(
+      const char* kernel_name, const void* kernel_data, size_t kernel_size,
+      SourceFormat format, XLA_FFI_LaunchDims launch_dims,
+      uint32_t shared_mem_bytes, KernelArgSpan args,
+      DepSpan dependencies = {}) {
     std::vector<XLA_FFI_KernelArg> raw_args = ConvertArgs(args);
     XLA_FFI_KernelArgs ffi_args{raw_args.data(),
                                 static_cast<int64_t>(raw_args.size())};
@@ -191,94 +189,112 @@ class RecordContextBase {
         std::size(dependencies), &out_command);
 
     if (err) {
-      return Converter::ToStatusOr(out_command, err);
+      return StatusOr<const XLA_FFI_Command*>(
+          ErrorPolicy::TakeError(api_, err));
     }
     if (!out_command) {
-      return Converter::ToError(XLA_FFI_Error_Code_INTERNAL,
-                                "out_command is null but no error was returned "
-                                "during create_launch.");
+      return StatusOr<const XLA_FFI_Command*>(ErrorPolicy::FromErrorCode(
+          XLA_FFI_Error_Code_INTERNAL,
+          "out_command is null but no error was returned during "
+          "create_launch."));
     }
     if (!commands().push_back(out_command)) {
-      return Converter::ToError(
+      return StatusOr<const XLA_FFI_Command*>(ErrorPolicy::FromErrorCode(
           XLA_FFI_Error_Code_RESOURCE_EXHAUSTED,
-          "Maximum number of commands that can be "
-          "recorded per FFI::Record call has been reached.");
+          "Maximum number of commands that can be recorded per FFI::Record "
+          "call has been reached."));
     }
     return out_command;
   }
 
   template <typename KernelArgSpan>
-  StatusT UpdateLaunch(const XLA_FFI_Command* command, KernelArgSpan args) {
+  Status UpdateLaunch(const XLA_FFI_Command* command, KernelArgSpan args) {
     std::vector<XLA_FFI_KernelArg> raw_args = ConvertArgs(args);
     XLA_FFI_KernelArgs ffi_args{raw_args.data(),
                                 static_cast<int64_t>(raw_args.size())};
     XLA_FFI_Error* err =
         frame_->api->update_launch(frame_->record_ctx, command, &ffi_args);
-    return Converter::ToStatus(err);
+    if (err) {
+      return ErrorPolicy::TakeError(api_, err);
+    }
+    return ErrorPolicy::Ok();
   }
 
   template <typename DepSpan = std::initializer_list<const XLA_FFI_Command*>>
-  StatusOrT CreateEmptyCommand(DepSpan dependencies = {}) {
+  StatusOr<const XLA_FFI_Command*> CreateEmptyCommand(
+      DepSpan dependencies = {}) {
     const XLA_FFI_Command* out_command = nullptr;
     XLA_FFI_Error* err = frame_->api->create_empty_command(
         frame_->record_ctx, std::data(dependencies), std::size(dependencies),
         &out_command);
     if (err) {
-      return Converter::ToStatusOr(out_command, err);
+      return StatusOr<const XLA_FFI_Command*>(
+          ErrorPolicy::TakeError(api_, err));
     }
     if (!out_command) {
-      return Converter::ToError(XLA_FFI_Error_Code_INTERNAL,
-                                "out_command is null but no error was returned "
-                                "during create_empty_command.");
+      return StatusOr<const XLA_FFI_Command*>(ErrorPolicy::FromErrorCode(
+          XLA_FFI_Error_Code_INTERNAL,
+          "out_command is null but no error was returned during "
+          "create_empty_command."));
     }
     if (!commands().push_back(out_command)) {
-      return Converter::ToError(
+      return StatusOr<const XLA_FFI_Command*>(ErrorPolicy::FromErrorCode(
           XLA_FFI_Error_Code_RESOURCE_EXHAUSTED,
           "Maximum number of commands that can be recorded per FFI::Record "
-          "call has been reached.");
+          "call has been reached."));
     }
     return out_command;
   }
 
-  StatusT RequestStreamCapture() {
+  Status RequestStreamCapture() {
     XLA_FFI_Error* err =
         frame_->api->request_stream_capture(frame_->record_ctx);
-    return Converter::ToStatus(err);
+    if (err) {
+      return ErrorPolicy::TakeError(api_, err);
+    }
+    return ErrorPolicy::Ok();
   }
 
   template <typename DepSpan = std::initializer_list<const XLA_FFI_Command*>>
-  StatusOrT CreateMemcpyD2D(void* dst, void* src, size_t size,
-                            DepSpan dependencies = {}) {
+  StatusOr<const XLA_FFI_Command*> CreateMemcpyD2D(void* dst, void* src,
+                                                   size_t size,
+                                                   DepSpan dependencies = {}) {
     const XLA_FFI_Command* out_command = nullptr;
     XLA_FFI_Error* err = frame_->api->create_memcpy_d2d(
         frame_->record_ctx, dst, src, size, std::data(dependencies),
         std::size(dependencies), &out_command);
 
     if (err) {
-      return Converter::ToStatusOr(out_command, err);
+      return StatusOr<const XLA_FFI_Command*>(
+          ErrorPolicy::TakeError(api_, err));
     }
     if (!out_command) {
-      return Converter::ToError(XLA_FFI_Error_Code_INTERNAL,
-                                "out_command is null but no error was returned "
-                                "during create_memcpy_d2d.");
+      return StatusOr<const XLA_FFI_Command*>(ErrorPolicy::FromErrorCode(
+          XLA_FFI_Error_Code_INTERNAL,
+          "out_command is null but no error was returned during "
+          "create_memcpy_d2d."));
     }
     if (!commands().push_back(out_command)) {
-      return Converter::ToError(
+      return StatusOr<const XLA_FFI_Command*>(ErrorPolicy::FromErrorCode(
           XLA_FFI_Error_Code_RESOURCE_EXHAUSTED,
           "Maximum number of commands that can be recorded per FFI::Record "
-          "call has been reached.");
+          "call has been reached."));
     }
     return out_command;
   }
 
-  StatusT UpdateMemcpyD2D(const XLA_FFI_Command* command, void* dst, void* src,
-                          size_t size) {
+  Status UpdateMemcpyD2D(const XLA_FFI_Command* command, void* dst, void* src,
+                         size_t size) {
     XLA_FFI_Error* err = frame_->api->update_memcpy_d2d(
         frame_->record_ctx, command, dst, src, size);
-    return Converter::ToStatus(err);
+    if (err) {
+      return ErrorPolicy::TakeError(api_, err);
+    }
+    return ErrorPolicy::Ok();
   }
 
  private:
+  const XLA_FFI_Api* api_;
   const XLA_FFI_RecordFrame* frame_;
 };
 
@@ -297,8 +313,8 @@ struct RecordExtensionBase {
       XLA_FFI_Extension_Record_MinorVersion;
 
   // Builds a context from the extension.
-  static RecordContextT Create(const CExtension* ext) {
-    return RecordContextT(ext->record_frame);
+  static RecordContextT Create(const XLA_FFI_Api* api, const CExtension* ext) {
+    return RecordContextT(api, ext->record_frame);
   }
 };
 

--- a/xla/ffi/api/record_api.h
+++ b/xla/ffi/api/record_api.h
@@ -189,20 +189,19 @@ class RecordContextBase {
         std::size(dependencies), &out_command);
 
     if (err) {
-      return StatusOr<const XLA_FFI_Command*>(
-          ErrorPolicy::TakeError(api_, err));
+      return ErrorPolicy::TakeError(api_, err);
     }
     if (!out_command) {
-      return StatusOr<const XLA_FFI_Command*>(ErrorPolicy::FromErrorCode(
+      return ErrorPolicy::FromErrorCode(
           XLA_FFI_Error_Code_INTERNAL,
           "out_command is null but no error was returned during "
-          "create_launch."));
+          "create_launch.");
     }
     if (!commands().push_back(out_command)) {
-      return StatusOr<const XLA_FFI_Command*>(ErrorPolicy::FromErrorCode(
+      return ErrorPolicy::FromErrorCode(
           XLA_FFI_Error_Code_RESOURCE_EXHAUSTED,
           "Maximum number of commands that can be recorded per FFI::Record "
-          "call has been reached."));
+          "call has been reached.");
     }
     return out_command;
   }
@@ -228,20 +227,19 @@ class RecordContextBase {
         frame_->record_ctx, std::data(dependencies), std::size(dependencies),
         &out_command);
     if (err) {
-      return StatusOr<const XLA_FFI_Command*>(
-          ErrorPolicy::TakeError(api_, err));
+      return ErrorPolicy::TakeError(api_, err);
     }
     if (!out_command) {
-      return StatusOr<const XLA_FFI_Command*>(ErrorPolicy::FromErrorCode(
+      return ErrorPolicy::FromErrorCode(
           XLA_FFI_Error_Code_INTERNAL,
           "out_command is null but no error was returned during "
-          "create_empty_command."));
+          "create_empty_command.");
     }
     if (!commands().push_back(out_command)) {
-      return StatusOr<const XLA_FFI_Command*>(ErrorPolicy::FromErrorCode(
+      return ErrorPolicy::FromErrorCode(
           XLA_FFI_Error_Code_RESOURCE_EXHAUSTED,
           "Maximum number of commands that can be recorded per FFI::Record "
-          "call has been reached."));
+          "call has been reached.");
     }
     return out_command;
   }
@@ -265,20 +263,19 @@ class RecordContextBase {
         std::size(dependencies), &out_command);
 
     if (err) {
-      return StatusOr<const XLA_FFI_Command*>(
-          ErrorPolicy::TakeError(api_, err));
+      return ErrorPolicy::TakeError(api_, err);
     }
     if (!out_command) {
-      return StatusOr<const XLA_FFI_Command*>(ErrorPolicy::FromErrorCode(
+      return ErrorPolicy::FromErrorCode(
           XLA_FFI_Error_Code_INTERNAL,
           "out_command is null but no error was returned during "
-          "create_memcpy_d2d."));
+          "create_memcpy_d2d.");
     }
     if (!commands().push_back(out_command)) {
-      return StatusOr<const XLA_FFI_Command*>(ErrorPolicy::FromErrorCode(
+      return ErrorPolicy::FromErrorCode(
           XLA_FFI_Error_Code_RESOURCE_EXHAUSTED,
           "Maximum number of commands that can be recorded per FFI::Record "
-          "call has been reached."));
+          "call has been reached.");
     }
     return out_command;
   }

--- a/xla/ffi/api/record_ffi.h
+++ b/xla/ffi/api/record_ffi.h
@@ -21,10 +21,6 @@ limitations under the License.
        See README.md for more details.
 #endif  // XLA_FFI_API_RECORD_FFI_H_
 
-#include <string>
-#include <string_view>
-#include <utility>
-
 #include "xla/ffi/api/api.h"
 #include "xla/ffi/api/c_api.h"
 #include "xla/ffi/api/ffi.h"
@@ -32,44 +28,9 @@ limitations under the License.
 
 namespace xla::ffi {
 
-namespace internal {
-
-inline Error ConvertError(XLA_FFI_Error* err) {
-  const XLA_FFI_Api* api = XLA_FFI_GetApi();
-  std::string msg = internal::GetErrorMessage(api, err);
-  internal::DestroyError(api, err);
-  return Error(ErrorCode::kInternal, std::move(msg));
-}
-
-// Error converter for external XLA:FFI.
-struct ErrorConverter {
-  template <typename T>
-  static xla::ffi::ErrorOr<T> ToStatusOr(T value, XLA_FFI_Error* err) {
-    if (err) {
-      return xla::ffi::Unexpected(ConvertError(err));
-    }
-    return value;
-  }
-
-  static xla::ffi::Error ToStatus(XLA_FFI_Error* err) {
-    if (err) {
-      return ConvertError(err);
-    }
-    return xla::ffi::Error::Success();  // PASS-THROUGH
-  }
-
-  static xla::ffi::Unexpected<xla::ffi::Error> ToError(XLA_FFI_Error_Code err_c,
-                                                       std::string_view msg) {
-    return xla::ffi::Unexpected(xla::ffi::Error(err_c, std::string(msg)));
-  }
-
-  static xla::ffi::Error Success() { return xla::ffi::Error::Success(); }
-};
-}  // namespace internal
-
 struct RecordContext
-    : public internal::RecordContextBase<internal::ErrorConverter> {
-  using Base = internal::RecordContextBase<internal::ErrorConverter>;
+    : public internal::RecordContextBase<internal::ErrorPolicy> {
+  using Base = internal::RecordContextBase<internal::ErrorPolicy>;
   using Base::Base;
 };
 

--- a/xla/ffi/ffi.h
+++ b/xla/ffi/ffi.h
@@ -16,7 +16,6 @@ limitations under the License.
 #ifndef XLA_FFI_FFI_H_
 #define XLA_FFI_FFI_H_
 
-#include <string_view>
 #ifdef XLA_FFI_API_FFI_H_
 #error Two different XLA FFI implementations cannot be included together. \
        See README.md for more details.
@@ -95,9 +94,8 @@ struct ErrorPolicy {
   static Status Ok() { return absl::OkStatus(); }
 
   static Status FromErrorCode(XLA_FFI_Error_Code errc,
-                              std::string_view message) {
-    return Status(static_cast<absl::StatusCode>(errc),
-                  absl::string_view(message.data(), message.size()));
+                              absl::string_view message) {
+    return Status(static_cast<absl::StatusCode>(errc), message);
   }
 
   static Status TakeError(const XLA_FFI_Api*, XLA_FFI_Error* error) {

--- a/xla/ffi/ffi.h
+++ b/xla/ffi/ffi.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef XLA_FFI_FFI_H_
 #define XLA_FFI_FFI_H_
 
+#include <string_view>
 #ifdef XLA_FFI_API_FFI_H_
 #error Two different XLA FFI implementations cannot be included together. \
        See README.md for more details.
@@ -50,6 +51,7 @@ limitations under the License.
 #include "xla/ffi/api/c_api_internal.h"  // IWYU pragma: keep
 #include "xla/ffi/execution_context.h"
 #include "xla/ffi/execution_state.h"
+#include "xla/ffi/ffi_interop.h"
 #include "xla/ffi/type_registry.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/primitive_util.h"
@@ -76,6 +78,34 @@ struct CalledComputation {};  // binds `HloComputation*`
 // must be linked into the target process exactly once, or it is possible to
 // have multiple global static registries of FFI handlers and types.
 const XLA_FFI_Api* GetXlaFfiApi();
+
+//===----------------------------------------------------------------------===//
+// Error policy
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+// Error policy for internal FFI handlers statically linked into XLA.
+struct ErrorPolicy {
+  using Status = absl::Status;
+
+  template <typename T>
+  using StatusOr = absl::StatusOr<T>;
+
+  static Status Ok() { return absl::OkStatus(); }
+
+  static Status FromErrorCode(XLA_FFI_Error_Code errc,
+                              std::string_view message) {
+    return Status(static_cast<absl::StatusCode>(errc),
+                  absl::string_view(message.data(), message.size()));
+  }
+
+  static Status TakeError(const XLA_FFI_Api*, XLA_FFI_Error* error) {
+    return xla::ffi::TakeError(error);
+  }
+};
+
+}  // namespace internal
 
 //===----------------------------------------------------------------------===//
 // Arguments
@@ -154,7 +184,7 @@ class AnyBuffer {
   }
 
  private:
-  friend struct match::internal::BufferCast;
+  friend struct internal::BufferCast;
 
   const XLA_FFI_Buffer* buf_;
 };
@@ -201,7 +231,7 @@ class Buffer {
   }
 
  private:
-  friend struct match::internal::BufferCast;
+  friend struct internal::BufferCast;
 
   const XLA_FFI_Buffer* buf_;
 };
@@ -273,7 +303,6 @@ TypeRegistry::TypeId GetTypeId(const XLA_FFI_Api* api) {
 // Buffer Matching
 //===----------------------------------------------------------------------===//
 
-namespace match {
 namespace internal {
 
 struct BufferCast {
@@ -296,6 +325,8 @@ struct ValuePrinter<PrimitiveType> {
 
 }  // namespace internal
 
+namespace match {
+
 // A buffer-matching pattern specialized to the internal `PrimitiveType` enum.
 template <typename DTypes = DTypeSet<PrimitiveType>, typename Ranks = RankSet<>>
 using BufferPattern = internal::BufferPatternBase<DTypes, Ranks>;
@@ -317,11 +348,7 @@ inline BufferPattern<> Buffer() { return {}; }
 template <typename BufferType, typename DTypes, typename Ranks>
 absl::Status Verify(absl::string_view name, BufferType buffer,
                     const match::BufferPattern<DTypes, Ranks>& pattern) {
-  DiagnosticEngine diagnostic;
-  if (!internal::MatchBuffer(name, buffer, pattern, diagnostic)) {
-    return absl::InvalidArgumentError(diagnostic.Result());
-  }
-  return absl::OkStatus();
+  return internal::VerifyBuffer<internal::ErrorPolicy>(name, buffer, pattern);
 }
 
 // Matches an AnyBuffer and returns the concrete buffer type specified by a
@@ -331,16 +358,18 @@ absl::StatusOr<Buffer<dtype, rank>> Match(
     absl::string_view name, AnyBuffer buffer,
     const match::BufferPattern<match::DTypeSet<PrimitiveType, dtype>,
                                match::RankSet<rank>>& pattern) {
-  ABSL_RETURN_IF_ERROR(Verify(name, buffer, pattern));
-  return match::internal::BufferCast::Cast<Buffer<dtype, rank>>(buffer);
+  return internal::MatchBuffer<internal::ErrorPolicy, Buffer<dtype, rank>>(
+      name, buffer, pattern, [](AnyBuffer buffer) {
+        return internal::BufferCast::Cast<Buffer<dtype, rank>>(buffer);
+      });
 }
 
 template <PrimitiveType dtype, size_t rank, typename DTypes, typename Ranks>
 absl::StatusOr<Buffer<dtype, rank>> Match(
     absl::string_view name, Buffer<dtype, rank> buffer,
     const match::BufferPattern<DTypes, Ranks>& pattern) {
-  ABSL_RETURN_IF_ERROR(Verify(name, buffer, pattern));
-  return buffer;
+  return internal::MatchBuffer<internal::ErrorPolicy, Buffer<dtype, rank>>(
+      name, buffer, pattern, [](Buffer<dtype, rank> buffer) { return buffer; });
 }
 
 namespace internal {

--- a/xla/ffi/ffi_api.cc
+++ b/xla/ffi/ffi_api.cc
@@ -152,16 +152,44 @@ static XLA_FFI_Error* XLA_FFI_Error_Create(XLA_FFI_Error_Create_Args* args) {
       absl::Status(ToStatusCode(args->errc), args->message)};
 }
 
-static void XLA_FFI_Error_GetMessage(XLA_FFI_Error_GetMessage_Args* args) {
+namespace {
+
+// This is the argument layout for XLA_FFI_Error_GetDetails (called
+// XLA_FFI_Error_GetMessage at the time) in XLA:FFI version 0.3. We use it to
+// support older FFI modules. This can be removed 5 Aug 2027.
+struct XLA_FFI_Error_GetDetails_Args_V03 {
+  size_t struct_size;
+  XLA_FFI_InternalExtension* extension_start;
+  XLA_FFI_Error* error;
+  const char* message;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Error_GetDetails_Args_V03, message);
+
+}  // namespace
+
+static void XLA_FFI_Error_GetDetails(XLA_FFI_Error_GetDetails_Args* args) {
+  if (args->struct_size == XLA_FFI_Error_GetDetails_Args_V03_STRUCT_SIZE) {
+    // memcpy to safely avoid U.B.
+    XLA_FFI_Error_GetDetails_Args_V03 v03{};
+    std::memcpy(&v03, args, XLA_FFI_Error_GetDetails_Args_V03_STRUCT_SIZE);
+    v03.message = v03.error->status.message().data();
+    std::memcpy(args, &v03, XLA_FFI_Error_GetDetails_Args_V03_STRUCT_SIZE);
+    return;
+  }
+
   absl::Status struct_size_check = ActualStructSizeIsGreaterOrEqual(
-      "XLA_FFI_Error_GetMessage", XLA_FFI_Error_GetMessage_Args_STRUCT_SIZE,
+      "XLA_FFI_Error_GetDetails", XLA_FFI_Error_GetDetails_Args_STRUCT_SIZE,
       args->struct_size);
   if (!struct_size_check.ok()) {
     LOG(ERROR) << struct_size_check.message();
+    return;
   }
+
   // absl::Status owns error message in a std::string which guarantees that
   // we'll get a null terminated string.
   args->message = args->error->status.message().data();
+  args->errc = static_cast<XLA_FFI_Error_Code>(args->error->status.code());
 }
 
 static void XLA_FFI_Error_Destroy(XLA_FFI_Error_Destroy_Args* args) {
@@ -635,7 +663,7 @@ const XLA_FFI_Api* GetXlaFfiApi() {
       internal::GetInternalApi(),
 
       XLA_FFI_Error_Create,
-      XLA_FFI_Error_GetMessage,
+      XLA_FFI_Error_GetDetails,
       XLA_FFI_Error_Destroy,
       XLA_FFI_Handler_Register,
       XLA_FFI_Stream_Get,

--- a/xla/ffi/ffi_interop.cc
+++ b/xla/ffi/ffi_interop.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "xla/ffi/ffi_interop.h"
 
-#include <string>
 #include <utility>
 
 #include "absl/base/optimization.h"
@@ -27,7 +26,7 @@ limitations under the License.
 
 namespace xla::ffi {
 
-absl::Status TakeStatus(XLA_FFI_Error* error) {
+absl::Status TakeError(XLA_FFI_Error* error) {
   if (ABSL_PREDICT_TRUE(error == nullptr)) {
     return absl::OkStatus();
   }
@@ -67,13 +66,7 @@ XLA_FFI_Error* CreateError(absl::Status status) {
   if (status.ok()) {
     return nullptr;
   }
-  XLA_FFI_Error_Create_Args args;
-  args.struct_size = XLA_FFI_Error_Create_Args_STRUCT_SIZE;
-  args.extension_start = nullptr;
-  args.errc = static_cast<XLA_FFI_Error_Code>(status.code());
-  std::string message(status.message());
-  args.message = message.c_str();
-  return XLA_FFI_GetApi()->XLA_FFI_Error_Create(&args);
+  return new XLA_FFI_Error{std::move(status)};
 }
 
 }  // namespace xla::ffi

--- a/xla/ffi/ffi_interop.h
+++ b/xla/ffi/ffi_interop.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef XLA_FFI_FFI_INTEROP_H_
 #define XLA_FFI_FFI_INTEROP_H_
 
+#include "absl/base/macros.h"
 #include "absl/status/status.h"
 #include "xla/ffi/api/c_api.h"
 #include "xla/tsl/concurrency/async_value_ref.h"
@@ -29,7 +30,12 @@ namespace xla::ffi {
 
 // Takes ownership of the XLA FFI error and returns underlying status. Frees
 // `error` if it's not nullptr. If `error` is nullptr, returns OkStatus.
-absl::Status TakeStatus(XLA_FFI_Error* error);
+absl::Status TakeError(XLA_FFI_Error* error);
+
+ABSL_DEPRECATE_AND_INLINE()
+inline absl::Status TakeStatus(XLA_FFI_Error* error) {
+  return TakeError(error);
+}
 
 // Takes ownership of the XLA FFI future and returns underlying AsyncValue.
 // Frees `future` if it's not nullptr. If `future` is nullptr, returns available

--- a/xla/ffi/ffi_test.cc
+++ b/xla/ffi/ffi_test.cc
@@ -281,14 +281,18 @@ struct MyContext {
 struct MyExtension {
   using Type = MyContext;
   using CExtension = MyCExtension;
+
   static constexpr auto kName = "MyExtension";
   static constexpr int64_t kExtensionType = 1234;
   static constexpr int32_t kMajorVersion = 1;
   static constexpr int32_t kMinorVersion = 2;
 
-  static Type Create(const CExtension* ext) { return Type{ext}; }
   static bool Support(int32_t major_version, int32_t minor_version) {
     return major_version == kMajorVersion && minor_version <= kMinorVersion;
+  }
+
+  static Type Create(const XLA_FFI_Api*, const CExtension* ext) {
+    return Type{ext};
   }
 };
 

--- a/xla/ffi/record_ffi.h
+++ b/xla/ffi/record_ffi.h
@@ -21,11 +21,6 @@ limitations under the License.
        See README.md for more details.
 #endif  // XLA_FFI_API_RECORD_FFI_H_
 
-#include <string>
-#include <utility>
-
-#include "absl/status/status.h"
-#include "absl/strings/string_view.h"
 #include "xla/ffi/api/api.h"
 #include "xla/ffi/api/c_api.h"
 #include "xla/ffi/api/record_api.h"
@@ -34,40 +29,9 @@ limitations under the License.
 // Internal API for the record context.
 namespace xla::ffi {
 
-namespace internal {
-
-inline absl::Status ConvertError(XLA_FFI_Error* err) {
-  const XLA_FFI_Api* api = XLA_FFI_GetApi();
-  std::string msg = internal::GetErrorMessage(api, err);
-  internal::DestroyError(api, err);
-  return absl::InternalError(std::move(msg));
-}
-
-struct ErrorConverter {
-  template <typename T>
-  static absl::StatusOr<T> ToStatusOr(T value, XLA_FFI_Error* err) {
-    if (err) {
-      return ConvertError(err);
-    }
-    return value;
-  }
-  static absl::Status ToStatus(XLA_FFI_Error* err) {
-    if (err) {
-      return ConvertError(err);
-    }
-    return absl::OkStatus();
-  }
-  static absl::Status ToError(XLA_FFI_Error_Code err_c, absl::string_view msg) {
-    return absl::Status(static_cast<absl::StatusCode>(err_c), msg);
-  }
-  static absl::Status Success() { return absl::OkStatus(); }
-};
-
-}  // namespace internal
-
 struct RecordContext
-    : public internal::RecordContextBase<internal::ErrorConverter> {
-  using Base = internal::RecordContextBase<internal::ErrorConverter>;
+    : public internal::RecordContextBase<internal::ErrorPolicy> {
+  using Base = internal::RecordContextBase<internal::ErrorPolicy>;
   using Base::Base;
 };
 


### PR DESCRIPTION
Introduce an `ErrorPolicy` compatibility layer for shared FFI APIs that need to report errors using different user-facing types:

  - External FFI uses `Error` and `ErrorOr<T>`.
  - Internal FFI uses `absl::Status` and `absl::StatusOr<T>`.

Parameterize `RecordContextBase` with this policy instead of routing individual API errors through `DiagnosticEngine`. Argument, attribute, and dictionary decoding continue using `DiagnosticEngine`, where collecting multiple decoding failures is useful.

Also migrate buffer matching and verification APIs on top of ErrorPolicy and stop abusing DiagnosticEngine. The rule of thumb is that diagnostic engine should be used in attr decoding then collecting all errors during decoding stage is important for usability.

Additional changes:

  - Replace XLA_FFI_Error_GetMessage with XLA_FFI_Error_GetDetails, returning both the message and error code.
  - Preserve binary compatibility with the smaller XLA FFI 0.3 message-only argument structure.
  - Make `ffi_interop::TakeError` the canonical privileged conversion API.
  - Keep `TakeStatus` as a deprecated inline compatibility bridge.
  - Construct and consume `XLA_FFI_Error` directly inside privileged interop code, preserving the complete `absl::Status` and avoiding `XLA_FFI_GetApi()` calls.