### PR TITLE
[xla:gpu] DUSV2 thunk is a leaf thunk from Walking perspective

### DIFF
--- a/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.cc
+++ b/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.cc
@@ -518,14 +518,6 @@ Thunk::BufferUses DynamicSliceFusionV2Thunk::buffer_uses() const {
   return uses;
 }
 
-absl::Status DynamicSliceFusionV2Thunk::WalkNested(Walker callback) {
-  return executor_.thunks().WalkNested(callback);
-}
-
-absl::Status DynamicSliceFusionV2Thunk::TransformNested(Transformer callback) {
-  return executor_.thunks().TransformNested(callback);
-}
-
 //===----------------------------------------------------------------------===//
 // Serialization
 //===----------------------------------------------------------------------===//

--- a/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.h
+++ b/xla/backends/gpu/runtime/dynamic_slice_fusion_v2_thunk.h
@@ -95,6 +95,9 @@ class DynamicSliceFusionV2Thunk : public Command {
 
   BufferUses buffer_uses() const override;
 
+  // Embedded thunks are an implementation detail and use a private synthetic
+  // allocation namespace. They are intentionally not exposed through generic
+  // Thunk::Walk or ThunkSequence::TransformNested traversal.
   const ThunkSequence& thunks() const { return executor_.thunks(); }
 
   absl::Span<const DynamicSliceFusion::Parameter> parameters() const {
@@ -125,10 +128,6 @@ class DynamicSliceFusionV2Thunk : public Command {
       ThunkInfo thunk_info, const DynamicSliceFusionThunkProto& proto,
       absl::Span<const BufferAllocation> buffer_allocations,
       const DeserializerWithCustomAllocations& deserializer);
-
- protected:
-  absl::Status WalkNested(Walker callback) override;
-  absl::Status TransformNested(Transformer callback) override;
 
  private:
   std::vector<se::DeviceAddressBase> BuildDynamicSliceBuffers(


### PR DESCRIPTION
Treat `DynamicSliceFusionV2Thunk` as a leaf for generic thunk walking and transformation.

Its embedded thunks use a private synthetic buffer-allocation namespace. Exposing them through `WalkNested()` allowed consumers collecting `buffer_uses()` to mix synthetic allocation indices with executable allocation indices, potentially producing invalid buffer analysis and spurious conflicts.

This removes the `WalkNested()` and `TransformNested()` overrides. Intentional consumers can still access the implementation through the explicit thunks() accessor. Execution, serialization, and command-buffer conversion are unchanged.