### PR TITLE
[XLA:CPU] Add support for __truncsfhf2/__extendhfsf2 on s390x

### DIFF
--- a/xla/backends/cpu/codegen/builtin_definition_generator.cc
+++ b/xla/backends/cpu/codegen/builtin_definition_generator.cc
@@ -106,12 +106,12 @@ uint16_t __truncsfbf2(float);
 // Converts an F64 value to a BF16.
 uint16_t __truncdfbf2(double);
 
-#ifdef __APPLE__
+#ifdef __APPLE__ || defined(__s390x__)
 // Converts an F32 value to a F16.
 uint16_t __truncsfhf2(float);
 
 float __extendhfsf2(uint16_t a);
-#endif  // __APPLE__
+#endif  // __APPLE__ || __s390x__
 
 }  // extern "C"
 
@@ -240,9 +240,12 @@ static Registry CreateRegistry() {
 
 #undef REGISTER_LIBM_SYMBOL
 
-#ifdef __APPLE__
+#ifdef __APPLE__ || defined(__s390x__)
   registry["__truncsfhf2"] = SymbolDef(__truncsfhf2);
   registry["__extendhfsf2"] = SymbolDef(__extendhfsf2);
+#endif
+
+#ifdef __APPLE__
   registry["__bzero"] = SymbolDef(bzero);
   registry["bzero"] = SymbolDef(bzero);
   registry["memset_pattern16"] = SymbolDef(memset_pattern16);


### PR DESCRIPTION
📝 Summary of Changes
Adds support for __truncsfhf2 and __extendhfsf2 on s390x in XLA CPU's
builtin symbol registry.

🎯 Justification
These symbols were not found on s390x, causing JIT symbol resolution
to fail before the compiled kernel could run.

🚀 Kind of Contribution
🐛 Bug Fix