### PR TITLE
[ROCm] Skip unsupported subtests in ragged_all_to_all_e2e

### DIFF
--- a/xla/backends/gpu/tests/ragged_all_to_all_e2e_test.cc
+++ b/xla/backends/gpu/tests/ragged_all_to_all_e2e_test.cc
@@ -252,6 +252,10 @@ class RaggedAllToAllTestBase : public CollectiveOpsWithFlagsBase {
       GTEST_SKIP() << "Symmetric memory is only supported on Hopper "
                       "architecture and above.";
     }
+    if (impl_type_ == RaggedAllToAllImplType::kDeviceKernel &&
+        Capability().IsRocm()) {
+      GTEST_SKIP() << "Device initiated communication not supported on ROCm.";
+    }
   }
 
   DebugOptions GetDebugOptionsForTest() const override {
@@ -274,6 +278,7 @@ class RaggedAllToAllTestBase : public CollectiveOpsWithFlagsBase {
         // devices are actually connected via fast interconnect.
         // TODO: b/493935137 - Enable for all architectures once we get
         // NCCL 2.29 integrated with host API to check LSA connectivity.
+        Capability().IsCuda() &&
         Capability().cuda_compute_capability()->IsAtLeastHopper()) {
       opts.set_xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel(true);
       opts.set_xla_gpu_experimental_ragged_all_to_all_use_barrier(false);


### PR DESCRIPTION
📝 Summary of Changes
Skip failing tests.

🎯 Justification
Device-initiated communication is not supported on ROCm. 

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix
