### PR TITLE
[XLA:GPU][OneAPI] Enable dot algorithm presets supported on OneAPI platform.

### DIFF
--- a/xla/service/algorithm_util.cc
+++ b/xla/service/algorithm_util.cc
@@ -279,6 +279,8 @@ bool IsSupportedDotAlgorithmOnGpu(
                             gpu_compute_capability.rocm_compute_capability()
                                 ->has_bf16_dtype_support();
 
+  const bool is_sycl = gpu_compute_capability.IsOneAPI();
+
   switch (algorithm) {
     case PrecisionConfig::ALG_DOT_ANY_F8_ANY_F8_F32:
     case PrecisionConfig::ALG_DOT_ANY_F8_ANY_F8_F32_FAST_ACCUM:
@@ -304,7 +306,7 @@ bool IsSupportedDotAlgorithmOnGpu(
       return lhs_storage_type == rhs_storage_type && lhs_storage_type == F16 &&
              (output_storage_type == F16 || output_storage_type == F32);
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32:
-      if (!is_cuda_ge_ampere && !is_rocm_bf16) {
+      if (!is_cuda_ge_ampere && !is_rocm_bf16 && !is_sycl) {
         return false;
       }
       if (lhs_storage_type != rhs_storage_type) {
@@ -321,7 +323,7 @@ bool IsSupportedDotAlgorithmOnGpu(
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32_X3:
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32_X6:
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32_X9:
-      return (is_cuda_ge_ampere || is_rocm_bf16) &&
+      return (is_cuda_ge_ampere || is_rocm_bf16 || is_sycl) &&
              lhs_storage_type == rhs_storage_type && lhs_storage_type == F32 &&
              output_storage_type == F32;
     case PrecisionConfig::ALG_DOT_TF32_TF32_F32_X3:


### PR DESCRIPTION
OneAPI

📝 Summary of Changes
This PR enables following dot algorithm presets on OneAPI.

ALG_DOT_BF16_BF16_F32
ALG_DOT_BF16_BF16_F32_X3
ALG_DOT_BF16_BF16_F32_X6
ALG_DOT_BF16_BF16_F32_X9


