### PR TITLE
[XLA:GPU] Add GPU communicator FFI extension

### DIFF
--- a/xla/backends/gpu/BUILD
+++ b/xla/backends/gpu/BUILD
@@ -51,3 +51,31 @@ cc_library(
         "@com_google_absl//absl/base:core_headers",
     ],
 )
+
+cc_library(
+    name = "ffi_gpu_collectives",
+    srcs = ["ffi_gpu_collectives.cc"],
+    hdrs = ["ffi_gpu_collectives.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//xla:util",
+        "//xla:xla_data_proto_cc",
+        "//xla/backends/gpu/collectives:gpu_clique_key",
+        "//xla/backends/gpu/collectives:gpu_communicator",
+        "//xla/backends/gpu/runtime:collective_clique_requests",
+        "//xla/backends/gpu/runtime:collective_cliques",
+        "//xla/backends/gpu/runtime:collective_execution",
+        "//xla/backends/gpu/runtime:collective_params",
+        "//xla/ffi:ffi_api",
+        "//xla/ffi/api:c_api",
+        "//xla/ffi/api:ffi_gpu_collectives",
+        "//xla/service:collective_ops_utils",
+        "//xla/tsl/platform:errors",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)

--- a/xla/backends/gpu/ffi_gpu_collectives.cc
+++ b/xla/backends/gpu/ffi_gpu_collectives.cc
@@ -1,0 +1,293 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/ffi_gpu_collectives.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/algorithm/container.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/gpu/collectives/gpu_clique_key.h"
+#include "xla/backends/gpu/collectives/gpu_communicator.h"
+#include "xla/backends/gpu/runtime/collective_clique_requests.h"
+#include "xla/backends/gpu/runtime/collective_cliques.h"
+#include "xla/backends/gpu/runtime/collective_execution.h"
+#include "xla/backends/gpu/runtime/collective_params.h"
+#include "xla/ffi/api/c_api.h"
+#include "xla/ffi/api/ffi_gpu_collectives.h"
+#include "xla/service/collective_ops_utils.h"
+#include "xla/tsl/platform/errors.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/util.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::ffi {
+const XLA_FFI_Api* GetXlaFfiApi();
+}  // namespace xla::ffi
+
+namespace xla::gpu {
+namespace {
+
+absl::Status ActualStructSizeIsGreaterOrEqual(absl::string_view struct_name,
+                                              size_t expected, size_t actual) {
+  if (actual < expected) {
+    return InvalidArgument("Unexpected %s size: expected %zu, got %zu",
+                           struct_name, expected, actual);
+  }
+  if (actual > expected) {
+    VLOG(2) << "Unexpected " << struct_name << " size: expected " << expected
+            << ", got " << actual << ". Check installed software versions.";
+  }
+  return absl::OkStatus();
+}
+
+XLA_FFI_Error* MakeError(const absl::Status& status) {
+  if (status.ok()) {
+    return nullptr;
+  }
+  const std::string message(status.message());
+  XLA_FFI_Error_Create_Args args;
+  args.struct_size = XLA_FFI_Error_Create_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.message = message.c_str();
+  args.errc = static_cast<XLA_FFI_Error_Code>(status.code());
+  return ffi::GetXlaFfiApi()->XLA_FFI_Error_Create(&args);
+}
+
+#define XLA_FFI_RETURN_IF_ERROR(expr) \
+  do {                                \
+    absl::Status _status = (expr);    \
+    if (!_status.ok()) {              \
+      return MakeError(_status);      \
+    }                                 \
+  } while (false)
+
+#define XLA_FFI_STATUS_MACROS_CONCAT_INNER(x, y) x##y
+#define XLA_FFI_STATUS_MACROS_CONCAT(x, y) \
+  XLA_FFI_STATUS_MACROS_CONCAT_INNER(x, y)
+
+#define XLA_FFI_ASSIGN_OR_RETURN(lhs, rexpr)                             \
+  XLA_FFI_ASSIGN_OR_RETURN_IMPL(                                         \
+      XLA_FFI_STATUS_MACROS_CONCAT(_ffi_status_or_value, __LINE__), lhs, \
+      rexpr)
+
+#define XLA_FFI_ASSIGN_OR_RETURN_IMPL(statusor, lhs, rexpr) \
+  auto statusor = (rexpr);                                  \
+  if (!statusor.ok()) {                                     \
+    return MakeError(std::move(statusor).status());         \
+  }                                                         \
+  lhs = std::move(statusor).value()
+
+absl::StatusOr<CollectiveOpGroupMode> ToCollectiveOpGroupMode(
+    XLA_FFI_Gpu_GroupMode group_mode) {
+  switch (group_mode) {
+    case XLA_FFI_GPU_GROUP_CROSS_REPLICA:
+      return CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA;
+    case XLA_FFI_GPU_GROUP_CROSS_PARTITION:
+      return CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION;
+    case XLA_FFI_GPU_GROUP_CROSS_REPLICA_AND_PARTITION:
+      return CollectiveOpGroupMode::
+          COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA_AND_PARTITION;
+    case XLA_FFI_GPU_GROUP_FLATTENED_ID:
+      return CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID;
+    default:
+      return InvalidArgument("Invalid GPU collective group mode: %d",
+                             static_cast<int>(group_mode));
+  }
+}
+
+absl::StatusOr<std::vector<ReplicaGroup>> ToReplicaGroups(
+    const XLA_FFI_Gpu_ReplicaGroup* groups, size_t num_groups) {
+  if (groups == nullptr && num_groups != 0) {
+    return InvalidArgument("groups must be set when num_groups is non-zero");
+  }
+
+  std::vector<ReplicaGroup> replica_groups;
+  replica_groups.reserve(num_groups);
+  for (size_t i = 0; i < num_groups; ++i) {
+    if (groups[i].ids == nullptr && groups[i].size != 0) {
+      return InvalidArgument(
+          "group ids must be set when group size is non-zero");
+    }
+    ReplicaGroup replica_group;
+    for (size_t j = 0; j < groups[i].size; ++j) {
+      replica_group.add_replica_ids(groups[i].ids[j]);
+    }
+    replica_groups.push_back(std::move(replica_group));
+  }
+  return replica_groups;
+}
+
+absl::StatusOr<GpuCliqueKey> GetCliqueKey(
+    const CollectiveParams& params, XLA_FFI_Gpu_GroupMode group_mode,
+    const std::vector<ReplicaGroup>& replica_groups, int64_t communication_id) {
+  if (communication_id < 0) {
+    return InvalidArgument("communication_id must be non-negative");
+  }
+  TF_ASSIGN_OR_RETURN(CollectiveOpGroupMode mode,
+                      ToCollectiveOpGroupMode(group_mode));
+  return GetGpuCliqueKey(params, replica_groups, mode,
+                         CommunicationId(communication_id));
+}
+
+absl::StatusOr<std::vector<std::vector<GlobalDeviceId>>> GetDeviceGroups(
+    const CollectiveParams& params, XLA_FFI_Gpu_GroupMode group_mode,
+    const std::vector<ReplicaGroup>& replica_groups) {
+  TF_RET_CHECK(params.device_assn != nullptr)
+      << "Device assignment is required for GPU communicator FFI calls";
+
+  TF_ASSIGN_OR_RETURN(CollectiveOpGroupMode mode,
+                      ToCollectiveOpGroupMode(group_mode));
+
+  TF_ASSIGN_OR_RETURN(
+      std::vector<std::vector<GlobalDeviceId>> device_groups,
+      GetParticipatingDevicesGroups(*params.device_assn, replica_groups, mode));
+
+  for (auto& group : device_groups) {
+    absl::c_sort(group);
+  }
+  absl::c_sort(device_groups);
+  return device_groups;
+}
+
+XLA_FFI_Error* CommunicatorRequest(
+    const XLA_FFI_Gpu_Collectives_Extension* self,
+    XLA_FFI_Gpu_Communicator_Request_Args* args) {
+  if (self == nullptr) {
+    return MakeError(
+        InvalidArgument("GPU collectives extension is not available"));
+  }
+  if (args == nullptr) {
+    return MakeError(
+        InvalidArgument("XLA_FFI_Gpu_Communicator_Request_Args is null"));
+  }
+  XLA_FFI_RETURN_IF_ERROR(ActualStructSizeIsGreaterOrEqual(
+      "XLA_FFI_Gpu_Communicator_Request_Args",
+      XLA_FFI_Gpu_Communicator_Request_Args_STRUCT_SIZE, args->struct_size));
+
+  const auto* params =
+      reinterpret_cast<const CollectiveParams*>(self->collective_params);
+  if (params == nullptr) {
+    return MakeError(InvalidArgument("Collective params are not available"));
+  }
+
+  auto* clique_requests = reinterpret_cast<CollectiveCliqueRequests*>(
+      self->collective_clique_requests);
+  if (clique_requests == nullptr) {
+    return MakeError(FailedPrecondition(
+        "GPU communicator request is only available during the prepare stage"));
+  }
+
+  XLA_FFI_ASSIGN_OR_RETURN(std::vector<ReplicaGroup> replica_groups,
+                           ToReplicaGroups(args->groups, args->num_groups));
+  XLA_FFI_ASSIGN_OR_RETURN(
+      GpuCliqueKey clique_key,
+      GetCliqueKey(*params, args->group_mode, replica_groups,
+                   args->communication_id));
+  XLA_FFI_ASSIGN_OR_RETURN(
+      std::vector<std::vector<GlobalDeviceId>> device_groups,
+      GetDeviceGroups(*params, args->group_mode, replica_groups));
+  XLA_FFI_RETURN_IF_ERROR(
+      clique_requests->RequestClique(clique_key, device_groups));
+  return nullptr;
+}
+
+XLA_FFI_Error* CommunicatorGet(const XLA_FFI_Gpu_Collectives_Extension* self,
+                               XLA_FFI_Gpu_Communicator_Get_Args* args) {
+  if (self == nullptr) {
+    return MakeError(
+        InvalidArgument("GPU collectives extension is not available"));
+  }
+  if (args == nullptr) {
+    return MakeError(
+        InvalidArgument("XLA_FFI_Gpu_Communicator_Get_Args is null"));
+  }
+  XLA_FFI_RETURN_IF_ERROR(ActualStructSizeIsGreaterOrEqual(
+      "XLA_FFI_Gpu_Communicator_Get_Args",
+      XLA_FFI_Gpu_Communicator_Get_Args_STRUCT_SIZE, args->struct_size));
+
+  const auto* params =
+      reinterpret_cast<const CollectiveParams*>(self->collective_params);
+  if (params == nullptr) {
+    return MakeError(InvalidArgument("Collective params are not available"));
+  }
+
+  const auto* cliques =
+      reinterpret_cast<const CollectiveCliques*>(self->collective_cliques);
+  if (cliques == nullptr) {
+    return MakeError(FailedPrecondition(
+        "GPU communicator get is only available after cliques are acquired"));
+  }
+
+  XLA_FFI_ASSIGN_OR_RETURN(std::vector<ReplicaGroup> replica_groups,
+                           ToReplicaGroups(args->groups, args->num_groups));
+  XLA_FFI_ASSIGN_OR_RETURN(
+      GpuCliqueKey clique_key,
+      GetCliqueKey(*params, args->group_mode, replica_groups,
+                   args->communication_id));
+  XLA_FFI_ASSIGN_OR_RETURN(
+      GpuCommunicator * comm,
+      cliques->GetComm(clique_key, params->global_device_id));
+
+  PlatformCommunicatorHandle platform_comm = comm->platform_comm();
+  if (platform_comm.handle == nullptr) {
+    return MakeError(
+        Unimplemented("Platform communicator handle is not available"));
+  }
+
+  args->communicator = platform_comm.handle;
+  return nullptr;
+}
+
+#undef XLA_FFI_ASSIGN_OR_RETURN_IMPL
+#undef XLA_FFI_ASSIGN_OR_RETURN
+#undef XLA_FFI_STATUS_MACROS_CONCAT
+#undef XLA_FFI_STATUS_MACROS_CONCAT_INNER
+#undef XLA_FFI_RETURN_IF_ERROR
+
+}  // namespace
+
+XLA_FFI_Gpu_Collectives_Extension MakeGpuCollectivesExtension(
+    const CollectiveParams* collective_params,
+    CollectiveCliqueRequests* collective_clique_requests,
+    const CollectiveCliques* collective_cliques) {
+  XLA_FFI_Gpu_Collectives_Extension extension;
+  extension.extension_base = XLA_FFI_Extension{
+      /*struct_size=*/sizeof(XLA_FFI_Gpu_Collectives_Extension),
+      /*id=*/
+      XLA_FFI_ExtensionId{
+          /*extension_type=*/XLA_FFI_Gpu_Collectives_Extension_Type,
+          /*major_version=*/XLA_FFI_Gpu_Collectives_Extension_Major,
+          /*minor_version=*/XLA_FFI_Gpu_Collectives_Extension_Minor},
+      /*next=*/nullptr};
+  extension.collective_params =
+      const_cast<void*>(reinterpret_cast<const void*>(collective_params));
+  extension.collective_clique_requests =
+      reinterpret_cast<void*>(collective_clique_requests);
+  extension.collective_cliques =
+      const_cast<void*>(reinterpret_cast<const void*>(collective_cliques));
+  extension.request_communicator = CommunicatorRequest;
+  extension.get_communicator = CommunicatorGet;
+  return extension;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/ffi_gpu_collectives.h
+++ b/xla/backends/gpu/ffi_gpu_collectives.h
@@ -1,0 +1,33 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_FFI_GPU_COLLECTIVES_H_
+#define XLA_BACKENDS_GPU_FFI_GPU_COLLECTIVES_H_
+
+#include "xla/backends/gpu/runtime/collective_clique_requests.h"
+#include "xla/backends/gpu/runtime/collective_cliques.h"
+#include "xla/backends/gpu/runtime/collective_params.h"
+#include "xla/ffi/api/ffi_gpu_collectives.h"
+
+namespace xla::gpu {
+
+XLA_FFI_Gpu_Collectives_Extension MakeGpuCollectivesExtension(
+    const CollectiveParams* collective_params,
+    CollectiveCliqueRequests* collective_clique_requests,
+    const CollectiveCliques* collective_cliques);
+
+}  // namespace xla::gpu
+
+#endif  // XLA_BACKENDS_GPU_FFI_GPU_COLLECTIVES_H_

--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -1087,6 +1087,7 @@ cc_library(
         "//xla:shape_util",
         "//xla:util",
         "//xla/backends/cpu:target_machine_options",
+        "//xla/backends/gpu:ffi_gpu_collectives",
         "//xla/ffi",
         "//xla/ffi:attribute_map",
         "//xla/ffi:call_frame",

--- a/xla/backends/gpu/runtime/custom_call_thunk.cc
+++ b/xla/backends/gpu/runtime/custom_call_thunk.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include "absl/types/span.h"
 #include "xla/tsl/platform/status_macros.h"
 #include "xla/backends/cpu/target_machine_options.h"
+#include "xla/backends/gpu/ffi_gpu_collectives.h"
 #include "xla/backends/gpu/runtime/collective_clique_requests.h"
 #include "xla/backends/gpu/runtime/collective_cliques.h"
 #include "xla/backends/gpu/runtime/collective_params.h"
@@ -155,7 +156,7 @@ absl::StatusOr<std::unique_ptr<CustomCallThunk>> CustomCallThunk::Create(
     std::unique_ptr<ffi::ExecutionState> execution_state,
     std::optional<xla::cpu::TargetMachineOptions> cpu_target_machine_options) {
   ABSL_ASSIGN_OR_RETURN(ffi::HandlerRegistration registration,
-                   ffi::FindHandler(target_name, platform_name));
+                        ffi::FindHandler(target_name, platform_name));
 
   return Create(thunk_info, std::move(target_name),
                 std::move(registration.bundle), std::move(operands),
@@ -178,8 +179,9 @@ absl::StatusOr<std::unique_ptr<CustomCallThunk>> CustomCallThunk::Create(
     if (bundle.instantiate) {
       // Build a call frame with placeholder buffers so the instantiate handler
       // can read operand/result types and shapes. Data pointers are nullptr.
-      ABSL_ASSIGN_OR_RETURN(CallFrame call_frame,
-                       BuildCallFramePrototype(operands, results, attributes));
+      ABSL_ASSIGN_OR_RETURN(
+          CallFrame call_frame,
+          BuildCallFramePrototype(operands, results, attributes));
 
       if (!cpu_target_machine_options.has_value()) {
         cpu_target_machine_options = xla::cpu::TargetMachineOptions();
@@ -188,13 +190,13 @@ absl::StatusOr<std::unique_ptr<CustomCallThunk>> CustomCallThunk::Create(
           execution_state.get(), &gpu_compute_capability,
           &*cpu_target_machine_options);
       ABSL_RETURN_IF_ERROR(Invoke(ffi::GetXlaFfiApi(), bundle.instantiate,
-                             call_frame, call_options,
-                             XLA_FFI_ExecutionStage_INSTANTIATE));
+                                  call_frame, call_options,
+                                  XLA_FFI_ExecutionStage_INSTANTIATE));
     }
   }
 
   ABSL_ASSIGN_OR_RETURN(CallFrame call_frame,
-                   BuildCallFramePrototype(operands, results, attributes));
+                        BuildCallFramePrototype(operands, results, attributes));
   return absl::WrapUnique(new CustomCallThunk(
       thunk_info, std::move(target_name), std::move(bundle),
       std::move(operands), std::move(results), std::move(call_frame),
@@ -220,8 +222,9 @@ absl::StatusOr<std::unique_ptr<CustomCallThunk>> CustomCallThunk::Create(
   if (bundle.instantiate) {
     // Build a call frame with placeholder buffers so the instantiate handler
     // can read operand/result types and shapes. Data pointers are nullptr.
-    ABSL_ASSIGN_OR_RETURN(CallFrame call_frame,
-                     BuildCallFramePrototype(operands, results, attributes));
+    ABSL_ASSIGN_OR_RETURN(
+        CallFrame call_frame,
+        BuildCallFramePrototype(operands, results, attributes));
 
     if (!cpu_target_machine_options.has_value()) {
       cpu_target_machine_options = xla::cpu::TargetMachineOptions();
@@ -229,12 +232,13 @@ absl::StatusOr<std::unique_ptr<CustomCallThunk>> CustomCallThunk::Create(
     InvokeContext context = BuildInstantiateInvokeContext(
         execution_state.get(), &gpu_compute_capability,
         &*cpu_target_machine_options);
-    ABSL_RETURN_IF_ERROR(Invoke(ffi::GetXlaFfiApi(), *bundle.instantiate, call_frame,
-                           context, xla::ffi::ExecutionStage::kInstantiate));
+    ABSL_RETURN_IF_ERROR(Invoke(ffi::GetXlaFfiApi(), *bundle.instantiate,
+                                call_frame, context,
+                                xla::ffi::ExecutionStage::kInstantiate));
   }
 
   ABSL_ASSIGN_OR_RETURN(CallFrame call_frame,
-                   BuildCallFramePrototype(operands, results, attributes));
+                        BuildCallFramePrototype(operands, results, attributes));
   return absl::WrapUnique(new CustomCallThunk(
       thunk_info, std::move(target_name), std::move(bundle),
       std::move(operands), std::move(results), std::move(call_frame),
@@ -379,6 +383,11 @@ absl::Status CustomCallThunk::ExecuteFfiHandler(
       collective_params, collective_clique_requests, collective_memory_requests,
       collective_cliques, collective_memory, execution_context,
       computation_streams);
+  XLA_FFI_Gpu_Collectives_Extension gpu_collectives =
+      MakeGpuCollectivesExtension(collective_params, collective_clique_requests,
+                                  collective_cliques);
+  gpu_collectives.extension_base.next = context.extension_start;
+  context.extension_start = &gpu_collectives.extension_base;
   return Invoke(ffi::GetXlaFfiApi(), handler, *call_frame, context, stage);
 }
 
@@ -404,6 +413,11 @@ absl::Status CustomCallThunk::ExecuteFfiHandler(
       collective_params, collective_clique_requests, collective_memory_requests,
       collective_cliques, collective_memory, execution_context,
       computation_streams);
+  XLA_FFI_Gpu_Collectives_Extension gpu_collectives =
+      MakeGpuCollectivesExtension(collective_params, collective_clique_requests,
+                                  collective_cliques);
+  gpu_collectives.extension_base.next = context.extension_start;
+  context.extension_start = &gpu_collectives.extension_base;
   return Invoke(ffi::GetXlaFfiApi(), handler, *call_frame, context, stage);
 }
 
@@ -520,12 +534,12 @@ absl::StatusOr<ThunkProto> CustomCallThunk::ToProto() const {
 
   for (const NullableShapedSlice& operand : operands_) {
     ABSL_ASSIGN_OR_RETURN(*proto.mutable_custom_call_thunk()->add_operands(),
-                     operand.ToProto());
+                          operand.ToProto());
   }
 
   for (const NullableShapedSlice& result : results_) {
     ABSL_ASSIGN_OR_RETURN(*proto.mutable_custom_call_thunk()->add_results(),
-                     result.ToProto());
+                          result.ToProto());
   }
 
   if (attributes_.has_value()) {
@@ -568,7 +582,7 @@ absl::StatusOr<std::unique_ptr<CustomCallThunk>> CustomCallThunk::FromProto(
   }
 
   ABSL_ASSIGN_OR_RETURN(ffi::AttributesMap attributes,
-                   ffi::AttributesMap::FromProto(proto.attributes()));
+                        ffi::AttributesMap::FromProto(proto.attributes()));
 
   HloComputation* called_computation = nullptr;
   if (proto.has_called_computation()) {

--- a/xla/backends/gpu/tests/BUILD
+++ b/xla/backends/gpu/tests/BUILD
@@ -1448,7 +1448,9 @@ xla_test(
         "//xla/core/collectives:reduction_kind",
         "//xla/ffi",
         "//xla/ffi:ffi_api",
+        "//xla/ffi:ffi_interop",
         "//xla/ffi/api:c_api",
+        "//xla/ffi/api:ffi_gpu_collectives",
         "//xla/runtime:device_id",
         "//xla/service:collective_ops_utils",
         "//xla/service:rendezvous",
@@ -1464,6 +1466,7 @@ xla_test(
         "//xla/tsl/platform:status_macros",
         "//xla/tsl/platform:statusor",
         "//xla/tsl/platform:test",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:no_destructor",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
@@ -1474,6 +1477,7 @@ xla_test(
         "@com_google_absl//absl/types:span",
     ] + if_cuda_is_configured([
         ":collective_ops_ffi_kernels_cuda",
+        "@local_config_nccl//:nccl",
     ]),
 )
 

--- a/xla/backends/gpu/tests/collective_ops_ffi_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_ffi_test.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "absl/base/casts.h"
 #include "absl/base/no_destructor.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
@@ -47,7 +48,9 @@ limitations under the License.
 #include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
 #include "xla/ffi/api/c_api.h"
+#include "xla/ffi/api/ffi_gpu_collectives.h"
 #include "xla/ffi/ffi.h"
+#include "xla/ffi/ffi_interop.h"
 #include "xla/future.h"
 #include "xla/literal.h"
 #include "xla/runtime/device_id.h"
@@ -62,6 +65,10 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 #include "xla/tsl/platform/test.h"
 #include "xla/xla_data.pb.h"
+
+#if GOOGLE_CUDA
+#include "third_party/nccl/nccl.h"
+#endif  // GOOGLE_CUDA
 
 namespace xla::gpu {
 using ::testing::Values;
@@ -320,6 +327,81 @@ static absl::Status PreparePeerAllReduce(
   return absl::OkStatus();
 }
 
+static XLA_FFI_Gpu_ReplicaGroup PublicApiReplicaGroup() {
+  static std::vector<int64_t> replica_ids = [] {
+    std::vector<int64_t> ids;
+    ids.reserve(kNumReplicas);
+    for (int64_t i = 0; i < kNumReplicas; ++i) {
+      ids.push_back(i);
+    }
+    return ids;
+  }();
+  return XLA_FFI_Gpu_ReplicaGroup{replica_ids.data(), replica_ids.size()};
+}
+
+// Prepare handler: requests the XLA-owned collective clique via the public GPU
+// collectives FFI extension found on the invoke context.
+static absl::Status PreparePublicApiAllReduce(
+    const XLA_FFI_Gpu_Collectives_Extension* gpu_collectives) {
+  TF_RET_CHECK(gpu_collectives != nullptr);
+
+  XLA_FFI_Gpu_ReplicaGroup group = PublicApiReplicaGroup();
+  XLA_FFI_Gpu_Communicator_Request_Args args;
+  args.struct_size = XLA_FFI_Gpu_Communicator_Request_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.group_mode = XLA_FFI_GPU_GROUP_FLATTENED_ID;
+  args.groups = &group;
+  args.num_groups = 1;
+  args.communication_id = 0;
+
+  if (XLA_FFI_Error* error =
+          gpu_collectives->request_communicator(gpu_collectives, &args)) {
+    return ffi::TakeStatus(error);
+  }
+  return absl::OkStatus();
+}
+
+// Execute handler: gets the XLA-owned ncclComm_t via the public GPU collectives
+// FFI extension and runs an NCCL all-reduce on it.
+static absl::Status PublicApiAllReduce(
+    se::Stream* stream, ffi::BufferR0<U32> src,
+    ffi::Result<ffi::BufferR0<U32>> dst,
+    const XLA_FFI_Gpu_Collectives_Extension* gpu_collectives) {
+  TF_RET_CHECK(gpu_collectives != nullptr);
+
+  XLA_FFI_Gpu_ReplicaGroup group = PublicApiReplicaGroup();
+  XLA_FFI_Gpu_Communicator_Get_Args get_args;
+  get_args.struct_size = XLA_FFI_Gpu_Communicator_Get_Args_STRUCT_SIZE;
+  get_args.extension_start = nullptr;
+  get_args.group_mode = XLA_FFI_GPU_GROUP_FLATTENED_ID;
+  get_args.groups = &group;
+  get_args.num_groups = 1;
+  get_args.communication_id = 0;
+  get_args.communicator = nullptr;
+
+  if (XLA_FFI_Error* error =
+          gpu_collectives->get_communicator(gpu_collectives, &get_args)) {
+    return ffi::TakeStatus(error);
+  }
+  TF_RET_CHECK(get_args.communicator != nullptr);
+
+#if GOOGLE_CUDA
+  ncclComm_t comm = reinterpret_cast<ncclComm_t>(get_args.communicator);
+  cudaStream_t cuda_stream =
+      absl::bit_cast<cudaStream_t>(stream->platform_specific_handle().stream);
+
+  ncclResult_t result = ncclAllReduce(
+      src.device_memory().opaque(), dst->device_memory().opaque(),
+      /*count=*/src.element_count(), ncclUint32, ncclSum, comm, cuda_stream);
+  TF_RET_CHECK(result == ncclSuccess)
+      << "ncclAllReduce failed: " << ncclGetErrorString(result);
+  return stream->BlockHostUntilDone();
+#else
+  return Unimplemented(
+      "Public GPU FFI communicator all-reduce test requires CUDA/NCCL");
+#endif  // GOOGLE_CUDA
+}
+
 // FFI handler that uses XLA:GPU collectives API to perform an all reduce. This
 // is just a test that demonstrates how to use XLA:GPU collectives API in an FFI
 // handler, builtin all-reduce is a much better option. This version
@@ -344,8 +426,8 @@ static absl::Status AllReduce(se::Stream* stream,
 
   // Get the communicator for the requested clique.
   ABSL_ASSIGN_OR_RETURN(Communicator * comm,
-                   collective_cliques->GetComm(
-                       clique_key, collective_params->global_device_id));
+                        collective_cliques->GetComm(
+                            clique_key, collective_params->global_device_id));
 
   // Synchronize communication stream with the main stream: make the
   // communication stream wait for all prior work on the main stream.
@@ -396,16 +478,17 @@ static absl::Status DeviceAllReduce(se::Stream* stream, ffi::BufferR0<U32> src,
           GpuDeviceCommunicator::Requirements{.lsa_barrier_count = 8}));
 
   // Load custom kernel that does device-initiated collectives.
-  ABSL_ASSIGN_OR_RETURN(auto kernel, se::gpu::GpuKernelRegistry::GetGlobalRegistry()
-                                    .LoadKernel<SymmetricAllReduce>(
-                                        collective_params->executor));
+  ABSL_ASSIGN_OR_RETURN(
+      auto kernel,
+      se::gpu::GpuKernelRegistry::GetGlobalRegistry()
+          .LoadKernel<SymmetricAllReduce>(collective_params->executor));
 
   se::BlockDim block_dims(1);
   se::ThreadDim thread_dims(8);
 
   ABSL_RETURN_IF_ERROR(kernel.Launch(thread_dims, block_dims, stream, dev_comm,
-                                sym_src, sym_dst, src_offset, dst_offset,
-                                src.element_count()));
+                                     sym_src, sym_dst, src_offset, dst_offset,
+                                     src.element_count()));
   ABSL_RETURN_IF_ERROR(stream->BlockHostUntilDone());
   SynchronizationSignals* signals = global_signals->get();
   signals->IncrementFinishedKernels();
@@ -419,7 +502,7 @@ static absl::Status BlockedDeviceAllReduce(
     const CollectiveCliques* collective_cliques,
     const CollectiveMemory* collective_memory) {
   ABSL_RETURN_IF_ERROR(DeviceAllReduce(stream, src, dst, collective_params,
-                                  collective_cliques, collective_memory));
+                                       collective_cliques, collective_memory));
   return stream->BlockHostUntilDone();
 }
 
@@ -434,7 +517,7 @@ static absl::Status DelayedDeviceAllReduce(
   ABSL_RETURN_IF_ERROR(
       stream->DoHostCallback([]() { absl::SleepFor(absl::Seconds(1)); }));
   ABSL_RETURN_IF_ERROR(DeviceAllReduce(stream, src, dst, collective_params,
-                                  collective_cliques, collective_memory));
+                                       collective_cliques, collective_memory));
   return absl::OkStatus();
 }
 
@@ -453,7 +536,7 @@ static absl::Status ExecuteMultiGpuBarrier(
 
   auto rank = clique_key.rank(collective_params->global_device_id);
   ABSL_ASSIGN_OR_RETURN(GpuCommunicator * comm,
-                   collective_cliques->GetComm(clique_key, *rank));
+                        collective_cliques->GetComm(clique_key, *rank));
 
   GpuCollectives::Executor executor(stream);
   ABSL_RETURN_IF_ERROR(comm->LaunchMultiGpuBarrier(executor));
@@ -461,7 +544,7 @@ static absl::Status ExecuteMultiGpuBarrier(
   // Copy src to dst so the HLO copy/return is valid.
   auto dst_addr = dst->device_memory();
   ABSL_RETURN_IF_ERROR(stream->Memcpy(&dst_addr, src.device_memory(),
-                                 src.element_count() * sizeof(uint32_t)));
+                                      src.element_count() * sizeof(uint32_t)));
   ABSL_RETURN_IF_ERROR(stream->BlockHostUntilDone());
   SynchronizationSignals* signals = global_signals->get();
   signals->IncrementFinishedKernels();
@@ -487,9 +570,10 @@ static absl::Status MulticastAllReduce(
   TF_RET_CHECK(src_mmem != nullptr);
 
   // Load custom kernel that does device-initiated collectives.
-  ABSL_ASSIGN_OR_RETURN(auto kernel, se::gpu::GpuKernelRegistry::GetGlobalRegistry()
-                                    .LoadKernel<MultimemAllReduce>(
-                                        collective_params->executor));
+  ABSL_ASSIGN_OR_RETURN(
+      auto kernel,
+      se::gpu::GpuKernelRegistry::GetGlobalRegistry()
+          .LoadKernel<MultimemAllReduce>(collective_params->executor));
 
   // Create device addresses from multimem pointer.
   auto src_addr =
@@ -511,8 +595,8 @@ static absl::Status MulticastAllReduce(
   se::ThreadDim thread_dims(8);
 
   ABSL_RETURN_IF_ERROR(kernel.Launch(thread_dims, block_dims, stream, src_addr,
-                                dst->device_memory(), src_offset,
-                                src.element_count()));
+                                     dst->device_memory(), src_offset,
+                                     src.element_count()));
   ABSL_RETURN_IF_ERROR(stream->BlockHostUntilDone());
   SynchronizationSignals* signals = global_signals->get();
   signals->IncrementFinishedKernels();
@@ -529,7 +613,7 @@ static absl::Status DelayedMulticastAllReduce(
   ABSL_RETURN_IF_ERROR(
       stream->DoHostCallback([]() { absl::SleepFor(absl::Seconds(1)); }));
   ABSL_RETURN_IF_ERROR(MulticastAllReduce(stream, src, dst, collective_params,
-                                     collective_memory));
+                                          collective_memory));
   return absl::OkStatus();
 }
 
@@ -541,7 +625,7 @@ static absl::Status BlockedMulticastAllReduce(
     const CollectiveParams* collective_params,
     const CollectiveMemory* collective_memory) {
   ABSL_RETURN_IF_ERROR(MulticastAllReduce(stream, src, dst, collective_params,
-                                     collective_memory));
+                                          collective_memory));
   return stream->BlockHostUntilDone();
 }
 
@@ -563,9 +647,10 @@ static absl::Status SymMulticastAllReduce(
       collective_memory->FindSymmetricMemory(clique_key, src.device_memory());
 
   // Load custom kernel that does device-initiated collectives.
-  ABSL_ASSIGN_OR_RETURN(auto kernel, se::gpu::GpuKernelRegistry::GetGlobalRegistry()
-                                    .LoadKernel<MultimemAllReduce>(
-                                        collective_params->executor));
+  ABSL_ASSIGN_OR_RETURN(
+      auto kernel,
+      se::gpu::GpuKernelRegistry::GetGlobalRegistry()
+          .LoadKernel<MultimemAllReduce>(collective_params->executor));
 
   // Get multimem address for the src buffer.
   ABSL_ASSIGN_OR_RETURN(auto src_multimem, sym_src->multimem_addr());
@@ -589,9 +674,9 @@ static absl::Status SymMulticastAllReduce(
   se::ThreadDim thread_dims(8);
 
   ABSL_RETURN_IF_ERROR(kernel.Launch(thread_dims, block_dims, stream,
-                                se::DeviceAddress<uint32_t>(src_multimem),
-                                dst->device_memory(), src_offset,
-                                src.element_count()));
+                                     se::DeviceAddress<uint32_t>(src_multimem),
+                                     dst->device_memory(), src_offset,
+                                     src.element_count()));
   ABSL_RETURN_IF_ERROR(stream->BlockHostUntilDone());
   SynchronizationSignals* signals = global_signals->get();
   signals->IncrementFinishedKernels();
@@ -607,8 +692,8 @@ static absl::Status DelayedSymMulticastAllReduce(
     const CollectiveMemory* collective_memory) {
   ABSL_RETURN_IF_ERROR(
       stream->DoHostCallback([]() { absl::SleepFor(absl::Seconds(1)); }));
-  ABSL_RETURN_IF_ERROR(SymMulticastAllReduce(stream, src, dst, collective_params,
-                                        collective_memory));
+  ABSL_RETURN_IF_ERROR(SymMulticastAllReduce(
+      stream, src, dst, collective_params, collective_memory));
   return absl::OkStatus();
 }
 
@@ -619,8 +704,8 @@ static absl::Status BlockedSymMulticastAllReduce(
     ffi::Result<ffi::BufferR0<U32>> dst,
     const CollectiveParams* collective_params,
     const CollectiveMemory* collective_memory) {
-  ABSL_RETURN_IF_ERROR(SymMulticastAllReduce(stream, src, dst, collective_params,
-                                        collective_memory));
+  ABSL_RETURN_IF_ERROR(SymMulticastAllReduce(
+      stream, src, dst, collective_params, collective_memory));
   return stream->BlockHostUntilDone();
 }
 
@@ -642,9 +727,10 @@ static absl::Status SymPeerAllReduce(
       collective_memory->FindSymmetricMemory(clique_key, src.device_memory());
 
   // Load custom kernel that does device-initiated collectives.
-  ABSL_ASSIGN_OR_RETURN(auto kernel, se::gpu::GpuKernelRegistry::GetGlobalRegistry()
-                                    .LoadKernel<Peer2AllReduce>(
-                                        collective_params->executor));
+  ABSL_ASSIGN_OR_RETURN(
+      auto kernel,
+      se::gpu::GpuKernelRegistry::GetGlobalRegistry()
+          .LoadKernel<Peer2AllReduce>(collective_params->executor));
 
   // Get peer addresses for src buffer.
   ABSL_ASSIGN_OR_RETURN(auto src0, sym_src->peer_addr(RankId(0)));
@@ -669,10 +755,10 @@ static absl::Status SymPeerAllReduce(
   se::BlockDim block_dims(1);
   se::ThreadDim thread_dims(8);
 
-  ABSL_RETURN_IF_ERROR(kernel.Launch(thread_dims, block_dims, stream,
-                                se::DeviceAddress<uint32_t>(src0),
-                                se::DeviceAddress<uint32_t>(src1),
-                                dst->device_memory(), src.element_count()));
+  ABSL_RETURN_IF_ERROR(kernel.Launch(
+      thread_dims, block_dims, stream, se::DeviceAddress<uint32_t>(src0),
+      se::DeviceAddress<uint32_t>(src1), dst->device_memory(),
+      src.element_count()));
   ABSL_RETURN_IF_ERROR(stream->BlockHostUntilDone());
   SynchronizationSignals* signals = global_signals->get();
   signals->IncrementFinishedKernels();
@@ -727,9 +813,10 @@ static absl::Status PeerAllReduce(se::Stream* stream, ffi::BufferR0<U32> src,
   TF_RET_CHECK(src0 && src1);
 
   // Load custom kernel that does device-initiated collectives.
-  ABSL_ASSIGN_OR_RETURN(auto kernel, se::gpu::GpuKernelRegistry::GetGlobalRegistry()
-                                    .LoadKernel<Peer2AllReduce>(
-                                        collective_params->executor));
+  ABSL_ASSIGN_OR_RETURN(
+      auto kernel,
+      se::gpu::GpuKernelRegistry::GetGlobalRegistry()
+          .LoadKernel<Peer2AllReduce>(collective_params->executor));
 
   // Block the host CPU thread until the asynchronous GPU copies / memory maps
   // are complete.
@@ -746,8 +833,9 @@ static absl::Status PeerAllReduce(se::Stream* stream, ffi::BufferR0<U32> src,
   se::BlockDim block_dims(1);
   se::ThreadDim thread_dims(8);
 
-  ABSL_RETURN_IF_ERROR(kernel.Launch(thread_dims, block_dims, stream, *src0, *src1,
-                                dst->device_memory(), src.element_count()));
+  ABSL_RETURN_IF_ERROR(kernel.Launch(thread_dims, block_dims, stream, *src0,
+                                     *src1, dst->device_memory(),
+                                     src.element_count()));
   ABSL_RETURN_IF_ERROR(stream->BlockHostUntilDone());
   SynchronizationSignals* signals = global_signals->get();
   signals->IncrementFinishedKernels();
@@ -780,6 +868,17 @@ XLA_FFI_DEFINE_HANDLER(kPrepareAllReduce, PrepareAllReduce,
                        ffi::Ffi::BindPrepare()
                            .Ctx<ffi::CollectiveParams>()
                            .Ctx<ffi::CollectiveCliqueRequests>());
+
+XLA_FFI_DEFINE_HANDLER(
+    kPreparePublicApiAllReduce, PreparePublicApiAllReduce,
+    ffi::Ffi::BindPrepare().Ctx<ffi::Extension<ffi::GpuCollectives>>());
+
+XLA_FFI_DEFINE_HANDLER(kPublicApiAllReduce, PublicApiAllReduce,
+                       ffi::Ffi::Bind()
+                           .Ctx<ffi::Stream>()
+                           .Arg<ffi::BufferR0<U32>>()  // src
+                           .Ret<ffi::BufferR0<U32>>()  // dst
+                           .Ctx<ffi::Extension<ffi::GpuCollectives>>());
 
 // Preprocessor fails to parse comma inside macro call, introduce an alias to
 // request multiple comm streams for test.
@@ -939,6 +1038,15 @@ XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(), "__xla_test$$all_reduce", "gpu",
                              /*prepare=*/kPrepareAllReduce,
                              /*initialize=*/nullptr,
                              /*execute=*/kAllReduce,
+                         });
+
+XLA_FFI_REGISTER_HANDLER(ffi::GetXlaFfiApi(),
+                         "__xla_test$$public_api_all_reduce", "gpu",
+                         XLA_FFI_Handler_Bundle{
+                             /*instantiate=*/nullptr,
+                             /*prepare=*/kPreparePublicApiAllReduce,
+                             /*initialize=*/nullptr,
+                             /*execute=*/kPublicApiAllReduce,
                          });
 
 // Register handler bundle for the custom all-reduce operation with
@@ -1101,6 +1209,47 @@ TEST_F(CollectiveOpsTestFFI, AllReduce) {
   for (int i = 0; i < kNumReplicas; ++i) {
     LiteralTestUtil::ExpectR0Equal<uint32_t>(expected, results[i]);
   }
+}
+
+TEST_F(CollectiveOpsTestFFI, PublicApiAllReduce) {
+#if !GOOGLE_CUDA
+  GTEST_SKIP() << "Public GPU FFI communicator all-reduce requires CUDA/NCCL";
+#else
+  if (device_count() < kNumReplicas) {
+    GTEST_SKIP() << "Test requires at least " << kNumReplicas << " devices ("
+                 << device_count() << " available)";
+  }
+
+  constexpr absl::string_view hlo_string = R"(
+      HloModule m, replica_count=2
+
+      ENTRY test_computation {
+        id = u32[] replica-id()
+        ROOT all-reduce = u32[] custom-call(id),
+          custom_call_target="__xla_test$$public_api_all_reduce",
+          api_version=API_VERSION_TYPED_FFI
+      }
+    )";
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto module, ParseAndReturnVerifiedModule(hlo_string, kNumReplicas));
+
+  TF_ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module),
+                        /*arguments=*/std::vector<Literal*>(),
+                        /*run_hlo_passes=*/false));
+
+  absl::Span<const Literal> results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+
+  // Each replica contributes its replica id, so the all-reduce sum is
+  // sum [0, kNumReplicas).
+  const uint32_t expected = kNumReplicas * (kNumReplicas - 1) / 2;
+  for (int i = 0; i < kNumReplicas; ++i) {
+    LiteralTestUtil::ExpectR0Equal<uint32_t>(expected, results[i]);
+  }
+#endif  // GOOGLE_CUDA
 }
 
 class AllReduceTest : public CollectiveOpsTestFFI,

--- a/xla/ffi/BUILD
+++ b/xla/ffi/BUILD
@@ -404,6 +404,7 @@ xla_cc_test(
         "//xla/backends/cpu:ffi",
         "//xla/backends/gpu:ffi",
         "//xla/ffi/api:c_api",
+        "//xla/ffi/api:ffi_gpu_collectives",
         "//xla/stream_executor:device_address",
         "//xla/stream_executor:stream",
         "//xla/tsl/concurrency:async_value",

--- a/xla/ffi/api/BUILD
+++ b/xla/ffi/api/BUILD
@@ -94,6 +94,13 @@ cc_library(
 )
 
 cc_library(
+    name = "ffi_gpu_collectives",
+    hdrs = ["ffi_gpu_collectives.h"],
+    visibility = ["//visibility:public"],
+    deps = [":c_api"],
+)
+
+cc_library(
     name = "ffi",
     hdrs = ["ffi.h"],
     deps = [

--- a/xla/ffi/api/ffi_gpu_collectives.h
+++ b/xla/ffi/api/ffi_gpu_collectives.h
@@ -1,0 +1,140 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_FFI_API_FFI_GPU_COLLECTIVES_H_
+#define XLA_FFI_API_FFI_GPU_COLLECTIVES_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include "xla/ffi/api/c_api.h"
+
+// XLA:GPU collectives FFI extension.
+//
+// Exposes the XLA-owned host collective communicator (e.g. `ncclComm_t`) to FFI
+// handlers: `request_communicator` requests a clique in the Prepare stage and
+// `get_communicator` returns the handle once cliques are acquired. Retrieved
+// via `Ctx<Extension<xla::ffi::GpuCollectives>>()`; header-only, no
+// registration.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Unique extension id ("gpu_coll" in ASCII).
+#define XLA_FFI_Gpu_Collectives_Extension_Type INT64_C(0x6770755f636f6c6c)
+#define XLA_FFI_Gpu_Collectives_Extension_Major 1
+#define XLA_FFI_Gpu_Collectives_Extension_Minor 0
+
+// Mirrors `xla::CollectiveOpGroupMode`.
+typedef enum {
+  XLA_FFI_GPU_GROUP_CROSS_REPLICA = 0,
+  XLA_FFI_GPU_GROUP_CROSS_PARTITION = 1,
+  XLA_FFI_GPU_GROUP_CROSS_REPLICA_AND_PARTITION = 2,
+  XLA_FFI_GPU_GROUP_FLATTENED_ID = 3,
+} XLA_FFI_Gpu_GroupMode;
+
+typedef struct {
+  const int64_t* ids;
+  size_t size;
+} XLA_FFI_Gpu_ReplicaGroup;
+
+typedef struct XLA_FFI_Gpu_Collectives_Extension
+    XLA_FFI_Gpu_Collectives_Extension;
+
+struct XLA_FFI_Gpu_Communicator_Request_Args {
+  size_t struct_size;
+  XLA_FFI_InternalExtension* extension_start;
+
+  XLA_FFI_Gpu_GroupMode group_mode;
+  const XLA_FFI_Gpu_ReplicaGroup* groups;
+  size_t num_groups;
+  int64_t communication_id;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Gpu_Communicator_Request_Args,
+                             communication_id);
+
+// Requests the collective clique so it is acquired before execution. Prepare
+// stage only.
+typedef XLA_FFI_Error* XLA_FFI_Gpu_Communicator_Request(
+    const XLA_FFI_Gpu_Collectives_Extension* self,
+    XLA_FFI_Gpu_Communicator_Request_Args* args);
+
+struct XLA_FFI_Gpu_Communicator_Get_Args {
+  size_t struct_size;
+  XLA_FFI_InternalExtension* extension_start;
+
+  XLA_FFI_Gpu_GroupMode group_mode;
+  const XLA_FFI_Gpu_ReplicaGroup* groups;
+  size_t num_groups;
+  int64_t communication_id;
+  void* communicator;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Gpu_Communicator_Get_Args, communicator);
+
+// Returns the non-owning communicator handle for the clique. Valid once cliques
+// are acquired (Initialize/Execute stages).
+typedef XLA_FFI_Error* XLA_FFI_Gpu_Communicator_Get(
+    const XLA_FFI_Gpu_Collectives_Extension* self,
+    XLA_FFI_Gpu_Communicator_Get_Args* args);
+
+struct XLA_FFI_Gpu_Collectives_Extension {
+  XLA_FFI_Extension extension_base;
+
+  // Opaque per-invocation backend state, set by the GPU runtime.
+  // `collective_clique_requests` is non-null only in Prepare;
+  // `collective_cliques` only once cliques are acquired.
+  void* collective_params;
+  void* collective_clique_requests;
+  void* collective_cliques;
+
+  XLA_FFI_Gpu_Communicator_Request* request_communicator;
+  XLA_FFI_Gpu_Communicator_Get* get_communicator;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Gpu_Collectives_Extension,
+                             get_communicator);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#ifdef __cplusplus
+namespace xla::ffi {
+
+// Traits for `Ctx<Extension<GpuCollectives>>()`; yields the extension pointer.
+struct GpuCollectives {
+  using CExtension = XLA_FFI_Gpu_Collectives_Extension;
+  using Type = const XLA_FFI_Gpu_Collectives_Extension*;
+
+  static constexpr auto kName = "GpuCollectives";
+  static constexpr int64_t kExtensionType =
+      XLA_FFI_Gpu_Collectives_Extension_Type;
+  static constexpr int32_t kMajorVersion =
+      XLA_FFI_Gpu_Collectives_Extension_Major;
+  static constexpr int32_t kMinorVersion =
+      XLA_FFI_Gpu_Collectives_Extension_Minor;
+
+  static Type Create(const CExtension* ext) { return ext; }
+  static bool Support(int32_t major_version, int32_t minor_version) {
+    return major_version == kMajorVersion && minor_version >= kMinorVersion;
+  }
+};
+
+}  // namespace xla::ffi
+#endif  // __cplusplus
+
+#endif  // XLA_FFI_API_FFI_GPU_COLLECTIVES_H_

--- a/xla/ffi/ffi_test.cc
+++ b/xla/ffi/ffi_test.cc
@@ -40,6 +40,7 @@ limitations under the License.
 #include "xla/executable_run_options.h"
 #include "xla/ffi/api/api.h"
 #include "xla/ffi/api/c_api.h"
+#include "xla/ffi/api/ffi_gpu_collectives.h"
 #include "xla/ffi/attribute_map.h"
 #include "xla/ffi/call_frame.h"
 #include "xla/ffi/execution_context.h"
@@ -358,6 +359,68 @@ TEST(FfiTest, DecodeExtensionNotFound) {
   EXPECT_FALSE(status.ok());
   EXPECT_THAT(status.message(), HasSubstr("Extension not found in context"));
   EXPECT_FALSE(handler_called);
+}
+
+static XLA_FFI_Error* MockCommunicatorRequest(
+    const XLA_FFI_Gpu_Collectives_Extension* self,
+    XLA_FFI_Gpu_Communicator_Request_Args* args) {
+  return nullptr;
+}
+
+static XLA_FFI_Error* MockCommunicatorGet(
+    const XLA_FFI_Gpu_Collectives_Extension* self,
+    XLA_FFI_Gpu_Communicator_Get_Args* args) {
+  return nullptr;
+}
+
+TEST(FfiTest, DecodeGpuCollectivesExtension) {
+  int fake_params = 0;
+  int fake_clique_requests = 0;
+  int fake_cliques = 0;
+
+  XLA_FFI_Gpu_Collectives_Extension test_ext;
+  test_ext.extension_base = MakeExtensionHeader<GpuCollectives>();
+  test_ext.collective_params = &fake_params;
+  test_ext.collective_clique_requests = &fake_clique_requests;
+  test_ext.collective_cliques = &fake_cliques;
+  test_ext.request_communicator = MockCommunicatorRequest;
+  test_ext.get_communicator = MockCommunicatorGet;
+
+  bool handler_called = false;
+
+  auto handler = Ffi::Bind().Ctx<Extension<GpuCollectives>>().To(
+      [&](const GpuCollectives::Type ext) -> absl::Status {
+        EXPECT_NE(ext, nullptr);
+        EXPECT_EQ(ext->extension_base.id.extension_type,
+                  GpuCollectives::kExtensionType);
+        EXPECT_EQ(ext->extension_base.id.major_version,
+                  GpuCollectives::kMajorVersion);
+        EXPECT_EQ(ext->extension_base.id.minor_version,
+                  GpuCollectives::kMinorVersion);
+        EXPECT_EQ(ext->collective_params, &fake_params);
+        EXPECT_EQ(ext->collective_clique_requests, &fake_clique_requests);
+        EXPECT_EQ(ext->collective_cliques, &fake_cliques);
+        EXPECT_EQ(ext->request_communicator, MockCommunicatorRequest);
+        EXPECT_EQ(ext->get_communicator, MockCommunicatorGet);
+        handler_called = true;
+        return absl::OkStatus();
+      });
+
+  CallFrameBuilder builder(/*num_args=*/0, /*num_rets=*/0);
+  auto call_frame = builder.Build();
+
+  InvokeContext context;
+  context.extension_start = reinterpret_cast<XLA_FFI_Extension*>(&test_ext);
+
+  auto status = Invoke(Api(), *handler, call_frame, context);
+  EXPECT_TRUE(handler_called);
+  ASSERT_OK(status);
+
+  // A major-version mismatch fails the extension's Support() check.
+  test_ext.extension_base.id.major_version = GpuCollectives::kMajorVersion + 1;
+  status = Invoke(Api(), *handler, call_frame, context);
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status.message(), HasSubstr("Extension version mismatch"));
 }
 
 TEST(FfiTest, BuiltinAttributes) {


### PR DESCRIPTION
📝 Summary of Changes
This PR adds a GPU communicator FFI extension so custom-call FFI handlers on the XLA:GPU backend can obtain the XLA-owned host communicator (ncclComm_t) and participate in collectives.

🎯 Justification
Users writing custom GPU kernels that need collectives currently have to create and manage their own communicator. This extension gives them XLA's existing ncclComm_t directly, so their kernels reuse the same communicator XLA already set up, and can register symmetric memory (e.g. ncclCommWindowRegister) against it.

🚀 Kind of Contribution
✨ New Feature, 🧪 Tests

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
xla/ffi/ffi_test.cc (FfiTest.DecodeGpuCollectivesExtension)
xla/backends/gpu/tests/collective_ops_ffi_test.cc (CollectiveOpsTestFFI.PublicApiAllReduce)

🧪 Execution Tests:
N/A
