### PR TITLE
[ROCm] Do not use NCCL symmetric buffers on ROCm

### DIFF
--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -2504,6 +2504,36 @@ bool RequiresCollectiveOutput(const HloValue* value, const DebugOptions& opts) {
   return false;
 }
 
+// Symmetric buffers require registering the collective buffers with
+// ncclCommWindowRegister(..., NCCL_WIN_COLL_SYMMETRIC). RCCL declares that
+// entry point in rccl.h and reports an NCCL version above the one that
+// introduced it, so both the build-time and version-based checks pass, but it
+// rejects every registration at runtime with ncclInvalidUsage. Enabling
+// symmetric buffers therefore fails every multi-device collective on ROCm.
+//
+// This has to be decided from the device being compiled for, not from a
+// build-time define: the defaults are set in
+// DefaultDebugOptionsIgnoringFlags(), which is compiled into the
+// backend-agnostic jaxlib, while only the plugin and PJRT artifacts are built
+// with ROCm configured.
+void DisableSymmetricBuffersIfUnsupported(
+    HloModule* module, const se::DeviceDescription& device_description) {
+  if (device_description.gpu_compute_capability().rocm_compute_capability() ==
+      nullptr) {
+    return;
+  }
+  DebugOptions& opts = module->mutable_config().mutable_debug_options();
+  if (opts.xla_enable_nccl_symmetric_buffers_for_collectives().empty() &&
+      !opts.xla_gpu_experimental_enable_nccl_symmetric_buffers()) {
+    return;
+  }
+  LOG_FIRST_N(WARNING, 1)
+      << "Disabling NCCL symmetric buffers: RCCL does not implement collective "
+         "window registration (ncclCommWindowRegister).";
+  opts.clear_xla_enable_nccl_symmetric_buffers_for_collectives();
+  opts.set_xla_gpu_experimental_enable_nccl_symmetric_buffers(false);
+}
+
 void GpuCollectiveBufferAnalysis(
     HloModule* module, const HloAliasAnalysis& alias_analysis,
     std::function<void(HloInstruction*, const ShapeIndex&)> add_index_to_copy) {
@@ -2959,6 +2989,11 @@ absl::StatusOr<std::unique_ptr<Executable>> GpuCompiler::RunBackend(
   llvm::LLVMContext llvm_context;
   const se::DeviceDescription& gpu_device_info =
       gpu_topology.gpu_target_config().device_description;
+
+  // Must happen before CompileToBackendResult(): buffer assignment colors
+  // collective buffers into the collective memory space and thunk emission
+  // selects the symmetric kernels, both from these debug options.
+  DisableSymmetricBuffersIfUnsupported(module.get(), gpu_device_info);
 
   if (module->config().hlo_profiling_enabled() || VLOG_IS_ON(1)) {
     HloCostAnalysis::Options cost_analysis_options{ShapeSizeBytesFunction()};


### PR DESCRIPTION
## Problem

`7a57c69ea6` ("Enable NCCL symmetric kernels for collectives up to 8 MB") turned on `xla_enable_nccl_symmetric_buffers_for_collectives` by default for ALLREDUCE, ALLGATHER and REDUCESCATTER up to 8 MB. This breaks **every multi-device collective on ROCm**:

```
INTERNAL: RCCL operation ncclCommWindowRegister(
    comm, addr.opaque(), addr.size(), &win, 0x01) failed: invalid usage
```

Symmetric buffers require registering collective buffers via `ncclCommWindowRegister(..., NCCL_WIN_COLL_SYMMETRIC)`. RCCL declares that entry point in `rccl.h`, so the build and link both succeed, and it reports `NCCL_VERSION_CODE 23004` — above the NCCL version that introduced symmetric memory — so version-based feature detection passes too. It then rejects every registration at runtime.

### Root cause

The general issue is that **RCCL's version code aliases into NCCL's numbering**, so any `NCCL_VERSION_CODE`-based capability check silently misfires for RCCL. This particular feature is one instance of that.

## Fix

Clear the filters during HLO compilation, keyed on the compute capability of the device being compiled for.

**Why not a build-time guard.** The defaults are set in `DefaultDebugOptionsIgnoringFlags()`, which compiles into a backend-agnostic `jaxlib`. Interjecting the issue here would required a custom `jaxlib` for ROCm.

**Why `RunBackend()`.** It is the single choke point: buffer assignment colors the collective buffers and thunk emission selects the symmetric kernels, and both run under `CompileToBackendResult()`.

## Validation

8× MI355X (gfx950), JAX `//tests:pmap_test_gpu`. The filters were forced on explicitly so the result does not depend on compiled-in defaults:

```
--xla_enable_nccl_symmetric_buffers_for_collectives=allreduce:8388608,allgather:8388608,reducescatter:8388608
```

| | Result |
|---|---|
| without this change | **FAILED** — 40 errors, all `ncclCommWindowRegister ... invalid usage`, on all 3 attempts |
| with this change | **PASSED** — 288 tests, 0 RCCL failures, warning fires once from `RunBackend()` |

## Notes for reviewers

- This hardcodes "ROCm means unsupported" rather than probing the capability. A true probe needs a live communicator, which does not exist at compile time. It will need removing once RCCL implements window registration.
- Separately: **the flag cannot be disabled.** Its setter only calls `add_...` and never clears, so `--xla_enable_nccl_symmetric_buffers_for_collectives=` appends to the defaults rather than replacing them, and there is no way to turn the feature off via `XLA_FLAGS` on any platform. Deliberately not changed here to keep this focused, but worth fixing. It is what turned this regression into a hard outage with no mitigation.
