### PR TITLE
[XLA:GPU][oneAPI] Fix sycl_event_test compilation failure

### DIFF
--- a/xla/stream_executor/sycl/sycl_event_test.cc
+++ b/xla/stream_executor/sycl/sycl_event_test.cc
@@ -15,6 +15,9 @@ limitations under the License.
 
 #include "xla/stream_executor/sycl/sycl_event.h"
 
+#include <utility>
+
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "xla/stream_executor/platform_manager.h"
 #include "xla/stream_executor/sycl/sycl_platform_id.h"
@@ -27,11 +30,11 @@ const int kDefaultDeviceOrdinal = 0;
 class SyclEventTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    TF_ASSERT_OK_AND_ASSIGN(
+    ASSERT_OK_AND_ASSIGN(
         Platform * platform,
         stream_executor::PlatformManager::PlatformWithId(kSyclPlatformId));
-    TF_ASSERT_OK_AND_ASSIGN(executor_,
-                            platform->ExecutorForDevice(kDefaultDeviceOrdinal));
+    ASSERT_OK_AND_ASSIGN(executor_,
+                         platform->ExecutorForDevice(kDefaultDeviceOrdinal));
   }
 
   StreamExecutor* executor_;
@@ -40,7 +43,7 @@ class SyclEventTest : public ::testing::Test {
 // TODO (intel-tf): Add a test for events with dependencies once SyclStream
 // class is supported.
 TEST_F(SyclEventTest, CreateEvent) {
-  TF_ASSERT_OK_AND_ASSIGN(SyclEvent event, SyclEvent::Create(executor_));
+  ASSERT_OK_AND_ASSIGN(SyclEvent event, SyclEvent::Create(executor_));
 
   ::sycl::event sycl_event = event.GetEvent();
 
@@ -50,8 +53,7 @@ TEST_F(SyclEventTest, CreateEvent) {
 }
 
 TEST_F(SyclEventTest, MoveEvent) {
-  TF_ASSERT_OK_AND_ASSIGN(SyclEvent orig_sycl_event,
-                          SyclEvent::Create(executor_));
+  ASSERT_OK_AND_ASSIGN(SyclEvent orig_sycl_event, SyclEvent::Create(executor_));
 
   // Make a copy of the event wrapper handle to check after move.
   ::sycl::event orig_event = orig_sycl_event.GetEvent();


### PR DESCRIPTION
## 📝 Summary of Changes

`xla/stream_executor/sycl/sycl_event_test.cc` uses `TF_ASSERT_OK_AND_ASSIGN` but never includes a header that defines it. It compiled only through a transitive include, and that include went away with the recent TSL dependency cleanups (around 72d7032240 and the TF_ macro deprecation changes). Since then the test fails to compile and the "XLA Linux X86 GPU ONEAPI" CI job is red for every PR, with errors like `'Platform' does not refer to a value`, which is the typical symptom of the macro not being defined at all.

This change switches the test to `ASSERT_OK_AND_ASSIGN` (the documented replacement for the deprecated `TF_` variant, provided through gmock in XLA tests) and adds the `<gmock/gmock.h>` and `<utility>` includes.

## 🎯 Justification

The oneAPI CI job currently fails for all PRs, for example [this run](https://github.com/openxla/xla/actions/runs/31159488701/job/92807553683) on an unrelated CPU change. This unblocks it.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

No new tests, this fixes the build of an existing test. I could not compile the target locally since it is `oneapi-only` and needs the Intel toolchain, so the ONEAPI CI job on this PR is the verification. The touched lines are clang-format clean.

## 🧪 Execution Tests:

None needed, the test itself is unchanged in behavior.