### PR TITLE
[XLA] Initialize dynamic dimension sizes in Literal::Broadcast

### DIFF
--- a/xla/literal.cc
+++ b/xla/literal.cc
@@ -1109,6 +1109,14 @@ absl::StatusOr<Literal> BroadcastHelper(const LiteralBase& src,
 
   TF_RET_CHECK(result_shape.element_type() == src_shape.element_type());
   Literal result(result_shape);
+  // Start every dynamic dimension at its bound: a broadcast fills dimensions
+  // completely, and dimensions not mapped from the source (e.g. a scalar
+  // broadcast) would otherwise keep uninitialized sizes.
+  for (int64_t i = 0; i < result_shape.dimensions().size(); ++i) {
+    if (result_shape.is_dynamic_dimension(i)) {
+      result.SetDynamicSize(i, result_shape.dimensions(i));
+    }
+  }
   if (src_shape.is_dynamic()) {
     for (int64_t i = 0; i < dimensions.size(); ++i) {
       if (src_shape.is_dynamic_dimension(i)) {

--- a/xla/literal_test.cc
+++ b/xla/literal_test.cc
@@ -3022,6 +3022,44 @@ TEST_F(LiteralUtilTest, DynamicBroadcast) {
   EXPECT_EQ(broadcasted_literal.GetDynamicSize(1), 1);
 }
 
+TEST_F(LiteralUtilTest, BroadcastScalarToDynamicShape) {
+  Literal literal = LiteralUtil::CreateR0<int32_t>(9);
+  ASSERT_OK_AND_ASSIGN(
+      Literal broadcasted_literal,
+      literal.Broadcast(
+          /*result_shape=*/ShapeUtil::MakeShape(S32, {64}, {true}),
+          /*dimensions=*/{}));
+  EXPECT_EQ(broadcasted_literal.GetDynamicSize(0), 64);
+  EXPECT_EQ(broadcasted_literal.Get<int32_t>({0}), 9);
+  EXPECT_EQ(broadcasted_literal.Get<int32_t>({63}), 9);
+}
+
+TEST_F(LiteralUtilTest, BroadcastVectorToMatrixWithUnmappedDynamicDim) {
+  Literal literal = LiteralUtil::CreateR1<int64_t>({1, 2});
+  ASSERT_OK_AND_ASSIGN(
+      Literal broadcasted_literal,
+      literal.Broadcast(
+          /*result_shape=*/ShapeUtil::MakeShape(S64, {8, 2}, {true, false}),
+          /*dimensions=*/{1}));
+  EXPECT_EQ(broadcasted_literal.GetDynamicSize(0), 8);
+  EXPECT_EQ(broadcasted_literal.Get<int64_t>({0, 0}), 1);
+  EXPECT_EQ(broadcasted_literal.Get<int64_t>({7, 1}), 2);
+}
+
+TEST_F(LiteralUtilTest, BroadcastDynamicVectorToDynamicMatrix) {
+  Literal literal = LiteralUtil::CreateR1<int64_t>({1, 2});
+  literal.SetDynamicSize(0, 1);
+  ASSERT_OK_AND_ASSIGN(
+      Literal broadcasted_literal,
+      literal.Broadcast(
+          /*result_shape=*/ShapeUtil::MakeShape(S64, {8, 2}, {true, true}),
+          /*dimensions=*/{1}));
+  // The unmapped dimension gets its bound; the mapped dimension keeps the
+  // source's actual size.
+  EXPECT_EQ(broadcasted_literal.GetDynamicSize(0), 8);
+  EXPECT_EQ(broadcasted_literal.GetDynamicSize(1), 1);
+}
+
 TEST_F(LiteralUtilTest, GetAsScalarInt64) {
   auto scalar1 = LiteralUtil::CreateR0<int32_t>(12);
   EXPECT_EQ(LiteralUtil::LiteralAsScalarInt64(scalar1).value(), (int64_t)12);


### PR DESCRIPTION
## 📝 Summary of Changes

`LiteralBase::Broadcast` only wrote dynamic dimension sizes for result dimensions that are mapped from source dimensions. For a scalar broadcast into a dynamic shape (empty `dimensions`) no dimension is mapped, and since literal buffers are not zero initialized the result's dynamic sizes were uninitialized memory. This change initializes every dynamic result dimension to its bound first, then lets the existing loop overwrite the mapped ones with the actual source sizes.

## 🎯 Justification

Fixes #44941. `ValueInference` creates exactly these scalar-broadcast literals while tf2xla lowers `tf.where`, so compiling `tf.where(diagflat(unique(x)))` aborted with `Check failed: subshape->dimensions(dim_index) >= size (64 vs. 255)` when the garbage happened to be larger than the bound, and silently used a wrong dynamic size when it was smaller. The failure is nondeterministic for exactly that reason (we saw 80 and 85 instead of the reported 255 on the same script).

Note that a few other evaluator paths also leave dynamic size buffers unwritten (for example elementwise ops in the typed visitor), but none of them are reachable from this issue's reproduction and they are left as is to keep the change minimal.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

Three new tests in `literal_test.cc`: a scalar broadcast into `s32[<=64]`, a vector broadcast into `s64[<=8,2]` with an unmapped dynamic dimension, and a dynamic vector into `s64[<=8,<=2]` checking that the mapped dimension keeps the source's actual size while the unmapped one gets the bound. Without the fix the first two fail (the uninitialized size reads as garbage); with the fix all pass. Also ran `value_inference_test`, `hlo_evaluator_test`, and `caching_hlo_evaluator_test`.

## 🧪 Execution Tests:

None. The defect is in host-side compile-time evaluation, there is no device code path involved.