### PR TITLE
[ROCm] Capture application-emitted ROCTX markers in the profiler timeline (PR1)

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -434,6 +434,15 @@ rocm_lib_import(
 )
 
 rocm_lib_import(
+    name = "rocprofiler_sdk_roctx",
+    data = glob(["%{rocm_root}/lib/librocprofiler-sdk-roctx.so*"]),
+    interface_library = "%{rocm_root}/lib/librocprofiler-sdk-roctx.so",
+    # NEEDED librocprofiler-register.so, which the glob above does not match.
+    # Without this a hermetic build stages the shim without it and fails at load.
+    deps = [":rocprofiler_register_libs"],
+)
+
+rocm_lib_import(
     name = "rocsolver",
     data = glob([
         "%{rocm_root}/lib/librocsolver.so*",

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -591,6 +591,7 @@ cc_library(
         "@com_google_absl//absl/status:status_macros",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
@@ -616,13 +617,17 @@ xla_cc_test(
         ":rocm_tracer",
         ":rocm_tracer_utils",
         "//xla/tsl/lib/core:status_test_util",
+        "//xla/tsl/platform:env_time",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
         "@local_config_rocm//rocm:hip",  # buildcleaner: keep
         "@local_config_rocm//rocm:rocm_headers",
         "@local_config_rocm//rocm:rocprofiler_sdk",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocprofiler_sdk_roctx",  # buildcleaner: keep
         "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
     ],
 )
@@ -642,6 +647,7 @@ xla_cc_test(
         ":rocm_collector",
         ":rocm_tracer_utils",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
         "//xla/tsl/profiler/utils:xplane_utils",
         "@tsl//tsl/profiler/protobuf:xplane_proto_cc",

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -206,7 +206,8 @@ void PerDeviceCollector::CreateXEvent(const RocmTracerEvent& event,
   VLOG(7) << "Adding event to line=" << line->Id();
   xevent.SetTimestampNs(event.start_time_ns);
   xevent.SetEndTimestampNs(event.end_time_ns);
-  if (event.source == RocmTracerEventSource::ApiCallback) {
+  if (event.source == RocmTracerEventSource::ApiCallback &&
+      event.device_id != RocmTracerEvent::kInvalidDeviceId) {
     xevent.AddStatValue(
         *plane->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kDeviceId)),
         event.device_id);
@@ -221,10 +222,20 @@ void PerDeviceCollector::CreateXEvent(const RocmTracerEvent& event,
                             GetStatTypeStr(StatType::kScopeRangeId)),
                         event.scope_range_id);
   }
-  if (!event.roctx_range.empty()) {
+  // Two sources for the same stat, by event type:
+  //   Generic (a ROCTX marker) owns its label in `name`.
+  //   Kernel / HIP-API events carry a view into AnnotationMap's pool, set from
+  //   the ROCTX range that was active when the call was made.
+  // Markers deliberately do not populate roctx_range: a view into their own
+  // `name` would dangle as soon as the event is moved, and interning them
+  // elsewhere would duplicate bytes `name` already owns.
+  const absl::string_view roctx_label =
+      event.type == RocmTracerEventType::Generic ? absl::string_view(event.name)
+                                                 : event.roctx_range;
+  if (!roctx_label.empty()) {
     xevent.AddStatValue(
         *plane->GetOrCreateStatMetadata(GetStatTypeStr(StatType::kNVTXRange)),
-        *plane->GetOrCreateStatMetadata(event.roctx_range));
+        *plane->GetOrCreateStatMetadata(roctx_label));
   }
 
   if (event.type == RocmTracerEventType::Kernel &&
@@ -362,6 +373,7 @@ void PerDeviceCollector::Export(uint64_t start_walltime_ns,
                                 uint64_t start_gputime_ns,
                                 uint64_t end_gputime_ns,
                                 XPlaneBuilder* device_plane,
+                                XPlaneBuilder* marker_plane,
                                 XPlaneBuilder* host_plane) {
   int host_ev_cnt = 0, dev_ev_cnt = 0;
   absl::MutexLock lock(events_mutex_);
@@ -406,7 +418,14 @@ void PerDeviceCollector::Export(uint64_t start_walltime_ns,
       continue;
     }
     auto* plane = is_host_event ? host_plane : device_plane;
-    VLOG(9) << "Event" << " type=" << static_cast<int>(event.type)
+    // Generic events (ROCTX markers) are always host-side; the is_host_event
+    // guard is redundant here but made explicit to document the assumption.
+    if (event.type == RocmTracerEventType::Generic && is_host_event &&
+        marker_plane != nullptr) {
+      plane = marker_plane;
+    }
+    VLOG(9) << "Event"
+            << " type=" << static_cast<int>(event.type)
             << " line_id=" << line_id
             << (is_host_event ? " host plane=" : " device plane=")
             << plane->Name();
@@ -423,6 +442,17 @@ void PerDeviceCollector::Export(uint64_t start_walltime_ns,
   host_plane->ForEachLine([&](XLineBuilder line) {
     line.SetName(absl::StrCat("Host Threads/", line.Id()));
   });
+  if (marker_plane != nullptr) {
+    // "Host Threads/<tid>/ROCTX", matching CUPTI's "Host Threads/<tid>/NVTX"
+    // (cupti_collector.cc). Line names are sorted after the merge into
+    // /host:CPU, so this form places each marker track directly beneath the
+    // host thread that produced it. The former "ROCTX Threads/<tid>" sorted
+    // into a separate alphabetical block, divorcing every marker track from
+    // its thread. The line name -- not the plane name -- is what a user sees.
+    marker_plane->ForEachLine([&](XLineBuilder line) {
+      line.SetName(absl::StrCat("Host Threads/", line.Id(), "/ROCTX"));
+    });
+  }
   events_.clear();
 }
 
@@ -526,6 +556,34 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
                                       bool is_auxiliary) {
   absl::MutexLock lock(event_maps_mutex_);
 
+  // Generic events (e.g. ROCTX/NVTX markers) have no GPU-side activity
+  // counterpart. Route them directly to standalone_events_ so they bypass
+  // ApiActivityInfoExchange and are flushed straight to per_device_collector_.
+  // Check this BEFORE the source-based branching below.
+  //
+  // The cap is enforced here rather than inherited from the branch below,
+  // because that branch is unreachable for Generic events. Marker volume is
+  // driven by application code -- a per-op roctx hook can emit millions of
+  // ranges a second -- and standalone_events_ is only drained in Flush() at
+  // Disable(), so without this guard a long capture retains every marker for
+  // the whole session and can exhaust memory in the process being profiled.
+  // Counting them in num_callback_events_ also keeps the VLOG(3) summary and
+  // the documented XLA_FLAGS=--xla_gpu_rocm_max_trace_events knob honest;
+  // both silently ignored this path before.
+  if (event.type == RocmTracerEventType::Generic) {
+    if (num_callback_events_ >= options_.max_callback_api_events) {
+      OnEventsDropped(
+          "ROCTX marker event dropped: max_callback_api_events "
+          "reached. To collect more, set "
+          "XLA_FLAGS=--xla_gpu_rocm_max_trace_events=X",
+          event.correlation_id);
+      return;
+    }
+    num_callback_events_++;
+    standalone_events_.push_back(std::move(event));
+    return;
+  }
+
   if (event.source == RocmTracerEventSource::ApiCallback) {
     if (!is_auxiliary) {
       if (num_callback_events_ >= options_.max_callback_api_events) {
@@ -601,6 +659,26 @@ void RocmTraceCollectorImpl::Flush() {
     }
   }
 
+  // Flush standalone events (e.g. ROCTX markers) directly — they have no
+  // GPU-side activity counterpart and bypass ApiActivityInfoExchange.
+  // All standalone events are bucketed into slot [0] regardless of which
+  // thread produced them; ROCTX markers are host-side and have no per-device
+  // meaning. If num_gpus_ is zero (e.g. a CI node where rocprofiler reports
+  // no GPU agents), per_device_collector_[0] is never exported by Export(),
+  // so we drop rather than silently lose events into an unexported slot.
+  if (!standalone_events_.empty()) {
+    if (num_gpus_ == 0) {
+      LOG(WARNING) << "Dropping " << standalone_events_.size()
+                   << " standalone ROCTX events: no GPUs reported by "
+                      "rocprofiler, so no device plane exists to export them.";
+    } else {
+      for (auto& event : standalone_events_) {
+        per_device_collector_[0].AddEvent(std::move(event));
+      }
+    }
+    standalone_events_.clear();
+  }
+
   activity_ops_events_map_.clear();
   api_events_map_.clear();
   auxiliary_api_events_map_.clear();
@@ -622,6 +700,15 @@ void RocmTraceCollectorImpl::Export(XSpace* space) {
   uint64_t end_gputime_ns = get_timestamp();
   XPlaneBuilder host_plane(FindOrAddMutablePlaneWithName(
       space, tsl::profiler::kRoctracerApiPlaneName));
+  // ROCTX markers go into the same plane CUDA uses for NVTX. The plane is a
+  // transient routing token: PostProcessSingleHostXSpace merges it into
+  // /host:CPU and deletes it, and nothing downstream reads a plane name. Using
+  // the existing constant means the already-shipped NVTX merge block handles
+  // ROCm unchanged -- which matters across the PJRT plugin boundary, where the
+  // collector XSpace is serialized without post-processing and a plane name the
+  // host does not recognise would leak into the viewer unmerged.
+  XPlaneBuilder marker_plane(FindOrAddMutablePlaneWithName(
+      space, tsl::profiler::kCuptiActivityNvtxPlaneName));
 
   VLOG(3) << "Calling RocmTraceCollectorImpl::Export num_gpus " << num_gpus_;
 
@@ -635,10 +722,11 @@ void RocmTraceCollectorImpl::Export(XSpace* space) {
     }
     per_device_collector_[id].Export(start_walltime_ns_, start_gputime_ns_,
                                      end_gputime_ns, &device_plane,
-                                     &host_plane);
+                                     &marker_plane, &host_plane);
     NormalizeTimeStamps(&device_plane, start_walltime_ns_);
   }
   NormalizeTimeStamps(&host_plane, start_walltime_ns_);
+  NormalizeTimeStamps(&marker_plane, start_walltime_ns_);
   ExportScopeRangeIdTree(space);
 }
 
@@ -697,7 +785,7 @@ std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
                         "Type="
                      << GetRocmTracerEventTypeName(api_event.type);
     }  // switch
-  }  // for
+  }    // for
 
   // Make sure for all activity events we have API callback events.
   //
@@ -770,8 +858,8 @@ std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
                           "Type="
                        << GetRocmTracerEventTypeName(activity_event.type);
       }  // switch
-    }  // for activity_event
-  }  // for activity_iter
+    }    // for activity_event
+  }      // for activity_iter
 
   return aggregated_events;
 }

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -24,7 +24,6 @@ limitations under the License.
 #include <tuple>
 #include <vector>
 
-#include "rocprofiler-sdk/agent.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/node_hash_map.h"
@@ -32,6 +31,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
 #include "rocm/include/hip/hip_runtime.h"
+#include "rocprofiler-sdk/agent.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/profiler/utils/xplane_builder.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
@@ -154,6 +154,7 @@ class PerDeviceCollector {
   void Export(uint64_t start_walltime_ns, uint64_t start_gputime_ns,
               uint64_t end_gputime_ns,
               tsl::profiler::XPlaneBuilder* device_plane,
+              tsl::profiler::XPlaneBuilder* marker_plane,
               tsl::profiler::XPlaneBuilder* host_plane);
 
   PerDeviceCollector() = default;
@@ -226,6 +227,12 @@ class RocmTraceCollectorImpl : public RocmTraceCollector {
   // This is for the APIs that we track because we need some information from
   // them to populate the corresponding activity that we actually track.
   absl::flat_hash_map<uint64_t, RocmTracerEvent> auxiliary_api_events_map_
+      ABSL_GUARDED_BY(event_maps_mutex_);
+
+  // Host-side events that need no API↔Activity join (e.g. ROCTX markers).
+  // Flushed directly to per_device_collector_ without going through
+  // ApiActivityInfoExchange.
+  std::vector<RocmTracerEvent> standalone_events_
       ABSL_GUARDED_BY(event_maps_mutex_);
 
   std::vector<RocmTracerEvent> ApiActivityInfoExchange()

--- a/xla/backends/profiler/gpu/rocm_collector_test.cc
+++ b/xla/backends/profiler/gpu/rocm_collector_test.cc
@@ -22,6 +22,9 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "absl/container/flat_hash_set.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/profiler/utils/xplane_utils.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
@@ -198,6 +201,191 @@ TEST(RocmCollectorTest, MultipleActivitiesPerCorrelationIdAllExported) {
   EXPECT_TRUE(seen_names.contains("kernel_a"));
   EXPECT_TRUE(seen_names.contains("kernel_b"));
   EXPECT_TRUE(seen_names.contains("kernel_c"));
+}
+
+// ---------------------------------------------------------------------------
+// ROCTX marker (Generic event) handling.
+//
+// These live here rather than in rocm_tracer_test.cc deliberately: they drive
+// RocmTraceCollectorImpl directly, with no rocprofiler context and no tracer
+// singleton, so they exercise the collector contract on any host.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+RocmTracerEvent MakeMarkerEvent(absl::string_view label, uint64_t tid,
+                                uint64_t start_ns, uint64_t end_ns) {
+  RocmTracerEvent e;
+  e.type = RocmTracerEventType::Generic;
+  // ApiCallback is what routes this to a host line keyed on thread_id.
+  e.source = RocmTracerEventSource::ApiCallback;
+  e.domain = RocmTracerEventDomain::InvalidDomain;
+  e.name = std::string(label);
+  e.start_time_ns = start_ns;
+  e.end_time_ns = end_ns;
+  e.thread_id = tid;
+  e.device_id = RocmTracerEvent::kInvalidDeviceId;
+  e.correlation_id = RocmTracerEvent::kInvalidCorrelationId;
+  e.stream_id = RocmTracerEvent::kInvalidStreamId;
+  return e;
+}
+
+// Counts drops so the cap can be asserted on rather than inferred.
+class DropCountingCollector : public RocmTraceCollectorImpl {
+ public:
+  using RocmTraceCollectorImpl::RocmTraceCollectorImpl;
+  void OnEventsDropped(const std::string& reason, uint64_t id) override {
+    ++drops_;
+  }
+  int drops() const { return drops_; }
+
+ private:
+  int drops_ = 0;
+};
+
+}  // namespace
+
+// Marker events are routed to standalone_events_ by an early return that sits
+// above the source-based branching, so they do not inherit the cap enforced
+// there. Without an explicit guard an application emitting markers in a hot
+// loop grows standalone_events_ without bound for the whole session -- the
+// buffer is only drained at Flush(). This is the regression guard for that.
+TEST(RocmCollectorTest, MarkerEventsRespectMaxCallbackApiEvents) {
+  RocmTraceCollectorOptions options;
+  options.max_callback_api_events = 8;
+  options.max_activity_api_events = 100;
+  options.max_annotation_strings = 100;
+  options.num_gpus = 1;
+
+  DropCountingCollector collector(options, /*start_walltime_ns=*/1000,
+                                  /*start_gputime_ns=*/2000);
+
+  constexpr int kEmitted = 25;
+  for (int i = 0; i < kEmitted; ++i) {
+    collector.AddEvent(MakeMarkerEvent(absl::StrCat("marker_", i), /*tid=*/7,
+                                       3000 + i, 3100 + i),
+                       /*is_auxiliary=*/false);
+  }
+
+  EXPECT_EQ(collector.drops(), kEmitted - options.max_callback_api_events)
+      << "every marker past the cap must be reported through OnEventsDropped, "
+         "not silently retained";
+
+  collector.Flush();
+  XSpace space;
+  collector.Export(&space);
+
+  int marker_events = 0;
+  for (const auto& plane : space.planes()) {
+    for (const auto& line : plane.lines()) {
+      if (absl::EndsWith(line.name(), "/ROCTX")) {
+        marker_events += line.events_size();
+      }
+    }
+  }
+  EXPECT_EQ(marker_events, static_cast<int>(options.max_callback_api_events))
+      << "the cap must bound what is retained, not just what is reported";
+}
+
+// Flush() buckets standalone events into per_device_collector_[0], but
+// Export() only iterates [0, num_gpus_). With no GPUs that slot is created and
+// never exported, so the events would be silently lost; drop them explicitly
+// instead, and do not crash.
+TEST(RocmCollectorTest, MarkerEventsDroppedWhenNoGpusReported) {
+  RocmTraceCollectorOptions options;
+  options.max_callback_api_events = 100;
+  options.max_activity_api_events = 100;
+  options.max_annotation_strings = 100;
+  options.num_gpus = 0;
+
+  RocmTraceCollectorImpl collector(options, /*start_walltime_ns=*/1000,
+                                   /*start_gputime_ns=*/2000);
+  collector.AddEvent(MakeMarkerEvent("orphan", /*tid=*/11, 3000, 3100),
+                     /*is_auxiliary=*/false);
+  collector.Flush();
+
+  XSpace space;
+  collector.Export(&space);  // must not crash
+
+  for (const auto& plane : space.planes()) {
+    for (const auto& line : plane.lines()) {
+      EXPECT_FALSE(absl::EndsWith(line.name(), "/ROCTX"))
+          << "no device plane exists to carry marker events";
+    }
+  }
+}
+
+// The routing contract, stated once without a tracer singleton: a marker and a
+// kernel-launch API event on the SAME thread must land on different lines --
+// "Host Threads/<tid>/ROCTX" and "Host Threads/<tid>" -- so marker bands sort
+// directly beneath their owning thread after the merge into /host:CPU.
+TEST(RocmCollectorTest, MarkerAndApiEventsOnSameThreadGetSeparateLines) {
+  RocmTraceCollectorOptions options;
+  options.max_callback_api_events = 100;
+  options.max_activity_api_events = 100;
+  options.max_annotation_strings = 100;
+  options.num_gpus = 1;
+
+  RocmTraceCollectorImpl collector(options, /*start_walltime_ns=*/1000,
+                                   /*start_gputime_ns=*/2000);
+
+  constexpr uint64_t kTid = 4242;
+  collector.AddEvent(MakeMarkerEvent("my_range", kTid, 3000, 4000),
+                     /*is_auxiliary=*/false);
+
+  // The API event needs its Activity counterpart: ApiActivityInfoExchange
+  // drops any ApiCallback event whose correlation_id has no activity record
+  // (rocm_collector.cc, "could not find activity counterpart"). Markers are
+  // exempt because they never enter that exchange -- which is the asymmetry
+  // this test is here to pin down.
+  constexpr uint32_t kCorrelationId = 55;
+
+  RocmTracerEvent api_event;
+  api_event.type = RocmTracerEventType::Kernel;
+  api_event.source = RocmTracerEventSource::ApiCallback;
+  api_event.domain = RocmTracerEventDomain::HIP_API;
+  api_event.name = "some_kernel_launch";
+  api_event.correlation_id = kCorrelationId;
+  api_event.thread_id = kTid;
+  api_event.device_id = 0;
+  api_event.start_time_ns = 3100;
+  api_event.end_time_ns = 3200;
+  api_event.kernel_info = KernelDetails{};
+  collector.AddEvent(std::move(api_event), /*is_auxiliary=*/false);
+
+  RocmTracerEvent activity_event;
+  activity_event.type = RocmTracerEventType::Kernel;
+  activity_event.source = RocmTracerEventSource::Activity;
+  activity_event.domain = RocmTracerEventDomain::HIP_OPS;
+  activity_event.name = "some_kernel_launch";
+  activity_event.correlation_id = kCorrelationId;
+  activity_event.thread_id = kTid;
+  activity_event.device_id = 0;
+  activity_event.stream_id = 1;
+  activity_event.start_time_ns = 3150;
+  activity_event.end_time_ns = 3250;
+  activity_event.kernel_info = KernelDetails{};
+  collector.AddEvent(std::move(activity_event), /*is_auxiliary=*/false);
+
+  collector.Flush();
+  XSpace space;
+  collector.Export(&space);
+
+  bool found_marker_line = false;
+  bool found_plain_host_line = false;
+  for (const auto& plane : space.planes()) {
+    for (const auto& line : plane.lines()) {
+      if (line.name() == absl::StrCat("Host Threads/", kTid, "/ROCTX")) {
+        found_marker_line = true;
+        EXPECT_EQ(line.events_size(), 1);
+      } else if (line.name() == absl::StrCat("Host Threads/", kTid)) {
+        found_plain_host_line = true;
+      }
+    }
+  }
+  EXPECT_TRUE(found_marker_line) << "marker must get its own /ROCTX line";
+  EXPECT_TRUE(found_plain_host_line)
+      << "the API event must stay on the plain host-thread line";
 }
 
 }  // namespace test

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "absl/status/status_macros.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "rocm/include/rocprofiler-sdk/agent.h"
@@ -45,6 +46,7 @@ limitations under the License.
 #include "rocm/include/rocprofiler-sdk/fwd.h"
 #include "rocm/include/rocprofiler-sdk/hip/runtime_api_id.h"
 #include "rocm/include/rocprofiler-sdk/internal_threading.h"
+#include "rocm/include/rocprofiler-sdk/marker.h"
 #include "rocm/include/rocprofiler-sdk/registration.h"
 #include "rocm/include/rocprofiler-sdk/rocprofiler.h"
 #include "xla/backends/profiler/gpu/rocm_collector.h"
@@ -72,6 +74,13 @@ absl::Status RocprofilerStatusToAbslStatus(rocprofiler_status_t status) {
 // and exit, the external correlation callback snapshots the current stream.
 // Initialized with 0 (the default HIP stream).
 thread_local absl::InlinedVector<uint64_t, 4> tls_stream_stack = {0};
+
+// Thread-local ROCTX range stack. roctxRangePushA/Pop are thread-local by
+// definition and the rocprofiler marker callback runs synchronously on the
+// calling thread, so this needs no lock -- which matters because the HIP API
+// callback reads the current label on EVERY HIP call. Dies with the thread,
+// so no per-thread bookkeeping outlives it.
+thread_local std::vector<RoctxFrame> tls_roctx_stack;
 
 }  // namespace
 
@@ -154,6 +163,16 @@ absl::Status RocmTracer::Enable(const RocmTracerOptions& options,
   if (collector_ != nullptr) {
     return absl::AlreadyExistsError("ROCM tracer is already running");
   }
+
+  // Clear per-session state while holding collector_mutex_ so no in-flight
+  // callback can race between the clear and the new session start.
+  annotation_map_.Clear();
+  // ROCTX frames live on thread_local stacks this thread cannot reach, so
+  // isolate by generation instead of clearing: any frame pushed before this
+  // point is now stale and will be dropped at pop rather than emitted into
+  // the new session. See roctx_generation_ in rocm_tracer.h.
+  roctx_generation_.fetch_add(1, std::memory_order_relaxed);
+
   options_ = options;
   collector_ = collector;
 
@@ -165,7 +184,6 @@ absl::Status RocmTracer::Enable(const RocmTracerOptions& options,
     return absl::InternalError(
         absl::StrCat("rocprofiler_start_context failed: ", errstr));
   }
-  annotation_map_.Clear();
   api_tracing_enabled_ = true;
   activity_tracing_enabled_ = true;
   VLOG(1) << "GpuTracer started with number of GPUs = " << NumGpus();
@@ -188,6 +206,8 @@ void RocmTracer::HipApiEvent(const rocprofiler_record_header_t* hdr,
   trace_event->correlation_id = rec.correlation_id.internal;
   trace_event->annotation =
       annotation_map()->LookUp(trace_event->correlation_id);
+  trace_event->roctx_range =
+      annotation_map()->LookUpRoctxRange(trace_event->correlation_id);
   trace_event->scope_range_id =
       annotation_map()->LookUpScopeRangeId(trace_event->correlation_id);
   trace_event->thread_id = rec.thread_id;
@@ -284,6 +304,8 @@ void RocmTracer::MemcpyEvent(const rocprofiler_record_header_t* hdr,
   trace_event->correlation_id = rec.correlation_id.internal;
   trace_event->annotation =
       annotation_map()->LookUp(trace_event->correlation_id);
+  trace_event->roctx_range =
+      annotation_map()->LookUpRoctxRange(trace_event->correlation_id);
   trace_event->scope_range_id =
       annotation_map()->LookUpScopeRangeId(trace_event->correlation_id);
   trace_event->thread_id = rec.thread_id;
@@ -318,6 +340,8 @@ void RocmTracer::KernelEvent(const rocprofiler_record_header_t* hdr,
   trace_event->correlation_id = rec.correlation_id.internal;
   trace_event->annotation =
       annotation_map()->LookUp(trace_event->correlation_id);
+  trace_event->roctx_range =
+      annotation_map()->LookUpRoctxRange(trace_event->correlation_id);
   trace_event->scope_range_id =
       annotation_map()->LookUpScopeRangeId(trace_event->correlation_id);
   trace_event->thread_id = rec.thread_id;
@@ -338,6 +362,111 @@ void RocmTracer::KernelEvent(const rocprofiler_record_header_t* hdr,
 
   auto it = kernel_info_.find(kinfo.kernel_id);
   if (it != kernel_info_.end()) trace_event->name = it->second.name;
+}
+
+void RocmTracer::EmitMarkerEvent(std::string label, uint64_t start_ns,
+                                 uint64_t end_ns, uint64_t tid) {
+  RocmTracerEvent event;
+  event.type = RocmTracerEventType::Generic;
+  // ApiCallback is load-bearing, not incidental: PerDeviceCollector::
+  // IsHostEvent keys off it to set line_id = thread_id, which is what places
+  // markers on a per-thread line rather than a device stream line.
+  event.source = RocmTracerEventSource::ApiCallback;
+  // These arrive via MARKER_CORE_API, not the HIP API. InvalidDomain is the
+  // honest value; HIP_API here would be wrong and would start counting
+  // markers as activity events if the Generic early-return in
+  // RocmTraceCollectorImpl::AddEvent were ever reordered.
+  event.domain = RocmTracerEventDomain::InvalidDomain;
+  // The label is owned by event.name. Deliberately no roctx_range view: that
+  // field is for kernel/HIP-API events, where it points into AnnotationMap's
+  // session-scoped pool. A view into our own name would dangle the moment the
+  // event is moved (small-string optimisation relocates the buffer), and a
+  // separate intern pool would only duplicate bytes name already owns.
+  // CreateXEvent reads name for the kNVTXRange stat on Generic events.
+  event.name = std::move(label);
+  event.start_time_ns = start_ns;
+  event.end_time_ns = end_ns;
+  event.thread_id = tid;
+  event.device_id = RocmTracerEvent::kInvalidDeviceId;
+  // Markers correlate with nothing downstream: a Generic event has no GPU
+  // activity record to be paired with, so it carries no correlation id.
+  event.correlation_id = RocmTracerEvent::kInvalidCorrelationId;
+  event.stream_id = RocmTracerEvent::kInvalidStreamId;
+  event.scope_range_id = 0;
+
+  absl::MutexLock lock(&collector_mutex_);
+  if (collector()) {
+    collector()->AddEvent(std::move(event), /*is_auxiliary=*/false);
+  }
+}
+
+void RocmTracer::MarkerCallback(
+    const rocprofiler_callback_tracing_record_t& record) {
+  if (record.kind != ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API) return;
+
+  const auto* data =
+      static_cast<const rocprofiler_callback_tracing_marker_api_data_t*>(
+          record.payload);
+  const uint64_t tid = record.thread_id;
+
+  if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA &&
+      record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+    const char* msg = data ? data->args.roctxRangePushA.message : nullptr;
+    // Push unconditionally, even when GetTimestamp() fails (ts == 0) or the
+    // label is absent. Skipping the push would desynchronise the whole
+    // thread's stack: the matching pop would consume the ENCLOSING frame and
+    // emit it with the inner end time, and every outer level after it would
+    // be off by one. A frame with start_ns == 0 is dropped at pop instead,
+    // which costs one bogus range rather than corrupting the rest.
+    tls_roctx_stack.push_back(
+        RoctxFrame{msg ? std::string(msg) : std::string(), GetTimestamp(),
+                   roctx_generation_.load(std::memory_order_relaxed)});
+
+  } else if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop &&
+             record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) {
+    if (tls_roctx_stack.empty()) return;  // unmatched pop
+    RoctxFrame frame = std::move(tls_roctx_stack.back());
+    tls_roctx_stack.pop_back();
+
+    const uint64_t ts = GetTimestamp();
+    // Drop rather than emit: a frame from a previous session would carry that
+    // session's start timestamp, a failed clock read cannot produce a valid
+    // duration, and an unlabelled range renders as an anonymous "Generic"
+    // band. Popping first (above) keeps the stack balanced in every case.
+    if (frame.generation != roctx_generation_.load(std::memory_order_relaxed) ||
+        frame.start_ns == 0 || ts == 0 || frame.message.empty()) {
+      return;
+    }
+    EmitMarkerEvent(std::move(frame.message), frame.start_ns, ts, tid);
+
+  } else if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA &&
+             record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+    const uint64_t ts = GetTimestamp();
+    if (ts == 0) return;
+    const char* msg = data ? data->args.roctxMarkA.message : nullptr;
+    if (!msg || msg[0] == '\0') return;
+    EmitMarkerEvent(std::string(msg), ts, ts, tid);
+
+  } else if (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+    // roctxRangeStartA/roctxRangeStop -- the documented idiom for ranges that
+    // begin and end on different threads or that overlap -- are not handled.
+    // Warn once rather than dropping silently, so a user whose instrumentation
+    // produces an empty ROCTX row can tell "unsupported" from "broken".
+    LOG_FIRST_N(WARNING, 1)
+        << "ROCTX marker operation " << record.operation
+        << " is not captured by the XLA profiler (only roctxRangePushA/"
+           "roctxRangePop/roctxMarkA are). Ranges created with "
+           "roctxRangeStartA/roctxRangeStop will not appear in the trace.";
+  }
+}
+
+absl::string_view RocmTracer::GetCurrentRoctxLabel() {
+  if (tls_roctx_stack.empty()) return {};
+  const RoctxFrame& frame = tls_roctx_stack.back();
+  if (frame.generation != roctx_generation_.load(std::memory_order_relaxed)) {
+    return {};
+  }
+  return frame.message;
 }
 
 void RocmTracer::TracingCallback(rocprofiler_context_id_t context,
@@ -579,17 +708,56 @@ absl::Status RocmTracer::InitProfiling(void* tool_data) {
             [](rocprofiler_callback_tracing_record_t record,
                rocprofiler_user_data_t*, void*) {
               if (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+                auto& tracer = RocmTracer::GetRocmTracerSingleton();
                 const std::string& annotation =
                     tsl::profiler::AnnotationStack::Get();
-                if (!annotation.empty()) {
+                // Aliases the thread_local roctx frame. Safe to hold across
+                // Add(): this callback runs synchronously on the thread that
+                // owns the stack, so nothing can pop it in between, and Add()
+                // interns a copy.
+                absl::string_view roctx = tracer.GetCurrentRoctxLabel();
+                // Store when either field is non-empty: annotation populates
+                // kTfOp on kernel events; roctx populates kNVTXRange.
+                if (!annotation.empty() || !roctx.empty()) {
                   absl::Span<const int64_t> range_ids =
                       tsl::profiler::AnnotationStack::GetScopeRangeIds();
-                  RocmTracer::GetRocmTracerSingleton().annotation_map()->Add(
-                      record.correlation_id.internal, annotation, range_ids);
+                  tracer.annotation_map()->Add(record.correlation_id.internal,
+                                               annotation, roctx, range_ids);
                 }
               }
             },
             nullptr)));
+  }
+
+  // ROCTX marker tracing: capture roctxRangePushA, roctxRangePop, and
+  // roctxMarkA so user-emitted ranges appear as named bands in the XPlane host
+  // thread timeline (kNVTXRange stat on Generic events).
+  //
+  // The producer is the application, not XLA. On ROCm, nvtx_utils_impl builds
+  // nvtx_utils_stub.cc, whose DefaultProfilerDomain() returns null, so
+  // scoped_annotation.h takes its AnnotationStack branch and XLA emits no
+  // roctx call. Only code that links librocprofiler-sdk-roctx and calls it
+  // directly reaches this callback. A follow-up adds the XLA-side emitter.
+  // Log and continue rather than RETURN_IF_ERROR. A failure here propagates to
+  // toolInit, which returns -1 and tears down HIP-API, kernel-dispatch and
+  // memcpy tracing along with it. That is far too much collateral for an
+  // optional feature whose producer is the application: MARKER_CORE_API may be
+  // absent in an older rocprofiler-sdk, or already claimed by another tool in
+  // the process (ROCPROFILER_STATUS_ERROR_SERVICE_ALREADY_CONFIGURED). Losing
+  // ROCTX bands is acceptable; losing all GPU profiling is not.
+  if (absl::Status marker_status = RocprofilerStatusToAbslStatus(
+          rocprofiler_configure_callback_tracing_service(
+              context_, ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API, nullptr,
+              0,
+              [](rocprofiler_callback_tracing_record_t record,
+                 rocprofiler_user_data_t*, void*) {
+                RocmTracer::GetRocmTracerSingleton().MarkerCallback(record);
+              },
+              nullptr));
+      !marker_status.ok()) {
+    LOG(WARNING) << "ROCTX marker tracing unavailable; continuing without it. "
+                    "ROCTX ranges will not appear in the trace. Reason: "
+                 << marker_status.message();
   }
 
   auto client_thread = rocprofiler_callback_thread_t{};

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -16,9 +16,13 @@ limitations under the License.
 #ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_
 #define XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_
 
+#include <atomic>
+#include <cstdint>
+#include <string>
+
 #include "absl/container/flat_hash_map.h"
-#include "absl/container/node_hash_set.h"
 #include "absl/status/status.h"
+#include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/optional.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
@@ -72,6 +76,30 @@ class RocmTracer {
   void CodeObjectCallback(rocprofiler_callback_tracing_record_t record,
                           void* callback_data);
 
+  // Called from the MARKER_CORE_API callback. Handles roctxRangePushA,
+  // roctxRangePop, and roctxMarkA, emitting RocmTracerEvent(Generic) for each
+  // completed range or instantaneous mark.
+  void MarkerCallback(const rocprofiler_callback_tracing_record_t& record);
+
+  // Returns the label of the innermost ROCTX range active on the CALLING
+  // thread, or empty if none. Takes no thread id: the range stack is
+  // thread_local, and the HIP API callback that consumes this runs on the same
+  // thread that pushed the range.
+  //
+  // The view aliases the thread_local frame, so it is only valid until this
+  // thread makes its next roctx call. That is enough for the caller: the HIP
+  // API callback runs synchronously on the thread that owns the stack, so no
+  // pop can interleave, and AnnotationMap::Add interns a copy before
+  // returning. Do not store the view.
+  absl::string_view GetCurrentRoctxLabel();
+
+  // Builds and hands a Generic (ROCTX marker) event to the collector. Shared
+  // by the range-pop and mark paths so the two cannot drift in how they set
+  // source/domain/ids -- an earlier duplicated version diverged on empty-label
+  // handling and emitted anonymous "Generic" bands.
+  void EmitMarkerEvent(std::string label, uint64_t start_ns, uint64_t end_ns,
+                       uint64_t tid);
+
   AnnotationMap* annotation_map() { return &annotation_map_; }
 
  protected:
@@ -94,6 +122,21 @@ class RocmTracer {
   bool activity_tracing_enabled_{false};
 
   AnnotationMap annotation_map_{/* default size, e.g. */ 1024 * 1024};
+
+  // ROCTX range state lives in a thread_local stack in rocm_tracer.cc, not
+  // here. roctx pushes and pops are thread-local by definition and the
+  // rocprofiler callback runs synchronously on the calling thread, so no
+  // shared structure is needed -- and the HIP API callback reads the current
+  // label on every single HIP call, which must not touch a process-wide lock.
+  // Keeping it thread_local also means no per-thread map entry outlives the
+  // thread, and there is no lock to order against collector_mutex_.
+  //
+  // Session isolation is by generation instead of by clearing: Enable() bumps
+  // this counter, and a pop whose frame carries an older generation is
+  // discarded rather than emitted into the new session. Relaxed ordering is
+  // sufficient -- a racing push either sees the old or the new value, and
+  // either way the frame is consistently tagged and consistently judged.
+  std::atomic<uint64_t> roctx_generation_{0};
 
  public:
   using kernel_symbol_data_t =

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -18,20 +18,30 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "rocm/include/hip/hip_runtime.h"
+#include "rocm/include/rocprofiler-sdk-roctx/roctx.h"
+#include "rocm/include/rocprofiler-sdk/callback_tracing.h"
 #include "rocm/include/rocprofiler-sdk/context.h"
 #include "rocm/include/rocprofiler-sdk/fwd.h"
+#include "rocm/include/rocprofiler-sdk/marker.h"
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/lib/core/status_test_util.h"
+#include "xla/tsl/platform/env_time.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
 
 namespace xla {
@@ -335,6 +345,598 @@ TEST(RocmTracerTest, DisableIsolatesNextSession) {
       << " events despite no HIP activity between its Enable() and Disable();"
       << " these must have leaked from the preceding no-profiler window of "
       << kLeakedPairs << " hipMemcpy pairs";
+}
+
+// MarkerCallback unit tests — exercise MarkerCallback() directly without
+// requiring real ROCTX API calls, using a capturing collector.
+// ============================================================================
+
+// Collector variant that captures the full RocmTracerEvent for inspection.
+class MarkerCapturingCollector : public RocmTraceCollector {
+ public:
+  MarkerCapturingCollector() : RocmTraceCollector(MakeCollectorOptions()) {}
+
+  void AddEvent(RocmTracerEvent&& event, bool) override {
+    absl::MutexLock lock(&mu_);
+    events_.push_back(std::move(event));
+  }
+  void OnEventsDropped(const std::string&, uint64_t) override {}
+  void Flush() override {}
+  void Export(tsl::profiler::XSpace*) override {}
+
+  std::vector<RocmTracerEvent> TakeEvents() {
+    absl::MutexLock lock(&mu_);
+    return std::exchange(events_, {});
+  }
+
+ private:
+  static RocmTraceCollectorOptions MakeCollectorOptions() {
+    RocmTraceCollectorOptions o;
+    o.max_callback_api_events = 1024;
+    o.max_activity_api_events = 1024;
+    o.max_annotation_strings = 1024;
+    o.num_gpus = 1;
+    return o;
+  }
+  absl::Mutex mu_;
+  std::vector<RocmTracerEvent> events_ ABSL_GUARDED_BY(mu_);
+};
+
+// Build a minimal rocprofiler_callback_tracing_record_t for MARKER_CORE_API.
+// `payload` must point to a live rocprofiler_callback_tracing_marker_api_data_t
+// for the duration of the MarkerCallback call.
+static rocprofiler_callback_tracing_record_t MakeMarkerRecord(
+    rocprofiler_marker_core_api_id_t op, rocprofiler_callback_phase_t phase,
+    uint64_t thread_id, void* payload) {
+  rocprofiler_callback_tracing_record_t rec{};
+  rec.kind = ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API;
+  rec.operation = static_cast<rocprofiler_tracing_operation_t>(op);
+  rec.phase = phase;
+  rec.thread_id = thread_id;
+  rec.correlation_id.internal = 99;
+  rec.payload = payload;
+  return rec;
+}
+
+TEST(RocmTracerTest, MarkerCallbackPushPopEmitsRoctxRange) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  const uint64_t tid = 12345;
+  const char* label = "my_roctx_range";
+
+  // Simulate roctxRangePushA ENTER
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = label;
+  auto push_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data);
+  tracer.MarkerCallback(push_rec);
+
+  // No event yet — PUSH doesn't emit
+  EXPECT_TRUE(cptr->TakeEvents().empty())
+      << "roctxRangePushA must not emit an event until the matching Pop";
+
+  // Simulate roctxRangePop EXIT
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  auto pop_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data);
+  tracer.MarkerCallback(pop_rec);
+
+  tracer.Disable();
+
+  auto events = cptr->TakeEvents();
+  ASSERT_EQ(events.size(), 1u)
+      << "Expected exactly one range event from Push+Pop";
+
+  const RocmTracerEvent& e = events[0];
+  EXPECT_EQ(e.type, RocmTracerEventType::Generic);
+  // ApiCallback is what makes PerDeviceCollector place this on a per-thread
+  // line rather than a device stream line.
+  EXPECT_EQ(e.source, RocmTracerEventSource::ApiCallback);
+  // Markers own their label in `name`; `roctx_range` is reserved for
+  // kernel/HIP-API events, where it views AnnotationMap's pool.
+  EXPECT_EQ(e.name, label);
+  EXPECT_TRUE(e.roctx_range.empty())
+      << "marker events must not carry a roctx_range view";
+  EXPECT_EQ(e.thread_id, tid);
+  // GE, not GT: both timestamps come from rocprofiler_get_timestamp and a
+  // zero-length range is legal, so strict inequality is a flake tail.
+  EXPECT_GE(e.end_time_ns, e.start_time_ns);
+}
+
+TEST(RocmTracerTest, MarkerCallbackMarkEmitsInstantaneousEvent) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  const uint64_t tid = 77777;
+  const char* label = "checkpoint";
+
+  rocprofiler_callback_tracing_marker_api_data_t mark_data{};
+  mark_data.args.roctxMarkA.message = label;
+  auto mark_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &mark_data);
+  tracer.MarkerCallback(mark_rec);
+
+  tracer.Disable();
+
+  auto events = cptr->TakeEvents();
+  ASSERT_EQ(events.size(), 1u) << "roctxMarkA must emit exactly one event";
+
+  const RocmTracerEvent& e = events[0];
+  EXPECT_EQ(e.type, RocmTracerEventType::Generic);
+  EXPECT_EQ(e.name, label);
+  EXPECT_TRUE(e.roctx_range.empty());
+  EXPECT_EQ(e.thread_id, tid);
+  EXPECT_EQ(e.start_time_ns, e.end_time_ns)
+      << "roctxMarkA produces an instantaneous event (start == end)";
+}
+
+TEST(RocmTracerTest, MarkerCallbackUnmatchedPopIsIgnored) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  // Pop without any preceding Push — must not crash, must not emit any event.
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  auto pop_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, 1111, &pop_data);
+  tracer.MarkerCallback(pop_rec);
+
+  tracer.Disable();
+
+  EXPECT_TRUE(cptr->TakeEvents().empty())
+      << "An unmatched roctxRangePop must not emit an event";
+}
+
+TEST(RocmTracerTest, MarkerCallbackNullLabelRangeIsDroppedNotEmitted) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  const uint64_t tid = 2222;
+
+  // Push with a null message — must not crash, and must still push so the
+  // matching pop consumes THIS frame rather than an enclosing one.
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = nullptr;
+  auto push_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data);
+  tracer.MarkerCallback(push_rec);
+
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  auto pop_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data);
+  tracer.MarkerCallback(pop_rec);
+
+  tracer.Disable();
+
+  // An unlabelled range carries no information and renders in the trace
+  // viewer as an anonymous "Generic" band (CreateXEvent falls back to the
+  // event-type name when `name` is empty). Drop it, matching how roctxMarkA
+  // already treats a null/empty message.
+  EXPECT_THAT(cptr->TakeEvents(), ::testing::IsEmpty())
+      << "A range with no label must be dropped, not emitted as \"Generic\"";
+}
+
+// The counterpart to the above: dropping the unlabelled range must NOT
+// desynchronise the thread's stack. If the null push were skipped entirely,
+// this pop would consume "outer" and report it with the inner end time.
+TEST(RocmTracerTest, MarkerCallbackNullLabelRangeKeepsStackBalanced) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  MarkerCapturingCollector* cptr = collector.get();
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, cptr));
+
+  const uint64_t tid = 2223;
+
+  rocprofiler_callback_tracing_marker_api_data_t outer{};
+  outer.args.roctxRangePushA.message = "outer";
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &outer));
+
+  rocprofiler_callback_tracing_marker_api_data_t inner{};
+  inner.args.roctxRangePushA.message = nullptr;  // unlabelled inner range
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &inner));
+
+  rocprofiler_callback_tracing_marker_api_data_t pop{};
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop));  // inner
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop));  // outer
+
+  tracer.Disable();
+
+  auto events = cptr->TakeEvents();
+  ASSERT_EQ(events.size(), 1u) << "only the labelled range should be emitted";
+  EXPECT_EQ(events[0].name, "outer")
+      << "the surviving event must be the outer range, not a shifted frame";
+}
+
+// Integration test: verifies the full pipeline — MarkerCallback → AddEvent →
+// PerDeviceCollector::Export — produces a Generic event in the XSpace host
+// plane. Uses the unit-test collector path (real rocprofiler context is live
+// because Enable() starts it; we inject the event via MarkerCallback directly
+// rather than going through the real ROCTX library).
+TEST(RocmTracerTest, MarkerEventAppearsInExportedXSpace) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  RocmTraceCollectorOptions col_opts;
+  col_opts.max_callback_api_events = 1024;
+  col_opts.max_activity_api_events = 1024;
+  col_opts.max_annotation_strings = 1024;
+  col_opts.num_gpus = tracer.NumGpus() > 0 ? tracer.NumGpus() : 1;
+
+  uint64_t start_gpu = RocmTracer::GetTimestamp();
+  uint64_t start_wall = tsl::EnvTime::NowNanos();
+  auto collector =
+      std::make_unique<RocmTraceCollectorImpl>(col_opts, start_wall, start_gpu);
+  collector->SetGpuAgents(tracer.GpuAgents());
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  const uint64_t tid = 4242;
+  const char* label = "integration_label";
+
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = label;
+  auto push_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data);
+  tracer.MarkerCallback(push_rec);
+
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  auto pop_rec =
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data);
+  tracer.MarkerCallback(pop_rec);
+
+  tracer.Disable();
+
+  tsl::profiler::XSpace space;
+  collector->Export(&space);
+
+  // Assert on the LINE name, not the plane name. The marker plane is a
+  // transient routing token that PostProcessSingleHostXSpace merges into
+  // /host:CPU and deletes, so a plane-name assertion pins an implementation
+  // detail that never reaches a user. The line name does survive, and the
+  // "/ROCTX" suffix is applied only to lines on the marker plane -- so this
+  // single check covers both halves of the routing contract: markers land on
+  // the marker plane, and they do NOT land on the HIP-API host plane (whose
+  // lines are named "Host Threads/<tid>" with no suffix).
+  bool found_nvtx_stat = false;
+  bool found_correct_label = false;
+  bool found_on_non_marker_line = false;
+  for (const auto& plane : space.planes()) {
+    // Build a map from stat metadata ID -> stat name for this plane.
+    absl::flat_hash_map<int64_t, std::string> stat_id_to_name;
+    for (const auto& [id, stat_md] : plane.stat_metadata()) {
+      stat_id_to_name[id] = stat_md.name();
+    }
+
+    // CreateXEvent writes the label via
+    //   AddStatValue(md(kNVTXRange), *plane->GetOrCreateStatMetadata(label))
+    // whose second argument is an XStatMetadata&, so the label arrives as a
+    // ref_value naming another stat_metadata entry -- NOT as a str_value.
+    // Reading str_value alone silently yields "" and the assertion can never
+    // pass. Handle both encodings, as RealRoctxCallsProduceNvtxRangeInXSpace
+    // below already does.
+    auto label_of =
+        [&](const tensorflow::profiler::XStat& stat) -> std::string {
+      if (stat.value_case() == tensorflow::profiler::XStat::kRefValue) {
+        auto it = plane.stat_metadata().find(stat.ref_value());
+        return it != plane.stat_metadata().end() ? it->second.name() : "";
+      }
+      return stat.str_value();
+    };
+
+    for (const auto& line : plane.lines()) {
+      const bool is_marker_line = absl::EndsWith(line.name(), "/ROCTX");
+      for (const auto& event : line.events()) {
+        for (const auto& stat : event.stats()) {
+          auto name_it = stat_id_to_name.find(stat.metadata_id());
+          if (name_it == stat_id_to_name.end() ||
+              name_it->second != "nvtx_range") {
+            continue;
+          }
+          found_nvtx_stat = true;
+          if (!is_marker_line) {
+            found_on_non_marker_line = true;
+            continue;
+          }
+          if (label_of(stat) == label) found_correct_label = true;
+        }
+      }
+    }
+  }
+  EXPECT_TRUE(found_nvtx_stat)
+      << "XSpace should contain an nvtx_range stat after a ROCTX range";
+  EXPECT_TRUE(found_correct_label)
+      << "nvtx_range stat on a \"Host Threads/<tid>/ROCTX\" line must equal "
+         "the pushed label: "
+      << label;
+  EXPECT_FALSE(found_on_non_marker_line)
+      << "ROCTX markers must not be routed onto the HIP-API host plane";
+}
+
+// ============================================================================
+// Integration test: real librocprofiler-sdk-roctx.so → MarkerCallback →
+// kNVTXRange stat in exported XSpace.
+//
+// Linked directly against @local_config_rocm//rocm:rocprofiler_sdk_roctx,
+// which stages the library and its librocprofiler-register.so dependency so
+// rocprofiler-sdk intercepts the calls. libroctx64.so (old roctracer-era
+// roctx) would NOT be intercepted, which is why this test requires the
+// rocprofiler-sdk-integrated variant.
+// ============================================================================
+
+// Test: real roctxRangePushA/roctxRangePop → kNVTXRange stat in XSpace.
+TEST(RocmTracerTest, RealRoctxCallsProduceNvtxRangeInXSpace) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  RocmTraceCollectorOptions col_opts;
+  col_opts.max_callback_api_events = 1024;
+  col_opts.max_activity_api_events = 1024;
+  col_opts.max_annotation_strings = 1024;
+  col_opts.num_gpus = tracer.NumGpus() > 0 ? tracer.NumGpus() : 1;
+
+  uint64_t start_gpu = RocmTracer::GetTimestamp();
+  uint64_t start_wall = tsl::EnvTime::NowNanos();
+  auto collector =
+      std::make_unique<RocmTraceCollectorImpl>(col_opts, start_wall, start_gpu);
+  collector->SetGpuAgents(tracer.GpuAgents());
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  // Emit real ROCTX ranges — rocprofiler-sdk intercepts these and fires
+  // MarkerCallback, which emits Generic RocmTracerEvents.
+  EXPECT_GE(roctxRangePushA("unit_test_outer"), 0);
+  EXPECT_GE(roctxRangePushA("unit_test_inner"), 0);
+  roctxMarkA("unit_test_mark");
+  roctxRangePop();  // end unit_test_inner
+  roctxRangePop();  // end unit_test_outer
+
+  tracer.Disable();
+
+  // Export and verify kNVTXRange stat appears in XSpace.
+  tsl::profiler::XSpace space;
+  collector->Export(&space);
+
+  bool found_nvtx_stat = false;
+  bool found_on_marker_line = false;
+  std::vector<std::string> found_labels;
+
+  for (const auto& plane : space.planes()) {
+    // Find the nvtx_range stat metadata id in this plane.
+    int64_t nvtx_stat_id = -1;
+    for (const auto& [sid, smd] : plane.stat_metadata()) {
+      if (smd.name() == "nvtx_range") {
+        nvtx_stat_id = sid;
+        found_nvtx_stat = true;
+        break;
+      }
+    }
+    if (nvtx_stat_id < 0) continue;
+
+    // Collect the label strings from event stats. Routing is asserted via the
+    // line name ("Host Threads/<tid>/ROCTX"), which is what survives the merge
+    // into /host:CPU -- the marker plane itself is deleted in post-processing.
+    for (const auto& line : plane.lines()) {
+      const bool is_marker_line = absl::EndsWith(line.name(), "/ROCTX");
+      for (const auto& event : line.events()) {
+        for (const auto& stat : event.stats()) {
+          if (stat.metadata_id() != nvtx_stat_id) continue;
+          if (is_marker_line) found_on_marker_line = true;
+          if (stat.value_case() == tensorflow::profiler::XStat::kRefValue) {
+            int64_t ref = stat.ref_value();
+            auto it = plane.stat_metadata().find(ref);
+            if (it != plane.stat_metadata().end()) {
+              found_labels.push_back(it->second.name());
+            }
+          } else if (stat.value_case() ==
+                     tensorflow::profiler::XStat::kStrValue) {
+            found_labels.push_back(stat.str_value());
+          }
+        }
+      }
+    }
+  }
+
+  EXPECT_TRUE(found_nvtx_stat)
+      << "XSpace should contain 'nvtx_range' stat metadata after real ROCTX "
+         "calls via librocprofiler-sdk-roctx.so";
+  EXPECT_TRUE(found_on_marker_line)
+      << "ROCTX events must land on a \"Host Threads/<tid>/ROCTX\" line";
+
+  if (found_nvtx_stat) {
+    std::set<std::string> label_set(found_labels.begin(), found_labels.end());
+    EXPECT_TRUE(label_set.count("unit_test_outer"))
+        << "Expected 'unit_test_outer' in nvtx_range labels. Found: "
+        << absl::StrJoin(found_labels, ", ");
+    EXPECT_TRUE(label_set.count("unit_test_inner"))
+        << "Expected 'unit_test_inner' in nvtx_range labels. Found: "
+        << absl::StrJoin(found_labels, ", ");
+    // roctxMarkA emits an instantaneous event — label is present
+    EXPECT_TRUE(label_set.count("unit_test_mark"))
+        << "Expected 'unit_test_mark' in nvtx_range labels. Found: "
+        << absl::StrJoin(found_labels, ", ");
+  }
+}
+
+// ============================================================================
+// GetCurrentRoctxLabel and AnnotationMap roctx_range tests (Commit B)
+// ============================================================================
+
+TEST(RocmTracerTest, GetCurrentRoctxLabelReturnsTopOfStack) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  const uint64_t tid = 55555;
+
+  EXPECT_EQ(tracer.GetCurrentRoctxLabel(), "");
+
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = "outer";
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data));
+  EXPECT_EQ(tracer.GetCurrentRoctxLabel(), "outer");
+
+  push_data.args.roctxRangePushA.message = "inner";
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data));
+  EXPECT_EQ(tracer.GetCurrentRoctxLabel(), "inner");
+
+  tracer.Disable();
+}
+
+TEST(RocmTracerTest, GetCurrentRoctxLabelEmptyAfterPop) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  const uint64_t tid = 55556;
+
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = "only_range";
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data));
+  EXPECT_EQ(tracer.GetCurrentRoctxLabel(), "only_range");
+
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data));
+  EXPECT_EQ(tracer.GetCurrentRoctxLabel(), "");
+
+  tracer.Disable();
+}
+
+TEST(RocmTracerTest, AnnotationMapStoresRoctxRange) {
+  AnnotationMap map(1024);
+  map.Add(99, "my_annotation", "my_roctx_label", {});
+  EXPECT_EQ(map.LookUp(99), "my_annotation");
+  EXPECT_EQ(map.LookUpRoctxRange(99), "my_roctx_label");
+
+  EXPECT_EQ(map.LookUpRoctxRange(100), "");
+
+  map.Clear();
+  EXPECT_EQ(map.LookUpRoctxRange(99), "");
+}
+
+TEST(RocmTracerTest, AnnotationMapRoctxRangeEmptyWhenNotProvided) {
+  AnnotationMap map(1024);
+  map.Add(42, "some_op", {}, {});
+  EXPECT_EQ(map.LookUp(42), "some_op");
+  EXPECT_EQ(map.LookUpRoctxRange(42), "");
+}
+
+// Verify that Add() stores the roctx_range even when annotation is empty,
+// so that standalone ROCTX annotations (no XLA AnnotationStack text) still
+// produce kNVTXRange on kernel events.
+TEST(RocmTracerTest, AnnotationMapStoresRoctxRangeWhenAnnotationEmpty) {
+  AnnotationMap map(1024);
+  // annotation is empty, roctx_range is not.
+  map.Add(77, /*annotation=*/"", "roctx_only_label", {});
+  EXPECT_EQ(map.LookUp(77), "")
+      << "correlation_map should not have an entry when annotation is empty";
+  EXPECT_EQ(map.LookUpRoctxRange(77), "roctx_only_label")
+      << "roctx_range_map must store the label even with no annotation";
+}
+
+// GetCurrentRoctxLabel returns a view aliasing the thread_local frame. It is
+// valid until this thread makes its next roctx call, which is the whole window
+// the HIP API callback needs: that callback runs synchronously on the pushing
+// thread, so no pop can interleave, and AnnotationMap::Add interns a copy
+// before returning. This models that sequence -- read the view, materialise it
+// the way Add does, then pop -- and confirms the materialised copy outlives the
+// frame and that the stack reads empty afterwards.
+TEST(RocmTracerTest, GetCurrentRoctxLabelViewIsValidUntilNextRoctxCall) {
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  auto collector = std::make_unique<MarkerCapturingCollector>();
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  const uint64_t tid = 66666;
+  const char* label = "lifetime_check";
+
+  // Push a range.
+  rocprofiler_callback_tracing_marker_api_data_t push_data{};
+  push_data.args.roctxRangePushA.message = label;
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA,
+                       ROCPROFILER_CALLBACK_PHASE_ENTER, tid, &push_data));
+
+  // Read the view while the frame is live, then intern it -- this is the
+  // HIP API callback's sequence, all on the pushing thread.
+  absl::string_view view = tracer.GetCurrentRoctxLabel();
+  EXPECT_EQ(view, label);
+  std::string interned(view);
+
+  // Pop the range: this destroys the RoctxFrame::message inside roctx_stack_.
+  // `view` dangles from here on and must not be read again.
+  rocprofiler_callback_tracing_marker_api_data_t pop_data{};
+  tracer.MarkerCallback(
+      MakeMarkerRecord(ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop,
+                       ROCPROFILER_CALLBACK_PHASE_EXIT, tid, &pop_data));
+
+  EXPECT_EQ(interned, label)
+      << "Copy taken before the pop must outlive the source frame";
+  EXPECT_EQ(tracer.GetCurrentRoctxLabel(), "")
+      << "Stack must be empty after pop";
+
+  tracer.Disable();
 }
 
 }  // namespace

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -90,26 +91,43 @@ const char* GetRocmTracerEventTypeName(const RocmTracerEventType& type) {
 }
 
 void AnnotationMap::Add(uint64_t correlation_id, const std::string& annotation,
+                        absl::string_view roctx_range,
                         absl::Span<const int64_t> scope_range_ids) {
-  if (annotation.empty()) {
+  // Skip if both fields are empty — nothing to store.
+  if (annotation.empty() && roctx_range.empty()) {
     return;
   }
-  VLOG(3) << "Add annotation: " << " correlation_id=" << correlation_id
-          << ", annotation: " << annotation;
+  VLOG(3) << "Add annotation: "
+          << " correlation_id=" << correlation_id
+          << ", annotation: " << annotation << ", roctx_range: " << roctx_range;
   absl::MutexLock lock(map_.mutex);
-  if (map_.annotations.size() < max_size_) {
-    absl::string_view annotation_str =
-        *map_.annotations.insert(annotation).first;
-    map_.correlation_map.emplace(correlation_id, annotation_str);
-    if (!scope_range_ids.empty()) {
-      map_.scope_range_id_map.emplace(correlation_id, scope_range_ids.back());
-      if (scope_range_ids.size() > 1) {
-        const int64_t* head = scope_range_ids.data();
-        const int64_t* curr = &scope_range_ids.back();
-        for (; curr > head && !map_.scope_range_id_tree.contains(*curr);
-             --curr) {
-          map_.scope_range_id_tree.emplace(*curr, *(curr - 1));
-        }
+  // Each branch re-checks the size guard before inserting to avoid exceeding
+  // max_size_ by 1 when both annotation and roctx_range are non-empty (two
+  // insertions under a single size check would silently violate the capacity
+  // contract).
+  // Only insert into correlation_map when annotation is non-empty; it may
+  // be empty when only a ROCTX range (no XLA AnnotationStack text) is active.
+  if (!annotation.empty() && map_.annotations.size() < max_size_) {
+    const std::string& interned = *map_.annotations.insert(annotation).first;
+    map_.correlation_map.emplace(correlation_id, std::cref(interned));
+  }
+  if (!roctx_range.empty() && map_.annotations.size() < max_size_) {
+    const std::string& interned =
+        *map_.annotations.insert(std::string(roctx_range)).first;
+    map_.roctx_range_map.emplace(correlation_id, std::cref(interned));
+  }
+  // max_size_ gates the whole map, not just the string pool: scope_range_id_map
+  // takes one entry per correlation id and would otherwise grow without bound
+  // for the rest of the session once the annotation cache fills. Keeping the
+  // same gate here preserves the "maximum number of annotation strings that we
+  // can accommodate" contract in rocm_tracer_utils.h.
+  if (!scope_range_ids.empty() && map_.annotations.size() < max_size_) {
+    map_.scope_range_id_map.emplace(correlation_id, scope_range_ids.back());
+    if (scope_range_ids.size() > 1) {
+      const int64_t* head = scope_range_ids.data();
+      const int64_t* curr = &scope_range_ids.back();
+      for (; curr > head && !map_.scope_range_id_tree.contains(*curr); --curr) {
+        map_.scope_range_id_tree.emplace(*curr, *(curr - 1));
       }
     }
   }
@@ -118,7 +136,15 @@ void AnnotationMap::Add(uint64_t correlation_id, const std::string& annotation,
 absl::string_view AnnotationMap::LookUp(uint64_t correlation_id) {
   absl::MutexLock lock(map_.mutex);
   auto it = map_.correlation_map.find(correlation_id);
-  return it != map_.correlation_map.end() ? it->second : absl::string_view();
+  return it != map_.correlation_map.end() ? it->second.get()
+                                          : absl::string_view();
+}
+
+absl::string_view AnnotationMap::LookUpRoctxRange(uint64_t correlation_id) {
+  absl::MutexLock lock(map_.mutex);
+  auto it = map_.roctx_range_map.find(correlation_id);
+  return it != map_.roctx_range_map.end() ? it->second.get()
+                                          : absl::string_view();
 }
 
 int64_t AnnotationMap::LookUpScopeRangeId(uint64_t correlation_id) {
@@ -135,6 +161,7 @@ ScopeRangeIdTree AnnotationMap::TakeScopeRangeIdTree() {
 void AnnotationMap::Clear() {
   absl::MutexLock lock(map_.mutex);
   map_.correlation_map.clear();
+  map_.roctx_range_map.clear();
   map_.scope_range_id_map.clear();
   map_.scope_range_id_tree.clear();
   map_.annotations.clear();

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <string>
 
@@ -137,6 +138,12 @@ struct RocmTracerEvent {
   // This points to strings in AnnotationMap, which should outlive the point
   // where serialization happens.
   absl::string_view annotation;
+  // Set only for kernel/HIP-API events: the ROCTX label that was active on
+  // the dispatching thread at call time, stored via AnnotationMap::Add and
+  // retrieved by AnnotationMap::LookUpRoctxRange. Empty for Generic (marker)
+  // events, which carry their label in `name` instead.
+  // The view points into AnnotationMap's interning pool, which is session-
+  // scoped. Export() runs within the same session, so the lifetime is safe.
   absl::string_view roctx_range;
   uint64_t start_time_ns = 0;
   uint64_t end_time_ns = 0;
@@ -157,6 +164,26 @@ struct RocmTracerEvent {
   };
 };
 
+// Represents one pending ROCTX range pushed via roctxRangePushA. Stored on
+// a per-thread stack in RocmTracer and consumed when roctxRangePop fires.
+struct RoctxFrame {
+  // TODO(rocm-profiler): carry a reference into AnnotationMap's intern pool
+  // instead of owning a copy. Blocked on lifetime, not on the generation
+  // check: the generation guards *emission*, but Enable() calls
+  // annotation_map_.Clear() while frames pushed before it are still live on
+  // some other thread's stack, so a reference would dangle even though the
+  // frame is correctly dropped at pop. Needs the pool to outlive the session
+  // (or a per-frame refcount) before the copy can go.
+  std::string message;  // the range label (owned here for lifetime safety)
+  uint64_t start_ns;    // timestamp captured at push time
+  // Profiling session this frame was pushed in. Frames live on a thread_local
+  // stack that no session boundary can reach, so a range pushed before
+  // Enable() and popped after it would otherwise emit an event with a
+  // previous session's start timestamp into the new session's collector.
+  // Enable() bumps the generation; a pop whose frame predates it is dropped.
+  uint64_t generation;
+};
+
 struct RocmTraceCollectorOptions {
   // Maximum number of events to collect from callback API; if -1, no limit.
   // if 0, the callback API is enabled to build a correlation map, but no
@@ -174,8 +201,10 @@ class AnnotationMap {
  public:
   explicit AnnotationMap(uint64_t max_size) : max_size_(max_size) {}
   void Add(uint64_t correlation_id, const std::string& annotation,
+           absl::string_view roctx_range = {},
            absl::Span<const int64_t> scope_range_ids = {});
   absl::string_view LookUp(uint64_t correlation_id);
+  absl::string_view LookUpRoctxRange(uint64_t correlation_id);
   int64_t LookUpScopeRangeId(uint64_t correlation_id);
   ScopeRangeIdTree TakeScopeRangeIdTree();
   void Clear();
@@ -186,10 +215,14 @@ class AnnotationMap {
     // callback/activity api related threads.
     absl::Mutex mutex;
     // Annotation tends to be repetitive, use a hash_set to store the strings,
-    // an use the reference to the string in the map.
+    // and use a reference_wrapper into the set in the maps. node_hash_set
+    // guarantees pointer and reference stability on rehash, so the stored
+    // references remain valid for the lifetime of the set.
     absl::node_hash_set<std::string> annotations ABSL_GUARDED_BY(mutex);
-    absl::flat_hash_map<uint64_t, absl::string_view> correlation_map
-        ABSL_GUARDED_BY(mutex);
+    absl::flat_hash_map<uint64_t, std::reference_wrapper<const std::string>>
+        correlation_map ABSL_GUARDED_BY(mutex);
+    absl::flat_hash_map<uint64_t, std::reference_wrapper<const std::string>>
+        roctx_range_map ABSL_GUARDED_BY(mutex);
     absl::flat_hash_map<uint64_t, int64_t> scope_range_id_map
         ABSL_GUARDED_BY(mutex);
     ScopeRangeIdTree scope_range_id_tree ABSL_GUARDED_BY(mutex);


### PR DESCRIPTION

First of two stacked PRs adding ROCTX support to the ROCm profiler. Design discussion:
https://github.com/openxla/xla/discussions/46782

This PR is the **listener**: ROCTX ranges emitted by an application — `roctxRangePushA`,
`roctxRangePop`, `roctxMarkA` — now appear as named bands in the XPlane host-thread
timeline, the ROCm counterpart to CUPTI's NVTX rows. XLA itself emits nothing here; that
is PR2, which stacks on this one.

### What it does

`RocmTracer::InitProfiling` registers `ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API`
alongside the existing HIP-API, kernel-dispatch and memory-copy buffer services.
`MarkerCallback` pairs push/pop into a `Generic` `RocmTracerEvent` and emits `roctxMarkA`
as a zero-duration event.

Range state is a `thread_local` stack rather than a mutex-guarded per-thread map. roctx
push/pop is thread-local by definition and the marker callback runs synchronously on the
calling thread, so nothing shared is required — which matters because the HIP-API callback
reads the current label on **every** HIP call and must not touch a process-wide lock.

Session isolation is by generation, not by clearing, since `Enable()` cannot reach another
thread's stack: each frame carries the generation it was pushed in, `Enable()` bumps an
atomic counter, and a pop whose frame predates it is dropped rather than emitted into the
new session with the previous session's timestamp.

`Generic` events bypass `ApiActivityInfoExchange` — they are host-side and have no GPU
activity record to merge with — and are capped by `max_callback_api_events` with drops
reported through `OnEventsDropped`.

This also activates `kNVTXRange` on kernel events. The field and its stat emission already
existed upstream but nothing ever wrote it; `GetCurrentRoctxLabel` and
`AnnotationMap::LookUpRoctxRange` supply the writers.

### No XPlane schema change

Markers land on the existing `kCuptiActivityNvtxPlaneName` plane rather than a new
constant. **This PR touches no files under `xla/tsl/`.**

The plane is a transient routing token: `PostProcessSingleHostXSpace` merges it into
`/host:CPU` and `RemovePlanes`'s it before serialization, `MergePlanes` never reads the
source plane name, and nothing downstream branches on it. Reuse is also safer across the
PJRT plugin boundary, where the collector's XSpace is produced in the plugin binary and
merged in the client binary — a plane name the client does not recognise would leak into
the viewer unmerged.

Lines are named `Host Threads/<tid>/ROCTX`, mirroring CUPTI's `/NVTX`. Lines are sorted by
name after the merge, so this places each marker track directly beneath the thread that
produced it.

### Also fixed

Two pre-existing collector defects found while working here, both small and separable if
you would rather they landed on their own:

- a meaningless `kDeviceId=4294967295` stat emitted for events with no device
- a race where `annotation_map_.Clear()` ran after `rocprofiler_start_context` and could
  wipe callbacks arriving in between

### Testing

`rocm_tracer_test` — 13 marker tests added (push/pop, instantaneous mark, unmatched pop,
null-label drop, null-label stack balance, export routing, the three `GetCurrentRoctxLabel`
lifetime cases, the three `AnnotationMap` roctx cases).

`rocm_collector_test` — 3 added, driving `RocmTraceCollectorImpl` directly with no
rocprofiler context so they run on any host: cap enforcement, the `num_gpus_ == 0` drop
path, and marker-vs-API line routing on the same thread. The cap test was verified to fail
without the cap (0 drops instead of 17, 25 events retained instead of 8).

On ROCm hardware, `RealRoctxCallsProduceNvtxRangeInXSpace` `dlopen`s
`librocprofiler-sdk-roctx.so` and drives the real intercept path end to end. Runtime
`dlopen`, so it adds no build-time dependency. Note `libroctx64.so` is **not** a substitute
— rocprofiler-sdk does not intercept it.

Measured: `rocm_tracer_test` 19 passed / 3 failed, `rocm_collector_test` 5 passed. The 3
failures are pre-existing tests requiring GPU device nodes (`hipErrorNoDevice`);
`upstream/main` unmodified fails the same 3 on the same host.

### Known gap

`roctxRangeStartA` / `roctxRangeStop` are not captured — the documented idiom for ranges
that begin and end on different threads or that overlap, which a thread-local LIFO cannot
express. `MarkerCallback` warns once rather than dropping them silently. CUPTI drops the
NVTX equivalent too, so this is a shared limitation rather than a ROCm-only gap.
