### PR TITLE
[XLA:MemoryScheduling] Don't warn when there is no pass to record metrics on.

### DIFF
--- a/xla/hlo/transforms/simplifiers/hlo_memory_scheduler.cc
+++ b/xla/hlo/transforms/simplifiers/hlo_memory_scheduler.cc
@@ -684,7 +684,14 @@ absl::StatusOr<HloSchedule> DefaultMemoryScheduler::Run(
   if (auto status =
           module->metadata()->set_custom_metadata(memory_scheduler_metrics);
       !status.ok()) {
-    LOG(WARNING) << "failed to set custom metadata: " << status;
+    if (absl::IsNotFound(status)) {
+      // There is no currently running pass to attach the metrics to. This is
+      // expected: ScheduleModule is also invoked outside of an HloPassPipeline,
+      // e.g. by GpuCompiler::CompileToBackendResult via ScheduleGpuModule.
+      VLOG(2) << "not recording memory scheduler metrics: " << status;
+    } else {
+      LOG(WARNING) << "failed to set custom metadata: " << status;
+    }
   }
 
   return *selected_sequence;


### PR DESCRIPTION
Collecting memory scheduler metrics logs a warning for every module that is scheduled outside of an `HloPassPipeline`:

```
W... hlo_memory_scheduler.cc:687] failed to set custom metadata: NOT_FOUND: HloPassMetadata for currently running pass not found, either because the pass did not call RecordPassStart or because a pass is creating/switching modules.
=== Source Location Trace: ===
xla/util.h:304
xla/hlo/ir/hlo_module_metadata.cc:101
```

`HloModuleMetadata::set_custom_metadata` attaches metrics to the innermost running pass and returns `NotFound` when there is none. That is a normal condition rather than a failure: `GpuCompiler::CompileToBackendResult` calls `ScheduleGpuModule` -> `ScheduleGpuModuleWithMemoryScheduler` -> `ScheduleModule` directly, before it builds any pipeline, so `DefaultMemoryScheduler::Run` warns **once per compiled module** on every GPU backend. `HloPassInterface::SetKVMetric` already documents the same case ("It usually means the pass was invoked on its own"), and the existing `DefaultSchedulerRunsThreeSchedulers` test only sees metrics because it calls `RecordPassStart()` by hand.

This showed up as 144 copies of the warning, each with a source-location trace, in a single pytest shard of our ROCm nightly CI, where it buries the actual test failures. It is not ROCm-specific.

This change logs the missing-pass case at `VLOG(2)` and keeps `LOG(WARNING)` for genuine failures, such as a proto that fails to pack.

Note this only silences the log. The metrics themselves are still dropped for every module scheduled outside a pipeline, which is the entire GPU compile path, so the metrics added in 35e79ec2aa are currently not collected there at all. Giving those call sites a pass context so the metrics actually land seemed like your call rather than mine, so I left it out; happy to follow up if you would like it in the same PR.

Tested with `bazel test //xla/hlo/transforms/simplifiers:hlo_memory_scheduler_test` (passes).