### PR TITLE
[XLA:GPU] Don't free pinned host memory with a pending async memset in CheckRedzones

### DIFF
--- a/xla/stream_executor/gpu/redzone_allocator.cc
+++ b/xla/stream_executor/gpu/redzone_allocator.cc
@@ -268,6 +268,13 @@ absl::StatusOr<DeviceAddressBase> RedzoneAllocator::CreateBuffer(
 }
 
 absl::StatusOr<RedzoneCheckStatus> RedzoneAllocator::CheckRedzones() const {
+  // Nothing to check. This also avoids freeing the pinned out-param below
+  // while its async MemZero is still pending on the stream; see
+  // https://github.com/openxla/xla/issues/46093.
+  if (allocated_buffers_.empty()) {
+    return RedzoneCheckStatus::OK();
+  }
+
   StreamExecutor* executor = stream_->parent();
 
   ABSL_ASSIGN_OR_RETURN(auto kernel,

--- a/xla/stream_executor/gpu/redzone_allocator_test.cc
+++ b/xla/stream_executor/gpu/redzone_allocator_test.cc
@@ -144,5 +144,21 @@ TEST(RedzoneAllocatorTest, VeryLargeRedzone) {
   EXPECT_REDZONE_OK(allocator.CheckRedzones());
 }
 
+TEST(RedzoneAllocatorTest, CheckRedzonesWithoutAllocationsIsOk) {
+  // Regression test for https://github.com/openxla/xla/issues/46093: with no
+  // allocated buffers, CheckRedzones used to enqueue an async memset of a
+  // pinned host buffer and free it without synchronizing the stream.
+  Platform* platform =
+      PlatformManager::PlatformWithName(GpuPlatformName()).value();
+  StreamExecutor* stream_exec = platform->ExecutorForDevice(0).value();
+  StreamExecutorAddressAllocator se_allocator(platform, {stream_exec});
+  TF_ASSERT_OK_AND_ASSIGN(auto stream, stream_exec->CreateStream());
+  RedzoneAllocator allocator(stream.get(), &se_allocator,
+                             /*memory_limit=*/(1LL << 32),
+                             /*redzone_size=*/1 << 23,
+                             /*redzone_pattern=*/0x7e);
+  EXPECT_REDZONE_OK(allocator.CheckRedzones());
+}
+
 }  // namespace gpu
 }  // namespace stream_executor


### PR DESCRIPTION
## 📝 Summary of Changes

Return early from `RedzoneAllocator::CheckRedzones()` when no buffers were
allocated, before the comparison kernel load, the pinned host allocation and
its async memset.

## 🎯 Justification

Fixes #46093.

`CheckRedzones()` pins a small host buffer for the comparison kernel's out
param and zeroes it with `stream_->MemZero`, which is an async
`cuMemsetD32Async` on the stream. The only stream synchronization happens
inside the per-buffer check loop. So when `allocated_buffers_` is empty the
RAII allocation is freed (`cuMemFreeHost`) right after the memset with no
sync in between. `cuMemFreeHost` is not stream scoped and its docs promise no
implicit sync, so this is undefined behavior. On the NUMA path it is worse:
`cuMemHostUnregister` + `NUMAFree` returns the page to the host heap while
the device may still DMA into it.

Confirmed the sequence with an LD_PRELOAD shim over the CUDA driver API on
an RTX 2070: with the stream kept busy by other work, `cuMemFreeHost` runs while `cuStreamQuery` still returns `CUDA_ERROR_NOT_READY`, with no synchronization call since the memset.

The empty case is not rare. The autotuner warm-up added in #46078 calls
`CheckRedzones()` on a `RedzoneDeviceAddressAllocator` that only sees the
buffers the executable allocates on demand, which is often none. The early
return also skips a pointless kernel load, host allocation and memset on that
path.

The error-return paths inside the check loop can in principle still free with
pending work (pre-existing, applies to `BufferComparator` too); this PR fixes
the reported and demonstrated sequence.

One small behavior note: with no buffers, `CheckRedzones()` no longer probes
whether the comparison kernel is loadable, so on a platform without the
kernel it now returns OK instead of the load error. With nothing allocated
there is nothing to verify, so OK is the right answer there (and it stops the
profiler from spuriously failing on such platforms).

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

Added `RedzoneAllocatorTest.CheckRedzonesWithoutAllocationsIsOk` to
`xla/stream_executor/gpu/redzone_allocator_test.cc`, covering the previously
untested empty-allocator path. All variants of
`//xla/stream_executor/gpu:redzone_allocator_test` pass on an RTX 2070
(sm_75). The race itself is only visible with driver interception, so the
before/after proof is the shim trace above: without the fix it reports the
unsynchronized free, with the fix the sequence no longer occurs.

## 🧪 Execution Tests:

`//xla/stream_executor/gpu:redzone_allocator_test` and
`//xla/backends/gpu/autotuner:gpu_profiler_test` on a single GPU (RTX 2070).