### PR TITLE
Return a parse error instead of crashing on reshape element-count mismatch in the HLO parser

### DIFF
--- a/xla/hlo/parser/hlo_parser.cc
+++ b/xla/hlo/parser/hlo_parser.cc
@@ -2370,6 +2370,22 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
         TokenError("DynamicReshape requires at least one operand.");
         return nullptr;
       }
+      if (!shape->IsArray() || !operands[0]->shape().IsArray() ||
+          ShapeUtil::StaticExtentProduct(*shape) !=
+              ShapeUtil::StaticExtentProduct(operands[0]->shape())) {
+        TokenError(
+            StrCat("expects the same number of elements in result shape ",
+                   ShapeUtil::HumanString(*shape), " and operand shape ",
+                   ShapeUtil::HumanString(operands[0]->shape())));
+        return nullptr;
+      }
+      if (operands.size() - 1 != shape->dimensions().size()) {
+        TokenError(
+            StrCat("expects one dim size operand per result dimension; got ",
+                   operands.size() - 1, " for ", shape->dimensions().size(),
+                   " result dimensions"));
+        return nullptr;
+      }
       return builder->AddInstruction(HloInstruction::CreateDynamicReshape(
           *shape, operands[0],
           absl::Span<HloInstruction* const>(operands).subspan(1)));
@@ -2381,6 +2397,16 @@ HloInstruction* HloParserImpl::CreateInstruction(  // NOLINT
       if ((!preset_operands &&
            !ParseOperands(&operands, builder, /*expected_size=*/1)) ||
           !ParseAttributes(attrs, allow_attributes, shape)) {
+        return nullptr;
+      }
+      if (!shape->IsArray() || !operands[0]->shape().IsArray() ||
+          (!operands[0]->shape().is_unbounded_dynamic() &&
+           ShapeUtil::StaticExtentProduct(*shape) !=
+               ShapeUtil::StaticExtentProduct(operands[0]->shape()))) {
+        TokenError(
+            StrCat("expects the same number of elements in result shape ",
+                   ShapeUtil::HumanString(*shape), " and operand shape ",
+                   ShapeUtil::HumanString(operands[0]->shape())));
         return nullptr;
       }
       return builder->AddInstruction(HloInstruction::CreateReshape(

--- a/xla/hlo/parser/hlo_parser_test.cc
+++ b/xla/hlo/parser/hlo_parser_test.cc
@@ -5015,6 +5015,68 @@ ENTRY %test_entry () -> f32[10,20] {
               HasSubstr("DynamicReshape requires at least one operand."));
 }
 
+TEST_F(HloParserTest, ParseReshapeElementCountMismatch) {
+  // Regression test for https://github.com/openxla/xla/issues/46955: this
+  // used to crash on a fatal CHECK instead of returning a parse error.
+  const std::string original = R"(
+HloModule test_module
+ENTRY %test_entry {
+  %a = f32[4,8] parameter(0)
+  ROOT %result = f32[31] reshape(%a)
+}
+)";
+  auto status = ParseAndReturnUnverifiedModule(original).status();
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status.message(),
+              HasSubstr("expects the same number of elements in result shape "
+                        "f32[31] and operand shape f32[4,8]"));
+}
+
+TEST_F(HloParserTest, ParseDynamicReshapeElementCountMismatch) {
+  const std::string original = R"(
+HloModule test_module
+ENTRY %test_entry {
+  %a = f32[4,<=8] parameter(0)
+  %size = s32[] parameter(1)
+  ROOT %result = f32[4,<=7] dynamic-reshape(%a, %size, %size)
+}
+)";
+  auto status = ParseAndReturnUnverifiedModule(original).status();
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status.message(),
+              HasSubstr("expects the same number of elements in result shape "
+                        "f32[4,<=7] and operand shape f32[4,<=8]"));
+}
+
+TEST_F(HloParserTest, ParseDynamicReshapeDimSizeOperandCountMismatch) {
+  const std::string original = R"(
+HloModule test_module
+ENTRY %test_entry {
+  %a = f32[4,<=8] parameter(0)
+  %size = s32[] parameter(1)
+  ROOT %result = f32[4,<=8] dynamic-reshape(%a, %size)
+}
+)";
+  auto status = ParseAndReturnUnverifiedModule(original).status();
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status.message(),
+              HasSubstr("expects one dim size operand per result dimension; "
+                        "got 1 for 2 result dimensions"));
+}
+
+TEST_F(HloParserTest, ParseReshapeUnboundedDynamicOperandStillParses) {
+  // An unbounded dynamic operand exempts the element-count check, matching
+  // HloInstruction::CreateReshape and CreateFromProto.
+  const std::string original = R"(
+HloModule test_module
+ENTRY %test_entry {
+  %a = f32[?] parameter(0)
+  ROOT %result = f32[3] reshape(%a)
+}
+)";
+  EXPECT_OK(ParseAndReturnUnverifiedModule(original).status());
+}
+
 TEST_F(HloParserTest, ParseCollectiveDeviceListV1) {
   const std::string original = "{{0,1},{2,3}}";
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<CollectiveDeviceListBase> device_list,


### PR DESCRIPTION
## 📝 Summary of Changes

Validate reshape and dynamic-reshape invariants in
`HloParserImpl::CreateInstruction` before calling the `HloInstruction`
factories, so malformed HLO text gets a parse error instead of a fatal
CHECK.

## 🎯 Justification

Fixes #46955.

Parsing HLO text where a `reshape` (or `dynamic-reshape`) output shape has a
different element count than its operand kills the process:
`HloInstruction::CreateReshape` / `CreateDynamicReshape` enforce the
invariant with fatal `CHECK`s, and the text parser calls them unguarded. The
proto path already guards the exact same invariants with Status-returning
`TF_RET_CHECK` in `CreateFromProto`; this change gives the text parser the
same treatment, using the parser's `TokenError` so the message carries
line/column context.

Three cases are covered (the third is not in the issue but is the same hole):

- `reshape` with mismatched element count (respecting the factory's
  unbounded-dynamic operand escape),
- `dynamic-reshape` with mismatched element count,
- `dynamic-reshape` with the wrong number of dim-size operands.

The factory CHECKs themselves are intentionally left alone; every internal
caller guarantees the invariant, and weakening them would hide real bugs.

Two scope notes. The guards mirror the proto path exactly, which is slightly
stricter than the factory CHECK for non-array shapes (e.g. reshaping a token
now gets a parse error; it previously parsed and then failed in the verifier,
and DCHECK-crashed debug builds). And the same bug class exists for
`replica-id`/`partition-id` with an explicit non-`u32[]` shape (their
factories CHECK the shape); left out of scope here since #46955 is about
reshape, can file a follow-up.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

Four tests in `xla/hlo/parser/hlo_parser_test.cc`: three negative
(`ParseReshapeElementCountMismatch`,
`ParseDynamicReshapeElementCountMismatch`,
`ParseDynamicReshapeDimSizeOperandCountMismatch`) that crash the test binary
with the issue's exact CHECK signature without the parser change and pass
with it, plus `ParseReshapeUnboundedDynamicOperandStillParses` pinning the
unbounded-dynamic escape hatch. Full `//xla/hlo/parser:hlo_parser_test` and
`//xla/service:hlo_verifier_test` pass.

## 🧪 Execution Tests:

None needed; the change is parse-time only (CPU, no accelerator involved).