### PR TITLE
[ROCm: XLA profiler] Emit GPU device name to XPlane

### DIFF
--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -513,6 +513,13 @@ void PerDeviceCollector::GetDeviceCapabilities(
           compute_capability_minor);
     }
   }
+
+  // Emit the agent name (the GCN architecture string), for example "gfx942"
+  if (agent.name != nullptr && agent.name[0] != '\0') {
+    device_plane->AddStatValue(*device_plane->GetOrCreateStatMetadata(
+                                   GetStatTypeStr(StatType::kGpuDeviceName)),
+                               agent.name);
+  }
 }
 
 void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,


### PR DESCRIPTION
📝 Summary of Changes
Emit the ROCm agent name (GPU device name) to the XPlane stat `kGpuDeviceName`

🎯 Justification
For downstream consumption in XProf. Instead of relying on `kDevCapComputeCapMajor` and `kDevCapComputeCapMinor` (which is a lossy encoding for gfx architecture, as there is no equivalent `kDevCapComputeStep` stat in the XPlane proto), emitting the GPU device name as its GCN architecture allows for more detailed keying of compute capability within XProf

Proposed XProf changes which utilise this: <https://github.com/openxla/xprof/pull/3163>

🚀 Kind of Contribution
✨ New Feature

📊 Benchmark (for Performance Improvements)


🧪 Unit Tests:


🧪 Execution Tests:

