### PR TITLE
[NVIDIA GPU] Ensure host memory checked in LHS host DUS check

### DIFF
--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -611,6 +611,17 @@ LegalizeSchedulingAnnotations::Config SchedulingAnnotationsConfig() {
   return annotation_config;
 }
 
+bool IsHostShape(const Shape& shape) {
+  return shape.IsArray() && shape.has_layout() &&
+         shape.layout().memory_space() == Layout::kHostMemorySpace;
+}
+
+bool IsDUSWithHost(const HloInstruction* instr) {
+  return instr->opcode() == HloOpcode::kDynamicUpdateSlice &&
+         (IsHostShape(instr->operand(0)->shape()) ||
+          IsHostShape(instr->shape()));
+}
+
 // Delays MoveToHostAsyncStart as late as possible
 // to achieve better overlapping with computation.
 // The only pattern we are seeing is async start of a fusion with a dynamic
@@ -644,7 +655,7 @@ DelayMoveToHostAsyncStartCandidateCondition(
                                 .async_wrapped_instruction()
                                 ->fused_instructions();
         for (auto instr : fused_instrs) {
-          if (instr->opcode() == HloOpcode::kDynamicUpdateSlice) {
+          if (IsDUSWithHost(instr)) {
             is_send_host_dus = true;
             break;
           }

--- a/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/xla/service/gpu/gpu_hlo_schedule.cc
@@ -101,7 +101,7 @@ absl::StatusOr<bool> UsesMultipleCollectiveDomains(const HloModule& module) {
         continue;
       }
       ABSL_ASSIGN_OR_RETURN(CollectiveCommunicationDomain domain,
-                       GetCollectiveCommunicationDomain(*instruction));
+                            GetCollectiveCommunicationDomain(*instruction));
       if (first_domain.has_value() && *first_domain != domain) {
         return true;
       }
@@ -683,7 +683,7 @@ absl::Status RunLatencyHidingSchedulerPasses(
   HloPassPipeline pipeline("latency-hiding-scheduler");
   const DebugOptions& options = module->config().debug_options();
   ABSL_ASSIGN_OR_RETURN(bool uses_multiple_collective_domains,
-                   UsesMultipleCollectiveDomains(*module));
+                        UsesMultipleCollectiveDomains(*module));
 
   pipeline.AddPass<LegalizeSchedulingAnnotations>(
       SchedulingAnnotationsConfig());
@@ -957,9 +957,10 @@ absl::StatusOr<ScheduleMetadata> ScheduleGpuModule(
   // See `xla::LatencyHidingScheduler::Run`.
   ABSL_RETURN_IF_ERROR(RunP2PSchedulePreparation(module));
   int64_t peak_memory_bytes;
-  ABSL_ASSIGN_OR_RETURN(HloSchedule schedule,
-                   ScheduleGpuModuleWithMemoryScheduler(
-                       module, alias_info, pointer_size, &peak_memory_bytes));
+  ABSL_ASSIGN_OR_RETURN(
+      HloSchedule schedule,
+      ScheduleGpuModuleWithMemoryScheduler(module, alias_info, pointer_size,
+                                           &peak_memory_bytes));
   ABSL_RETURN_IF_ERROR(module->set_schedule(std::move(schedule)));
 
   bool enable_latency_hiding_scheduler =

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -1017,7 +1017,7 @@ ENTRY main {
   std::vector<HloInstruction*> instruction_sequence =
       schedule.sequence(module->entry_computation()).instructions();
   EXPECT_TRUE(GetIndexByName(instruction_sequence, "dynamic-slice-start") <
-                  GetIndexByName(instruction_sequence, "add") ||
+                  GetIndexByName(instruction_sequence, "add") &&
               GetIndexByName(instruction_sequence, "add") <
                   GetIndexByName(instruction_sequence, "dynamic-slice-done"));
 }
@@ -2137,6 +2137,76 @@ TEST_F(GpuLatencyHidingSchedulerBaseTest, DelayMoveToHostAsyncStart) {
   EXPECT_TRUE(
       GetIndexByName(instruction_sequence, "dynamic-update-slice-start.18") <
       GetIndexByName(instruction_sequence, "all-to-all-start.4"));
+}
+
+TEST_F(GpuLatencyHidingSchedulerBaseTest, NoDelayMoveToDeviceAsyncStart) {
+  absl::string_view kHloModule = R"(
+    HloModule noDelay_moveToDevic_asyncStart, is_scheduled=false
+
+
+    %wrapped_dynamic-update-slice_computation.6 (p0.0: bf16[8,2,4,128,128], p1.0: bf16[1,2,4,128,128], p2.0: s32[], p3.0: s32[], p4.0: s32[], p5.0: s32[], p6.0: s32[]) -> bf16[8,2,4,128,128] {
+      %p0.0 = bf16[8,2,4,128,128]{4,3,2,1,0} parameter(0)
+      %p1.0 = bf16[1,2,4,128,128]{4,3,2,1,0} parameter(1)
+      %p2.0 = s32[] parameter(2)
+      %p3.0 = s32[] parameter(3)
+      %p4.0 = s32[] parameter(4)
+      %p5.0 = s32[] parameter(5)
+      %p6.0 = s32[] parameter(6)
+      ROOT %dynamic-update-slice.536.1 = bf16[8,2,4,128,128]{4,3,2,1,0} dynamic-update-slice(%p0.0, %p1.0, %p2.0, %p3.0, %p4.0, /*index=5*/%p5.0, %p6.0)
+    }
+
+    %async_computation.6 (param_0.6: bf16[8,2,4,128,128], param_1.6: bf16[1,2,4,128,128], param_2.6: s32[], param_3.6: s32[], param_4.6: s32[], param_5.2: s32[], param_6: s32[]) -> bf16[8,2,4,128,128] {
+      %param_0.6 = bf16[8,2,4,128,128]{4,3,2,1,0} parameter(0)
+      %param_1.6 = bf16[1,2,4,128,128]{4,3,2,1,0} parameter(1)
+      %param_2.6 = s32[] parameter(2)
+      %param_3.6 = s32[] parameter(3)
+      %param_4.6 = s32[] parameter(4)
+      %param_5.2 = s32[] parameter(5)
+      %param_6 = s32[] parameter(6)
+      ROOT %wrapped_dynamic-update-slice.6 = bf16[8,2,4,128,128]{4,3,2,1,0} fusion(%param_0.6, %param_1.6, %param_2.6, %param_3.6, %param_4.6, /*index=5*/%param_5.2, %param_6), kind=kLoop, calls=%wrapped_dynamic-update-slice_computation.6
+    }
+
+    %async_computation.46 (param_0.38229: bf16[1,8,16,16,128,7168]) -> bf16[1,8,16,16,128,7168] {
+      %param_0.38229 = bf16[1,8,16,16,128,7168]{5,4,3,1,0,2} parameter(0)
+      ROOT %all-to-all.32.1 = bf16[1,8,16,16,128,7168]{5,4,3,1,0,2} all-to-all(%param_0.38229), channel_id=474, replica_groups=[8,16]<=[128], dimensions={2}
+    }
+
+
+    ENTRY main {
+      p0 = bf16[8,2,4,128,128] parameter(0)
+      p1 = bf16[1,2,4,128,128] parameter(1)
+      p2 = s32[] parameter(2)
+      p3 = s32[] parameter(3)
+      p4 = s32[] parameter(4)
+      p5 = s32[] parameter(5)
+      p6 = s32[] parameter(6)
+      p7 = bf16[1,8,16,16,128,7168] parameter(7)
+      p8 = bf16[] parameter(8)
+
+      %all-to-all-start.4 = ((bf16[1,8,16,16,128,7168]{5,4,3,1,0,2}), bf16[1,8,16,16,128,7168]{5,4,3,1,0,2}) async-start(p7), calls=%async_computation.46
+      %all-to-all-done.4 = bf16[1,8,16,16,128,7168]{5,4,3,1,0,2} async-done(%all-to-all-start.4)
+      %bitcast.309.7 = bf16[128,16,128,7168]{3,2,1,0} bitcast(%all-to-all-done.4)
+      %broadcast_in_dim.6026.9 = bf16[128,16,128,7168]{3,2,1,0} broadcast(%p8), dimensions={}
+      %mul.5173.7 = bf16[128,16,128,7168]{3,2,1,0} multiply(%bitcast.309.7, %broadcast_in_dim.6026.9)
+      %dynamic-update-slice-start.18 = ((bf16[8,2,4,128,128]{4,3,2,1,0}, bf16[1,2,4,128,128]{4,3,2,1,0}, s32[], s32[], s32[], /*index=5*/s32[], s32[]), bf16[8,2,4,128,128]{4,3,2,1,0}, u32[]) async-start(p0, p1, p2, p3, p4, p5, p6), calls=%async_computation.6
+      %dynamic-update-slice-done.18 = bf16[8,2,4,128,128]{4,3,2,1,0} async-done(%dynamic-update-slice-start.18)
+      ROOT _ = (bf16[128,16,128,7168], bf16[8,2,4,128,128]) tuple(%mul.5173.7, %dynamic-update-slice-done.18)
+    }
+  )";
+
+  absl::string_view kFdoProfile = "";
+  xla::HloModuleConfig config = GetModuleConfig(kFdoProfile);
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<xla::HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloModule, config));
+
+  EXPECT_OK(ScheduleModule(module.get()));
+  const HloSchedule& schedule = module->schedule();
+  const std::vector<xla::HloInstruction*>& instruction_sequence =
+      schedule.sequence(module->entry_computation()).instructions();
+
+  EXPECT_TRUE(
+      GetIndexByName(instruction_sequence, "all-to-all-start.4") <
+      GetIndexByName(instruction_sequence, "dynamic-update-slice-start.18"));
 }
 
 TEST_F(GpuLatencyHidingSchedulerBaseTest,

--- a/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
+++ b/xla/service/gpu/gpu_latency_hiding_scheduler_test.cc
@@ -90,9 +90,9 @@ class GpuLatencyHidingSchedulerBaseTest
     options.set_xla_gpu_pgle_accuracy_checker(strictness);
 
     ABSL_RETURN_IF_ERROR(ScheduleGpuModule(module, /*pointer_size=*/8,
-                                      gpu_device_info, &mlir_context_,
-                                      &alias_info)
-                        .status());
+                                           gpu_device_info, &mlir_context_,
+                                           &alias_info)
+                             .status());
     return module;
   }
 


### PR DESCRIPTION
📝 Summary of Changes
The LHS will schedule fused Host-DUS as early as possible (even scheduled earlier than comm kernels) to maximize overlap with computation since it can be performed asynchronously and typically has lower BW than HBM. However, the check for this incorrectly assumes that all fused host-DUS are done with host memory which is not necessarily the case with device-side DUS fusions which leads to false positives.

This PR fixes that by guaranteeing that by adding an additional check for host memory as well, so that async, fused device-side DUS can be scheduled correctly w.r.t. to other kernels

This PR also has some formatting changes.

🎯 Justification
This is important because it leads to proper scheduling relationships between kernels. For example, communication kernels that would have once been schedule later in the timeline because a competing device-side DUS was scheduled earlier will now be correctly scheduled before the device-side DUS, opening better overlapping opportunity.

🚀 Kind of Contribution
 🐛 Bug Fix, 🧪 Tests, some formatting

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
The original test already correctly included host-side memory annotations and are now being checked.
A new test was added to validate that device-side DUS are not scheduled earlier than comm kernels. This the same as the original test but without the host-side annotations and a different outcome.

🧪 Execution Tests:
This was a small bug fix, so I didn't create a full E2E test for this.