### PR TITLE
Fix infinite backpedal loop in BFCAllocator::Extend for small allocations

### DIFF
--- a/xla/tsl/framework/bfc_allocator.cc
+++ b/xla/tsl/framework/bfc_allocator.cc
@@ -195,7 +195,15 @@ bool BFCAllocator::Extend(size_t alignment, size_t rounded_bytes) {
 
     // Try allocating less memory.
     while (mem_addr == nullptr) {
-      bytes = RoundedBytes(bytes * kBackpedalFactor);
+      size_t backpedal_bytes = RoundedBytes(bytes * kBackpedalFactor);
+      // RoundedBytes rounds up to a multiple of kMinAllocationSize, so for
+      // small sizes (bytes <= 10 * kMinAllocationSize) the backpedal can round
+      // back up to the same value. Force strict progress so a persistently
+      // failing sub-allocator cannot make this loop spin forever.
+      if (backpedal_bytes >= bytes) {
+        backpedal_bytes = bytes - kMinAllocationSize;
+      }
+      bytes = backpedal_bytes;
       if (bytes < rounded_bytes) {
         return false;
       }

--- a/xla/tsl/framework/bfc_allocator_test.cc
+++ b/xla/tsl/framework/bfc_allocator_test.cc
@@ -92,6 +92,40 @@ class FakeSubAllocator : public SubAllocator {
   uintptr_t next_ = kBase;
 };
 
+// SubAllocator that always fails. A fuse guards against the pre-fix behavior
+// of BFCAllocator::Extend retrying the same size forever: after kFuse calls
+// it reports a test failure and starts succeeding, so a stalled loop
+// terminates and the test fails immediately instead of hanging.
+class AlwaysFailingSubAllocator : public SubAllocator {
+ public:
+  static constexpr int kFuse = 1000;
+
+  AlwaysFailingSubAllocator() : SubAllocator({}, {}) {}
+
+  void* Alloc(size_t alignment, size_t num_bytes,
+              size_t* bytes_received) override {
+    if (++calls_ > kFuse) {
+      ADD_FAILURE() << "Extend retried " << kFuse
+                    << " times; the backpedal loop is making no progress";
+      uintptr_t aligned = (next_ + (alignment - 1)) & ~(alignment - 1);
+      next_ = aligned + num_bytes;
+      *bytes_received = num_bytes;
+      return absl::bit_cast<void*>(aligned);
+    }
+    return nullptr;
+  }
+
+  void Free(void* ptr, size_t num_bytes) override {}
+
+  bool SupportsCoalescing() const override { return false; }
+
+  int calls() const { return calls_; }
+
+ private:
+  int calls_ = 0;
+  uintptr_t next_ = FakeSubAllocator::kBase;
+};
+
 // Helper to check pointer alignment.
 bool IsAligned(const void* ptr, size_t alignment) {
   return (absl::bit_cast<uintptr_t>(ptr) & (alignment - 1)) == 0;
@@ -150,6 +184,29 @@ TEST(BFCAllocatorTest, OomLogsAllocationAnnotations) {
 
   log.StopCapturingLogs();
   alloc.DeallocateRaw(ptr);
+}
+
+// Regression test for the backpedal loop in BFCAllocator::Extend. The loop
+// shrinks the attempt by kBackpedalFactor (0.9) and re-rounds it with
+// RoundedBytes, which rounds up to a multiple of kMinAllocationSize; for
+// attempts below 10 * kMinAllocationSize the rounding undid the shrink, so a
+// persistently failing sub-allocator used to spin the loop forever on the
+// same size. The fuse in the sub-allocator converts such a stall into an
+// immediate test failure instead of a hang.
+TEST(BFCAllocatorTest, ExtendTerminatesWhenSubAllocatorAlwaysFails) {
+  // A pool of 8 * kMinAllocationSize (2048 bytes) makes the first backpedal
+  // attempt land in the formerly-stalling zone:
+  // RoundedBytes(0.9 * 2048) == 2048.
+  constexpr size_t kPool = 8 * BFCAllocator::kMinAllocationSize;
+  BFCAllocator::Options opts;
+  opts.allow_growth = false;
+  opts.allow_retry_on_failure = false;
+  auto sub_owner = std::make_unique<AlwaysFailingSubAllocator>();
+  AlwaysFailingSubAllocator* sub = sub_owner.get();
+  BFCAllocator alloc(std::move(sub_owner), kPool, /*name=*/"backpedal", opts);
+
+  EXPECT_EQ(alloc.AllocateRaw(kAlignment, 100), nullptr);
+  EXPECT_LE(sub->calls(), AlwaysFailingSubAllocator::kFuse);
 }
 
 // Parameterized test that verifies alignment is respected for various


### PR DESCRIPTION
This issue came up as part of building JAX for CUDA on Windows (https://github.com/eterevsky/winjax)

## Symptom

When a sub-allocator persistently fails a small allocation, `BFCAllocator::Extend` spins forever in its backpedal loop, emitting an unbounded stream of "could not allocate" warnings (observed: 5 GB of log within minutes, tests turned into multi-hour timeouts instead of clean allocation errors).

## Root cause

The backpedal loop in `BFCAllocator::Extend` (`xla/tsl/framework/bfc_allocator.cc`) shrinks the attempt by 10% per iteration, but re-rounds the result with `RoundedBytes`, which rounds *up* to a multiple of `kMinAllocationSize` (256 bytes):

```cpp
while (mem_addr == nullptr) {
  bytes = RoundedBytes(bytes * kBackpedalFactor);
  if (bytes < rounded_bytes) return false;
  mem_addr = sub_allocator_->Alloc(alignment, bytes, &bytes_received);
}
```

For `bytes < 10 * kMinAllocationSize` (i.e. up to 2304 bytes), `RoundedBytes(0.9 * bytes)` rounds back up to the same value, so the attempt size never decreases and the loop never terminates while the sub-allocator keeps failing.

## Fix

Force strict progress: if the re-rounded backpedal size did not decrease, step down by one `kMinAllocationSize` instead. The loop then always reaches `bytes < rounded_bytes` and returns a clean allocation failure.

The bug is platform-independent (any persistently failing sub-allocator triggers it). It was found while porting XLA to native Windows, where pinned-host `cuMemHostAlloc` can keep failing under WDDM commit pressure after the device pool has taken the GPU budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
