### PR TITLE
GPU: emit memzero for collective-permute with no source-target pairs

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -291,6 +291,7 @@ cc_library(
     srcs = ["hlo_to_ir_bindings.cc"],
     hdrs = ["hlo_to_ir_bindings.h"],
     deps = [
+        "//xla/tsl/platform:logging",
         "//xla:shape_tree",
         "//xla:shape_util",
         "//xla:util",
@@ -532,6 +533,7 @@ cc_library(
         "//xla/backends/gpu/runtime:host_to_device_copy_thunk",
         "//xla/backends/gpu/runtime:infeed_thunk",
         "//xla/backends/gpu/runtime:legacy_custom_call_thunk",
+        "//xla/backends/gpu/runtime:memset_thunk",
         "//xla/backends/gpu/runtime:norm_thunk",
         "//xla/backends/gpu/runtime:outfeed_thunk",
         "//xla/backends/gpu/runtime:ragged_all_to_all_thunk",
@@ -1112,6 +1114,7 @@ cc_library(
     hdrs = ["reduction_utils.h"],
     compatible_with = get_compatible_with_portable(),
     deps = [
+        "//xla/tsl/platform:logging",
         ":ir_emission_utils",
         "//xla:shape_util",
         "//xla:util",
@@ -1146,6 +1149,7 @@ cc_library(
     hdrs = ["cublas_cudnn.h"],
     compatible_with = get_compatible_with_portable(),
     deps = [
+        "//xla/tsl/platform:statusor",
         ":backend_configs_cc",
         "//xla:util",
         "//xla/hlo/ir:hlo",
@@ -1459,6 +1463,7 @@ xla_cc_test(
     name = "fusion_process_dump_test",
     srcs = ["fusion_process_dump_test.cc"],
     deps = [
+        "//xla/tsl/platform:statusor",
         ":fusion_process_dump",
         ":fusion_process_dump_proto_cc",
         ":gpu_device_info_for_tests",
@@ -1553,6 +1558,9 @@ cc_library(
     srcs = ["gpu_transfer_manager.cc"],
     hdrs = ["gpu_transfer_manager.h"],
     deps = [
+        "//xla/tsl/platform:errors",
+        "//xla/tsl/platform:logging",
+        "//xla/tsl/platform:statusor",
         ":io_feed_manager",
         ":target_constants",
         "//xla:literal",
@@ -2382,6 +2390,7 @@ xla_test(
     srcs = ["gpu_offloading_test.cc"],
     backends = ["gpu"],
     deps = [
+        "//xla/tsl/platform:statusor",
         ":backend_configs_cc",
         "//xla:autotune_results_proto_cc",
         "//xla:error_spec",
@@ -2416,6 +2425,7 @@ xla_test(
     tags = ["no_oss"],  # TODO(b/277355322): Make autosharding work in OSS
     use_legacy_runtime = True,
     deps = [
+        "//xla/tsl/platform:logging",
         "//xla:xla_data_proto_cc",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:pattern_matcher_gmock",
@@ -2806,6 +2816,7 @@ cc_library(
     name = "xfeed_queue",
     hdrs = ["xfeed_queue.h"],
     deps = [
+        "//xla/tsl/platform:logging",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/synchronization",
         "@tsl//tsl/platform:logging",
@@ -2823,6 +2834,9 @@ cc_library(
         "outfeed_manager.h",
     ],
     deps = [
+        "//xla/tsl/platform:errors",
+        "//xla/tsl/platform:logging",
+        "//xla/tsl/platform:statusor",
         ":xfeed_queue",
         "//xla:literal",
         "//xla:shape_tree",
@@ -2988,6 +3002,8 @@ xla_cc_test(
         "gpu_spmd_pipeline_test.cc",
     ],
     deps = [
+        "//xla/tsl/platform:errors",
+        "//xla/tsl/platform:statusor",
         ":gpu_spmd_pipeline",
         "//xla:shape_util",
         "//xla:util",
@@ -3113,6 +3129,7 @@ xla_cc_test(
     name = "gpu_asm_opts_util_test",
     srcs = ["gpu_asm_opts_util_test.cc"],
     deps = [
+        "//xla/tsl/platform:test",
         ":gpu_asm_opts_util",
         "//xla:xla_proto_cc",
         "//xla/tests:xla_internal_test_main",
@@ -3431,6 +3448,7 @@ xla_cc_test(
         "no_oss",
     ],
     deps = [
+        "//xla/tsl/platform:test",
         ":metrics",
         "//xla/tests:xla_internal_test_main",
         "//xla/tsl/lib/monitoring:collected_metrics",
@@ -3446,6 +3464,7 @@ cc_library(
     hdrs = ["hlo_fusion_stats.h"],
     deps = [
         "//xla/hlo/ir:hlo",
+        "//xla/tsl/platform:errors",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@tsl//tsl/platform:errors",
@@ -3505,6 +3524,7 @@ cc_library(
     srcs = ["conv_layout_normalization.cc"],
     hdrs = ["conv_layout_normalization.h"],
     deps = [
+        "//xla/tsl/platform:statusor",
         ":cublas_cudnn",
         "//xla:shape_util",
         "//xla:status_macros",
@@ -3884,6 +3904,7 @@ xla_test(
     ]),
     use_legacy_runtime = True,
     deps = [
+        "//xla/stream_executor/sycl:sycl_platform_id",
         ":intel_gpu_compiler",
         "//xla/tests/restricted:hlo_test_base_legacy",
         "@com_google_googletest//:gtest_main",

--- a/xla/service/gpu/gpu_compiler_test.cc
+++ b/xla/service/gpu/gpu_compiler_test.cc
@@ -1644,6 +1644,43 @@ ENTRY main {
   EXPECT_EQ(thunks[0]->kind(), Thunk::Kind::kCommandBuffer);
 }
 
+// A collective permute with no source-target pairs delivers no data to any
+// participant, so every participant's output is zeroed. The emitter must
+// produce a memzero rather than a collective thunk, which would pointlessly
+// acquire a communicator (and fail outright on builds without collectives
+// support).
+TEST_F(GpuCompilerTest, CollectivePermuteWithNoSourceTargetPairsEmitsMemzero) {
+  const char* hlo_text = R"(
+HloModule test
+
+ENTRY main {
+  p = u32[2] parameter(0)
+  ROOT permute = u32[2] collective-permute(p), source_target_pairs={}
+}
+)";
+
+  auto hlo_module = ParseAndReturnVerifiedModule(hlo_text).value();
+
+  Compiler::CompileOptions compile_options;
+  compile_options.gpu_topology =
+      GetSingleDeviceGpuTopology(/*platform_version=*/"", gpu_target_config());
+  compile_options.early_exit_with_layouts = false;
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<Executable> executable,
+      compiler()->RunBackend(std::move(hlo_module), /*executor=*/nullptr,
+                             compile_options));
+  GpuExecutable* gpu_exec = absl::down_cast<GpuExecutable*>(executable.get());
+  ASSERT_NE(gpu_exec, nullptr);
+
+  std::vector<Thunk::Kind> kinds;
+  kinds.reserve(gpu_exec->thunk_executor().thunks().size());
+  for (const auto& thunk : gpu_exec->thunk_executor().thunks()) {
+    kinds.push_back(thunk->kind());
+  }
+  using ::testing::ElementsAre;
+  EXPECT_THAT(kinds, ElementsAre(Thunk::Kind::kMemzero));
+}
+
 TEST_F(GpuCompilerTest, NoCudnnVectorizationOnHopperAndBeyond) {
   if (gpu_target_config().dnn_version_info <
           stream_executor::dnn::VersionInfo(9, 12, 0) &&

--- a/xla/service/gpu/thunk_emitter.cc
+++ b/xla/service/gpu/thunk_emitter.cc
@@ -90,6 +90,7 @@ limitations under the License.
 #include "xla/backends/gpu/runtime/host_to_device_copy_thunk.h"
 #include "xla/backends/gpu/runtime/infeed_thunk.h"
 #include "xla/backends/gpu/runtime/legacy_custom_call_thunk.h"
+#include "xla/backends/gpu/runtime/memset_thunk.h"
 #include "xla/backends/gpu/runtime/norm_thunk.h"
 #include "xla/backends/gpu/runtime/outfeed_thunk.h"
 #include "xla/backends/gpu/runtime/ragged_all_to_all_thunk.h"
@@ -2054,6 +2055,26 @@ Future<ThunkSequence> ThunkEmitter::EmitCollective(
       std::vector<CollectiveThunk::Buffer> buffers,
       GetCollectiveBuffers(ir_emitter_context_->buffer_assignment(), inst, kind,
                            has_dynamic_root));
+
+  // A collective permute with no source-target pairs receives no data on any
+  // participant, which the collective runtimes implement by zeroing the
+  // output (see RunCollectivePermute). Emit the memzero directly and skip the
+  // collective thunk; besides avoiding a pointless communicator acquisition,
+  // this keeps such programs (e.g. the gradient of a single-device ppermute)
+  // working on builds without collectives support.
+  if constexpr (is_collective_permute) {
+    if (inst->source_target_pairs().empty()) {
+      ThunkSequence thunks;
+      for (int64_t i = 0; i < buffers.size(); ++i) {
+        thunks.Emplace<MemzeroThunk>(
+            Thunk::ThunkInfo::WithProfileAnnotation(
+                inst, ir_emitter_context_->GetNextThunkId()),
+            ShapedSlice{buffers[i].destination_buffer.slice,
+                        inst->operand(i)->shape()});
+      }
+      return thunks;
+    }
+  }
 
   // A given collective op can be degenerate if across all groups
   // formed by it are singleton. In such a case, we don't need to do


### PR DESCRIPTION
This issue came up as part of building JAX for CUDA on Windows (https://github.com/eterevsky/winjax)

## Symptom

A collective-permute with an empty source-target-pairs list — jax emits one for the gradient of `ppermute` on a single device — fails with `UNIMPLEMENTED` on builds without collectives support, because the emitted thunk tries to acquire a communicator that no data transfer needs.

## Root cause

`CollectivePermuteThunk::IsDegenerate` treats the empty-pairs case as *not* degenerate (the pair list does not cover all participants), so `ThunkEmitter::EmitCollective` produces a full `CollectivePermuteThunk`. At run time the collective runtime implements "no source for this rank" by zeroing the output (see `RunCollectivePermute`), so the communicator acquisition is pure overhead — and a hard failure on builds compiled without collectives (e.g. native Windows, which has no NCCL).

## Fix

In `ThunkEmitter::EmitCollective`, when the instruction is a collective-permute with no source-target pairs, emit a `MemzeroThunk` per output buffer instead of the collective thunk. This is semantically identical (every participant's output is zeroed), cheaper everywhere, and keeps such programs working on collectives-less builds. The copy-based degenerate path is intentionally not reused: a degenerate permute copies input to output, whereas the empty permute must zero the output.

Found while porting XLA to native Windows; fixes jax's `pmap_test::testCollectivePermuteGrad` there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
