### PR TITLE
[XLA] Treat unknown custom calls as dynamic in value inference instead of erroring

### DIFF
--- a/xla/hlo/builder/value_inference.cc
+++ b/xla/hlo/builder/value_inference.cc
@@ -1504,12 +1504,14 @@ absl::StatusOr<PostorderDFSNode> PostorderDFSVisitor::AnalyzeIsDynamic(
       } else if (root->custom_call_target() == "Sharding") {
         return result.AddVisit([](Literal operand) { return operand; });
       } else {
-        return InvalidArgument(
-            "Dynamic inferencing on custom call %s is not supported",
-            root->DebugString());
+        // An opaque custom call cannot be analyzed; conservatively assume
+        // the whole result is dynamic. AnalyzeConstant relies on this to
+        // mask out the garbage literal it returns for custom calls.
+        ABSL_ASSIGN_OR_RETURN(Shape root_shape,
+                              Shape::FromProto(root->shape()));
+        return CreateAllDynamicResult(
+            ShapeUtil::GetSubshape(root_shape, context.shape_index), type);
       }
-
-      break;
     }
 
     case HloOpcode::kRecv:

--- a/xla/hlo/builder/value_inference_test.cc
+++ b/xla/hlo/builder/value_inference_test.cc
@@ -247,6 +247,73 @@ TEST_F(DynamismInferenceTest, GetDimensionSize) {
   EXPECT_EQ(ComputeDynamismScalar(tuple_2, &b, {1}).value(), false);
 }
 
+TEST_F(DynamismInferenceTest, UnknownCustomCallIsConservativelyDynamic) {
+  XlaBuilder b(TestName());
+  auto p = Parameter(&b, 0, ShapeUtil::MakeShape(F32, {2}), "p0");
+  auto cc =
+      CustomCall(&b, "UnknownTarget", {p}, ShapeUtil::MakeShape(F32, {2}));
+  auto value = ComputeDynamismLiteral(cc, &b);
+  ASSERT_TRUE(value.ok()) << value.status();
+  EXPECT_TRUE(value.value().Get<bool>({0}));
+  EXPECT_TRUE(value.value().Get<bool>({1}));
+}
+
+TEST_F(DynamismInferenceTest, QrCustomCallsAreConservativelyDynamic) {
+  // Mirrors https://github.com/openxla/xla/issues/45839: value inference is
+  // asked whether a reduction of XLA's own QR decomposition (lowered to the
+  // "Qr" and "ProductOfElementaryHouseholderReflectors" custom calls) is
+  // dynamic. It must answer "dynamic" instead of erroring out.
+  XlaBuilder b(TestName());
+  auto p = Parameter(&b, 0, ShapeUtil::MakeShape(F32, {3, 32, 32}), "p0");
+  Shape qr_shape =
+      ShapeUtil::MakeTupleShape({ShapeUtil::MakeShape(F32, {3, 32, 32}),
+                                 ShapeUtil::MakeShape(F32, {3, 32})});
+  auto qr = CustomCall(&b, "Qr", {p}, qr_shape);
+  auto q_and_r = GetTupleElement(qr, 0);
+  auto taus = GetTupleElement(qr, 1);
+  auto q = CustomCall(&b, "ProductOfElementaryHouseholderReflectors",
+                      {q_and_r, taus}, ShapeUtil::MakeShape(F32, {3, 32, 32}));
+  auto max = Reduce(q, ConstantR0<float>(&b, 0),
+                    CreateScalarMaxComputation(F32, &b), {0, 1, 2});
+  auto value = ComputeDynamismScalar(max, &b);
+  ASSERT_TRUE(value.ok()) << value.status();
+  EXPECT_TRUE(value.value());
+  // The tuple-shaped custom call, queried directly and through a
+  // get-tuple-element (non-empty shape index).
+  auto qr_dynamism = ComputeDynamismLiteral(qr, &b);
+  ASSERT_TRUE(qr_dynamism.ok()) << qr_dynamism.status();
+  EXPECT_TRUE(qr_dynamism.value().Get<bool>({0, 0, 0}, {0}));
+  EXPECT_TRUE(qr_dynamism.value().Get<bool>({0, 0}, {1}));
+  auto taus_dynamism = ComputeDynamismLiteral(taus, &b);
+  ASSERT_TRUE(taus_dynamism.ok()) << taus_dynamism.status();
+  EXPECT_TRUE(taus_dynamism.value().Get<bool>({0, 0}));
+}
+
+TEST_F(DynamismInferenceTest, AnalyzeConstantOnCustomCallReportsUnknown) {
+  // AnalyzeConstant must report "unknown value" (fully masked) for opaque
+  // custom calls instead of erroring, in every mode. This is the query
+  // tf2xla's compile-time-constant resolution makes.
+  XlaBuilder b(TestName());
+  auto p = Parameter(&b, 0, ShapeUtil::MakeShape(F32, {3, 32, 32}), "p0");
+  Shape qr_shape =
+      ShapeUtil::MakeTupleShape({ShapeUtil::MakeShape(F32, {3, 32, 32}),
+                                 ShapeUtil::MakeShape(F32, {3, 32})});
+  auto qr = CustomCall(&b, "Qr", {p}, qr_shape);
+  auto q_and_r = GetTupleElement(qr, 0);
+  auto taus = GetTupleElement(qr, 1);
+  auto q = CustomCall(&b, "ProductOfElementaryHouseholderReflectors",
+                      {q_and_r, taus}, ShapeUtil::MakeShape(F32, {3, 32, 32}));
+  auto max = Reduce(q, ConstantR0<float>(&b, 0),
+                    CreateScalarMaxComputation(F32, &b), {0, 1, 2});
+  for (auto mode : {ValueInferenceMode::kValue, ValueInferenceMode::kUpperBound,
+                    ValueInferenceMode::kLowerBound}) {
+    ValueInference value_inference(&b);
+    auto result = value_inference.AnalyzeConstant(max, mode);
+    ASSERT_TRUE(result.ok()) << result.status();
+    EXPECT_FALSE(result.value().GetValue().has_value());
+  }
+}
+
 TEST_F(DynamismInferenceTest, DynamicSliceWithConstantOperands) {
   XlaBuilder b(TestName());
 


### PR DESCRIPTION
## 📝 Summary of Changes

Fixes #45839.

`ValueInference::AnalyzeIsDynamic` returns an `InvalidArgument` error when the graph contains any custom call other than `SetBound` or `Sharding`. That includes custom calls XLA emits itself: `tf.linalg.qr` is lowered by the builder library (`xla/hlo/builder/lib/qr.cc`) to the `Qr` and `ProductOfElementaryHouseholderReflectors` custom calls, so asking value inference about anything downstream of a QR decomposition kills the whole compilation with an error carrying a raw proto dump (that's the "goo.gle/debugstr" in the issue title, it is just protobuf redaction).

This change makes the unknown-custom-call case answer conservatively instead: everything in the result is dynamic, via the existing `CreateAllDynamicResult` helper. That is the same fallback the function already uses for `kWhile`, `kSend`/`kRecv` and unhandled opcodes, and it is what `AnalyzeConstant` already expects: its custom-call case returns a garbage literal with a comment saying it "will be masked out later" by exactly this dynamism mask. Since every `AnalyzeConstant` mode computes the dynamism mask first, the fix also stops the same error coming out of constant/bound queries.

## 🎯 Justification

With this fix, tf2xla's compile-time-constant resolution gets a clean "this value is not a compile-time constant" answer for values coming out of a QR decomposition, and reports its normal actionable diagnostic instead of an internal error. Programs where a custom call only sits near (not on) the queried path now compile. The conservative answer can never be wrong, it can only miss a folding opportunity, and before this change the same query errored anyway.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

Three new tests in `xla/hlo/builder/value_inference_test.cc`, all failing before the fix and passing after:

- `UnknownCustomCallIsConservativelyDynamic`: `AnalyzeIsDynamic` on an unknown custom call returns all-dynamic instead of an error.
- `QrCustomCallsAreConservativelyDynamic`: the issue's graph shape (Qr tuple custom call, GTEs, reflectors custom call, reduce), the exact question tf2xla asks for `Range`'s limit, plus direct queries of the tuple-shaped custom call and of a tuple element.
- `AnalyzeConstantOnCustomCallReportsUnknown`: `AnalyzeConstant` in all three modes reports "unknown value" instead of erroring.

`bazel test //xla/hlo/builder:value_inference_test` and `bazel test //xla/hlo/builder:xla_builder_test` pass.

## 🧪 Execution Tests:

Not applicable, the change is in builder-level analysis and fully covered by the unit tests above (CPU-only, no GPU needed).