### PR TITLE
[xla:gpu] Assign scale-up communication domains from GPU topology

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -1795,6 +1795,7 @@ cc_library(
         "//xla:side_effect_util",
         "//xla:util",
         "//xla:xla_data_proto_cc",
+        "//xla/backends/gpu/transforms/collectives:collective_domain",
         "//xla/hlo/analysis:hlo_reachability",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/pass:hlo_pass",
@@ -1819,9 +1820,11 @@ xla_cc_test(
     deps = [
         ":explicit_collectives_group_async_wrapper",
         ":group_collectives_by_key",
+        "//xla/backends/gpu/transforms/collectives:collective_domain",
         "//xla/hlo/ir:hlo",
         "//xla/hlo/testlib:filecheck",
         "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service/gpu:backend_configs_cc",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest_main",  # fixdeps: keep

--- a/xla/backends/gpu/transforms/collectives/BUILD
+++ b/xla/backends/gpu/transforms/collectives/BUILD
@@ -114,6 +114,49 @@ cc_library(
 )
 
 cc_library(
+    name = "collective_domain_assigner",
+    srcs = ["collective_domain_assigner.cc"],
+    hdrs = ["collective_domain_assigner.h"],
+    deps = [
+        ":collective_domain",
+        "//xla:side_effect_util",
+        "//xla:xla_data_proto_cc",
+        "//xla:xla_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/hlo/utils:hlo_query",
+        "//xla/runtime:device_id",
+        "//xla/service:collective_ops_utils",
+        "//xla/service:computation_placer_hdr",
+        "//xla/service:gpu_topology",
+        "//xla/service:hlo_module_config",
+        "//xla/service/gpu:backend_configs_cc",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status:status_macros",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+xla_cc_test(
+    name = "collective_domain_assigner_test",
+    srcs = ["collective_domain_assigner_test.cc"],
+    deps = [
+        ":collective_domain_assigner",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:filecheck",
+        "//xla/hlo/testlib:hlo_hardware_independent_test_base",
+        "//xla/service:gpu_topology",
+        "//xla/tests:xla_internal_test_main",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
     name = "legalize_collective_domain",
     srcs = ["legalize_collective_domain.cc"],
     hdrs = ["legalize_collective_domain.h"],

--- a/xla/backends/gpu/transforms/collectives/BUILD
+++ b/xla/backends/gpu/transforms/collectives/BUILD
@@ -135,6 +135,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status:status_macros",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
     ],

--- a/xla/backends/gpu/transforms/collectives/collective_domain_assigner.cc
+++ b/xla/backends/gpu/transforms/collectives/collective_domain_assigner.cc
@@ -1,0 +1,219 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/collectives/collective_domain_assigner.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "absl/algorithm/container.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status_macros.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "xla/backends/gpu/transforms/collectives/collective_domain.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/utils/hlo_query.h"
+#include "xla/runtime/device_id.h"
+#include "xla/service/collective_ops_utils.h"
+#include "xla/service/computation_placer.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu_topology.h"
+#include "xla/service/hlo_module_config.h"
+#include "xla/side_effect_util.h"
+#include "xla/xla.pb.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla::gpu {
+namespace {
+
+absl::StatusOr<std::vector<std::vector<GlobalDeviceId>>>
+GetCollectiveParticipantGroups(const HloInstruction& collective,
+                               const DeviceAssignment& device_assignment) {
+  ABSL_ASSIGN_OR_RETURN(CollectiveOpGroupMode group_mode,
+                        GetCollectiveOpGroupMode(&collective));
+
+  if (HloPredicateIsOp<HloOpcode::kCollectivePermute,
+                       HloOpcode::kCollectivePermuteStart>(&collective)) {
+    std::vector<ReplicaGroup> source_target_groups;
+    source_target_groups.reserve(collective.source_target_pairs().size());
+    for (const auto& [source, target] : collective.source_target_pairs()) {
+      ReplicaGroup& group = source_target_groups.emplace_back();
+      group.add_replica_ids(source);
+      group.add_replica_ids(target);
+    }
+    return GetParticipatingDevicesGroups(device_assignment,
+                                         source_target_groups, group_mode);
+  }
+
+  return GetParticipatingDevicesGroups(device_assignment,
+                                       collective.replica_groups(), group_mode);
+}
+
+bool IsWithinScaleUpFabricDomain(absl::Span<const GlobalDeviceId> group,
+                                 int32_t scale_up_fabric_size) {
+  if (group.empty()) {
+    return false;
+  }
+
+  auto [min_device, max_device] =
+      std::minmax_element(group.begin(), group.end());
+  int64_t min_device_id = min_device->value();
+  int64_t max_device_id = max_device->value();
+  if (min_device_id < 0) {
+    return false;
+  }
+
+  int64_t min_domain_id = min_device_id / scale_up_fabric_size;
+  int64_t max_domain_id = max_device_id / scale_up_fabric_size;
+  return min_domain_id == max_domain_id;
+}
+
+bool IsWithinScaleUpFabricDomain(
+    absl::Span<const std::vector<GlobalDeviceId>> groups,
+    int32_t scale_up_fabric_size) {
+  if (groups.empty()) {
+    return false;
+  }
+
+  return absl::c_all_of(groups, [&](absl::Span<const GlobalDeviceId> group) {
+    return IsWithinScaleUpFabricDomain(group, scale_up_fabric_size);
+  });
+}
+
+absl::StatusOr<bool> IsScaleUpFabricCollective(
+    const HloInstruction& collective, const DeviceAssignment& device_assignment,
+    int32_t scale_up_fabric_size) {
+  ABSL_ASSIGN_OR_RETURN(CollectiveCommunicationDomain current_domain,
+                        GetCollectiveCommunicationDomain(collective));
+  if (current_domain != kUnspecifiedCollectiveDomain) {
+    return current_domain == kScaleUpFabricCollectiveDomain;
+  }
+  ABSL_ASSIGN_OR_RETURN(
+      auto participant_groups,
+      GetCollectiveParticipantGroups(collective, device_assignment));
+  return IsWithinScaleUpFabricDomain(participant_groups, scale_up_fabric_size);
+}
+
+absl::StatusOr<bool> IsScaleUpFabricEligible(
+    const HloInstruction& instruction,
+    const DeviceAssignment& device_assignment, int32_t scale_up_fabric_size) {
+  if (instruction.opcode() != HloOpcode::kCall) {
+    return IsScaleUpFabricCollective(instruction, device_assignment,
+                                     scale_up_fabric_size);
+  }
+
+  bool has_collective = false;
+  for (const HloInstruction* member : instruction.to_apply()->instructions()) {
+    if (!hlo_query::IsCollectiveCommunicationOp(member->opcode())) {
+      continue;
+    }
+    has_collective = true;
+    ABSL_ASSIGN_OR_RETURN(bool is_scale_up,
+                          IsScaleUpFabricCollective(*member, device_assignment,
+                                                    scale_up_fabric_size));
+    if (!is_scale_up) {
+      return false;
+    }
+  }
+  return has_collective;
+}
+
+absl::StatusOr<bool> AssignDomain(HloInstruction& instruction,
+                                  const DeviceAssignment& device_assignment,
+                                  int32_t scale_up_fabric_size) {
+  ABSL_ASSIGN_OR_RETURN(CollectiveCommunicationDomain current_domain,
+                        GetCollectiveCommunicationDomain(instruction));
+  if (current_domain != kUnspecifiedCollectiveDomain) {
+    return false;
+  }
+
+  ABSL_ASSIGN_OR_RETURN(bool is_eligible,
+                        IsScaleUpFabricEligible(instruction, device_assignment,
+                                                scale_up_fabric_size));
+  if (!is_eligible) {
+    return false;
+  }
+
+  ABSL_ASSIGN_OR_RETURN(GpuBackendConfig config,
+                        instruction.backend_config<GpuBackendConfig>());
+  config.mutable_collective_backend_config()->set_communication_domain(
+      kScaleUpFabricCollectiveDomain);
+  ABSL_RETURN_IF_ERROR(instruction.set_backend_config(config));
+  return true;
+}
+
+bool IsDomainAssignmentCandidate(const HloInstruction& instruction) {
+  return hlo_query::IsCollectiveCommunicationOp(instruction.opcode()) ||
+         (instruction.opcode() == HloOpcode::kCall &&
+          instruction.frontend_attributes().map().contains(
+              kCollectiveGroupMarkerAttr));
+}
+
+}  // namespace
+
+CollectiveDomainAssigner::CollectiveDomainAssigner(
+    const GpuTopology& gpu_topology)
+    : gpu_topology_(gpu_topology) {}
+
+absl::StatusOr<bool> CollectiveDomainAssigner::RunImpl(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  if (!module->config()
+           .debug_options()
+           .xla_gpu_enable_scale_up_fabric_assignment()) {
+    return false;
+  }
+
+  int32_t scale_up_fabric_size = gpu_topology_.slice_size();
+  if (scale_up_fabric_size <= 1) {
+    return false;
+  }
+
+  // XLA:GPU supports IOTA device assignments. When a useful static assignment
+  // is unavailable, use the corresponding zero-based IOTA assignment. The
+  // all-zero case is a sentinel used by functional_hlo_runner.
+  DeviceAssignment default_device_assignment(module->config().replica_count(),
+                                             module->config().num_partitions());
+  default_device_assignment.FillIota(0);
+  const DeviceAssignment* device_assignment = &default_device_assignment;
+  if (module->config().has_static_device_assignment() &&
+      !module->config().static_device_assignment().IsAll(0)) {
+    device_assignment = &module->config().static_device_assignment();
+  }
+
+  bool changed = false;
+  for (HloComputation* computation :
+       module->MakeNonfusionComputations(execution_threads)) {
+    for (HloInstruction* instruction : computation->instructions()) {
+      if (!IsDomainAssignmentCandidate(*instruction)) {
+        continue;
+      }
+      ABSL_ASSIGN_OR_RETURN(
+          bool instruction_changed,
+          AssignDomain(*instruction, *device_assignment, scale_up_fabric_size));
+      changed |= instruction_changed;
+    }
+  }
+
+  return changed;
+}
+
+}  // namespace xla::gpu

--- a/xla/backends/gpu/transforms/collectives/collective_domain_assigner.cc
+++ b/xla/backends/gpu/transforms/collectives/collective_domain_assigner.cc
@@ -23,6 +23,8 @@ limitations under the License.
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status_macros.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/transforms/collectives/collective_domain.h"
@@ -43,6 +45,21 @@ limitations under the License.
 
 namespace xla::gpu {
 namespace {
+
+absl::StatusOr<absl::flat_hash_set<CollectiveCommunicationDomain>>
+ParseDomainsToAssign(absl::string_view value) {
+  absl::flat_hash_set<CollectiveCommunicationDomain> domains;
+  for (absl::string_view domain_name :
+       absl::StrSplit(value, ',', absl::SkipWhitespace())) {
+    domain_name = absl::StripAsciiWhitespace(domain_name);
+    ABSL_ASSIGN_OR_RETURN(CollectiveCommunicationDomain domain,
+                          ParseCollectiveCommunicationDomain(domain_name));
+    if (domain != kUnspecifiedCollectiveDomain) {
+      domains.insert(domain);
+    }
+  }
+  return domains;
+}
 
 absl::StatusOr<std::vector<std::vector<GlobalDeviceId>>>
 GetCollectiveParticipantGroups(const HloInstruction& collective,
@@ -176,9 +193,13 @@ CollectiveDomainAssigner::CollectiveDomainAssigner(
 absl::StatusOr<bool> CollectiveDomainAssigner::RunImpl(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
-  if (!module->config()
-           .debug_options()
-           .xla_gpu_enable_scale_up_fabric_assignment()) {
+  const HloModuleConfig& config = module->config();
+
+  absl::string_view domain_assignment =
+      config.debug_options().xla_gpu_collective_domain_assignment();
+  ABSL_ASSIGN_OR_RETURN(auto domains_to_assign,
+                        ParseDomainsToAssign(domain_assignment));
+  if (!domains_to_assign.contains(kScaleUpFabricCollectiveDomain)) {
     return false;
   }
 
@@ -190,13 +211,14 @@ absl::StatusOr<bool> CollectiveDomainAssigner::RunImpl(
   // XLA:GPU supports IOTA device assignments. When a useful static assignment
   // is unavailable, use the corresponding zero-based IOTA assignment. The
   // all-zero case is a sentinel used by functional_hlo_runner.
-  DeviceAssignment default_device_assignment(module->config().replica_count(),
-                                             module->config().num_partitions());
+  DeviceAssignment default_device_assignment(config.replica_count(),
+                                             config.num_partitions());
   default_device_assignment.FillIota(0);
+
   const DeviceAssignment* device_assignment = &default_device_assignment;
-  if (module->config().has_static_device_assignment() &&
-      !module->config().static_device_assignment().IsAll(0)) {
-    device_assignment = &module->config().static_device_assignment();
+  if (config.has_static_device_assignment() &&
+      !config.static_device_assignment().IsAll(0)) {
+    device_assignment = &config.static_device_assignment();
   }
 
   bool changed = false;

--- a/xla/backends/gpu/transforms/collectives/collective_domain_assigner.h
+++ b/xla/backends/gpu/transforms/collectives/collective_domain_assigner.h
@@ -1,0 +1,54 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_TRANSFORMS_COLLECTIVES_COLLECTIVE_DOMAIN_ASSIGNER_H_
+#define XLA_BACKENDS_GPU_TRANSFORMS_COLLECTIVES_COLLECTIVE_DOMAIN_ASSIGNER_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+
+namespace xla {
+
+class GpuTopology;
+
+namespace gpu {
+
+// Assigns the SCALE_UP_FABRIC communication domain to collectives whose every
+// participant group is contained in a contiguous range of global devices. The
+// range size is the fast-interconnect partition size from GpuTopology.
+class CollectiveDomainAssigner : public HloModulePass {
+ public:
+  explicit CollectiveDomainAssigner(const GpuTopology& gpu_topology);
+
+  absl::string_view name() const override {
+    return "collective-domain-assigner";
+  }
+
+ protected:
+  absl::StatusOr<bool> RunImpl(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  const GpuTopology& gpu_topology_;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_GPU_TRANSFORMS_COLLECTIVES_COLLECTIVE_DOMAIN_ASSIGNER_H_

--- a/xla/backends/gpu/transforms/collectives/collective_domain_assigner_test.cc
+++ b/xla/backends/gpu/transforms/collectives/collective_domain_assigner_test.cc
@@ -1,0 +1,130 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/collectives/collective_domain_assigner.h"
+
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/testlib/filecheck.h"
+#include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/service/gpu_topology.h"
+
+namespace xla::gpu {
+namespace {
+
+void ExpectFileCheck(absl::string_view input, absl::string_view pattern) {
+  ASSERT_OK_AND_ASSIGN(bool matches, RunFileCheck(std::string(input), pattern));
+  EXPECT_TRUE(matches);
+}
+
+class CollectiveDomainAssignerTest : public HloHardwareIndependentTestBase {
+ protected:
+  void EnableAssignment(HloModule& module) {
+    module.mutable_config()
+        .mutable_debug_options()
+        .set_xla_gpu_enable_scale_up_fabric_assignment(true);
+  }
+
+  absl::StatusOr<bool> RunAssigner(HloModule& module) {
+    return RunHloPass(CollectiveDomainAssigner(gpu_topology_), &module);
+  }
+
+  GpuTopology gpu_topology_{"", /*num_partitions=*/2,
+                            /*num_hosts_per_partition=*/1,
+                            /*num_devices_per_host=*/8};
+};
+
+TEST_F(CollectiveDomainAssignerTest, AssignsDomainFromReplicaGroups) {
+  constexpr absl::string_view kHlo = R"(
+  HloModule m, replica_count=16
+
+  add {
+    lhs = f32[] parameter(0)
+    rhs = f32[] parameter(1)
+    ROOT sum = f32[] add(lhs, rhs)
+  }
+
+  ENTRY main {
+    p0 = f32[8] parameter(0)
+    local = f32[8] all-reduce(p0), to_apply=add,
+        replica_groups={{0,1,2,3,4,5,6,7},{8,9,10,11,12,13,14,15}}
+    cross = f32[8] all-reduce(p0), to_apply=add,
+        replica_groups={{0,8},{1,9},{2,10},{3,11},{4,12},{5,13},{6,14},{7,15}}
+    ROOT result = (f32[8], f32[8]) tuple(local, cross)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  module->mutable_config().reset_static_device_assignment();
+  EnableAssignment(*module);
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunAssigner(*module));
+  EXPECT_TRUE(changed);
+  const absl::string_view expected_hlo = R"(
+  //       CHECK: %local = {{.*}} all-reduce({{.*}})
+  //  CHECK-SAME:   backend_config={{.*}}communication_domain
+  //  CHECK-SAME:   COLLECTIVE_COMMUNICATION_DOMAIN_SCALE_UP_FABRIC
+  //       CHECK: %cross = {{.*}} all-reduce({{.*}})
+  //   CHECK-NOT:   communication_domain
+  //       CHECK: ROOT %result
+  )";
+  ExpectFileCheck(module->ToString(), expected_hlo);
+}
+
+TEST_F(CollectiveDomainAssignerTest, AssignsExplicitCollectivesGroupCall) {
+  constexpr absl::string_view kHlo = R"(
+  HloModule m, replica_count=2
+
+  add {
+    lhs = f32[] parameter(0)
+    rhs = f32[] parameter(1)
+    ROOT sum = f32[] add(lhs, rhs)
+  }
+
+  collectives {
+    p0 = f32[8] parameter(0)
+    ar = f32[8] all-reduce(p0), to_apply=add, replica_groups={{0,1}}
+    ag = f32[16] all-gather(p0), dimensions={0}, replica_groups={{0,1}}
+    ROOT result = (f32[8], f32[16]) tuple(ar, ag)
+  }
+
+  ENTRY main {
+    p0 = f32[8] parameter(0)
+    ROOT group = (f32[8], f32[16]) call(p0), to_apply=collectives,
+        frontend_attributes={_collectives_group=""}
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  EnableAssignment(*module);
+
+  ASSERT_OK_AND_ASSIGN(bool changed, RunAssigner(*module));
+  EXPECT_TRUE(changed);
+  const absl::string_view expected_hlo = R"(
+  //       CHECK: ROOT %group = {{.*}} call({{.*}})
+  //  CHECK-SAME:   frontend_attributes={_collectives_group=""}
+  //  CHECK-SAME:   backend_config={{.*}}communication_domain
+  //  CHECK-SAME:   COLLECTIVE_COMMUNICATION_DOMAIN_SCALE_UP_FABRIC
+  )";
+  ExpectFileCheck(module->ToString(), expected_hlo);
+}
+
+}  // namespace
+}  // namespace xla::gpu

--- a/xla/backends/gpu/transforms/collectives/collective_domain_assigner_test.cc
+++ b/xla/backends/gpu/transforms/collectives/collective_domain_assigner_test.cc
@@ -39,7 +39,7 @@ class CollectiveDomainAssignerTest : public HloHardwareIndependentTestBase {
   void EnableAssignment(HloModule& module) {
     module.mutable_config()
         .mutable_debug_options()
-        .set_xla_gpu_enable_scale_up_fabric_assignment(true);
+        .set_xla_gpu_collective_domain_assignment("scale_up_fabric");
   }
 
   absl::StatusOr<bool> RunAssigner(HloModule& module) {

--- a/xla/backends/gpu/transforms/group_collectives_by_key.cc
+++ b/xla/backends/gpu/transforms/group_collectives_by_key.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
+#include "xla/backends/gpu/transforms/collectives/collective_domain.h"
 #include "xla/hlo/analysis/hlo_reachability.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
@@ -418,7 +419,10 @@ absl::StatusOr<bool> GroupCollectivesInComputation(
 
   // A btree_map keeps keys sorted, so groups are processed in a deterministic
   // order without a separate ordering vector.
-  absl::btree_map<std::string, std::vector<HloInstruction*>> key_to_collectives;
+  using DomainAwareGroupKey =
+      std::pair<std::string, CollectiveCommunicationDomain>;
+  absl::btree_map<DomainAwareGroupKey, std::vector<HloInstruction*>>
+      key_to_collectives;
   for (HloInstruction* instr : computation->instructions()) {
     if (!predicate(instr)) {
       continue;
@@ -427,7 +431,9 @@ absl::StatusOr<bool> GroupCollectivesInComputation(
     if (!key.has_value()) {
       continue;
     }
-    key_to_collectives[std::string(*key)].push_back(instr);
+    ABSL_ASSIGN_OR_RETURN(CollectiveCommunicationDomain domain,
+                          GetCollectiveCommunicationDomain(*instr));
+    key_to_collectives[{std::string(*key), domain}].push_back(instr);
   }
   if (key_to_collectives.empty()) {
     return false;
@@ -444,10 +450,11 @@ absl::StatusOr<bool> GroupCollectivesInComputation(
   // guarantees an invalid later key never leaves earlier keys half-transformed.
   std::vector<CollectiveGroup> groups_to_form;
   groups_to_form.reserve(key_to_collectives.size());
-  for (auto& [key, collectives] : key_to_collectives) {
+  for (auto& [group_key, collectives] : key_to_collectives) {
+    const auto& [key, domain] = group_key;
     if (collectives.size() <= 1) {
       LOG(WARNING) << "collective_group_key \"" << key << "\" ("
-                   << computation->name()
+                   << computation->name() << ", domain=" << domain
                    << ") has only one collective, skipping";
       continue;
     }
@@ -472,8 +479,7 @@ absl::StatusOr<bool> GroupCollectivesInComputation(
           return FailedPrecondition(
               "Collectives %s and %s share collective_group_key=%s but are not "
               "independent (one is reachable from the other).\n"
-              "Computation: %s\n"
-              "Reachability chain %s -> %s:\n%s",
+              "Computation: %s\n Reachability chain %s -> %s:\n%s",
               collectives[i]->name(), collectives[j]->name(), key,
               computation->name(), a->name(), b->name(), chain);
         }
@@ -493,15 +499,15 @@ absl::StatusOr<bool> GroupCollectivesInComputation(
     groups_to_form.push_back({key, std::move(collectives)});
   }
 
-  ABSL_RETURN_IF_ERROR(ValidateGroupGraphIsAcyclic(groups_to_form, *reachability,
-                                              computation->name()));
+  ABSL_RETURN_IF_ERROR(ValidateGroupGraphIsAcyclic(
+      groups_to_form, *reachability, computation->name()));
 
   // Phase two: every group validated against a consistent, mutation-free map,
   // so it is now safe to form them.
   bool changed = false;
   for (const CollectiveGroup& group : groups_to_form) {
     ABSL_RETURN_IF_ERROR(CreateCollectivesGroup(computation, group.collectives,
-                                           execution_thread));
+                                                execution_thread));
     changed = true;
   }
   return changed;
@@ -522,8 +528,8 @@ absl::StatusOr<bool> GroupCollectivesByKey::RunImpl(
       continue;
     }
     ABSL_ASSIGN_OR_RETURN(bool comp_changed,
-                     GroupCollectivesInComputation(comp, predicate_,
-                                                   comp->execution_thread()));
+                          GroupCollectivesInComputation(
+                              comp, predicate_, comp->execution_thread()));
     changed |= comp_changed;
   }
   return changed;

--- a/xla/backends/gpu/transforms/group_collectives_by_key_test.cc
+++ b/xla/backends/gpu/transforms/group_collectives_by_key_test.cc
@@ -17,13 +17,17 @@ limitations under the License.
 
 #include <string>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
+#include "xla/backends/gpu/transforms/collectives/collective_domain.h"
 #include "xla/backends/gpu/transforms/explicit_collectives_group_async_wrapper.h"
+#include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/hlo/testlib/filecheck.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
+#include "xla/service/gpu/backend_configs.pb.h"
 
 namespace xla::gpu {
 namespace {
@@ -827,6 +831,71 @@ TEST_F(GroupCollectivesByKeyTest, ErrorsWhenGroupedNodeGraphHasCycle) {
   //       CHECK: %g1_first = {{.*}} all-reduce(
   //       CHECK: %g1_second = {{.*}} all-reduce(
   //       CHECK: %g0_second = {{.*}} all-reduce(
+  )";
+  ExpectFileCheck(module->ToString(), expected_hlo);
+}
+
+TEST_F(GroupCollectivesByKeyTest, SeparatesCommunicationDomains) {
+  const absl::string_view hlo_string = R"(
+  HloModule test, replica_count=2
+
+  add {
+    a = f32[] parameter(0)
+    b = f32[] parameter(1)
+    ROOT sum = f32[] add(a, b)
+  }
+
+  ENTRY main {
+    w0 = f32[2] parameter(0)
+    g0 = f32[4] parameter(1)
+    w1 = f32[2] parameter(2)
+    g1 = f32[4] parameter(3)
+    scale_ag = f32[4] all-gather(w0), dimensions={0},
+        replica_groups={{0,1}},
+        frontend_attributes={collective_group_key="g0"}
+    scale_rs = f32[2] reduce-scatter(g0), dimensions={0},
+        replica_groups={{0,1}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    default_ag = f32[4] all-gather(w1), dimensions={0},
+        replica_groups={{0,1}},
+        frontend_attributes={collective_group_key="g0"}
+    default_rs = f32[2] reduce-scatter(g1), dimensions={0},
+        replica_groups={{0,1}}, to_apply=add,
+        frontend_attributes={collective_group_key="g0"}
+    ROOT result = (f32[4], f32[2], f32[4], f32[2])
+        tuple(scale_ag, scale_rs, default_ag, default_rs)
+  }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+  for (absl::string_view name : {"scale_ag", "scale_rs"}) {
+    HloInstruction* collective =
+        module->entry_computation()->GetInstructionWithName(name);
+    ASSERT_NE(collective, nullptr);
+    GpuBackendConfig config;
+    config.mutable_collective_backend_config()->set_communication_domain(
+        kScaleUpFabricCollectiveDomain);
+    ASSERT_OK(collective->set_backend_config(config));
+  }
+
+  GroupCollectivesByKey pass;
+  ASSERT_OK_AND_ASSIGN(bool changed, pass.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  const absl::string_view expected_hlo = R"(
+  // CHECK-LABEL: ENTRY %main
+  //       CHECK: %[[SCALE_START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //  CHECK-SAME:   backend_config={{.*}}communication_domain
+  //  CHECK-SAME:   COLLECTIVE_COMMUNICATION_DOMAIN_SCALE_UP_FABRIC
+  //       CHECK: %[[SCALE_DONE:[^ ]+]] = {{.*}} async-done(%[[SCALE_START]])
+  //       CHECK: %[[DEFAULT_START:[^ ]+]] = {{.*}} async-start
+  //  CHECK-SAME:   frontend_attributes={_collectives_group="",
+  //  CHECK-SAME:   collective_group_key="g0"}
+  //   CHECK-NOT:   communication_domain
+  //       CHECK: %[[DEFAULT_DONE:[^ ]+]] = {{.*}} async-done(%[[DEFAULT_START]])
+  //   CHECK-NOT:   async-start(
   )";
   ExpectFileCheck(module->ToString(), expected_hlo);
 }

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -512,7 +512,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_dot_merger_threshold_mb(64);
   opts.set_xla_enable_fast_math(false);
   opts.set_xla_gpu_experimental_parallel_collective_overlap_limit(1);
-  opts.set_xla_gpu_enable_scale_up_fabric_assignment(false);
+  opts.set_xla_gpu_collective_domain_assignment("");
   opts.set_xla_gpu_experimental_collective_start_as_early_as_possible(false);
   opts.set_xla_gpu_experimental_enable_selective_memcpy_overlap(false);
   opts.set_xla_gpu_experimental_parallel_async_compute_limit(2);
@@ -3160,14 +3160,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "This controls how many in-flight collectives "
       "latency hiding scheduler can schedule."));
   flag_list->push_back(tsl::Flag(
-      "xla_gpu_enable_scale_up_fabric_assignment",
-      bool_setter_for(
-          &DebugOptions::set_xla_gpu_enable_scale_up_fabric_assignment),
-      debug_options->xla_gpu_enable_scale_up_fabric_assignment(),
-      "If enabled, use the fast-interconnect partition size from GpuTopology "
-      "to assign the SCALE_UP_FABRIC communication domain to collectives "
-      "whose every participant group is contained in one topology "
-      "partition."));
+      "xla_gpu_collective_domain_assignment",
+      string_setter_for(
+          &DebugOptions::set_xla_gpu_collective_domain_assignment),
+      debug_options->xla_gpu_collective_domain_assignment(),
+      "Comma-separated list of collective communication domains to assign "
+      "automatically."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_collective_start_as_early_as_possible",
       bool_setter_for(

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -512,6 +512,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_dot_merger_threshold_mb(64);
   opts.set_xla_enable_fast_math(false);
   opts.set_xla_gpu_experimental_parallel_collective_overlap_limit(1);
+  opts.set_xla_gpu_enable_scale_up_fabric_assignment(false);
   opts.set_xla_gpu_experimental_collective_start_as_early_as_possible(false);
   opts.set_xla_gpu_experimental_enable_selective_memcpy_overlap(false);
   opts.set_xla_gpu_experimental_parallel_async_compute_limit(2);
@@ -3158,6 +3159,15 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_experimental_parallel_collective_overlap_limit(),
       "This controls how many in-flight collectives "
       "latency hiding scheduler can schedule."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_scale_up_fabric_assignment",
+      bool_setter_for(
+          &DebugOptions::set_xla_gpu_enable_scale_up_fabric_assignment),
+      debug_options->xla_gpu_enable_scale_up_fabric_assignment(),
+      "If enabled, use the fast-interconnect partition size from GpuTopology "
+      "to assign the SCALE_UP_FABRIC communication domain to collectives "
+      "whose every participant group is contained in one topology "
+      "partition."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_collective_start_as_early_as_possible",
       bool_setter_for(

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -1895,6 +1895,7 @@ cc_library(
         "//xla/backends/gpu/transforms/collectives:async_collective_annotator",
         "//xla/backends/gpu/transforms/collectives:collective_backend_assigner",
         "//xla/backends/gpu/transforms/collectives:collective_combiner_annotator",
+        "//xla/backends/gpu/transforms/collectives:collective_domain_assigner",
         "//xla/backends/gpu/transforms/collectives:collective_fusion",
         "//xla/backends/gpu/transforms/collectives:collective_kernel_strategy_annotator",
         "//xla/backends/gpu/transforms/collectives:collective_ops_utils",

--- a/xla/service/gpu/gpu_compiler.cc
+++ b/xla/service/gpu/gpu_compiler.cc
@@ -88,6 +88,7 @@ limitations under the License.
 #include "xla/backends/gpu/transforms/collectives/all_reduce_splitter.h"
 #include "xla/backends/gpu/transforms/collectives/collective_backend_assigner.h"
 #include "xla/backends/gpu/transforms/collectives/collective_combiner_annotator.h"
+#include "xla/backends/gpu/transforms/collectives/collective_domain_assigner.h"
 #include "xla/backends/gpu/transforms/collectives/collective_fusion.h"
 #include "xla/backends/gpu/transforms/collectives/collective_kernel_strategy_annotator.h"
 #include "xla/backends/gpu/transforms/collectives/collective_permute_cycle_decomposer.h"
@@ -1521,9 +1522,12 @@ absl::Status RunPostFusionPasses(
                               alias_info, pointer_size, options, gpu_topology,
                               mlir_context);
 
+  pipeline.AddPass<CollectiveDomainAssigner>(gpu_topology);
+
   // Form async collective groups from collectives sharing a
   // `collective_group_key` frontend attribute; runs after the combiner so
-  // combined collectives are grouped as a unit.
+  // combined collectives are grouped as a unit. Domain assignment runs first
+  // so collectives from different communication domains are grouped separately.
   pipeline.AddPass<GroupCollectivesByKey>();
 
   pipeline.AddPass<AllReduceContiguous>();
@@ -1537,6 +1541,10 @@ absl::Status RunPostFusionPasses(
   }
 
   AddDoubleBufferingPasses(*hlo_module, pipeline);
+
+  // Assign domains to collectives created by post-group transformations such
+  // as BlueConnect and loop unrolling.
+  pipeline.AddPass<CollectiveDomainAssigner>(gpu_topology);
 
   return pipeline.Run(hlo_module, {HloInstruction::kMainExecutionThread})
       .status();

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -649,6 +649,16 @@ message DebugOptions {
   // Maximum number of instructions to be combined in collective combiners.
   optional int64 xla_gpu_collective_combine_threshold_count = 461;
 
+  // Comma-separated list of collective communication domains to assign
+  // automatically.
+  //
+  // scale_up_fabric: uses the fast-interconnect partition size from GpuTopology
+  //   and assigns the domain when every participant group is contained in one
+  //   topology partition.
+  //
+  // An empty string disables automatic assignment.
+  optional string xla_gpu_collective_domain_assignment = 534;
+
   // Inflate collective cost by running each collective multiple times.
   optional int32 xla_gpu_collective_inflation_factor = 205;
 
@@ -1078,11 +1088,6 @@ message DebugOptions {
   //   coll.1-done = collective(coll.1-start)
   //   coll.2-done = collective(coll.2-start)
   optional int32 xla_gpu_experimental_parallel_collective_overlap_limit = 336;
-
-  // If enabled, use the fast-interconnect partition size from GpuTopology to
-  // assign the SCALE_UP_FABRIC communication domain to collectives whose every
-  // participant group is contained in one topology partition.
-  optional bool xla_gpu_enable_scale_up_fabric_assignment = 534;
 
   optional PipelineParallelismOptLevel
       xla_gpu_experimental_pipeline_parallelism_opt_level = 351;
@@ -1797,7 +1802,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 534
+  // Next id: 535
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1079,6 +1079,11 @@ message DebugOptions {
   //   coll.2-done = collective(coll.2-start)
   optional int32 xla_gpu_experimental_parallel_collective_overlap_limit = 336;
 
+  // If enabled, use the fast-interconnect partition size from GpuTopology to
+  // assign the SCALE_UP_FABRIC communication domain to collectives whose every
+  // participant group is contained in one topology partition.
+  optional bool xla_gpu_enable_scale_up_fabric_assignment = 534;
+
   optional PipelineParallelismOptLevel
       xla_gpu_experimental_pipeline_parallelism_opt_level = 351;
 


### PR DESCRIPTION
Follow up to: https://github.com/openxla/xla/pull/46541.

Add an opt-in `CollectiveDomainAssigner` pass that annotates collectives using the `SCALE_UP_FABRIC` communication domain when every participant group is contained within one fast-interconnect partition.

Controlled by `--xla_gpu_enable_scale_up_fabric_assignment`, disabled by default.

  - Uses `GpuTopology::slice_size()` to determine the scale-up fabric domain size.
  - Resolves replica groups through the module device assignment, falling back to the GPU-supported IOTA assignment when no meaningful static assignment is available.
  - Preserves existing communication-domain annotations.
  - Annotates explicit collective-group calls when all contained collectives use the scale-up fabric.
  - Runs before `GroupCollectivesByKey`, and again after later collective transformations that may create new collectives.

Update `GroupCollectivesByKey` to include the communication domain in its grouping key, preventing collectives from unrelated domains from being grouped together.

**Acknowledgements:** This change builds on work originally designed and implemented by [@yliu120](https://github.com/yliu120) and [@CanYangGetYang](https://github.com/CanYangGetYang) at Amazon