### PR TITLE
[xla] Cleanup collective ops utils

### DIFF
--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -5813,6 +5813,7 @@ cc_library(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:status_macros",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",

--- a/xla/service/all_reduce_simplifier.cc
+++ b/xla/service/all_reduce_simplifier.cc
@@ -66,9 +66,9 @@ absl::StatusOr<bool> AllReduceSimplifier::RunImpl(
     int64_t num_devices = config.num_partitions();
     int64_t num_replicas = config.replica_count();
     ABSL_ASSIGN_OR_RETURN(std::vector<int64_t> participant_counts,
-                     GetPariticipantCountsForReplicaGroups(
-                         num_replicas, num_devices,
-                         all_reduce->replica_groups(), group_mode));
+                          GetParticipantCountsForReplicaGroups(
+                              num_replicas, num_devices,
+                              all_reduce->replica_groups(), group_mode));
     if (participant_counts.empty()) {
       return -1;
     }
@@ -144,7 +144,7 @@ absl::StatusOr<bool> AllReduceSimplifier::RunImpl(
         continue;
       }
       ABSL_ASSIGN_OR_RETURN(int64_t group_size,
-                       get_participant_counts_for_replica_group(inst));
+                            get_participant_counts_for_replica_group(inst));
 
       // We will not simplify this all reduce if any of the following is true:
       // 1. All group do not have the same size.

--- a/xla/service/collective_ops_utils.cc
+++ b/xla/service/collective_ops_utils.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/status/status_macros.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
@@ -61,39 +62,9 @@ limitations under the License.
 namespace xla {
 using CycleType = collective_permute_cycle::CycleType;
 
-std::optional<absl::string_view> GetCollectiveGroupKey(
-    const HloInstruction& instruction) {
-  const auto& attributes = instruction.frontend_attributes().map();
-  auto it = attributes.find(kCollectiveGroupKeyAttr);
-  if (it == attributes.end() || it->second.empty()) {
-    return std::nullopt;
-  }
-  return it->second;
-}
-
-bool HasCollectiveGroupKey(const HloInstruction& instruction) {
-  return GetCollectiveGroupKey(instruction).has_value();
-}
-
-bool HaveCompatibleCollectiveGroupKeys(const HloInstruction& lhs,
-                                       const HloInstruction& rhs) {
-  return GetCollectiveGroupKey(lhs) == GetCollectiveGroupKey(rhs);
-}
-
-void CopyCollectiveGroupKey(const HloInstruction& source,
-                            HloInstruction& destination) {
-  std::optional<std::string> value =
-      source.get_frontend_attribute(kCollectiveGroupKeyAttr);
-  if (value.has_value()) {
-    destination.set_frontend_attribute(kCollectiveGroupKeyAttr, *value);
-  } else {
-    destination.erase_frontend_attribute(kCollectiveGroupKeyAttr);
-  }
-}
-
-void ClearCollectiveGroupKey(HloInstruction& instruction) {
-  instruction.erase_frontend_attribute(kCollectiveGroupKeyAttr);
-}
+//===----------------------------------------------------------------------===//
+// Reduction utilities.
+//===----------------------------------------------------------------------===//
 
 std::optional<ReductionKind> OpcodeToReductionKind(HloOpcode hlo_opcode,
                                                    PrimitiveType type) {
@@ -189,6 +160,135 @@ std::optional<Literal> GetReductionIdentity(ReductionKind kind,
   }
 }
 
+//===----------------------------------------------------------------------===//
+// Collective operation classification.
+//===----------------------------------------------------------------------===//
+
+bool IsNonFusionCollective(const HloInstruction* instruction) {
+  switch (instruction->opcode()) {
+    case HloOpcode::kAllReduce:
+    case HloOpcode::kAllReduceStart:
+    case HloOpcode::kAllReduceDone:
+    case HloOpcode::kAllGather:
+    case HloOpcode::kAllGatherStart:
+    case HloOpcode::kAllGatherDone:
+    case HloOpcode::kAllToAll:
+    case HloOpcode::kCollectiveBroadcast:
+    case HloOpcode::kCollectivePermute:
+    case HloOpcode::kCollectivePermuteStart:
+    case HloOpcode::kCollectivePermuteDone:
+    case HloOpcode::kRaggedAllToAll:
+    case HloOpcode::kReduceScatter:
+      return true;
+    case HloOpcode::kAsyncStart:
+    case HloOpcode::kAsyncUpdate:
+    case HloOpcode::kAsyncDone:
+      return IsNonFusionCollective(instruction->async_wrapped_instruction());
+    case HloOpcode::kSend:
+    case HloOpcode::kRecv:
+      return !Cast<HloSendRecvInstruction>(instruction)->is_host_transfer();
+    default:
+      return false;
+  }
+}
+
+bool IsCollective(const HloInstruction* instruction) {
+  if (IsNonFusionCollective(instruction)) {
+    return true;
+  }
+  if (instruction->opcode() == HloOpcode::kFusion &&
+      instruction->IsCustomFusion()) {
+    for (const auto* inner_inst : instruction->fused_instructions()) {
+      if (IsCollective(inner_inst)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+absl::StatusOr<bool> IsAsyncCollective(const HloInstruction* instruction) {
+  if (!IsNonFusionCollective(instruction)) {
+    return false;
+  }
+  if (instruction->IsAsynchronous()) {
+    switch (instruction->async_wrapped_opcode()) {
+      case HloOpcode::kAllGather:
+      case HloOpcode::kAllReduce:
+      case HloOpcode::kAllToAll:
+      case HloOpcode::kCollectiveBroadcast:
+      case HloOpcode::kCollectivePermute:
+      case HloOpcode::kRaggedAllToAll:
+      case HloOpcode::kReduceScatter:
+        return true;
+      default:
+        return absl::InvalidArgumentError("Async instruction " +
+                                          instruction->ToString() +
+                                          " is not a collective.");
+    }
+  }
+  switch (instruction->opcode()) {
+    case HloOpcode::kAllGatherStart:
+    case HloOpcode::kAllGatherDone:
+    case HloOpcode::kAllReduceStart:
+    case HloOpcode::kAllReduceDone:
+    case HloOpcode::kCollectivePermuteStart:
+    case HloOpcode::kCollectivePermuteDone:
+      return true;
+    case HloOpcode::kSend:
+    case HloOpcode::kRecv:
+      return !Cast<HloSendRecvInstruction>(instruction)->is_host_transfer();
+    case HloOpcode::kAllGather:
+    case HloOpcode::kAllReduce:
+    case HloOpcode::kAllToAll:
+    case HloOpcode::kCollectiveBroadcast:
+    case HloOpcode::kCollectivePermute:
+    case HloOpcode::kRaggedAllToAll:
+    case HloOpcode::kReduceScatter:
+      return false;
+    default:
+      return absl::InvalidArgumentError("Instruction " +
+                                        instruction->ToString() +
+                                        " is not an async collective.");
+  }
+}
+
+bool IsRaggedAllToAllOrAsyncStartRaggedAllToAll(
+    const HloInstruction* instruction) {
+  return instruction->opcode() == HloOpcode::kRaggedAllToAll ||
+         (instruction->opcode() == HloOpcode::kAsyncStart &&
+          instruction->async_wrapped_opcode() == HloOpcode::kRaggedAllToAll);
+}
+
+bool IsRaggedAllToAllOrAsyncDoneRaggedAllToAll(
+    const HloInstruction* instruction) {
+  return instruction->opcode() == HloOpcode::kRaggedAllToAll ||
+         (instruction->opcode() == HloOpcode::kAsyncDone &&
+          instruction->async_wrapped_opcode() == HloOpcode::kRaggedAllToAll);
+}
+
+HloInstruction* IsOrHasCollectiveWithChannelId(HloInstruction* instruction) {
+  if (instruction->opcode() == HloOpcode::kFusion) {
+    for (auto* inner_inst : instruction->fused_instructions()) {
+      if (IsOrHasCollectiveWithChannelId(inner_inst) != nullptr) {
+        return inner_inst;
+      }
+    }
+    return nullptr;
+  }
+  if (DynCast<HloChannelInstruction>(instruction) == nullptr) {
+    return nullptr;
+  }
+  if (IsCollective(instruction) && instruction->channel_id().has_value()) {
+    return instruction;
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// Replica group utilities.
+//===----------------------------------------------------------------------===//
+
 absl::StatusOr<std::vector<int>> GetParticipatingIDs(
     CollectiveOpGroupMode group_mode, int current_id,
     std::optional<int> total_participant_count,
@@ -278,6 +378,334 @@ absl::StatusOr<CollectiveOpGroupMode> GetCollectiveOpGroupMode(
   }
   return Internal("Unexpected instruction type.");
 }
+
+absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>>
+GetParticipatingFlattenedIdGroups(
+    const DeviceAssignment& device_assignment,
+    const CollectiveDeviceListBase& collective_device_list,
+    CollectiveOpGroupMode group_mode) {
+  return GetParticipatingFlattenedIdGroups(
+      collective_device_list, group_mode, device_assignment.replica_count(),
+      device_assignment.computation_count());
+}
+
+absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>>
+GetParticipatingFlattenedIdGroups(
+    const CollectiveDeviceListBase& collective_device_list,
+    CollectiveOpGroupMode group_mode, int replica_count, int partition_count) {
+  if (group_mode ==
+      CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID) {
+    return collective_device_list.Clone();
+  }
+  std::vector<ReplicaGroup> filled_empty_replica_group;
+  absl::Span<const ReplicaGroup> original_replica_groups =
+      collective_device_list.replica_groups();
+  std::vector<ReplicaGroup> flattened_replica_groups;
+  if (collective_device_list.replica_groups().empty()) {
+    filled_empty_replica_group.emplace_back();
+    const int64_t id_count =
+        group_mode ==
+                CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION
+            ? partition_count
+            : replica_count;
+    for (int i = 0; i < id_count; ++i) {
+      filled_empty_replica_group.back().add_replica_ids(i);
+    }
+    original_replica_groups = filled_empty_replica_group;
+  }
+  if (group_mode ==
+      CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA) {
+    flattened_replica_groups.resize(original_replica_groups.size() *
+                                    partition_count);
+    for (int64_t i = 0, current_group_offset = 0;
+         i < original_replica_groups.size();
+         ++i, current_group_offset += partition_count) {
+      for (int64_t replica_id : original_replica_groups.at(i).replica_ids()) {
+        for (int64_t partition_id = 0; partition_id < partition_count;
+             ++partition_id) {
+          const int64_t flattened_id =
+              replica_id * partition_count + partition_id;
+          flattened_replica_groups[current_group_offset + partition_id]
+              .add_replica_ids(flattened_id);
+        }
+      }
+    }
+  } else if (group_mode ==
+             CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION) {
+    flattened_replica_groups.resize(original_replica_groups.size() *
+                                    replica_count);
+    for (int64_t i = 0, current_group_offset = 0;
+         i < original_replica_groups.size();
+         ++i, current_group_offset += replica_count) {
+      for (int64_t partition_id : original_replica_groups.at(i).replica_ids()) {
+        for (int64_t replica_id = 0; replica_id < replica_count; ++replica_id) {
+          const int64_t flattened_id =
+              replica_id * partition_count + partition_id;
+          flattened_replica_groups[current_group_offset + replica_id]
+              .add_replica_ids(flattened_id);
+        }
+      }
+    }
+  } else {
+    CHECK(group_mode ==
+          CollectiveOpGroupMode::
+              COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA_AND_PARTITION);
+    flattened_replica_groups.resize(original_replica_groups.size());
+    for (int64_t i = 0; i < original_replica_groups.size(); ++i) {
+      for (int64_t replica_id : original_replica_groups.at(i).replica_ids()) {
+        for (int64_t partition_id = 0; partition_id < partition_count;
+             ++partition_id) {
+          const int64_t flattened_id =
+              replica_id * partition_count + partition_id;
+          flattened_replica_groups[i].add_replica_ids(flattened_id);
+        }
+      }
+    }
+  }
+  return std::make_unique<CollectiveDeviceList>(flattened_replica_groups);
+}
+
+absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>>
+GetParticipatingFlattenedIdGroups(const HloInstruction* hlo,
+                                  const DeviceAssignment& device_assignment) {
+  ABSL_ASSIGN_OR_RETURN(CollectiveOpGroupMode mode,
+                        GetCollectiveOpGroupMode(hlo));
+  ABSL_ASSIGN_OR_RETURN(
+      std::unique_ptr<CollectiveDeviceListBase> collective_device_list,
+      GetParticipatingFlattenedIdGroups(device_assignment, *hlo->device_list(),
+                                        mode));
+  return collective_device_list;
+}
+
+absl::StatusOr<std::vector<int64_t>> GetParticipantCountsForReplicaGroups(
+    int64_t num_replicas, int64_t num_partitions,
+    absl::Span<const ReplicaGroup> replica_groups,
+    CollectiveOpGroupMode group_mode) {
+  std::vector<int64_t> participant_counts;
+
+  // If replica groups are empty, assume a group with all replicas.
+  std::optional<ReplicaGroup> all_replica_groups;
+  if (replica_groups.empty()) {
+    if (group_mode ==
+        CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID) {
+      // replica groups contain flattened-ids and cannot be empty.
+      TF_RET_CHECK(!replica_groups.empty())
+          << "replica groups cannot be empty for kFlattenedID mode";
+    }
+
+    int total_participant_count;
+    if (group_mode ==
+        CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION) {
+      // replica group are partition ids.
+      total_participant_count = num_partitions;
+    } else {
+      // replica group are replica ids.
+      total_participant_count = num_replicas;
+    }
+
+    all_replica_groups.emplace();
+    all_replica_groups->mutable_replica_ids()->Reserve(total_participant_count);
+    for (int id = 0; id < total_participant_count; id++) {
+      all_replica_groups->add_replica_ids(id);
+    }
+    replica_groups = absl::MakeConstSpan(&*all_replica_groups, 1);
+  }
+
+  switch (group_mode) {
+    case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA: {
+      for (const auto& replica_group : replica_groups) {
+        for (int partition_id = 0; partition_id < num_partitions;
+             ++partition_id) {
+          participant_counts.push_back(replica_group.replica_ids().size());
+        }
+      }
+      return participant_counts;
+    }
+    case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION: {
+      for (const auto& replica_group : replica_groups) {
+        participant_counts.push_back(replica_group.replica_ids().size());
+      }
+      return participant_counts;
+    }
+    case CollectiveOpGroupMode::
+        COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA_AND_PARTITION: {
+      for (const auto& replica_group : replica_groups) {
+        participant_counts.push_back(replica_group.replica_ids().size() *
+                                     num_partitions);
+      }
+      return participant_counts;
+    }
+    case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID: {
+      for (const auto& replica_group : replica_groups) {
+        participant_counts.push_back(replica_group.replica_ids().size());
+      }
+      return participant_counts;
+    }
+    default: {
+      return InvalidArgument("Invalid collective op group mode: %d",
+                             static_cast<int>(group_mode));
+    }
+  }
+}
+
+absl::StatusOr<std::optional<std::pair<int64_t, int64_t>>>
+GetReplicaGroupCountAndSize(const HloInstruction* hlo) {
+  std::shared_ptr<CollectiveDeviceListBase> device_list = hlo->device_list();
+  auto config = hlo->GetModule()->config();
+
+  if (device_list->version() == CollectiveDeviceListVersion::kIota) {
+    return std::make_pair(device_list->num_replica_groups(),
+                          device_list->num_devices_per_group());
+  }
+  ABSL_ASSIGN_OR_RETURN(CollectiveOpGroupMode group_mode,
+                        GetCollectiveOpGroupMode(hlo));
+  ABSL_ASSIGN_OR_RETURN(std::vector<int64_t> participant_counts,
+                        GetParticipantCountsForReplicaGroups(
+                            config.replica_count(), config.num_partitions(),
+                            device_list->replica_groups(), group_mode));
+  int64_t replica_group_size = participant_counts[0];
+  for (int64_t participant_count : participant_counts) {
+    if (participant_count != replica_group_size) {
+      return std::nullopt;
+    }
+  }
+  return std::make_pair(participant_counts.size(), replica_group_size);
+}
+
+bool ReplicaGroupsOrthogonal(absl::Span<const ReplicaGroup> first,
+                             absl::Span<const ReplicaGroup> second) {
+  if (first.size() != second[0].replica_ids_size()) {
+    return false;
+  }
+  if (first[0].replica_ids_size() != second.size()) {
+    return false;
+  }
+  for (int64_t i = 0; i < first.size(); ++i) {
+    for (int64_t j = 0; j < first[i].replica_ids_size(); ++j) {
+      if (first[i].replica_ids(j) != second[j].replica_ids(i)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool ReplicaGroupsEqual(absl::Span<const ReplicaGroup> first,
+                        absl::Span<const ReplicaGroup> second) {
+  if (first.size() != second.size()) {
+    return false;
+  }
+  for (int64_t i = 0; i < first.size(); ++i) {
+    if (first[i].replica_ids_size() != second[i].replica_ids_size()) {
+      return false;
+    }
+    for (int j = 0; j < first[i].replica_ids_size(); ++j) {
+      if (first[i].replica_ids(j) != second[i].replica_ids(j)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool IsExclusivelyCrossModule(absl::Span<const ReplicaGroup> replica_groups,
+                              bool use_global_ids, bool has_channel_id,
+                              const DeviceAssignment& device_assignment) {
+  if (!has_channel_id) {
+    return false;
+  }
+  if (!use_global_ids) {
+    // Each id in a replica group is a replica id. If any group
+    // has more than one id then this is not exclusively cross module.
+    for (const ReplicaGroup& replica_group : replica_groups) {
+      if (replica_group.replica_ids_size() != 1) {
+        return false;
+      }
+    }
+    return true;
+  }
+  // Each id in a replica group is a global id. Check if all replica groups are
+  // exclusively cross module (all participants in a group have the same replica
+  // id).
+  const int64_t partition_count = device_assignment.computation_count();
+  for (const ReplicaGroup& replica_group : replica_groups) {
+    std::optional<int64_t> first_replica_id;
+    for (int64_t global_id : replica_group.replica_ids()) {
+      int64_t replica_id = global_id / partition_count;
+      if (!first_replica_id.has_value()) {
+        first_replica_id = replica_id;
+      } else if (replica_id != first_replica_id) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool IsExclusivelyCrossReplica(absl::Span<const ReplicaGroup> replica_groups,
+                               bool use_global_ids, bool has_channel_id,
+                               const DeviceAssignment& device_assignment) {
+  if (!has_channel_id) {
+    return true;
+  }
+  const int64_t partition_count = device_assignment.computation_count();
+  if (!use_global_ids) {
+    // Each id in a replica group is a replica id and we will perform the
+    // collective between all devices with that replica id. If partition count
+    // is > 1, then this is not exclusively cross replica.
+    return partition_count == 1;
+  }
+  // Each id in a replica group is a global id. Check if all replica groups are
+  // exclusively cross replica (all participants in a group have the same
+  // partition id).
+  for (const ReplicaGroup& replica_group : replica_groups) {
+    std::optional<int64_t> first_partition_id;
+    for (int64_t global_id : replica_group.replica_ids()) {
+      int64_t partition_id = global_id % partition_count;
+      if (!first_partition_id.has_value()) {
+        first_partition_id = partition_id;
+      } else if (partition_id != first_partition_id) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+int64_t GetSubgroupSize(const HloCollectiveInstruction* hlo,
+                        CollectiveOpGroupMode group_mode) {
+  const HloModuleConfig& config = hlo->GetModule()->config();
+  switch (group_mode) {
+    case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA:
+    case CollectiveOpGroupMode::
+        COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA_AND_PARTITION: {
+      int64_t replica_subgroup_size =
+          hlo->replica_groups().empty()
+              ? config.replica_count()
+              : hlo->replica_groups()[0].replica_ids_size();
+      if (group_mode ==
+          CollectiveOpGroupMode::
+              COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA_AND_PARTITION) {
+        // Replicas from all partitions participate.
+        replica_subgroup_size *= config.num_partitions();
+      }
+      return replica_subgroup_size;
+    }
+    case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID:
+      // Empty replica groups not allowed in this mode.
+      return hlo->replica_groups()[0].replica_ids_size();
+    case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION:
+      return hlo->replica_groups().empty()
+                 ? config.num_partitions()
+                 : hlo->replica_groups()[0].replica_ids_size();
+    default:
+      LOG(FATAL) << "Invalid collective op group mode: " << group_mode;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Global device ID utilities.
+//===----------------------------------------------------------------------===//
 
 absl::StatusOr<std::vector<std::vector<GlobalDeviceId>>>
 GetParticipatingDevicesGroups(const DeviceAssignment& device_assignment,
@@ -402,106 +830,9 @@ GetParticipatingDevicesGroups(const HloInstruction* collective) {
   const DeviceAssignment& device_assignment =
       collective->GetModule()->config().static_device_assignment();
   ABSL_ASSIGN_OR_RETURN(CollectiveOpGroupMode mode,
-                   GetCollectiveOpGroupMode(collective));
+                        GetCollectiveOpGroupMode(collective));
   return GetParticipatingDevicesGroups(device_assignment,
                                        collective->replica_groups(), mode);
-}
-
-absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>>
-GetParticipatingFlattenedIdGroups(
-    const DeviceAssignment& device_assignment,
-    const CollectiveDeviceListBase& collective_device_list,
-    CollectiveOpGroupMode group_mode) {
-  return GetParticipatingFlattenedIdGroups(
-      collective_device_list, group_mode, device_assignment.replica_count(),
-      device_assignment.computation_count());
-}
-
-absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>>
-GetParticipatingFlattenedIdGroups(
-    const CollectiveDeviceListBase& collective_device_list,
-    CollectiveOpGroupMode group_mode, int replica_count, int partition_count) {
-  if (group_mode ==
-      CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID) {
-    return collective_device_list.Clone();
-  }
-  std::vector<ReplicaGroup> filled_empty_replica_group;
-  absl::Span<const ReplicaGroup> original_replica_groups =
-      collective_device_list.replica_groups();
-  std::vector<ReplicaGroup> flattened_replica_groups;
-  if (collective_device_list.replica_groups().empty()) {
-    filled_empty_replica_group.emplace_back();
-    const int64_t id_count =
-        group_mode ==
-                CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION
-            ? partition_count
-            : replica_count;
-    for (int i = 0; i < id_count; ++i) {
-      filled_empty_replica_group.back().add_replica_ids(i);
-    }
-    original_replica_groups = filled_empty_replica_group;
-  }
-  if (group_mode ==
-      CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA) {
-    flattened_replica_groups.resize(original_replica_groups.size() *
-                                    partition_count);
-    for (int64_t i = 0, current_group_offset = 0;
-         i < original_replica_groups.size();
-         ++i, current_group_offset += partition_count) {
-      for (int64_t replica_id : original_replica_groups.at(i).replica_ids()) {
-        for (int64_t partition_id = 0; partition_id < partition_count;
-             ++partition_id) {
-          const int64_t flattened_id =
-              replica_id * partition_count + partition_id;
-          flattened_replica_groups[current_group_offset + partition_id]
-              .add_replica_ids(flattened_id);
-        }
-      }
-    }
-  } else if (group_mode ==
-             CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION) {
-    flattened_replica_groups.resize(original_replica_groups.size() *
-                                    replica_count);
-    for (int64_t i = 0, current_group_offset = 0;
-         i < original_replica_groups.size();
-         ++i, current_group_offset += replica_count) {
-      for (int64_t partition_id : original_replica_groups.at(i).replica_ids()) {
-        for (int64_t replica_id = 0; replica_id < replica_count; ++replica_id) {
-          const int64_t flattened_id =
-              replica_id * partition_count + partition_id;
-          flattened_replica_groups[current_group_offset + replica_id]
-              .add_replica_ids(flattened_id);
-        }
-      }
-    }
-  } else {
-    CHECK(group_mode ==
-          CollectiveOpGroupMode::
-              COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA_AND_PARTITION);
-    flattened_replica_groups.resize(original_replica_groups.size());
-    for (int64_t i = 0; i < original_replica_groups.size(); ++i) {
-      for (int64_t replica_id : original_replica_groups.at(i).replica_ids()) {
-        for (int64_t partition_id = 0; partition_id < partition_count;
-             ++partition_id) {
-          const int64_t flattened_id =
-              replica_id * partition_count + partition_id;
-          flattened_replica_groups[i].add_replica_ids(flattened_id);
-        }
-      }
-    }
-  }
-  return std::make_unique<CollectiveDeviceList>(flattened_replica_groups);
-}
-
-absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>>
-GetParticipatingFlattenedIdGroups(const HloInstruction* hlo,
-                                  const DeviceAssignment& device_assignment) {
-  ABSL_ASSIGN_OR_RETURN(CollectiveOpGroupMode mode, GetCollectiveOpGroupMode(hlo));
-  ABSL_ASSIGN_OR_RETURN(
-      std::unique_ptr<CollectiveDeviceListBase> collective_device_list,
-      GetParticipatingFlattenedIdGroups(device_assignment, *hlo->device_list(),
-                                        mode));
-  return collective_device_list;
 }
 
 absl::StatusOr<std::vector<GlobalDeviceId>> GetParticipatingDevices(
@@ -512,7 +843,7 @@ absl::StatusOr<std::vector<GlobalDeviceId>> GetParticipatingDevices(
   int partition_count = device_assignment.computation_count();
 
   ABSL_ASSIGN_OR_RETURN(const DeviceAssignment::LogicalID logical_id,
-                   device_assignment.LogicalIdForDevice(device_id));
+                        device_assignment.LogicalIdForDevice(device_id));
   int current_replica_id = logical_id.replica_id;
   int current_partition_id = logical_id.computation_id;
   TF_RET_CHECK(0 <= current_replica_id && current_replica_id < replica_count)
@@ -528,8 +859,8 @@ absl::StatusOr<std::vector<GlobalDeviceId>> GetParticipatingDevices(
       // use current replica id to find the set of participating replicas. If
       // replica groups are empty, assume a group with all replicas.
       ABSL_ASSIGN_OR_RETURN(std::vector<int> participating_replicas,
-                       GetParticipatingIDs(group_mode, current_replica_id,
-                                           replica_count, replica_groups));
+                            GetParticipatingIDs(group_mode, current_replica_id,
+                                                replica_count, replica_groups));
 
       // The set of participating devices is the replicas from the current
       // partition.
@@ -546,9 +877,10 @@ absl::StatusOr<std::vector<GlobalDeviceId>> GetParticipatingDevices(
     case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION: {
       // replica_groups contain partition_id, group contains all partitions for
       // the current replica.
-      ABSL_ASSIGN_OR_RETURN(std::vector<int> participating_partitions,
-                       GetParticipatingIDs(group_mode, current_partition_id,
-                                           partition_count, replica_groups));
+      ABSL_ASSIGN_OR_RETURN(
+          std::vector<int> participating_partitions,
+          GetParticipatingIDs(group_mode, current_partition_id, partition_count,
+                              replica_groups));
       participants.reserve(participating_partitions.size());
       for (int partition_id : participating_partitions) {
         TF_RET_CHECK(0 <= partition_id && partition_id < partition_count)
@@ -564,8 +896,8 @@ absl::StatusOr<std::vector<GlobalDeviceId>> GetParticipatingDevices(
       // replica_groups contain replica_ids. Group contains replicas for all
       // partitions.
       ABSL_ASSIGN_OR_RETURN(std::vector<int> participating_replicas,
-                       GetParticipatingIDs(group_mode, current_replica_id,
-                                           replica_count, replica_groups));
+                            GetParticipatingIDs(group_mode, current_replica_id,
+                                                replica_count, replica_groups));
       participants.reserve(participating_replicas.size() * partition_count);
       for (int replica_id : participating_replicas) {
         TF_RET_CHECK(0 <= replica_id && replica_id < replica_count)
@@ -613,325 +945,9 @@ absl::StatusOr<std::vector<GlobalDeviceId>> GetParticipatingDevices(
   }
 }
 
-absl::StatusOr<std::vector<int64_t>> GetPariticipantCountsForReplicaGroups(
-    int64_t num_replicas, int64_t num_partitions,
-    absl::Span<const ReplicaGroup> replica_groups,
-    CollectiveOpGroupMode group_mode) {
-  std::vector<int64_t> participant_counts;
-
-  // If replica groups are empty, assume a group with all replicas.
-  std::optional<ReplicaGroup> all_replica_groups;
-  if (replica_groups.empty()) {
-    if (group_mode ==
-        CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID) {
-      // replica groups contain flattened-ids and cannot be empty.
-      TF_RET_CHECK(!replica_groups.empty())
-          << "replica groups cannot be empty for kFlattenedID mode";
-    }
-
-    int total_participant_count;
-    if (group_mode ==
-        CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION) {
-      // replica group are partition ids.
-      total_participant_count = num_partitions;
-    } else {
-      // replica group are replica ids.
-      total_participant_count = num_replicas;
-    }
-
-    all_replica_groups.emplace();
-    all_replica_groups->mutable_replica_ids()->Reserve(total_participant_count);
-    for (int id = 0; id < total_participant_count; id++) {
-      all_replica_groups->add_replica_ids(id);
-    }
-    replica_groups = absl::MakeConstSpan(&*all_replica_groups, 1);
-  }
-
-  switch (group_mode) {
-    case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA: {
-      for (const auto& replica_group : replica_groups) {
-        for (int partition_id = 0; partition_id < num_partitions;
-             ++partition_id) {
-          participant_counts.push_back(replica_group.replica_ids().size());
-        }
-      }
-      return participant_counts;
-    }
-    case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION: {
-      for (const auto& replica_group : replica_groups) {
-        participant_counts.push_back(replica_group.replica_ids().size());
-      }
-      return participant_counts;
-    }
-    case CollectiveOpGroupMode::
-        COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA_AND_PARTITION: {
-      for (const auto& replica_group : replica_groups) {
-        participant_counts.push_back(replica_group.replica_ids().size() *
-                                     num_partitions);
-      }
-      return participant_counts;
-    }
-    case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID: {
-      for (const auto& replica_group : replica_groups) {
-        participant_counts.push_back(replica_group.replica_ids().size());
-      }
-      return participant_counts;
-    }
-    default: {
-      return InvalidArgument("Invalid collective op group mode: %d",
-                             static_cast<int>(group_mode));
-    }
-  }
-}
-
-absl::StatusOr<std::optional<std::pair<int64_t, int64_t>>>
-GetReplicaGroupCountAndSize(const HloInstruction* hlo) {
-  std::shared_ptr<CollectiveDeviceListBase> device_list = hlo->device_list();
-  auto config = hlo->GetModule()->config();
-
-  if (device_list->version() == CollectiveDeviceListVersion::kIota) {
-    return std::make_pair(device_list->num_replica_groups(),
-                          device_list->num_devices_per_group());
-  }
-  ABSL_ASSIGN_OR_RETURN(CollectiveOpGroupMode group_mode,
-                   GetCollectiveOpGroupMode(hlo));
-  ABSL_ASSIGN_OR_RETURN(std::vector<int64_t> participant_counts,
-                   GetPariticipantCountsForReplicaGroups(
-                       config.replica_count(), config.num_partitions(),
-                       device_list->replica_groups(), group_mode));
-  int64_t replica_group_size = participant_counts[0];
-  for (int64_t participant_count : participant_counts) {
-    if (participant_count != replica_group_size) {
-      return std::nullopt;
-    }
-  }
-  return std::make_pair(participant_counts.size(), replica_group_size);
-}
-
-bool ReplicaGroupsOrthogonal(absl::Span<const ReplicaGroup> first,
-                             absl::Span<const ReplicaGroup> second) {
-  if (first.size() != second[0].replica_ids_size()) {
-    return false;
-  }
-  if (first[0].replica_ids_size() != second.size()) {
-    return false;
-  }
-  for (int64_t i = 0; i < first.size(); ++i) {
-    for (int64_t j = 0; j < first[i].replica_ids_size(); ++j) {
-      if (first[i].replica_ids(j) != second[j].replica_ids(i)) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
-bool ReplicaGroupsEqual(absl::Span<const ReplicaGroup> first,
-                        absl::Span<const ReplicaGroup> second) {
-  if (first.size() != second.size()) {
-    return false;
-  }
-  for (int64_t i = 0; i < first.size(); ++i) {
-    if (first[i].replica_ids_size() != second[i].replica_ids_size()) {
-      return false;
-    }
-    for (int j = 0; j < first[i].replica_ids_size(); ++j) {
-      if (first[i].replica_ids(j) != second[i].replica_ids(j)) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
-bool IsNonFusionCollective(const HloInstruction* instruction) {
-  switch (instruction->opcode()) {
-    case HloOpcode::kAllReduce:
-    case HloOpcode::kAllReduceStart:
-    case HloOpcode::kAllReduceDone:
-    case HloOpcode::kAllGather:
-    case HloOpcode::kAllGatherStart:
-    case HloOpcode::kAllGatherDone:
-    case HloOpcode::kAllToAll:
-    case HloOpcode::kCollectiveBroadcast:
-    case HloOpcode::kCollectivePermute:
-    case HloOpcode::kCollectivePermuteStart:
-    case HloOpcode::kCollectivePermuteDone:
-    case HloOpcode::kRaggedAllToAll:
-    case HloOpcode::kReduceScatter:
-      return true;
-    case HloOpcode::kAsyncStart:
-    case HloOpcode::kAsyncUpdate:
-    case HloOpcode::kAsyncDone:
-      return IsNonFusionCollective(instruction->async_wrapped_instruction());
-    case HloOpcode::kSend:
-    case HloOpcode::kRecv:
-      return !Cast<HloSendRecvInstruction>(instruction)->is_host_transfer();
-    default:
-      return false;
-  }
-}
-
-bool IsCollective(const HloInstruction* instruction) {
-  if (IsNonFusionCollective(instruction)) {
-    return true;
-  }
-  if (instruction->opcode() == HloOpcode::kFusion &&
-      instruction->IsCustomFusion()) {
-    for (const auto* inner_inst : instruction->fused_instructions()) {
-      if (IsCollective(inner_inst)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-absl::StatusOr<bool> IsAsyncCollective(const HloInstruction* instruction) {
-  if (!IsNonFusionCollective(instruction)) {
-    return false;
-  }
-  if (instruction->IsAsynchronous()) {
-    switch (instruction->async_wrapped_opcode()) {
-      case HloOpcode::kAllGather:
-      case HloOpcode::kAllReduce:
-      case HloOpcode::kAllToAll:
-      case HloOpcode::kCollectiveBroadcast:
-      case HloOpcode::kCollectivePermute:
-      case HloOpcode::kRaggedAllToAll:
-      case HloOpcode::kReduceScatter:
-        return true;
-      default:
-        return absl::InvalidArgumentError("Async instruction " +
-                                          instruction->ToString() +
-                                          " is not a collective.");
-    }
-  }
-  switch (instruction->opcode()) {
-    case HloOpcode::kAllGatherStart:
-    case HloOpcode::kAllGatherDone:
-    case HloOpcode::kAllReduceStart:
-    case HloOpcode::kAllReduceDone:
-    case HloOpcode::kCollectivePermuteStart:
-    case HloOpcode::kCollectivePermuteDone:
-      return true;
-    case HloOpcode::kSend:
-    case HloOpcode::kRecv:
-      return !Cast<HloSendRecvInstruction>(instruction)->is_host_transfer();
-    case HloOpcode::kAllGather:
-    case HloOpcode::kAllReduce:
-    case HloOpcode::kAllToAll:
-    case HloOpcode::kCollectiveBroadcast:
-    case HloOpcode::kCollectivePermute:
-    case HloOpcode::kRaggedAllToAll:
-    case HloOpcode::kReduceScatter:
-      return false;
-    default:
-      return absl::InvalidArgumentError("Instruction " +
-                                        instruction->ToString() +
-                                        " is not an async collective.");
-  }
-}
-
-bool IsRaggedAllToAllOrAsyncStartRaggedAllToAll(
-    const HloInstruction* instruction) {
-  return instruction->opcode() == HloOpcode::kRaggedAllToAll ||
-         (instruction->opcode() == HloOpcode::kAsyncStart &&
-          instruction->async_wrapped_opcode() == HloOpcode::kRaggedAllToAll);
-}
-
-bool IsRaggedAllToAllOrAsyncDoneRaggedAllToAll(
-    const HloInstruction* instruction) {
-  return instruction->opcode() == HloOpcode::kRaggedAllToAll ||
-         (instruction->opcode() == HloOpcode::kAsyncDone &&
-          instruction->async_wrapped_opcode() == HloOpcode::kRaggedAllToAll);
-}
-
-bool IsOneShotRaggedAllToAllWithNcclEnabled(const DebugOptions& opts) {
-  return opts.xla_gpu_experimental_ragged_all_to_all_use_barrier_with_nccl();
-}
-
-HloInstruction* IsOrHasCollectiveWithChannelId(HloInstruction* instruction) {
-  if (instruction->opcode() == HloOpcode::kFusion) {
-    for (auto* inner_inst : instruction->fused_instructions()) {
-      if (IsOrHasCollectiveWithChannelId(inner_inst) != nullptr) {
-        return inner_inst;
-      }
-    }
-    return nullptr;
-  }
-  if (DynCast<HloChannelInstruction>(instruction) == nullptr) {
-    return nullptr;
-  }
-  if (IsCollective(instruction) && instruction->channel_id().has_value()) {
-    return instruction;
-  }
-  return nullptr;
-}
-
-bool IsExclusivelyCrossModule(absl::Span<const ReplicaGroup> replica_groups,
-                              bool use_global_ids, bool has_channel_id,
-                              const DeviceAssignment& device_assignment) {
-  if (!has_channel_id) {
-    return false;
-  }
-  if (!use_global_ids) {
-    // Each id in a replica group is a replica id. If any group
-    // has more than one id then this is not exclusively cross module.
-    for (const ReplicaGroup& replica_group : replica_groups) {
-      if (replica_group.replica_ids_size() != 1) {
-        return false;
-      }
-    }
-    return true;
-  }
-  // Each id in a replica group is a global id. Check if all replica groups are
-  // exclusively cross module (all participants in a group have the same replica
-  // id).
-  const int64_t partition_count = device_assignment.computation_count();
-  for (const ReplicaGroup& replica_group : replica_groups) {
-    std::optional<int64_t> first_replica_id;
-    for (int64_t global_id : replica_group.replica_ids()) {
-      int64_t replica_id = global_id / partition_count;
-      if (!first_replica_id.has_value()) {
-        first_replica_id = replica_id;
-      } else if (replica_id != first_replica_id) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
-bool IsExclusivelyCrossReplica(absl::Span<const ReplicaGroup> replica_groups,
-                               bool use_global_ids, bool has_channel_id,
-                               const DeviceAssignment& device_assignment) {
-  if (!has_channel_id) {
-    return true;
-  }
-  const int64_t partition_count = device_assignment.computation_count();
-  if (!use_global_ids) {
-    // Each id in a replica group is a replica id and we will perform the
-    // collective between all devices with that replica id. If partition count
-    // is > 1, then this is not exclusively cross replica.
-    return partition_count == 1;
-  }
-  // Each id in a replica group is a global id. Check if all replica groups are
-  // exclusively cross replica (all participants in a group have the same
-  // partition id).
-  for (const ReplicaGroup& replica_group : replica_groups) {
-    std::optional<int64_t> first_partition_id;
-    for (int64_t global_id : replica_group.replica_ids()) {
-      int64_t partition_id = global_id % partition_count;
-      if (!first_partition_id.has_value()) {
-        first_partition_id = partition_id;
-      } else if (partition_id != first_partition_id) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
+//===----------------------------------------------------------------------===//
+// Point-to-point utilities.
+//===----------------------------------------------------------------------===//
 
 bool HasDuplicateSourcesOrTargets(const SourceTargetPairs& pairs) {
   std::set<int> sources;
@@ -946,35 +962,50 @@ bool HasDuplicateSourcesOrTargets(const SourceTargetPairs& pairs) {
   return false;
 }
 
-int64_t GetSubgroupSize(const HloCollectiveInstruction* hlo,
-                        CollectiveOpGroupMode group_mode) {
-  const HloModuleConfig& config = hlo->GetModule()->config();
-  switch (group_mode) {
-    case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA:
-    case CollectiveOpGroupMode::
-        COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA_AND_PARTITION: {
-      int64_t replica_subgroup_size =
-          hlo->replica_groups().empty()
-              ? config.replica_count()
-              : hlo->replica_groups()[0].replica_ids_size();
-      if (group_mode ==
-          CollectiveOpGroupMode::
-              COLLECTIVE_OP_GROUP_MODE_CROSS_REPLICA_AND_PARTITION) {
-        // Replicas from all partitions participate.
-        replica_subgroup_size *= config.num_partitions();
-      }
-      return replica_subgroup_size;
-    }
-    case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_FLATTENED_ID:
-      // Empty replica groups not allowed in this mode.
-      return hlo->replica_groups()[0].replica_ids_size();
-    case CollectiveOpGroupMode::COLLECTIVE_OP_GROUP_MODE_CROSS_PARTITION:
-      return hlo->replica_groups().empty()
-                 ? config.num_partitions()
-                 : hlo->replica_groups()[0].replica_ids_size();
-    default:
-      LOG(FATAL) << "Invalid collective op group mode: " << group_mode;
+//===----------------------------------------------------------------------===//
+// Collective group attributes.
+//===----------------------------------------------------------------------===//
+
+std::optional<absl::string_view> GetCollectiveGroupKey(
+    const HloInstruction& instruction) {
+  const auto& attributes = instruction.frontend_attributes().map();
+  auto it = attributes.find(kCollectiveGroupKeyAttr);
+  if (it == attributes.end() || it->second.empty()) {
+    return std::nullopt;
   }
+  return it->second;
+}
+
+bool HasCollectiveGroupKey(const HloInstruction& instruction) {
+  return GetCollectiveGroupKey(instruction).has_value();
+}
+
+bool HaveCompatibleCollectiveGroupKeys(const HloInstruction& lhs,
+                                       const HloInstruction& rhs) {
+  return GetCollectiveGroupKey(lhs) == GetCollectiveGroupKey(rhs);
+}
+
+void CopyCollectiveGroupKey(const HloInstruction& source,
+                            HloInstruction& destination) {
+  std::optional<std::string> value =
+      source.get_frontend_attribute(kCollectiveGroupKeyAttr);
+  if (value.has_value()) {
+    destination.set_frontend_attribute(kCollectiveGroupKeyAttr, *value);
+  } else {
+    destination.erase_frontend_attribute(kCollectiveGroupKeyAttr);
+  }
+}
+
+void ClearCollectiveGroupKey(HloInstruction& instruction) {
+  instruction.erase_frontend_attribute(kCollectiveGroupKeyAttr);
+}
+
+//===----------------------------------------------------------------------===//
+// Collective execution utilities.
+//===----------------------------------------------------------------------===//
+
+bool IsOneShotRaggedAllToAllWithNcclEnabled(const DebugOptions& opts) {
+  return opts.xla_gpu_experimental_ragged_all_to_all_use_barrier_with_nccl();
 }
 
 namespace {
@@ -1105,6 +1136,10 @@ bool IsNcclSymmetricBuffersEnabledForCollective(
   NcclSymmetricBuffersSpec spec(opts);
   return spec.IsEnabled(*instruction);
 }
+
+//===----------------------------------------------------------------------===//
+// Async collective configuration.
+//===----------------------------------------------------------------------===//
 
 absl::StatusOr<AsyncCollectiveConfig> ParseAsyncCollectiveConfig(
     absl::string_view config_json_str) {

--- a/xla/service/collective_ops_utils.h
+++ b/xla/service/collective_ops_utils.h
@@ -45,30 +45,9 @@ limitations under the License.
 
 namespace xla {
 
-// Returns the nonempty collective_group_key frontend attribute. An absent or
-// empty attribute does not opt the instruction into collective grouping.
-std::optional<absl::string_view> GetCollectiveGroupKey(
-    const HloInstruction& instruction);
-
-// Returns whether an instruction has a nonempty collective_group_key frontend
-// attribute.
-bool HasCollectiveGroupKey(const HloInstruction& instruction);
-
-// Returns whether two distinct collective payloads may be coalesced without
-// changing explicit collective groups. Nonempty collective group keys must
-// match; an absent or empty key matches only another absent or empty key.
-// This compatibility check must not gate common-subexpression elimination or
-// decomposition into an equivalent sequence of operations.
-bool HaveCompatibleCollectiveGroupKeys(const HloInstruction& lhs,
-                                       const HloInstruction& rhs);
-
-// Copies the collective_group_key from `source` to `destination`. Attribute
-// absence is copied as well, so any existing key on `destination` is cleared.
-void CopyCollectiveGroupKey(const HloInstruction& source,
-                            HloInstruction& destination);
-
-// Removes the collective_group_key attribute.
-void ClearCollectiveGroupKey(HloInstruction& instruction);
+//===----------------------------------------------------------------------===//
+// Reduction utilities.
+//===----------------------------------------------------------------------===//
 
 absl::StatusOr<ReductionKind> StringToReductionKind(
     absl::string_view reduction_kind);
@@ -104,6 +83,38 @@ HloOpcode ReductionKindToOpcode(ReductionKind reduction_kind,
 std::optional<Literal> GetReductionIdentity(ReductionKind kind,
                                             PrimitiveType type);
 
+//===----------------------------------------------------------------------===//
+// Collective operation classification.
+//===----------------------------------------------------------------------===//
+
+// Returns true if instruction is a collective op that is not a collective
+// fusion.
+bool IsNonFusionCollective(const HloInstruction* instruction);
+
+// Returns true if instruction is a collective op or a collective fusion.
+bool IsCollective(const HloInstruction* instruction);
+
+// Returns true if instruction is an async collective op.
+absl::StatusOr<bool> IsAsyncCollective(const HloInstruction* instruction);
+
+// Returns true if instruction is a RaggedAllToAll op or an async-start that
+// wraps a RaggedAllToAll op.
+bool IsRaggedAllToAllOrAsyncStartRaggedAllToAll(
+    const HloInstruction* instruction);
+
+// Returns true if instruction is a RaggedAllToAll op or an async-done that
+// wraps a RaggedAllToAll op.
+bool IsRaggedAllToAllOrAsyncDoneRaggedAllToAll(
+    const HloInstruction* instruction);
+
+// Returns the collective instruction if argument is a collective op (or a
+// collective fusion) with channel_id.
+HloInstruction* IsOrHasCollectiveWithChannelId(HloInstruction* instruction);
+
+//===----------------------------------------------------------------------===//
+// Replica group utilities.
+//===----------------------------------------------------------------------===//
+
 // Figures out which IDs are participating in the collective subgroup.
 // An empty `groups` indicates that all [0, total_participant_count) IDs
 // are participating. Note that for CollectiveOpGroupMode::kFlattenedID,
@@ -132,6 +143,61 @@ absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>> GetAsyncReplicaGroups(
 //   * HloRaggedAllToAllInstruction
 absl::StatusOr<CollectiveOpGroupMode> GetCollectiveOpGroupMode(
     const HloInstruction* instr);
+
+// Returns the flattened IDs in each participating replica group.
+absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>>
+GetParticipatingFlattenedIdGroups(
+    const DeviceAssignment& device_assignment,
+    const CollectiveDeviceListBase& collective_device_list,
+    CollectiveOpGroupMode group_mode);
+
+// Same as above, but takes replica and partition counts instead of a device
+// assignment.
+absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>>
+GetParticipatingFlattenedIdGroups(
+    const CollectiveDeviceListBase& collective_device_list,
+    CollectiveOpGroupMode group_mode, int replica_count, int partition_count);
+
+// Same as above, with collective group mode determined by the collective
+// instruction.
+absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>>
+GetParticipatingFlattenedIdGroups(const HloInstruction* hlo,
+                                  const DeviceAssignment& device_assignment);
+
+// Figures out how many ranks are participating in each collective subgroup.
+absl::StatusOr<std::vector<int64_t>> GetParticipantCountsForReplicaGroups(
+    int64_t num_replicas, int64_t num_partitions,
+    absl::Span<const ReplicaGroup> replica_groups,
+    CollectiveOpGroupMode group_mode);
+
+absl::StatusOr<std::optional<std::pair<int64_t, int64_t>>>
+GetReplicaGroupCountAndSize(const HloInstruction* hlo);
+
+// Returns true if the two replica groups are orthogonal.
+bool ReplicaGroupsOrthogonal(absl::Span<const ReplicaGroup> first,
+                             absl::Span<const ReplicaGroup> second);
+
+// Returns true if the two replica groups are equal.
+bool ReplicaGroupsEqual(absl::Span<const ReplicaGroup> first,
+                        absl::Span<const ReplicaGroup> second);
+
+// Returns true if all subgroups in replica_groups are exclusively cross-module.
+bool IsExclusivelyCrossModule(absl::Span<const ReplicaGroup> replica_groups,
+                              bool use_global_ids, bool has_channel_id,
+                              const DeviceAssignment& device_assignment);
+
+// Returns true if all subgroups in replica_groups are exclusively
+// cross-replica.
+bool IsExclusivelyCrossReplica(absl::Span<const ReplicaGroup> replica_groups,
+                               bool use_global_ids, bool has_channel_id,
+                               const DeviceAssignment& device_assignment);
+
+int64_t GetSubgroupSize(const HloCollectiveInstruction* hlo,
+                        CollectiveOpGroupMode group_mode);
+
+//===----------------------------------------------------------------------===//
+// Global device ID utilities.
+//===----------------------------------------------------------------------===//
 
 // Figures out subgroups of participating devices from given replica_groups and
 // group_mode.
@@ -164,96 +230,68 @@ GetParticipatingDevicesGroups(const DeviceAssignment& device_assignment,
 absl::StatusOr<std::vector<std::vector<GlobalDeviceId>>>
 GetParticipatingDevicesGroups(const HloInstruction* collective);
 
-// Same as above, except that it returns the flattened id in the replica groups
-// instead of device id.
-absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>>
-GetParticipatingFlattenedIdGroups(
-    const DeviceAssignment& device_assignment,
-    const CollectiveDeviceListBase& collective_device_list,
-    CollectiveOpGroupMode group_mode);
-
-// Same as above, but take replica/partition count instead of device assignment.
-absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>>
-GetParticipatingFlattenedIdGroups(
-    const CollectiveDeviceListBase& collective_device_list,
-    CollectiveOpGroupMode group_mode, int replica_count, int partition_count);
-
-// Same as above, with collective group mode determined by the collective
-// instruction.
-absl::StatusOr<std::unique_ptr<CollectiveDeviceListBase>>
-GetParticipatingFlattenedIdGroups(const HloInstruction* hlo,
-                                  const DeviceAssignment& device_assignment);
-
 // Figures out which devices are participating in the collective subgroup.
 absl::StatusOr<std::vector<GlobalDeviceId>> GetParticipatingDevices(
     GlobalDeviceId device_id, const DeviceAssignment& device_assignment,
     absl::Span<const ReplicaGroup> replica_groups,
     CollectiveOpGroupMode group_mode);
 
-// Figures out how many ranks are participating in each collective subgroup.
-absl::StatusOr<std::vector<int64_t>> GetPariticipantCountsForReplicaGroups(
-    int64_t num_replicas, int64_t num_partitions,
-    absl::Span<const ReplicaGroup> replica_groups,
-    CollectiveOpGroupMode group_mode);
-
-absl::StatusOr<std::optional<std::pair<int64_t, int64_t>>>
-GetReplicaGroupCountAndSize(const HloInstruction* hlo);
-
-// Returns true if the two replica group are orthogonal.
-bool ReplicaGroupsOrthogonal(absl::Span<const ReplicaGroup> first,
-                             absl::Span<const ReplicaGroup> second);
-
-// Returns true if the two replica group are Equal.
-bool ReplicaGroupsEqual(absl::Span<const ReplicaGroup> first,
-                        absl::Span<const ReplicaGroup> second);
-
-// Returns true if all subgroups in replica_groups are exclusively cross-module.
-bool IsExclusivelyCrossModule(absl::Span<const ReplicaGroup> replica_groups,
-                              bool use_global_ids, bool has_channel_id,
-                              const DeviceAssignment& device_assignment);
-
-// Returns true if all subgroups in replica_groups are exclusively
-// cross-replica.
-bool IsExclusivelyCrossReplica(absl::Span<const ReplicaGroup> replica_groups,
-                               bool use_global_ids, bool has_channel_id,
-                               const DeviceAssignment& device_assignment);
+//===----------------------------------------------------------------------===//
+// Point-to-point utilities.
+//===----------------------------------------------------------------------===//
 
 bool HasDuplicateSourcesOrTargets(const SourceTargetPairs& pairs);
 
-// A custom call target that can be used to create a nop that can legally
-// replace a collective op.
-inline constexpr absl::string_view kNopCustomCallTarget = "AllocateBuffer";
-// A custom call target that can be used to create a nop that can legally
-// replace a collective op and it returns a token.
-inline constexpr absl::string_view kNopReturnTokenCustomCallTarget =
-    "NopReturnToken";
+// We only pipeline Send-Recv chains with channel_id > 0, where each chain has a
+// unique channel_id, and allow multiple Send-Recv chains using channel_id 0.
+inline bool MayPipelineSendRecvChannel(int64_t channel_id) {
+  return channel_id > 0;
+}
 
-// Returns true if instruction is a collective op that is not a collective
-// fusion.
-bool IsNonFusionCollective(const HloInstruction* instruction);
+// When a Send or Recv is annotated with frontend attribute
+// _xla_send_recv_pipeline="1", asynchronous stream kP2P1 is used to execute the
+// Send or Recv. For all other cases, asynchronous stream kP2P0 is used.
+inline constexpr char kSendRecvPipelineAttr[] = "_xla_send_recv_pipeline";
 
-// Returns true if instruction is a collective op or a collective fusion.
-bool IsCollective(const HloInstruction* instruction);
+// Attribute to indicate that collective operations should be issued on a
+// dedicated p2p stream. This is a hint and there is no guarantee that this will
+// be honored.
+inline constexpr absl::string_view kCollectiveStreamAttrName =
+    "_xla_gpu_collective_stream";
+inline constexpr absl::string_view kCollectiveStreamP2P = "p2p";
 
-// Returns true if instruction is an async collective op.
-absl::StatusOr<bool> IsAsyncCollective(const HloInstruction* instruction);
+//===----------------------------------------------------------------------===//
+// Collective group attributes.
+//===----------------------------------------------------------------------===//
 
-// Returns true if instruction is a RaggedAllToAll op or an async-start that
-// wraps a RaggedAllToAll op.
-bool IsRaggedAllToAllOrAsyncStartRaggedAllToAll(
-    const HloInstruction* instruction);
+// Returns the nonempty collective_group_key frontend attribute. An absent or
+// empty attribute does not opt the instruction into collective grouping.
+std::optional<absl::string_view> GetCollectiveGroupKey(
+    const HloInstruction& instruction);
 
-// Returns true if instruction is a RaggedAllToAll op or an async-done that
-// wraps a RaggedAllToAll op.
-bool IsRaggedAllToAllOrAsyncDoneRaggedAllToAll(
-    const HloInstruction* instruction);
+// Returns whether an instruction has a nonempty collective_group_key frontend
+// attribute.
+bool HasCollectiveGroupKey(const HloInstruction& instruction);
 
-// Returns true if the one-shot RaggedAllToAll with NCCL feature is enabled.
-bool IsOneShotRaggedAllToAllWithNcclEnabled(const DebugOptions& opts);
+// Returns whether two distinct collective payloads may be coalesced without
+// changing explicit collective groups. Nonempty collective group keys must
+// match; an absent or empty key matches only another absent or empty key.
+// This compatibility check must not gate common-subexpression elimination or
+// decomposition into an equivalent sequence of operations.
+bool HaveCompatibleCollectiveGroupKeys(const HloInstruction& lhs,
+                                       const HloInstruction& rhs);
 
-// Returns the collective instruction if argument is a collective op (or a
-// collective fusion) with channel_id.
-HloInstruction* IsOrHasCollectiveWithChannelId(HloInstruction* instruction);
+// Copies the collective_group_key from `source` to `destination`. Attribute
+// absence is copied as well, so any existing key on `destination` is cleared.
+void CopyCollectiveGroupKey(const HloInstruction& source,
+                            HloInstruction& destination);
+
+// Removes the collective_group_key attribute.
+void ClearCollectiveGroupKey(HloInstruction& instruction);
+
+//===----------------------------------------------------------------------===//
+// Collective rendezvous.
+//===----------------------------------------------------------------------===//
 
 // Key that identifies a particular Rendezvous object in our global hashtable.
 // This determines which calls to ExecuteOnStream communicate with each other.
@@ -333,27 +371,20 @@ struct RendezvousKey {
   int64_t op_id;
 };
 
-// We only pipeline Send-Recv chains with channel_id > 0, where each chain
-// has a unique channel_id, and allows multiple Send-Recv chains using
-// channel_id 0.
-inline bool MayPipelineSendRecvChannel(int64_t channel_id) {
-  return channel_id > 0;
-}
+//===----------------------------------------------------------------------===//
+// Collective execution utilities.
+//===----------------------------------------------------------------------===//
 
-// When a Send or Recv is annotated with frontend attribute
-// _xla_send_recv_pipeline="1", asynchronous stream kP2P1 is used to execute the
-// Send or Recv. For all other cases, asynchronous stream kP2P0 is used.
-inline constexpr char kSendRecvPipelineAttr[] = "_xla_send_recv_pipeline";
+// A custom call target that can be used to create a nop that can legally
+// replace a collective op.
+inline constexpr absl::string_view kNopCustomCallTarget = "AllocateBuffer";
+// A custom call target that can be used to create a nop that can legally
+// replace a collective op and it returns a token.
+inline constexpr absl::string_view kNopReturnTokenCustomCallTarget =
+    "NopReturnToken";
 
-// Attribute to indicate that collective operations should be issued on a
-// dedicated p2p stream. This is a hint and there is no guarantee that this will
-// be honored.
-inline constexpr absl::string_view kCollectiveStreamAttrName =
-    "_xla_gpu_collective_stream";
-inline constexpr absl::string_view kCollectiveStreamP2P = "p2p";
-
-int64_t GetSubgroupSize(const HloCollectiveInstruction* hlo,
-                        CollectiveOpGroupMode group_mode);
+// Returns true if the one-shot RaggedAllToAll with NCCL feature is enabled.
+bool IsOneShotRaggedAllToAllWithNcclEnabled(const DebugOptions& opts);
 
 class NcclSymmetricBuffersSpec {
  public:
@@ -372,6 +403,10 @@ class NcclSymmetricBuffersSpec {
 
 bool IsNcclSymmetricBuffersEnabledForCollective(
     const HloInstruction* instruction, const DebugOptions& opts);
+
+//===----------------------------------------------------------------------===//
+// Async collective configuration.
+//===----------------------------------------------------------------------===//
 
 struct AsyncCollectiveConfig {
   std::vector<ReplicaGroup> replica_groups;

--- a/xla/service/collective_ops_utils_test.cc
+++ b/xla/service/collective_ops_utils_test.cc
@@ -706,11 +706,11 @@ absl::StatusOr<std::unique_ptr<HloComputation>> CreateMaxComputation() {
   Shape scalar = ShapeUtil::MakeScalarShape(F32);
   auto builder_max = HloComputation::Builder("max");
   ABSL_ASSIGN_OR_RETURN(HloInstruction * a,
-                   builder_max.AddParameter(
-                       HloInstruction::CreateParameter(0, scalar, "a")));
+                        builder_max.AddParameter(
+                            HloInstruction::CreateParameter(0, scalar, "a")));
   ABSL_ASSIGN_OR_RETURN(HloInstruction * b,
-                   builder_max.AddParameter(
-                       HloInstruction::CreateParameter(1, scalar, "b")));
+                        builder_max.AddParameter(
+                            HloInstruction::CreateParameter(1, scalar, "b")));
   HloInstruction* max = builder_max.AddInstruction(
       HloInstruction::CreateBinary(scalar, HloOpcode::kMaximum, a, b), "max");
   return builder_max.Build(max);
@@ -826,7 +826,7 @@ struct TestCase {
   std::vector<std::vector<int64_t>> participating_device_groups;
   // Expected output for GetParticipatingFlattenedIdGroups.
   std::vector<std::vector<int64_t>> participating_flattened_id_groups;
-  // Expected output for GetPariticipantCountsForReplicaGroups.
+  // Expected output for GetParticipantCountsForReplicaGroups.
   std::vector<int64_t> participant_counts_for_replica_groups;
   // Expected output for GetReplicaGroupCountAndSize.
   std::optional<std::pair<int64_t, int64_t>> replica_group_count_and_size;
@@ -1199,10 +1199,10 @@ TEST_P(GetParticipatingTest, Test) {
   EXPECT_EQ(actual_flattened_id_groups_int,
             tc.participating_flattened_id_groups);
 
-  // Test GetPariticipantCountsForReplicaGroups.
+  // Test GetParticipantCountsForReplicaGroups.
   absl::StatusOr<std::vector<int64_t>> actual_participant_counts =
-      GetPariticipantCountsForReplicaGroups(num_replicas, num_partitions,
-                                            replica_groups, *group_mode);
+      GetParticipantCountsForReplicaGroups(num_replicas, num_partitions,
+                                           replica_groups, *group_mode);
   if (!actual_participant_counts.ok()) {
     EXPECT_TRUE(tc.expected_failure);
     return;
@@ -1257,7 +1257,7 @@ INSTANTIATE_TEST_SUITE_P(GetParticipating, GetParticipatingTest,
 
 }  // namespace GetParticipatingTest
 
-namespace GetPariticipantCountsForReplicaGroupsTest {
+namespace GetParticipantCountsForReplicaGroupsTest {
 
 struct TestCase {
   std::string test_name;
@@ -1268,18 +1268,18 @@ struct TestCase {
   std::vector<int64_t> expected;
 };
 
-class GetPariticipantCountsForReplicaGroupsTest
+class GetParticipantCountsForReplicaGroupsTest
     : public testing::TestWithParam<TestCase> {};
 
-TEST_P(GetPariticipantCountsForReplicaGroupsTest, Test) {
+TEST_P(GetParticipantCountsForReplicaGroupsTest, Test) {
   const TestCase& tc = GetParam();
 
   std::vector<ReplicaGroup> replica_groups =
       CreateReplicaGroups(tc.replica_groups);
   TF_ASSERT_OK_AND_ASSIGN(
       std::vector<int64_t> actual,
-      GetPariticipantCountsForReplicaGroups(tc.num_replicas, tc.num_partitions,
-                                            replica_groups, tc.group_mode));
+      GetParticipantCountsForReplicaGroups(tc.num_replicas, tc.num_partitions,
+                                           replica_groups, tc.group_mode));
   EXPECT_THAT(actual, testing::ElementsAreArray(tc.expected));
 }
 
@@ -1321,11 +1321,10 @@ std::vector<TestCase> GetTestCases() {
   };
 }
 INSTANTIATE_TEST_SUITE_P(
-    GetPariticipantCountsForReplicaGroups,
-    GetPariticipantCountsForReplicaGroupsTest,
-    testing::ValuesIn(GetTestCases()),
+    GetParticipantCountsForReplicaGroups,
+    GetParticipantCountsForReplicaGroupsTest, testing::ValuesIn(GetTestCases()),
     [](const testing::TestParamInfo<
-        GetPariticipantCountsForReplicaGroupsTest::ParamType>& info) {
+        GetParticipantCountsForReplicaGroupsTest::ParamType>& info) {
       return info.param.test_name;
     });
 
@@ -1337,7 +1336,7 @@ TEST(GetReductionIdentity, NoCrashForComplexType) {
   EXPECT_FALSE(identity.has_value());
 }
 
-}  // namespace GetPariticipantCountsForReplicaGroupsTest
+}  // namespace GetParticipantCountsForReplicaGroupsTest
 class IsNcclSymmetricBuffersEnabledForCollectiveTest : public ::testing::Test {
  protected:
   void SetUp() override {

--- a/xla/service/gpu/model/gpu_hlo_cost_analysis.cc
+++ b/xla/service/gpu/model/gpu_hlo_cost_analysis.cc
@@ -68,17 +68,18 @@ static constexpr absl::string_view kCollBytesTransferred =
 template <typename T>
 absl::StatusOr<int64_t> NumRanks(const T& instr) {
   const HloModuleConfig& config = instr.GetModule()->config();
-  ABSL_ASSIGN_OR_RETURN(CollectiveOpGroupMode group_mode,
-                   GetCollectiveOpGroupMode(instr.channel_id().has_value(),
-                                            instr.use_global_device_ids()));
+  ABSL_ASSIGN_OR_RETURN(
+      CollectiveOpGroupMode group_mode,
+      GetCollectiveOpGroupMode(instr.channel_id().has_value(),
+                               instr.use_global_device_ids()));
 
   // Get number of ranks for this instruction based on replica groups and mode.
   int64_t num_devices = config.num_partitions();
   int64_t num_replicas = config.replica_count();
   ABSL_ASSIGN_OR_RETURN(
       std::vector<int64_t> participant_counts,
-      GetPariticipantCountsForReplicaGroups(
-          num_replicas, num_devices, instr.replica_groups(), group_mode));
+      GetParticipantCountsForReplicaGroups(num_replicas, num_devices,
+                                           instr.replica_groups(), group_mode));
   int64_t num_ranks = 1;
 
   for (auto count : participant_counts) {
@@ -340,7 +341,7 @@ absl::Status GpuHloCostAnalysis::HandleCustomCall(
     // here:
     // https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemm
     ABSL_ASSIGN_OR_RETURN(auto gpu_config,
-                     custom_call->backend_config<gpu::GpuBackendConfig>());
+                          custom_call->backend_config<gpu::GpuBackendConfig>());
     const gpu::GemmBackendConfig& gemm_config =
         gpu_config.gemm_backend_config();
     // Technically, in addition to the dot product (A * B), cuBLAS gemm also
@@ -489,7 +490,7 @@ int64_t GpuHloCostAnalysis::GetFlopsForElementwiseOp(
 absl::Status GpuHloCostAnalysis::HandleAllReduce(
     const HloInstruction* allreduce) {
   ABSL_ASSIGN_OR_RETURN(int64_t num_ranks,
-                   NumRanks(*Cast<HloAllReduceInstruction>(allreduce)));
+                        NumRanks(*Cast<HloAllReduceInstruction>(allreduce)));
 
   VLOG(5) << "Computing cost for " << num_ranks << " ranks in "
           << allreduce->ToString();
@@ -607,7 +608,7 @@ void GpuHloCostAnalysis::SetRingCollectiveProperties(int64_t num_ranks,
 absl::Status GpuHloCostAnalysis::HandleAllReduceStart(
     const HloInstruction* hlo) {
   ABSL_ASSIGN_OR_RETURN(int64_t num_ranks,
-                   NumRanks(*Cast<HloAllReduceInstruction>(hlo)));
+                        NumRanks(*Cast<HloAllReduceInstruction>(hlo)));
 
   int64_t bytes_transferred = ShapeSize(hlo->shape(), options_.shape_size);
 
@@ -623,7 +624,7 @@ absl::Status GpuHloCostAnalysis::HandleAllReduceStart(
 
 absl::Status GpuHloCostAnalysis::HandleAllGather(const HloInstruction* hlo) {
   ABSL_ASSIGN_OR_RETURN(int64_t num_ranks,
-                   NumRanks(*Cast<HloAllGatherInstruction>(hlo)));
+                        NumRanks(*Cast<HloAllGatherInstruction>(hlo)));
 
   int64_t bytes_transferred = ShapeSize(hlo->shape(), options_.shape_size);
   int64_t rank_size_bytes = bytes_transferred / num_ranks;
@@ -640,7 +641,7 @@ absl::Status GpuHloCostAnalysis::HandleAllGather(const HloInstruction* hlo) {
 absl::Status GpuHloCostAnalysis::HandleAllGatherStart(
     const HloInstruction* hlo) {
   ABSL_ASSIGN_OR_RETURN(int64_t num_ranks,
-                   NumRanks(*Cast<HloAllGatherInstruction>(hlo)));
+                        NumRanks(*Cast<HloAllGatherInstruction>(hlo)));
 
   int64_t bytes_transferred =
       ShapeSize(hlo->shape(), options_.shape_size, /*index_to_skip=*/0);
@@ -670,7 +671,7 @@ absl::Status GpuHloCostAnalysis::HandleAsyncStart(const HloInstruction* hlo) {
 absl::Status GpuHloCostAnalysis::HandleReduceScatter(
     const HloInstruction* hlo) {
   ABSL_ASSIGN_OR_RETURN(int64_t num_ranks,
-                   NumRanks(*Cast<HloReduceScatterInstruction>(hlo)));
+                        NumRanks(*Cast<HloReduceScatterInstruction>(hlo)));
 
   int64_t bytes_transferred = 0;
   for (HloInstruction* operand : hlo->operands()) {


### PR DESCRIPTION
**NFC:** just moving code around to make it more human-friendly

`collective_ops_util.h` became a kitchen sink for anything that is anywhere close to collectives. Add `//===---===//` separators and group various APIs that are semantically close. This is first step before extracting functionality into separate targets (i.e. collective rendezvous certainly can be separate)

- Organize collective operation utilities into clearly delimited functional sections in both the header and implementation. 
- Group helpers for reduction, collective classification, replica groups, global device IDs, point-to-point operations, collective attributes, execution, and async configuration.
- Fix typo in `GetPariticipantCountsForReplicaGroups`
