### PR TITLE
[ROCm] Fix collective_ops_sharded_unsharded_e2e_test

### DIFF
--- a/xla/backends/gpu/tests/collective_ops_sharded_unsharded_e2e_test.cc
+++ b/xla/backends/gpu/tests/collective_ops_sharded_unsharded_e2e_test.cc
@@ -49,7 +49,7 @@ namespace {
 class CollectiveOpsTestE2EShardedUnsharded : public CollectiveOpsE2ETestBase {
  public:
   CollectiveOpsTestE2EShardedUnsharded()
-      : CollectiveOpsE2ETestBase(/*memory_size=*/64 * kMB,
+      : CollectiveOpsE2ETestBase(/*memory_size=*/128 * kMB,
                                  /*collectives_memory_size=*/0) {}
 
   void CollectiveOpsCompareShardedUnsharded(


### PR DESCRIPTION
📝 Summary of Changes
The PR increases the memory pool size used in the test from `64*kMb` to `128*kMb` (workspace size needed by hipBLASLt on gfx942 is 76MiB https://github.com/openxla/xla/blob/ca49fde4e8646aaa17a6ecbc3cdb62d579c75594/xla/service/gpu/matmul_utils.h#L104)

🎯 Justification
The test started failing after this commit was reverted https://github.com/openxla/xla/commit/ee09369ca9283ba7be016661f5ff7bd95d360e50 with:

```
RESOURCE_EXHAUSTED: Out of memory while trying to allocate 76.00MiB with allocator GPU_0_bfc on device 0. [executable_name='module'] [tf-allocator-allocation-error='']
```

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix
