### PR TITLE
[WIP] enable fast fp32 dots emulation on gfx950

### DIFF
--- a/third_party/triton/common/series.bzl
+++ b/third_party/triton/common/series.bzl
@@ -54,5 +54,6 @@ common_patch_list = [
     "//third_party/triton:common/llvm_cl959585509.patch",
     "//third_party/triton:common/old_ptxas.patch",
     "//third_party/triton:common/blackwell_nvfp4_mn_major_fallback.patch",
+    "//third_party/triton:common/tf32_bf16x3_gfx950.patch",
     # Add new patches just above this line
 ]

--- a/third_party/triton/common/tf32_bf16x3_gfx950.patch
+++ b/third_party/triton/common/tf32_bf16x3_gfx950.patch
@@ -1,0 +1,161 @@
+diff --git a/include/triton/Dialect/TritonGPU/Transforms/Passes.td b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+index 5b3f6d8..935c0e5 100644
+--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
++++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+@@ -168,11 +168,16 @@ def TritonGPUF32DotTC : Pass<"tritongpu-F32DotTC", "mlir::ModuleOp"> {
+       See https://arxiv.org/abs/1904.06376
+   }];
+ 
+-  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect"];
++  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
++                           "mlir::math::MathDialect"];
+   let options = [
+     Option<"emuTF32", "emu-tf32",
+            "bool", /*default*/"false",
+-           "whether to handle InputPrecision TF32xN for Nvidia GPUs">
++           "whether to handle InputPrecision TF32xN for Nvidia GPUs">,
++    Option<"emulateTF32AsBF16x3", "emulate-tf32-as-bf16x3",
++           "bool", /*default*/"false",
++           "whether to decompose InputPrecision TF32 dots via the BF16x3 trick, for "
++           "targets with f32 operands but no native TF32/XF32 tensor-core path">
+   ];
+ }
+ 
+diff --git a/lib/Dialect/TritonGPU/Transforms/F32DotTC.cpp b/lib/Dialect/TritonGPU/Transforms/F32DotTC.cpp
+index f66c3c1..c4f74cf 100644
+--- a/lib/Dialect/TritonGPU/Transforms/F32DotTC.cpp
++++ b/lib/Dialect/TritonGPU/Transforms/F32DotTC.cpp
+@@ -1,7 +1,10 @@
++#include "mlir/Dialect/Math/IR/Math.h"
+ #include "mlir/IR/PatternMatch.h"
+ #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+ #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+ 
++#include <limits>
++
+ namespace mlir::triton::gpu {
+ 
+ #define GEN_PASS_DEF_TRITONGPUF32DOTTC
+@@ -52,17 +55,39 @@ Value dot(Value lhs, Value rhs, Value acc, PatternRewriter &rewriter,
+                        maxNumImpreciseAcc);
+ };
+ 
+-Value replaceNansWithZeros(Value value, PatternRewriter &rewriter) {
+-  auto nans = arith::CmpFOp::create(rewriter, value.getLoc(),
+-                                    arith::CmpFPredicate::UNO, value, value);
+-  auto zero = zeroLike(value, rewriter);
+-  return arith::SelectOp::create(rewriter, value.getLoc(), nans, zero, value);
++// Zeroes out non-finite partial products (NaN and +/-inf).
++//
++// A cross-product term can go non-finite two ways: NaN, when an operand is
++// infinite (inf - inf during the split), or +/-inf, when operands are merely
++// large enough that the term overflows f32 even though the exact result is
++// representable. Both carry no usable information. Zeroing only the NaNs is
++// not enough: a surviving +/-inf cross term produces inf + (-inf) = NaN in the
++// final accumulation, where the correct answer is +/-inf from the leading
++// hi*hi term. This matches the finiteness test XLA uses in its own BF16xN
++// emitter (ZeroNaNs in stablehlo_lower_to_triton.cc).
++Value replaceNonFiniteWithZeros(Value value, PatternRewriter &rewriter) {
++  auto loc = value.getLoc();
++  Value posInf = SplatOp::create(
++      rewriter, loc, value.getType(),
++      arith::ConstantOp::create(rewriter, loc,
++                                rewriter.getF32FloatAttr(
++                                    std::numeric_limits<float>::infinity())));
++  Value absValue = math::AbsFOp::create(rewriter, loc, value);
++  Value isFinite = arith::CmpFOp::create(
++      rewriter, loc, arith::CmpFPredicate::OGT, posInf, absValue);
++  return arith::SelectOp::create(rewriter, loc, isFinite, value,
++                                 zeroLike(value, rewriter));
+ };
+ 
+-unsigned getBF16Count(triton::InputPrecision precision) {
++unsigned getBF16Count(triton::InputPrecision precision,
++                      bool treatTF32AsBF16x3) {
+   switch (precision) {
+   default:
+     return 0;
++  case InputPrecision::TF32:
++    // On targets with f32 operands but no native TF32/XF32 tensor-core path,
++    // route TF32 through the same decomposition as BF16x3.
++    return treatTF32AsBF16x3 ? 2 : 0;
+   case InputPrecision::BF16x3:
+     // BF16x3 only needs the first 2 values derived from splitting an F32
+     return 2;
+@@ -77,7 +102,11 @@ unsigned getBF16Count(triton::InputPrecision precision) {
+ // As well as
+ // https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py#L288-L330
+ struct BF16xN : public OpRewritePattern<DotOp> {
+-  using OpRewritePattern::OpRewritePattern;
++  BF16xN(MLIRContext *context, bool treatTF32AsBF16x3)
++      : OpRewritePattern<DotOp>(context),
++        treatTF32AsBF16x3(treatTF32AsBF16x3) {}
++
++  bool treatTF32AsBF16x3;
+ 
+   LogicalResult matchAndRewrite(DotOp dotOp,
+                                 PatternRewriter &rewriter) const override {
+@@ -85,7 +114,8 @@ struct BF16xN : public OpRewritePattern<DotOp> {
+     const unsigned hi = 0;
+     const unsigned mid = 1;
+     const unsigned lo = 2;
+-    const unsigned N = getBF16Count(dotOp.getInputPrecision());
++    const unsigned N =
++        getBF16Count(dotOp.getInputPrecision(), treatTF32AsBF16x3);
+ 
+     if (!isF32(dotOp.getA()) || !isF32(dotOp.getB()) || !N)
+       return failure();
+@@ -97,7 +127,9 @@ struct BF16xN : public OpRewritePattern<DotOp> {
+ 
+     switch (dotOp.getInputPrecision()) {
+     default:
+-      assert(false && "BF16DotTCPass expects BF16x6 or BF16x3");
++      assert(false &&
++             "BF16DotTCPass expects BF16x6, BF16x3, or (with "
++             "treatTF32AsBF16x3) TF32");
+       return failure();
+ 
+       // clang-format off
+@@ -114,12 +146,13 @@ struct BF16xN : public OpRewritePattern<DotOp> {
+       result = dot(lhs_parts[lo], rhs_parts[hi], result, rewriter);
+       result = dot(lhs_parts[hi], rhs_parts[lo], result, rewriter);
+ 
++    case InputPrecision::TF32:
+     case InputPrecision::BF16x3:
+       result = dot(lhs_parts[mid], rhs_parts[hi], result, rewriter);
+       result = dot(lhs_parts[hi], rhs_parts[mid], result, rewriter);
+-      result = replaceNansWithZeros(result, rewriter);
++      result = replaceNonFiniteWithZeros(result, rewriter);
+ 
+-      // NOTE: For BF16x1 bail without replaceNansWithZeros
++      // NOTE: For BF16x1 bail without replaceNonFiniteWithZeros
+       // case InputPrecision::BF16x1: break;
+     }
+ 
+@@ -140,7 +173,7 @@ struct BF16xN : public OpRewritePattern<DotOp> {
+ //  let bBig = f32ToTF32(b), bSmall = b - bBig;
+ //  let small = dot(aSmall, bBig, inputPrecision="tf32") +
+ //              dot(aBig, bSmall, inputPrecision="tf32")
+-//  let masked_nans = replaceNansWithZeros(small)
++//  let masked_nans = replaceNonFiniteWithZeros(small)
+ //  let big = dot(aBig, bBig, inputPrecision="tf32")
+ //  return big + masked_nans;
+ class TF32x3 : public OpRewritePattern<DotOp> {
+@@ -189,7 +222,7 @@ public:
+     // We would get the wrong result if we sum these partial products. Instead,
+     // we must override any accumulated result if the last partial product is
+     // non-finite.
+-    auto dot2withZeroedNans = replaceNansWithZeros(dot2, rewriter);
++    auto dot2withZeroedNans = replaceNonFiniteWithZeros(dot2, rewriter);
+     auto dot3 = dot(aBig, bBig, dot2withZeroedNans, rewriter,
+                     InputPrecision::TF32, dotOp.getMaxNumImpreciseAcc());
+ 
+@@ -212,7 +245,7 @@ struct F32DotTCPass : public impl::TritonGPUF32DotTCBase<F32DotTCPass> {
+     if (this->emuTF32) {
+       decomposePatterns.add<TF32x3>(context);
+     }
+-    decomposePatterns.add<BF16xN>(context);
++    decomposePatterns.add<BF16xN>(context, this->emulateTF32AsBF16x3);
+     if (applyPatternsGreedily(m, std::move(decomposePatterns)).failed()) {
+       signalPassFailure();
+     }

--- a/xla/backends/gpu/codegen/triton/compilation_pipeline.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline.cc
@@ -101,18 +101,21 @@ void CreateTritonCudaPipeline(
 void CreateTritonRocmPipeline(
     mlir::OpPassManager* pm,
     const stream_executor::RocmComputeCapability& rocm_cc, int num_warps,
-    int num_ctas, int num_stages);
+    int num_ctas, int num_stages, bool emulate_tf32_as_bf16x3);
 
 void CreateTritonPipeline(mlir::OpPassManager* pm,
                           const stream_executor::GpuComputeCapability& gpu_cc,
-                          int num_warps, int num_ctas, int num_stages) {
+                          int num_warps, int num_ctas, int num_stages,
+                          bool emulate_tf32_as_bf16x3) {
   if (auto* cuda_cc = gpu_cc.cuda_compute_capability()) {
+    // CUDA targets with TF32 tensor cores use them natively; there is nothing
+    // to emulate.
     return CreateTritonCudaPipeline(pm, *cuda_cc, num_warps, num_ctas,
                                     num_stages);
   }
 
   CreateTritonRocmPipeline(pm, *gpu_cc.rocm_compute_capability(), num_warps,
-                           num_ctas, num_stages);
+                           num_ctas, num_stages, emulate_tf32_as_bf16x3);
 }
 
 }  // namespace xla::gpu

--- a/xla/backends/gpu/codegen/triton/compilation_pipeline.h
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline.h
@@ -29,9 +29,15 @@ void CreateTritonXlaPipeline(
     bool enable_pdl);
 
 // Creates a Triton compilation pipeline.
+//
+// `emulate_tf32_as_bf16x3` corresponds to the
+// `xla_gpu_emulate_tf32_as_bf16x3` debug option. It only has an effect on
+// targets that lack a native XF32 matrix instruction (AMD gfx950); the
+// backend-specific pipeline applies that additional gate.
 void CreateTritonPipeline(mlir::OpPassManager* pm,
                           const stream_executor::GpuComputeCapability& gpu_cc,
-                          int num_warps, int num_ctas, int num_stages);
+                          int num_warps, int num_ctas, int num_stages,
+                          bool emulate_tf32_as_bf16x3 = true);
 
 // Returns the default PTX version for a given CUDA compute capability.
 int GetDefaultPtxVersion(const stream_executor::CudaComputeCapability& cuda_cc);

--- a/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
+++ b/xla/backends/gpu/codegen/triton/compilation_pipeline_rocm.cc
@@ -68,16 +68,30 @@ static bool is_in_thread_transpose_enabled(
   return rocm_cc.gfx9_mi300();
 }
 
+// CDNA4 (gfx950) dropped the XF32 MFMA that CDNA3 (gfx942) has, so a dot
+// requesting TF32 input precision there would otherwise silently lower to a
+// full-rate IEEE f32 MFMA. Route it through the 3xBF16 decomposition instead.
+// gfx942 must keep using its native XF32 MFMA.
+static bool is_tf32_as_bf16x3_emulation_enabled(
+    const stream_executor::RocmComputeCapability& rocm_cc,
+    bool emulate_tf32_as_bf16x3) {
+  return emulate_tf32_as_bf16x3 && rocm_cc.gfx9_mi350();
+}
+
 // Based on make_ttgir() in
 // @triton//:third_party/amd/backend/compiler.py
 static void MakeTTGIR(mlir::OpPassManager* pm,
                       const stream_executor::RocmComputeCapability& rocm_cc,
-                      int num_warps, int num_ctas, int num_stages) {
+                      int num_warps, int num_ctas, int num_stages,
+                      bool emulate_tf32_as_bf16x3) {
   pm->addPass(mt::createConvertTritonToTritonGPU(
       {absl::StrCat("hip:", rocm_cc.gfx_version()), num_warps,
        rocm_cc.threads_per_warp(), num_ctas}));
   pm->addPass(mt::gpu::createTritonGPUCoalesce());
-  pm->addPass(mt::gpu::createTritonGPUF32DotTC({false}));
+  pm->addPass(mt::gpu::createTritonGPUF32DotTC(
+      {/*emuTF32=*/false,
+       /*emulateTF32AsBF16x3=*/is_tf32_as_bf16x3_emulation_enabled(
+           rocm_cc, emulate_tf32_as_bf16x3)}));
   pm->addPass(mt::gpu::createTritonGPURemoveLayoutConversions());
   pm->addPass(mt::gpu::createTritonGPUOptimizeThreadLocality());
   pm->addPass(
@@ -190,9 +204,10 @@ static void MakeLLIR(mlir::OpPassManager* pm,
 void CreateTritonRocmPipeline(
     mlir::OpPassManager* pm,
     const stream_executor::RocmComputeCapability& rocm_cc, int num_warps,
-    int num_ctas, int num_stages) {
+    int num_ctas, int num_stages, bool emulate_tf32_as_bf16x3) {
   MakeTTIR(pm, rocm_cc);
-  MakeTTGIR(pm, rocm_cc, num_warps, num_ctas, num_stages);
+  MakeTTGIR(pm, rocm_cc, num_warps, num_ctas, num_stages,
+            emulate_tf32_as_bf16x3);
   MakeLLIR(pm, rocm_cc, num_stages);
 }
 

--- a/xla/backends/gpu/codegen/triton/xtile_compiler.cc
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.cc
@@ -541,7 +541,9 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
                           block_level_parameters.is_warp_specialization_allowed,
                           enable_pdl);
 
-  CreateTritonPipeline(&pm, gpu_cc, num_warps, num_ctas, num_stages);
+  CreateTritonPipeline(
+      &pm, gpu_cc, num_warps, num_ctas, num_stages,
+      hlo_config.debug_options().xla_gpu_emulate_tf32_as_bf16x3());
 
   // Triton generates pointers to the global address space, while XLA needs a
   // kernel signature with pointers to the generic address space.

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -441,6 +441,9 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_experimental_enable_fusion_block_level_rewriter(false);
 
   opts.set_xla_gpu_default_to_alg_dot_bf16_bf16_f32(false);
+  // Enabled by default; additionally gated on the target lacking a native XF32
+  // matrix instruction (AMD gfx950), so this is a no-op elsewhere.
+  opts.set_xla_gpu_emulate_tf32_as_bf16x3(true);
   opts.set_xla_gpu_enable_libnvptxcompiler(
       stream_executor::IsLibNvPtxCompilerSupported());
   opts.set_xla_gpu_libnvjitlink_mode(DebugOptions::LIB_NV_JIT_LINK_MODE_AUTO);
@@ -1984,6 +1987,14 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_gpu_default_to_alg_dot_bf16_bf16_f32(),
       "Use the dot precision algorithm `ALG_DOT_BF16_BF16_F32 by default for "
       "f32 dots."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_emulate_tf32_as_bf16x3",
+      bool_setter_for(&DebugOptions::set_xla_gpu_emulate_tf32_as_bf16x3),
+      debug_options->xla_gpu_emulate_tf32_as_bf16x3(),
+      "In the Triton emitter, emulate TF32 input precision with the 3xBF16 "
+      "decomposition on targets that have no native XF32 matrix instruction. "
+      "Only affects AMD gfx950, where a TF32 dot would otherwise silently fall "
+      "back to a full-rate IEEE f32 MFMA. Enabled by default."));
   flag_list->push_back(
       tsl::Flag("xla_gpu_deterministic_ops",
                 bool_setter_for(&DebugOptions::set_xla_gpu_deterministic_ops),

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -867,6 +867,15 @@ message DebugOptions {
   // Determine the while loop unrolling scheme.
   optional WhileLoopUnrolling xla_gpu_enable_while_loop_unrolling = 294;
 
+  // Emulates TF32 input precision using the 3xBF16 decomposition
+  // (https://arxiv.org/abs/1904.06376) in the Triton emitter, on targets that
+  // have no native XF32 matrix instruction. Only takes effect on AMD gfx950
+  // (CDNA4), which dropped the XF32 MFMA that CDNA3 has; without it, a dot
+  // requesting TF32 there silently falls back to a full-rate IEEE f32 MFMA.
+  // The emulation is both faster and more accurate than the TF32 it stands in
+  // for, but it is not bit-identical to f32, so this provides an opt-out.
+  optional bool xla_gpu_emulate_tf32_as_bf16x3 = 534;
+
   // Excludes non-deterministic ops from compiled executables.
   // This flag disables autotuning and selects the first __valid__ autotune
   // config.
@@ -1792,7 +1801,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 534
+  // Next id: 535
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
TBD

📝 Summary of Changes
Please provide a clear and concise summary of the changes you've made.

🎯 Justification
Explain why this change is important and which workload benefits from this
change.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, ⚡️ Performance Improvement,
✨ New Feature, ♻️ Cleanup, 📚 Documentation, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.
