### PR TITLE
[XLA:TSL] Skip thread NUMA binding when the node has no allowed CPUs

### DIFF
--- a/xla/tsl/platform/numa_hwloc.cc
+++ b/xla/tsl/platform/numa_hwloc.cc
@@ -116,6 +116,14 @@ void NUMASetThreadNodeAffinity(int node) {
     return;
   }
 
+  // An empty cpuset means no CPU of this node is allowed (e.g. cgroup/SLURM
+  // restrictions); binding would fail with EINVAL, so fall back quietly.
+  if (hwloc_bitmap_iszero(obj->cpuset)) {
+    VLOG(1) << "No allowed CPUs on NUMA node " << node
+            << ", falling back to OS scheduling.";
+    return;
+  }
+
   if (hwloc_set_cpubind(topology, obj->cpuset,
                         HWLOC_CPUBIND_THREAD | HWLOC_CPUBIND_STRICT)) {
     LOG_FIRST_N(ERROR, 1).WithPerror() << "Call to hwloc_set_cpubind() failed";


### PR DESCRIPTION
## 📝 Summary of Changes

`NUMASetThreadNodeAffinity` now returns early (with a `VLOG(1)`) when the hwloc NUMA node object has an empty cpuset instead of calling `hwloc_set_cpubind` and logging an ERROR.

The topology is loaded without `HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED`, so hwloc already intersects every object's cpuset with the cgroup-allowed set at load time. An empty cpuset therefore means the environment forbids every CPU of that node, and the bind is guaranteed to fail: hwloc rejects empty sets with `EINVAL` in `hwloc_fix_cpubind` before any syscall. Genuinely unexpected bind failures still log at ERROR as before.

## 🎯 Justification

Fixes #45484. On SLURM clusters the job cgroup often grants no CPUs on the GPU's NUMA node, so every process prints a fatal-looking `E ... numa_hwloc.cc:121] Call to hwloc_set_cpubind() failed: Invalid argument [22]` during startup even though XLA falls back to normal OS scheduling and works fine. Failing to pin a thread because of cluster policy is an expected condition, not an error. Before the NUMA code consolidation in October 2025 this failure was silently ignored, so the ERROR is not a long-standing contract.

Known related path, intentionally out of scope: if the cgroup also restricts the node's memory (`cpuset.mems`), hwloc drops the node object entirely and the "Could not find hwloc NUMA node" ERROR a few lines above fires instead. The issue reports only the cpubind message, so this change stays minimal and does not touch that path.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

There is no existing test for `numa_hwloc.cc`, and the new branch depends on host cgroup state (the topology is a process-wide singleton over the real machine). A deterministic test would need a dedicated binary loading a crafted XML topology via `HWLOC_XMLFILE` before the first `tsl::port` call, plus log capture; that coupling to hwloc internals costs more than a 7-line log-noise fix justifies, so no unit test is added. The mechanism and the fix were verified against the vendored hwloc 2.7.1 with a standalone harness: a synthetic two-node topology restricted to one node's CPUs (the cgroup situation) keeps the other node's object alive with an empty cpuset, `hwloc_set_cpubind` on it fails with `EINVAL` (the exact reported error), and the guarded logic skips it. On nodes with any allowed CPU the guard is unreachable, so behavior on unrestricted hosts is unchanged. `//xla/tsl/platform:env_test` and `//xla/tsl/platform:threadpool_test` (which exercise the thread-start path that calls this function) pass.

## 🧪 Execution Tests:

Not applicable: logging-only change in host runtime code, no change to compiled programs or device execution.