### PR TITLE
[XLA] Log the GSPMD sharding propagation deprecation warning only once

### DIFF
--- a/xla/service/sharding_propagation.cc
+++ b/xla/service/sharding_propagation.cc
@@ -3193,10 +3193,11 @@ std::vector<HloInstruction*> ShardingPropagation::GetRelatedInstructions(
 absl::StatusOr<bool> ShardingPropagation::RunImpl(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
-  LOG(WARNING) << "GSPMD sharding propagation is going to be deprecated and "
-                  "not supported in the future. Please consider migrating to "
-                  "Shardy (https://openxla.org/shardy). For reference, Shardy "
-                  "is already the default partitioner in JAX.";
+  LOG_FIRST_N(WARNING, 1)
+      << "GSPMD sharding propagation is going to be deprecated and "
+         "not supported in the future. Please consider migrating to "
+         "Shardy (https://openxla.org/shardy). For reference, Shardy "
+         "is already the default partitioner in JAX.";
   // Register custom-call partitioner for SharBarrierFrom and ShardBarrierTo.
   ABSL_CONST_INIT static absl::once_flag did_registration;
   absl::call_once(did_registration, [] {


### PR DESCRIPTION
## 📝 Summary of Changes

Change the deprecation warning at the top of `ShardingPropagation::RunImpl` from `LOG(WARNING)` to `LOG_FIRST_N(WARNING, 1)`, so it is printed once per process instead of once per pass invocation. Message text unchanged.

## 🎯 Justification

Fixes #38574. The pass runs at least once per compiled module, so jobs that compile many modules print the same deprecation nudge over and over with no way to suppress it. Once per process keeps the migration reminder visible while stopping the log bloat; the function already uses the once-per-process idiom (`absl::call_once`) three lines below for partitioner registration. Same fix shape as earlier log-spam cleanups (e.g. the gemm_fusion one).

Measured: a single filtered run of `sharding_propagation_test` printed the warning 32 times before this change and once after.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

Logging-only change; `//xla/service:sharding_propagation_test` passes. No log-count test added, matching precedent for `LOG` -> `LOG_FIRST_N` changes in this repo.

## 🧪 Execution Tests:

Not applicable (no behavior change).