### PR TITLE
Add an XLA flag to enable/disable cupti multi-subscriber support

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -54,6 +54,7 @@ cc_library(
         ":cupti_tracer",
         ":cupti_tracer_options_utils",
         ":gpu_metadata",
+        "//xla:debug_options_flags",
         "//xla/tsl/platform:errors",
         "//xla/tsl/profiler/utils:time_utils",
         "//xla/tsl/util:env_var",

--- a/xla/backends/profiler/gpu/device_tracer_cuda.cc
+++ b/xla/backends/profiler/gpu/device_tracer_cuda.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/backends/profiler/gpu/cupti_tracer.h"
 #include "xla/backends/profiler/gpu/cupti_tracer_options_utils.h"
 #include "xla/backends/profiler/gpu/gpu_metadata.h"
+#include "xla/debug_options_flags.h"
 #include "xla/tsl/platform/errors.h"
 #include "xla/tsl/profiler/utils/time_utils.h"
 #include "xla/tsl/util/env_var.h"
@@ -86,6 +87,8 @@ absl::Status GpuTracer::DoStart() {
   }
 
   options_.cbids_selected = CuptiTracer::CreateDefaultCallbackIds();
+  options_.prefer_cupti_v2 =
+      xla::GetDebugOptionsFromFlags().xla_gpu_enable_cupti_multi_subscriber();
 
   bool trace_concurrent_kernels = false;
   ReadBoolFromEnvVar("TF_GPU_CUPTI_FORCE_CONCURRENT_KERNEL", true,

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -298,6 +298,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
 
   opts.set_xla_gpu_enable_cublaslt(true);
   opts.set_xla_gpu_trace_annotation_level(0);
+  opts.set_xla_gpu_enable_cupti_multi_subscriber(true);
 
   opts.add_xla_gpu_enable_command_buffer(DebugOptions::CONDITIONAL);
   opts.add_xla_gpu_enable_command_buffer(DebugOptions::CUBLAS);
@@ -2775,6 +2776,12 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "names and basic structured payloads. Level 1 additionally emits "
       "detailed HLO and collective metadata in XProf annotation names and "
       "structured payloads. NVTX names remain compact."));
+  flag_list->push_back(tsl::Flag(
+      "xla_gpu_enable_cupti_multi_subscriber",
+      bool_setter_for(&DebugOptions::set_xla_gpu_enable_cupti_multi_subscriber),
+      debug_options->xla_gpu_enable_cupti_multi_subscriber(),
+      "Enable CUPTI V2 multi-subscriber APIs for GPU profiling when "
+      "available."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_operand_bytes_threshold_for_windowed_einsum",
       int64_setter_for(

--- a/xla/xla.proto
+++ b/xla/xla.proto
@@ -1313,6 +1313,10 @@ message DebugOptions {
   // names remain compact.
   optional int32 xla_gpu_trace_annotation_level = 530;
 
+  // Enables CUPTI V2 multi-subscriber APIs for GPU profiling when available.
+  // Allows XLA profiling to coexist with tools such as Nsight Systems.
+  optional bool xla_gpu_enable_cupti_multi_subscriber = 534;
+
   // Creates triton fusion for all supported gemms.
   // To make sure only triton gemm is chosen by the autotuner run with
   // `xla_gpu_cublas_fallback` set to false.
@@ -1792,7 +1796,7 @@ message DebugOptions {
   // Note: when adding a new flag, please add it to one of the hardware-specific
   // or hardware-agnostic sections at the top of this proto message.
 
-  // Next id: 534
+  // Next id: 535
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
📝 Summary of Changes
Added --xla_gpu_enable_cupti_multi_subscriber, enabled by default.

🎯 Justification
CUPTI V2 multi-subscriber support is the preferred default for CUDA 13.3+ profiling, including concurrent profiling workloads such as PGLE and NVIDIA tooling. This flag provides a supported rollback for users encountering CUPTI V2 compatibility or interoperability issues, without removing the existing V1 fallback.

🚀 Kind of Contribution
Please remove what does not apply: 
✨ New Feature, ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
No new unit tests added. The change only exposes existing prefer_cupti_v2 behavior through XLA_FLAGS; existing CUPTI tracer tests cover V2 selection and V1 fallback behavior.

🧪 Execution Tests:
Manually ran the existing GPU PGLE target with V2 disabled:

XLA_FLAGS=--xla_gpu_enable_cupti_multi_subscriber=false \
bazel test --nocache_test_results //tests:pgle_test_gpu

Result: 9 tests passed, 1 skipped.

The captured NVLOG contained none of the V2 multi-subscriber markers (Multiple subscribers are allowed and Auto-enabled global raw timestamps), confirming the legacy CUPTI path was used.