### PR TITLE
[ROCM] Wire all MORI collectives through a dedicated CollectivesFacade

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -1,4 +1,5 @@
-load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured",
+     "rocm_library")
 load("@local_config_sycl//sycl:build_defs.bzl", "if_sycl_is_configured")
 load("//xla:xla.default.bzl", "xla_cc_test")
 load("//xla/stream_executor:build_defs.bzl", "if_cuda_or_rocm_is_configured")
@@ -1266,6 +1267,30 @@ cc_library(
     ],
 )
 
+
+rocm_library(
+    name = "mori_kernels",
+    hdrs = [
+        "mori_kernels.h",
+        "mori_stub.h",
+    ],
+    srcs = [
+        "mori_kernels.cu.cc",
+    ],
+    copts = ["-U__HIP_DISABLE_CPP_FUNCTIONS__"],   # <-- only if needed
+    # copybara:uncomment compatible_with = ["//buildenv/target:non_prod"],
+    tags = [
+        "gpu",
+        "no-oneapi",
+        "rocm-only",
+    ],
+    deps = [
+        "//xla/service:collective_opt_utils",
+        "@com_google_absl//absl/status",
+    ],
+    linkstatic = True,
+)
+
 cc_library(
     name = "mori_collectives",
     srcs = [
@@ -1279,6 +1304,8 @@ cc_library(
     ],
     tags = [
         "gpu",
+        "no-oneapi",
+        "rocm-only",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -1298,6 +1325,7 @@ cc_library(
         "//xla/core/collectives:communicator",
         "//xla/core/collectives:rank_id",
         "//xla/core/collectives:reduction_kind",
+        "//xla/core/collectives:symmetric_memory",
         "//xla/pjrt/distributed:key_value_store_interface",
         "//xla/runtime:device_id",
         "//xla/runtime:process_id",
@@ -1306,6 +1334,7 @@ cc_library(
         "//xla/stream_executor:platform_manager",
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
+        "//xla/stream_executor/rocm:rocm_status",
         "//xla/tsl/platform:env",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base",
@@ -1328,7 +1357,10 @@ cc_library(
         "@com_google_absl//absl/types:span",
         "@tsl//tsl/platform:casts",
         "@tsl//tsl/platform:numbers",
-    ],
+    ] + if_rocm_is_configured([
+        ":mori_kernels",
+        "@local_config_rocm//rocm:rocm_headers",
+    ]),
     alwayslink = True,
 )
 

--- a/xla/backends/gpu/collectives/mori_communicator.cc
+++ b/xla/backends/gpu/collectives/mori_communicator.cc
@@ -112,7 +112,7 @@ absl::StatusOr<::mori::collective::ReduceOpKind> ToMoriReduceOp(
 
 absl::StatusOr<se::Stream*> ToStream(const Communicator::Executor& executor) {
   if (auto* gpu_executor =
-          tsl::down_cast<const GpuCollectives::Executor*>(&executor)) {
+          absl::down_cast<const GpuCollectives::Executor*>(&executor)) {
     return gpu_executor->stream();
   }
   return InvalidArgument("Communicator executor is not a GPU executor");

--- a/xla/backends/gpu/collectives/mori_communicator.cc
+++ b/xla/backends/gpu/collectives/mori_communicator.cc
@@ -36,13 +36,14 @@ limitations under the License.
 #include "xla/backends/gpu/collectives/cancellation_token.h"
 #include "xla/backends/gpu/collectives/gpu_collectives.h"
 #include "xla/backends/gpu/collectives/mori_collectives.h"
-#include "xla/backends/gpu/collectives/mori_stub.h"
+#include "xla/backends/gpu/collectives/mori_kernels.h"
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
 #include "xla/future.h"
 #include "xla/primitive_util.h"
 #include "xla/stream_executor/device_address.h"
+#include "xla/stream_executor/rocm/rocm_status.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
@@ -51,17 +52,72 @@ limitations under the License.
 namespace shmem = ::mori::shmem;
 namespace xla::gpu {
 
-static auto AsRocmStream(se::Stream* stream) {
-  return reinterpret_cast<std::intptr_t>(
+using ::mori::collective::CollectivesFacade;
+namespace {
+
+hipStream_t AsHipStream(se::Stream* stream) {
+  return reinterpret_cast<hipStream_t>(
       stream->platform_specific_handle().stream);
 }
 
-static size_t ToMoriByteCount(PrimitiveType dtype, size_t count) {
+size_t ToMoriByteCount(PrimitiveType dtype, size_t count) {
   if (primitive_util::IsComplexType(dtype)) {
     count *= 2;
   }
   return count * primitive_util::BitWidth(dtype) / 8;
 }
+
+absl::StatusOr<::mori::collective::DataType> ToMoriDataType(
+    PrimitiveType dtype) {
+#define MORI_TYPE_DISPATCH(x) \
+  case x:                     \
+    return ::mori::collective::DataType::x;
+  switch (dtype) {
+    MORI_TYPE_DISPATCH(F8E5M2)
+    MORI_TYPE_DISPATCH(F8E4M3FN)
+    MORI_TYPE_DISPATCH(F16)
+    MORI_TYPE_DISPATCH(BF16)
+    MORI_TYPE_DISPATCH(S8)
+    MORI_TYPE_DISPATCH(U8)
+    MORI_TYPE_DISPATCH(S32)
+    MORI_TYPE_DISPATCH(U32)
+    MORI_TYPE_DISPATCH(S64)
+    MORI_TYPE_DISPATCH(U64)
+    MORI_TYPE_DISPATCH(F32)
+    MORI_TYPE_DISPATCH(F64)
+    default:
+      return absl::UnimplementedError(absl::StrFormat(
+          "MORI: unsupported dtype: %d", static_cast<int>(dtype)));
+  }
+#undef MORI_TYPE_DISPATCH
+}
+
+// Translate an XLA ReductionKind to the facade's reduction-op enum.
+absl::StatusOr<::mori::collective::ReduceOpKind> ToMoriReduceOp(
+    ReductionKind r) {
+#define MORI_OP_DISPATCH(x) \
+  case ReductionKind::x:    \
+    return ::mori::collective::ReduceOpKind::x;
+  switch (r) {
+    MORI_OP_DISPATCH(SUM)
+    MORI_OP_DISPATCH(PRODUCT)
+    MORI_OP_DISPATCH(MIN)
+    MORI_OP_DISPATCH(MAX)
+    default:
+      return absl::UnimplementedError(absl::StrFormat(
+          "MORI: unsupported reduction op: %d", static_cast<int>(r)));
+  }
+#undef MORI_OP_DISPATCH
+}
+
+absl::StatusOr<se::Stream*> ToStream(const Communicator::Executor& executor) {
+  if (auto* gpu_executor =
+          tsl::down_cast<const GpuCollectives::Executor*>(&executor)) {
+    return gpu_executor->stream();
+  }
+  return InvalidArgument("Communicator executor is not a GPU executor");
+}
+}  // namespace
 
 absl::StatusOr<std::unique_ptr<MoriCommunicator>> MoriCommunicator::Create(
     MoriCollectives* coll, std::shared_ptr<CancellationToken> cancel, int rank,
@@ -69,13 +125,31 @@ absl::StatusOr<std::unique_ptr<MoriCommunicator>> MoriCommunicator::Create(
   auto comm = absl::WrapUnique(new MoriCommunicator(coll, cancel));
 
   const int num_ranks = static_cast<int>(rank_to_pe.size());
+  if (num_ranks <= 0) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "MoriCommunicator: unsupported number of ranks %d", num_ranks));
+  }
   comm->rank_ = rank;
   comm->num_ranks_ = num_ranks;
+
+  // The CollectivesFacade owns this communicator's symmetric-heap staging
+  // buffer and the push reduce-scatter group counters. It records the rank
+  // identity (rank/num_ranks) and allocates the ~2GB staging; the unique_ptr
+  // frees it (before ShmemFinalize) when the communicator is destroyed.
+  const size_t buffer_size = 2UL << 30;  // 2GB
+  comm->facade_ = CollectivesFacade::Create(rank, num_ranks, buffer_size);
+  if (comm->facade_ == nullptr) {
+    return absl::InternalError("CollectivesFacade::Create failed");
+  }
   VLOG(1) << "Created " << *comm << " with participants: " << num_ranks;
   return comm;
 }
 
-MoriCommunicator::~MoriCommunicator() {}
+MoriCommunicator::~MoriCommunicator() {
+  // facade_ (unique_ptr) releases this communicator's staging + counters via
+  // the CollectivesFacade dtor here, before MoriCollectives::Finalize() ->
+  // ShmemFinalize.
+}
 
 #define CHECK_CANCELLED()                                               \
   if (cancel_->IsCancelled()) {                                         \
@@ -97,41 +171,26 @@ absl::Status MoriCommunicator::Abort() {
   return absl::OkStatus();
 }
 
-absl::Status MoriCommunicator::Barrier(const Communicator::Executor& executor) {
+absl::Status MoriCommunicator::Barrier(const Executor& executor) {
   VLOG(1) << "Barrier: " << ToString();
   CHECK_CANCELLED()
   ABSL_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
-  (void)stream;
-  // return xla_mori::BarrierOnStream(AsRocmStream(stream));
-  return absl::OkStatus();
+  return se::gpu::ToStatus(facade_->RunBarrier(AsHipStream(stream)));
 }
 
 absl::StatusOr<size_t> MoriCommunicator::NumRanks() const {
-  VLOG(5) << "Get the number of ranks in MORI communicator: " << ToString();
   CHECK_CANCELLED()
-
   return static_cast<size_t>(num_ranks_);
 }
 
 absl::StatusOr<size_t> MoriCommunicator::CurrentRank() {
-  VLOG(5) << "Get current rank in MORI communicator: " << ToString();
   CHECK_CANCELLED()
-
   return static_cast<size_t>(rank_);
 }
 
 std::string MoriCommunicator::ToString() const {
-  return absl::StrFormat("MoriCommunicator(rank=%d, num_ranks=%d, my_pe=%d)",
-                         rank_, num_ranks_, shmem::ShmemMyPe());
-}
-
-absl::StatusOr<se::Stream*> MoriCommunicator::ToStream(
-    const Executor& executor) {
-  if (auto* gpu_executor =
-          absl::down_cast<const GpuCollectives::Executor*>(&executor)) {
-    return gpu_executor->stream();
-  }
-  return InvalidArgument("Communicator executor is not a GPU executor");
+  return absl::StrFormat("MoriCommunicator(rank=%d, num_ranks=%d)", rank_,
+                         num_ranks_);
 }
 
 Future<> MoriCommunicator::AllReduce(se::DeviceAddressBase send_buffer,
@@ -201,20 +260,20 @@ Future<> MoriCommunicator::CollectivePermute(
   });
 }
 
-Future<> MoriCommunicator::Send(se::DeviceAddressBase recv_buffer,
-                                se::DeviceAddressBase send_buffer,
+Future<> MoriCommunicator::Send(se::DeviceAddressBase send_buffer,
                                 PrimitiveType dtype, size_t count, RankId peer,
                                 const Executor& executor) {
-  return P2P(P2PType::Send, dtype, recv_buffer, send_buffer, count, peer,
-             executor);
+  return Execute([send_buffer, dtype, count, peer, &executor, this]() {
+    return LaunchSend(send_buffer, dtype, count, peer, executor);
+  });
 }
 
 Future<> MoriCommunicator::Recv(se::DeviceAddressBase recv_buffer,
-                                se::DeviceAddressBase send_buffer,
                                 PrimitiveType dtype, size_t count, RankId peer,
                                 const Executor& executor) {
-  return P2P(P2PType::Recv, dtype, recv_buffer, send_buffer, count, peer,
-             executor);
+  return Execute([recv_buffer, dtype, count, peer, &executor, this]() {
+    return LaunchRecv(recv_buffer, dtype, count, peer, executor);
+  });
 }
 
 absl::Status MoriCommunicator::LaunchAllGather(
@@ -222,11 +281,14 @@ absl::Status MoriCommunicator::LaunchAllGather(
     PrimitiveType dtype, size_t count, const Executor& executor) {
   CHECK_CANCELLED()
   ABSL_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
-  VLOG(3) << "LaunchAllGather: send_buffer=" << send_buffer.opaque()
+
+  VLOG(3) << "Launch AllGather: send_buffer=" << send_buffer.opaque()
           << " recv_buffer=" << recv_buffer.opaque() << " count=" << count
           << " dtype=" << primitive_util::LowercasePrimitiveTypeName(dtype)
-          << " stream=" << AsRocmStream(stream);
-  return absl::UnimplementedError("Not implemented");
+          << " stream=" << AsHipStream(stream);
+  return se::gpu::ToStatus(facade_->RunAllGather(
+      send_buffer.opaque(), recv_buffer.opaque(), ToMoriByteCount(dtype, count),
+      AsHipStream(stream)));
 }
 
 absl::Status MoriCommunicator::LaunchAllReduce(
@@ -234,25 +296,20 @@ absl::Status MoriCommunicator::LaunchAllReduce(
     PrimitiveType dtype, size_t count, ReductionKind reduction_kind,
     const Executor& executor) {
   CHECK_CANCELLED()
-
   ABSL_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
-  auto gpu_stream = AsRocmStream(stream);
-  (void)gpu_stream;
-  void* source_ptr = send_buffer.opaque();
-  void* dest_ptr = recv_buffer.opaque();
-  (void)source_ptr;
-  (void)dest_ptr;
-  if (primitive_util::IsComplexType(dtype)) {
-    count *= 2;
-  }
 
   VLOG(3) << absl::StreamFormat(
-      "Launch MORI AllReduce send_buffer=%p; recv_buffer=%p; dtype=%s; "
-      "count=%d; reduction_kind=%v; device_ordinal=%d",
+      "Launch AllReduce: send_buffer=%p; recv_buffer=%p; dtype=%s; count=%d; "
+      "reduction_kind=%v; stream=%p",
       send_buffer.opaque(), recv_buffer.opaque(),
       primitive_util::LowercasePrimitiveTypeName(dtype), count, reduction_kind,
-      stream->parent()->device_ordinal());
-  return absl::UnimplementedError("Not implemented");
+      stream);
+
+  ABSL_ASSIGN_OR_RETURN(auto dt, ToMoriDataType(dtype));
+  ABSL_ASSIGN_OR_RETURN(auto op, ToMoriReduceOp(reduction_kind));
+  return se::gpu::ToStatus(facade_->RunAllReduce(send_buffer.opaque(),
+                                                 recv_buffer.opaque(), count,
+                                                 dt, op, AsHipStream(stream)));
 }
 
 absl::Status MoriCommunicator::LaunchReduceScatter(
@@ -265,8 +322,78 @@ absl::Status MoriCommunicator::LaunchReduceScatter(
   VLOG(3) << "LaunchReduceScatter: send_buffer=" << send_buffer.opaque()
           << " recv_buffer=" << recv_buffer.opaque() << " count=" << count
           << " dtype=" << primitive_util::LowercasePrimitiveTypeName(dtype)
-          << " stream=" << AsRocmStream(stream);
-  return absl::UnimplementedError("Not implemented");
+          << " stream=" << AsHipStream(stream);
+
+  ABSL_ASSIGN_OR_RETURN(auto dt, ToMoriDataType(dtype));
+  ABSL_ASSIGN_OR_RETURN(auto op, ToMoriReduceOp(kind));
+  return se::gpu::ToStatus(
+      facade_->RunReduceScatter(send_buffer.opaque(), recv_buffer.opaque(),
+                                count, dt, op, AsHipStream(stream)));
+}
+
+absl::Status MoriCommunicator::LaunchAllToAll(
+    absl::InlinedVector<se::DeviceAddressBase, 4> send_buffers,
+    absl::InlinedVector<se::DeviceAddressBase, 4> recv_buffers,
+    PrimitiveType dtype, size_t count, const Executor& executor) {
+  CHECK_CANCELLED()
+  ABSL_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
+
+  auto format_addr = [](std::string* out, se::DeviceAddressBase buf) {
+    absl::StrAppendFormat(out, "%p", buf.opaque());
+  };
+  VLOG(3) << absl::StreamFormat(
+      "Launch MORI AllToAll operation; send_buffers=[%s]; recv_buffers=[%s]; "
+      "dtype=%s; count=%d; stream=%p",
+      absl::StrJoin(send_buffers, ", ", format_addr),
+      absl::StrJoin(recv_buffers, ", ", format_addr),
+      primitive_util::LowercasePrimitiveTypeName(dtype), count,
+      AsHipStream(stream));
+
+  if (send_buffers.size() != recv_buffers.size() ||
+      send_buffers.size() != static_cast<size_t>(num_ranks_)) {
+    return InvalidArgument(
+        "Number of send/recv buffers and number of  ranks mismatch");
+  }
+
+  CollectivesFacade::AddressVector addrs;
+  addrs.reserve(num_ranks_);
+  for (int p = 0; p < num_ranks_; ++p) {
+    addrs.emplace_back(send_buffers[p].opaque(), recv_buffers[p].opaque());
+  }
+  return se::gpu::ToStatus(facade_->RunAllToAll(
+      addrs, ToMoriByteCount(dtype, count), AsHipStream(stream)));
+}
+
+absl::Status MoriCommunicator::LaunchSend(se::DeviceAddressBase send_buffer,
+                                          PrimitiveType dtype, size_t count,
+                                          RankId peer,
+                                          const Executor& executor) {
+  CHECK_CANCELLED()
+  ABSL_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
+  VLOG(3) << absl::StreamFormat(
+      "Launch MORI Send operation; send_buffer=%p; dtype=%s; count=%d; "
+      "peer=%d; stream=%p",
+      send_buffer.opaque(), primitive_util::LowercasePrimitiveTypeName(dtype),
+      count, peer.value(), AsHipStream(stream));
+  return se::gpu::ToStatus(
+      facade_->RunSend(send_buffer.opaque(), ToMoriByteCount(dtype, count),
+                       static_cast<int>(peer.value()), AsHipStream(stream)));
+}
+
+absl::Status MoriCommunicator::LaunchRecv(se::DeviceAddressBase recv_buffer,
+                                          PrimitiveType dtype, size_t count,
+                                          RankId peer,
+                                          const Executor& executor) {
+  CHECK_CANCELLED()
+  ABSL_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
+  VLOG(3) << absl::StreamFormat(
+      "Launch MORI Recv operation; recv_buffer=%p; dtype=%s; count=%d; "
+      "peer=%d; stream=%p",
+      recv_buffer.opaque(), primitive_util::LowercasePrimitiveTypeName(dtype),
+      count, peer.value(), AsHipStream(stream));
+  return se::gpu::ToStatus(
+      facade_->RunRecv(recv_buffer.opaque(), ToMoriByteCount(dtype, count),
+                       static_cast<int>(peer.value()), AsHipStream(stream)));
 }
 
 absl::Status MoriCommunicator::LaunchCollectivePermute(
@@ -275,13 +402,11 @@ absl::Status MoriCommunicator::LaunchCollectivePermute(
     absl::Span<const RankId> target_ranks, const Executor& executor) {
   CHECK_CANCELLED()
   ABSL_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
-  size_t bytes = ToMoriByteCount(dtype, count);
-  (void)bytes;
   auto rank_formatter = [](std::string* out, RankId rank) {
     absl::StrAppendFormat(out, "%d", rank.value());
   };
   VLOG(3) << absl::StreamFormat(
-      "[%d] Launch MORI CollectivePermute operation; send_buffer=%p; "
+      "[%d] Launch CollectivePermute: send_buffer=%p; "
       "recv_buffer=%p; dtype=%s; source_rank=%s; target_[ranks=%s]; count=%d; "
       "stream=%p",
       stream->parent()->device_ordinal(), send_buffer.opaque(),
@@ -289,41 +414,15 @@ absl::Status MoriCommunicator::LaunchCollectivePermute(
       source_rank ? absl::StrCat(source_rank->value()) : "<empty>",
       absl::StrJoin(target_ranks, ", ", rank_formatter), count, stream);
 
-  return absl::UnimplementedError("Not implemented");
-}
-
-// Performs point-to-point communication between two ranks using MORI.
-// Send: launches a single GPU kernel that copies data to the peer via P2P
-//       and sets a completion flag on the peer.
-// Recv: launches a single-thread GPU kernel that waits for the flag.
-absl::Status MoriCommunicator::P2P(P2PType p2p_type, PrimitiveType dtype,
-                                   se::DeviceAddressBase recv_buffer,
-                                   se::DeviceAddressBase send_buffer,
-                                   size_t count, RankId peer,
-                                   const Executor& executor) {
-  const char* stype = (p2p_type == P2PType::Send ? " Send" : " Recv");
-  VLOG(1) << CurrentRank().value() << stype << " to " << peer.value()
-          << " count " << count << " MORI communicator: " << ToString();
-  CHECK_CANCELLED()
-
-  void* source_ptr = send_buffer.opaque();
-  void* dest_ptr = recv_buffer.opaque();
-
-  ABSL_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
-  auto gpu_stream = AsRocmStream(stream);
-  size_t bytes = ToMoriByteCount(dtype, count);
-  int res = 0;
-  (void)bytes;
-  (void)res;
-  (void)gpu_stream;
-  (void)source_ptr;
-  (void)dest_ptr;
-  (void)peer;
-  (void)stream;
-  (void)dtype;
-  (void)count;
-  (void)p2p_type;
-  return absl::UnimplementedError("Not implemented");
+  std::vector<int> dstPes;
+  dstPes.reserve(target_ranks.size());
+  for (RankId rank : target_ranks) {
+    dstPes.push_back(static_cast<int>(rank.value()));
+  }
+  const int srcPe = source_rank ? static_cast<int>(source_rank->value()) : -1;
+  return se::gpu::ToStatus(facade_->RunCollectivePermute(
+      send_buffer.opaque(), recv_buffer.opaque(), ToMoriByteCount(dtype, count),
+      srcPe, dstPes, AsHipStream(stream)));
 }
 
 Future<> MoriCommunicator::GroupExecute(
@@ -339,19 +438,16 @@ absl::Status MoriCommunicator::GroupLaunch(
 }
 
 absl::Status MoriCommunicator::Quiet(const Executor& executor) {
-  VLOG(1) << "Quiet MORI communicator: " << ToString();
+  VLOG(1) << "Quiet: " << ToString();
   CHECK_CANCELLED()
   ABSL_ASSIGN_OR_RETURN(se::Stream * stream, ToStream(executor));
-  auto gpu_stream = AsRocmStream(stream);
-  (void)gpu_stream;
-  return absl::UnimplementedError("Not implemented");
+  return se::gpu::ToStatus(facade_->RunQuiet(AsHipStream(stream)));
 }
 
 absl::Status MoriCommunicator::Fence() {
-  VLOG(1) << "Fence MORI communicator: " << ToString();
+  VLOG(1) << "Fence: " << ToString();
   CHECK_CANCELLED()
-  // rocm_mori_fence();
-  return absl::UnimplementedError("Not implemented");
+  return se::gpu::ToStatus(facade_->RunFence());
 }
 
 absl::Status MoriCommunicator::PollUntilDone() const {

--- a/xla/backends/gpu/collectives/mori_communicator.h
+++ b/xla/backends/gpu/collectives/mori_communicator.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "absl/functional/function_ref.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/collectives/cancellation_token.h"
@@ -32,19 +33,44 @@ limitations under the License.
 #include "xla/core/collectives/communicator.h"
 #include "xla/core/collectives/rank_id.h"
 #include "xla/core/collectives/reduction_kind.h"
+#include "xla/core/collectives/symmetric_memory.h"
 #include "xla/future.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/xla_data.pb.h"
 
+namespace mori::collective {
+class CollectivesFacade;
+}  // namespace mori::collective
+
 namespace xla::gpu {
 
 class MoriCollectives;
 
+// Dummy symmetric memory for the MORI backend. MORI collective buffers are
+// allocated directly from the symmetric shmem heap, so the local device
+// address doubles as the symmetric handle and no separate registration is
+// required. This simply returns the address it was created with.
+class MoriSymmetricMemory : public SymmetricMemory {
+ public:
+  explicit MoriSymmetricMemory(se::DeviceAddressBase addr) : addr_(addr) {}
+
+  se::DeviceAddressBase addr() const final { return addr_; }
+
+  std::string ToString() const final {
+    return absl::StrFormat("MoriSymmetricMemory(addr=%p, size=%d)",
+                           addr_.opaque(), addr_.size());
+  }
+
+  PackedKernelArg PackKernelArg() const final { return addr_.opaque(); }
+
+ private:
+  se::DeviceAddressBase addr_;
+};
+
 // XLA collectives communicator wrapping a MORI communicator.
 class MoriCommunicator : public GpuCommunicator {
  public:
-  constexpr static uint32_t kMaxTeams = 24;
 
   friend class MoriCollectives;
   ~MoriCommunicator() override;
@@ -62,6 +88,14 @@ class MoriCommunicator : public GpuCommunicator {
   absl::Status Abort() final;
   absl::StatusOr<size_t> NumRanks() const final;
   absl::StatusOr<size_t> CurrentRank() final;
+
+  absl::StatusOr<std::unique_ptr<SymmetricMemory>> CreateSymmetricMemory(
+      se::DeviceAddressBase addr) final {
+    // Dummy implementation: MORI buffers are already allocated from the
+    // symmetric shmem heap, so the local device address is the symmetric
+    // handle. Just wrap and return it unchanged.
+    return std::make_unique<MoriSymmetricMemory>(addr);
+  }
 
   absl::Status Barrier(const Executor& executor) final;
 
@@ -98,21 +132,9 @@ class MoriCommunicator : public GpuCommunicator {
                              const Executor& executor) final;
 
   Future<> Send(se::DeviceAddressBase send_buffer, PrimitiveType dtype,
-                size_t count, RankId peer, const Executor& executor) final {
-    return absl::UnimplementedError("Not implemented");
-  }
-
-  Future<> Recv(se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
-                size_t count, RankId peer, const Executor& executor) final {
-    return absl::UnimplementedError("Not implemented");
-  }
-
-  Future<> Send(se::DeviceAddressBase recv_buffer,
-                se::DeviceAddressBase send_buffer, PrimitiveType dtype,
                 size_t count, RankId peer, const Executor& executor) final;
 
-  Future<> Recv(se::DeviceAddressBase recv_buffer,
-                se::DeviceAddressBase send_buffer, PrimitiveType dtype,
+  Future<> Recv(se::DeviceAddressBase recv_buffer, PrimitiveType dtype,
                 size_t count, RankId peer, const Executor& executor) final;
 
   // Polls the communicator until any pending non-blocking operations are done
@@ -149,9 +171,7 @@ class MoriCommunicator : public GpuCommunicator {
   absl::Status LaunchAllToAll(
       absl::InlinedVector<se::DeviceAddressBase, 4> send_buffers,
       absl::InlinedVector<se::DeviceAddressBase, 4> recv_buffers,
-      PrimitiveType dtype, size_t count, const Executor& executor) final {
-    return absl::UnimplementedError("Not implemented");
-  }
+      PrimitiveType dtype, size_t count, const Executor& executor) final;
 
   absl::Status LaunchCollectivePermute(se::DeviceAddressBase send_buffer,
                                        se::DeviceAddressBase recv_buffer,
@@ -162,15 +182,11 @@ class MoriCommunicator : public GpuCommunicator {
 
   absl::Status LaunchSend(se::DeviceAddressBase send_buffer,
                           PrimitiveType dtype, size_t count, RankId peer,
-                          const Executor& executor) final {
-    return absl::UnimplementedError("Not implemented");
-  }
+                          const Executor& executor) final;
 
   absl::Status LaunchRecv(se::DeviceAddressBase recv_buffer,
                           PrimitiveType dtype, size_t count, RankId peer,
-                          const Executor& executor) final {
-    return absl::UnimplementedError("Not implemented");
-  }
+                          const Executor& executor) final;
 
   absl::Status Quiet(const Executor& executor) final;
 
@@ -186,22 +202,16 @@ class MoriCommunicator : public GpuCommunicator {
                    std::shared_ptr<CancellationToken> cancel)
       : collectives_(coll), cancel_(std::move(cancel)) {}
 
-  enum class P2PType : int32_t { Send, Recv };
-
-  absl::Status P2P(P2PType p2p_type, PrimitiveType type,
-                   se::DeviceAddressBase recv_buffer,
-                   se::DeviceAddressBase send_buffer, size_t count, RankId peer,
-                   const Executor& executor);
-
-  static absl::StatusOr<se::Stream*> ToStream(const Executor& executor);
-
   MoriCollectives* collectives_;  // Parent MoriCollectives instance
 
   // This communicator's participant set (NOT the global MORI clique). `rank_`
-  // is this rank within the collective, `num_ranks_` the participant count, and
-  // `rank_to_pe_dev_` a device array mapping collective rank -> global MORI PE.
+  // is this rank within the collective, `num_ranks_` the participant count.
   int rank_ = 0;
   int num_ranks_ = 0;
+  // Owns this communicator's staging buffer + group counters (created in
+  // Create(), freed by the facade dtor before ShmemFinalize). Header-only
+  // facade.
+  std::unique_ptr<::mori::collective::CollectivesFacade> facade_;
   // Should all pending collectives cancel?
   std::shared_ptr<CancellationToken> cancel_;
   bool aborted_ = false;  // Has Abort() been called?

--- a/xla/backends/gpu/collectives/mori_kernels.cu.cc
+++ b/xla/backends/gpu/collectives/mori_kernels.cu.cc
@@ -1,0 +1,19 @@
+/* Copyright 2026 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This is the single device translation unit for the MORI XLA collectives. It
+// is compiled as HIP and defines MORI_KERNELS_IMPL before including the facade,
+// so the facade's device path (kernels + non-templated Run* definitions) is
+// compiled here exactly once. The host mori_communicator.cc includes the same
+// header without MORI_KERNELS_IMPL (decl-only) and links against these symbols.
+#define MORI_KERNELS_IMPL
+#include "xla/backends/gpu/collectives/mori_kernels.h"

--- a/xla/backends/gpu/collectives/mori_kernels.h
+++ b/xla/backends/gpu/collectives/mori_kernels.h
@@ -1,0 +1,27 @@
+/* Copyright 2026 The OpenXLA Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_COLLECTIVES_MORI_KERNELS_H_
+#define XLA_BACKENDS_GPU_COLLECTIVES_MORI_KERNELS_H_
+
+#include <cstddef>
+#include <cstdint>
+
+// The CollectivesFacade owns the per-device staging + Run* entry points, which
+// are non-templated and take mori::collective::DataType / ReduceOpKind enums.
+// Host includers (mori_communicator.cc) see decl-only Run* methods; the device
+// TU (mori_kernels.cu.cc, compiled as HIP with MORI_KERNELS_IMPL) pulls in the
+// full device path and emits the definitions that resolve the host's
+// references.
+#include "xla/backends/gpu/collectives/mori_stub.h"
+
+#endif  // XLA_BACKENDS_GPU_COLLECTIVES_MORI_KERNELS_H_

--- a/xla/backends/gpu/collectives/mori_stub.h
+++ b/xla/backends/gpu/collectives/mori_stub.h
@@ -16,9 +16,14 @@ limitations under the License.
 #ifndef XLA_BACKENDS_GPU_COLLECTIVES_MORI_STUB_H_
 #define XLA_BACKENDS_GPU_COLLECTIVES_MORI_STUB_H_
 
+#include <hip/hip_runtime.h>
+
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
 
 // Inert stand-in for the subset of the MORI shmem host API used by the MORI
 // collectives/communicator backbone. These placeholders let the backbone
@@ -70,6 +75,76 @@ inline void* ShmemMalloc(size_t /*size*/) {
 inline void ShmemFree(void* /*ptr*/) {}
 
 }  // namespace shmem
+}  // namespace mori
+
+namespace mori {
+namespace collective {
+
+// Element type + reduction op enums mirror the real facade's non-templated API
+// (mori/collective/collectives_facade.hpp), so the communicator's enum dispatch
+// compiles against either the stub or the real facade.
+enum class DataType {
+  F8E5M2,
+  F8E4M3FN,
+  F16,
+  BF16,
+  S8,
+  U8,
+  S32,
+  U32,
+  S64,
+  U64,
+  F32,
+  F64
+};
+enum class ReduceOpKind { SUM, PRODUCT, MIN, MAX };
+
+// Inert stand-in for the real MORI CollectivesFacade. Header-only, all Run* are
+// no-ops returning hipSuccess. Lets the collectives/communicator wiring compile
+// and link without @roc_mori.
+class CollectivesFacade {
+  CollectivesFacade() = default;
+
+ public:
+  using AddressVector = std::vector<std::pair<const void*, void*>>;
+
+  CollectivesFacade(const CollectivesFacade&) = delete;
+  CollectivesFacade& operator=(const CollectivesFacade&) = delete;
+
+  static std::unique_ptr<CollectivesFacade> Create(int /*myPe*/, int /*nPes*/,
+                                                   size_t /*maxStagingBytes*/) {
+    return std::unique_ptr<CollectivesFacade>(new CollectivesFacade());
+  }
+  ~CollectivesFacade() = default;
+
+  hipError_t RunReduceScatter(const void*, void*, size_t, DataType,
+                              ReduceOpKind, hipStream_t) {
+    return hipSuccess;
+  }
+  hipError_t RunAllReduce(const void*, void*, size_t, DataType, ReduceOpKind,
+                          hipStream_t) {
+    return hipSuccess;
+  }
+  hipError_t RunAllGather(const void*, void*, size_t, hipStream_t) {
+    return hipSuccess;
+  }
+  hipError_t RunAllToAll(const AddressVector&, size_t, hipStream_t) {
+    return hipSuccess;
+  }
+  hipError_t RunBarrier(hipStream_t) { return hipSuccess; }
+  hipError_t RunSend(const void*, size_t, int, hipStream_t) {
+    return hipSuccess;
+  }
+  hipError_t RunRecv(void*, size_t, int, hipStream_t) { return hipSuccess; }
+  hipError_t RunCollectivePermute(const void*, void*, size_t, int,
+                                  const std::vector<int>&, hipStream_t) {
+    return hipSuccess;
+  }
+  hipError_t RunQuiet(hipStream_t) { return hipSuccess; }
+  hipError_t RunFence() { return hipSuccess; }
+};
+
+}  // namespace collective
 }  // namespace mori
 
 #endif  // XLA_BACKENDS_GPU_COLLECTIVES_MORI_STUB_H_


### PR DESCRIPTION
## Summary

This PR routes every MORI GPU collective in `MoriCommunicator` through a single, dedicated `CollectivesFacade` entry point instead of the previous ad-hoc per-op plumbing. It also introduces a thin shared header and an inert stub facade so the XLA side compiles, links, and can be committed **without** depending on the external `@roc_mori` library.

The facade exposes a **non-templated, enum-based** public API: `Run*` methods take `mori::collective::DataType` and `ReduceOpKind` enums rather than `<T, Op>` template arguments. Host translation units (the communicator) see decl-only method declarations, while a single device translation unit (`mori_kernels.cu.cc`, compiled as HIP) defines `MORI_KERNELS_IMPL` before including the facade and thereby compiles the method definitions exactly once. This replaces the earlier `template <class = void>` + explicit-instantiation machinery.

## Motivation

- Consolidate all collective launches (all-reduce, reduce-scatter, all-gather, all-to-all, barrier, send/recv, collective-permute, quiet, fence) behind one facade owned by the communicator, so staging buffers and group counters have a single, clearly-scoped owner and lifetime.
- Present a clean compiled boundary: a small non-templated public API instead of template dispatch leaking through the header, no explicit-instantiation lists to maintain, and the type/op dispatch localized inside the facade.
- Decouple the XLA build from the MORI source tree so this wiring can land independently, with a compile-time switch to bring in the real device facade later.

## What changed

### `mori_communicator.cc` / `mori_communicator.h`
- Each communicator owns a `std::unique_ptr<mori::collective::CollectivesFacade>`, created in `MoriCommunicator::Create` (records rank identity and allocates the symmetric-heap staging buffer). The `unique_ptr` frees the staging/counters via the facade destructor before `ShmemFinalize`.
- All `Launch*` paths now call `facade_->Run*` and convert the returned `hipError_t` to `absl::Status` via `se::gpu::ToStatus`.
- Reduction dispatch is now enum translation, not macro/switch-key generation: `ToMoriDataType(PrimitiveType)` and `ToMoriReduceOp(ReductionKind)` map XLA enums to the facade enums (returning `Unimplemented` for unsupported dtypes), then `LaunchAllReduce` / `LaunchReduceScatter` call the non-templated `facade_->RunAllReduce(...)` / `RunReduceScatter(...)` directly. The old `MoriRedKey` key-packing and `MORI_FOR_EACH_DTYPE` x `MORI_FOR_EACH_OP` case tables are gone.
- Supported dtypes include the OCP fp8 types `F8E5M2` and `F8E4M3FN` alongside F16/BF16/S8/U8/S32/U32/S64/U64/F32/F64.
- Removed the old `P2P`/`P2PType` indirection; `Send`/`Recv` now go straight through `LaunchSend`/`LaunchRecv`. `Send` dropped its unused `recv_buffer` parameter and `Recv` its unused `send_buffer` parameter.
- Stream handle helper switched from `AsRocmStream` (intptr) to `AsHipStream` (`hipStream_t`); `ToStream` moved into an anonymous namespace.
- `MoriCommunicator::Create` now validates `num_ranks > 0`.

### `mori_kernels.h` (new)
- Thin seam included by both the host communicator (decl-only) and the device TU. It selects the facade implementation: by default includes the inert stub (`mori_stub.h`); defining `XLA_GPU_USE_REAL_MORI` pulls in the real `mori/collective/collectives_facade.hpp` instead.
- No longer defines any dtype/op expansion macros; the type/op dispatch now lives inside the facade.

### `mori_kernels.cu.cc` (new)
- Single HIP device TU. It `#define`s `MORI_KERNELS_IMPL` and includes `mori_kernels.h`, which compiles the facade's device path (kernels + non-templated `Run*` definitions) exactly once and emits the symbols the host references. No explicit template instantiations. In the default (stub) build it is a harmless near-empty TU.

### `mori_stub.h`
- Inert, header-only `mori::collective::CollectivesFacade` mirroring the real facade's non-templated enum API. Defines the `DataType` (incl. `F8E5M2`/`F8E4M3FN`) and `ReduceOpKind` enums and the `AddressVector` alias. `Create` returns a valid empty facade; every `Run*` is a no-op returning `hipSuccess`.
