### PR TITLE
[ROCm] Remove xla bes keyword from jax CI

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -111,7 +111,6 @@ jobs:
             --repo_env=HERMETIC_PYTHON_VERSION=3.14 \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${DOCKER_IMAGE}" \
             --jobs=20 \
-            --bes_keywords=xla \
             --bes_keywords=jax \
             --bes_keywords=upstream \
             --bes_keywords=gpu \


### PR DESCRIPTION
📝 Summary of Changes
Remove xla bes keyword from jax CI

🎯 Justification
Makes it easier to filter out xla only tests

🚀 Kind of Contribution
 ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
N\A

🧪 Unit Tests:
N\A
🧪 Execution Tests:
N\A