### PR TITLE
[XLA:GPU] Demote and rate-limit the delay kernel timeout log

### DIFF
--- a/xla/stream_executor/cuda/cuda_timer.cc
+++ b/xla/stream_executor/cuda/cuda_timer.cc
@@ -85,9 +85,10 @@ absl::StatusOr<absl::Duration> CudaTimer::GetElapsedDuration() {
   if (semaphore_) {
     if (*semaphore_ == GpuSemaphoreState::kTimedOut) {
       // The delay kernel did not achieve the intended result.
-      LOG(ERROR) << "Delay kernel timed out: measured time has sub-optimal "
-                    "accuracy. There may be a missing warmup execution, please "
-                    "investigate in Nsight Systems.";
+      LOG_FIRST_N(WARNING, 5)
+          << "Delay kernel timed out: measured time has sub-optimal "
+             "accuracy. There may be a missing warmup execution, please "
+             "investigate in Nsight Systems.";
     } else {
       // Signal that the kernel can exit
       *semaphore_ = GpuSemaphoreState::kRelease;


### PR DESCRIPTION
## 📝 Summary of Changes

Changes the "Delay kernel timed out" message in `CudaTimer::GetElapsedDuration` from an unconditional `LOG(ERROR)` to `LOG_FIRST_N(WARNING, 5)`.

## 🎯 Justification

Fixes #26466.

The delay kernel timing out only means one timing measurement has reduced accuracy; execution continues normally. The message fires once per timed execution, so during autotuning of a larger model it repeats hundreds of times at ERROR severity, and there is nothing an end user can do about it. The delay kernel itself documents the intent in `delay_kernel_cuda.cu.cc`: "Signal this back to the host so that we can emit a warning".

This matches the ROCm delay kernel added in #47065, which logs the same condition with `LOG_FIRST_N(WARNING, 5)`, and the earlier delay kernel log spam cleanup in #16566. The message text keeps the "missing warmup execution / Nsight Systems" sentence that the ROCm variant drops, since Nsight is CUDA-specific and that sentence is the actionable part of the message.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

No new test: the change only affects the log macro on an otherwise unchanged code path, and forcing a delay kernel timeout deterministically in a unit test would need a >100 ms host stall (flaky by construction). Existing `//xla/stream_executor/cuda:cuda_timer_test` still passes on an RTX 2070.

## 🧪 Execution Tests:

Built `//xla/stream_executor/cuda:cuda_timer` and ran `//xla/stream_executor/cuda:cuda_timer_test` locally on a single RTX 2070 (sm_75).