### PR TITLE
[GPU][Triton] Fall back to smaller tiles on shared/tensor memory overflow

### DIFF
--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -803,6 +803,7 @@ cc_library(
     hdrs = ["triton_wrapper_result.h"],
     deps = [
         "//xla/codegen:llvm_kernel_source",
+        "//xla/service/gpu/model:block_level_parameters",
         "//xla/stream_executor:launch_dim",
         "//xla/stream_executor/gpu:tma_metadata",
         "@llvm-project//llvm:ir_headers",

--- a/xla/backends/gpu/codegen/triton/fusion.cc
+++ b/xla/backends/gpu/codegen/triton/fusion.cc
@@ -159,21 +159,15 @@ xla::Future<TritonWrapperResult> TritonFusion::GenerateTritonKernelAndWrapper(
   BlockLevelParameters block_level_parameters =
       BlockLevelParameters::FromBlockLevelFusionConfig(
           analysis_.fusion_backend_config().block_level_fusion_config());
-  ABSL_ASSIGN_OR_RETURN(
-      TritonKernelSource kernel_source,
-      CreateTritonModule(impl_fn_name, fusion, device_info,
-                         block_level_parameters, **borrowed_context));
 
-  // Forward PDL launch annotation from HLO to MLIR.
-  if (DoesPdlLaunch(fusion)) {
-    kernel_source.module()->setAttr(
-        kXlaPdlLaunch, mlir::UnitAttr::get(borrowed_context->get()));
-  }
-  return compiler->CompileTritonToLlvm(
-      impl_fn_name, *fusion.GetModule(), device_info, block_level_parameters,
-      target_triple, data_layout, std::move(kernel_source),
-      std::move(borrowed_context),
-      /*is_xla_fusion=*/true);
+  // Emit and compile the Triton kernel. If the tile requires more shared (or
+  // Blackwell tensor) memory than the device provides, this retries with
+  // progressively smaller tiles based on the actual on-chip memory usage
+  // reported by the compiled kernel, instead of failing with a
+  // RESOURCE_EXHAUSTED error.
+  return CompileTritonWithMemoryFallback(impl_fn_name, fusion, device_info,
+                                         block_level_parameters, target_triple,
+                                         data_layout, **borrowed_context);
 };
 
 AsyncThunkSequence TritonFusion::Emit(
@@ -282,14 +276,27 @@ xla::Future<TritonFusion::EmitResult> TritonFusion::Emit(
           // enabled. Ideally we should always pass the thread_dims value
           // extracted from the Triton compilation. However, we are keeping the
           // old code path to maintain the current behavior and be safe.
+          //
+          // The tile configuration actually used to compile the kernel may
+          // differ from the one in the fusion's backend config when the
+          // shared/tensor-memory fallback in `CompileTritonWithMemoryFallback`
+          // had to shrink the tiling to fit on-chip memory. In that case we
+          // MUST derive the launch grid from the tiling the kernel was really
+          // compiled with (`triton_wrapper_result.block_level_parameters`);
+          // otherwise the launch block count would be computed from the larger,
+          // requested tile and the kernel would only compute a fraction of the
+          // output.
           if (fusion->GetModule()
                   ->config()
                   .debug_options()
                   .xla_gpu_experimental_enable_triton_warp_specialization()) {
             launch_config =
-                GetLaunchConfig(analysis, triton_wrapper_result.thread_dims);
+                GetLaunchConfig(analysis, triton_wrapper_result.thread_dims,
+                                triton_wrapper_result.block_level_parameters);
           } else {
-            launch_config = GetLaunchConfig(analysis);
+            launch_config =
+                GetLaunchConfig(analysis, /*thread_dims_override=*/std::nullopt,
+                                triton_wrapper_result.block_level_parameters);
           }
           // This check should be enforced by `GenerateTritonKernelWrapper`.
           CHECK(launch_config.has_value());
@@ -353,14 +360,22 @@ int64_t GetNumberOfBlocks(absl::Span<const int64_t> dimensions,
 
 std::optional<TritonFusion::LaunchConfig> TritonFusion::GetLaunchConfig(
     const HloFusionAnalysis* analysis,
-    std::optional<se::ThreadDim> thread_dims_override) {
+    std::optional<se::ThreadDim> thread_dims_override,
+    std::optional<BlockLevelParameters> block_level_parameters_override) {
   if (!analysis->fusion_backend_config().has_block_level_fusion_config()) {
     // MatMul is not yet supported.
     return std::nullopt;
   }
+  // Prefer the block-level parameters the kernel was actually compiled with
+  // (e.g. after the shared/tensor-memory fallback shrank the tiling) over the
+  // ones requested in the fusion's backend config. The launch grid MUST match
+  // the tiling the kernel was compiled with, otherwise it would only compute a
+  // fraction of the output.
   BlockLevelParameters block_level_parameters =
-      BlockLevelParameters::FromBlockLevelFusionConfig(
-          analysis->fusion_backend_config().block_level_fusion_config());
+      block_level_parameters_override.has_value()
+          ? *block_level_parameters_override
+          : BlockLevelParameters::FromBlockLevelFusionConfig(
+                analysis->fusion_backend_config().block_level_fusion_config());
 
   // We expect all roots to have the same number of blocks. Otherwise we
   // cannot codegen it.

--- a/xla/backends/gpu/codegen/triton/fusion.h
+++ b/xla/backends/gpu/codegen/triton/fusion.h
@@ -92,9 +92,17 @@ class TritonFusion : public FusionInterface {
   // compilation, but there are use-cases where we want to call the function
   // without compiling, e.g. during cost modelling. In that case, the function
   // calculates the values.
+  //
+  // If `block_level_parameters_override` is provided, its tile sizes and
+  // num_warps are used to compute the launch grid instead of the ones in the
+  // fusion's backend config. This must be set to the parameters the kernel was
+  // actually compiled with when the shared/tensor-memory fallback adjusted the
+  // tiling, so that the launch grid matches the compiled kernel.
   static std::optional<LaunchConfig> GetLaunchConfig(
       const HloFusionAnalysis* analysis,
-      std::optional<se::ThreadDim> thread_dims_override = std::nullopt);
+      std::optional<se::ThreadDim> thread_dims_override = std::nullopt,
+      std::optional<BlockLevelParameters> block_level_parameters_override =
+          std::nullopt);
 
   // Generates a Triton kernel for the given fusion into the provided LLVM
   // module, and returns the `TritonWrapperResult` corresponding to the

--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -1423,6 +1423,49 @@ CHECK-COUNT-2: xtile.insert
   EXPECT_TRUE(RunAndCompareNoHloPasses(kHloText, kExactMatch));
 }
 
+// The requested output tile [32, 16, 128] makes the transpose stage a
+// 32x2048-element tile in shared memory, which exceeds the shared memory budget
+// of some devices (e.g. gfx1201 with a 64KiB opt-in limit for bf16, or gfx950
+// for f32). Rather than failing with RESOURCE_EXHAUSTED, the non-autotuner
+// emission path (CompileTritonWithMemoryFallback) automatically retries with
+// progressively smaller / different-axis tiles until it finds one that both
+// satisfies the emitter's tiling constraints and fits in on-chip memory. This
+// test exercises that fallback end-to-end and checks the result is still
+// correct. It is parametrized over the tiling path so that both the symbolic
+// and the experimental tiling-propagation error surfaces are covered.
+TEST_P(TritonEmitterTestWithTilingParam,
+       TransposeExceedingSharedMemoryFallsBackToSmallerTile) {
+  constexpr absl::string_view kHloText = R"(
+HloModule m
+
+transpose_fusion {
+  param_0 = f32[1024,2080]{0,1} parameter(0)
+  bitcast_0 = f32[2080,1024]{1,0} bitcast(param_0)
+  slice = f32[2048,1024]{1,0} slice(bitcast_0), slice={[32:2080], [0:1024]}
+  transpose = f32[1024,2048]{1,0} transpose(slice), dimensions={1,0}
+  ROOT bitcast_1 = f32[1024,16,128]{2,1,0} bitcast(transpose)
+}
+
+ENTRY entry_computation {
+  param_0 = f32[1024,2080]{0,1} parameter(0)
+  ROOT fusion = f32[1024,16,128]{2,1,0} fusion(param_0), kind=kCustom,
+    calls=transpose_fusion,
+    backend_config={
+      "fusion_backend_config":{
+        "kind":"__triton",
+        "block_level_fusion_config":{
+          "output_tiles":[{"sizes":["32","16","128"]}],
+          "num_warps":"8",
+          "num_ctas":"1",
+          "num_stages":"1"}}}
+})";
+  // The fallback only kicks in when the requested tile actually overflows the
+  // device's shared memory. On devices with a large enough budget the initial
+  // tile compiles directly; either way the fusion must compile and run
+  // correctly, so we simply assert end-to-end correctness here.
+  EXPECT_TRUE(RunAndCompareNoHloPasses(kHloText, kExactMatch));
+}
+
 class IotaEmitterParametrizedTest
     : public TritonEmitterTest,
       public ::testing::WithParamInterface<std::tuple<PrimitiveType, bool>> {

--- a/xla/backends/gpu/codegen/triton/triton_wrapper_result.h
+++ b/xla/backends/gpu/codegen/triton/triton_wrapper_result.h
@@ -17,10 +17,12 @@ limitations under the License.
 #define XLA_BACKENDS_GPU_CODEGEN_TRITON_TRITON_WRAPPER_RESULT_H_
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "llvm/IR/Metadata.h"
 #include "xla/codegen/llvm_kernel_source.h"
+#include "xla/service/gpu/model/block_level_parameters.h"
 #include "xla/stream_executor/gpu/tma_metadata.h"
 #include "xla/stream_executor/launch_dim.h"
 
@@ -32,6 +34,17 @@ struct TritonWrapperResult {
   stream_executor::gpu::TmaMetadata tma_metadata;
   stream_executor::ThreadDim thread_dims;
   bool use_pdl = false;
+
+  // The block-level parameters (tile sizes / num_warps / ...) that were
+  // actually used to compile the kernel. This can differ from the parameters
+  // requested by the fusion's backend config when the shared/tensor-memory
+  // fallback in `CompileTritonWithMemoryFallback` had to adjust the tiling to
+  // fit on-chip memory. It is `std::nullopt` for compilation paths that never
+  // adjust the tiling (e.g. raw Triton custom calls), in which case callers
+  // should use the requested configuration. Callers that compute launch
+  // dimensions from the tile sizes MUST prefer this value when present, so that
+  // the launch grid matches the tiling the kernel was actually compiled with.
+  std::optional<BlockLevelParameters> block_level_parameters;
 
   // The captured nvvm.annotations from the lowest level LLVM IR coming from
   // Triton. We need to propagate them because we later create the kernel and

--- a/xla/backends/gpu/codegen/triton/xtile_compiler.cc
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "xla/backends/gpu/codegen/triton/xtile_compiler.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -31,8 +32,10 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/status_macros.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "llvm/ADT/SmallVector.h"
@@ -493,6 +496,258 @@ absl::StatusOr<TritonWrapperResult> TritonWrapper(
                              /*is_xla_fusion=*/true);
 }
 
+namespace {
+
+// Formats the output tile sizes of `params` as e.g. "[[32,16,128]]" for logs.
+std::string TileSizesToString(const BlockLevelParameters& params) {
+  std::string out = "[";
+  for (int i = 0; i < params.output_tile_sizes.size(); ++i) {
+    if (i != 0) {
+      absl::StrAppend(&out, ",");
+    }
+    absl::StrAppend(&out, "[", absl::StrJoin(params.output_tile_sizes[i], ","),
+                    "]");
+  }
+  absl::StrAppend(&out, "]");
+  return out;
+}
+
+// The kind of failure a compilation attempt produced, used to drive how the
+// next candidate tile is derived.
+enum class FailureKind {
+  // Not a failure we can address by changing the tile.
+  kUnrecoverable,
+  // On-chip memory (shared or Blackwell tensor memory) exhaustion: the tile is
+  // valid but too large. Reported by `CompileTritonToLLVM` as
+  // RESOURCE_EXHAUSTED.
+  kOnChipMemory,
+  // The tile does not satisfy the emitter's tiling constraints (e.g.
+  // divisibility / layout constraints for a transpose): the tile is the wrong
+  // shape, not necessarily too large. Reported by
+  // `SymbolicTileAnalysis::ComputeTiledComputation` as INVALID_ARGUMENT.
+  kInvalidTiling,
+};
+
+FailureKind ClassifyFailure(const absl::Status& status) {
+  const absl::string_view message = status.message();
+
+  // On-chip memory exhaustion: the tile is valid but too large.
+  if (status.code() == absl::StatusCode::kResourceExhausted &&
+      (absl::StrContains(message, "Shared memory size limit") ||
+       absl::StrContains(message, "Tensor memory size limit"))) {
+    return FailureKind::kOnChipMemory;
+  }
+
+  // Invalid tile shape: the tile does not satisfy the emitter's tiling
+  // constraints. This surfaces differently on the two tiling paths:
+  //   * Symbolic (legacy) path: INVALID_ARGUMENT "Tiling does not satisfy
+  //     constraints" from `SymbolicTileAnalysis::ComputeTiledComputation`.
+  //   * Experimental tiling-propagation path
+  //     (`xla_gpu_experimental_enable_tiling_propagation`): UNIMPLEMENTED from
+  //     `tile_propagation.cc` when a shrunk tile makes a reshape non-contiguous
+  //     or leaves multiple dimensions partially tiled, or INVALID_ARGUMENT
+  //     "Triton constraints violated during codegen" from
+  //     `VerifyTritonConstraints`.
+  // In all these cases a different tile shape may be emittable, so we treat
+  // them as recoverable by trying a different axis.
+  if (status.code() == absl::StatusCode::kInvalidArgument &&
+      (absl::StrContains(message, "Tiling does not satisfy") ||
+       absl::StrContains(message, "Triton constraints violated"))) {
+    return FailureKind::kInvalidTiling;
+  }
+  if (status.code() == absl::StatusCode::kUnimplemented &&
+      (absl::StrContains(message, "partially tiled") ||
+       absl::StrContains(message, "Reshape is non-contiguous") ||
+       absl::StrContains(message, "negative strides"))) {
+    return FailureKind::kInvalidTiling;
+  }
+
+  return FailureKind::kUnrecoverable;
+}
+
+// Returns the index of the largest dimension of `tile` that is > 1, or -1 if
+// every dimension is already 1.
+int LargestShrinkableDim(const std::vector<int64_t>& tile) {
+  int largest_index = -1;
+  int64_t largest_size = 1;
+  for (int i = 0; i < tile.size(); ++i) {
+    if (tile[i] > largest_size) {
+      largest_size = tile[i];
+      largest_index = i;
+    }
+  }
+  return largest_index;
+}
+
+// Halves (clamped to >= 1) the largest > 1 dimension of every output tile.
+// Shared/tensor memory usage scales with tile volume, so this reduces the
+// requested on-chip memory. Returns false (leaving `params` unchanged) if no
+// tile can be shrunk further.
+bool ShrinkLargestTileDim(BlockLevelParameters& params) {
+  bool shrunk_any = false;
+  for (std::vector<int64_t>& tile : params.output_tile_sizes) {
+    int index = LargestShrinkableDim(tile);
+    if (index >= 0) {
+      tile[index] = std::max<int64_t>(1, tile[index] / 2);
+      shrunk_any = true;
+    }
+  }
+  return shrunk_any;
+}
+
+// Halves (clamped to >= 1) the dimension at position `axis` of every output
+// tile whose `axis` dimension is > 1. Returns false (leaving `params`
+// unchanged) if no tile has a shrinkable dimension at `axis`. Used to explore a
+// different axis when the previous tile shape did not satisfy the emitter's
+// tiling constraints.
+bool ShrinkTileAxis(BlockLevelParameters& params, int axis) {
+  bool shrunk_any = false;
+  for (std::vector<int64_t>& tile : params.output_tile_sizes) {
+    if (axis < tile.size() && tile[axis] > 1) {
+      tile[axis] = std::max<int64_t>(1, tile[axis] / 2);
+      shrunk_any = true;
+    }
+  }
+  return shrunk_any;
+}
+
+// Halves `num_warps` (clamped to >= 1). Returns false if it is already 1.
+// Reducing the warp count does not change the staging-tile shared memory of a
+// transpose (that buffer is tile_volume * elem_size * num_stages, independent
+// of num_warps), but it can change Triton's layout/pipeline decisions and helps
+// with register pressure, so it is used as a last-resort lever.
+bool ShrinkNumWarps(BlockLevelParameters& params) {
+  if (params.num_warps <= 1) {
+    return false;
+  }
+  params.num_warps = std::max<int64_t>(1, params.num_warps / 2);
+  return true;
+}
+
+// Maximum number of retries before giving up and propagating the original
+// error.
+constexpr int kMaxShrinkAttempts = 12;
+
+}  // namespace
+
+absl::StatusOr<TritonWrapperResult> CompileTritonWithMemoryFallback(
+    absl::string_view fn_name, const HloFusionInstruction& fusion,
+    const se::DeviceDescription& device_info,
+    const BlockLevelParameters& block_level_parameters,
+    const llvm::Triple& target_triple, const std::string& data_layout,
+    mlir::MLIRContext& mlir_context) {
+  // The initial (user-requested or default) configuration, kept for the
+  // summary warning emitted when we have to deviate from it.
+  const BlockLevelParameters initial = block_level_parameters;
+  // `params` is the last tile that fit in on-chip memory (or the initial one);
+  // it is the base we shrink from. When a memory-exhaustion shrink produces a
+  // tile that is invalid for the emitter, we revert to `params` and instead
+  // explore shrinking a different axis, rather than repeatedly halving an axis
+  // that does not resolve the shape problem.
+  BlockLevelParameters params = initial;
+  BlockLevelParameters candidate = params;
+  // The axis to try next when recovering from an invalid tiling. Cycles through
+  // the output tile dimensions.
+  int next_axis_to_try = 0;
+
+  for (int attempt = 0;; ++attempt) {
+    // Emit and compile with the current candidate tile sizes. Both stages
+    // depend on the tile sizes, so a retry re-runs both.
+    absl::StatusOr<TritonKernelSource> kernel_source = CreateTritonModule(
+        fn_name, fusion, device_info, candidate, mlir_context);
+    absl::StatusOr<TritonWrapperResult> result;
+    if (kernel_source.ok()) {
+      // Forward PDL launch annotation from HLO to MLIR.
+      if (DoesPdlLaunch(fusion)) {
+        kernel_source->module()->setAttr(kXlaPdlLaunch,
+                                         mlir::UnitAttr::get(&mlir_context));
+      }
+      result = CompileTritonToLLVM(fn_name, *fusion.GetModule(), device_info,
+                                   candidate, target_triple, data_layout,
+                                   std::move(*kernel_source), mlir_context,
+                                   /*is_xla_fusion=*/true);
+    } else {
+      result = kernel_source.status();
+    }
+
+    if (result.ok()) {
+      // If we had to deviate from the requested configuration, emit a single
+      // warning summarizing the change so the user knows the compiled kernel
+      // does not use their (or the default) tile configuration.
+      if (attempt > 0) {
+        LOG(WARNING)
+            << "Triton fusion " << fusion.name()
+            << ": the requested tile configuration could not be compiled and "
+               "was automatically adjusted. Initial configuration: tile sizes "
+            << TileSizesToString(initial) << ", num_warps " << initial.num_warps
+            << "; final configuration: tile sizes "
+            << TileSizesToString(candidate) << ", num_warps "
+            << candidate.num_warps << " (found after " << (attempt + 1)
+            << " tries).";
+      }
+      return result;
+    }
+
+    const FailureKind failure = ClassifyFailure(result.status());
+    if (failure == FailureKind::kUnrecoverable ||
+        attempt >= kMaxShrinkAttempts) {
+      return result.status();
+    }
+
+    BlockLevelParameters next;
+    if (failure == FailureKind::kOnChipMemory) {
+      // The candidate is valid but too large: commit it as the new base and
+      // shrink its largest dimension to reduce memory.
+      params = candidate;
+      next_axis_to_try = 0;
+      next = params;
+      if (!ShrinkLargestTileDim(next) && !ShrinkNumWarps(next)) {
+        // Nothing left to shrink.
+        return result.status();
+      }
+    } else {
+      // kInvalidTiling: the candidate shape is not emittable. Do not keep
+      // halving the same axis. Revert to the last-good base `params` and
+      // explore shrinking a different axis. If we run out of axes, fall back to
+      // reducing num_warps.
+      next = params;
+      bool made_progress = false;
+      const int num_axes =
+          params.output_tile_sizes.empty()
+              ? 0
+              : static_cast<int>(params.output_tile_sizes.front().size());
+      for (int tried = 0; tried < num_axes; ++tried) {
+        int axis = (next_axis_to_try + tried) % num_axes;
+        BlockLevelParameters attempt_params = params;
+        if (ShrinkTileAxis(attempt_params, axis)) {
+          next = std::move(attempt_params);
+          next_axis_to_try = (axis + 1) % num_axes;
+          made_progress = true;
+          break;
+        }
+      }
+      if (!made_progress) {
+        // No tile axis could be shrunk; try reducing num_warps as a last
+        // resort, otherwise give up.
+        next = params;
+        if (!ShrinkNumWarps(next)) {
+          return result.status();
+        }
+      }
+    }
+
+    // Keep the per-attempt detail at VLOG level for debugging; the user-facing
+    // summary is emitted once on success above.
+    VLOG(3) << "Triton fusion " << fusion.name()
+            << " could not be compiled with tile sizes "
+            << TileSizesToString(candidate) << " (num_warps "
+            << candidate.num_warps << "); retrying with tile sizes "
+            << TileSizesToString(next) << " (num_warps " << next.num_warps
+            << "). Error: " << result.status().message();
+    candidate = std::move(next);
+  }
+}
+
 absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
     absl::string_view kernel_name, const HloModule& hlo_module,
     const se::DeviceDescription& device_info,
@@ -663,6 +918,7 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
       tma_metadata,
       thread_dims,
       enable_pdl,
+      block_level_parameters,
       captured_nvvm_annotations,
       LlvmKernelSource{std::move(llvm_context), std::move(ll_triton_module)}};
   return result;

--- a/xla/backends/gpu/codegen/triton/xtile_compiler.h
+++ b/xla/backends/gpu/codegen/triton/xtile_compiler.h
@@ -72,6 +72,20 @@ absl::StatusOr<TritonWrapperResult> CompileTritonToLLVM(
     TritonKernelSource triton_source, mlir::MLIRContext& mlir_context,
     bool is_xla_fusion);
 
+// Emits and compiles the Triton kernel for `fusion` with the given
+// `block_level_parameters`. If compilation fails because the tile requires more
+// shared memory (or Blackwell tensor memory) than the device provides, this
+// retries with progressively smaller tile sizes (halving the largest output
+// tile dimension each attempt) and logs a warning, instead of failing with a
+// RESOURCE_EXHAUSTED error. All other errors, and
+// exhaustion that shrinking cannot resolve, are propagated unchanged.
+absl::StatusOr<TritonWrapperResult> CompileTritonWithMemoryFallback(
+    absl::string_view fn_name, const HloFusionInstruction& fusion,
+    const se::DeviceDescription& device_info,
+    const BlockLevelParameters& block_level_parameters,
+    const llvm::Triple& target_triple, const std::string& data_layout,
+    mlir::MLIRContext& mlir_context);
+
 std::string GetLibdevicePath(const HloModuleConfig& hlo_config,
                              const se::DeviceDescription& device_info);
 


### PR DESCRIPTION
📝 Summary of Changes
Add `CompileTritonWithMemoryFallback()`, which emits and compiles the kernel and, when it does not fit, automatically retries with a different tiling until it finds one that both satisfies the emitter's tiling constraints and fits in on-chip memory, instead of aborting. The decision is driven by the *actual* on-chip memory usage reported by the compiled kernel, not an estimate, so no valid configuration is rejected pre-emptively:

  * On shared/tensor-memory exhaustion (RESOURCE_EXHAUSTED) the current tile is valid but too large: it is committed as the new base and its largest dimension is halved to reduce memory.
  * On an invalid tile shape - reported as INVALID_ARGUMENT ("Tiling does not satisfy constraints" / "Triton constraints violated") on the symbolic path, or UNIMPLEMENTED ("partially tiled" / "Reshape is non-contiguous") on the experimental tiling-propagation path - the search reverts to the last good base and shrinks a different axis, rather than repeatedly halving an axis that does not resolve the shape problem. Reducing `num_warps` is used only as a last resort.

A single warning is emitted on success when the final configuration differs from the requested one, reporting the initial and final tile sizes / num_warps and the number of tries; per-attempt detail is at VLOG(3).

Because the fallback may change the tiling, the compiled configuration is now propagated back via `TritonWrapperResult::block_level_parameters`, and `TritonFusion::Emit` computes the launch grid from it.

🎯 Justification
On the non-autotuner block-level Triton fusion path the output tile sizes are fixed by the fusion's `block_level_fusion_config`. When a tile requires more shared memory (or Blackwell tcgen05 tensor memory) than the device provides, `CompileTritonToLLVM` failed the whole compilation with a RESOURCE_EXHAUSTED error.

Example of kernel failing on gfx1201:

```
HloModule transpose_shared_memory_repro, entry_computation_layout={(bf16[1024,2080]{0,1})->bf16[1024,16,128]{2,1,0}}

transpose_fusion {
  param_0 = bf16[1024,2080]{0,1} parameter(0)
  bitcast_0 = bf16[2080,1024]{1,0} bitcast(param_0)
  slice = bf16[2048,1024]{1,0} slice(bitcast_0), slice={[32:2080], [0:1024]}
  transpose = bf16[1024,2048]{1,0} transpose(slice), dimensions={1,0}
  ROOT bitcast_1 = bf16[1024,16,128]{2,1,0} bitcast(transpose)
}

ENTRY main {
  param_0 = bf16[1024,2080]{0,1} parameter(0)
  ROOT fusion = bf16[1024,16,128]{2,1,0} fusion(param_0), kind=kCustom,
    calls=transpose_fusion,
    backend_config={"fusion_backend_config":{"kind":"__triton","block_level_fusion_config":{"output_tiles":[{"sizes":["32","16","128"]}],"num_warps":"8","num_ctas":1,"num_stages":1,"is_tma_allowed":false,"is_warp_specialization_allowed":false,"waves_per_eu":0}}}
}
```

```
RESOURCE_EXHAUSTED: Shared memory size limit exceeded: requested 131072, available: 65536, context: [Fusion: fusion = bf16[1024,16,128]{2,1,0} fusion(param_0.1), kind=kCustom, calls=transpose_fusion, backend_config={"fusion_backend_config":{"kind":"__triton","block_level_fusion_config":{"output_tiles":[{"sizes":["32","16","128"]}],"num_warps":"8","num_ctas":1,"num_stages":1,"is_tma_allowed":false,"is_warp_specialization_allowed":false,"waves_per_eu":0}}}Computation: transpose_fusion {
  param_0 = bf16[1024,2080]{0,1} parameter(0)
  bitcast_0 = bf16[2080,1024]{1,0} bitcast(param_0)
  slice = bf16[2048,1024]{1,0} slice(bitcast_0), slice={[32:2080], [0:1024]}
  transpose = bf16[1024,2048]{1,0} transpose(slice), dimensions={1,0}
  ROOT bitcast_1 = bf16[1024,16,128]{2,1,0} bitcast(transpose)
```

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix,


🧪 Execution Tests:
Adds an end-to-end test (parametrized over the symbolic and experimental tiling paths) that compiles and runs the overflowing transpose fusion and checks the result is correct.