### PR TITLE
[ROCm] Revert to use ROCm-7.2.4 in CI

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash
         run: |
           # hermetic llvm based on  ghcr.io/rocm/jax-ubu22.rocm7.2.4:latest
-          echo "docker-image=ghcr.io/rocm/jax-build-ubu24.rocmless@sha256:68854ed30b800d3e8c390f6e651721e2bead58830da1c59e1b828354eb8f077f" >> "$GITHUB_OUTPUT"
+          echo "docker-image=ghcr.io/rocm/jax-ubu22.rocm7.2.4@sha256:248db525342fb7438ccbc6f5f1396ec82c783f7e0ae5667cb698edcddc8fe2fd" >> "$GITHUB_OUTPUT"
           echo "docker-image-jax=ghcr.io/rocm/jax-ubu22.rocm7.2.4@sha256:248db525342fb7438ccbc6f5f1396ec82c783f7e0ae5667cb698edcddc8fe2fd" >> "$GITHUB_OUTPUT"
 
   jax:
@@ -111,7 +111,6 @@ jobs:
             --repo_env=HERMETIC_PYTHON_VERSION=3.14 \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${DOCKER_IMAGE}" \
             --jobs=20 \
-            --bes_keywords=xla \
             --bes_keywords=jax \
             --bes_keywords=upstream \
             --bes_keywords=gpu \
@@ -150,13 +149,11 @@ jobs:
         timeout-minutes: 120
         run: |
           build_tools/rocm/execute_ci_build_upstream.sh \
-            --config=rocm_ci_hermetic \
+            --config=rocm_ci \
             --config=rocm_rbe \
             --config=ci_single_gpu \
             --local_test_jobs=1 \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${DOCKER_IMAGE}" \
-            --repo_env=ROCM_DISTRO_URL="https://repo.amd.com/rocm/tarball-multi-arch/therock-dist-linux-multiarch-7.14.0.tar.gz" \
-            --repo_env=ROCM_DISTRO_HASH="baadd54cff7a064b3b0ae51c19606ee4bced0f4215a21c89f616cf9c01ea4b47" \
             --local_test_jobs=1 \
             --internal_spawn_scheduler \
             --strategy=TestRunner=dynamic \
@@ -168,14 +165,12 @@ jobs:
         timeout-minutes: 80
         run: |
           build_tools/rocm/execute_ci_build_upstream.sh \
-            --config=rocm_ci_hermetic \
+            --config=rocm_ci \
             --config=rocm_rbe \
             --config=ci_rocm_cpu \
             --local_test_jobs=200 \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${DOCKER_IMAGE}" \
             --repo_env=ROCM_PATH="" \
-            --repo_env=ROCM_DISTRO_URL="https://repo.amd.com/rocm/tarball-multi-arch/therock-dist-linux-multiarch-7.14.0.tar.gz" \
-            --repo_env=ROCM_DISTRO_HASH="baadd54cff7a064b3b0ae51c19606ee4bced0f4215a21c89f616cf9c01ea4b47" \
             --bes_keywords=xla \
             --bes_keywords=upstream \
             --bes_keywords=cpu \


### PR DESCRIPTION
📝 Summary of Changes
Use ROCm-7.2.4 image for CI testing

🎯 Justification
RBE queues are bit overstretched. Reverting to use 7.2.4 to reduce stress on RBE nodes

🚀 Kind of Contribution
 🧪 Tests


