### PR TITLE
[xla:gpu] Fix DUS Fusion V2 descriptors when double-buffering loops

### DIFF
--- a/xla/backends/gpu/transforms/double_buffer_loop_unrolling.cc
+++ b/xla/backends/gpu/transforms/double_buffer_loop_unrolling.cc
@@ -139,14 +139,15 @@ absl::Status AdjustDynamicSliceConfig(HloInstruction* instr,
       });
 }
 
-// Adjusts the DS/DUS DynamicSliceConfig on `instr` and, if it is a fusion,
-// recurses into its fused computation. Fusion computations are cloned with the
-// fusion instruction, so each clone has its own private fused computation and
-// no cross-clone deduplication is needed.
+// Adjusts the DS/DUS DynamicSliceConfig on `instr` and recurses into private
+// computations cloned together with the instruction. Fusion and async-start
+// clones each own a distinct computation, so no cross-clone deduplication is
+// needed.
 absl::Status AdjustDynamicSliceConfigsForInstruction(
     HloInstruction* instr, const LoopIteration& loop_iteration) {
   ABSL_RETURN_IF_ERROR(AdjustDynamicSliceConfig(instr, loop_iteration));
-  if (instr->opcode() == HloOpcode::kFusion) {
+  if (instr->opcode() == HloOpcode::kFusion ||
+      instr->opcode() == HloOpcode::kAsyncStart) {
     for (HloComputation* called_computation : instr->called_computations()) {
       for (HloInstruction* nested : called_computation->instructions()) {
         ABSL_RETURN_IF_ERROR(

--- a/xla/backends/gpu/transforms/double_buffer_loop_unrolling_test.cc
+++ b/xla/backends/gpu/transforms/double_buffer_loop_unrolling_test.cc
@@ -387,6 +387,81 @@ ENTRY main {
 }
 
 TEST_F(GpuLoopDoubleBufferTransformerTest,
+       UpdatesDynamicSliceConfigInsideClonedAsyncComputation) {
+  constexpr absl::string_view kModuleString = R"(
+HloModule m
+
+condition {
+  input_tuple = (s32[], f32[8,4], f32[1,4]) parameter(0)
+  ivar = s32[] get-tuple-element(input_tuple), index=0
+  limit = s32[] constant(4)
+  ROOT done = pred[] compare(ivar, limit), direction=LT
+}
+
+async_dus {
+  buffer = f32[8,4] parameter(0)
+  update = f32[1,4] parameter(1)
+  ivar = s32[] parameter(2)
+  c0 = s32[] parameter(3)
+  ROOT updated = f32[8,4] dynamic-update-slice(buffer, update, ivar, c0),
+      backend_config={"dynamic_slice_config":{"loop_index":0,"byte_offset":16,"byte_stride":32}}
+}
+
+body {
+  input_tuple = (s32[], f32[8,4], f32[1,4]) parameter(0)
+  ivar = s32[] get-tuple-element(input_tuple), index=0
+  buffer = f32[8,4] get-tuple-element(input_tuple), index=1
+  update = f32[1,4] get-tuple-element(input_tuple), index=2
+  c0 = s32[] constant(0)
+  updated_start = ((f32[8,4], f32[1,4], s32[], s32[]), f32[8,4], u32[])
+      async-start(buffer, update, ivar, c0), calls=async_dus
+  updated = f32[8,4] async-done(updated_start), calls=async_dus
+  one = s32[] constant(1)
+  ivar_plus_1 = s32[] add(ivar, one)
+  ROOT output_tuple = (s32[], f32[8,4], f32[1,4])
+      tuple(ivar_plus_1, updated, update)
+}
+
+ENTRY main {
+  buffer = f32[8,4] parameter(0)
+  update = f32[1,4] parameter(1)
+  init = s32[] constant(0)
+  tuple = (s32[], f32[8,4], f32[1,4]) tuple(init, buffer, update)
+  ROOT while = (s32[], f32[8,4], f32[1,4]) while(tuple),
+      condition=condition, body=body,
+      backend_config={"known_trip_count":{"n":"4"},
+                      "known_init_step":{"init":"0","step":"1"},
+                      "known_induction_variable":{"tuple_index":"0"}}
+})";
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kModuleString));
+  DoubleBufferLoopUnrolling unroller(
+      DoubleBufferLoopUnrolling::UnrollStrategy::kDoubleBuffer);
+  ASSERT_OK_AND_ASSIGN(bool changed, unroller.Run(module.get()));
+  EXPECT_TRUE(changed);
+
+  HloComputation* body = module->GetComputationWithName("body");
+  HloInstruction* original_start =
+      body->GetInstructionWithName("updated_start");
+  HloInstruction* cloned_start =
+      body->GetInstructionWithName("updated_start.double_buffer_clone");
+  ASSERT_NE(original_start, nullptr);
+  ASSERT_NE(cloned_start, nullptr);
+
+  ExpectDynamicSliceConfig(hlo_query::GetFirstInstructionWithOpcode(
+                               *original_start->async_wrapped_computation(),
+                               HloOpcode::kDynamicUpdateSlice),
+                           /*loop_index=*/0, /*byte_offset=*/16,
+                           /*byte_stride=*/64);
+  ExpectDynamicSliceConfig(hlo_query::GetFirstInstructionWithOpcode(
+                               *cloned_start->async_wrapped_computation(),
+                               HloOpcode::kDynamicUpdateSlice),
+                           /*loop_index=*/0, /*byte_offset=*/48,
+                           /*byte_stride=*/64);
+}
+
+TEST_F(GpuLoopDoubleBufferTransformerTest,
        UpdatesDynamicSliceConfigForPeeledOddDoubleBuffering) {
   constexpr absl::string_view kModuleString = R"(
 HloModule m


### PR DESCRIPTION
Fix DynamicSlice Fusion V2 descriptors when double-buffering loops containing asynchronous computations.

Double buffering adjusts dynamic-slice descriptors for each unrolled iteration, including descriptors inside fusion computations. However, it did not recurse into computations wrapped by async-start. Consequently, both copies retained the original single-iteration descriptor, causing incorrect offsets.

Recurse into private async-start computations when adjusting descriptors. Add regression coverage verifying that the original and cloned async computations receive the correct offsets and doubled stride.

(This fixes MaxText Llama 3 8B custom-remat activation offloading with `JAX_OPTIMIZATION_LEVEL=O1`)