### PR TITLE
[ROCm] Update versioning math to match the one used by HIP.

### DIFF
--- a/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -257,13 +257,16 @@ static std::string GpuPlatformVersionFromDevices(
     const se::DeviceDescription& desc =
         local_device_state->executor()->GetDeviceDescription();
     const se::SemanticVersion v = desc.runtime_version();
-    const int encoded_version =
-        v.major_version() * 1000 + v.minor_version() * 10 + v.patch_version();
     const se::GpuComputeCapability& cc = desc.gpu_compute_capability();
     if (cc.rocm_compute_capability() != nullptr) {
+      const int encoded_version = v.major_version() * 10000000 +
+                                  v.minor_version() * 100000 +
+                                  v.patch_version();
       return absl::StrCat("rocm ", encoded_version);
     }
     if (cc.cuda_compute_capability() != nullptr) {
+      const int encoded_version =
+          v.major_version() * 1000 + v.minor_version() * 10 + v.patch_version();
       return absl::StrCat("cuda ", encoded_version);
     }
     if (cc.oneapi_compute_capability() != nullptr) {


### PR DESCRIPTION
📝 Summary of Changes
The patch aligns the math used by hip to report its version number with the current implementation.

🎯 Justification
The number of digits used for the patch number changed recently. The current implementation is incorrect and leads to version numbers printed by the rocm jax plugin that are misleading.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix
