### PR TITLE
[ROCm] Widen correlation ids to uint64_t to match rocprofiler-sdk

### DIFF
--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -135,7 +135,7 @@ class RocmTraceCollector {
   virtual void SetGpuAgents(std::vector<rocprofiler_agent_v0_t> /*agents*/) {}
   virtual void AddEvent(RocmTracerEvent&& event, bool is_auxiliary) = 0;
   virtual void OnEventsDropped(const std::string& reason,
-                               uint32_t num_events) = 0;
+                               uint64_t num_events) = 0;
   virtual void Flush() = 0;
   virtual void Export(tsl::profiler::XSpace* space) = 0;
   virtual void SetScopeRangeIdTree(ScopeRangeIdTree tree) {}
@@ -200,7 +200,7 @@ class RocmTraceCollectorImpl : public RocmTraceCollector {
   }
 
   void OnEventsDropped(const std::string& reason,
-                       uint32_t correlation_id) override {
+                       uint64_t correlation_id) override {
     VLOG(2) << "RocmTracerEvent dropped (correlation_id=" << correlation_id
             << ",) : " << reason << ".";
   }
@@ -214,18 +214,18 @@ class RocmTraceCollectorImpl : public RocmTraceCollector {
   std::vector<rocprofiler_agent_v0_t> gpu_agents_;
 
   absl::Mutex event_maps_mutex_;
-  absl::flat_hash_map<uint32_t, RocmTracerEvent> api_events_map_
+  absl::flat_hash_map<uint64_t, RocmTracerEvent> api_events_map_
       ABSL_GUARDED_BY(event_maps_mutex_);
 
   /* Some apis such as MEMSETD32 (based on an observation with ResNet50),
    trigger multiple HIP ops domain activities. We keep them in a vector and
    merge them with api activities at flush time.
  */
-  absl::flat_hash_map<uint32_t, std::vector<RocmTracerEvent>>
+  absl::flat_hash_map<uint64_t, std::vector<RocmTracerEvent>>
       activity_ops_events_map_ ABSL_GUARDED_BY(event_maps_mutex_);
   // This is for the APIs that we track because we need some information from
   // them to populate the corresponding activity that we actually track.
-  absl::flat_hash_map<uint32_t, RocmTracerEvent> auxiliary_api_events_map_
+  absl::flat_hash_map<uint64_t, RocmTracerEvent> auxiliary_api_events_map_
       ABSL_GUARDED_BY(event_maps_mutex_);
 
   std::vector<RocmTracerEvent> ApiActivityInfoExchange()

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -53,20 +53,20 @@ class TestRocmTraceCollector : public RocmTraceCollectorImpl {
   }
 
   void OnEventsDropped(const std::string& reason,
-                       uint32_t correlation_id) override {
+                       uint64_t correlation_id) override {
     dropped_reason_ = reason;
     dropped_id_ = correlation_id;
   }
 
   bool exported() const { return exported_; }
   const std::string& dropped_reason() const { return dropped_reason_; }
-  uint32_t dropped_id() const { return dropped_id_; }
+  uint64_t dropped_id() const { return dropped_id_; }
   XSpace* exported_space() const { return exported_space_; }
 
  private:
   bool exported_ = false;
   std::string dropped_reason_;
-  uint32_t dropped_id_ = 0;
+  uint64_t dropped_id_ = 0;
   XSpace* exported_space_ = nullptr;
 };
 
@@ -196,7 +196,7 @@ class EventCapturingCollector : public RocmTraceCollector {
   }
 
   void OnEventsDropped(const std::string& reason,
-                       uint32_t num_events) override {}
+                       uint64_t num_events) override {}
   void Flush() override {}
   void Export(tsl::profiler::XSpace* space) override {}
 

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.cc
@@ -89,7 +89,7 @@ const char* GetRocmTracerEventTypeName(const RocmTracerEventType& type) {
   return "";
 }
 
-void AnnotationMap::Add(uint32_t correlation_id, const std::string& annotation,
+void AnnotationMap::Add(uint64_t correlation_id, const std::string& annotation,
                         absl::Span<const int64_t> scope_range_ids) {
   if (annotation.empty()) {
     return;
@@ -115,13 +115,13 @@ void AnnotationMap::Add(uint32_t correlation_id, const std::string& annotation,
   }
 }
 
-absl::string_view AnnotationMap::LookUp(uint32_t correlation_id) {
+absl::string_view AnnotationMap::LookUp(uint64_t correlation_id) {
   absl::MutexLock lock(map_.mutex);
   auto it = map_.correlation_map.find(correlation_id);
   return it != map_.correlation_map.end() ? it->second : absl::string_view();
 }
 
-int64_t AnnotationMap::LookUpScopeRangeId(uint32_t correlation_id) {
+int64_t AnnotationMap::LookUpScopeRangeId(uint64_t correlation_id) {
   absl::MutexLock lock(map_.mutex);
   auto it = map_.scope_range_id_map.find(correlation_id);
   return it != map_.scope_range_id_map.end() ? it->second : 0;

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -125,8 +125,9 @@ struct RocmTracerEvent {
       std::numeric_limits<uint32_t>::max();
   static constexpr uint64_t kInvalidThreadId =
       std::numeric_limits<uint64_t>::max();
-  static constexpr uint32_t kInvalidCorrelationId =
-      std::numeric_limits<uint32_t>::max();
+  // Matches rocprofiler_correlation_id_t::internal, which is 64-bit.
+  static constexpr uint64_t kInvalidCorrelationId =
+      std::numeric_limits<uint64_t>::max();
   static constexpr uint64_t kInvalidStreamId =
       std::numeric_limits<uint64_t>::max();
   RocmTracerEventType type;
@@ -140,7 +141,7 @@ struct RocmTracerEvent {
   uint64_t start_time_ns = 0;
   uint64_t end_time_ns = 0;
   uint32_t device_id = kInvalidDeviceId;
-  uint32_t correlation_id = kInvalidCorrelationId;
+  uint64_t correlation_id = kInvalidCorrelationId;
   uint64_t thread_id = kInvalidThreadId;
   uint64_t stream_id = kInvalidStreamId;
   uint64_t queue_id = 0;  // HSA queue handle, preserved for debugging/rocprof
@@ -172,10 +173,10 @@ struct RocmTraceCollectorOptions {
 class AnnotationMap {
  public:
   explicit AnnotationMap(uint64_t max_size) : max_size_(max_size) {}
-  void Add(uint32_t correlation_id, const std::string& annotation,
+  void Add(uint64_t correlation_id, const std::string& annotation,
            absl::Span<const int64_t> scope_range_ids = {});
-  absl::string_view LookUp(uint32_t correlation_id);
-  int64_t LookUpScopeRangeId(uint32_t correlation_id);
+  absl::string_view LookUp(uint64_t correlation_id);
+  int64_t LookUpScopeRangeId(uint64_t correlation_id);
   ScopeRangeIdTree TakeScopeRangeIdTree();
   void Clear();
 
@@ -187,9 +188,9 @@ class AnnotationMap {
     // Annotation tends to be repetitive, use a hash_set to store the strings,
     // an use the reference to the string in the map.
     absl::node_hash_set<std::string> annotations ABSL_GUARDED_BY(mutex);
-    absl::flat_hash_map<uint32_t, absl::string_view> correlation_map
+    absl::flat_hash_map<uint64_t, absl::string_view> correlation_map
         ABSL_GUARDED_BY(mutex);
-    absl::flat_hash_map<uint32_t, int64_t> scope_range_id_map
+    absl::flat_hash_map<uint64_t, int64_t> scope_range_id_map
         ABSL_GUARDED_BY(mutex);
     ScopeRangeIdTree scope_range_id_tree ABSL_GUARDED_BY(mutex);
   };

--- a/xla/service/gpu/model/hlo_op_profiler_rocm.cc
+++ b/xla/service/gpu/model/hlo_op_profiler_rocm.cc
@@ -92,7 +92,7 @@ class RocmKernelTracer : public HloOpProfiler::KernelTracer,
   }
 
   void OnEventsDropped(const std::string& reason,
-                       uint32_t num_events) override {
+                       uint64_t num_events) override {
     LOG(WARNING) << "Dropped " << num_events << " events: " << reason;
   }
   void Flush() override {}


### PR DESCRIPTION
`rocprofiler_correlation_id_t::internal` is `uint64_t`, but `RocmTracerEvent::correlation_id` and every map keyed by it are `uint32_t`, so each id is silently truncated on the way in.

`HipApiEvent`, `KernelEvent` and `MemcpyEvent` assign `rec.correlation_id.internal` into the 32-bit field, and the HIP-API callback passes the same `record.correlation_id.internal` to `AnnotationMap::Add`. The truncation is identical on the insert and the lookup path, so the maps are self-consistent and this has never surfaced as a lookup miss. What it does cost:

- two live ids differing only above bit 32 collide, silently merging the annotations of unrelated dispatches;
- the `kCorrelationId` stat emitted into XPlane is the truncated value, so an XProf trace can no longer be cross-referenced against a `rocprofv3` run for ids past 2<sup>32</sup>.

### What changed

Widened to `uint64_t`:

| file | |
|---|---|
| `rocm_tracer_utils.h` | `RocmTracerEvent::correlation_id`, `kInvalidCorrelationId`, the `AnnotationMap::Add` / `LookUp` / `LookUpScopeRangeId` signatures, `correlation_map`, `scope_range_id_map` |
| `rocm_tracer_utils.cc` | the three matching definitions |
| `rocm_collector.h` | `RocmTraceCollector::OnEventsDropped`'s second parameter and its override, `api_events_map_`, `activity_ops_events_map_`, `auxiliary_api_events_map_` |
| `rocm_tracer_test.cc` | the two `OnEventsDropped` overrides and the `dropped_id_` member |

`rocm_tracer.cc` is untouched: the assignments from `rec.correlation_id.internal`
simply stop narrowing.

One naming note. `OnEventsDropped`'s second parameter is declared as `num_events` in
the base class, but all four call sites in `rocm_collector.cc` pass a correlation id.
It is widened on that basis. Renaming it is a separate one-line change and is not
done here, to keep this diff mechanical.

### What did not change

No behaviour, other than ids no longer being truncated. No new dependency, no API
added or removed, no XPlane schema change — `kCorrelationId` is an `int64` stat and
already accommodated the full range.

### Testing

`rocm_tracer_test` and `rocm_collector_test` pass under `--config=rocm` on MI300X.
`build_tools/ci/run_clang_format.sh` (clang-format 17.0.6) and buildifier 6.4.0
`--lint=warn` are clean.

### Relationship to the ROCTX PRs

Precursor to #46933, which #46935 stacks on. #46933 adds more 32-bit correlation
surface (`LookUpRoctxRange` and `roctx_range_map`), so landing the widening first
means that code is born 64-bit instead of needing the same lines touched twice. It
also answers the review question on #46933 about the 32/64-bit mismatch. #46933 will
be rebased on this once it merges.

This change is entirely pre-existing code and carries no ROCTX content, so it stands
on its own.