### PR TITLE
[ROCm] Add ROCM_PATH env to use correct header paths

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -154,6 +154,7 @@ jobs:
             --config=ci_single_gpu \
             --local_test_jobs=1 \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${DOCKER_IMAGE}" \
+            --repo_env=ROCM_PATH="/opt/rocm" \
             --local_test_jobs=1 \
             --internal_spawn_scheduler \
             --strategy=TestRunner=dynamic \
@@ -170,7 +171,7 @@ jobs:
             --config=ci_rocm_cpu \
             --local_test_jobs=200 \
             --repo_env=TF_ROCM_RBE_DOCKER_IMAGE="${DOCKER_IMAGE}" \
-            --repo_env=ROCM_PATH="" \
+            --repo_env=ROCM_PATH="/opt/rocm" \
             --bes_keywords=xla \
             --bes_keywords=upstream \
             --bes_keywords=cpu \


### PR DESCRIPTION
📝 Summary of Changes
Add ROCM_PATH env to bazel test targets to get headers from correct location
This was breaking build for rocm_cpu tests targets and in some cases for rocm_gpu targets as well.


🚀 Kind of Contribution
 🐛 Bug Fix,  🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

