### PR TITLE
[ROCm] Make gfx1250 scalar bf16 log correctly-rounded via f32 log2

### DIFF
--- a/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
@@ -106,10 +106,16 @@ struct TranscendentalBF16ToAMDGPU : public mlir::ConvertOpToLLVMPattern<OpTy> {
   llvm::StringRef intrinsic;
 };
 
-// Lowers a scalar bf16 `math.log` to the native gfx1250 `v_log_bf16`
-// instruction by rewriting log(x) = log2(x) * ln(2) and emitting the
-// `llvm.amdgcn.log` intrinsic. See TranscendentalBF16ToAMDGPU for the
-// rationale.
+// Lowers a scalar bf16 `math.log` on gfx1250 by rewriting
+// log(x) = log2(x) * ln(2) and computing log2 with the native `v_log_f32`
+// transcendental (the `llvm.amdgcn.log` intrinsic) in f32.
+//
+// Everything is computed in f32 and rounded to bf16 only once, at the end.
+// Using f32 log2 rather than the native bf16 `v_log_bf16` (which only has
+// bf16 mantissa precision) makes the result correctly-rounded, for one extra
+// input widening. The input `fpext` is exact (a bit
+// shift) and the trailing `fmul` + `fptrunc` fuse into one `v_fma_mixlo_bf16`,
+// so this lowers to `v_lshlrev_b32` + `v_log_f32` + `v_fma_mixlo_bf16`.
 struct LogBF16ToAMDGPU
     : public mlir::ConvertOpToLLVMPattern<mlir::math::LogOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
@@ -123,15 +129,19 @@ struct LogBF16ToAMDGPU
     mlir::Location loc = op.getLoc();
     mlir::Value operand = adaptor.getOperands().front();
     mlir::Type bf16 = operand.getType();
-    mlir::Value log2x = rewriter
-                            .create<mlir::LLVM::CallIntrinsicOp>(
-                                loc, /*resultType=*/bf16,
-                                rewriter.getStringAttr("llvm.amdgcn.log"),
-                                mlir::ValueRange{operand})
-                            .getResults();
-    mlir::Value ln2 = rewriter.create<mlir::LLVM::ConstantOp>(
-        loc, bf16, rewriter.getFloatAttr(bf16, kLn2));
-    rewriter.replaceOpWithNewOp<mlir::LLVM::FMulOp>(op, log2x, ln2);
+    mlir::Type f32 = rewriter.getF32Type();
+    mlir::Value x_f32 =
+        mlir::LLVM::FPExtOp::create(rewriter, loc, f32, operand);
+    mlir::Value log2x =
+        mlir::LLVM::CallIntrinsicOp::create(
+            rewriter, loc, /*resultType=*/f32,
+            rewriter.getStringAttr("llvm.amdgcn.log"), mlir::ValueRange{x_f32})
+            .getResults();
+    mlir::Value ln2_f32 = mlir::LLVM::ConstantOp::create(
+        rewriter, loc, f32, rewriter.getFloatAttr(f32, kLn2));
+    mlir::Value logx_f32 =
+        mlir::LLVM::FMulOp::create(rewriter, loc, log2x, ln2_f32);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::FPTruncOp>(op, bf16, logx_f32);
     return mlir::success();
   }
 };

--- a/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
+++ b/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
@@ -94,7 +94,11 @@ module {
 // -----
 
 // A plain bf16 log is rewritten to log2(x) * ln(2) on gfx1250 so it also uses
-// the native instruction.
+// the native transcendental. The whole computation is done in f32: the bf16
+// input is widened to f32, log2 is evaluated with the native f32 instruction,
+// multiplied by an f32 ln(2), then rounded once back to bf16. Using the f32
+// log2 (rather than the lower-precision native bf16 log2) keeps the result
+// close to correctly-rounded.
 module {
   func.func @log_bf16(%arg0: bf16) -> bf16 {
     %0 = math.log %arg0 : bf16
@@ -103,6 +107,8 @@ module {
 }
 
 // CHECK-LABEL: llvm.func @log_bf16
-// CHECK: llvm.call_intrinsic "llvm.amdgcn.log"({{.*}}) : (bf16) -> bf16
-// CHECK: llvm.fmul
+// CHECK: llvm.fpext {{.*}} : bf16 to f32
+// CHECK: llvm.call_intrinsic "llvm.amdgcn.log"({{.*}}) : (f32) -> f32
+// CHECK: llvm.fmul {{.*}} : f32
+// CHECK: llvm.fptrunc {{.*}} : f32 to bf16
 // CHECK-NOT: __ocml


### PR DESCRIPTION
📝 Summary of Changes
On gfx1250, lower scalar bf16 `math.log` by computing log2 in f32 (native
v_log_f32 / llvm.amdgcn.log.f32) and rounding to bf16 once, instead of using
the bf16 v_log_bf16.

🎯 Justification
bf16-precision log2 was the dominant error source. Computing in f32 makes bf16
`log` correctly-rounded (≤0.5 ULP vs. max 1.77 ULP before), for one extra cheap
instruction. Benefits any gfx1250 workload using bf16 natural log

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, 🧪 Tests

📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
Updated the FileCheck test `@log_bf16` in
`codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir` to expect
the new IR shape: fpext bf16→f32, llvm.amdgcn.log (f32)→f32, fmul f32,
fptrunc f32→bf16.