### PR TITLE
[XLA:GPU] Saturate SMs in the ragged all-to-all device kernel

### DIFF
--- a/xla/backends/gpu/runtime/collective_thunk.cc
+++ b/xla/backends/gpu/runtime/collective_thunk.cc
@@ -289,9 +289,9 @@ absl::StatusOr<std::vector<CollectiveThunk::Buffer>> GetCollectiveBuffers(
         ShapeUtil::GetSubshape(dst->shape(), dst_shape_index);
 
     ABSL_ASSIGN_OR_RETURN(auto src_slice,
-                     buffer_assignment.GetUniqueSlice(src, /*index=*/{}));
-    ABSL_ASSIGN_OR_RETURN(auto dst_slice,
-                     buffer_assignment.GetUniqueSlice(dst, dst_shape_index));
+                          buffer_assignment.GetUniqueSlice(src, /*index=*/{}));
+    ABSL_ASSIGN_OR_RETURN(
+        auto dst_slice, buffer_assignment.GetUniqueSlice(dst, dst_shape_index));
 
     buffers.push_back(CollectiveThunk::Buffer{
         /*element_count=*/ShapeUtil::ElementsIn(src_shape),
@@ -318,7 +318,7 @@ absl::StatusOr<std::vector<CollectiveThunk::Buffer>> GetCollectiveBuffers(
     ABSL_RETURN_IF_ERROR(
         add_buffer(inst->operand(0), inst->operand(0), ShapeIndex({})));
     ABSL_RETURN_IF_ERROR(add_buffer(inst->operand(1), inst,
-                               GetCollectiveResultShapeIndex(inst, 0)));
+                                    GetCollectiveResultShapeIndex(inst, 0)));
 
     for (int64_t i = 2; i < operand_count; i++) {
       ABSL_RETURN_IF_ERROR(
@@ -349,9 +349,10 @@ absl::StatusOr<std::vector<CollectiveThunk::Buffer>> GetCollectiveBuffers(
 absl::StatusOr<CollectiveBufferProto> CollectiveThunk::Buffer::ToProto() const {
   CollectiveBufferProto proto;
   proto.set_element_count(element_count);
-  ABSL_ASSIGN_OR_RETURN(*proto.mutable_source_buffer(), source_buffer.ToProto());
+  ABSL_ASSIGN_OR_RETURN(*proto.mutable_source_buffer(),
+                        source_buffer.ToProto());
   ABSL_ASSIGN_OR_RETURN(*proto.mutable_destination_buffer(),
-                   destination_buffer.ToProto());
+                        destination_buffer.ToProto());
   proto.set_source_memory_space(source_memory_space);
   proto.set_destination_memory_space(destination_memory_space);
   return proto;
@@ -365,9 +366,10 @@ absl::StatusOr<CollectiveThunk::Buffer> CollectiveThunk::Buffer::FromProto(
   ABSL_ASSIGN_OR_RETURN(
       res.source_buffer,
       ShapedSlice::FromProto(buffer_proto.source_buffer(), buffer_allocations));
-  ABSL_ASSIGN_OR_RETURN(res.destination_buffer,
-                   ShapedSlice::FromProto(buffer_proto.destination_buffer(),
-                                          buffer_allocations));
+  ABSL_ASSIGN_OR_RETURN(
+      res.destination_buffer,
+      ShapedSlice::FromProto(buffer_proto.destination_buffer(),
+                             buffer_allocations));
   res.source_memory_space = buffer_proto.source_memory_space();
   res.destination_memory_space = buffer_proto.destination_memory_space();
   return res;
@@ -400,7 +402,7 @@ absl::Status CollectiveThunk::Prepare(const PrepareParams& params) {
                       config().group_mode, communication_id_));
 
   ABSL_RETURN_IF_ERROR(params.collective_clique_requests->RequestClique(
-      clique_key, *device_groups_, GetCliqueRequirements(clique_key)));
+      clique_key, *device_groups_, GetCliqueRequirements(clique_key, params)));
 
   if (CanUseSymmetricBuffer() && config().use_symmetric_buffer) {
     for (const Buffer& buffer : buffers_) {
@@ -473,16 +475,17 @@ absl::Status CollectiveThunk::RunWithCommAndRendezvous(
       GpuCliqueKey clique_key,
       GetGpuCliqueKey(*params.collective_params, config().replica_groups,
                       config().group_mode, communication_id_));
-  ABSL_ASSIGN_OR_RETURN(Communicator * comm,
-                   params.collective_cliques->GetComm(
-                       clique_key, params.collective_params->global_device_id));
+  ABSL_ASSIGN_OR_RETURN(
+      Communicator * comm,
+      params.collective_cliques->GetComm(
+          clique_key, params.collective_params->global_device_id));
   DCHECK(comm) << "Failed to get communicator for collective operation";
 
   ABSL_RETURN_IF_ERROR(FirstCallRendezvous(params, clique_key, "before",
-                                      pre_call_rendezvous_flag_));
+                                           pre_call_rendezvous_flag_));
   ABSL_RETURN_IF_ERROR(fn(clique_key, *comm));
   ABSL_RETURN_IF_ERROR(FirstCallRendezvous(params, clique_key, "after",
-                                      post_call_rendezvous_flag_));
+                                           post_call_rendezvous_flag_));
   return absl::OkStatus();
 }
 
@@ -503,14 +506,14 @@ absl::StatusOr<const se::CommandBuffer::Command*> CollectiveThunk::Record(
   ABSL_RETURN_IF_ERROR(RunWithCommAndRendezvous(
       execute_params,
       [&](const GpuCliqueKey& clique_key, Communicator& comm) -> absl::Status {
-        ABSL_ASSIGN_OR_RETURN(nested_cmd,
-                         se::TraceCommandBufferFactory::Create(
-                             execute_params.stream->parent(),
-                             execute_params.command_buffer_trace_stream,
-                             [&](se::Stream* stream) {
-                               return RunCollective(execute_params, clique_key,
-                                                    *stream, comm);
-                             }));
+        ABSL_ASSIGN_OR_RETURN(
+            nested_cmd, se::TraceCommandBufferFactory::Create(
+                            execute_params.stream->parent(),
+                            execute_params.command_buffer_trace_stream,
+                            [&](se::Stream* stream) {
+                              return RunCollective(execute_params, clique_key,
+                                                   *stream, comm);
+                            }));
         return absl::OkStatus();
       }));
 

--- a/xla/backends/gpu/runtime/collective_thunk.h
+++ b/xla/backends/gpu/runtime/collective_thunk.h
@@ -121,7 +121,7 @@ class CollectiveThunk : public Command {
   static std::string GetDeviceString(const CollectiveParams& params);
 
   virtual CollectiveCliqueRequests::CliqueRequirements GetCliqueRequirements(
-      const GpuCliqueKey& clique_key) {
+      const GpuCliqueKey& clique_key, const PrepareParams& params) {
     return {};
   }
 

--- a/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
+++ b/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
@@ -201,8 +201,8 @@ absl::Status LoadRaggedTensorMetadata(
         << "RaggedAllToAll metadata buffer " << i << " has "
         << metadata_buffer.size() << " bytes, expected at least "
         << metadata_bytes << " bytes";
-    ABSL_RETURN_IF_ERROR(stream.Memcpy(ragged_metadata_allocs[i], metadata_buffer,
-                                  metadata_bytes));
+    ABSL_RETURN_IF_ERROR(stream.Memcpy(ragged_metadata_allocs[i],
+                                       metadata_buffer, metadata_bytes));
   }
 
   // Wait for the copies to complete.
@@ -232,14 +232,14 @@ absl::Status RunAllToAllOnIndexBuffer(
       se::DeviceAddressBase recv_slice =
           GpuCollectives::Slice(destination_buffer, element_type, offset,
                                 /*count=*/num_updates_per_replica);
-      ABSL_RETURN_IF_ERROR(gpu_comm->LaunchSend(send_slice, element_type,
-                                           /*count=*/num_updates_per_replica,
-                                           RankId(peer),
-                                           GpuCollectives::On(stream)));
-      ABSL_RETURN_IF_ERROR(gpu_comm->LaunchRecv(recv_slice, element_type,
-                                           /*count=*/num_updates_per_replica,
-                                           RankId(peer),
-                                           GpuCollectives::On(stream)));
+      ABSL_RETURN_IF_ERROR(
+          gpu_comm->LaunchSend(send_slice, element_type,
+                               /*count=*/num_updates_per_replica, RankId(peer),
+                               GpuCollectives::On(stream)));
+      ABSL_RETURN_IF_ERROR(
+          gpu_comm->LaunchRecv(recv_slice, element_type,
+                               /*count=*/num_updates_per_replica, RankId(peer),
+                               GpuCollectives::On(stream)));
     }
     return absl::OkStatus();
   });
@@ -433,8 +433,8 @@ absl::Status RunNcclFallbackRaggedAllToAll(
     output_offsets_buffer_pair.source_buffer = output_offsets_device_buffer;
   }
 
-  ABSL_RETURN_IF_ERROR(LoadRaggedTensorMetadata(stream, buffers, num_total_updates,
-                                           ragged_metadata_allocs));
+  ABSL_RETURN_IF_ERROR(LoadRaggedTensorMetadata(
+      stream, buffers, num_total_updates, ragged_metadata_allocs));
 
   const int64_t* input_offsets = ragged_metadata_allocs[0];
   const int64_t* send_sizes = ragged_metadata_allocs[1];
@@ -475,9 +475,10 @@ absl::Status RunNcclFallbackRaggedAllToAll(
     GpuSignalDesc signal_desc(/*sig_idx=*/0, /*ctx=*/0);
     for (int peer = 0; peer < num_ranks; ++peer) {
       ABSL_RETURN_IF_ERROR(comm.WaitSignal(RankId(peer),
-                                      /*op_cnt=*/num_updates_per_replica,
-                                      signal_desc, GpuCollectives::On(stream))
-                          .Await());
+                                           /*op_cnt=*/num_updates_per_replica,
+                                           signal_desc,
+                                           GpuCollectives::On(stream))
+                               .Await());
     }
 
     return absl::OkStatus();
@@ -572,10 +573,12 @@ RaggedAllToAllThunk::RaggedAllToAllThunk(
 }
 
 CollectiveCliqueRequests::CliqueRequirements
-RaggedAllToAllThunk::GetCliqueRequirements(const GpuCliqueKey& clique_key) {
+RaggedAllToAllThunk::GetCliqueRequirements(const GpuCliqueKey& clique_key,
+                                           const PrepareParams& params) {
   CollectiveCliqueRequests::CliqueRequirements clique_reqs;
   if (UsesDeviceKernel()) {
-    clique_reqs.dev_comm = DeviceKernelLsaDevCommRequirements();
+    const int core_count = params.executor->GetDeviceDescription().core_count();
+    clique_reqs.dev_comm = DeviceKernelLsaDevCommRequirements(core_count);
   }
   return clique_reqs;
 }
@@ -607,8 +610,8 @@ absl::StatusOr<RaggedAllToAllStreamState*> RaggedAllToAllThunk::InitializeOnce(
   // ragged tensors from device memory.
   for (int64_t i = 0; i < kNumRaggedMetadataOperands; ++i) {
     ABSL_ASSIGN_OR_RETURN(std::unique_ptr<se::MemoryAllocation> alloc,
-                     executor->HostMemoryAllocate(config_.num_total_updates *
-                                                  sizeof(int64_t)));
+                          executor->HostMemoryAllocate(
+                              config_.num_total_updates * sizeof(int64_t)));
     state->host_buffer_allocs.push_back(std::move(alloc));
   }
 
@@ -630,7 +633,7 @@ absl::StatusOr<RaggedAllToAllStreamState*> RaggedAllToAllThunk::InitializeOnce(
       state->lsa_size = config_.fast_interconnect_slice_size_override.value();
     } else {
       ABSL_ASSIGN_OR_RETURN(auto* comm, params.collective_cliques->GetComm(
-                                       state->clique_key, state->rank));
+                                            state->clique_key, state->rank));
 
       state->lsa_size = comm->LsaSize();
     }
@@ -657,11 +660,12 @@ absl::StatusOr<RaggedAllToAllStreamState*> RaggedAllToAllThunk::InitializeOnce(
 
     // This value acts as the local step counter.
     ABSL_ASSIGN_OR_RETURN(state->barrier_signal_value,
-                     collective_allocator->Allocate(sizeof(uint32_t)));
+                          collective_allocator->Allocate(sizeof(uint32_t)));
 
-    ABSL_ASSIGN_OR_RETURN(state->output_buffer_ptr_storage,
-                     collective_allocator->Allocate(
-                         MultiGpuBarrierKernel::kMaxPeers * sizeof(void*)));
+    ABSL_ASSIGN_OR_RETURN(
+        state->output_buffer_ptr_storage,
+        collective_allocator->Allocate(MultiGpuBarrierKernel::kMaxPeers *
+                                       sizeof(void*)));
 
     ABSL_RETURN_IF_ERROR(ZeroBarrierSignalBuffers(
         *params.stream, state->barrier_signal_buffer->address(),
@@ -684,7 +688,8 @@ absl::StatusOr<RaggedAllToAllStreamState*> RaggedAllToAllThunk::InitializeOnce(
 absl::Status RaggedAllToAllThunk::Initialize(const InitializeParams& params) {
   ABSL_RETURN_IF_ERROR(CollectiveThunk::Initialize(params));
 
-  ABSL_ASSIGN_OR_RETURN(RaggedAllToAllStreamState * state, InitializeOnce(params));
+  ABSL_ASSIGN_OR_RETURN(RaggedAllToAllStreamState * state,
+                        InitializeOnce(params));
 
   // If the symmetric memory handlers are not initialized, initialize it.
   // This can happen in two scenarios:
@@ -697,16 +702,17 @@ absl::Status RaggedAllToAllThunk::Initialize(const InitializeParams& params) {
       state->lsa_size.value() == state->clique_key.num_devices() &&
       config_.use_multi_gpu_barrier_with_nccl_in_one_shot_kernel) {
     ABSL_ASSIGN_OR_RETURN(auto* comm, params.collective_cliques->GetComm(
-                                     state->clique_key, state->rank));
+                                          state->clique_key, state->rank));
 
     if (state->barrier_signal_symmetric_memory.Expired()) {
       ABSL_ASSIGN_OR_RETURN(
           auto symmetric_memory,
           comm->CreateSymmetricMemory(state->barrier_signal_buffer->address()));
 
-      ABSL_ASSIGN_OR_RETURN(state->barrier_signal_symmetric_memory,
-                       params.collective_cliques->Tie(
-                           state->clique_key, std::move(symmetric_memory)));
+      ABSL_ASSIGN_OR_RETURN(
+          state->barrier_signal_symmetric_memory,
+          params.collective_cliques->Tie(state->clique_key,
+                                         std::move(symmetric_memory)));
     }
   } else if (is_local(params.local_device_count)) {
     // Rendezvous - Exchange output pointers and barrier signal buffers.
@@ -741,8 +747,8 @@ absl::StatusOr<const se::CommandBuffer::Command*> RaggedAllToAllThunk::Record(
          "kernel to work";
 
   ABSL_ASSIGN_OR_RETURN(GpuCliqueKey clique_key,
-                   GetCollectiveGpuCliqueKey(*execute_params.collective_params,
-                                             config_.config));
+                        GetCollectiveGpuCliqueKey(
+                            *execute_params.collective_params, config_.config));
 
   int device_ordinal = executor->device_ordinal();
   const std::optional<RankId> rank_opt =
@@ -924,12 +930,14 @@ absl::Status RaggedAllToAllThunk::RunCollective(const ExecuteParams& params,
                                                 const GpuCliqueKey& clique_key,
                                                 se::Stream& stream,
                                                 Communicator& comm) {
-  ABSL_ASSIGN_OR_RETURN(std::vector<DeviceBufferPair> device_buffers,
-                   ConvertToDeviceBuffers(params.buffer_allocations, buffers(),
-                                          config_.config.operand_element_type));
+  ABSL_ASSIGN_OR_RETURN(
+      std::vector<DeviceBufferPair> device_buffers,
+      ConvertToDeviceBuffers(params.buffer_allocations, buffers(),
+                             config_.config.operand_element_type));
 
-  ABSL_ASSIGN_OR_RETURN(bool peer_access_enabled,
-                   params.collective_cliques->peer_access_enabled(clique_key));
+  ABSL_ASSIGN_OR_RETURN(
+      bool peer_access_enabled,
+      params.collective_cliques->peer_access_enabled(clique_key));
 
   RaggedAllToAllStreamState* state = nullptr;
   {
@@ -952,6 +960,8 @@ absl::Status RaggedAllToAllThunk::RunCollective(const ExecuteParams& params,
 
     if (input_sym != nullptr && output_sym != nullptr) {
       ABSL_ASSIGN_OR_RETURN(int32_t num_ranks, comm.NumRanks());
+      const int core_count =
+          stream.parent()->GetDeviceDescription().core_count();
 
       const int64_t lsa_size = state->lsa_size.value();
       const bool has_remote_peers = state->lsa_size.value() < num_ranks;
@@ -965,17 +975,17 @@ absl::Status RaggedAllToAllThunk::RunCollective(const ExecuteParams& params,
             GpuDeviceCommunicator * dev_comm,
             params.collective_cliques->GetDeviceComm(
                 clique_key, state->rank,
-                has_remote_peers ? DeviceKernelDevCommRequirements()
-                                 : DeviceKernelLsaDevCommRequirements()));
+                has_remote_peers
+                    ? DeviceKernelDevCommRequirements(core_count)
+                    : DeviceKernelLsaDevCommRequirements(core_count)));
 
         const int64_t num_updates_per_replica =
             config_.num_total_updates / num_ranks;
         // Remote peers are reached via GIN puts; local peers via LSA copies.
         const int64_t num_active_updates =
             (gin ? num_ranks : lsa_size) * num_updates_per_replica;
-        const int32_t cta_count = DeviceKernelLaunchCtaCount(
-            stream.parent()->GetDeviceDescription().core_count(),
-            num_active_updates);
+        const int32_t cta_count =
+            DeviceKernelLaunchCtaCount(core_count, num_active_updates);
         const PrimitiveType element_type = device_buffers[0].element_type;
 
         XLA_VLOG_DEVICE(3, state->device_ordinal)
@@ -1142,7 +1152,8 @@ absl::Status RaggedAllToAllThunk::PrepareCollective(
 
     ABSL_RETURN_IF_ERROR(device_groups().status());
     CollectiveCliqueRequests::CliqueRequirements gin_reqs;
-    gin_reqs.dev_comm = DeviceKernelDevCommRequirements();
+    gin_reqs.dev_comm = DeviceKernelDevCommRequirements(
+        params.executor->GetDeviceDescription().core_count());
     ABSL_RETURN_IF_ERROR(params.collective_clique_requests->RequestClique(
         clique_key, *device_groups(), gin_reqs));
   }
@@ -1211,9 +1222,9 @@ absl::Status RunOneShotRaggedAllToAllWithNccl(
   const int64_t num_updates_per_replica = num_total_updates / num_ranks;
 
   if (VLOG_IS_ON(5)) {
-    ABSL_RETURN_IF_ERROR(CheckRaggedAllToAllBounds(stream, num_total_updates,
-                                              num_row_elements, output_sym_mem,
-                                              output_sym_offset, buffers));
+    ABSL_RETURN_IF_ERROR(
+        CheckRaggedAllToAllBounds(stream, num_total_updates, num_row_elements,
+                                  output_sym_mem, output_sym_offset, buffers));
   }
 
   ABSL_RETURN_IF_ERROR(RunRaggedAllToAllWithSymmetricMemoryKernel(
@@ -1287,8 +1298,8 @@ absl::Status RunOneShotRaggedAllToAll(
   // Ensures that all peers have reached this point and their output buffers are
   // ready to receive data. This prevents the kernel from attempting to write
   // to a peer's memory before that peer has completed the rendezvous setup.
-  ABSL_RETURN_IF_ERROR(LaunchMultiGpuBarrier(&stream, rank, num_ranks, participants,
-                                        barrier_signal_value));
+  ABSL_RETURN_IF_ERROR(LaunchMultiGpuBarrier(
+      &stream, rank, num_ranks, participants, barrier_signal_value));
 
   // 2. Execution of RunRaggedAllToAllKernel
   const int64_t num_updates_per_replica = num_total_updates / num_ranks;
@@ -1309,8 +1320,8 @@ absl::Status RunOneShotRaggedAllToAll(
   // We wait for all peers to signal completion.
   // This guarantees that all P2P writes to our output buffer are complete and
   // safe to consume.
-  ABSL_RETURN_IF_ERROR(LaunchMultiGpuBarrier(&stream, rank, num_ranks, participants,
-                                        barrier_signal_value));
+  ABSL_RETURN_IF_ERROR(LaunchMultiGpuBarrier(
+      &stream, rank, num_ranks, participants, barrier_signal_value));
 
   return absl::OkStatus();
 }

--- a/xla/backends/gpu/runtime/ragged_all_to_all_thunk.h
+++ b/xla/backends/gpu/runtime/ragged_all_to_all_thunk.h
@@ -152,7 +152,7 @@ class RaggedAllToAllThunk : public CollectiveThunk {
       int64_t partition_count);
 
   CollectiveCliqueRequests::CliqueRequirements GetCliqueRequirements(
-      const GpuCliqueKey& clique_key) override;
+      const GpuCliqueKey& clique_key, const PrepareParams& params) override;
 
   absl::Status Initialize(const InitializeParams& params) override;
 
@@ -187,40 +187,43 @@ class RaggedAllToAllThunk : public CollectiveThunk {
 
   // Number of per-CTA barrier/signal slots reserved when creating the device
   // communicator. The kernel indexes its cooperative barrier by blockIdx.x, so
-  // registration must cover the largest grid we might launch. It is a compile
-  // time constant so every rank reserves identical resources, independent of
-  // the executor (which is not available at clique-requirement time).
-  static constexpr int32_t device_kernel_barrier_count() {
-    return kMaxDeviceKernelCtaCount;
+  // registration must cover the largest grid we might launch, which is
+  // bounded by the executor's SM count. Callers pass the SM count from
+  // se::DeviceDescription::core_count(); all participating ranks are expected
+  // to be homogeneous so every rank arrives at the same value.
+  static int32_t device_kernel_barrier_count(int core_count) {
+    return std::max<int32_t>(core_count, kMinDeviceKernelCtaCount);
   }
 
-  // Launch grid for the device kernel. Scales with the device SM count and the
-  // amount of copy work, clamped to [kMin, kMax]. All inputs are identical
-  // across ranks (collective config + homogeneous GPUs), so every rank launches
-  // the same grid, which the cross-rank cooperative barriers require.
+  // Launch grid for the device kernel. Sized to saturate the SMs (grid =
+  // ctas_per_update * num_active_updates, chosen so grid <= sm_cap and evenly
+  // divides `total_lsa_updates` in RaggedAllToAllCopy). All ranks launch the
+  // same grid, which the cross-rank cooperative barriers require.
   static int32_t DeviceKernelLaunchCtaCount(int core_count,
                                             int64_t num_active_updates) {
-    int64_t work_cap = std::max<int64_t>(kMinDeviceKernelCtaCount,
-                                         num_active_updates * kCtasPerUpdate);
-    int64_t grid = std::min<int64_t>(core_count, work_cap);
-    grid = std::clamp<int64_t>(grid, kMinDeviceKernelCtaCount,
-                               kMaxDeviceKernelCtaCount);
-    return static_cast<int32_t>(grid);
+    const int64_t sm_cap = std::max<int64_t>(1, core_count);
+    const int64_t updates = std::max<int64_t>(1, num_active_updates);
+    const int64_t ctas_per_update = std::max<int64_t>(1, sm_cap / updates);
+    const int64_t grid = ctas_per_update * updates;
+    return static_cast<int32_t>(
+        std::clamp<int64_t>(grid, kMinDeviceKernelCtaCount, sm_cap));
   }
 
-  GpuDeviceCommunicator::Requirements DeviceKernelLsaDevCommRequirements()
-      const {
+  GpuDeviceCommunicator::Requirements DeviceKernelLsaDevCommRequirements(
+      int core_count) const {
     GpuDeviceCommunicator::Requirements requirements;
-    requirements.lsa_barrier_count = device_kernel_barrier_count();
+    requirements.lsa_barrier_count = device_kernel_barrier_count(core_count);
     return requirements;
   }
 
-  GpuDeviceCommunicator::Requirements DeviceKernelDevCommRequirements() const {
+  GpuDeviceCommunicator::Requirements DeviceKernelDevCommRequirements(
+      int core_count) const {
     GpuDeviceCommunicator::Requirements requirements;
-    requirements.barrier_count = device_kernel_barrier_count();
-    requirements.lsa_barrier_count = device_kernel_barrier_count();
-    requirements.rail_gin_barrier_count = device_kernel_barrier_count();
-    requirements.gin_signal_count = device_kernel_barrier_count();
+    const int32_t c = device_kernel_barrier_count(core_count);
+    requirements.barrier_count = c;
+    requirements.lsa_barrier_count = c;
+    requirements.rail_gin_barrier_count = c;
+    requirements.gin_signal_count = c;
     requirements.gin_connection_full = true;
     return requirements;
   }
@@ -253,14 +256,10 @@ class RaggedAllToAllThunk : public CollectiveThunk {
 
   const RaggedAllToAllConfig config_;
 
-  // Upper bound on the device-kernel launch grid and the number of barrier
-  static constexpr int32_t kMaxDeviceKernelCtaCount = 64;
   // Floor on the launch grid so small shapes still get some parallelism.
+  // The upper bound is derived from the executor's SM count at Prepare /
+  // Initialize / Run time via device_kernel_barrier_count().
   static constexpr int32_t kMinDeviceKernelCtaCount = 8;
-  // Target number of CTAs per (peer, update) copy unit before the grid
-  // saturates at the SM count. Gives each update several CTAs of row-copy
-  // bandwidth.
-  static constexpr int32_t kCtasPerUpdate = 4;
 
   mutable absl::Mutex mutex_;
   absl::flat_hash_map<se::StreamExecutor*,


### PR DESCRIPTION
📝 Summary of Changes
Pick the number of blocks for the ragged all-to-all device kernel from how many SMs the GPU has, instead of always capping it at 64. The barrier slots we reserve now come from that same number.

🎯 Justification
The old cap often started fewer blocks than the GPU has SMs, so part of the copy bandwidth sat idle on big GPUs. The new count keeps all the SMs busy, and it stays a whole multiple of the number of updates, which is how the kernel hands work out to blocks.

🚀 Kind of Contribution
⚡️ Performance Improvement

📊 Benchmark (for Performance Improvements)
N/A

🧪 Unit Tests:
Existing unit tests

🧪 Execution Tests:
DeepSeekv3
