### PR TITLE
[ROCm] Improve gfx1250 scalar bf16 exp.

### DIFF
--- a/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
+++ b/xla/codegen/emitters/transforms/lower_to_llvm_gpu.cc
@@ -74,6 +74,9 @@ namespace se = ::stream_executor;
 // ln(2), used to express log(x) = log2(x) * ln(2).
 constexpr double kLn2 = 0.6931471805599453;
 
+// log2(e), used to express exp(x) = exp2(x * log2(e)).
+constexpr double kLog2e = 1.4426950408889634;
+
 // Lowers a scalar bf16 unary `math` op to the matching native gfx1250 bf16
 // transcendental instruction (v_exp_bf16, v_sqrt_bf16, v_rsq_bf16, v_tanh_bf16,
 // v_log_bf16, ...) via its `llvm.amdgcn.*` intrinsic, when the op maps 1:1 to
@@ -136,6 +139,48 @@ struct LogBF16ToAMDGPU
   }
 };
 
+// Lowers a scalar bf16 `math.exp` on gfx1250 by rewriting
+// exp(x) = 2^(x * log2(e)) and computing exp2 with the native `v_exp_f32`
+// transcendental (the `llvm.amdgcn.exp2` intrinsic) in f32.
+//
+// Everything is computed in f32: the bf16 input is widened to f32, scaled by
+// an f32 log2(e), exponentiated in f32, and the result rounded once to bf16.
+// Scaling and exponentiating in f32 rather than using the native bf16
+// `v_exp_bf16` (which would round x * log2(e) to bf16 before exponentiating)
+// keeps the result accurate: the bf16-rounded-exponent error otherwise grows
+// with |x| and can overflow to inf, which is why the native bf16 exp path was
+// removed. Lowers to
+// `v_lshlrev_b32` + `v_mul_f32` + `v_exp_f32` + `v_cvt_pk_bf16_f32`.
+struct ExpBF16ToAMDGPU
+    : public mlir::ConvertOpToLLVMPattern<mlir::math::ExpOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  mlir::LogicalResult matchAndRewrite(
+      mlir::math::ExpOp op, OpAdaptor adaptor,
+      mlir::ConversionPatternRewriter& rewriter) const override {
+    if (!op.getType().isBF16()) {
+      return rewriter.notifyMatchFailure(op, "not a scalar bf16 exp");
+    }
+    mlir::Location loc = op.getLoc();
+    mlir::Value operand = adaptor.getOperands().front();
+    mlir::Type bf16 = operand.getType();
+    mlir::Type f32 = rewriter.getF32Type();
+    mlir::Value x_f32 =
+        mlir::LLVM::FPExtOp::create(rewriter, loc, f32, operand);
+    mlir::Value log2e = mlir::LLVM::ConstantOp::create(
+        rewriter, loc, f32, rewriter.getFloatAttr(f32, kLog2e));
+    mlir::Value scaled =
+        mlir::LLVM::FMulOp::create(rewriter, loc, x_f32, log2e);
+    mlir::Value exp2x = mlir::LLVM::CallIntrinsicOp::create(
+                            rewriter, loc, /*resultType=*/f32,
+                            rewriter.getStringAttr("llvm.amdgcn.exp2"),
+                            mlir::ValueRange{scaled})
+                            .getResults();
+    rewriter.replaceOpWithNewOp<mlir::LLVM::FPTruncOp>(op, bf16, exp2x);
+    return mlir::success();
+  }
+};
+
 class LowerToLLVMGPUPass
     : public impl::LowerToLLVMGPUPassBase<LowerToLLVMGPUPass> {
  public:
@@ -187,6 +232,7 @@ class LowerToLLVMGPUPass
                 .has_bf16_transcendental_support()) {
           mlir::PatternBenefit benefit(2);
           patterns.add<LogBF16ToAMDGPU>(converter, benefit);
+          patterns.add<ExpBF16ToAMDGPU>(converter, benefit);
           patterns.add<TranscendentalBF16ToAMDGPU<mlir::math::Exp2Op>>(
               converter, "llvm.amdgcn.exp2", benefit);
           patterns.add<TranscendentalBF16ToAMDGPU<mlir::math::SqrtOp>>(

--- a/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
+++ b/xla/codegen/emitters/transforms/tests/bf16_transcendental_amdgpu.mlir
@@ -33,6 +33,27 @@ module {
 
 // -----
 
+// A plain bf16 exp is rewritten to exp2(x * log2(e)) computed in f32 on
+// gfx1250: the input is widened to f32, scaled by an f32 log2(e), passed to the
+// native f32 exp2 (llvm.amdgcn.exp2), then rounded back to bf16. Computing in
+// f32 avoids rounding the scaled exponent to bf16, which loses accuracy and can
+// overflow to inf (why the native bf16 exp path is not used).
+module {
+  func.func @exp_bf16(%arg0: bf16) -> bf16 {
+    %0 = math.exp %arg0 : bf16
+    return %0 : bf16
+  }
+}
+
+// CHECK-LABEL: llvm.func @exp_bf16
+// CHECK: llvm.fpext {{.*}} : bf16 to f32
+// CHECK: llvm.fmul {{.*}} : f32
+// CHECK: llvm.call_intrinsic "llvm.amdgcn.exp2"({{.*}}) : (f32) -> f32
+// CHECK: llvm.fptrunc {{.*}} : f32 to bf16
+// CHECK-NOT: __ocml
+
+// -----
+
 // gfx1250 has a native bf16 sqrt instruction (v_sqrt_bf16), reached via the
 // llvm.amdgcn.sqrt intrinsic.
 module {

--- a/xla/service/gpu/gpu_float_support.cc
+++ b/xla/service/gpu/gpu_float_support.cc
@@ -140,7 +140,14 @@ bool GpuFloatSupport::IsSupported(const HloInstruction& hlo) const {
     // Elementwise ops.
     case HloOpcode::kExp:
       if (LowPrecisionType() == BF16) {
-        return compute_capability_.IsCuda();
+        if (compute_capability_.IsCuda()) {
+          return true;
+        }
+        // gfx1250 lowers bf16 exp as exp2(x * log2(e)) computed in f32, so
+        // there is no need to upcast bf16 exp to f32 in FloatNormalization.
+        if (auto* rocm_cc = compute_capability_.rocm_compute_capability()) {
+          return rocm_cc->has_bf16_transcendental_support();
+        }
       }
       return false;
     case HloOpcode::kLog:

--- a/xla/service/gpu/gpu_float_support_test.cc
+++ b/xla/service/gpu/gpu_float_support_test.cc
@@ -668,23 +668,13 @@ ENTRY main {
       ROOT r = bf16[4] $0(p0)
 })";
 
-  for (absl::string_view op : {"log", "sqrt", "rsqrt", "tanh"}) {
+  for (absl::string_view op : {"exponential", "log", "sqrt", "rsqrt", "tanh"}) {
     ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(
                                           absl::Substitute(kHloModule, op)));
     EXPECT_FALSE(
         Normalize(module.get(), se::GpuComputeCapability{cc}, BF16, F32))
         << "bf16 " << op << " should not be normalized on gfx1250";
   }
-
-  // bf16 exp is rewritten as exp2(x * log2(e)), whose rounded-to-bf16
-  // exponent gets exponentiated, so error grows (and can overflow to inf)
-  // with the input magnitude. It is kept on the f32 path rather than using
-  // the native v_exp_bf16 instruction directly.
-  ASSERT_OK_AND_ASSIGN(auto module_exp,
-                       ParseAndReturnVerifiedModule(
-                           absl::Substitute(kHloModule, "exponential")));
-  EXPECT_TRUE(
-      Normalize(module_exp.get(), se::GpuComputeCapability{cc}, BF16, F32));
 
   // sine has a native bf16 hardware instruction (v_sin_bf16) but is not yet
   // wired up in XLA (no lowering / gate), so it is still normalized to f32.

--- a/xla/stream_executor/rocm/rocm_compute_capability.h
+++ b/xla/stream_executor/rocm/rocm_compute_capability.h
@@ -202,7 +202,7 @@ class RocmComputeCapability {
   // Native bf16 transcendental instructions (v_exp_bf16, v_sqrt_bf16,
   // v_rsq_bf16, v_tanh_bf16, v_log_bf16, etc.), backed by the LLVM
   // FeatureBF16TransInsts subtarget feature. Lets us compute these bf16 ops
-  // without upcasting to f32 (currently used for log, sqrt, rsqrt, tanh).
+  // without upcasting to f32 (currently used for exp, log, sqrt, rsqrt, tanh).
   bool has_bf16_transcendental_support() const { return gfx1250(); }
 
   bool has_tdm_support() const { return gfx1250(); }


### PR DESCRIPTION
📝 Summary of Changes
Lower scalar bf16 `math.exp` on gfx1250 as `2^(x · log2(e))` computed in f32
(widen → scale by f32 `log2(e)` → native `v_exp_f32` → round to bf16), and stop
upcasting bf16 `exp` to f32 in `FloatNormalization`.

🎯 Justification
Uses the hardware transcendental instead of an f32 upcast + `__ocml_exp_f32`
call, while staying accurate. The native *bf16* exp path was removed for
overflowing as |x| grows; computing in f32 fixes that.

🚀 Kind of Contribution
Please remove what does not apply: ⚡️ Performance Improvement, 🧪 Tests

🧪 Unit Tests:
- FileCheck test `@exp_bf16` in `bf16_transcendental_amdgpu.mlir`: verifies the
  lowering emits `fpext → fmul f32 → llvm.amdgcn.exp2 → fptrunc` and no `__ocml`.
- `gpu_float_support_test.cc`: asserts bf16 `exp` is not normalized on gfx1250.