### PR TITLE
[ROCm] Add rocm support for abort_collectives_on_task_failure_test

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -236,11 +236,10 @@ cc_library(
     ],
 )
 
-xla_cc_test(
+xla_test(
     name = "abort_collectives_on_task_failure_test",
     srcs = ["abort_collectives_on_task_failure_test.cc"],
-    tags = [
-        "cuda-only",
+    backends = [
         "gpu",
     ],
     deps = [
@@ -248,7 +247,6 @@ xla_cc_test(
         ":gpu_clique_key",
         ":gpu_cliques",
         ":gpu_collectives",
-        ":nccl_or_rccl_collectives",  # fixdeps: keep
         "//xla:executable_run_options",
         "//xla:future",
         "//xla/core/collectives:clique_id",
@@ -256,20 +254,21 @@ xla_cc_test(
         "//xla/core/collectives:rank_id",
         "//xla/pjrt/distributed/coordination:coordination_service_proto_cc",
         "//xla/runtime:device_id",
+        "//xla/service:platform_util",
         "//xla/stream_executor:platform",
         "//xla/stream_executor:platform_manager",
         "//xla/stream_executor:stream_executor_h",
-        "//xla/stream_executor/cuda:cuda_platform",  # fixdeps: keep
         "//xla/tsl/concurrency:executor",
         "//xla/tsl/platform:env",
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:status_macros",
         "@com_google_absl//absl/status:status_matchers",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-    ],
+    ] + if_cuda_or_rocm_is_configured(["nccl_or_rccl_collectives"]),
 )
 
 xla_test(

--- a/xla/backends/gpu/collectives/abort_collectives_on_task_failure_test.cc
+++ b/xla/backends/gpu/collectives/abort_collectives_on_task_failure_test.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/status_macros.h"
 #include "absl/status/status_matchers.h"
+#include "absl/strings/ascii.h"
 #include "absl/types/span.h"
 #include "xla/backends/gpu/collectives/gpu_clique.h"
 #include "xla/backends/gpu/collectives/gpu_clique_key.h"
@@ -37,6 +38,7 @@ limitations under the License.
 #include "xla/future.h"
 #include "xla/pjrt/distributed/coordination/coordination_service.pb.h"
 #include "xla/runtime/device_id.h"
+#include "xla/service/platform_util.h"
 #include "xla/stream_executor/platform.h"
 #include "xla/stream_executor/platform_manager.h"
 #include "xla/stream_executor/stream_executor.h"
@@ -157,8 +159,11 @@ TEST(AbortCollectivesOnTaskFailureTest, AbortsAcquiredGpuCliqueOnTaskFailure) {
   });
   ResetProcessTaskState();
 
+  ASSERT_OK_AND_ASSIGN(auto platform_name,
+                       xla::PlatformUtil::CanonicalPlatformName("gpu"));
   ASSERT_OK_AND_ASSIGN(se::Platform * platform,
-                       se::PlatformManager::PlatformWithName("CUDA"));
+                       se::PlatformManager::PlatformWithName(
+                           absl::AsciiStrToUpper(platform_name)));
   if (platform->VisibleDeviceCount() < 2) {
     GTEST_SKIP() << "Test requires at least 2 GPUs";
   }


### PR DESCRIPTION
📝 Summary of Changes
Add rocm support for  abort_collectives_on_task_failure_test

🎯 Justification
Provides extended unit test coverage on ROCm platforms

🚀 Kind of Contribution: 🧪 Tests

