### PR TITLE
 [ROCm] Emit theoretical occupancy on kernel events (PR2)

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -525,6 +525,37 @@ cc_library(
     ],
 )
 
+# Theoretical-occupancy model for AMDGPU kernels. Deliberately has NO ROCm
+# dependency and NO "rocm-only" tag: it is pure arithmetic, so it builds and
+# tests on a CPU-only host. Keeping it inside :rocm_collector -- which pulls in
+# hip_runtime.h and rocprofiler-sdk -- would mean the formula could never be
+# covered by CPU CI. Do not add ROCm deps here.
+cc_library(
+    name = "rocm_occupancy",
+    srcs = ["rocm_occupancy.cc"],
+    hdrs = ["rocm_occupancy.h"],
+    deps = [
+        "@com_google_absl//absl/log",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_occupancy_test",
+    size = "small",
+    srcs = ["rocm_occupancy_test.cc"],
+    # Untagged, on purpose, and do not add "gpu" here. openxla's CPU, ARM64 and
+    # Windows configs all filter -no_oss,-gpu,-requires-gpu-*, so any of those
+    # tags removes this target from every mainstream CI job and leaves it
+    # running only under ROCm's own ci_rocm_cpu, whose ",gpu," filter is
+    # positive. Untagged is what gets the golden table built and run on every
+    # PR, which is the whole reason the model is kept free of ROCm deps.
+    deps = [
+        ":rocm_occupancy",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "rocm_collector",
     srcs = ["rocm_collector.cc"],

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library")
-load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured", "rocm_library")
 load("//xla:xla.default.bzl", "xla_cc_test")
 load("//xla/tests:build_defs.bzl", "xla_test")
 load(
@@ -568,6 +568,7 @@ cc_library(
         "manual",
     ]),
     deps = [
+        ":rocm_occupancy",
         ":rocm_tracer_utils",
         "//xla/stream_executor/rocm:roctracer_wrapper",
         "//xla/tsl/platform:status",
@@ -602,6 +603,7 @@ cc_library(
     ],
     deps = [
         ":rocm_collector",
+        ":rocm_occupancy",
         ":rocm_tracer_utils",
         "//xla/stream_executor/rocm:roctracer_wrapper",
         "//xla/tsl/platform:errors",
@@ -624,6 +626,18 @@ cc_library(
     ],
 )
 
+rocm_library(
+    name = "rocm_occupancy_test_kernel",
+    testonly = 1,
+    srcs = ["rocm_occupancy_test_kernel.hip.cc"],
+    hdrs = ["rocm_occupancy_test_kernel.h"],
+    tags = ["rocm-only"],
+    deps = [
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
 xla_cc_test(
     name = "rocm_tracer_test",
     size = "small",
@@ -637,6 +651,7 @@ xla_cc_test(
     ]),
     deps = [
         ":rocm_collector",
+        ":rocm_occupancy_test_kernel",
         ":rocm_tracer",
         ":rocm_tracer_utils",
         "//xla/tsl/lib/core:status_test_util",
@@ -662,12 +677,12 @@ xla_cc_test(
         "manual",
     ]),
     deps = [
-        # ":rocm_tracer",
         ":rocm_collector",
+        ":rocm_occupancy",
         ":rocm_tracer_utils",
+        "//xla/tsl/profiler/utils:xplane_utils",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_googletest//:gtest_main",
-        "//xla/tsl/profiler/utils:xplane_utils",
         "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
     ],
 )

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -148,40 +148,6 @@ uint64_t get_timestamp() {
 }
 }  // namespace
 
-OccupancyStats PerDeviceCollector::GetOccupancy(
-    const RocmDeviceOccupancyParams& params) const {
-  // TODO(rocm-profiler): hipOccupancyMaxActiveBlocksPerMultiprocessor only
-  // return hipSuccess for HIP_API_ID_hipLaunchKernel
-  OccupancyStats stats;
-  int number_of_active_blocks;
-  hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
-      &number_of_active_blocks, params.func_ptr, params.block_size,
-      params.dynamic_smem_size);
-
-  if (err != hipError_t::hipSuccess) {
-    return {};
-  }
-
-  stats.occupancy_pct = number_of_active_blocks * params.block_size * 100;
-  // TODO(ROCm): GetOccupancy is currently dead code -- no callers populate
-  // max_waves_per_cu / wave_front_size, so occupancy_pct stays zero.
-  // Wire up agent data when occupancy reporting is enabled.
-  auto max_threads = params.max_waves_per_cu * params.wave_front_size;
-  if (max_threads > 0) {
-    stats.occupancy_pct /= max_threads;
-  }
-
-  err = hipOccupancyMaxPotentialBlockSize(
-      &stats.min_grid_size, &stats.suggested_block_size,
-      static_cast<const void*>(params.func_ptr), params.dynamic_smem_size, 0);
-
-  if (err != hipError_t::hipSuccess) {
-    return {};
-  }
-
-  return stats;
-}
-
 void PerDeviceCollector::CreateXEvent(const RocmTracerEvent& event,
                                       XPlaneBuilder* plane,
                                       uint64_t start_gpu_ns,

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -35,6 +36,7 @@ limitations under the License.
 #include "rocm/include/hip/hip_runtime.h"
 #include "rocm/include/rocprofiler-sdk/fwd.h"
 #include "rocm/include/rocprofiler-sdk/rocprofiler.h"
+#include "xla/backends/profiler/gpu/rocm_occupancy.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/platform/status.h"
 #include "xla/tsl/profiler/utils/parse_annotation.h"
@@ -195,11 +197,79 @@ void PerDeviceCollector::CreateXEvent(const RocmTracerEvent& event,
 
   if (event.type == RocmTracerEventType::Kernel &&
       event.source == RocmTracerEventSource::Activity) {
+    std::optional<double> occupancy_pct;
+    if (gfx_target_version_ != 0 && (event.kernel_info.arch_vgpr_count > 0 ||
+                                     event.kernel_info.accum_vgpr_count > 0)) {
+      // Unused y/z dimensions arrive as 0 and mean 1, so default them -- but
+      // only them. A zero x-dimension is not an unused dimension, it is a
+      // dispatch record that carried no launch geometry at all (SDK skew, a
+      // truncated record, the graph-replay path). Defaulting x too would turn
+      // that into a fabricated one-thread workgroup, which GetOccupancy()
+      // would then model at a confident 1.5625% -- non-zero, so nothing
+      // downstream filters it, and flatly contradicted by the `block:0,0,0`
+      // in the same event's kKernelDetails. Leaving block_size at 0 is what
+      // lets the guard in GetOccupancy() decline instead.
+      const uint32_t block_size =
+          event.kernel_info.workgroup_x == 0
+              ? 0
+              : event.kernel_info.workgroup_x *
+                    std::max(event.kernel_info.workgroup_y, 1u) *
+                    std::max(event.kernel_info.workgroup_z, 1u);
+
+      RocmDeviceOccupancyParams params{};
+      params.arch_vgpr_count = event.kernel_info.arch_vgpr_count;
+      params.accum_vgpr_count = event.kernel_info.accum_vgpr_count;
+      params.sgpr_count = event.kernel_info.sgpr_count;
+      params.block_size = block_size;
+      // group_segment_size from the dispatch record is already the total LDS
+      // per workgroup (static + runtime). Use it directly; do not add the
+      // symbol's static_group_segment_size on top (that would double-count).
+      params.smem_bytes = event.kernel_info.group_segment_size;
+      params.gfx_target_version = gfx_target_version_;
+
+      // Membership means computed; a nullopt mapped value means "modelled and
+      // came back unmodelable". Do not use has_value() as the miss test, or
+      // unmodelable launches recompute on every single event.
+      auto [it, inserted] = occupancy_cache_.try_emplace(params);
+      if (inserted) {
+        it->second = GetOccupancy(params, cu_count_);
+      }
+      const std::optional<OccupancyStats>& occ = it->second;
+
+      if (occ.has_value()) {
+        occupancy_pct = occ->occupancy_pct;
+        // Emitted unconditionally on a successful model, including a genuine
+        // 0.0 -- CUPTI does the same, and suppressing it makes "the kernel
+        // occupies nothing" indistinguishable from "we never looked". The
+        // converse case, a model that declined, leaves occupancy_pct empty so
+        // that neither this stat nor ToXStat's occ_pct token is written.
+        xevent.AddStatValue(*plane->GetOrCreateStatMetadata(GetStatTypeStr(
+                                StatType::kTheoreticalOccupancyPct)),
+                            occ->occupancy_pct);
+        if (occ->min_grid_size > 0) {
+          xevent.AddStatValue(*plane->GetOrCreateStatMetadata(GetStatTypeStr(
+                                  StatType::kOccupancyMinGridSize)),
+                              static_cast<int32_t>(occ->min_grid_size));
+        }
+      }
+    }
+    // The register count that goes next to occ_pct has to be the same charge
+    // the occupancy model used, or the two numbers contradict each other in
+    // the tooltip. Without a known target we cannot say how the arch and
+    // accum files combine, so fall back to the non-unified max() -- which is
+    // also what UnifiedVgprCount would return for such a target.
+    const uint32_t regs_per_thread =
+        target_constants_.has_value()
+            ? UnifiedVgprCount(*target_constants_,
+                               event.kernel_info.arch_vgpr_count,
+                               event.kernel_info.accum_vgpr_count)
+            : std::max(event.kernel_info.arch_vgpr_count,
+                       event.kernel_info.accum_vgpr_count);
     xevent.AddStatValue(
         *plane->GetOrCreateStatMetadata(
             GetStatTypeStr(StatType::kKernelDetails)),
-        *plane->GetOrCreateStatMetadata(ToXStat(event.kernel_info,
-                                                /*occupancy_pct*/ 0)));
+        *plane->GetOrCreateStatMetadata(
+            ToXStat(event.kernel_info, regs_per_thread, occupancy_pct)));
   } else if (event.type == RocmTracerEventType::MemcpyH2D ||
              event.type == RocmTracerEventType::MemcpyD2H ||
              event.type == RocmTracerEventType::MemcpyD2D ||
@@ -329,7 +399,6 @@ void PerDeviceCollector::Export(uint64_t start_walltime_ns,
                                 uint64_t end_gputime_ns,
                                 XPlaneBuilder* device_plane,
                                 XPlaneBuilder* host_plane) {
-  int host_ev_cnt = 0, dev_ev_cnt = 0;
   absl::MutexLock lock(events_mutex_);
   // Tracking event types per line.
   absl::flat_hash_map<int64_t, absl::flat_hash_set<RocmTracerEventType> >
@@ -360,19 +429,14 @@ void PerDeviceCollector::Export(uint64_t start_walltime_ns,
       }
     }
 
-    if (is_host_event) {
-      host_ev_cnt++;
-    } else {
-      dev_ev_cnt++;
-    }
-
     if (line_id == RocmTracerEvent::kInvalidThreadId ||
         line_id == RocmTracerEvent::kInvalidStreamId) {
       VLOG(3) << "Ignoring event, type=" << static_cast<int>(event.type);
       continue;
     }
     auto* plane = is_host_event ? host_plane : device_plane;
-    VLOG(9) << "Event" << " type=" << static_cast<int>(event.type)
+    VLOG(9) << "Event"
+            << " type=" << static_cast<int>(event.type)
             << " line_id=" << line_id
             << (is_host_event ? " host plane=" : " device plane=")
             << plane->Name();
@@ -460,8 +524,9 @@ void PerDeviceCollector::GetDeviceCapabilities(
     }
   }
 
-  // gfx_target_version encodes: major=((value/10000)%100),
-  // minor=((value/100)%100), patch=(value%100)
+  // gfx_target_version encodes, all in decimal: major=((value/10000)%100),
+  // minor=((value/100)%100), step=(value%100). The step renders in hex in the
+  // agent *name* only, which is why gfx90a is 90010 and not 9010a.
   auto gfx_ver = agent.gfx_target_version;
   if (gfx_ver) {
     auto compute_capability_major = (gfx_ver / 10000) % 100;
@@ -471,12 +536,53 @@ void PerDeviceCollector::GetDeviceCapabilities(
               GetStatTypeStr(StatType::kDevCapComputeCapMajor)),
           compute_capability_major);
     }
+    // Emitted unguarded: 0 is a real minor version. The old `if (minor)` guard
+    // meant every gfx90x part -- gfx900, gfx906, gfx90a -- published a major
+    // with no minor at all. The stepping has no home in this CUDA-shaped
+    // schema (it renders as a hex digit in the target name, so gfx90a is
+    // major 9, minor 0, step 0xa); occupancy therefore keys off the raw
+    // gfx_target_version below, never off these two stats.
     auto compute_capability_minor = (gfx_ver / 100) % 100;
-    if (compute_capability_minor) {
-      device_plane->AddStatValue(
-          *device_plane->GetOrCreateStatMetadata(
-              GetStatTypeStr(StatType::kDevCapComputeCapMinor)),
-          compute_capability_minor);
+    device_plane->AddStatValue(
+        *device_plane->GetOrCreateStatMetadata(
+            GetStatTypeStr(StatType::kDevCapComputeCapMinor)),
+        compute_capability_minor);
+  }
+
+  gfx_target_version_ = agent.gfx_target_version;
+  cu_count_ = agent.cu_count;
+
+  // Cross-check the per-target table against what the runtime reports. The
+  // table is the source of truth for occupancy (the agent does not expose
+  // register-file size or granules at all), so a mismatch here means the table
+  // needs a new entry -- e.g. a stale ROCr claiming max_waves_per_simd 10 on
+  // gfx90a, or silicon disagreeing with LLVM about gfx950's LDS.
+  target_constants_ = LookupTargetConstants(gfx_target_version_);
+  if (target_constants_.has_value() && target_constants_->exact) {
+    const AmdGpuTargetConstants& tc = *target_constants_;
+    // lds_size_in_kb is the LDS capacity per CU in KiB.
+    const uint32_t agent_lds_bytes = agent.lds_size_in_kb * 1024;
+    if (agent_lds_bytes != 0 && agent_lds_bytes != tc.lds_per_cu) {
+      LOG_FIRST_N(WARNING, 1)
+          << "Occupancy target table disagrees with the runtime for " << tc.name
+          << ": table lds_per_cu=" << tc.lds_per_cu << ", agent reports "
+          << agent_lds_bytes << " bytes. Occupancy will use the table value.";
+    }
+    if (agent.max_waves_per_simd != 0 &&
+        agent.max_waves_per_simd != tc.max_waves_per_simd) {
+      LOG_FIRST_N(WARNING, 1)
+          << "Occupancy target table disagrees with the runtime for " << tc.name
+          << ": table max_waves_per_simd=" << tc.max_waves_per_simd
+          << ", agent reports " << agent.max_waves_per_simd
+          << ". Occupancy will use the table value.";
+    }
+    if (agent.wave_front_size != 0 &&
+        agent.wave_front_size != tc.wave_front_size) {
+      LOG_FIRST_N(WARNING, 1)
+          << "Occupancy target table disagrees with the runtime for " << tc.name
+          << ": table wave_front_size=" << tc.wave_front_size
+          << ", agent reports " << agent.wave_front_size
+          << ". Occupancy will use the table value.";
     }
   }
 
@@ -598,6 +704,15 @@ void RocmTraceCollectorImpl::Export(XSpace* space) {
     if (id < static_cast<int>(gpu_agents_.size())) {
       per_device_collector_[id].GetDeviceCapabilities(gpu_agents_[id],
                                                       &device_plane);
+    } else {
+      // Without capabilities this device has no gfx_target_version, so every
+      // kernel on it silently loses its occupancy stats. Say so once rather
+      // than leaving a plane that is quietly missing a column.
+      LOG_FIRST_N(WARNING, 1)
+          << "No rocprofiler agent for device " << id << " (only "
+          << gpu_agents_.size()
+          << " GPU agents were enumerated); device capabilities and "
+             "theoretical occupancy will be missing for this plane.";
     }
     per_device_collector_[id].Export(start_walltime_ns_, start_gputime_ns_,
                                      end_gputime_ns, &device_plane,
@@ -663,7 +778,7 @@ std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
                         "Type="
                      << GetRocmTracerEventTypeName(api_event.type);
     }  // switch
-  }  // for
+  }    // for
 
   // Make sure for all activity events we have API callback events.
   //
@@ -699,7 +814,22 @@ std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
     for (auto& activity_event : activity_iter.second) {
       switch (activity_event.type) {
         case RocmTracerEventType::Kernel:
-          activity_event.kernel_info = api_event->kernel_info;
+          // Deliberately does NOT copy kernel_info from the API event. The
+          // dispatch record is the sole authoritative source: KernelEvent()
+          // builds KernelDetails per dispatch (rocm_tracer.cc), while the API
+          // callback path zeroes it. Copying api->activity here corrupted two
+          // cases:
+          //   * N dispatches under one correlation_id (a hipGraphLaunch
+          //     replay) all received dispatch #1's registers and LDS, because
+          //     the loop above seeds api_event from `.front()`. A 5-VGPR
+          //     elementwise kernel and a 416-VGPR flash-attention kernel in
+          //     one graph reported identical occupancy.
+          //   * A correlation_id present only in auxiliary_api_events_map_
+          //     (never visited by the loop above) wiped kernel_info to zero
+          //     for every one of its dispatches, suppressing occupancy
+          //     entirely.
+          // The memset/memcpy cases below still need their api->activity copy;
+          // only kernel_info flows the other way.
           PrintRocmTracerEvent(activity_event,
                                ". activity event from api_event.");
           aggregated_events.push_back(activity_event);
@@ -736,8 +866,8 @@ std::vector<RocmTracerEvent> RocmTraceCollectorImpl::ApiActivityInfoExchange() {
                           "Type="
                        << GetRocmTracerEventTypeName(activity_event.type);
       }  // switch
-    }  // for activity_event
-  }  // for activity_iter
+    }    // for activity_event
+  }      // for activity_iter
 
   return aggregated_events;
 }

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -20,11 +20,10 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
-#include <tuple>
 #include <vector>
 
-#include "rocprofiler-sdk/agent.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/node_hash_map.h"
@@ -32,6 +31,8 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
 #include "rocm/include/hip/hip_runtime.h"
+#include "rocprofiler-sdk/agent.h"
+#include "xla/backends/profiler/gpu/rocm_occupancy.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/profiler/utils/xplane_builder.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
@@ -39,8 +40,33 @@ limitations under the License.
 namespace xla {
 namespace profiler {
 
+// `regs_per_thread` is the UNIFIED arch+accum VGPR charge from
+// UnifiedVgprCount(), not kernel_info.arch_vgpr_count. Reporting the arch
+// count alone next to occ_pct would show an MFMA kernel holding 5 registers
+// and running at 37.5%, which reads as a bug in the occupancy number.
+//
+// Token names and order follow the CUDA collector's kernel-details string
+// (cupti_buffer_events.h ToXStat) wherever the concept exists on both
+// vendors, so one XProf tooltip parses both: `regs:`, `static_shared:`,
+// `dynamic_shared:`, `grid:`, `block:`, `occ_pct:`. The single ROCm-only
+// token is `private_mem:` (scratch per work-item), which has no CUPTI
+// counterpart. The former `group_mem:` was the static+dynamic total; it is
+// split here rather than reported alongside, because the sum carries no
+// information the two parts do not and a third LDS number in the same string
+// invites misreading.
+//
+// `occupancy_pct` is optional because GetOccupancy() is: nullopt means the
+// model declined to answer (unrecognised target, missing symbol data, a
+// geometry the hardware could not have made resident). In that case the
+// `occ_pct:` token is omitted entirely rather than written as 0. Emitting a
+// zero here would be read downstream as a measured 0% -- XProf's kernel-stats
+// table parses this very string (kernel_stats_utils.cc) and sets
+// occupancy_pct only when it finds the key -- and it would contradict
+// rocm_occupancy.h's contract that a caller "must then emit no occupancy
+// stats, NOT zero ones". A genuine modelled 0.0 is still written.
 inline std::string ToXStat(const KernelDetails& kernel_info,
-                           double occupancy_pct) {
+                           uint32_t regs_per_thread,
+                           std::optional<double> occupancy_pct) {
   uint32_t grid_x = kernel_info.workgroup_x != 0
                         ? kernel_info.grid_x / kernel_info.workgroup_x
                         : 0,
@@ -51,14 +77,31 @@ inline std::string ToXStat(const KernelDetails& kernel_info,
                         ? kernel_info.grid_z / kernel_info.workgroup_z
                         : 0;
 
-  return absl::StrCat(" grid:", grid_x, ",", grid_y, ",", grid_z,
-                      " block:", kernel_info.workgroup_x, ",",
-                      kernel_info.workgroup_y, ",", kernel_info.workgroup_z,
-                      " private_mem:", kernel_info.private_segment_size,
-                      " group_mem:", kernel_info.group_segment_size,
-                      " occ_pct:", occupancy_pct);
+  // The dispatch record carries the total LDS per workgroup; the code-object
+  // symbol carries the static half. A zero static figure means the symbol
+  // lookup missed, in which case attributing the whole total to `dynamic` is
+  // the honest reading -- we know what was allocated, not how it was declared.
+  const uint32_t static_shared = kernel_info.static_group_segment_size;
+  const uint32_t dynamic_shared =
+      kernel_info.group_segment_size > static_shared
+          ? kernel_info.group_segment_size - static_shared
+          : 0;
+
+  std::string stat =
+      absl::StrCat("regs:", regs_per_thread, " static_shared:", static_shared,
+                   " dynamic_shared:", dynamic_shared, " grid:", grid_x, ",",
+                   grid_y, ",", grid_z, " block:", kernel_info.workgroup_x, ",",
+                   kernel_info.workgroup_y, ",", kernel_info.workgroup_z,
+                   " private_mem:", kernel_info.private_segment_size);
+  if (occupancy_pct.has_value()) {
+    absl::StrAppend(&stat, " occ_pct:", *occupancy_pct);
+  }
+  return stat;
 }
 
+// RocmDeviceOccupancyParams, OccupancyStats, OccupancyLimiter and
+// GetOccupancy() live in rocm_occupancy.h, which has no ROCm includes so that
+// the model can be unit-tested on a CPU-only host.
 
 class RocmTraceCollector {
  public:
@@ -108,6 +151,25 @@ class PerDeviceCollector {
  private:
   absl::Mutex events_mutex_;
   std::vector<RocmTracerEvent> events_ ABSL_GUARDED_BY(events_mutex_);
+  // The fields below are written once in GetDeviceCapabilities() and read in
+  // CreateXEvent(), both called sequentially from Export() after Flush().
+  // No concurrent access, so no mutex guard is needed.
+  //
+  // A nullopt mapped value means "we tried and this launch cannot be modelled",
+  // NOT "not computed yet" -- membership in the map is what says "computed".
+  // Using the optional itself as the not-yet-computed sentinel would make every
+  // unmodelable kernel recompute on every event, which is the cost this cache
+  // exists to avoid.
+  absl::flat_hash_map<RocmDeviceOccupancyParams, std::optional<OccupancyStats>>
+      occupancy_cache_;
+  // Kept only so the occupancy model can be keyed and the agent values
+  // cross-checked against the per-target table; see GetDeviceCapabilities().
+  uint32_t gfx_target_version_ = 0;
+  uint32_t cu_count_ = 0;
+  // Resolved once from gfx_target_version_, alongside the cross-check that
+  // needs it anyway. nullopt means "target we cannot model" -- gfx10+, where
+  // ToXStat falls back to a non-unified register count.
+  std::optional<AmdGpuTargetConstants> target_constants_;
 };  // PerDeviceCollector
 
 class RocmTraceCollectorImpl : public RocmTraceCollector {

--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -59,70 +59,6 @@ inline std::string ToXStat(const KernelDetails& kernel_info,
                       " occ_pct:", occupancy_pct);
 }
 
-struct RocmDeviceOccupancyParams {
-  hipFuncAttributes attributes = {};
-  int block_size = 0;
-  size_t dynamic_smem_size = 0;
-  void* func_ptr;
-  uint32_t max_waves_per_cu = 0;
-  uint32_t wave_front_size = 0;
-
-  friend bool operator==(const RocmDeviceOccupancyParams& a,
-                         const RocmDeviceOccupancyParams& b) noexcept {
-    // Compare only the fields that affect occupancy decisions.
-    return std::tuple{a.attributes.binaryVersion,
-                      a.attributes.cacheModeCA,
-                      a.attributes.constSizeBytes,
-                      a.attributes.localSizeBytes,
-                      a.attributes.maxDynamicSharedSizeBytes,
-                      a.attributes.maxThreadsPerBlock,
-                      a.attributes.numRegs,
-                      a.attributes.preferredShmemCarveout,
-                      a.attributes.ptxVersion,
-                      a.block_size,
-                      a.dynamic_smem_size,
-                      a.func_ptr,
-                      a.max_waves_per_cu,
-                      a.wave_front_size} ==
-           std::tuple{b.attributes.binaryVersion,
-                      b.attributes.cacheModeCA,
-                      b.attributes.constSizeBytes,
-                      b.attributes.localSizeBytes,
-                      b.attributes.maxDynamicSharedSizeBytes,
-                      b.attributes.maxThreadsPerBlock,
-                      b.attributes.numRegs,
-                      b.attributes.preferredShmemCarveout,
-                      b.attributes.ptxVersion,
-                      b.block_size,
-                      b.dynamic_smem_size,
-                      b.func_ptr,
-                      b.max_waves_per_cu,
-                      b.wave_front_size};
-  }
-
-  friend bool operator!=(const RocmDeviceOccupancyParams& a,
-                         const RocmDeviceOccupancyParams& b) noexcept {
-    return !(a == b);
-  }
-
-  template <typename H>
-  friend H AbslHashValue(H hash_state,
-                         const RocmDeviceOccupancyParams& params) {
-    return H::combine(
-        std::move(hash_state), params.attributes.maxThreadsPerBlock,
-        params.attributes.numRegs, params.attributes.sharedSizeBytes,
-        params.attributes.maxDynamicSharedSizeBytes, params.block_size,
-        params.dynamic_smem_size, params.func_ptr, params.max_waves_per_cu,
-        params.wave_front_size);
-  }
-};
-
-// FIXME: rocprofiler-sdk does not have this one yet
-struct OccupancyStats {
-  double occupancy_pct = 0.0;
-  int min_grid_size = 0;
-  int suggested_block_size = 0;
-};
 
 class RocmTraceCollector {
  public:
@@ -163,7 +99,6 @@ class PerDeviceCollector {
                              tsl::profiler::XPlaneBuilder* device_plane);
 
  private:
-  OccupancyStats GetOccupancy(const RocmDeviceOccupancyParams& params) const;
   void CreateXEvent(const RocmTracerEvent& event,
                     tsl::profiler::XPlaneBuilder* plane, uint64_t start_gpu_ns,
                     uint64_t end_gpu_ns, tsl::profiler::XLineBuilder* line);
@@ -173,8 +108,6 @@ class PerDeviceCollector {
  private:
   absl::Mutex events_mutex_;
   std::vector<RocmTracerEvent> events_ ABSL_GUARDED_BY(events_mutex_);
-  absl::flat_hash_map<RocmDeviceOccupancyParams, OccupancyStats>
-      occupancy_cache_;
 };  // PerDeviceCollector
 
 class RocmTraceCollectorImpl : public RocmTraceCollector {

--- a/xla/backends/profiler/gpu/rocm_collector_test.cc
+++ b/xla/backends/profiler/gpu/rocm_collector_test.cc
@@ -22,7 +22,10 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "absl/container/flat_hash_set.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+#include "xla/tsl/profiler/utils/xplane_schema.h"
 #include "xla/tsl/profiler/utils/xplane_utils.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
 
@@ -31,6 +34,8 @@ namespace profiler {
 namespace test {
 
 using tsl::profiler::FindOrAddMutablePlaneWithName;
+using tsl::profiler::GetStatTypeStr;
+using tsl::profiler::StatType;
 using tsl::profiler::XSpace;
 
 TEST(RocmCollectorTest, TestAddKernelEventAndExport) {
@@ -57,16 +62,12 @@ TEST(RocmCollectorTest, TestAddKernelEventAndExport) {
   api_event.name = "test_rocm_kernel";
   api_event.correlation_id = kCorrelationId;
   api_event.thread_id = 999;
+  // KernelDetails is a union member with no default member initializer, so it
+  // has to be value-initialized explicitly. It is left zeroed here on purpose:
+  // ApiActivityInfoExchange copies activity->api, so the ACTIVITY side below
+  // is the authoritative one -- same direction as the real tracer, which
+  // builds KernelDetails in KernelEvent() on the dispatch record.
   api_event.kernel_info = KernelDetails{};
-  api_event.kernel_info.private_segment_size = 32;
-  api_event.kernel_info.group_segment_size = 1024;
-  api_event.kernel_info.workgroup_x = 256;
-  api_event.kernel_info.workgroup_y = 1;
-  api_event.kernel_info.workgroup_z = 1;
-  api_event.kernel_info.grid_x = 100;
-  api_event.kernel_info.grid_y = 1;
-  api_event.kernel_info.grid_z = 1;
-  api_event.kernel_info.func_ptr = reinterpret_cast<void*>(0xdeadbeef);
 
   collector.AddEvent(std::move(api_event), /*is_auxiliary=*/false);
 
@@ -81,6 +82,16 @@ TEST(RocmCollectorTest, TestAddKernelEventAndExport) {
   activity_event.end_time_ns = kEndTimeNs;
   activity_event.device_id = 100;
   activity_event.stream_id = 123;
+  activity_event.kernel_info = KernelDetails{};
+  activity_event.kernel_info.private_segment_size = 32;
+  activity_event.kernel_info.group_segment_size = 1024;
+  activity_event.kernel_info.workgroup_x = 256;
+  activity_event.kernel_info.workgroup_y = 1;
+  activity_event.kernel_info.workgroup_z = 1;
+  activity_event.kernel_info.grid_x = 100;
+  activity_event.kernel_info.grid_y = 1;
+  activity_event.kernel_info.grid_z = 1;
+  activity_event.kernel_info.arch_vgpr_count = 32;
 
   collector.AddEvent(std::move(activity_event), /*is_auxiliary=*/false);
 
@@ -137,20 +148,24 @@ TEST(RocmCollectorTest, MultipleActivitiesPerCorrelationIdAllExported) {
   api_event.correlation_id = kCorrelationId;
   api_event.thread_id = 999;
   api_event.kernel_info = KernelDetails{};
-  api_event.kernel_info.func_ptr = reinterpret_cast<void*>(0xdeadbeef);
+  api_event.kernel_info.arch_vgpr_count = 32;
   collector.AddEvent(std::move(api_event), /*is_auxiliary=*/false);
 
   // Three GPU activity records, same correlation_id, same stream (so
   // they land on the same XLine), distinct names and timestamps.
+  // Distinct register counts per dispatch: a graph replay mixes a cheap
+  // elementwise kernel with an expensive MFMA one, and each must keep its own
+  // KernelDetails through the api/activity merge.
   struct ActivityShape {
     const char* name;
     uint64_t start_ns;
     uint64_t end_ns;
+    uint32_t arch_vgpr_count;
   };
   constexpr ActivityShape kActivities[] = {
-      {"kernel_a", 3000, 3500},
-      {"kernel_b", 3500, 4000},
-      {"kernel_c", 4000, 4500},
+      {"kernel_a", 3000, 3500, 8},
+      {"kernel_b", 3500, 4000, 64},
+      {"kernel_c", 4000, 4500, 256},
   };
   for (const auto& shape : kActivities) {
     RocmTracerEvent activity;
@@ -163,6 +178,11 @@ TEST(RocmCollectorTest, MultipleActivitiesPerCorrelationIdAllExported) {
     activity.end_time_ns = shape.end_ns;
     activity.device_id = kDeviceId;
     activity.stream_id = kStreamId;
+    activity.kernel_info = KernelDetails{};
+    activity.kernel_info.workgroup_x = 256;
+    activity.kernel_info.workgroup_y = 1;
+    activity.kernel_info.workgroup_z = 1;
+    activity.kernel_info.arch_vgpr_count = shape.arch_vgpr_count;
     collector.AddEvent(std::move(activity), /*is_auxiliary=*/false);
   }
 
@@ -179,13 +199,30 @@ TEST(RocmCollectorTest, MultipleActivitiesPerCorrelationIdAllExported) {
   // appear on the stream line. Dense stream remapping converts the raw
   // stream_id (123) to a sequential index (0), so we look for events on
   // any device line rather than matching a specific line ID.
+  int64_t details_id = -1;
+  for (const auto& [id, smd] : gpu_plane->stat_metadata()) {
+    if (smd.name() == GetStatTypeStr(tsl::profiler::StatType::kKernelDetails)) {
+      details_id = id;
+      break;
+    }
+  }
+
   size_t total_kernel_events = 0;
   absl::flat_hash_set<std::string> seen_names;
+  absl::flat_hash_map<std::string, std::string> details_by_name;
   for (const auto& line : gpu_plane->lines()) {
     total_kernel_events += line.events_size();
     for (const auto& ev : line.events()) {
-      seen_names.insert(
-          gpu_plane->event_metadata().at(ev.metadata_id()).name());
+      const std::string& name =
+          gpu_plane->event_metadata().at(ev.metadata_id()).name();
+      seen_names.insert(name);
+      for (const auto& stat : ev.stats()) {
+        if (stat.metadata_id() != details_id) continue;
+        auto it = gpu_plane->stat_metadata().find(stat.ref_value());
+        if (it != gpu_plane->stat_metadata().end()) {
+          details_by_name[name] = it->second.name();
+        }
+      }
     }
   }
 
@@ -198,7 +235,538 @@ TEST(RocmCollectorTest, MultipleActivitiesPerCorrelationIdAllExported) {
   EXPECT_TRUE(seen_names.contains("kernel_a"));
   EXPECT_TRUE(seen_names.contains("kernel_b"));
   EXPECT_TRUE(seen_names.contains("kernel_c"));
+
+  // Each dispatch must keep its OWN registers. Before the merge fix, the
+  // api/activity exchange seeded the shared api_event from `.front()` and then
+  // copied it back over every activity, so all three reported regs:8 -- and
+  // therefore all three would report kernel_a's occupancy. No agent is
+  // registered here, so regs is the non-unified max(arch, accum) == arch.
+  for (const auto& shape : kActivities) {
+    auto it = details_by_name.find(shape.name);
+    ASSERT_NE(it, details_by_name.end())
+        << shape.name << " has no kKernelDetails stat";
+    EXPECT_EQ(
+        it->second.rfind(absl::StrCat("regs:", shape.arch_vgpr_count, " "), 0),
+        0u)
+        << shape.name
+        << " must report its own register count, got: " << it->second;
+  }
 }
+
+// ============================================================================
+// Occupancy unit tests
+//
+// The formula itself is pinned by a 16-row golden table in
+// rocm_occupancy_test.cc, which needs no ROCm at all. What is tested here is
+// the collector's half of the job: that KernelDetails reaches
+// RocmDeviceOccupancyParams intact, that the agent's gfx_target_version and
+// cu_count reach the model, and that the resulting XStats are the ones XProf
+// expects.
+// ============================================================================
+
+// gfx942 == MI300X. Decoded as major=(v/10000)%100, minor=(v/100)%100,
+// step=v%100, all decimal.
+constexpr uint32_t kGfx942 = 90402;
+constexpr uint32_t kCuCount = 304;  // MI300X
+
+// Returns the first stat of `type` found on any event in `plane`, or nullptr
+// if that stat was never emitted.
+const tensorflow::profiler::XStat* FindEventStat(
+    const tensorflow::profiler::XPlane& plane, StatType type) {
+  absl::string_view key = GetStatTypeStr(type);
+  int64_t stat_id = -1;
+  for (const auto& [id, smd] : plane.stat_metadata()) {
+    if (smd.name() == key) {
+      stat_id = id;
+      break;
+    }
+  }
+  if (stat_id < 0) return nullptr;
+  for (const auto& line : plane.lines()) {
+    for (const auto& ev : line.events()) {
+      for (const auto& stat : ev.stats()) {
+        if (stat.metadata_id() == stat_id) return &stat;
+      }
+    }
+  }
+  return nullptr;
+}
+
+// Returns the kKernelDetails string of the first kernel event in `plane`, or
+// the empty string if there is none. The details value is a reference into the
+// plane's stat metadata, so it takes two lookups to reach.
+std::string FindKernelDetails(const tensorflow::profiler::XPlane& plane) {
+  const auto* stat = FindEventStat(plane, StatType::kKernelDetails);
+  if (stat == nullptr) return "";
+  auto it = plane.stat_metadata().find(stat->ref_value());
+  if (it == plane.stat_metadata().end()) return "";
+  return it->second.name();
+}
+
+// Helper: build a RocmTraceCollectorImpl and inject a paired API + Activity
+// kernel event, optionally with GPU agent data for occupancy.
+struct OccupancyTestFixture {
+  RocmTraceCollectorImpl collector;
+
+  static RocmTraceCollectorOptions MakeOpts() {
+    RocmTraceCollectorOptions o;
+    o.max_callback_api_events = 100;
+    o.max_activity_api_events = 100;
+    o.max_annotation_strings = 100;
+    o.num_gpus = 1;
+    return o;
+  }
+
+  OccupancyTestFixture()
+      : collector(MakeOpts(), /*start_walltime_ns=*/1000,
+                  /*start_gputime_ns=*/2000) {}
+
+  // Injects a synthetic rocprofiler agent so the occupancy success path can be
+  // exercised with no GPU and no ROCm runtime. Only the fields
+  // GetDeviceCapabilities reads are set; the rest stay zeroed, and
+  // mem_banks_count == 0 keeps the VRAM branch out of the way.
+  void SetSyntheticAgent(uint32_t gfx_target_version, uint32_t cu_count) {
+    rocprofiler_agent_v0_t agent{};
+    agent.gfx_target_version = gfx_target_version;
+    agent.cu_count = cu_count;
+    // Matching the gfx942 row of the occupancy target table, so the
+    // cross-check in GetDeviceCapabilities stays quiet.
+    agent.lds_size_in_kb = 64;
+    agent.max_waves_per_simd = 8;
+    agent.simd_per_cu = 4;
+    agent.wave_front_size = 64;
+    collector.SetGpuAgents({agent});
+  }
+
+  void AddKernelPair(uint32_t arch_vgpr_count, uint32_t wg_x, uint32_t wg_y,
+                     uint32_t wg_z, uint32_t smem, uint64_t start_ns,
+                     uint64_t end_ns, uint32_t corr_id = 1,
+                     uint32_t accum_vgpr_count = 0, uint32_t sgpr_count = 0,
+                     uint32_t static_smem = 0) {
+    RocmTracerEvent api;
+    api.type = RocmTracerEventType::Kernel;
+    api.source = RocmTracerEventSource::ApiCallback;
+    api.domain = RocmTracerEventDomain::HIP_API;
+    api.name = "test_kernel";
+    api.correlation_id = corr_id;
+    api.thread_id = 1;
+    // Zeroed, exactly as the real API-callback path leaves it: the launch
+    // parameters arrive on the dispatch record, not on the HIP API callback,
+    // and ApiActivityInfoExchange overwrites this side with that one.
+    api.kernel_info = KernelDetails{};
+    collector.AddEvent(std::move(api), false);
+
+    RocmTracerEvent act;
+    act.type = RocmTracerEventType::Kernel;
+    act.source = RocmTracerEventSource::Activity;
+    act.domain = RocmTracerEventDomain::HIP_OPS;
+    act.name = "test_kernel";
+    act.correlation_id = corr_id;
+    act.start_time_ns = start_ns;
+    act.end_time_ns = end_ns;
+    act.device_id = 0;
+    act.stream_id = 1;
+    // The dispatch record is where KernelDetails actually comes from: the
+    // workgroup and LDS sizes straight from rocprofiler, the register counts
+    // grafted on from the code-object kernel-symbol callback.
+    act.kernel_info = KernelDetails{};
+    act.kernel_info.arch_vgpr_count = arch_vgpr_count;
+    act.kernel_info.accum_vgpr_count = accum_vgpr_count;
+    act.kernel_info.sgpr_count = sgpr_count;
+    act.kernel_info.workgroup_x = wg_x;
+    act.kernel_info.workgroup_y = wg_y;
+    act.kernel_info.workgroup_z = wg_z;
+    act.kernel_info.group_segment_size = smem;
+    act.kernel_info.static_group_segment_size = static_smem;
+    collector.AddEvent(std::move(act), false);
+  }
+};
+
+// A kernel symbol with no VGPRs at all means the code-object callback never
+// ran for it (a real kernel always allocates at least one register), so there
+// is nothing to model and the occupancy block must not be written.
+TEST(RocmCollectorOccupancyTest, ZeroVgprCountSkipsOccupancyStats) {
+  OccupancyTestFixture f;
+  f.AddKernelPair(/*arch_vgpr_count=*/0, 256, 1, 1, 0, 3000, 4000);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  absl::string_view kOccKey =
+      GetStatTypeStr(StatType::kTheoreticalOccupancyPct);
+  for (const auto& [id, smd] : gpu->stat_metadata()) {
+    EXPECT_NE(smd.name(), kOccKey)
+        << "kTheoreticalOccupancyPct must not appear with no register counts";
+  }
+}
+
+// Without agent data there is no gfx_target_version, and without a target the
+// model has no register-file size, no LDS capacity and no granules -- every
+// one of which the formula needs. Occupancy must be skipped rather than
+// guessed, even though the register count here is perfectly valid.
+TEST(RocmCollectorOccupancyTest, NoAgentCapabilitiesSkipsOccupancyStats) {
+  OccupancyTestFixture f;
+  // Valid registers, but no agent injected, so gfx_target_version_ stays 0.
+  f.AddKernelPair(/*arch_vgpr_count=*/32, 256, 1, 1, 0, 3000, 4000);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  absl::string_view kOccKey =
+      GetStatTypeStr(StatType::kTheoreticalOccupancyPct);
+  for (const auto& [id, smd] : gpu->stat_metadata()) {
+    EXPECT_NE(smd.name(), kOccKey)
+        << "kTheoreticalOccupancyPct must not appear without a known target";
+  }
+}
+
+// The suggested-block-size stat is gone: it was computed as
+// waves_per_block * wave_front_size, which is just block_size rounded up to a
+// wavefront -- an echo of the input, not a suggestion. It must not come back.
+TEST(RocmCollectorOccupancyTest, SuggestedBlockSizeIsNeverEmitted) {
+  OccupancyTestFixture f;
+  // The agent matters here: without it occupancy is skipped entirely and the
+  // assertion below would pass for the wrong reason.
+  f.SetSyntheticAgent(kGfx942, kCuCount);
+  f.AddKernelPair(/*arch_vgpr_count=*/32, 256, 1, 1, 0, 3000, 4000);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  ASSERT_NE(FindEventStat(*gpu, StatType::kTheoreticalOccupancyPct), nullptr)
+      << "occupancy was not computed, so this test proves nothing";
+
+  absl::string_view kSuggestedKey =
+      GetStatTypeStr(StatType::kOccupancySuggestedBlockSize);
+  for (const auto& [id, smd] : gpu->stat_metadata()) {
+    EXPECT_NE(smd.name(), kSuggestedKey)
+        << "kOccupancySuggestedBlockSize was deliberately removed";
+  }
+}
+
+// The success path, end to end, with no GPU and no ROCm runtime: a synthetic
+// gfx942 agent plus known register counts must land on exactly the number the
+// golden table predicts. 128 arch VGPRs (no AGPRs, so the max() branch of the
+// unified count applies) granulate to 128, giving 512/128 = 4 waves/SIMD out
+// of 8 -> 50%.
+TEST(RocmCollectorOccupancyTest, VgprLimitedKernelReportsExactOccupancy) {
+  OccupancyTestFixture f;
+  f.SetSyntheticAgent(kGfx942, kCuCount);
+  f.AddKernelPair(/*arch_vgpr_count=*/128, 256, 1, 1, /*smem=*/0, 3000, 4000);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  const auto* occ = FindEventStat(*gpu, StatType::kTheoreticalOccupancyPct);
+  ASSERT_NE(occ, nullptr) << "occupancy stat missing on the success path";
+  EXPECT_DOUBLE_EQ(occ->double_value(), 50.0);
+
+  // Whole device, not per CU: 4 workgroups/CU * 304 CUs. The pre-change code
+  // reported the per-CU figure (4) under the same stat name, which XProf
+  // renders as "min grid size" -- off by the CU count.
+  const auto* grid = FindEventStat(*gpu, StatType::kOccupancyMinGridSize);
+  ASSERT_NE(grid, nullptr);
+  EXPECT_EQ(grid->int64_value(), 4 * kCuCount);
+}
+
+// The AGPR fix, end to end -- the reason this PR exists. On gfx942 the
+// register file is unified, so an MFMA kernel holding 5 arch VGPRs and 128
+// AGPRs really costs alignTo(5,4) + 128 = 132 VGPRs, granulated to 136: three
+// waves per SIMD out of eight, 37.5%.
+//
+// Reading only arch_vgpr_count -- what the collector did before -- sees 5
+// registers, concludes the kernel is unconstrained, and reports 100%. That is
+// a 2.7x over-report on precisely the kernels a profiler user is opening the
+// trace to look at.
+TEST(RocmCollectorOccupancyTest, MfmaAgprsReachTheModel) {
+  OccupancyTestFixture f;
+  f.SetSyntheticAgent(kGfx942, kCuCount);
+  f.AddKernelPair(/*arch_vgpr_count=*/5, 256, 1, 1, /*smem=*/0, 3000, 4000,
+                  /*corr_id=*/1, /*accum_vgpr_count=*/128);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  const auto* occ = FindEventStat(*gpu, StatType::kTheoreticalOccupancyPct);
+  ASSERT_NE(occ, nullptr);
+  EXPECT_DOUBLE_EQ(occ->double_value(), 37.5)
+      << "AGPRs are not reaching the occupancy model; a kernel with 128 AGPRs "
+         "cannot be at full occupancy on a unified register file";
+
+  const auto* grid = FindEventStat(*gpu, StatType::kOccupancyMinGridSize);
+  ASSERT_NE(grid, nullptr);
+  EXPECT_EQ(grid->int64_value(), 3 * kCuCount);
+}
+
+// LDS is the other input that only reaches the model through KernelDetails.
+// 32 KiB per workgroup out of gfx942's 64 KiB per CU allows two resident
+// workgroups, i.e. 512 of 2048 thread slots -> 25%, well under the 8
+// workgroups the 32 VGPRs would otherwise permit.
+TEST(RocmCollectorOccupancyTest, LdsLimitedKernelReportsExactOccupancy) {
+  OccupancyTestFixture f;
+  f.SetSyntheticAgent(kGfx942, kCuCount);
+  f.AddKernelPair(/*arch_vgpr_count=*/32, 256, 1, 1, /*smem=*/32768, 3000,
+                  4000);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  const auto* occ = FindEventStat(*gpu, StatType::kTheoreticalOccupancyPct);
+  ASSERT_NE(occ, nullptr);
+  EXPECT_DOUBLE_EQ(occ->double_value(), 25.0);
+
+  const auto* grid = FindEventStat(*gpu, StatType::kOccupancyMinGridSize);
+  ASSERT_NE(grid, nullptr);
+  EXPECT_EQ(grid->int64_value(), 2 * kCuCount);
+}
+
+// kKernelDetails stat must always be present for kernel activity events,
+// regardless of whether occupancy was computed.
+TEST(RocmCollectorOccupancyTest, KernelDetailsAlwaysPresent) {
+  OccupancyTestFixture f;
+  f.AddKernelPair(/*arch_vgpr_count=*/0, 64, 1, 1, 512, 3000, 4000);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  absl::string_view kDetailsKey = GetStatTypeStr(StatType::kKernelDetails);
+  bool found_details = false;
+  for (const auto& [id, smd] : gpu->stat_metadata()) {
+    if (smd.name() == kDetailsKey) {
+      found_details = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_details) << "kKernelDetails stat must be present for "
+                                "kernel events regardless of occupancy";
+}
+
+// When the model declines, the occ_pct token must be ABSENT, not zero.
+//
+// This test previously asserted the opposite -- that the string contains
+// "occ_pct:0" when the model is skipped -- which pinned a real defect in
+// place. XProf's kernel-stats table parses this string and sets its occupancy
+// column only when it finds the key (kernel_stats_utils.cc), so a literal 0
+// there is read as a measured 0%, and the trace-viewer tooltip asserts a
+// number nobody computed. rocm_occupancy.h is explicit: a nullopt result means
+// the caller "must then emit no occupancy stats, NOT zero ones".
+TEST(RocmCollectorOccupancyTest, KernelDetailsOmitsOccupancyWhenNotModelled) {
+  OccupancyTestFixture f;
+  // No agent -> gfx_target_version_ stays 0 -> the model is never consulted.
+  f.AddKernelPair(/*arch_vgpr_count=*/0, 128, 1, 1, 0, 3000, 4000);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  const std::string details = FindKernelDetails(*gpu);
+  ASSERT_FALSE(details.empty()) << "kKernelDetails stat not found";
+  EXPECT_EQ(details.find("occ_pct"), std::string::npos)
+      << "KernelDetails must omit the occ_pct token entirely when the model "
+         "declined; got: "
+      << details;
+  // The rest of the string must still be there -- omission is scoped to the
+  // one token, not a bail-out from emitting kernel details at all.
+  EXPECT_NE(details.find("regs:"), std::string::npos) << details;
+  EXPECT_NE(details.find("block:"), std::string::npos) << details;
+}
+
+// A genuine modelled result is still written, including the value 0.0. This is
+// the other half of the contract: "could not model" and "modelled as zero"
+// must be distinguishable in the string, not just in the numeric stat.
+TEST(RocmCollectorOccupancyTest, KernelDetailsKeepsOccupancyWhenModelled) {
+  OccupancyTestFixture f;
+  f.SetSyntheticAgent(kGfx942, kCuCount);
+  f.AddKernelPair(/*arch_vgpr_count=*/5, 256, 1, 1, /*smem=*/0, 3000, 4000,
+                  /*corr_id=*/1, /*accum_vgpr_count=*/128);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  const std::string details = FindKernelDetails(*gpu);
+  ASSERT_FALSE(details.empty()) << "kKernelDetails stat not found";
+  EXPECT_NE(details.find("occ_pct:37.5"), std::string::npos) << details;
+}
+
+// A dispatch record with no launch geometry must reach GetOccupancy()'s
+// block_size == 0 guard rather than being rounded up into a one-thread
+// workgroup. Before this, std::max(workgroup_*, 1u) on all three dimensions
+// produced block_size == 1, which the model happily rated at 1.5625% -- a
+// confident, non-zero, unfilterable number sitting next to `block:0,0,0` in
+// the very same string.
+TEST(RocmCollectorOccupancyTest, ZeroWorkgroupGeometrySkipsOccupancy) {
+  OccupancyTestFixture f;
+  f.SetSyntheticAgent(kGfx942, kCuCount);
+  // Registers present (so the outer guard passes) but every workgroup
+  // dimension zero, exactly as a truncated dispatch record arrives.
+  f.AddKernelPair(/*arch_vgpr_count=*/64, /*wg_x=*/0, /*wg_y=*/0, /*wg_z=*/0,
+                  /*smem=*/0, 3000, 4000);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  const std::string details = FindKernelDetails(*gpu);
+  ASSERT_FALSE(details.empty()) << "kKernelDetails stat not found";
+  EXPECT_EQ(details.find("occ_pct"), std::string::npos)
+      << "a zeroed workgroup size must not produce an occupancy figure; got: "
+      << details;
+
+  // ...and neither of the numeric occupancy stats may appear either.
+  EXPECT_EQ(FindEventStat(*gpu, StatType::kTheoreticalOccupancyPct), nullptr)
+      << "kTheoreticalOccupancyPct emitted for a dispatch with no geometry";
+  EXPECT_EQ(FindEventStat(*gpu, StatType::kOccupancyMinGridSize), nullptr)
+      << "kOccupancyMinGridSize emitted for a dispatch with no geometry";
+}
+
+// The `regs:` token must carry the same unified charge the occupancy model
+// used, not arch_vgpr_count. A tooltip reading "regs:5 ... occ_pct:37.5" reads
+// as a bug in the occupancy number; "regs:136 ... occ_pct:37.5" is the
+// explanation for it. This is also the only place the AGPR count becomes
+// visible to a user, which is the point of the whole change.
+TEST(RocmCollectorOccupancyTest, KernelDetailsRegsIsTheUnifiedVgprCount) {
+  OccupancyTestFixture f;
+  f.SetSyntheticAgent(kGfx942, kCuCount);
+  f.AddKernelPair(/*arch_vgpr_count=*/5, 256, 1, 1, /*smem=*/0, 3000, 4000,
+                  /*corr_id=*/1, /*accum_vgpr_count=*/128);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  const std::string details = FindKernelDetails(*gpu);
+  ASSERT_FALSE(details.empty()) << "kKernelDetails stat not found";
+  // Leading token, matching the CUDA collector's string layout.
+  EXPECT_EQ(details.rfind("regs:136 ", 0), 0u)
+      << "expected the string to start with the unified count 136 (= "
+         "alignTo(5,4) + 128); got: "
+      << details;
+  EXPECT_NE(details.find("occ_pct:37.5"), std::string::npos) << details;
+}
+
+// The dispatch record reports total LDS and the code-object symbol reports the
+// static half; the string carries both, under CUDA's names, so XProf shows the
+// same two fields for both vendors. This is the only reader of
+// KernelDetails::static_group_segment_size -- if this test goes, the field
+// should go with it.
+TEST(RocmCollectorOccupancyTest, KernelDetailsSplitsStaticAndDynamicLds) {
+  OccupancyTestFixture f;
+  f.SetSyntheticAgent(kGfx942, kCuCount);
+  f.AddKernelPair(/*arch_vgpr_count=*/8, 256, 1, 1, /*smem=*/16384, 3000, 4000,
+                  /*corr_id=*/1, /*accum_vgpr_count=*/0, /*sgpr_count=*/0,
+                  /*static_smem=*/4096);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  const std::string details = FindKernelDetails(*gpu);
+  ASSERT_FALSE(details.empty()) << "kKernelDetails stat not found";
+  EXPECT_NE(details.find(" static_shared:4096 "), std::string::npos) << details;
+  EXPECT_NE(details.find(" dynamic_shared:12288 "), std::string::npos)
+      << details;
+  // The superseded total must not linger alongside the split.
+  EXPECT_EQ(details.find("group_mem:"), std::string::npos) << details;
+}
+
+// When the code-object symbol lookup misses, the static figure is 0 and the
+// whole allocation is reported as dynamic rather than silently vanishing.
+TEST(RocmCollectorOccupancyTest, UnknownStaticLdsIsReportedAsDynamic) {
+  OccupancyTestFixture f;
+  f.SetSyntheticAgent(kGfx942, kCuCount);
+  f.AddKernelPair(/*arch_vgpr_count=*/8, 256, 1, 1, /*smem=*/16384, 3000, 4000);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  const std::string details = FindKernelDetails(*gpu);
+  ASSERT_FALSE(details.empty()) << "kKernelDetails stat not found";
+  EXPECT_NE(details.find(" static_shared:0 "), std::string::npos) << details;
+  EXPECT_NE(details.find(" dynamic_shared:16384 "), std::string::npos)
+      << details;
+}
+
+// Without a modellable target there is no way to know how the arch and accum
+// files combine, so `regs:` falls back to max() rather than guessing a sum.
+// The token still has to be there -- the register count is useful even when
+// the occupancy number is not available.
+TEST(RocmCollectorOccupancyTest, KernelDetailsRegsPresentWithoutAgent) {
+  OccupancyTestFixture f;  // no agent, so no target constants
+  f.AddKernelPair(/*arch_vgpr_count=*/5, 256, 1, 1, /*smem=*/0, 3000, 4000,
+                  /*corr_id=*/1, /*accum_vgpr_count=*/128);
+
+  f.collector.Flush();
+  tensorflow::profiler::XSpace space;
+  f.collector.Export(&space);
+
+  const auto* gpu = FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu, nullptr);
+
+  const std::string details = FindKernelDetails(*gpu);
+  ASSERT_FALSE(details.empty());
+  EXPECT_EQ(details.rfind("regs:128 ", 0), 0u) << details;
+  // With no agent there is no target, so the model is never consulted and the
+  // occ_pct token is omitted -- the register count still has to be there,
+  // which is what this test is actually about. (It asserted "occ_pct:0" here
+  // before; that was the same defect KernelDetailsOmitsOccupancyWhenNotModelled
+  // covers, asserted a second time as an aside.)
+  EXPECT_EQ(details.find("occ_pct"), std::string::npos) << details;
+}
+
+// The direct formula tests that used to live here -- FormulaGfx942VgprLimited,
+// FormulaGfx942FullOccupancy, FormulaLdsLimited, FormulaZeroParamsReturnsEmpty
+// and OccupancyParamsCacheKey -- moved to rocm_occupancy_test.cc, along with
+// the model itself. They needed no GPU and no ROCm toolchain, but sat in a
+// target tagged requires-gpu-amd, so they ran nowhere near often enough. The
+// replacements there cover 16 golden rows instead of 3, and run in CPU CI.
 
 }  // namespace test
 }  // namespace profiler

--- a/xla/backends/profiler/gpu/rocm_occupancy.cc
+++ b/xla/backends/profiler/gpu/rocm_occupancy.cc
@@ -1,0 +1,433 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/rocm_occupancy.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+#include "absl/log/log.h"
+
+namespace xla {
+namespace profiler {
+namespace {
+
+// Sentinel for "this resource does not bound the launch at all". Only ever
+// compared with std::min against real workgroup counts, never divided by.
+constexpr uint32_t kUnbounded = 0xFFFFFFFFu;
+
+// Saturating, not wrapping. These inputs are not adversarial but they are not
+// trustworthy either -- the version-skew guard below exists precisely because
+// an SDK that predates a target hands back register counts whose encoding we
+// do not understand. A wrapping AlignTo turns a huge count into 0, and 0 reads
+// downstream as "no resource pressure": it divides by zero in the VGPR bound
+// (a SIGFPE that would abort the *traced* process, the worst failure mode a
+// profiler has) and reports unbounded workgroups in the LDS bound. Saturating
+// turns garbage into "maximum pressure" instead, which the model already knows
+// how to degrade -- to the 1-wave / 1-workgroup floor.
+inline uint32_t AlignTo(uint32_t v, uint32_t a) {
+  if (a == 0) {
+    return v;
+  }
+  if (v > std::numeric_limits<uint32_t>::max() - (a - 1)) {
+    return std::numeric_limits<uint32_t>::max();
+  }
+  return ((v + a - 1) / a) * a;
+}
+
+inline uint32_t SaturatingAdd(uint32_t a, uint32_t b) {
+  return a > std::numeric_limits<uint32_t>::max() - b
+             ? std::numeric_limits<uint32_t>::max()
+             : a + b;
+}
+
+// Overflow-free, for the same reason AlignTo saturates: `(a + b - 1)` wraps
+// for a near-UINT32_MAX block_size and yields a small wave count that sails
+// past the feasibility guard in GetOccupancy, producing a confident wrong
+// answer instead of no answer.
+inline uint32_t CeilDiv(uint32_t a, uint32_t b) {
+  if (b == 0) {
+    return 0;
+  }
+  return a / b + (a % b != 0 ? 1 : 0);
+}
+
+// AMDGPUBaseInfo.cpp getOccupancyWithNumSGPRs, the closed form. Parameter
+// list mirrors LLVM's subtarget-free overload so the two can be diffed:
+//
+//   unsigned getOccupancyWithNumSGPRs(unsigned SGPRs, unsigned MaxWaves,
+//                                     unsigned TotalNumSGPRs,
+//                                     unsigned Granule, unsigned TrapReserve);
+//
+// This is the algebraic inverse of getMaxNumSGPRs(): the budget condition
+//   SGPRs <= alignDown(TotalNumSGPRs / W - TrapReserve, Granule)
+// solves to W <= TotalNumSGPRs / (alignTo(SGPRs, Granule) + TrapReserve).
+//
+// An earlier revision of this file used LLVM's pre-2026 step table
+// (<=80 -> 10, <=88 -> 9, <=100 -> 8, else 7). Upstream replaced that table
+// precisely because it ignored the allocation granule and therefore
+// contradicted getMaxNumSGPRs; the two now "encode one model"
+// (AMDGPUBaseInfo.cpp, comment above getSGPRBudgetPerWave). The LLVM that XLA
+// itself pins carries the closed form, so the table was a divergence from the
+// very tree this file is built against. AMD's published CDNA4 occupancy
+// guidance gives the same division. Do not reintroduce the table without
+// silicon measurements in the commit message.
+//
+// The two forms differ only where alignTo() crosses a step edge. After the
+// clamp to max_waves_per_simd = 8 the sole reachable window on CDNA is
+// 97..100 SGPRs (closed form 7, table 8). See the boundary test.
+inline uint32_t OccupancyWithNumSgprs(uint32_t sgprs, uint32_t max_waves,
+                                      uint32_t total_sgprs, uint32_t granule,
+                                      uint32_t trap_reserve) {
+  const uint32_t per_wave =
+      SaturatingAdd(AlignTo(sgprs, granule), trap_reserve);
+  if (per_wave == 0) {
+    return max_waves;
+  }
+  return std::clamp(total_sgprs / per_wave, 1u, max_waves);
+}
+
+// The FeatureGFX90AInsts family: gfx90a, gfx94x, gfx95x. LLVM keys almost
+// every constant that matters here off that one subtarget feature, so the
+// only differences between the three are the LDS pool size and its
+// allocation granule.
+constexpr AmdGpuTargetConstants MakeGfx90aFamily(const char* name,
+                                                 uint32_t lds_per_cu,
+                                                 uint32_t lds_granule) {
+  return AmdGpuTargetConstants{
+      /*name=*/name,
+      /*max_waves_per_simd=*/8,  // getMaxWavesPerEU: isGFX90A -> 8
+      /*simd_per_cu=*/4,         // getEUsPerCU: pre-GFX10 -> 4
+      /*wave_front_size=*/64,
+      /*total_vgprs=*/512,      // getTotalNumVGPRs: FeatureGFX90AInsts
+      /*vgpr_granule=*/8,       // getVGPRAllocGranule: FeatureGFX90AInsts
+      /*arch_vgpr_granule=*/4,  // getArchVGPRAllocGranule
+      /*lds_per_cu=*/lds_per_cu,
+      /*lds_granule=*/lds_granule,
+      /*total_sgprs=*/800,      // getTotalNumSGPRs: IsaVersion.Major >= 8
+      /*sgpr_granule=*/16,      // getSGPRAllocGranule: Major 8..9
+      /*sgpr_trap_reserve=*/0,  // no +trap-handler in normal HIP codegen
+      /*max_barriers=*/16,      // getMaxWorkGroupsPerCU; never binds on CDNA
+      /*sgpr_limited=*/true,    // isSGPROccupancyLimited: Major < 10
+      /*unified_vgpr_file=*/true,
+      /*exact=*/true};
+}
+
+}  // namespace
+
+const char* OccupancyLimiterName(OccupancyLimiter l) {
+  switch (l) {
+    case OccupancyLimiter::kNone:
+      return "none";
+    case OccupancyLimiter::kVGPR:
+      return "vgpr";
+    case OccupancyLimiter::kLDS:
+      return "lds";
+    case OccupancyLimiter::kSGPR:
+      return "sgpr";
+    case OccupancyLimiter::kWorkgroup:
+      return "workgroup";
+    case OccupancyLimiter::kBarrier:
+      return "barrier";
+  }
+  return "unknown";
+}
+
+std::optional<AmdGpuTargetConstants> LookupTargetConstants(
+    uint32_t gfx_target_version) {
+  const uint32_t major = (gfx_target_version / 10000) % 100;
+  const uint32_t minor = (gfx_target_version / 100) % 100;
+  const uint32_t step = gfx_target_version % 100;
+
+  if (major != 9) {
+    // gfx10/11/12 have wave32, a much larger VGPR file and different
+    // granules. We have no validated constants for them; emit nothing rather
+    // than a plausible-looking wrong number.
+    return std::nullopt;
+  }
+
+  if (minor == 0 && step == 10) {  // gfx90a, MI200
+    return MakeGfx90aFamily("gfx90a", /*lds_per_cu=*/65536,
+                            /*lds_granule=*/512);
+  }
+  if (minor == 4) {  // gfx940/941/942; MI300A/MI300X/MI325
+    return MakeGfx90aFamily("gfx94x", /*lds_per_cu=*/65536,
+                            /*lds_granule=*/512);
+  }
+  if (minor == 5) {  // gfx950, MI355
+    // AMDGPU.td:1904 gives 160 KiB, and getLdsDwGranularity returns 320
+    // dwords rather than gfx942's 128.
+    return MakeGfx90aFamily("gfx95x", /*lds_per_cu=*/163840,
+                            /*lds_granule=*/1280);
+  }
+
+  // Unrecognised gfx9 -- gfx900/906/908, or a part newer than this table.
+  // Degrade to LLVM's own pre-GFX90A fallthrough values rather than to
+  // anything invented here, so a reader can diff this against AMDGPUBaseInfo
+  // and see where it came from. Note these do NOT err in a single direction:
+  // max_waves_per_simd goes up (8 -> 10) while total_vgprs goes down
+  // (512 -> 256), so which way the answer moves depends on the kernel's
+  // register pressure.
+  //
+  // `exact=false` marks the constants as a guess for any future caller that
+  // wants to gate on it. Nothing consumes it yet, so the warning below is the
+  // only signal a user gets that this device's numbers are estimated. It is
+  // logged once per process rather than once per unrecognised target:
+  // LookupTargetConstants runs on every kernel event, and de-duplicating by
+  // version would put a lock or an allocation on that path to improve a
+  // diagnostic. A heterogeneous host therefore names only its first
+  // unmodelled target.
+  LOG_FIRST_N(WARNING, 1)
+      << "No validated occupancy constants for gfx_target_version "
+      << gfx_target_version
+      << "; falling back to LLVM's pre-GFX90A defaults. Reported occupancy for "
+         "this device is an estimate and may be wrong in either direction.";
+  AmdGpuTargetConstants g = MakeGfx90aFamily(
+      "gfx9-generic", /*lds_per_cu=*/65536, /*lds_granule=*/512);
+  g.max_waves_per_simd = 10;  // getMaxWavesPerEU fallthrough
+  g.total_vgprs = 256;        // getTotalNumVGPRs fallthrough
+  g.vgpr_granule = 4;         // getVGPRAllocGranule fallthrough (wave64)
+  g.unified_vgpr_file = false;
+  g.exact = false;
+  return g;
+}
+
+// AMDGPUBaseInfo.cpp getTotalNumVGPRs(has90AInsts, AGPR, VGPR):
+//   has90AInsts && AGPR ? alignTo(VGPR, 4) + AGPR : max(VGPR, AGPR)
+//
+// The max() branch is load-bearing, not defensive. On gfx908 the SDK's
+// accum_vgpr_count() *returns* arch_vgpr_count(), so an unconditional sum
+// would report MI100 register pressure at exactly 2x. Every caller that needs
+// a register count -- including ToXStat's `regs:` token -- must route through
+// here rather than adding the two fields itself.
+uint32_t UnifiedVgprCount(const AmdGpuTargetConstants& tc, uint32_t arch,
+                          uint32_t accum) {
+  if (tc.unified_vgpr_file && accum != 0) {
+    return SaturatingAdd(AlignTo(arch, tc.arch_vgpr_granule), accum);
+  }
+  return std::max(arch, accum);
+}
+
+std::optional<OccupancyStats> GetOccupancy(const RocmDeviceOccupancyParams& p,
+                                           uint32_t cu_count) {
+  std::optional<AmdGpuTargetConstants> tc_opt =
+      LookupTargetConstants(p.gfx_target_version);
+  if (!tc_opt.has_value()) {
+    return std::nullopt;
+  }
+  const AmdGpuTargetConstants& tc = *tc_opt;
+
+  if (p.block_size == 0) {
+    return std::nullopt;
+  }
+  // No register data at all means the code-object symbol lookup missed. We
+  // cannot distinguish "a kernel that uses zero registers" (which does not
+  // exist) from "we never saw the symbol", so model nothing.
+  if (p.arch_vgpr_count == 0 && p.accum_vgpr_count == 0) {
+    return std::nullopt;
+  }
+
+  const uint32_t slots = tc.max_waves_per_simd * tc.simd_per_cu;
+  const uint32_t waves_per_wg = CeilDiv(p.block_size, tc.wave_front_size);
+  // A workgroup that cannot fit in a CU's wave slots at all is not a launch
+  // geometry the hardware would have accepted; treat it as unmodelable.
+  if (waves_per_wg == 0 || waves_per_wg > slots) {
+    return std::nullopt;
+  }
+
+  const uint32_t vgprs =
+      UnifiedVgprCount(tc, p.arch_vgpr_count, p.accum_vgpr_count);
+
+  // ROCm version-skew guard. arch/accum are decoded by the *installed* SDK via
+  // a string match on the agent name, and an SDK predating a target's support
+  // silently falls through to a generic branch. On a unified-file target the
+  // hardware allocation of each component (arch and accum) is a multiple of
+  // arch_vgpr_granule (4 on all current CDNA targets). rocprofiler-sdk reports
+  // them pre-combination, so their sum is always a multiple of 4 when the SDK
+  // understands the target. Checking against vgpr_granule (8) was wrong: it
+  // suppressed valid MFMA kernels where AlignTo(arch,4)+accum is 12 or 20
+  // (arch=4,accum=8 or arch=16,accum=4), which the hardware executes fine by
+  // rounding the sum up to 16 or 24 at allocation time.
+  //
+  // NOTE, this deviates from the design doc, which applies the check to every
+  // unified-file kernel. That over-triggers: `accum == 0` takes the max()
+  // branch above, leaving `vgprs == arch_vgpr_count`, and arch counts are
+  // granulated to 4 rather than 8, so perfectly ordinary low-register kernels
+  // (arch=4, arch=100) would have their occupancy suppressed. Restricting the
+  // guard to the sum branch keeps it meaningful. The cost is that the one
+  // skew case the doc names -- an old SDK reporting accum=0 on gfx950 -- is
+  // not detectable here, because it is numerically indistinguishable from a
+  // genuine non-MFMA kernel. That case needs a documented minimum ROCm
+  // version, not arithmetic.
+  if (tc.unified_vgpr_file && p.accum_vgpr_count != 0 &&
+      (vgprs % tc.arch_vgpr_granule) != 0) {
+    LOG_FIRST_N(WARNING, 1)
+        << "rocprofiler-sdk reported a non-granulated unified VGPR count for "
+        << tc.name << " (arch=" << p.arch_vgpr_count
+        << ", accum=" << p.accum_vgpr_count
+        << "); the SDK may predate this target. Occupancy suppressed.";
+    return std::nullopt;
+  }
+
+  // --- VGPR bound, waves/SIMD (getNumWavesPerEUWithNumVGPRs).
+  const uint32_t occ_vgpr =
+      (vgprs < tc.vgpr_granule)
+          ? tc.max_waves_per_simd
+          : std::clamp(tc.total_vgprs / AlignTo(vgprs, tc.vgpr_granule), 1u,
+                       tc.max_waves_per_simd);
+
+  // --- SGPR bound, waves/SIMD (getOccupancyWithNumSGPRs).
+  // Live on gfx9: isSGPROccupancyLimited is IsaVersion.Major < 10, and
+  // gfx90a/942/950 are all Major 9. It costs at most one wave, but on an
+  // 8-wave target that is 12.5 pp and it is real.
+  //
+  // A zero sgpr_count is read as "the SDK did not report it" and skips the
+  // bound, where a zero VGPR count above suppresses the result entirely. The
+  // asymmetry is deliberate: no kernel uses zero registers of either kind, but
+  // the VGPR term decides the answer while this one can only shave a single
+  // wave off it, so a possibly-one-wave-optimistic number beats no number.
+  uint32_t occ_sgpr = tc.max_waves_per_simd;
+  if (tc.sgpr_limited && p.sgpr_count != 0) {
+    occ_sgpr = OccupancyWithNumSgprs(p.sgpr_count, tc.max_waves_per_simd,
+                                     tc.total_sgprs, tc.sgpr_granule,
+                                     tc.sgpr_trap_reserve);
+  }
+
+  // --- Convert the register bounds to whole workgroups per CU.
+  //
+  // DELIBERATE DIVERGENCE FROM LLVM #1. GCNSubtarget::computeOccupancy takes a
+  // flat min() in waves/EU and never re-quantizes to whole workgroups. We do,
+  // because hardware cannot resident a partial workgroup and neither can
+  // hipOccupancyMaxActiveBlocksPerMultiprocessor. Consequence for anyone
+  // adding tests: llc's "; Occupancy:" comment is NOT a valid oracle for this
+  // term.
+  const uint32_t wgs_vgpr = (occ_vgpr * tc.simd_per_cu) / waves_per_wg;
+  const uint32_t wgs_sgpr = (occ_sgpr * tc.simd_per_cu) / waves_per_wg;
+
+  // Zero workgroups from a register bound means this workgroup needs more
+  // registers than a CU can hold, so the hardware cannot resident even one of
+  // them -- the same class of impossible geometry the waves_per_wg check
+  // rejects above, and not something the compiler would have emitted. Model
+  // nothing rather than flooring to one: the floor would report a confident
+  // 50% for a gfx942 kernel with 240 VGPRs and a 1024-thread block, which
+  // needs 960 VGPRs per SIMD against a 512-entry file.
+  //
+  // The LDS term below floors to 1 instead, and that asymmetry is LLVM's:
+  // AMDGPUSubtarget treats an over-large LDS request as achievable-at-1.
+  if (wgs_vgpr == 0 || wgs_sgpr == 0) {
+    return std::nullopt;
+  }
+
+  // --- LDS bound, workgroups per CU (AMDGPUSubtarget.cpp).
+  uint32_t wgs_lds = kUnbounded;
+  if (p.smem_bytes != 0) {
+    // AlignTo saturates and smem_bytes is non-zero here, so lds_per_wg is at
+    // least one granule; it cannot be a zero divisor.
+    const uint32_t lds_per_wg = AlignTo(p.smem_bytes, tc.lds_granule);
+    wgs_lds = tc.lds_per_cu / lds_per_wg;
+    // LLVM: a queried LDS size may be larger than a CU has, "in which case we
+    // consider the only achievable occupancy to be 1". Returning nothing here
+    // would be a silent hole for exactly the kernels most worth flagging.
+    if (wgs_lds == 0) {
+      wgs_lds = 1;
+    }
+  }
+
+  // --- Wave-slot and barrier bounds, workgroups per CU.
+  const uint32_t wgs_slots = slots / waves_per_wg;
+  const uint32_t wgs_barrier =
+      (waves_per_wg == 1) ? slots : std::min(wgs_slots, tc.max_barriers);
+
+  // Every term is >= 1 by construction: the register bounds returned nullopt
+  // at zero, wgs_lds floors at 1, and wgs_slots/wgs_barrier are >= 1 because
+  // waves_per_wg <= slots. Deliberately no floor here, so that a zero would
+  // surface as a bug rather than being silently rounded up to a real answer.
+  const uint32_t wgs =
+      std::min({wgs_vgpr, wgs_sgpr, wgs_lds, wgs_slots, wgs_barrier});
+
+  // --- Attribute the limiter from the UNQUANTIZED bounds.
+  //
+  // The obvious version -- compare each quantized bound against the final wgs
+  // and let the last match win -- misattributes the pure-quantization cases.
+  // For a 320-thread block occ_vgpr is 8 (no VGPR pressure whatsoever) yet
+  // wgs_vgpr is 8*4/5 = 6, which ties the answer, so VGPR would claim the
+  // blame for a kernel using four registers. Requiring a resource to be
+  // strictly below the slot ceiling in its own units before it can claim
+  // attribution is what makes wg320 and wg768 correctly report "workgroup" --
+  // which is the entire reason the limiter exists.
+  OccupancyLimiter limiter = OccupancyLimiter::kNone;
+  uint32_t best = wgs_slots;
+  // Each check uses < rather than <= so that the first resource to reach the
+  // binding minimum keeps the attribution. On an exact tie between SGPR and
+  // VGPR (both at the same wgs count, both genuinely below the wave-slot
+  // ceiling), SGPR is attributed because it is checked first. That is the
+  // higher-value direction on CDNA: addressable SGPRs max out at 102 and the
+  // bound costs at most one wave (12.5 pp), so an engineer can act on a SGPR
+  // attribution quickly; VGPR pressure has far more headroom to explore.
+  if (wgs_barrier < wgs_slots && wgs_barrier < best) {
+    best = wgs_barrier;
+    limiter = OccupancyLimiter::kBarrier;
+  }
+  if (occ_sgpr < tc.max_waves_per_simd && wgs_sgpr < best) {
+    best = wgs_sgpr;
+    limiter = OccupancyLimiter::kSGPR;
+  }
+  if (wgs_lds < wgs_slots && wgs_lds < best) {
+    best = wgs_lds;
+    limiter = OccupancyLimiter::kLDS;
+  }
+  if (occ_vgpr < tc.max_waves_per_simd && wgs_vgpr < best) {
+    best = wgs_vgpr;
+    limiter = OccupancyLimiter::kVGPR;
+  }
+  // Nothing claimed the blame but the slots are not full: what is left is
+  // workgroup quantization. There is no converse case -- a resource strictly
+  // below the ceiling in its own units always leaves wgs * waves_per_wg <
+  // slots -- so this is the only assignment needed.
+  if (limiter == OccupancyLimiter::kNone && wgs * waves_per_wg < slots) {
+    limiter = OccupancyLimiter::kWorkgroup;
+  }
+
+  OccupancyStats s;
+  s.active_blocks_per_cu = wgs;
+  // wgs <= wgs_slots = slots / waves_per_wg, so this cannot exceed slots.
+  s.active_waves_per_cu = wgs * waves_per_wg;
+  s.waves_per_simd =
+      static_cast<double>(s.active_waves_per_cu) / tc.simd_per_cu;
+  // CUPTI parity: percent of THREADS per CU, not waves.
+  //
+  // DELIBERATE DIVERGENCE FROM LLVM #2 lives one level up, in what we do NOT
+  // copy: AMDGPUSubtarget::getOccupancyWithWorkGroupSizes returns
+  // clamp(divideCeil(wavesPerCU, EUsPerCU), 1, Wmax) and the asm printer takes
+  // the .second of that range, which rounds 30 waves/CU up to 8/8 = 100%. A
+  // profiler knows the exact launch geometry and must report the exact answer.
+  s.occupancy_pct = 100.0 * static_cast<double>(wgs) * p.block_size /
+                    (static_cast<double>(slots) * tc.wave_front_size);
+  s.limiter = limiter;
+  s.total_vgprs = vgprs;
+  // CUDA's min_grid_size is whole-device, not per-CU.
+  s.min_grid_size = cu_count == 0 ? 0 : wgs * cu_count;
+  // Carried so a consumer can mark generic-fallback numbers as estimates
+  // rather than rendering them beside measured ones. The LOG_FIRST_N in
+  // LookupTargetConstants is a process-lifetime diagnostic; this is the
+  // per-event signal.
+  s.exact = tc.exact;
+  return s;
+}
+
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_occupancy.h
+++ b/xla/backends/profiler/gpu/rocm_occupancy.h
@@ -1,0 +1,208 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_OCCUPANCY_H_
+#define XLA_BACKENDS_PROFILER_GPU_ROCM_OCCUPANCY_H_
+
+// Theoretical-occupancy model for AMDGPU kernels.
+//
+// This header deliberately has NO ROCm includes. It is a pure arithmetic
+// library so that the model can be unit-tested on any CPU host, without a
+// ROCm toolchain and without a GPU. rocm_collector.h pulls in hip_runtime.h
+// and rocprofiler-sdk/agent.h, so keeping the formula there would mean it
+// could never be covered by CPU CI.
+//
+// The model is a port of, and in two places a deliberate divergence from,
+// llvm/lib/Target/AMDGPU: AMDGPUAsmPrinter -> AMDGPUMCExpr::evaluateOccupancy
+// -> GCNSubtarget::computeOccupancy / getOccupancyWith{WorkGroupSizes,
+// NumSGPRs, NumVGPRs}. The two divergences are documented at GetOccupancy()
+// in the .cc; do not "fix" them back.
+//
+// UNITS -- these three quantities are all called "occupancy" in different
+// parts of the stack, and they are not the same number:
+//   * waves_per_simd (a.k.a. waves/EU) is what LLVM's evaluateOccupancy, the
+//     "; Occupancy:" asm comment and -Rpass-analysis=kernel-resource-usage
+//     report. Range [1, 8] on CDNA2/3/4.
+//   * active_waves_per_cu is per CU = waves_per_simd * simd_per_cu.
+//   * occupancy_pct is percent of THREADS per CU, matching CUPTI's
+//     activeBlocksPerMultiprocessor * block_size * 100 /
+//     maxThreadsPerMultiprocessor. It is the number users compare across
+//     vendors on one dashboard, so it takes CUDA's definition.
+
+#include <cstdint>
+#include <optional>
+#include <tuple>
+#include <utility>
+
+namespace xla {
+namespace profiler {
+
+// Which hardware resource bounded occupancy. Ordered by how actionable it is.
+//
+// This is the highest-value thing the model produces. A bare percentage
+// prompts the wrong reflex -- chase 100% -- when a well-tuned MFMA GEMM
+// legitimately runs at low occupancy by design. Each limiter value maps to a
+// distinct concrete action, and kNone tells the engineer to stop looking at
+// occupancy altogether.
+enum class OccupancyLimiter : uint8_t {
+  kNone = 0,   // at the wave-slot ceiling; occupancy is not the problem
+  kVGPR,       // unified arch+accum VGPR file
+  kLDS,        // group segment
+  kSGPR,       // scalar registers (gfx9 only)
+  kWorkgroup,  // wave-slot quantization by workgroup size
+  kBarrier,    // max concurrent workgroups per CU (never binds on CDNA)
+};
+
+const char* OccupancyLimiterName(OccupancyLimiter l);
+
+// Per-target constants that rocprofiler-sdk does NOT expose. Mirrors
+// llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp; every field names the LLVM
+// accessor it was read from.
+struct AmdGpuTargetConstants {
+  const char* name;             // "gfx942"
+  uint32_t max_waves_per_simd;  // getMaxWavesPerEU
+  uint32_t simd_per_cu;         // getEUsPerCU
+  uint32_t wave_front_size;
+  uint32_t total_vgprs;        // getTotalNumVGPRs, per SIMD lane (unified)
+  uint32_t vgpr_granule;       // getVGPRAllocGranule
+  uint32_t arch_vgpr_granule;  // getArchVGPRAllocGranule
+  uint32_t lds_per_cu;         // getAddressableLocalMemorySize
+  uint32_t lds_granule;        // getLdsDwGranularity * 4
+  uint32_t total_sgprs;        // getTotalNumSGPRs
+  uint32_t sgpr_granule;       // getSGPRAllocGranule
+  uint32_t sgpr_trap_reserve;  // TRAP_NUM_SGPRS if +trap-handler, else 0
+  uint32_t max_barriers;       // getMaxWorkGroupsPerCU cap
+  bool sgpr_limited;           // isSGPROccupancyLimited (IsaVersion.Major < 10)
+  bool unified_vgpr_file;      // FeatureGFX90AInsts: arch and accum share 512
+  bool exact;                  // false => generic fallback, values are a guess
+};
+
+// gfx_target_version decodes as major=(v/10000)%100, minor=(v/100)%100,
+// step=v%100 -- all decimal (rocprofiler-sdk agent.h). The *name* renders the
+// step in hex, which is why gfx90a is 90010 and not 9001a.
+//
+// Returns nullopt for targets we cannot model (anything with major != 9).
+// The caller MUST then emit no occupancy stats rather than guess: the
+// coincidence that makes a naive formula work on CDNA does not hold on
+// gfx10/11/12, which have wave32, a much larger VGPR file and different
+// allocation granules.
+std::optional<AmdGpuTargetConstants> LookupTargetConstants(
+    uint32_t gfx_target_version);
+
+// The number of VGPRs the hardware actually charges a wave.
+//
+// Exposed rather than kept private because the max() branch is load-bearing
+// rather than defensive -- see the gfx908 trap documented in the .cc -- so any
+// caller that needs a register count must route through here instead of adding
+// arch and accum itself.
+uint32_t UnifiedVgprCount(const AmdGpuTargetConstants& tc, uint32_t arch,
+                          uint32_t accum);
+
+// Everything that determines theoretical occupancy for one kernel launch.
+// Doubles as the key of the collector's memoization cache.
+struct RocmDeviceOccupancyParams {
+  // Kernel symbol data (DEVICE_KERNEL_SYMBOL_REGISTER callback).
+  uint32_t arch_vgpr_count = 0;   // callback_tracing.h arch_vgpr_count
+  uint32_t accum_vgpr_count = 0;  // callback_tracing.h accum_vgpr_count (AGPRs)
+  uint32_t sgpr_count = 0;        // callback_tracing.h, already 16-granulated
+
+  // Kernel dispatch record (rocprofiler_kernel_dispatch_info_t).
+  uint32_t block_size = 0;  // workgroup_size.x*y*z, zero dims treated as 1
+  // group_segment_size from the *dispatch* record: the TOTAL LDS per workgroup
+  // (static + runtime). Do NOT add the symbol's group_segment_size on top,
+  // that would double-count.
+  uint32_t smem_bytes = 0;
+
+  // Device identity. Everything else comes from LookupTargetConstants; the
+  // agent's own capability scalars carry no discriminating power here because
+  // they are invariant per device, while this field is the one that actually
+  // distinguishes a gfx90a from a gfx950 from a gfx1100.
+  uint32_t gfx_target_version = 0;
+
+  friend bool operator==(const RocmDeviceOccupancyParams& a,
+                         const RocmDeviceOccupancyParams& b) noexcept {
+    return std::tie(a.arch_vgpr_count, a.accum_vgpr_count, a.sgpr_count,
+                    a.block_size, a.smem_bytes, a.gfx_target_version) ==
+           std::tie(b.arch_vgpr_count, b.accum_vgpr_count, b.sgpr_count,
+                    b.block_size, b.smem_bytes, b.gfx_target_version);
+  }
+
+  friend bool operator!=(const RocmDeviceOccupancyParams& a,
+                         const RocmDeviceOccupancyParams& b) noexcept {
+    return !(a == b);
+  }
+
+  template <typename H>
+  friend H AbslHashValue(H h, const RocmDeviceOccupancyParams& p) {
+    return H::combine(std::move(h), p.arch_vgpr_count, p.accum_vgpr_count,
+                      p.sgpr_count, p.block_size, p.smem_bytes,
+                      p.gfx_target_version);
+  }
+};
+
+// CONSUMERS. There are none in production yet: this library has exactly one
+// caller in the tree, rocm_occupancy_test.cc, and the collector wiring lands
+// in the follow-up change. `limiter` in particular costs ~30 lines of the
+// subtlest reasoning in the .cc and is here because it is the number an
+// engineer can act on. If the wiring is abandoned, delete the attribution
+// block rather than leaving it to rot untested against a real consumer.
+struct OccupancyStats {
+  // Percent of THREADS per CU: active_blocks * block_size * 100 /
+  // (max_waves_per_cu * wave_front_size). Matches CUPTI exactly.
+  double occupancy_pct = 0.0;
+  // Waves resident per SIMD (== per EU). The unit LLVM's evaluateOccupancy and
+  // -Rpass-analysis=kernel-resource-usage report.
+  double waves_per_simd = 0.0;
+  uint32_t active_waves_per_cu = 0;
+  uint32_t active_blocks_per_cu = 0;
+  OccupancyLimiter limiter = OccupancyLimiter::kNone;
+  uint32_t total_vgprs = 0;  // what LLVM calls NumVGPRs: the unified charge
+  // Blocks needed to fill the whole DEVICE at this occupancy:
+  // active_blocks_per_cu * cu_count. 0 if cu_count was unknown.
+  //
+  // Same units as CUDA's min_grid_size but NOT the same quantity.
+  // cudaOccupancyMaxPotentialBlockSize reports the grid needed at the block
+  // size it *suggests*, which is a tuning hint independent of the launch; this
+  // is the grid needed at the block size actually launched. For a
+  // low-occupancy MFMA kernel the CUDA number is large and this one is small.
+  // A caller wiring this into the shared kOccupancyMinGridSize stat is
+  // changing what that stat means on ROCm, and should say so.
+  uint32_t min_grid_size = 0;
+  // Propagated from AmdGpuTargetConstants::exact. False means the target was
+  // not in the table and the generic gfx9 fallback supplied the constants, so
+  // every number above is an estimate that can be wrong in EITHER direction --
+  // the fallback raises max_waves_per_simd (8 -> 10) while lowering
+  // total_vgprs (512 -> 256), so which way it moves depends on the kernel.
+  //
+  // A consumer that renders an estimate identically to a measurement is
+  // lying by omission. Either mark it in the UI or drop the row; do not
+  // silently average the two together.
+  bool exact = true;
+};
+
+// Pure function, no device access.
+//
+// nullopt means "cannot model" -- an unrecognised target, a missing block
+// size, no register data at all, input the version-skew guard rejects, or a
+// geometry the hardware could not have made resident (a workgroup that needs
+// more wave slots or more registers than a CU has). The caller must then emit
+// no occupancy stats, NOT zero ones.
+std::optional<OccupancyStats> GetOccupancy(
+    const RocmDeviceOccupancyParams& params, uint32_t cu_count);
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_OCCUPANCY_H_

--- a/xla/backends/profiler/gpu/rocm_occupancy_test.cc
+++ b/xla/backends/profiler/gpu/rocm_occupancy_test.cc
@@ -1,0 +1,582 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Deviceless tests for the theoretical-occupancy model.
+//
+// This file has no ROCm dependency at all, by design: it runs in CPU CI on
+// every platform. That is the only way this arithmetic gets continuous
+// protection, since the collector it used to live in cannot be built without
+// a ROCm toolchain.
+//
+// The golden table below is the load-bearing test. Its expectations come from
+// EXTERNAL oracles, not from restating the implementation's own arithmetic:
+//   H = measured with hipOccupancyMaxActiveBlocksPerMultiprocessor on a live
+//       MI300X.
+//   S = derived from the LLVM source functions this model ports
+//       (AMDGPUBaseInfo.cpp / AMDGPUSubtarget.cpp / AMDGPUTargetParser.cpp).
+//
+// Do not regenerate these numbers from the code under test, and do not use
+// llc's "; Occupancy:" comment as an oracle for the LDS or workgroup terms --
+// the local /opt/rocm/llvm applies no LDS granule at all, and the asm printer
+// rounds up across EUs. Both traps are documented at GetOccupancy().
+
+#include "xla/backends/profiler/gpu/rocm_occupancy.h"
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+#include <gtest/gtest.h>
+#include "absl/strings/str_cat.h"
+
+namespace xla {
+namespace profiler {
+namespace {
+
+constexpr uint32_t kGfx90a = 90010;
+constexpr uint32_t kGfx942 = 90402;
+constexpr uint32_t kGfx950 = 90500;
+
+RocmDeviceOccupancyParams MakeParams(uint32_t gfx, uint32_t arch,
+                                     uint32_t accum, uint32_t sgpr,
+                                     uint32_t block, uint32_t smem) {
+  RocmDeviceOccupancyParams p;
+  p.gfx_target_version = gfx;
+  p.arch_vgpr_count = arch;
+  p.accum_vgpr_count = accum;
+  p.sgpr_count = sgpr;
+  p.block_size = block;
+  p.smem_bytes = smem;
+  return p;
+}
+
+// ===========================================================================
+// The golden table
+// ===========================================================================
+
+struct GoldenRow {
+  const char* name;
+  uint32_t gfx;
+  uint32_t arch_vgpr;
+  uint32_t accum_vgpr;
+  uint32_t sgpr;
+  uint32_t block;
+  uint32_t smem;
+  double expected_pct;
+  OccupancyLimiter expected_limiter;
+  const char* what_it_pins;
+};
+
+const GoldenRow kGoldenTable[] = {
+    // --- The row that would have caught the CRITICAL bug on day one. An MFMA
+    // kernel with 5 arch VGPRs and 128 AGPRs: charging arch only reports
+    // 100%, the hardware truth measured on MI300X is 37.5%. alignTo(5,4)+128
+    // = 136 -> alignTo(136,8) = 136 -> 512/136 = 3 waves/SIMD.
+    {"mfma_agpr", kGfx942, 5, 128, 16, 256, 0, 37.5, OccupancyLimiter::kVGPR,
+     "AGPRs excluded from the unified VGPR file (reports 100% before the fix)"},
+    {"mfma_balanced", kGfx942, 128, 128, 16, 256, 0, 25.0,
+     OccupancyLimiter::kVGPR, "same defect, 2x overstatement"},
+    {"flash_attn", kGfx942, 168, 248, 16, 256, 0, 12.5, OccupancyLimiter::kVGPR,
+     "same defect, 3x overstatement"},
+
+    // --- Workgroup quantization. Hardware cannot resident a partial
+    // workgroup; a 320-thread block is 5 waves, and only 6 such blocks fit in
+    // 32 slots, leaving 2 slots idle. Measured on MI300X at 6 blocks/CU.
+    {"wg320", kGfx942, 4, 0, 14, 320, 0, 93.75, OccupancyLimiter::kWorkgroup,
+     "no workgroup quantization (reports 100% before the fix)"},
+    {"wg768", kGfx942, 4, 0, 14, 768, 0, 75.0, OccupancyLimiter::kWorkgroup,
+     "same defect at a larger block size"},
+
+    // --- The register bound must be re-quantized to whole workgroups too.
+    // 176 VGPRs gives 2 waves/SIMD = 8 slots, but a 384-thread block needs 6
+    // waves, so exactly one block fits and 2 slots go unused.
+    {"vgpr_wg_quant", kGfx942, 176, 0, 16, 384, 0, 18.75,
+     OccupancyLimiter::kVGPR,
+     "VGPR budget not rounded down to whole workgroups (reports 25%)"},
+
+    // --- VGPR allocation granule. 100 arch VGPRs are charged as 104.
+    {"granule100", kGfx942, 100, 0, 16, 256, 0, 50.0, OccupancyLimiter::kVGPR,
+     "missing alignTo(NumVGPRs, 8) (reports 62.5%)"},
+
+    // --- LDS allocation granule. alignTo(13000, 512) = 13312, and
+    // 65536/13312 = 4 workgroups, not the 5 an unrounded divide gives.
+    {"lds_unaligned", kGfx942, 4, 0, 14, 256, 13000, 50.0,
+     OccupancyLimiter::kLDS, "missing alignTo(LDS, granule) (reports 62.5%)"},
+    {"lds32k", kGfx942, 3, 0, 9, 256, 32768, 25.0, OccupancyLimiter::kLDS,
+     "LDS baseline, measured"},
+
+    // --- The best cross-architecture assertion available without MI355
+    // silicon: identical inputs, 4x the answer, because gfx950's LDS pool is
+    // 160 KiB rather than 64 KiB.
+    {"lds40k_gfx942", kGfx942, 3, 0, 9, 256, 40960, 12.5,
+     OccupancyLimiter::kLDS, "gfx942 LDS pool size"},
+    {"lds40k_gfx950", kGfx950, 3, 0, 9, 256, 40960, 50.0,
+     OccupancyLimiter::kLDS,
+     "gfx950 LDS pool size, same input as the row above"},
+    // Note 50.0 and not 62.5. alignTo(32768, 1280) = 33280 and
+    // 163840/33280 = 4. The 62.5% figure is 163840/32768 = 5, the
+    // un-granulated answer -- which is exactly what the local /opt/rocm/llvm
+    // oracle produces, and exactly why that oracle is invalid for this term.
+    {"lds32k_gfx950", kGfx950, 3, 0, 9, 256, 32768, 50.0,
+     OccupancyLimiter::kLDS, "gfx950's 1280-byte LDS granule"},
+
+    // --- The SGPR term is live on gfx9 (isSGPROccupancyLimited is Major < 10).
+    // alignTo(112,16) = 112, and 800/112 = 7 waves/SIMD.
+    {"sgpr112", kGfx942, 4, 0, 112, 256, 0, 87.5, OccupancyLimiter::kSGPR,
+     "missing SGPR bound (reports 100%)"},
+
+    // --- The SGPR granule, and the only window where the closed form and
+    // LLVM's retired step table disagree once clamped to 8 waves. 97 and 100
+    // SGPRs both round up to a 112-register per-wave budget, so both cost a
+    // wave; the step table returned 8 for anything <= 100 and reported 100%.
+    // These two rows are the regression guard for that revert.
+    // (S: LLVM AMDGPUBaseInfo.cpp getOccupancyWithNumSGPRs, closed form.)
+    {"sgpr96_boundary", kGfx942, 4, 0, 96, 256, 0, 100.0,
+     OccupancyLimiter::kNone, "the last SGPR count that does not bind"},
+    {"sgpr97_granule", kGfx942, 4, 0, 97, 256, 0, 87.5, OccupancyLimiter::kSGPR,
+     "SGPR step table instead of alignTo (reports 100%)"},
+    {"sgpr100_granule", kGfx942, 4, 0, 100, 256, 0, 87.5,
+     OccupancyLimiter::kSGPR, "the step table's <=100 boundary (reports 100%)"},
+
+    // --- Guards against someone adding a barrier term that binds. One-wave
+    // workgroups get the full 32 slots; getMaxWorkGroupsPerCU returns MaxWaves
+    // rather than 16 in that case.
+    {"wg64_full", kGfx942, 4, 0, 14, 64, 0, 100.0, OccupancyLimiter::kNone,
+     "the 16-workgroup barrier cap must not bind on CDNA"},
+
+    // --- LDS larger than a CU has. LLVM's contract is one workgroup, not
+    // zero; the pre-fix code returned empty stats and emitted nothing.
+    {"lds_over_cap", kGfx942, 4, 0, 14, 256, 81920, 12.5,
+     OccupancyLimiter::kLDS, "smem > LDS capacity returned {} before the fix"},
+
+    // --- gfx90a shares every constant with gfx942, so this row is really an
+    // assertion about the 90010 encoding: the step renders as hex in the
+    // agent *name* only, so gfx90a is 90010 and must not fall through to the
+    // inexact generic branch.
+    {"mfma_agpr_gfx90a", kGfx90a, 5, 128, 16, 256, 0, 37.5,
+     OccupancyLimiter::kVGPR, "the gfx90a target-version encoding"},
+
+    // --- A block size that is not a multiple of the wavefront. 100 threads
+    // occupy 2 whole waves, so 16 workgroups fill all 32 slots: the limiter is
+    // correctly kNone (no resource is short), yet occupancy_pct is 78.125,
+    // not 100. That pairing looks contradictory and is not -- occupancy_pct
+    // counts THREADS per CU (CUPTI's definition, see the UNITS note in the
+    // header), and 28 of every 128 thread slots are idle inside the partial
+    // wave. The deficit is intra-wave waste, which no amount of resource
+    // tuning recovers; only a block size that is a multiple of 64 does.
+    // Every other row here uses a multiple of 64, so without this one the
+    // interaction between partial waves and limiter attribution is untested.
+    {"partial_wave", kGfx942, 4, 0, 14, 100, 0, 78.125, OccupancyLimiter::kNone,
+     "partial-wave thread waste, which the limiter cannot express"},
+
+    // --- Two rows that caught bugs in the version-skew guard and limiter
+    // tie-break, both confirmed against LLVM's tables (S oracle).
+    //
+    // The version-skew guard checks (vgprs % arch_vgpr_granule != 0), where
+    // vgprs = AlignTo(arch, arch_vgpr_granule) + accum. arch=4, accum=8 gives
+    // unified=12, which is a multiple of arch_vgpr_granule=4 (valid SDK data)
+    // but NOT a multiple of vgpr_granule=8. The old guard tested %vgpr_granule
+    // and returned nullopt for this kernel; the hardware executes it at 100%
+    // occupancy (AlignTo(12,8)=16 VGPRs charged, 512/16=32 waves -> capped at
+    // 8 = max_waves_per_simd). (H: measured on MI300X.)
+    {"mfma_agpr_guard_gfx942", kGfx942, 4, 8, 32, 256, 0, 100.0,
+     OccupancyLimiter::kNone,
+     "version-skew guard false-positive on valid MFMA kernel"},
+
+    // Limiter tie: occ_sgpr = 800/AlignTo(101,16) = 800/112 = 7 waves/SIMD and
+    // occ_vgpr = 512/AlignTo(65,8) = 512/72 = 7 waves/SIMD both bind at 7 wgs
+    // for a 256-thread block (4 waves/wg, 7*4/4=7). Attribution must go to
+    // SGPRs, which is both the first check and the more actionable one: 101
+    // SGPRs is 11 past the 96-register budget that would have kept 8 waves,
+    // whereas the VGPR side has far more headroom to explore.
+    // (S: LLVM AMDGPUBaseInfo getOccupancyWithNumSGPRs.)
+    {"sgpr_vgpr_tie_gfx942", kGfx942, 65, 0, 101, 256, 0, 87.5,
+     OccupancyLimiter::kSGPR,
+     "SGPR/VGPR tie-break: SGPR binds first and must win"},
+};
+
+TEST(RocmOccupancyGoldenTest, AllRows) {
+  for (const GoldenRow& row : kGoldenTable) {
+    SCOPED_TRACE(absl::StrCat(row.name, " pins: ", row.what_it_pins));
+    std::optional<OccupancyStats> occ =
+        GetOccupancy(MakeParams(row.gfx, row.arch_vgpr, row.accum_vgpr,
+                                row.sgpr, row.block, row.smem),
+                     /*cu_count=*/304);
+    ASSERT_TRUE(occ.has_value());
+    EXPECT_DOUBLE_EQ(occ->occupancy_pct, row.expected_pct);
+    EXPECT_EQ(occ->limiter, row.expected_limiter)
+        << "got " << OccupancyLimiterName(occ->limiter) << ", want "
+        << OccupancyLimiterName(row.expected_limiter);
+  }
+}
+
+// Cross-checks the derived fields against the golden percentage, which comes
+// from an external oracle. Deliberately NOT `waves_per_simd * 4 ==
+// active_waves_per_cu` and friends: those restate the implementation's own
+// definitions and hold for any value, including a wrong one.
+TEST(RocmOccupancyGoldenTest, DerivedFieldsAgreeWithGoldenPercent) {
+  for (const GoldenRow& row : kGoldenTable) {
+    SCOPED_TRACE(row.name);
+    std::optional<OccupancyStats> occ =
+        GetOccupancy(MakeParams(row.gfx, row.arch_vgpr, row.accum_vgpr,
+                                row.sgpr, row.block, row.smem),
+                     /*cu_count=*/304);
+    ASSERT_TRUE(occ.has_value());
+    // Threads resident per CU implied by the oracle percentage, converted to
+    // blocks and waves independently of how the model got there.
+    const double threads_per_cu = row.expected_pct / 100.0 * 32 * 64;
+    EXPECT_EQ(occ->active_blocks_per_cu,
+              static_cast<uint32_t>(threads_per_cu / row.block))
+        << "blocks/CU disagrees with the golden percentage";
+    EXPECT_DOUBLE_EQ(occ->waves_per_simd,
+                     std::ceil(static_cast<double>(row.block) / 64) *
+                         occ->active_blocks_per_cu / 4);
+    EXPECT_EQ(occ->min_grid_size, occ->active_blocks_per_cu * 304);
+  }
+}
+
+TEST(RocmOccupancyGoldenTest, DerivedFieldsAreInRange) {
+  for (const GoldenRow& row : kGoldenTable) {
+    SCOPED_TRACE(row.name);
+    std::optional<OccupancyStats> occ =
+        GetOccupancy(MakeParams(row.gfx, row.arch_vgpr, row.accum_vgpr,
+                                row.sgpr, row.block, row.smem),
+                     /*cu_count=*/304);
+    ASSERT_TRUE(occ.has_value());
+    // All three golden targets are 4 SIMDs/CU, 8 waves/SIMD, 64-wide waves.
+    EXPECT_DOUBLE_EQ(occ->waves_per_simd * 4,
+                     static_cast<double>(occ->active_waves_per_cu));
+    EXPECT_LE(occ->active_waves_per_cu, 32u);
+    EXPECT_GE(occ->active_blocks_per_cu, 1u);
+    EXPECT_EQ(occ->min_grid_size, occ->active_blocks_per_cu * 304);
+    EXPECT_GT(occ->occupancy_pct, 0.0);
+    EXPECT_LE(occ->occupancy_pct, 100.0);
+  }
+}
+
+// ===========================================================================
+// Graceful degradation -- nullopt must mean "emit nothing", never zero
+// ===========================================================================
+
+TEST(RocmOccupancyTest, UnknownTargetReturnsNullopt) {
+  // gfx1100. Wave32, a 1536-entry VGPR file and different granules; we have
+  // no validated constants, so the caller must emit no occupancy at all.
+  EXPECT_FALSE(
+      GetOccupancy(MakeParams(110000, 40, 0, 20, 256, 0), 304).has_value());
+  EXPECT_FALSE(LookupTargetConstants(110000).has_value());
+  EXPECT_FALSE(LookupTargetConstants(100300).has_value());
+  EXPECT_FALSE(LookupTargetConstants(120000).has_value());
+  EXPECT_FALSE(LookupTargetConstants(0).has_value());
+}
+
+TEST(RocmOccupancyTest, UnknownGfx9DegradesInexactly) {
+  // gfx906 (MI50). Not in the table, but still gfx9: fall back to the
+  // pre-GFX90A LLVM values, which under-report rather than over-report.
+  std::optional<AmdGpuTargetConstants> tc = LookupTargetConstants(90600);
+  ASSERT_TRUE(tc.has_value());
+  EXPECT_FALSE(tc->exact);
+  EXPECT_FALSE(tc->unified_vgpr_file);
+  EXPECT_EQ(tc->total_vgprs, 256u);
+  EXPECT_EQ(tc->vgpr_granule, 4u);
+  EXPECT_EQ(tc->max_waves_per_simd, 10u);
+  // SGPR constants are unchanged by the fallback -- LLVM's getTotalNumSGPRs
+  // and getSGPRAllocGranule key off IsaVersion.Major, which is still 9.
+  EXPECT_EQ(tc->total_sgprs, 800u);
+  EXPECT_EQ(tc->sgpr_granule, 16u);
+}
+
+// `exact` has to reach the caller, not just sit in the constants table: the
+// LOG_FIRST_N warning fires once per process and a dashboard user never sees
+// it. Without this, an estimate renders identically to a measurement.
+TEST(RocmOccupancyTest, ExactnessIsPropagatedToStats) {
+  std::optional<OccupancyStats> known =
+      GetOccupancy(MakeParams(kGfx942, 5, 128, 16, 256, 0), 304);
+  ASSERT_TRUE(known.has_value());
+  EXPECT_TRUE(known->exact);
+
+  // gfx906 is gfx9 but not in the table, so the generic fallback supplies
+  // constants that can be wrong in either direction.
+  std::optional<OccupancyStats> guessed =
+      GetOccupancy(MakeParams(/*gfx=*/90600, 4, 0, 32, 256, 0), 60);
+  ASSERT_TRUE(guessed.has_value());
+  EXPECT_FALSE(guessed->exact);
+}
+
+// A workgroup whose registers cannot fit in a CU is not a launch the hardware
+// would have accepted. Before this was a nullopt the bound floored to one
+// workgroup and reported a confident 50% for it.
+TEST(RocmOccupancyTest, RegisterInfeasibleGeometryReturnsNullopt) {
+  // gfx942, 240 VGPRs, 1024 threads: 16 waves over 4 SIMDs is 4 waves/SIMD,
+  // 4 * 240 = 960 VGPRs against a 512-entry file.
+  EXPECT_FALSE(GetOccupancy(MakeParams(kGfx942, /*arch=*/240, /*accum=*/0,
+                                       /*sgpr=*/32, /*block=*/1024,
+                                       /*smem=*/0),
+                            /*cu_count=*/304)
+                   .has_value());
+  // One VGPR less per wave is feasible, so the guard is not simply rejecting
+  // every large block.
+  EXPECT_TRUE(GetOccupancy(MakeParams(kGfx942, /*arch=*/128, /*accum=*/0,
+                                      /*sgpr=*/32, /*block=*/1024, /*smem=*/0),
+                           /*cu_count=*/304)
+                  .has_value());
+}
+
+// getOccupancyWithNumSGPRs is a division against the granulated per-wave
+// budget, not a step table: clamp(800 / alignTo(sgprs, 16), 1, MaxWaves).
+//
+// This test previously pinned LLVM's pre-2026 step table and asserted
+// pct(100) == 100.0. Upstream replaced that table because it ignored the
+// allocation granule and disagreed with getMaxNumSGPRs; the LLVM revision XLA
+// pins carries the closed form. The behaviour change is confined to the
+// 97..100 window -- everywhere else the two agree once clamped to 8 waves --
+// so of the rows below only sgpr(97) and sgpr(100) move.
+//
+// (S: LLVM AMDGPUBaseInfo.cpp getOccupancyWithNumSGPRs.)
+TEST(RocmOccupancyTest, SgprClosedFormBoundaries) {
+  auto pct = [](uint32_t sgpr) {
+    std::optional<OccupancyStats> o =
+        GetOccupancy(MakeParams(kGfx942, /*arch=*/4, /*accum=*/0, sgpr,
+                                /*block=*/256, /*smem=*/0),
+                     /*cu_count=*/304);
+    return o.has_value() ? o->occupancy_pct : -1.0;
+  };
+  // 800/80 = 10, clamped to the 8-wave ceiling: SGPRs do not bind.
+  EXPECT_DOUBLE_EQ(pct(80), 100.0) << "80 SGPRs is exactly 8 waves' budget";
+  // alignTo(96,16) = 96 and 800/96 = 8: still exactly at the ceiling.
+  EXPECT_DOUBLE_EQ(pct(96), 100.0) << "96 SGPRs is the last non-binding value";
+  // One SGPR past the granule boundary costs a whole wave: alignTo(97,16)=112.
+  // The step table returned 8 here, which is the entire behaviour change.
+  EXPECT_DOUBLE_EQ(pct(97), 87.5) << "97 SGPRs rounds up to 112 -> 7 waves";
+  EXPECT_DOUBLE_EQ(pct(100), 87.5) << "still inside the 112-SGPR granule";
+  EXPECT_DOUBLE_EQ(pct(112), 87.5) << "112 SGPRs is exactly 7 waves' budget";
+  // alignTo(113,16) = 128 and 800/128 = 6.
+  EXPECT_DOUBLE_EQ(pct(113), 75.0) << "past 112 the next wave goes too";
+}
+
+// The generic gfx9 fallback keeps LLVM's SGPR constants (800/16) but raises
+// max_waves_per_simd to 10, which un-clamps the 81..88 window the CDNA rows
+// above cannot reach: alignTo(88,16) = 96 and 800/96 = 8, where the old step
+// table said 9.
+TEST(RocmOccupancyTest, SgprClosedFormOnGenericGfx9) {
+  // gfx906, 64-thread blocks: 1 wave/wg, so waves and workgroups are 1:1 and
+  // the SGPR bound is visible undiluted by quantization.
+  auto waves = [](uint32_t sgpr) {
+    std::optional<OccupancyStats> o =
+        GetOccupancy(MakeParams(/*gfx=*/90600, /*arch=*/4, /*accum=*/0, sgpr,
+                                /*block=*/64, /*smem=*/0),
+                     /*cu_count=*/60);
+    return o.has_value() ? o->waves_per_simd : -1.0;
+  };
+  EXPECT_DOUBLE_EQ(waves(80), 10.0) << "800/80 = 10, the fallback ceiling";
+  EXPECT_DOUBLE_EQ(waves(88), 8.0) << "alignTo(88,16)=96 -> 8; table said 9";
+}
+
+// The generic gfx9 fallback has different constants in every dimension
+// (10 waves/SIMD, 256 VGPRs, non-unified file), and it is the only path on
+// which the barrier cap can bind. Nothing exercised it end to end.
+TEST(RocmOccupancyTest, GenericGfx9FallbackComputesAndCanHitBarrierCap) {
+  // gfx906, 128-thread blocks: 2 waves/wg, 40 slots -> 20 workgroups by slots,
+  // but max_barriers caps concurrent workgroups per CU at 16.
+  std::optional<OccupancyStats> occ =
+      GetOccupancy(MakeParams(/*gfx=*/90600, /*arch=*/4, /*accum=*/0,
+                              /*sgpr=*/32, /*block=*/128, /*smem=*/0),
+                   /*cu_count=*/60);
+  ASSERT_TRUE(occ.has_value());
+  EXPECT_EQ(occ->active_blocks_per_cu, 16u);
+  EXPECT_EQ(occ->limiter, OccupancyLimiter::kBarrier)
+      << "got " << OccupancyLimiterName(occ->limiter);
+  EXPECT_EQ(occ->min_grid_size, 16u * 60);
+  // Non-unified file: arch and accum are max()'d, not summed.
+  EXPECT_EQ(occ->total_vgprs, 4u);
+}
+
+TEST(RocmOccupancyTest, MissingInputsReturnNullopt) {
+  // No symbol data at all -- the code-object lookup missed. Zero is a wrong
+  // answer here, not a conservative one.
+  EXPECT_FALSE(
+      GetOccupancy(MakeParams(kGfx942, 0, 0, 16, 256, 0), 304).has_value());
+  // No block size.
+  EXPECT_FALSE(
+      GetOccupancy(MakeParams(kGfx942, 64, 0, 16, 0, 0), 304).has_value());
+  // A workgroup larger than a CU's entire wave-slot budget is not a geometry
+  // the hardware would have accepted.
+  EXPECT_FALSE(
+      GetOccupancy(MakeParams(kGfx942, 64, 0, 16, 4096, 0), 304).has_value());
+}
+
+TEST(RocmOccupancyTest, UnknownCuCountLeavesMinGridSizeZero) {
+  std::optional<OccupancyStats> occ =
+      GetOccupancy(MakeParams(kGfx942, 5, 128, 16, 256, 0), /*cu_count=*/0);
+  ASSERT_TRUE(occ.has_value());
+  EXPECT_EQ(occ->min_grid_size, 0u);
+  EXPECT_DOUBLE_EQ(occ->occupancy_pct, 37.5);
+}
+
+// ===========================================================================
+// UnifiedVgprCount -- the gfx908 trap
+// ===========================================================================
+
+TEST(RocmOccupancyTest, UnifiedVgprCountSumsOnUnifiedTargets) {
+  const AmdGpuTargetConstants tc = *LookupTargetConstants(kGfx942);
+  // alignTo(5,4) + 128. This is the CRITICAL fix in one expression.
+  EXPECT_EQ(UnifiedVgprCount(tc, 5, 128), 136u);
+  EXPECT_EQ(UnifiedVgprCount(tc, 128, 128), 256u);
+  EXPECT_EQ(UnifiedVgprCount(tc, 168, 248), 416u);
+  // accum == 0 must take the max() branch, not add zero to a rounded-up arch.
+  EXPECT_EQ(UnifiedVgprCount(tc, 100, 0), 100u);
+}
+
+TEST(RocmOccupancyTest, UnifiedVgprCountDoesNotDoubleCountNonUnified) {
+  // On gfx908 the SDK's accum_vgpr_count() returns arch_vgpr_count(), so an
+  // unconditional sum reports exactly 2x. The generic gfx9 fallback is
+  // non-unified, so max() protects us.
+  const AmdGpuTargetConstants tc = *LookupTargetConstants(90800);
+  ASSERT_FALSE(tc.unified_vgpr_file);
+  EXPECT_EQ(UnifiedVgprCount(tc, 128, 128), 128u);
+}
+
+// ===========================================================================
+// Version-skew guard
+// ===========================================================================
+
+// On a unified-file target the hardware allocation is a multiple of the
+// 8-register granule. A sum that is not one means the installed SDK decoded
+// the code object with a scheme we do not recognise, and correct arithmetic
+// on wrong input is still wrong.
+TEST(RocmOccupancyTest, NonGranulatedUnifiedCountIsSuppressed) {
+  // alignTo(4,4) + 1 = 5, not a multiple of 8.
+  EXPECT_FALSE(
+      GetOccupancy(MakeParams(kGfx942, 4, 1, 16, 256, 0), 304).has_value());
+}
+
+// ...but the guard must NOT fire on the max() branch. arch counts are
+// granulated to 4, not 8, so ordinary low-register kernels reach it with an
+// odd multiple of 4 and must still be modelled. This is the case that makes
+// wg320, granule100 and every other accum-free row work.
+TEST(RocmOccupancyTest, GuardDoesNotFireWithoutAgprs) {
+  for (uint32_t arch : {4u, 12u, 20u, 36u, 100u, 172u}) {
+    SCOPED_TRACE(absl::StrCat("arch_vgpr_count=", arch));
+    EXPECT_TRUE(GetOccupancy(MakeParams(kGfx942, arch, 0, 16, 256, 0), 304)
+                    .has_value());
+  }
+}
+
+// ===========================================================================
+// Degenerate input
+//
+// The version-skew guard exists because the SDK is known to hand back register
+// counts we cannot decode. That makes "garbage in" a real path, not a
+// hypothetical one, and the model must degrade rather than crash: it runs
+// inside the profiled process, so a SIGFPE here takes down the user's training
+// job. These rows pin the saturating arithmetic in AlignTo/SaturatingAdd.
+// ===========================================================================
+
+TEST(RocmOccupancyTest, HugeRegisterCountsDoNotCrashOrOverReport) {
+  constexpr uint32_t kMax = std::numeric_limits<uint32_t>::max();
+
+  // Wrapping AlignTo(kMax, 8) == 0 divided by zero in the VGPR bound. The
+  // accum=0 path takes max(), so the skew guard does not intercept it.
+  std::optional<OccupancyStats> vgpr =
+      GetOccupancy(MakeParams(kGfx942, kMax, 0, 16, 256, 0), 304);
+  ASSERT_TRUE(vgpr.has_value());
+  EXPECT_EQ(vgpr->active_blocks_per_cu, 1u)
+      << "an impossible register demand must floor at one workgroup";
+
+  // The sum branch saturates, and kMax % 8 != 0, so the skew guard rejects it
+  // outright -- the stronger of the two outcomes.
+  EXPECT_FALSE(
+      GetOccupancy(MakeParams(kGfx942, kMax, 1, 16, 256, 0), 304).has_value());
+
+  // Wrapping AlignTo in the LDS bound made lds_per_wg 0, which read as "LDS
+  // never binds" and reported 100%. It must read as "LDS always binds".
+  std::optional<OccupancyStats> lds =
+      GetOccupancy(MakeParams(kGfx942, 4, 0, 16, 256, kMax - 255), 304);
+  ASSERT_TRUE(lds.has_value());
+  EXPECT_EQ(lds->active_blocks_per_cu, 1u);
+  EXPECT_EQ(lds->limiter, OccupancyLimiter::kLDS);
+  EXPECT_LT(lds->occupancy_pct, 100.0)
+      << "an impossible LDS demand must not report full occupancy";
+}
+
+// ===========================================================================
+// Target constants
+// ===========================================================================
+
+TEST(RocmOccupancyTest, TargetConstantsMatchLlvm) {
+  const AmdGpuTargetConstants gfx942 = *LookupTargetConstants(kGfx942);
+  EXPECT_TRUE(gfx942.exact);
+  EXPECT_TRUE(gfx942.unified_vgpr_file);
+  EXPECT_TRUE(gfx942.sgpr_limited);  // IsaVersion.Major < 10
+  EXPECT_EQ(gfx942.max_waves_per_simd, 8u);
+  EXPECT_EQ(gfx942.simd_per_cu, 4u);
+  EXPECT_EQ(gfx942.wave_front_size, 64u);
+  EXPECT_EQ(gfx942.total_vgprs, 512u);
+  EXPECT_EQ(gfx942.vgpr_granule, 8u);
+  EXPECT_EQ(gfx942.arch_vgpr_granule, 4u);
+  EXPECT_EQ(gfx942.lds_per_cu, 65536u);
+  EXPECT_EQ(gfx942.lds_granule, 512u);
+
+  // gfx950 differs from gfx942 in exactly two constants.
+  const AmdGpuTargetConstants gfx950 = *LookupTargetConstants(kGfx950);
+  EXPECT_TRUE(gfx950.exact);
+  EXPECT_EQ(gfx950.lds_per_cu, 163840u);
+  EXPECT_EQ(gfx950.lds_granule, 1280u);
+  EXPECT_EQ(gfx950.total_vgprs, gfx942.total_vgprs);
+  EXPECT_EQ(gfx950.max_waves_per_simd, gfx942.max_waves_per_simd);
+
+  // gfx90a: 90010, decimal decode, step 10.
+  const AmdGpuTargetConstants gfx90a = *LookupTargetConstants(kGfx90a);
+  EXPECT_TRUE(gfx90a.exact);
+  EXPECT_EQ(gfx90a.lds_per_cu, 65536u);
+  EXPECT_EQ(gfx90a.lds_granule, 512u);
+}
+
+TEST(RocmOccupancyTest, LimiterNamesAreStable) {
+  // No production caller emits these yet -- see the CONSUMERS note on
+  // OccupancyStats. They are pinned here so that the follow-up surfacing
+  // `limiter` as an XStat inherits a stable vocabulary rather than inventing
+  // one, and so a rename shows up as a test change rather than silently
+  // becoming a user-visible string later.
+  EXPECT_STREQ(OccupancyLimiterName(OccupancyLimiter::kNone), "none");
+  EXPECT_STREQ(OccupancyLimiterName(OccupancyLimiter::kVGPR), "vgpr");
+  EXPECT_STREQ(OccupancyLimiterName(OccupancyLimiter::kLDS), "lds");
+  EXPECT_STREQ(OccupancyLimiterName(OccupancyLimiter::kSGPR), "sgpr");
+  EXPECT_STREQ(OccupancyLimiterName(OccupancyLimiter::kWorkgroup), "workgroup");
+  EXPECT_STREQ(OccupancyLimiterName(OccupancyLimiter::kBarrier), "barrier");
+}
+
+// ===========================================================================
+// Cache key
+// ===========================================================================
+
+TEST(RocmOccupancyTest, ParamsCacheKeyDiscriminatesEveryField) {
+  const RocmDeviceOccupancyParams base =
+      MakeParams(kGfx942, 5, 128, 16, 256, 0);
+  EXPECT_EQ(base, MakeParams(kGfx942, 5, 128, 16, 256, 0));
+
+  EXPECT_NE(base, MakeParams(kGfx942, 6, 128, 16, 256, 0));
+  EXPECT_NE(base, MakeParams(kGfx942, 5, 129, 16, 256, 0));
+  EXPECT_NE(base, MakeParams(kGfx942, 5, 128, 17, 256, 0));
+  EXPECT_NE(base, MakeParams(kGfx942, 5, 128, 16, 512, 0));
+  EXPECT_NE(base, MakeParams(kGfx942, 5, 128, 16, 256, 1024));
+  // The field the pre-fix cache key discarded entirely, which is why the old
+  // model could not tell a gfx90a from a gfx1100.
+  EXPECT_NE(base, MakeParams(kGfx950, 5, 128, 16, 256, 0));
+}
+
+}  // namespace
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_occupancy_test.cc
+++ b/xla/backends/profiler/gpu/rocm_occupancy_test.cc
@@ -38,6 +38,7 @@ limitations under the License.
 #include <cstdint>
 #include <limits>
 #include <optional>
+#include <string>
 
 #include <gtest/gtest.h>
 #include "absl/strings/str_cat.h"

--- a/xla/backends/profiler/gpu/rocm_occupancy_test_kernel.h
+++ b/xla/backends/profiler/gpu/rocm_occupancy_test_kernel.h
@@ -1,0 +1,34 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_OCCUPANCY_TEST_KERNEL_H_
+#define XLA_BACKENDS_PROFILER_GPU_ROCM_OCCUPANCY_TEST_KERNEL_H_
+
+#include <stddef.h>
+
+namespace xla {
+namespace profiler {
+namespace test {
+
+// Allocates two device buffers of `n` floats, launches a simple element-wise
+// scale kernel with the given block size, synchronizes, and frees the buffers.
+// Returns 0 on success, non-zero hipError_t on failure.
+int RunOccupancyTestKernel(int n, int block_size);
+
+}  // namespace test
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_OCCUPANCY_TEST_KERNEL_H_

--- a/xla/backends/profiler/gpu/rocm_occupancy_test_kernel.hip.cc
+++ b/xla/backends/profiler/gpu/rocm_occupancy_test_kernel.hip.cc
@@ -1,0 +1,63 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file must be compiled by hipcc (not plain clang) so that __global__,
+// blockIdx, blockDim, threadIdx and <<<...>>> are available.  The BUILD rule
+// uses a .hip.cc extension which routes the file through hipcc_wrapper.
+
+#include "xla/backends/profiler/gpu/rocm_occupancy_test_kernel.h"
+
+#include "rocm/include/hip/hip_runtime.h"
+
+namespace xla {
+namespace profiler {
+namespace test {
+
+namespace {
+
+__global__ void ScaleKernel(const float* __restrict__ in,
+                            float* __restrict__ out, int n) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) out[i] = in[i] * 2.0f;
+}
+
+}  // namespace
+
+int RunOccupancyTestKernel(int n, int block_size) {
+  void* d_in = nullptr;
+  void* d_out = nullptr;
+
+  hipError_t err = hipMalloc(&d_in, static_cast<size_t>(n) * sizeof(float));
+  if (err != hipSuccess) return static_cast<int>(err);
+
+  err = hipMalloc(&d_out, static_cast<size_t>(n) * sizeof(float));
+  if (err != hipSuccess) {
+    hipFree(d_in);
+    return static_cast<int>(err);
+  }
+
+  int grid = (n + block_size - 1) / block_size;
+  ScaleKernel<<<grid, block_size>>>(static_cast<const float*>(d_in),
+                                    static_cast<float*>(d_out), n);
+
+  err = hipDeviceSynchronize();
+  hipFree(d_in);
+  hipFree(d_out);
+  return static_cast<int>(err);
+}
+
+}  // namespace test
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -326,18 +326,40 @@ void RocmTracer::KernelEvent(const rocprofiler_record_header_t* hdr,
   trace_event->queue_id = kinfo.queue_id.handle;
   trace_event->kernel_info = KernelDetails{
       .private_segment_size = kinfo.private_segment_size,
+      // The dispatch record's group_segment_size is the total LDS per
+      // workgroup, static plus runtime. The symbol's static-only figure is
+      // filled in below.
       .group_segment_size = kinfo.group_segment_size,
+      .static_group_segment_size = 0,
       .workgroup_x = kinfo.workgroup_size.x,
       .workgroup_y = kinfo.workgroup_size.y,
       .workgroup_z = kinfo.workgroup_size.z,
       .grid_x = kinfo.grid_size.x,
       .grid_y = kinfo.grid_size.y,
       .grid_z = kinfo.grid_size.z,
-      .func_ptr = nullptr,
+      .arch_vgpr_count = 0,
+      .accum_vgpr_count = 0,
+      .sgpr_count = 0,
   };
 
-  auto it = kernel_info_.find(kinfo.kernel_id);
-  if (it != kernel_info_.end()) trace_event->name = it->second.name;
+  {
+    absl::MutexLock lock(kernel_lock_);
+    auto it = kernel_info_.find(kinfo.kernel_id);
+    if (it != kernel_info_.end()) {
+      const ProfilerKernelInfo& sym = it->second;
+      trace_event->name = sym.name;
+      trace_event->kernel_info.arch_vgpr_count = sym.arch_vgpr_count;
+      // The VGPR file is unified on gfx90a/94x/95x: AGPRs are charged against
+      // the same 512-entry budget as the architectural VGPRs. Dropping this
+      // over-reports occupancy on MFMA GEMM and flash-attention kernels by up
+      // to 4x -- which is to say, on exactly the kernels people profile an
+      // MI300X for.
+      trace_event->kernel_info.accum_vgpr_count = sym.accum_vgpr_count;
+      trace_event->kernel_info.sgpr_count = sym.sgpr_count;
+      trace_event->kernel_info.static_group_segment_size =
+          sym.group_segment_size;
+    }
+  }
 }
 
 void RocmTracer::TracingCallback(rocprofiler_context_id_t context,
@@ -404,14 +426,16 @@ void RocmTracer::CodeObjectCallback(
     auto* data = static_cast<kernel_symbol_data_t*>(record.payload);
     if (record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD) {
       absl::MutexLock lock(kernel_lock_);
+      // Copy the scalars out rather than storing *data: its kernel_name is a
+      // const char* that rocprofiler frees when the code object unloads.
       kernel_info_.emplace(
           data->kernel_id,
-          ProfilerKernelInfo{tsl::port::MaybeAbiDemangle(data->kernel_name),
-                             *data});
-    } else if (record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD) {
-      // FIXME: clear these?  At minimum need kernel names at shutdown, async
-      // completion We don't erase it just in case a buffer callback still needs
-      // this kernel_info_.erase(data->kernel_id);
+          ProfilerKernelInfo{
+              /*name=*/tsl::port::MaybeAbiDemangle(data->kernel_name),
+              /*arch_vgpr_count=*/data->arch_vgpr_count,
+              /*accum_vgpr_count=*/data->accum_vgpr_count,
+              /*sgpr_count=*/data->sgpr_count,
+              /*group_segment_size=*/data->group_segment_size});
     }
   }
 }

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_
 #define XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_H_
 
+#include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/node_hash_set.h"
 #include "absl/status/status.h"
@@ -99,9 +100,20 @@ class RocmTracer {
   using kernel_symbol_data_t =
       rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;
 
+  // Scalars copied out of the SDK's kernel-symbol record, plus the demangled
+  // name.
+  //
+  // Deliberately not the kernel_symbol_data_t itself. That struct holds a
+  // `const char* kernel_name` owned by rocprofiler, which frees it when the
+  // code object unloads -- storing the struct for the lifetime of the process
+  // leaves a dangling pointer behind for whoever reads it next. Copying the
+  // scalars keeps this a POD with no borrowed storage.
   struct ProfilerKernelInfo {
     std::string name;
-    kernel_symbol_data_t data;
+    uint32_t arch_vgpr_count = 0;
+    uint32_t accum_vgpr_count = 0;
+    uint32_t sgpr_count = 0;
+    uint32_t group_segment_size = 0;  // static LDS declared by the symbol
   };
 
   using kernel_info_map_t =
@@ -123,8 +135,10 @@ class RocmTracer {
   rocprofiler_context_id_t hip_stream_ctx_{};
 
   // Maps & misc -------------------------------------------------------
-  kernel_info_map_t kernel_info_{};
   absl::Mutex kernel_lock_;
+  // One entry per kernel symbol, for the lifetime of the process. Unbounded
+  // by construction: long JAX runs add an entry per JIT recompile.
+  kernel_info_map_t kernel_info_ ABSL_GUARDED_BY(kernel_lock_){};
 
   callback_name_info name_info_;
   agent_info_map_t agents_;

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -19,19 +19,25 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
 #include "absl/log/log.h"
 #include "absl/strings/string_view.h"
+#include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "rocm/include/hip/hip_runtime.h"
+#include "rocm/include/rocprofiler-sdk/callback_tracing.h"
 #include "rocm/include/rocprofiler-sdk/context.h"
 #include "rocm/include/rocprofiler-sdk/fwd.h"
+#include "rocm/include/rocprofiler-sdk/marker.h"
 #include "xla/backends/profiler/gpu/rocm_collector.h"
+#include "xla/backends/profiler/gpu/rocm_occupancy_test_kernel.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/tsl/lib/core/status_test_util.h"
+#include "xla/tsl/profiler/utils/xplane_schema.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
 
 namespace xla {
@@ -335,6 +341,212 @@ TEST(RocmTracerTest, DisableIsolatesNextSession) {
       << " events despite no HIP activity between its Enable() and Disable();"
       << " these must have leaked from the preceding no-profiler window of "
       << kLeakedPairs << " hipMemcpy pairs";
+}
+
+// ============================================================================
+// Occupancy smoke tests — require real AMD GPU hardware.
+//
+// These tests launch a real HIP kernel via RunOccupancyTestKernel() (defined
+// in rocm_occupancy_test_kernel.hip.cc, compiled by hipcc so __global__ and
+// <<<...>>> are available there), capture the profiler event through the full
+// rocprofiler-sdk pipeline, and verify that the exported XSpace contains
+// theoretical occupancy statistics (kTheoreticalOccupancyPct and
+// kOccupancyMinGridSize).
+//
+// The arithmetic itself is NOT tested here -- it lives in rocm_occupancy.cc
+// and is pinned by a 16-row golden table in rocm_occupancy_test.cc, which runs
+// on any CPU host. What these tests cover is the plumbing that the golden
+// table cannot: that the code-object callback actually fires, that the symbol's
+// register counts reach KernelDetails, and that the agent's gfx_target_version
+// reaches PerDeviceCollector.
+// ============================================================================
+
+TEST(RocmTracerOccupancyTest, KernelDispatchProducesOccupancyStats) {
+  int device_count = 0;
+  ASSERT_EQ(hipGetDeviceCount(&device_count), hipSuccess);
+  ASSERT_GT(device_count, 0) << "No HIP devices available";
+
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+  ASSERT_GT(tracer.GpuAgents().size(), 0u) << "No GPU agents registered";
+
+  RocmTraceCollectorOptions col_opts;
+  col_opts.max_callback_api_events = 2 * 1024 * 1024;
+  col_opts.max_activity_api_events = 2 * 1024 * 1024;
+  col_opts.max_annotation_strings = 1024 * 1024;
+  col_opts.num_gpus = tracer.NumGpus() > 0 ? tracer.NumGpus() : 1;
+
+  uint64_t start_wall = RocmTracer::GetTimestamp();
+  uint64_t start_gpu = RocmTracer::GetTimestamp();
+  auto collector =
+      std::make_unique<RocmTraceCollectorImpl>(col_opts, start_wall, start_gpu);
+  collector->SetGpuAgents(tracer.GpuAgents());
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024 * 1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  // Launch a real kernel via the hipcc-compiled helper so the tracer captures
+  // a kernel dispatch record with a valid kernel_object / func_ptr.
+  const int launch_status =
+      test::RunOccupancyTestKernel(/*n=*/4096, /*block_size=*/256);
+
+  // Allow the rocprofiler-sdk buffer to flush.
+  absl::SleepFor(absl::Milliseconds(200));
+  // Disable BEFORE asserting. The tracer is a process-lifetime singleton
+  // holding a raw pointer to `collector`; a failed ASSERT returns from the
+  // test body immediately, which would destroy the collector and leave the
+  // singleton dangling for the next in-flight buffer callback or the next
+  // test in this binary. See DisableIsolatesNextSession.
+  tracer.Disable();
+  ASSERT_EQ(launch_status, 0);
+
+  tsl::profiler::XSpace space;
+  collector->Export(&space);
+
+  // Look for the theoretical occupancy stat in any GPU plane.
+  absl::string_view kOccKey = tsl::profiler::GetStatTypeStr(
+      tsl::profiler::StatType::kTheoreticalOccupancyPct);
+  absl::string_view kMinGridKey = tsl::profiler::GetStatTypeStr(
+      tsl::profiler::StatType::kOccupancyMinGridSize);
+  // Deliberately absent. The old suggested_block_size was block_size rounded
+  // up to a wavefront -- an echo of the input, not a suggestion -- and was
+  // deleted rather than fixed.
+  absl::string_view kSugBlockKey = tsl::profiler::GetStatTypeStr(
+      tsl::profiler::StatType::kOccupancySuggestedBlockSize);
+
+  bool found_occ_pct = false;
+  bool found_min_grid = false;
+  bool found_sug_block = false;
+
+  for (const auto& plane : space.planes()) {
+    for (const auto& [id, smd] : plane.stat_metadata()) {
+      if (smd.name() == kOccKey) found_occ_pct = true;
+      if (smd.name() == kMinGridKey) found_min_grid = true;
+      if (smd.name() == kSugBlockKey) found_sug_block = true;
+    }
+  }
+
+  EXPECT_TRUE(found_occ_pct)
+      << "XSpace must contain kTheoreticalOccupancyPct stat after a real "
+         "kernel dispatch — check that the code-object callback populated "
+         "arch_vgpr_count in KernelEvent() and that the agent's "
+         "gfx_target_version reached PerDeviceCollector (and that this device "
+         "is a target LookupTargetConstants knows: the model covers gfx9 only)";
+  EXPECT_TRUE(found_min_grid)
+      << "XSpace must contain kOccupancyMinGridSize stat";
+  EXPECT_FALSE(found_sug_block)
+      << "kOccupancySuggestedBlockSize was deliberately removed; it must not "
+         "come back";
+
+  // Verify that the kTheoreticalOccupancyPct value is in (0, 100].
+  for (const auto& plane : space.planes()) {
+    int64_t occ_stat_id = -1;
+    for (const auto& [sid, smd] : plane.stat_metadata()) {
+      if (smd.name() == kOccKey) {
+        occ_stat_id = sid;
+        break;
+      }
+    }
+    if (occ_stat_id < 0) continue;
+
+    for (const auto& line : plane.lines()) {
+      for (const auto& ev : line.events()) {
+        for (const auto& stat : ev.stats()) {
+          if (stat.metadata_id() != occ_stat_id) continue;
+          double pct = stat.double_value();
+          EXPECT_GT(pct, 0.0)
+              << "Theoretical occupancy must be positive for a running kernel";
+          EXPECT_LE(pct, 100.0) << "Theoretical occupancy cannot exceed 100%";
+        }
+      }
+    }
+  }
+}
+
+// Verify that kKernelDetails in the XSpace contains a non-zero occ_pct
+// string when occupancy is available.
+TEST(RocmTracerOccupancyTest, KernelDetailsStringContainsOccupancyPct) {
+  int device_count = 0;
+  ASSERT_EQ(hipGetDeviceCount(&device_count), hipSuccess);
+  ASSERT_GT(device_count, 0) << "No HIP devices available";
+
+  RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
+  ASSERT_TRUE(tracer.IsAvailable());
+
+  RocmTraceCollectorOptions col_opts;
+  col_opts.max_callback_api_events = 2 * 1024 * 1024;
+  col_opts.max_activity_api_events = 2 * 1024 * 1024;
+  col_opts.max_annotation_strings = 1024 * 1024;
+  col_opts.num_gpus = tracer.NumGpus() > 0 ? tracer.NumGpus() : 1;
+
+  uint64_t start_wall = RocmTracer::GetTimestamp();
+  uint64_t start_gpu = RocmTracer::GetTimestamp();
+  auto collector =
+      std::make_unique<RocmTraceCollectorImpl>(col_opts, start_wall, start_gpu);
+  collector->SetGpuAgents(tracer.GpuAgents());
+
+  RocmTracerOptions opts{/*max_annotation_strings=*/1024 * 1024};
+  TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
+
+  const int launch_status =
+      test::RunOccupancyTestKernel(/*n=*/1024, /*block_size=*/64);
+
+  absl::SleepFor(absl::Milliseconds(200));
+  // Disable before asserting -- see the note in the test above.
+  tracer.Disable();
+  ASSERT_EQ(launch_status, 0);
+
+  tsl::profiler::XSpace space;
+  collector->Export(&space);
+
+  absl::string_view kDetailsKey =
+      tsl::profiler::GetStatTypeStr(tsl::profiler::StatType::kKernelDetails);
+
+  bool found_nonzero_occ = false;
+  for (const auto& plane : space.planes()) {
+    int64_t details_id = -1;
+    for (const auto& [sid, smd] : plane.stat_metadata()) {
+      if (smd.name() == kDetailsKey) {
+        details_id = sid;
+        break;
+      }
+    }
+    if (details_id < 0) continue;
+
+    for (const auto& line : plane.lines()) {
+      for (const auto& ev : line.events()) {
+        for (const auto& stat : ev.stats()) {
+          if (stat.metadata_id() != details_id) continue;
+          int64_t ref = stat.ref_value();
+          auto it = plane.stat_metadata().find(ref);
+          if (it == plane.stat_metadata().end()) continue;
+          const std::string& details = it->second.name();
+          // The details string must contain "occ_pct:" followed by a non-zero
+          // value when occupancy was computed successfully.
+          auto pos = details.find("occ_pct:");
+          if (pos == std::string::npos) continue;
+          double pct = std::stod(details.substr(pos + 8));
+          if (pct <= 0.0) continue;
+          found_nonzero_occ = true;
+          // A non-zero occ_pct means GetOccupancy() ran, which it only does
+          // when at least one register count is non-zero -- so the `regs:`
+          // token on this same event must be present and non-zero. This is
+          // the only place the real code-object register decode is exercised;
+          // the golden table feeds the model synthetic counts.
+          ASSERT_EQ(details.rfind("regs:", 0), 0u)
+              << "kernel_details must lead with the regs: token: " << details;
+          EXPECT_GT(std::stoul(details.substr(5)), 0u)
+              << "occ_pct is non-zero, so the unified VGPR charge cannot be "
+                 "zero: "
+              << details;
+        }
+      }
+    }
+  }
+
+  EXPECT_TRUE(found_nonzero_occ)
+      << "kKernelDetails string must contain a non-zero occ_pct after a real "
+         "kernel dispatch with occupancy support enabled";
 }
 
 }  // namespace

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -61,8 +61,12 @@ struct KernelDetails {
   // The amount of private memory used by kernel,
   // number of register per thread (register spillage if > 0)
   uint32_t private_segment_size;
-  // The amount of shared memory (SMEM)
+  // The amount of shared memory (SMEM). From the *dispatch* record, this is
+  // the TOTAL LDS per workgroup: static plus any runtime addition.
   uint32_t group_segment_size;
+  // From the kernel symbol: the statically declared LDS only. The difference
+  // against group_segment_size is the dynamic part.
+  uint32_t static_group_segment_size;
   // X-dimension of a workgroup (grid.x*block.x)
   uint32_t workgroup_x;
   // Y-dimension of a workgroup (grid.x*block.x)
@@ -76,8 +80,27 @@ struct KernelDetails {
   // Z-dimension of a grid.
   uint32_t grid_z;
 
-  // kernel address. Used for calculating core occupancy
-  void* func_ptr;
+  // From the kernel symbol data (code-object callback). Used for occupancy.
+  // No in-class initializers: KernelDetails lives in a union inside
+  // RocmTracerEvent, so a non-trivial default constructor would delete
+  // RocmTracerEvent's default constructor. Callers zero these explicitly.
+  //
+  // Architectural VGPRs allocated per thread. Deliberately NOT named
+  // `num_regs`: on gfx90a/94x/95x this is only part of what the hardware
+  // charges a wave, and a name that implies otherwise is how the AGPR bug
+  // comes back in eighteen months. Use UnifiedVgprCount() to get the number
+  // the hardware actually allocates.
+  uint32_t arch_vgpr_count;
+  // Accumulation VGPRs (AGPRs). On the unified-register-file targets
+  // gfx90a/94x/95x these share the same 512-entry budget as the arch VGPRs,
+  // so dropping them over-reports MFMA kernels by up to 4x.
+  //
+  // A zero here does NOT generically mean "no AGPRs": rocprofiler-sdk returns
+  // 0 for targets it does not recognise, and on gfx908 it returns
+  // arch_vgpr_count instead. Both traps are handled in UnifiedVgprCount().
+  uint32_t accum_vgpr_count;
+  // Scalar registers, already rounded to the 16-register granule by the SDK.
+  uint32_t sgpr_count;
 };
 
 enum class RocmTracerEventType {


### PR DESCRIPTION
 Second of two. Depends on https://github.com/openxla/xla/pull/47468 — please review that one first.

  Wires the occupancy model from PR A into the ROCm profiler so that kernel
  events in the XPlane timeline carry kTheoreticalOccupancyPct and
  kOccupancyMinGridSize alongside the existing kernel details.

  ### What changes

  KernelDetails gains four new fields read from the DEVICE_KERNEL_SYMBOL_REGISTER
  code-object callback at load time:
  - arch_vgpr_count, accum_vgpr_count — split for correct unified-file accounting
  - sgpr_count — for the SGPR occupancy bound (gfx9 only)
  - static_group_segment_size — the symbol's static LDS; group_segment_size in the
    dispatch record is total (static + dynamic), so the two can be told apart

  arch_vgpr_count / accum_vgpr_count are deliberately not named num_regs — a name
  that implies "the register count" is how the AGPR under-accounting comes back.

  Note: kOccupancyMinGridSize on ROCm is active_blocks_per_cu * cu_count for the
  actual launch block size. This differs from CUDA's cudaOccupancyMaxPotentialBlockSize,
  which gives the grid needed at a *suggested* block size independent of the launch.

  ### Testing

  rocm_tracer_test gains two GPU smoke tests (rocm_occupancy_test_kernel.hip.cc)
  that launch a real kernel and assert the stats reach the XPlane. The arithmetic
  is pinned by the golden table in rocm_occupancy_test (PR A), which runs on CPU.
  rocm_collector_test adds coverage that each dispatch keeps its own registers:
  the previous api/activity exchange seeded from .front() and reported one
  kernel's registers for all three dispatches.