### PR TITLE
[oneDNN][TSL] Add AMX_FP8 CPU feature definition and CPUID detection

### DIFF
--- a/third_party/tsl/tsl/platform/cpu_info.cc
+++ b/third_party/tsl/tsl/platform/cpu_info.cc
@@ -93,6 +93,7 @@ class CPUIDInfo {
         have_amx_fp16_(0),
         have_amx_int8_(0),
         have_amx_tile_(0),
+        have_amx_fp8_(0),
         have_avx_(0),
         have_avx2_(0),
         have_avx512f_(0),
@@ -144,6 +145,7 @@ class CPUIDInfo {
 
     // Get vendor string (issue CPUID with eax = 0)
     GETCPUID(eax, ebx, ecx, edx, 0, 0);
+    const uint32_t kMaxLeaf = eax;
     cpuid->vendor_str_.append(reinterpret_cast<char *>(&ebx), 4);
     cpuid->vendor_str_.append(reinterpret_cast<char *>(&edx), 4);
     cpuid->vendor_str_.append(reinterpret_cast<char *>(&ecx), 4);
@@ -252,6 +254,13 @@ class CPUIDInfo {
       cpuid->have_avx_vnni_int8_ = (edx >> 4) & 0x1;
       cpuid->have_avx_ne_convert_ = (edx >> 5) & 0x1;
     }
+
+    // AMX_FP8: CPUID.(EAX=0x1E, ECX=0x01):EAX bit 4
+    // Ref: llvm/lib/TargetParser/Host.cpp (HasLeaf1E + amx-fp8)
+    if (kMaxLeaf >= 0x1e && cpuid->have_amx_tile_) {
+      GETCPUID(eax, ebx, ecx, edx, 0x1e, 0x1);
+      cpuid->have_amx_fp8_ = (eax >> 4) & 0x1;
+    }
   }
 
   static bool TestFeature(CPUFeature feature) {
@@ -264,6 +273,7 @@ class CPUIDInfo {
       case AMX_FP16:      return cpuid->have_amx_fp16_;
       case AMX_INT8:      return cpuid->have_amx_int8_;
       case AMX_TILE:      return cpuid->have_amx_tile_;
+      case AMX_FP8:       return cpuid->have_amx_fp8_;
       case AVX2:          return cpuid->have_avx2_;
       case AVX:           return cpuid->have_avx_;
       case AVX512F:       return cpuid->have_avx512f_;
@@ -323,6 +333,7 @@ class CPUIDInfo {
   int have_amx_fp16_ : 1;
   int have_amx_int8_ : 1;
   int have_amx_tile_ : 1;
+  int have_amx_fp8_ : 1;
   int have_avx_ : 1;
   int have_avx2_ : 1;
   int have_avx512f_ : 1;

--- a/third_party/tsl/tsl/platform/cpu_info.h
+++ b/third_party/tsl/tsl/platform/cpu_info.h
@@ -141,6 +141,7 @@ enum CPUFeature {
   AMX_FP16 = 45,        // Float16 tile matrix multiplication
   AVX_NE_CONVERT = 46,  // Instructions for faster bfloat16, float16 convert.
   AVX_VNNI_INT8 = 47,   // VNNI instructions for combinations of u8, s8 dtypes.
+  AMX_FP8 = 48,         // FP8 tile matrix multiplication
 
   //===--------------------------------------------------------------------===//
   // AArch64 features


### PR DESCRIPTION
This PR is part 1 and pre-requisite for PR https://github.com/openxla/xla/pull/43318 . 
The upstreamed https://github.com/openxla/xla/pull/43318 has errors. Penporn suggested to break into two, with first PR just adding the CPU feature definition and this PR just carves out the first part from PR43318.

🎯 Justification
The CI for TensorFlow uses its own pinned copy of TSL, not the one inside XLA's third_party/tsl/. Orig PR#43318 adds AMX_FP8 = 48 to XLA's local TSL copy and immediately references it in XLA code (cpu_features.cc, onednn_util.h, etc.). But when TF CI builds XLA, it resolves tsl::port::CPUFeature from its own TSL — which doesn't have AMX_FP8 yet — causing:
  error: no member named 'AMX_FP8' in 'tsl::port::CPUFeature' causing build failures.

Once this PR gets merged, PR43318 can be rebased, we won't see the CI errors.

