### PR TITLE
[ROCm] Sandbox GHA runners to assigned gpu

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -16,6 +16,7 @@
 name: CI ROCm
 permissions:
   contents: read
+  packages: read
 on:
   pull_request:
   workflow_dispatch:
@@ -41,14 +42,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docker-image: ${{ steps.out.outputs.docker-image }}
-      docker-image-jax: ${{ steps.out.outputs.docker-image-jax }}
     steps:
       - id: out
         shell: bash
         run: |
           # hermetic llvm based on  ghcr.io/rocm/jax-ubu22.rocm7.2.4:latest
           echo "docker-image=ghcr.io/rocm/jax-ubu22.rocm7.2.4@sha256:248db525342fb7438ccbc6f5f1396ec82c783f7e0ae5667cb698edcddc8fe2fd" >> "$GITHUB_OUTPUT"
-          echo "docker-image-jax=ghcr.io/rocm/jax-ubu22.rocm7.2.4@sha256:248db525342fb7438ccbc6f5f1396ec82c783f7e0ae5667cb698edcddc8fe2fd" >> "$GITHUB_OUTPUT"
 
   jax:
     needs: rocm-config
@@ -59,23 +58,11 @@ jobs:
     # Remove this once the JAX CI is stable.
     continue-on-error: true
     env:
-      DOCKER_IMAGE: ${{ needs.rocm-config.outputs.docker-image-jax }}
-    container:
-      image: ${{ needs.rocm-config.outputs.docker-image-jax }} # zizmor: ignore[unpinned-images] image is pinned in the rocm-config job.
-      volumes: &rocm_container_volumes
-        - /data/ci-cert.crt:/data/ci-cert.crt
-        - /data/ci-cert.key:/data/ci-cert.key
-        - /data:/data
-      options: &rocm_container_options >-
-        --device=/dev/dri
-        --device=/dev/kfd
-        --ipc=host
-        --shm-size=64G
-        --cap-add=SYS_PTRACE
-        --security-opt=seccomp=unconfined
-        --tmpfs /root/.cache/bazel:rw,exec,size=80g
-        --group-add video
-        --env-file /etc/podinfo/gha-gpu-isolation-settings
+      DOCKER_IMAGE: ${{ needs.rocm-config.outputs.docker-image }}
+      # Unique per run so a crashed run cannot collide with this one on a pooled node.
+      CONTAINER_NAME: jax-${{ github.run_id }}-${{ github.run_attempt }}
+      # Stable label so leftover containers from crashed runs can be swept on a pooled node.
+      CONTAINER_LABEL: ci-rocm-jax
     defaults:
       run:
         shell: bash
@@ -93,16 +80,68 @@ jobs:
           path: jax
           persist-credentials: false
 
+      - &start_container
+        name: Start container
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+
+          DOCKER_CONFIG="${RUNNER_TEMP}/.docker-${CONTAINER_NAME}"
+          export DOCKER_CONFIG
+          mkdir -p "${DOCKER_CONFIG}"
+
+          echo "::group::Log in to ghcr.io" >&2
+          # Authenticate to ghcr.io so the image pull below is authorized.
+          echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
+          echo "::endgroup::" >&2
+
+          echo "::group::Cleanup leftover containers" >&2
+          # Sweep any leftover containers from crashed runs of this job on this pooled node.
+          docker ps -aq --filter "label=${CONTAINER_LABEL}" | xargs -r docker rm -f || true
+          echo "::endgroup::" >&2
+
+          echo "::group::Start container" >&2
+          # Limit render devices depending on the runner.
+          if [ -f "/etc/podinfo/gha-render-devices" ]; then
+            DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)
+          else
+            DEVICE_FLAG="--device /dev/dri --group-add video"
+          fi
+          echo "Using device flags: ${DEVICE_FLAG}" >&2
+
+          GITHUB_HOME="${RUNNER_TEMP}/_github_home_${CONTAINER_NAME}"
+          mkdir -p "${GITHUB_HOME}"
+
+          # DEVICE_FLAG is intentionally unquoted so multiple flags word-split.
+          # shellcheck disable=SC2086
+          docker run -d --name "${CONTAINER_NAME}" \
+            --label "${CONTAINER_LABEL}" \
+            ${DEVICE_FLAG} \
+            --device=/dev/kfd \
+            --ipc=host \
+            --shm-size=64G \
+            --cap-add=SYS_PTRACE \
+            --security-opt=seccomp=unconfined \
+            -e HOME=/github/home \
+            -v "${GITHUB_HOME}":/github/home \
+            -v /data/ci-cert.crt:/data/ci-cert.crt \
+            -v /data/ci-cert.key:/data/ci-cert.key \
+            -v "${GITHUB_WORKSPACE}":/work \
+            -w /work \
+            "${DOCKER_IMAGE}" sleep infinity
+          echo "::endgroup::" >&2
+
       - name: CPU Info
         run: lscpu
 
       - name: Run JAX Unit Tests
         timeout-minutes: 60
-        working-directory: jax
         run: |
-          ./ci/run_bazel_test_rocm_rbe.sh \
-            --override_repository=xla="${GITHUB_WORKSPACE}" \
-            --override_module=xla="${GITHUB_WORKSPACE}" \
+          docker exec -w /work/jax "${CONTAINER_NAME}" ./ci/run_bazel_test_rocm_rbe.sh \
+            --override_repository=xla="/work" \
+            --override_module=xla="/work" \
             --config=single_gpu \
             --//jax:build_jaxlib=wheel \
             --//jax:build_jax=true \
@@ -115,6 +154,11 @@ jobs:
             --bes_keywords=upstream \
             --bes_keywords=gpu \
             --bes_keywords=pull_request
+
+      - &cleanup_container
+        name: Cleanup container
+        if: always()
+        run: docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
   xla:
     needs: rocm-config
     name: XLA Linux x86 AMD Instinct GPU
@@ -123,10 +167,10 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.rocm-config.outputs.docker-image }}
       EXECUTE_CI_BUILD_URL: https://raw.githubusercontent.com/ROCm/xla/refs/heads/${{ inputs.rocm_xla_branch || 'rocm-dev-infra' }}/build_tools/rocm/execute_ci_build_upstream.sh
-    container:
-      image: ${{ needs.rocm-config.outputs.docker-image }} # zizmor: ignore[unpinned-images] image is pinned in the rocm-config job.
-      volumes: *rocm_container_volumes
-      options: *rocm_container_options
+      # Unique per run so a crashed run cannot collide with this one on a pooled node.
+      CONTAINER_NAME: xla-${{ github.run_id }}-${{ github.run_attempt }}
+      # Stable label so leftover containers from crashed runs can be swept on a pooled node.
+      CONTAINER_LABEL: ci-rocm-xla
     defaults:
       run:
         shell: bash
@@ -142,13 +186,15 @@ jobs:
           wget -O build_tools/rocm/execute_ci_build_upstream.sh "${EXECUTE_CI_BUILD_URL}"
           chmod +x build_tools/rocm/execute_ci_build_upstream.sh
 
+      - *start_container
+
       - name: CPU Info
         run: lscpu
 
       - name: Test XLA [single_gpu]
         timeout-minutes: 120
         run: |
-          build_tools/rocm/execute_ci_build_upstream.sh \
+          docker exec "${CONTAINER_NAME}" build_tools/rocm/execute_ci_build_upstream.sh \
             --config=rocm_ci \
             --config=rocm_rbe \
             --config=ci_single_gpu \
@@ -162,10 +208,11 @@ jobs:
             --bes_keywords=upstream \
             --bes_keywords=gpu \
             --bes_keywords=pull_request \
+
       - name: Test XLA [rocm_cpu]
         timeout-minutes: 80
         run: |
-          build_tools/rocm/execute_ci_build_upstream.sh \
+          docker exec "${CONTAINER_NAME}" build_tools/rocm/execute_ci_build_upstream.sh \
             --config=rocm_ci \
             --config=rocm_rbe \
             --config=ci_rocm_cpu \
@@ -176,3 +223,5 @@ jobs:
             --bes_keywords=upstream \
             --bes_keywords=cpu \
             --bes_keywords=pull_request
+
+      - *cleanup_container


### PR DESCRIPTION
📝 Summary of Changes
Manually manage docker lifetime in ROCm CI in order to use /etc/podinfo/gha-render-devices to isolate runner gpus.

🎯 Justification
This prevents GHA runners sharing gpu resources leading to sporadic failures on local runs. Isolating gpus via env vars
in /etc/podinfo/gha-gpu-isolation-settings does not work with bazel.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
N\A

🧪 Unit Tests:
None

🧪 Execution Tests:
None
