### PR TITLE
Dev enable rocm sol estimator

### DIFF
--- a/xla/backends/gpu/transforms/collectives/collective_ops_utils.cc
+++ b/xla/backends/gpu/transforms/collectives/collective_ops_utils.cc
@@ -266,8 +266,12 @@ bool IsGPUSyncCollective(const HloInstruction& instr) {
 absl::StatusOr<GPUCommunicationType> CommunicationType(
     int num_devices_per_partition, const HloChannelInstruction& instr,
     const se::GpuComputeCapability& gpu_version) {
-  if (!gpu_version.IsCuda()) {
-    return absl::FailedPreconditionError("Only CUDA is supported.");
+  const bool is_supported_rocm =
+      gpu_version.IsRocm() &&
+      gpu_version.rocm_compute_capability()->gfx9_mi350();
+  if (!gpu_version.IsCuda() && !is_supported_rocm) {
+    return absl::FailedPreconditionError(
+        "Only CUDA and ROCm gfx950 (MI350) are supported.");
   }
 
   if (const auto* collective = DynCast<HloCollectiveInstruction>(&instr)) {

--- a/xla/service/gpu/gpu_hlo_schedule_test.cc
+++ b/xla/service/gpu/gpu_hlo_schedule_test.cc
@@ -582,10 +582,7 @@ TEST_P(GpuHloScheduleParameterizedTest,
 
   EXPECT_EQ(count_between_pairs_high_latency.size(), 2);
   EXPECT_EQ(count_between_pairs_low_latency.size(), 2);
-  EXPECT_NE(count_between_pairs_high_latency[0],
-            count_between_pairs_low_latency[0]);
-  EXPECT_NE(count_between_pairs_high_latency[1],
-            count_between_pairs_low_latency[1]);
+  EXPECT_NE(count_between_pairs_high_latency, count_between_pairs_low_latency);
 }
 
 TEST_P(GpuHloScheduleParameterizedTest,

--- a/xla/service/gpu/model/collective_interpolator_test.cc
+++ b/xla/service/gpu/model/collective_interpolator_test.cc
@@ -1081,6 +1081,56 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.test_name;
     });
 
+TEST(DefaultCollectivePerfTableTest, EstimatesGfx950DefaultProfile) {
+  se::DeviceDescription device_info = TestGpuDeviceInfo::RTXA6000DeviceInfo();
+  device_info.set_rocm_compute_capability("gfx950");
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<CollectiveInterpolator> interpolator,
+      CollectiveInterpolator::Create(kNumGpusPerHost, device_info));
+
+  absl::string_view kAllReduceHlo = R"(
+    HloModule m, num_partitions=8
+
+    wrapped_add {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT _ = f32[] add(a,b)
+    }
+
+    ENTRY main {
+      p = f32[256] parameter(0)
+      ROOT _ = f32[256] all-reduce(p), to_apply=wrapped_add,
+          replica_groups=[1,8]<=[8], use_global_device_ids=true, channel_id=1
+    }
+  )";
+  ASSERT_OK_AND_ASSIGN(auto all_reduce_module,
+                       ParseAndReturnUnverifiedModule(kAllReduceHlo));
+  HloInstruction* all_reduce =
+      all_reduce_module->entry_computation()->root_instruction();
+  ASSERT_OK_AND_ASSIGN(absl::Duration all_reduce_runtime,
+                       interpolator->EstimatedRuntime(*all_reduce));
+  EXPECT_NEAR(absl::ToDoubleMicroseconds(all_reduce_runtime),
+              1e6 * 1024.0 / 9855535.0, 0.01);
+
+  absl::string_view kCollectivePermuteHlo = R"(
+    HloModule m, num_partitions=8
+
+    ENTRY main {
+      p = f32[256] parameter(0)
+      ROOT _ = f32[256] collective-permute(p),
+          source_target_pairs={{0,4},{1,5},{2,6},{3,7}}, channel_id=1
+    }
+  )";
+  ASSERT_OK_AND_ASSIGN(auto collective_permute_module,
+                       ParseAndReturnUnverifiedModule(kCollectivePermuteHlo));
+  HloInstruction* collective_permute =
+      collective_permute_module->entry_computation()->root_instruction();
+  ASSERT_OK_AND_ASSIGN(absl::Duration collective_permute_runtime,
+                       interpolator->EstimatedRuntime(*collective_permute));
+  EXPECT_NEAR(absl::ToDoubleMicroseconds(collective_permute_runtime),
+              1e6 * 1024.0 / 38023096.0, 0.01);
+}
+
 struct CollectivePermuteTestCase {
   std::string test_name;
   CollectivePermuteCostModelType permute_type;

--- a/xla/service/gpu/model/default_collective_perf_table.txtpb
+++ b/xla/service/gpu/model/default_collective_perf_table.txtpb
@@ -77749,3 +77749,16136 @@ entries {
     }
   }
 }
+entries {
+  key: "gfx950"
+  value {
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "00ea231f198010898c495c8f3aa69249"
+      network_throughput_bytes_per_sec: 14108569
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "026c7aca115d50e9a725ad9cc129a53e"
+      network_throughput_bytes_per_sec: 64103897642
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "036547934bd0d0bb72c94bb8ac62df03"
+      network_throughput_bytes_per_sec: 59813084
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "041681439796b2c7e6a1130c7a70276e"
+      network_throughput_bytes_per_sec: 1848140889
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "048fd4ebffa26a0f555a13d497fffb5c"
+      network_throughput_bytes_per_sec: 8683140112
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "04daaa08891c88599cf6b5e5432743e1"
+      network_throughput_bytes_per_sec: 62338590386
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "04fd9fed92d16e173fc5208523f53283"
+      network_throughput_bytes_per_sec: 174222808
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "057eed0f675dbf7448cc6f9f13963459"
+      network_throughput_bytes_per_sec: 4194236892
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "063d71e21f991fc06c181d3f90af617b"
+      network_throughput_bytes_per_sec: 14270223189
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "06470add083211b0654aff4cb202e57c"
+      network_throughput_bytes_per_sec: 220498887588
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0655eca561666269145633dca1fd0bad"
+      network_throughput_bytes_per_sec: 340337138
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0763253379412eb8c92d451a4989af92"
+      network_throughput_bytes_per_sec: 1211386321
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "07adfd421c186a489807bf49b8eb6253"
+      network_throughput_bytes_per_sec: 231943846588
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "07ffe12ee7d0bc4514d508fe7cc19f09"
+      network_throughput_bytes_per_sec: 117385883544
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0828705e9e274be716d9bed985b9d04f"
+      network_throughput_bytes_per_sec: 127563020354
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "082a66d9bce9594529e3b56a01f55f6c"
+      network_throughput_bytes_per_sec: 35394671774
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0aabccd34a8a301bc3ddf7b1d46e2129"
+      network_throughput_bytes_per_sec: 79883136052
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0ac522248afbce29ceb2768f3938161e"
+      network_throughput_bytes_per_sec: 14361851
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0b11a13cda5a5f4706404093723fd1b0"
+      network_throughput_bytes_per_sec: 83919228095
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0b17520ef1c4f5cd7dea5e25a264eb0f"
+      network_throughput_bytes_per_sec: 228892990246
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0b37b4cf262c1d9b92406e50696e59c4"
+      network_throughput_bytes_per_sec: 22174101
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0b3c62ead25a10854182eb972d21a33d"
+      network_throughput_bytes_per_sec: 2534261407
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 536870912
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0b4253423ad3baa463934639904af66a"
+      network_throughput_bytes_per_sec: 64701000105
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0b7a2190bebed5eef89ea66815a0363b"
+      network_throughput_bytes_per_sec: 10912074
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0d8ff69f1887cddd6d6c7a7cb6e757ad"
+      network_throughput_bytes_per_sec: 82095575498
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0dcf986269bf50a46e4297b6dc978284"
+      network_throughput_bytes_per_sec: 100086895568
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "0de26ff26de5e012abea2cc8bcc34581"
+      network_throughput_bytes_per_sec: 18252611056
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0e252d37f4f95b65b0c309bd36d90e08"
+      network_throughput_bytes_per_sec: 43754018839
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0eba5f28aff574f84c270f76a1796685"
+      network_throughput_bytes_per_sec: 8613655
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0f61afe6ad7cda8a18c6818f6140079e"
+      network_throughput_bytes_per_sec: 92696154239
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0f9fab80196b5ca3a20c8b4d82429ffc"
+      network_throughput_bytes_per_sec: 213523423623
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "10afb3a674511ddbd597cb56dbb5c8fd"
+      network_throughput_bytes_per_sec: 6450393700
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "11b7ac8b9606f69c06dc08e59b9a053c"
+      network_throughput_bytes_per_sec: 2589332279
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "122edd8939058bb037abb5816debfc87"
+      network_throughput_bytes_per_sec: 8654473423
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "12b21848edee6fc36f0071df662c6159"
+      network_throughput_bytes_per_sec: 202524320833
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "132109fb8819d2dd18efd21168ba46cf"
+      network_throughput_bytes_per_sec: 413215636
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1463d8954f4946d066311dc7f75d49dc"
+      network_throughput_bytes_per_sec: 283061826709
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "15094deb985f983ccfd5b2545123a183"
+      network_throughput_bytes_per_sec: 61418557486
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "158a817bc197fa5908085609188b9810"
+      network_throughput_bytes_per_sec: 229197869441
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 536870912
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "15a31184e19613f6aefe5aa0d66bf174"
+      network_throughput_bytes_per_sec: 121453057230
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "16ea64590ed40dc5483002a49f0d6285"
+      network_throughput_bytes_per_sec: 165561843
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "173319bd44c6e326a43edec16eff8d2e"
+      network_throughput_bytes_per_sec: 3266999002
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "173b0bc7740214cfc9963e19610cf098"
+      network_throughput_bytes_per_sec: 45369822709
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 128
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "17900cdf63a9ee0ed1755baffe233181"
+      network_throughput_bytes_per_sec: 54802584
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "17aeda778598e4f09df04f7f7aa4003a"
+      network_throughput_bytes_per_sec: 6110582750
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "184135279c70089f7c6ca507b1582d55"
+      network_throughput_bytes_per_sec: 14806212934
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1841b260ab4a40af1b8ba495043826c7"
+      network_throughput_bytes_per_sec: 2349802796
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "184920561f3c0de7e3083fe2fc0bd31c"
+      network_throughput_bytes_per_sec: 64694684794
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "199effc00a48df62ad8aac2557ced496"
+      network_throughput_bytes_per_sec: 6524240915
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 536870912
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "19badbe16d051a71a5719fc1cbd40c7f"
+      network_throughput_bytes_per_sec: 228424554012
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1a63b72a7b77dfd3dbe86f522952c68a"
+      network_throughput_bytes_per_sec: 149871935
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1a7304fb341d7f07c57c9bf104fa240c"
+      network_throughput_bytes_per_sec: 3612266692
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1b6ab3ab54b060fef16d0df721e84115"
+      network_throughput_bytes_per_sec: 63186915351
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1cff4402d5277799435921d310e21a35"
+      network_throughput_bytes_per_sec: 51441445750
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1de71abe7c607c98ba5804bf7bfe52fd"
+      network_throughput_bytes_per_sec: 80073767909
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1e2b9985be63b818f1261076e2da88b4"
+      network_throughput_bytes_per_sec: 115733871398
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1e90f0394d981c53e9ef82dacccbd73d"
+      network_throughput_bytes_per_sec: 63980006
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1f8995887b89b71a8635d44959d3c644"
+      network_throughput_bytes_per_sec: 22939499677
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1ff7a5b620524694d519cb4f1cc2c428"
+      network_throughput_bytes_per_sec: 13090836454
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "20c467af3cb33d4f6820f682bdd18097"
+      network_throughput_bytes_per_sec: 50303478052
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2184b39554ab974feabcadff2e7fb123"
+      network_throughput_bytes_per_sec: 64876590281
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "219e6eafb24f19ca46f775efb9e79f4a"
+      network_throughput_bytes_per_sec: 62534220034
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "21b95933b3a9fcf0834be1a9a56d565f"
+      network_throughput_bytes_per_sec: 8838151750
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "21edd922fde3970e62fbd7ba9f2ddc48"
+      network_throughput_bytes_per_sec: 131399472121
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "222e31563730a12c12652876f75aa032"
+      network_throughput_bytes_per_sec: 626347580
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "23433bd8d9f0851f4d638a12a250765c"
+      network_throughput_bytes_per_sec: 3732065317
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "24684b883922432b7bb22b93bef42919"
+      network_throughput_bytes_per_sec: 856226442
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "24af6415e6f60b5a9f415abb5457248e"
+      network_throughput_bytes_per_sec: 125520652995
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "258669441dfeae8366b3ddc732953015"
+      network_throughput_bytes_per_sec: 53277835
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 128
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "26a483ffc11467c6c27c00096a99950b"
+      network_throughput_bytes_per_sec: 30694983
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "26a9264b3431e346ef5fef61c3213c53"
+      network_throughput_bytes_per_sec: 184993684581
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "273eb0c88e187b9a6a76c5d5bbda9095"
+      network_throughput_bytes_per_sec: 29831040810
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "28126f4b484edf49b2dcf198458b4937"
+      network_throughput_bytes_per_sec: 553513513
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2898f1b237631f585973476ece15eb4c"
+      network_throughput_bytes_per_sec: 227131578457
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "289bd78c54fef174d38cd7d0d2af0ed2"
+      network_throughput_bytes_per_sec: 61771327162
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2955d362c4784f9a6295fd859f6bf6dd"
+      network_throughput_bytes_per_sec: 12793753050
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "29a32f0bb7a1457842de5659e9e37786"
+      network_throughput_bytes_per_sec: 50113853194
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2bbf5f211c33a2ad2c630f148483dc2a"
+      network_throughput_bytes_per_sec: 247563500
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2c386b081607aab3778a5f87110bb32f"
+      network_throughput_bytes_per_sec: 62041805
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2c6f6210ff747b61044161f5f2d82027"
+      network_throughput_bytes_per_sec: 394713908445
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2d717ad201d941580b9e0106406fd7d5"
+      network_throughput_bytes_per_sec: 168075502
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2e50b732eb8b42bf4094cc1128021ee0"
+      network_throughput_bytes_per_sec: 29535195
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2eb056e21ce0ddec3c4acf722189b700"
+      network_throughput_bytes_per_sec: 117699458
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "30329f9a71a703dddba37a4140cf5ebd"
+      network_throughput_bytes_per_sec: 63716350627
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "30502fd073c5c5ea768072632ec9c21b"
+      network_throughput_bytes_per_sec: 721595225
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3064d5d2f82d8e6ced1ab7e947ef7391"
+      network_throughput_bytes_per_sec: 249072666
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3067ba1a1aa9f8fd0f9c70c28fd2aae5"
+      network_throughput_bytes_per_sec: 21328667
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "3095bedc178b27a02eb1a4143351df17"
+      network_throughput_bytes_per_sec: 9720918159
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "30970b3a64dad66be798dd9a326d7629"
+      network_throughput_bytes_per_sec: 1386110552
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "30bac766dc6b8bee2436ed12933994f3"
+      network_throughput_bytes_per_sec: 528175370
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "318caa16d4196637a0b49daf3312b6ca"
+      network_throughput_bytes_per_sec: 113064492161
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "32d57fabcd45bb4420ad3804d58b6daa"
+      network_throughput_bytes_per_sec: 78275493
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "33661ac19032bfe68c3d9b02871f9ed9"
+      network_throughput_bytes_per_sec: 38846737
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "33b97af27dc242fd69140fc6a5441d85"
+      network_throughput_bytes_per_sec: 621760085
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "34029e7be9d63c46e84a59f187976494"
+      network_throughput_bytes_per_sec: 207341784510
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "343586e8809857f6fca34bd73bbeed71"
+      network_throughput_bytes_per_sec: 852889120
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "34a00406559cb1523830491d95378f08"
+      network_throughput_bytes_per_sec: 8901173154
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "34af34ffe43466899ab24789bd5af0c9"
+      network_throughput_bytes_per_sec: 41148873
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "35b276d0339cf8c94aba45efe9bec4c7"
+      network_throughput_bytes_per_sec: 8011735941
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "364cc6f929827da70719a1a88a21eee6"
+      network_throughput_bytes_per_sec: 307187812983
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "36827cb7d9d81ad5d39c6724b093541c"
+      network_throughput_bytes_per_sec: 893335696
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "38b551890d391b77a1f157e4b7184870"
+      network_throughput_bytes_per_sec: 38023096
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3a6a7362223de42b37d4ea61ae462272"
+      network_throughput_bytes_per_sec: 45929741568
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3a85682307cc04bdf2d54b6e969ddf03"
+      network_throughput_bytes_per_sec: 10686560471
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "3a8645893cd88d826c0847a7ccfb1379"
+      network_throughput_bytes_per_sec: 38036673619
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3b8d159ab132a6a4de22cf70abec0b16"
+      network_throughput_bytes_per_sec: 155675402823
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "3dd676703d6ef499f65d3872b7be00c1"
+      network_throughput_bytes_per_sec: 58826555585
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3f17d3795d2154a17d98923926faec1e"
+      network_throughput_bytes_per_sec: 107563025
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3f30e55b4464b5fd1961a36ec3206917"
+      network_throughput_bytes_per_sec: 126524053363
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "417426246287e26b23b3f3fbb2db6735"
+      network_throughput_bytes_per_sec: 407235602618
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "421633cbe081af3cd0ad351606175269"
+      network_throughput_bytes_per_sec: 64874097314
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "425885911c59969621fc807b50dc017d"
+      network_throughput_bytes_per_sec: 62414773699
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "43520b1b002bd615e25c415898cef7db"
+      network_throughput_bytes_per_sec: 128222799244
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "44189885145704c5e0202393bb9877c9"
+      network_throughput_bytes_per_sec: 264768384
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "44ae733809312994206ebe478f6f6d88"
+      network_throughput_bytes_per_sec: 67269773297
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "44c3eecf750fab00b51b9c70c0fd2290"
+      network_throughput_bytes_per_sec: 1698913163
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4526400ba6777f813b834e26ba34cbf0"
+      network_throughput_bytes_per_sec: 71197901902
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "45bfdb58c636e6b400334106497f5f53"
+      network_throughput_bytes_per_sec: 377077100
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "460a0e15a081f4490055616ae5d0fa4c"
+      network_throughput_bytes_per_sec: 5290441065
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "46ba65401185eae7cf33ea01a44d150f"
+      network_throughput_bytes_per_sec: 75767665
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "473de5e2e2797b06e199daa05c708a59"
+      network_throughput_bytes_per_sec: 58546548390
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "47b532f58d2079ddc96d356ceefa38b8"
+      network_throughput_bytes_per_sec: 15856056
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "49048b9110f13a6c745074a7a718894f"
+      network_throughput_bytes_per_sec: 899713073
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4928da39d79385e5f104ae32acf39251"
+      network_throughput_bytes_per_sec: 23901619539
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "4951da2d8f297b24121287ac7e845ede"
+      network_throughput_bytes_per_sec: 155865900
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "49b9e194815f26ce0fdea12d8d8145da"
+      network_throughput_bytes_per_sec: 159220430668
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "49ee5c79563a6427d9cb86a3e99e129a"
+      network_throughput_bytes_per_sec: 61394171708
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4a3d963f9237ede18f970c615082a65b"
+      network_throughput_bytes_per_sec: 4408745375
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "4b078f6cd0c4e1a6730911dfbea26461"
+      network_throughput_bytes_per_sec: 61963421480
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4bd1e1be2e4f6abd94d41b47a4e4a20b"
+      network_throughput_bytes_per_sec: 345749995491
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4c4aa30c982edd7cb519d3e0f5f1a555"
+      network_throughput_bytes_per_sec: 224406741177
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4c90e212c6c2ead3940ec3f3968d901f"
+      network_throughput_bytes_per_sec: 502264697
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "4ca4e3406755d17f747a07b8511cb33a"
+      network_throughput_bytes_per_sec: 41805083225
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4cde049d4af2588421f1cd37e1a1d96d"
+      network_throughput_bytes_per_sec: 60439378574
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4d2170351e894746020dfac2fcac1a4d"
+      network_throughput_bytes_per_sec: 43754018839
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "4d3e5e4cd088394f4ad45e10894ef7ff"
+      network_throughput_bytes_per_sec: 156892787
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4e85a8b0501a8cb5bebaede38fa82634"
+      network_throughput_bytes_per_sec: 22677193
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4ebf30811a22fe550c8a474736c86ebd"
+      network_throughput_bytes_per_sec: 86373640856
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4fb0e0f55c14066295dd304d8371b0ee"
+      network_throughput_bytes_per_sec: 3823570595
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "512c78e43dde94eab5be4e2a23d40c2c"
+      network_throughput_bytes_per_sec: 134867717
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "522194310113ca1bf37c3e0f09ab8db8"
+      network_throughput_bytes_per_sec: 158359188
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "52b2577f0bfaf38305363f115bd77596"
+      network_throughput_bytes_per_sec: 191446599
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "52cb2f8abd5ba59c1eb59484cbdf0163"
+      network_throughput_bytes_per_sec: 415200010
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "549a754e6dd1d745599a351bc6375098"
+      network_throughput_bytes_per_sec: 245786365328
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "55594333fcb9e1747c94f550f2123a24"
+      network_throughput_bytes_per_sec: 99791913015
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "55ff80ff4a9a3beb6c7fbde2910fd13c"
+      network_throughput_bytes_per_sec: 1309920948
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "56d105d61538ea5d57669499dbb0cd31"
+      network_throughput_bytes_per_sec: 121615201
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "56fca87b103de1eb73c7e89c61448474"
+      network_throughput_bytes_per_sec: 36324384244
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5771f9afffba4af7a205f96eef84981b"
+      network_throughput_bytes_per_sec: 205462762879
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "582244bd08be612bf4fddfb765ebb9b2"
+      network_throughput_bytes_per_sec: 239392168
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "58234bff32af3126a5abb79263b6d567"
+      network_throughput_bytes_per_sec: 111362485030
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "58314732912345548ae7796528670d53"
+      network_throughput_bytes_per_sec: 311696217
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "58357e0bd8b0689ff1fe2c58de3ccb19"
+      network_throughput_bytes_per_sec: 117082678065
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "586bac400ee3830fcb0bfb33c5e1dec6"
+      network_throughput_bytes_per_sec: 394605009
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "59d80d26dc690f4b5ca94bf13c0a4edb"
+      network_throughput_bytes_per_sec: 43690211560
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5a42dd2bf4274cd2ff01caeea3ab825e"
+      network_throughput_bytes_per_sec: 2189605920
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 32
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5ad37bd1731c84de4e1fad9d11683e93"
+      network_throughput_bytes_per_sec: 9832822
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5b22cde9f2f97e685ff50ea81ec477f1"
+      network_throughput_bytes_per_sec: 4037954405
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5b3a40da645053c4c49583b44ff21960"
+      network_throughput_bytes_per_sec: 453610481344
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5c4855fe511cdd5117be76e7385d1cf7"
+      network_throughput_bytes_per_sec: 1443206342
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5e2663d7fceff11b5312332fa4e92638"
+      network_throughput_bytes_per_sec: 96307922
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5ea2cbe7f5e685aaa702c3ac87eb2424"
+      network_throughput_bytes_per_sec: 420767981967
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5f3eaa847e85cc2e010b81fbdc9f2856"
+      network_throughput_bytes_per_sec: 81434494541
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5f3fc5e4e7b3cece8395d7709beadc90"
+      network_throughput_bytes_per_sec: 146218143470
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "5fb3ea880a0b624efd5aaa39e8e94119"
+      network_throughput_bytes_per_sec: 64438036272
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6011d5117ac63690f82029dc8471949a"
+      network_throughput_bytes_per_sec: 5031554702
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "60532c3a26ca6a8fe1410171835f3cdc"
+      network_throughput_bytes_per_sec: 64024690613
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "60b6ca4ca57fed5c906e82faf7a25020"
+      network_throughput_bytes_per_sec: 104365857432
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "6162dcdb0d5f77647fc11bc90b514c9e"
+      network_throughput_bytes_per_sec: 78188829
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "617df37ce5fbbeb886ad387486913bd2"
+      network_throughput_bytes_per_sec: 34778640132
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "61c8e423ccee51351146a02330cbd321"
+      network_throughput_bytes_per_sec: 189915338944
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "62a78b2d792f227e3319cbc6d0f7397a"
+      network_throughput_bytes_per_sec: 207060618168
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "62deed7a65e09eb425eac9e48ddd5a47"
+      network_throughput_bytes_per_sec: 81783826733
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6335d98ead54a01eaf5ba646d0d77e2d"
+      network_throughput_bytes_per_sec: 203265952452
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6482bf31e7c22102c12db681032fb503"
+      network_throughput_bytes_per_sec: 140513374
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "650508cd9199d62c5d16ff3e25f0dd9f"
+      network_throughput_bytes_per_sec: 1144933612
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "65316f05eec205fc5387382135f2e6eb"
+      network_throughput_bytes_per_sec: 92395217561
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "66750fce8728e0f48633bfce62ae1980"
+      network_throughput_bytes_per_sec: 4484160109
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "66a1b5078d8f0097738c1d90c3e06c06"
+      network_throughput_bytes_per_sec: 1446694848
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "68055875bc25bbe6685e1b9b85eab565"
+      network_throughput_bytes_per_sec: 2130559167
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "68ae89524d1d819c91d1823b6f3d6537"
+      network_throughput_bytes_per_sec: 4880366384
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6b536595b1c234076e742dbd7dc69fab"
+      network_throughput_bytes_per_sec: 124458759
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6b5eb7277c0289f2b7bb2e6260cd4d46"
+      network_throughput_bytes_per_sec: 422045053
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6c8096ed8c910cfc7ac8df0127fb2d87"
+      network_throughput_bytes_per_sec: 793606200
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6ce7f2d96c09502b579b2cc31a252a14"
+      network_throughput_bytes_per_sec: 8251306263
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6dd504ab26947845d5c80bfc9586dd68"
+      network_throughput_bytes_per_sec: 61701385431
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6f02e702519475f50093c2ef72dac341"
+      network_throughput_bytes_per_sec: 100191494253
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6f2128c1096979ddb9bb3d2d1ecbc018"
+      network_throughput_bytes_per_sec: 226420309
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6fc32835aa0f0e4084c95aec9cc07042"
+      network_throughput_bytes_per_sec: 193983021
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "70348095a69033348d06a2ac297b5377"
+      network_throughput_bytes_per_sec: 1078604344
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "709c979785595ebfd212c19fbb0201e6"
+      network_throughput_bytes_per_sec: 76818051116
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "71252e403a93408fba96de8bd3825ccc"
+      network_throughput_bytes_per_sec: 222456021016
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "71984575aa654cfc93c69a828b619b03"
+      network_throughput_bytes_per_sec: 6735370820
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "71aee88e910b8b7555921506479bc0c9"
+      network_throughput_bytes_per_sec: 9855535
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "725a4a0ae76c1f2dc1f7c1877ad92a3d"
+      network_throughput_bytes_per_sec: 107854696644
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "72c4414d2ea15a15319031a9404c518d"
+      network_throughput_bytes_per_sec: 2769292528
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "7442c7f9a88e07c2359930d71b9cb4f7"
+      network_throughput_bytes_per_sec: 64290146890
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7534416b2a6d3452a3adf39b30eb8258"
+      network_throughput_bytes_per_sec: 3809069905
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "75cdf6eabbbdac74bc5568d6d46578eb"
+      network_throughput_bytes_per_sec: 103773704
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "75dfdcaad56647e9bf10057076c42406"
+      network_throughput_bytes_per_sec: 16718367346
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "75e40f7ad44a713cbbbd71adca9ca1c5"
+      network_throughput_bytes_per_sec: 50888778345
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "76925d8a3b4a506d081fd885b24126eb"
+      network_throughput_bytes_per_sec: 8871126301
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "76ba73613bb4d3e8a47d5731f98b069d"
+      network_throughput_bytes_per_sec: 250056549656
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 128
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7a54c034380c02751b62ec1327003385"
+      network_throughput_bytes_per_sec: 36689358
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7bf42174397e4f9e9e4164a352814b3d"
+      network_throughput_bytes_per_sec: 22652077640
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7c944feb506c3fd2ab7c35af07f3d758"
+      network_throughput_bytes_per_sec: 155357539054
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7ce0f5f18004ff9348daed57054665a7"
+      network_throughput_bytes_per_sec: 438015250185
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7d0d5395979bcdd88ab169ef67df3d5e"
+      network_throughput_bytes_per_sec: 48588374
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7d103ef6ef882da52bf468af2e2c89af"
+      network_throughput_bytes_per_sec: 5507123
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7d24ed151e4cd5c7633745a7ba79ff0b"
+      network_throughput_bytes_per_sec: 112311579116
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7d3fc6383c3bfc8d9b3e2269bf971b44"
+      network_throughput_bytes_per_sec: 21964076622
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7d507fb5fef893d318380fcd6940e951"
+      network_throughput_bytes_per_sec: 98022663468
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7db0a796043ec024eff5d858a1fb8cee"
+      network_throughput_bytes_per_sec: 89588801
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7ea858b3ed721e1f90bd0ad4e02171de"
+      network_throughput_bytes_per_sec: 57318321503
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7fd67d96daadd70a6f60920d4dcc86e5"
+      network_throughput_bytes_per_sec: 21553130
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "815e0561d46aa81f847e03864d64d42c"
+      network_throughput_bytes_per_sec: 621972515
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "82f362e9d321c948d13b3b80b6127e69"
+      network_throughput_bytes_per_sec: 118943112911
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "833cc5cec9d7cfba5770633083f5fb7e"
+      network_throughput_bytes_per_sec: 20070363
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8347a8a2df0cb35df36c10079023ab76"
+      network_throughput_bytes_per_sec: 2992511415
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "847322655433140629869e9781d50b4f"
+      network_throughput_bytes_per_sec: 26545891824
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "84feeac9978d4c556ab80dddd4768654"
+      network_throughput_bytes_per_sec: 1916257309
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "85e994016d8e47f32a5448d4032a348e"
+      network_throughput_bytes_per_sec: 33761673
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "85f5b62cb98aabd24d2b37c5dd910965"
+      network_throughput_bytes_per_sec: 33085621
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "863b7bb32c372a2dd7cae3096429baa4"
+      network_throughput_bytes_per_sec: 157988120
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "869218e49384a9020f9fbb1c8eb247de"
+      network_throughput_bytes_per_sec: 30313346
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "87a721da93ba6a8f0a6509223c6879d3"
+      network_throughput_bytes_per_sec: 14147359
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "89bf703c6da6a800c76bc44e3eeb91c1"
+      network_throughput_bytes_per_sec: 78368542747
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "89e6821bfad18005a5bee029eeb23f19"
+      network_throughput_bytes_per_sec: 139599570647
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "8a1da081231362bd028addc1b51d9c9b"
+      network_throughput_bytes_per_sec: 56083704946
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8b64b5d8f00d6d6ee4305d45a2ba83df"
+      network_throughput_bytes_per_sec: 16934366925
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8ba146534a3ced22d98ec89e13791de1"
+      network_throughput_bytes_per_sec: 24190595
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8c69870b341e765e470f58443bad0c5d"
+      network_throughput_bytes_per_sec: 41659753675
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8ced1638c13ee23a87f2ed048b266463"
+      network_throughput_bytes_per_sec: 375177467
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "8e2053ca4b68a7a30436f17d2fb23d82"
+      network_throughput_bytes_per_sec: 61577086439
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8e275b21c1aefcc7d9d9fdd8dadee7e3"
+      network_throughput_bytes_per_sec: 201236840369
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8e977f1d0af1a26d296c1aaa638dd4e2"
+      network_throughput_bytes_per_sec: 65679160044
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8eaf5a05d48989b38e5eaea491d6f0fb"
+      network_throughput_bytes_per_sec: 62100576691
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8ee9101aaefcb090d2a2098aa6d87667"
+      network_throughput_bytes_per_sec: 110250802231
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8f0369c1d10b99cad34e0efd03d26027"
+      network_throughput_bytes_per_sec: 494984894
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8fc7520997c9861590d3a11efee5e464"
+      network_throughput_bytes_per_sec: 1570100622
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8fe6f4a6145f5e93f984c0c9d228bffa"
+      network_throughput_bytes_per_sec: 4276411092
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "910aa36c56dc61f73860235229ece2c0"
+      network_throughput_bytes_per_sec: 3254021847
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "921e6393a965bcd40b2ee3799112ec42"
+      network_throughput_bytes_per_sec: 61835282
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "922a53422acacfe04e053f1e422ba8fd"
+      network_throughput_bytes_per_sec: 2509323429
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "92c147798a31c7520d2ee0ded8ad804a"
+      network_throughput_bytes_per_sec: 441110281080
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9324434db5366a8bec594bb1549c6777"
+      network_throughput_bytes_per_sec: 227757895808
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9336904dbf1c1d1c5b645493ee702e0f"
+      network_throughput_bytes_per_sec: 719851495
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "936f0c4ef7edb565c9896c0c4870960b"
+      network_throughput_bytes_per_sec: 53349071483
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "94a2bd79958b89a1cd906d3f4f29d6e0"
+      network_throughput_bytes_per_sec: 19297997644
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "94b441a1f24803f223f997cfc3551595"
+      network_throughput_bytes_per_sec: 486684493694
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9553913f2f28f76f48cad5808ac047a8"
+      network_throughput_bytes_per_sec: 183747136004
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "956a8ba9e3cb2a85b1f2051634580fa9"
+      network_throughput_bytes_per_sec: 55356099749
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9599ceb31c1d43d9bd34666de402264a"
+      network_throughput_bytes_per_sec: 6815928030
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "95a914bf79d60997a74f1dd9115ba2cf"
+      network_throughput_bytes_per_sec: 61188210
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9673d884e9031593a3e8c06b1d1286f0"
+      network_throughput_bytes_per_sec: 211841067
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "96db7ac42e083786dd2e2ace91847307"
+      network_throughput_bytes_per_sec: 122176111535
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "96f8309cce55a9949e1f2f0f3e0ec690"
+      network_throughput_bytes_per_sec: 4981074713
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "971ba4331155d73cf505b7046e927999"
+      network_throughput_bytes_per_sec: 146909536694
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9885b3b7a489530a5723707a6c245d21"
+      network_throughput_bytes_per_sec: 126669612462
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "99ed8a570257a0c3cc345f86a8001dfd"
+      network_throughput_bytes_per_sec: 122055007527
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9a00b4aca393f1e9d49eb3b5f09fc1c0"
+      network_throughput_bytes_per_sec: 206445617532
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9a2fa6100fdf7452201647b34f24d846"
+      network_throughput_bytes_per_sec: 408798446649
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9a97c97d215983128682ba3ef92d46a0"
+      network_throughput_bytes_per_sec: 233688337149
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9b4cd34c3b54a338ab91020d2c23470e"
+      network_throughput_bytes_per_sec: 125034214978
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9bb2cf7ea4be08f4379c34a8776dd615"
+      network_throughput_bytes_per_sec: 52164391739
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9c3c4a224e66a397bfac9accf9cc1a7f"
+      network_throughput_bytes_per_sec: 116620813457
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "9ce58729ac6905e5deb36d1567798b01"
+      network_throughput_bytes_per_sec: 62325165999
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9dc805264207f639505e60a61756f2ff"
+      network_throughput_bytes_per_sec: 27736253562
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9eba46fe48d732fc74500cac8fb7c3fe"
+      network_throughput_bytes_per_sec: 43298052554
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9f256fa6769acb746028a86f3a24c32b"
+      network_throughput_bytes_per_sec: 40461735850
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9f89f8e474b2d2108395576f404592f0"
+      network_throughput_bytes_per_sec: 10565414
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a16a4afaeeda93a334f1127435c9c469"
+      network_throughput_bytes_per_sec: 9836547842
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a1b2a20ae014e046611855ab2efdfda5"
+      network_throughput_bytes_per_sec: 119342836818
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a25e0b6606b5a56f34374dda554164b2"
+      network_throughput_bytes_per_sec: 61821317615
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a275e77e76f7666c635ad7320b1e2e59"
+      network_throughput_bytes_per_sec: 63257777923
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a35c1aa8de7b8a1b684b1b36ab4b04fd"
+      network_throughput_bytes_per_sec: 51175012201
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a41f12bbaed25af2cec9dd82edd3f358"
+      network_throughput_bytes_per_sec: 285810444544
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a4ff2d7f7e21480824c17556c4ea5f1e"
+      network_throughput_bytes_per_sec: 23589745897
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a72278a0ffa1250acd42babc5e4a2c7a"
+      network_throughput_bytes_per_sec: 223768844970
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "a76344596468a7872eadbfd9a21739c6"
+      network_throughput_bytes_per_sec: 30752734844
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a7d84fd4843073d498edbcd00f7ab6a4"
+      network_throughput_bytes_per_sec: 24650642
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a931cd9a10313d6131a6be303bf5d394"
+      network_throughput_bytes_per_sec: 2317356482
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a976ae7da30669c0a2326985521dd531"
+      network_throughput_bytes_per_sec: 6009720311
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "aa25b0c2ebe85af31775495126132917"
+      network_throughput_bytes_per_sec: 20037568912
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "aa54856c98f8ee17f5ae47bd848f98ac"
+      network_throughput_bytes_per_sec: 95316155019
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "aa8ffa9987c29072b26beb5ec031d86a"
+      network_throughput_bytes_per_sec: 14383758573
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "aaf348636c4e381eafbb9006118444ae"
+      network_throughput_bytes_per_sec: 82446835
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ab056536331bdda05cf9fb4e4e83c9ac"
+      network_throughput_bytes_per_sec: 123393751511
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "aba5522f4f72600896d0d38c2bace66e"
+      network_throughput_bytes_per_sec: 2183077948
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "abcc51b30fadae6e7deab4c52594727a"
+      network_throughput_bytes_per_sec: 11203501
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ac966f268b5c7c7311f92df25cfd603b"
+      network_throughput_bytes_per_sec: 389719437
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ace313bb59b4ef2c1f109158e10e2bc6"
+      network_throughput_bytes_per_sec: 23728538939
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "ad849cba863d23a00310bcc3ee950a88"
+      network_throughput_bytes_per_sec: 1237649191
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "adf9fe649eb56b23ae6e148efc55dbac"
+      network_throughput_bytes_per_sec: 15347784722
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "aefb2f182dc06d72825918161ea66565"
+      network_throughput_bytes_per_sec: 64228727433
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "af1dcdb3cca467fabadbfb453250b83e"
+      network_throughput_bytes_per_sec: 63886736447
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "af4f3c69b95e67b20c2ec30b01c7411a"
+      network_throughput_bytes_per_sec: 86036563915
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b00e61bfb66f71c42590fb44fafcd46c"
+      network_throughput_bytes_per_sec: 14417280233
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "b195ecd43415c6e2133f67d283c70392"
+      network_throughput_bytes_per_sec: 2484965684
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b1c4513e7ed44592d1eb64d50a5cceb1"
+      network_throughput_bytes_per_sec: 227056651779
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b1ee9be4f8941e8c5707b526de55ebcd"
+      network_throughput_bytes_per_sec: 15896908779
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b21eaf2dedc72a5542590064bb4f26bb"
+      network_throughput_bytes_per_sec: 256478894
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b2859bcf4713290fc071dba2107dd573"
+      network_throughput_bytes_per_sec: 13844232318
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "b2df91aa80c387f126f650e678c520b4"
+      network_throughput_bytes_per_sec: 28925436539
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b2fae3c053c9425aa7b2455cd42ed715"
+      network_throughput_bytes_per_sec: 98088569148
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b48e2044f7d3c623aadb3f9db7443ff5"
+      network_throughput_bytes_per_sec: 40494115
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b497a392f67a4f5b4072540892de137a"
+      network_throughput_bytes_per_sec: 98376148913
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b4d98a0368b1e111b67f10765613016d"
+      network_throughput_bytes_per_sec: 14662084
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b4ed48d632b88bc005d30df32b363ad9"
+      network_throughput_bytes_per_sec: 188019279
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "b52cca147cee2cf2afd9b52e23b0e447"
+      network_throughput_bytes_per_sec: 27947866414
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b7fbaf6afe0c082466ed59153b00a307"
+      network_throughput_bytes_per_sec: 101662943
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b97f24bb846a88481c2900cac902f6f1"
+      network_throughput_bytes_per_sec: 121362962
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ba06c43b0e9a16e6f70a35cf45d16045"
+      network_throughput_bytes_per_sec: 20527911825
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bb0c837eadcc79bc10233ea7ef4010a9"
+      network_throughput_bytes_per_sec: 33737695160
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bbc9ee9d4267db9c368730cb88915520"
+      network_throughput_bytes_per_sec: 114753007326
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bc9fc8450274035530c5644ee6a0cbc1"
+      network_throughput_bytes_per_sec: 51834978
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bcdb32b92ed02a87807bb1839f3142cf"
+      network_throughput_bytes_per_sec: 40555631834
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bd1b66688dfceaa021489d8ae3cf3eda"
+      network_throughput_bytes_per_sec: 208498237
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bd7b374fb5b1baf0fcab53db4ed3a18a"
+      network_throughput_bytes_per_sec: 111202207179
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bdc2c7412dbec535a96e650e8b71faba"
+      network_throughput_bytes_per_sec: 27335140771
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "be5aa918f7da473d687285a4e6e7e13f"
+      network_throughput_bytes_per_sec: 53111344
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "be83c13222556564f80565d69e4c5314"
+      network_throughput_bytes_per_sec: 43031301617
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "beaf14cc7bbcb59673df046c2e6aba77"
+      network_throughput_bytes_per_sec: 64811522372
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "bfac5cabd46928be7a0f7846d91a4c68"
+      network_throughput_bytes_per_sec: 2468585204
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c057bfe7ad7cd11029ee0025cf8c22e6"
+      network_throughput_bytes_per_sec: 9442922
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c06280b5ee6c4fa8a084614ad718f48d"
+      network_throughput_bytes_per_sec: 13999679572
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c25a500ce3140b364a6832b1b1362e4b"
+      network_throughput_bytes_per_sec: 22889674743
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c2aa34383cf2e341115876c717901bc4"
+      network_throughput_bytes_per_sec: 1896296296
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c33b5cae9b992934b5065b3df33efc63"
+      network_throughput_bytes_per_sec: 131661390443
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c34ec0c1f1d1ba3d22754d726aa60897"
+      network_throughput_bytes_per_sec: 82588612891
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c367cbc0001b4184f03992ff46f035c8"
+      network_throughput_bytes_per_sec: 222323182412
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c389be608049d2735a7f0f2da2adad8c"
+      network_throughput_bytes_per_sec: 206284432039
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c3b34f754c1e17af82ed0baa3ab2e457"
+      network_throughput_bytes_per_sec: 81952781
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "c41feadc1950e49d7e9eec9400f6e9d9"
+      network_throughput_bytes_per_sec: 59089684708
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c4bc78586046f9edb53d96b66049914a"
+      network_throughput_bytes_per_sec: 36350727
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c52376a097b88c64ce5161577dba2070"
+      network_throughput_bytes_per_sec: 9943581
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c5cd6dc54b5be0e57e2f5ff3b8b297a9"
+      network_throughput_bytes_per_sec: 14452967
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c654748a7104d2a0a9f9d067a746c65d"
+      network_throughput_bytes_per_sec: 112813603086
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c66e53fff207188081e98dfa77807537"
+      network_throughput_bytes_per_sec: 449185425155
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c6c8164390d18c7b8227ed85b0d93966"
+      network_throughput_bytes_per_sec: 90652618042
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c78e7b3217fa35a2d658c44700e18a84"
+      network_throughput_bytes_per_sec: 282062457444
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c847e212ae13666202c7fac95f296bb2"
+      network_throughput_bytes_per_sec: 21535535679
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c899fb206acc512aabad1c825500db25"
+      network_throughput_bytes_per_sec: 799404740
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "cb2bdec86e4c8f9a34f3e9f665f1a785"
+      network_throughput_bytes_per_sec: 34311761193
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "cb65fce6da1bd8410e8959d7b3b9b93d"
+      network_throughput_bytes_per_sec: 418599897
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "cbd1ef2c36141930a966889cfc48d322"
+      network_throughput_bytes_per_sec: 106792292556
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ce91af68036c36a9df8e3bbf567eee09"
+      network_throughput_bytes_per_sec: 220927723
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ceb6ede44fdcea933bdbf9fb08da4047"
+      network_throughput_bytes_per_sec: 19036818
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "cf9f897c04f74b0a135ecb4c11a26855"
+      network_throughput_bytes_per_sec: 66197457406
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "cfcef6f6eec1f07ea7bf67c6f7a8ae9a"
+      network_throughput_bytes_per_sec: 468371569901
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d1a6a800b1ee86a32a33db83fcf204e3"
+      network_throughput_bytes_per_sec: 13593155302
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "d2314470d36c1fb289de20e57d81e109"
+      network_throughput_bytes_per_sec: 59071688241
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d2b7c2d576d861a8c7c91e1bf57c188f"
+      network_throughput_bytes_per_sec: 7135014493
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "d2c52c9c7d7442d814395a7590d04e39"
+      network_throughput_bytes_per_sec: 53627028927
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d32b95bcb7f76a67d13b3caf116bf903"
+      network_throughput_bytes_per_sec: 134615111810
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d3ad67df0aff5eb378644f9090463629"
+      network_throughput_bytes_per_sec: 10538346348
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "d3b910fdeb6b07245ce93ccb67ea88bd"
+      network_throughput_bytes_per_sec: 1248590153
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d4331b2f624a701455e129bb32031a61"
+      network_throughput_bytes_per_sec: 230955737
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d46bc24d789e134da2ba22676a05d2a5"
+      network_throughput_bytes_per_sec: 45383077256
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "d650b9830fd51944cce5307dad5a78b6"
+      network_throughput_bytes_per_sec: 64930518162
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d941f2611b4071dac72664214a7d5d29"
+      network_throughput_bytes_per_sec: 463283034758
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "daa2296a0f8546b3da95ed15254e621b"
+      network_throughput_bytes_per_sec: 180069560457
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "dab6356615fe22377f82fa76542aacfd"
+      network_throughput_bytes_per_sec: 1047235538
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "dbc9494722e22aa9d9bbc19961fa2bd5"
+      network_throughput_bytes_per_sec: 38685304
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "dc56556d1adadef6f24e57a9b7767495"
+      network_throughput_bytes_per_sec: 61354104
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "dce7d2c5dcc9ed1735611e790b3ca454"
+      network_throughput_bytes_per_sec: 9553004628
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "dced792a6bb96b549cd4ed3e96bb281d"
+      network_throughput_bytes_per_sec: 9502791270
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "de1e3e1a4c273794678bc61b5d653b96"
+      network_throughput_bytes_per_sec: 1162800188
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "dec343e95dd864ed86b8292ac32fc83d"
+      network_throughput_bytes_per_sec: 1245174038
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "dee38aee4309c8a7e6c8bffa59ecf6fc"
+      network_throughput_bytes_per_sec: 759925788
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "df69c417ad310e1b1bb927730e2f10c0"
+      network_throughput_bytes_per_sec: 244387762
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "df795aac25ae021df12f1fc1c95816a9"
+      network_throughput_bytes_per_sec: 50705448566
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "e00ef2e375e79ce3a18a56da684651bd"
+      network_throughput_bytes_per_sec: 64946443741
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e05052a696f34e30c1714e84b65c4039"
+      network_throughput_bytes_per_sec: 197766984054
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e062c8ee9e86b399c11f6e70eeea5ab8"
+      network_throughput_bytes_per_sec: 24585315529
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e0693614b2f73e7073f66010f736214a"
+      network_throughput_bytes_per_sec: 221103771611
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "e1112f0402903c243e8cc21c4f38b20e"
+      network_throughput_bytes_per_sec: 311969229
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e116b749dc6fb00963e1e1c912a89c03"
+      network_throughput_bytes_per_sec: 351278064509
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 64
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e1b4ad01f4943d5c7e83afcac9a37b2b"
+      network_throughput_bytes_per_sec: 9937791
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e258bb39ba3efefc2c6bba1c0f94e170"
+      network_throughput_bytes_per_sec: 38994654196
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e2f8ceafe05d7294298b62da832dd887"
+      network_throughput_bytes_per_sec: 60357839636
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e45127722646074a5d9b4c24ebc6b49a"
+      network_throughput_bytes_per_sec: 785417240
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e45ba4475adc9a853d150aca5d1333d1"
+      network_throughput_bytes_per_sec: 655360000
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e48d6a945ecb9b02cc16939023bc2d96"
+      network_throughput_bytes_per_sec: 3082560176
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e4b01b4ff61fcac06330fb733e0e9d49"
+      network_throughput_bytes_per_sec: 7346982245
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e4c3db92efad6de5e5840e659c4c13ad"
+      network_throughput_bytes_per_sec: 11826800960
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e5806ec9f07cc39cc732e915835ae9bd"
+      network_throughput_bytes_per_sec: 2316578296
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e5db97fda4f5b604f27655ea77479506"
+      network_throughput_bytes_per_sec: 3556906377
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e6875d068a859fc9c823bbaa445bd205"
+      network_throughput_bytes_per_sec: 124879402388
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e6ae5e4e282b8bdb0243f76430a739a4"
+      network_throughput_bytes_per_sec: 2866183400
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "e747471da878022b0e610cf02be16904"
+      network_throughput_bytes_per_sec: 78197785
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e75477358c94574e1c6b9b50b78af270"
+      network_throughput_bytes_per_sec: 50233014
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "e7ff1ad5ce23298c66709c1a761fc80c"
+      network_throughput_bytes_per_sec: 18177304718
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e8636d435d0fae43c0c2a9e79a42691f"
+      network_throughput_bytes_per_sec: 109750948950
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e8ee4f3c9505eedcf86568c849ec03be"
+      network_throughput_bytes_per_sec: 544499833
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ea0954193cc480c6593f553bd3438c9e"
+      network_throughput_bytes_per_sec: 894811578
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "eac6121ff38a66212e2843295c8e1d87"
+      network_throughput_bytes_per_sec: 46800459713
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ed727b57d6a3ae32b3e8b3c460375593"
+      network_throughput_bytes_per_sec: 104572313656
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ed7f56a0e4cc2f90edd777cc7d0902f0"
+      network_throughput_bytes_per_sec: 4802887478
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ed9bb4a33c886916d5e152a46eac4310"
+      network_throughput_bytes_per_sec: 121494284605
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "edb08e654b739c98c5c485d7a96dd456"
+      network_throughput_bytes_per_sec: 1710653737
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 128
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ee756f40fb626c4aa03d562de5e5d7e4"
+      network_throughput_bytes_per_sec: 11034482
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "eebcf31aeb46f251deb8c25cfb0f09fc"
+      network_throughput_bytes_per_sec: 20238677488
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ef16ed48f2ab9a546f3605e4c3340419"
+      network_throughput_bytes_per_sec: 223166193623
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ef4fee03912d152ba48c7a9651d5e2ec"
+      network_throughput_bytes_per_sec: 29570254226
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ef6169f1bb54bc4a3a7a051048934504"
+      network_throughput_bytes_per_sec: 178860147706
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "efe3f776e8fbfab41dbe68168e3aa2e7"
+      network_throughput_bytes_per_sec: 17522245
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f0faf27f86b3a156830f2f3379c1a78a"
+      network_throughput_bytes_per_sec: 66085834
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "f11a1d62b4764b85d44c1b9054a4ee0c"
+      network_throughput_bytes_per_sec: 313665428
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 64
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f2247e58f9dfdee0211213f74e5f7feb"
+      network_throughput_bytes_per_sec: 25122669
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f2b280da4c9e108e14768760ebb4c392"
+      network_throughput_bytes_per_sec: 419887237
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "f2f94c05790a5d153abc20208696a019"
+      network_throughput_bytes_per_sec: 62358285122
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f33c96d99b16c475e9426acbf66dd505"
+      network_throughput_bytes_per_sec: 362375508595
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f4b02e73323ebe8b582ef8eea7eed6ba"
+      network_throughput_bytes_per_sec: 358000884
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f53f76968e917ef5f386872467c6ef38"
+      network_throughput_bytes_per_sec: 122384995867
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f569c9c702eb778090e38c0661443be4"
+      network_throughput_bytes_per_sec: 187778556898
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f5c609ce87a73de10f144d4057f242ed"
+      network_throughput_bytes_per_sec: 12527640052
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f650becd3ab75fdbc10bd51f46be4d0b"
+      network_throughput_bytes_per_sec: 57893893044
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f6900c72e82afa0a8c995380ea03dc9d"
+      network_throughput_bytes_per_sec: 100564694
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f6d023ca703280822f935c8b9b234a39"
+      network_throughput_bytes_per_sec: 304648568
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f72d81e32fb5cab52e1fbd4536ece85b"
+      network_throughput_bytes_per_sec: 43585788363
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f8236051598e374faf860e419eeb4ff9"
+      network_throughput_bytes_per_sec: 6816858556
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 64
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f8b5ec938cad8a87a80fc1dcd768c66b"
+      network_throughput_bytes_per_sec: 12015817
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f91111ab5af2a4c95a894ac69a514d2d"
+      network_throughput_bytes_per_sec: 33056990408
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f950cb6fec3ae1196c4e2b9969e4649f"
+      network_throughput_bytes_per_sec: 84054188376
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f97af309039c11855739ecdeec9bbc9c"
+      network_throughput_bytes_per_sec: 906934584
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f99414bac0801687d5d0b26afffa8232"
+      network_throughput_bytes_per_sec: 64932388
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fa424be17588fdb480397be00ca54b0c"
+      network_throughput_bytes_per_sec: 21828801
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "fa7774e70aad1ce38ac3bf38250e0a71"
+      network_throughput_bytes_per_sec: 64145854715
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "fb36e95d966ca073a983033d1cd853ee"
+      network_throughput_bytes_per_sec: 38360680
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fbc3523926dbdd757c935102891781d6"
+      network_throughput_bytes_per_sec: 207669011273
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fbda4473b6de260c6512121cc16e8f04"
+      network_throughput_bytes_per_sec: 375767402143
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fcc44e04fa5b43db434b13c1ff2715b0"
+      network_throughput_bytes_per_sec: 242008862
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fcfc7148888759b910ebf6b82fb52f3d"
+      network_throughput_bytes_per_sec: 98840091669
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fd1abf3e9a2d65d8c9875426308088db"
+      network_throughput_bytes_per_sec: 1368183716
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fdd21857630c37298563cd2c4a3d9d0b"
+      network_throughput_bytes_per_sec: 307507507
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fdf5fd552cc8266498cf173283d68c43"
+      network_throughput_bytes_per_sec: 103356043
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fdfd9b0e1d6925288b99fa31fb770d0f"
+      network_throughput_bytes_per_sec: 91756272
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 128
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "feace905f214b6dc5980b277dfb00077"
+      network_throughput_bytes_per_sec: 13041263
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "ff47ecd6d22ac749c3efe918866b3b13"
+      network_throughput_bytes_per_sec: 4775806157
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ff59d8600ca5d7625580430f6114aecd"
+      network_throughput_bytes_per_sec: 168919120830
+    }
+  }
+}

--- a/xla/service/gpu/model/default_matmul_perf_table.txtpb
+++ b/xla/service/gpu/model/default_matmul_perf_table.txtpb
@@ -8275,3 +8275,8258 @@ entries {
     }
   }
 }
+entries {
+  key: "gfx950"
+  value {
+    entries {
+      b: 1
+      m: 256
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 8603700512820 }
+      flops { key: "bf16xbf16->f32" value: 9642078160919 }
+      flops { key: "f16xf16->f16" value: 9754195348837 }
+      flops { key: "f16xf16->f32" value: 6990506666666 }
+      flops { key: "f32xf32->f32" value: 7423546902654 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 8830113684210 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 5886742456140 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 9118052173913 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 7951287203791 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 6078701449275 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 8516353299492 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 9167877595628 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 9218250549450 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 5805265051903 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 9425402247191 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 9020008602150 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 15462871889400 }
+      flops { key: "bf16xbf16->f32" value: 17119608163265 }
+      flops { key: "f16xf16->f16" value: 17848102127659 }
+      flops { key: "f16xf16->f32" value: 18538360220994 }
+      flops { key: "f32xf32->f32" value: 10652200634920 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 14401043776824 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 11413072108843 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 15978300952380 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 18436501098901 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 11452024573378 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 17032706598984 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 16611104950495 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 18436501098901 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 11450070636410 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 15606712558139 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 14039511297071 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 31805148815165 }
+      flops { key: "bf16xbf16->f32" value: 34592197938144 }
+      flops { key: "f16xf16->f16" value: 35686713108215 }
+      flops { key: "f16xf16->f32" value: 36080034408602 }
+      flops { key: "f32xf32->f32" value: 19796125073746 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 31956601904761 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 22221478145695 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 34065413197969 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 37076720441988 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 23221060207612 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 35135530890052 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 31956601904761 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 36873002197802 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 22595577104377 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 34414802051282 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 36275061621621 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 62426850232558 }
+      flops { key: "bf16xbf16->f32" value: 44881366995485 }
+      flops { key: "f16xf16->f16" value: 58355533913043 }
+      flops { key: "f16xf16->f32" value: 53473198406374 }
+      flops { key: "f32xf32->f32" value: 34592197938144 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 58102912554112 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 42744499363057 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 52022375193798 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 61567765137614 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 41936487423840 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 57604175107296 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 53902702008032 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 66117107389162 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 44150568421052 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 58102912554112 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 57358003418803 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 85488998726114 }
+      flops { key: "bf16xbf16->f32" value: 81591324012158 }
+      flops { key: "f16xf16->f16" value: 88301136842105 }
+      flops { key: "f16xf16->f32" value: 83886080000000 }
+      flops { key: "f32xf32->f32" value: 46522609358752 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 118776750442477 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 65793003921568 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 92563950344827 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 100915584962406 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 67615983879093 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 102066713307984 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 97969144525547 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 109120104065040 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 66117107389162 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 99420539259259 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 98328005860805 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 17207401025641 }
+      flops { key: "bf16xbf16->f32" value: 14339500854700 }
+      flops { key: "f16xf16->f16" value: 18538360220994 }
+      flops { key: "f16xf16->f32" value: 17753667724867 }
+      flops { key: "f32xf32->f32" value: 14039511297071 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 15114609009009 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 17119608163265 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 16131938461538 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 17567765445026 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 18040017204301 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 17753667724867 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 17567765445026 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 17032706598984 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 17476266666666 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 16368015609756 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 16861523618090 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 33723047236180 }
+      flops { key: "bf16xbf16->f32" value: 35887093048128 }
+      flops { key: "f16xf16->f16" value: 32736031219512 }
+      flops { key: "f16xf16->f32" value: 31359282242990 }
+      flops { key: "f32xf32->f32" value: 21372249681528 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 24403223272727 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 24855134814814 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 25228896240601 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 27962026666666 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 26011187596899 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 29177766956521 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 26630501587301 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 22519753020134 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 25324099622641 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 22904049146757 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 25228896240601 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 46765758885017 }
+      flops { key: "bf16xbf16->f32" value: 46442120415224 }
+      flops { key: "f16xf16->f16" value: 48620803477630 }
+      flops { key: "f16xf16->f32" value: 51033356653992 }
+      flops { key: "f32xf32->f32" value: 33058553694581 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 56158045188284 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 26317201568627 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 56859872061004 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 56394003361344 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 26472924654832 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 59918628571428 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 60187321973094 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 58867424561403 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 26525242687747 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 54120051612903 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 53902702008032 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 88592559735973 }
+      flops { key: "bf16xbf16->f32" value: 92547993794173 }
+      flops { key: "f16xf16->f16" value: 96213425089605 }
+      flops { key: "f16xf16->f32" value: 93842145079531 }
+      flops { key: "f32xf32->f32" value: 51424416858237 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 118776750442477 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 51033356653992 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 111848106666666 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 120916872072072 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 54011158148893 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 91929950684931 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 108240103225806 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 110014531147540 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 51921751644100 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 106522006349206 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 111848106666666 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 172074010256410 }
+      flops { key: "bf16xbf16->f32" value: 170435210158730 }
+      flops { key: "f16xf16->f16" value: 173184165161290 }
+      flops { key: "f16xf16->f32" value: 167249505295950 }
+      flops { key: "f32xf32->f32" value: 73639793155476 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 191739611428571 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 76471891175842 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 192426850179211 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 205697667432950 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 173184165161290 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 195225786181818 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 187717102097902 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 207286066409266 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 167772160000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 201075247940074 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 189039053521126 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 30229218018018 }
+      flops { key: "bf16xbf16->f32" value: 32109504306220 }
+      flops { key: "f16xf16->f16" value: 31655124528301 }
+      flops { key: "f16xf16->f32" value: 31359282242990 }
+      flops { key: "f32xf32->f32" value: 21859564820846 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 24763418450184 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 25614070229007 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 26843545600000 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 24947533085501 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 25134405992509 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 27385784125688 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 26843545600000 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 24577500091558 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 25910758301158 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 26011187596899 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 24314805797101 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 56158045188284 }
+      flops { key: "bf16xbf16->f32" value: 54560052032520 }
+      flops { key: "f16xf16->f16" value: 48454053429602 }
+      flops { key: "f16xf16->f32" value: 53261003174603 }
+      flops { key: "f32xf32->f32" value: 42473964556962 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 49526836900369 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 49895066171003 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 44150568421052 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 51033356653992 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 47259763380281 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 49164002930402 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 43577184415584 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 48106712544802 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 50081241791044 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 48629611594202 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 47426759010600 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 99790132342007 }
+      flops { key: "bf16xbf16->f32" value: 105683250393700 }
+      flops { key: "f16xf16->f16" value: 112316090376569 }
+      flops { key: "f16xf16->f32" value: 101296398490566 }
+      flops { key: "f32xf32->f32" value: 71966610187667 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 70455500262467 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 68820780925522 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 71573245167311 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 70827297097625 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 69184395876288 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 62426850232558 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 74565404444444 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 71203038726790 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 70817954359583 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 70827297097625 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 68130826395939 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 123988663279445 }
+      flops { key: "bf16xbf16->f32" value: 125437128971962 }
+      flops { key: "f16xf16->f16" value: 126620498113207 }
+      flops { key: "f16xf16->f32" value: 128131482577565 }
+      flops { key: "f32xf32->f32" value: 73043661496598 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 144709140700808 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 115456110107526 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 142784817021276 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 149525389778582 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 184491722336769 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 148306881767955 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 149546215041782 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 150806435955056 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 168800789812922 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 138726333850129 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 140911000524934 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 227487674576271 }
+      flops { key: "bf16xbf16->f32" value: 222306795859213 }
+      flops { key: "f16xf16->f16" value: 239674514285714 }
+      flops { key: "f16xf16->f32" value: 223672914071450 }
+      flops { key: "f32xf32->f32" value: 96127289525514 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 261888249756097 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 152520145454545 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 253240996226415 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 268435456000000 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 310330006936416 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 267766040897755 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 252052071361502 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 255045563895486 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 292572704087193 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 247405950230414 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 256262965155131 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 57113926808510 }
+      flops { key: "bf16xbf16->f32" value: 53687091200000 }
+      flops { key: "f16xf16->f16" value: 56631952742616 }
+      flops { key: "f16xf16->f32" value: 58102912554112 }
+      flops { key: "f32xf32->f32" value: 41547044729917 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 45191154208754 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 47093939649122 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 45343827027027 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 47934902857142 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 48806446545454 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 42473964556962 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 48806446545454 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 48106712544802 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 49344752941176 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 48629611594202 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 48629611594202 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 98689505882352 }
+      flops { key: "bf16xbf16->f32" value: 95869805714285 }
+      flops { key: "f16xf16->f16" value: 108240103225806 }
+      flops { key: "f16xf16->f32" value: 107374182400000 }
+      flops { key: "f32xf32->f32" value: 70827297097625 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 75615621408450 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 66774989054726 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 75615621408450 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 73543960547945 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 74773107520891 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 74773107520891 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 71392408510638 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 70455500262467 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 68644791203170 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 70827297097625 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 70640909473684 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 186413511111111 }
+      flops { key: "bf16xbf16->f32" value: 191057264056939 }
+      flops { key: "f16xf16->f16" value: 176602273684210 }
+      flops { key: "f16xf16->f32" value: 191057264056939 }
+      flops { key: "f32xf32->f32" value: 102066713307984 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 102652182026768 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 99790132342007 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 100537623970037 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 244032232727272 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 238609294222222 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 244032232727272 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 233422135652173 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 215610808032128 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 238609294222222 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 225576013445378 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 223696213333333 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 302462485633802 }
+      flops { key: "bf16xbf16->f32" value: 281084247120418 }
+      flops { key: "f16xf16->f16" value: 303316899435028 }
+      flops { key: "f16xf16->f32" value: 237029100220750 }
+      flops { key: "f32xf32->f32" value: 153391689142857 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 260616947572815 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 269108226566416 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 259985913801452 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 399086349749117 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 384853700358422 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 342993714742054 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 391876578102189 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 368983444673539 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 344148020512820 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 343048506070287 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 328361414067278 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 264794531196054 }
+      flops { key: "bf16xbf16->f32" value: 257183670419161 }
+      flops { key: "f16xf16->f16" value: 273216749109414 }
+      flops { key: "f16xf16->f32" value: 260917762954863 }
+      flops { key: "f32xf32->f32" value: 105628668650549 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 307200292969029 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 189205607753303 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 316738001179941 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 307662413753581 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 442780133608247 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 307662413753581 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 307222267238912 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 305909351566951 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 444613591718426 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 300347363356643 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 302037081293952 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 105683250393700 }
+      flops { key: "bf16xbf16->f32" value: 108678322267206 }
+      flops { key: "f16xf16->f16" value: 112292598201213 }
+      flops { key: "f16xf16->f32" value: 106946396812749 }
+      flops { key: "f32xf32->f32" value: 56992665817409 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 67446094472361 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 66941510224438 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 70455500262467 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 59520056762749 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 73746004395604 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 72746736043360 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 61008058181818 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 69006543958868 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 70271061780104 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 57113926808510 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 71966610187667 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 181990139661016 }
+      flops { key: "bf16xbf16->f32" value: 169895858227848 }
+      flops { key: "f16xf16->f16" value: 183232393174061 }
+      flops { key: "f16xf16->f32" value: 172627302893890 }
+      flops { key: "f32xf32->f32" value: 113973232565545 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 98871254511970 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 97790694353369 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 87867579705400 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 195938289051094 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 234441446288209 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 216480206451612 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 183859901369863 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 206488812307692 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 220029062295081 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 204133426615969 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 182609153741496 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 277416825733109 }
+      flops { key: "bf16xbf16->f32" value: 302462485633802 }
+      flops { key: "f16xf16->f16" value: 290161281988920 }
+      flops { key: "f16xf16->f32" value: 294984017582417 }
+      flops { key: "f32xf32->f32" value: 155389554848046 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 267766040897755 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 261888249756097 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 259985913801452 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 393312023443223 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 397682157037037 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 375434204195804 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 367719802739726 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 345254605787781 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 346368330322580 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 399160529368029 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 348560890764486 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 379380557901245 }
+      flops { key: "bf16xbf16->f32" value: 425244286732673 }
+      flops { key: "f16xf16->f16" value: 393276009156670 }
+      flops { key: "f16xf16->f32" value: 409044504380952 }
+      flops { key: "f32xf32->f32" value: 201831169924812 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 414572132818532 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 416987116116504 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 407492153320683 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 609993934952421 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 581973888346883 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 596523235555555 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 601536035854341 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 613566756571428 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 604924971267605 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 578836562803234 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 601536035854341 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 547129591847133 }
+      flops { key: "bf16xbf16->f32" value: 509486037485172 }
+      flops { key: "f16xf16->f16" value: 490265087152559 }
+      flops { key: "f16xf16->f32" value: 495382617762399 }
+      flops { key: "f32xf32->f32" value: 210635702704690 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 582763540841248 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 674196263401616 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 629760600586510 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 923549574454359 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 904203641263157 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 904203641263157 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 921666801716738 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 915771278464818 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 869426578137651 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 852091517904969 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 929646600865800 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 18236104347826 }
+      flops { key: "bf16xbf16->f32" value: 16946682828282 }
+      flops { key: "f16xf16->f16" value: 18850804494382 }
+      flops { key: "f16xf16->f32" value: 17476266666666 }
+      flops { key: "f32xf32->f32" value: 11257987585975 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 17385716062176 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 16368015609756 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 17296098969072 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 19173961142857 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 11814940845070 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 17848102127659 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 13584790283400 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 16448250980392 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 11691439721254 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 18745492737430 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 18436501098901 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 35135530890052 }
+      flops { key: "bf16xbf16->f32" value: 37076720441988 }
+      flops { key: "f16xf16->f16" value: 30504029090909 }
+      flops { key: "f16xf16->f32" value: 32896501960784 }
+      flops { key: "f32xf32->f32" value: 19395625433526 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 35887093048128 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 22519753020134 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 32896501960784 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 37282702222222 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 23061465292096 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 37914612429378 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 35320454736842 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 36472208695652 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 22595577104377 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 30643316894977 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 33213988616679 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 62137837037037 }
+      flops { key: "bf16xbf16->f32" value: 62426850232558 }
+      flops { key: "f16xf16->f16" value: 61286633789954 }
+      flops { key: "f16xf16->f32" value: 52841625196850 }
+      flops { key: "f32xf32->f32" value: 35320454736842 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 65154236893203 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 44296279867986 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 48279758273381 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 67786731313131 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 42074522884012 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 64219008612440 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 62137837037037 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 63913203809523 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 43436157928802 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 61286633789954 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 62137837037037 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 87154368831168 }
+      flops { key: "bf16xbf16->f32" value: 78033562790697 }
+      flops { key: "f16xf16->f16" value: 80854053012048 }
+      flops { key: "f16xf16->f32" value: 89478485333333 }
+      flops { key: "f32xf32->f32" value: 55461871074380 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 108240103225806 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 75192004481792 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 97969144525547 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 111384006639004 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 74358852077562 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 109565492244897 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 104044750387596 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 108240103225806 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 74565404444444 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 106100970750988 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 89478485333333 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 182609153741496 }
+      flops { key: "bf16xbf16->f32" value: 163655208657216 }
+      flops { key: "f16xf16->f16" value: 187063035540069 }
+      flops { key: "f16xf16->f32" value: 158345645774959 }
+      flops { key: "f32xf32->f32" value: 74256004426002 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 193816213718411 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 149963941899441 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 180158024161073 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 215610808032128 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 162688155151515 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 188375758596491 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 179525467981942 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 199580264684014 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 162196650151057 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 169895858227848 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 173744631715210 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 33213988616679 }
+      flops { key: "bf16xbf16->f32" value: 32736031219512 }
+      flops { key: "f16xf16->f16" value: 35135530890052 }
+      flops { key: "f16xf16->f32" value: 30643316894977 }
+      flops { key: "f32xf32->f32" value: 23967451428571 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 25040620895522 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 27280026016260 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 26214400000000 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 25910758301158 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 27391373061224 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 28197001680672 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 25516678326996 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 23140987586206 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 26420812598425 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 28802087553648 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 29051456277056 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 48629611594202 }
+      flops { key: "bf16xbf16->f32" value: 51622203076923 }
+      flops { key: "f16xf16->f16" value: 48629611594202 }
+      flops { key: "f16xf16->f32" value: 51033356653992 }
+      flops { key: "f32xf32->f32" value: 20552442845111 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 57604175107296 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 26368905304518 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 62718564485981 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 59918628571428 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 26525242687747 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 57852468965517 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 58610361572052 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 59652323555555 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 27005579074446 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 58355533913043 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 61851487557603 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 104044750387596 }
+      flops { key: "bf16xbf16->f32" value: 101680096969696 }
+      flops { key: "f16xf16->f16" value: 97969144525547 }
+      flops { key: "f16xf16->f32" value: 95528632028469 }
+      flops { key: "f32xf32->f32" value: 56040805010438 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 115208350214592 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 51721667822736 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 110923742148760 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 121464007239819 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 52836424761342 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 117220723144104 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 93206755555555 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 116711067826086 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 51622203076923 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 124275674074074 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 118776750442477 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 177185119471947 }
+      flops { key: "bf16xbf16->f32" value: 168298091536050 }
+      flops { key: "f16xf16->f16" value: 177771825165562 }
+      flops { key: "f16xf16->f32" value: 165191049846153 }
+      flops { key: "f32xf32->f32" value: 78027892159000 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 220934531687242 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 154273250574712 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 172627302893890 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 207286066409266 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 202592796981132 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 221847484297520 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 208089500775193 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 228455707234042 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 177771825165562 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 204912561832061 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 193816213718411 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 240749287892376 }
+      flops { key: "bf16xbf16->f32" value: 218684689205702 }
+      flops { key: "f16xf16->f16" value: 241290297528089 }
+      flops { key: "f16xf16->f32" value: 218240208130081 }
+      flops { key: "f32xf32->f32" value: 95698914795008 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 326365296048632 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 220480867351129 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 316738001179941 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 335544320000000 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 318617751928783 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 298261617777777 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 294175842191780 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 336596183072100 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 306783378285714 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 315806418823529 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 287866440750670 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 61851487557603 }
+      flops { key: "bf16xbf16->f32" value: 58597567343374 }
+      flops { key: "f16xf16->f16" value: 56859872061004 }
+      flops { key: "f16xf16->f32" value: 60458436036036 }
+      flops { key: "f32xf32->f32" value: 45964975342465 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 50268811985018 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 47093939649122 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 46603377777777 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 49526836900369 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 48279758273381 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 48629611594202 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 49164002930402 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 48806446545454 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 46929275524475 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 54120051612903 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 49164002930402 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 110014531147540 }
+      flops { key: "bf16xbf16->f32" value: 104024590583220 }
+      flops { key: "f16xf16->f16" value: 115208350214592 }
+      flops { key: "f16xf16->f32" value: 101296398490566 }
+      flops { key: "f32xf32->f32" value: 80357867385121 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 71392408510638 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 70087586422976 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 73143176021798 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 74773107520891 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 72746736043360 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 70087586422976 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 70446255347067 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 75829224858757 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 68304187277353 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 72160068817204 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 70455500262467 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 129992956900726 }
+      flops { key: "bf16xbf16->f32" value: 113025455157894 }
+      flops { key: "f16xf16->f16" value: 129055507692307 }
+      flops { key: "f16xf16->f32" value: 130625526034063 }
+      flops { key: "f32xf32->f32" value: 77025955810616 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 143548372192513 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 132560719012345 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 140911000524934 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 152520145454545 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 188375758596491 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 151231242816901 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 147087921095890 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 155614757101449 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 189039053521126 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 151231242816901 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 144320137634408 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 233930680610021 }
+      flops { key: "bf16xbf16->f32" value: 226527810970464 }
+      flops { key: "f16xf16->f16" value: 239140718040089 }
+      flops { key: "f16xf16->f32" value: 213467559443339 }
+      flops { key: "f32xf32->f32" value: 97254818531769 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 263786223805429 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 217797530223123 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 273216749109414 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 282563637894736 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 339791716455696 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 266437177171215 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 265777679207920 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 286292980669244 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 336596183072100 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 257492044124700 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 266437177171215 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 285949886551265 }
+      flops { key: "bf16xbf16->f32" value: 271833373164556 }
+      flops { key: "f16xf16->f16" value: 286331153066666 }
+      flops { key: "f16xf16->f32" value: 269108226566416 }
+      flops { key: "f32xf32->f32" value: 112489649197244 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 403662339849624 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 297435408310249 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 400649934328358 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 416987116116504 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 571063328812657 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 405951540264650 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 399903845065176 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 413733483864752 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 513690622652792 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 406720387878787 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 401361302308195 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 106946396812749 }
+      flops { key: "bf16xbf16->f32" value: 106522006349206 }
+      flops { key: "f16xf16->f16" value: 119304647111111 }
+      flops { key: "f16xf16->f32" value: 88011624918032 }
+      flops { key: "f32xf32->f32" value: 70271061780104 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 69006543958868 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 67446094472361 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 70455500262467 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 70455500262467 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 73746004395604 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 74153440883977 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 70631615840021 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 69723495064935 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 70827297097625 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 69542864248704 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 117220723144104 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 184491722336769 }
+      flops { key: "bf16xbf16->f32" value: 183828423900017 }
+      flops { key: "f16xf16->f16" value: 177185119471947 }
+      flops { key: "f16xf16->f32" value: 176023249836065 }
+      flops { key: "f32xf32->f32" value: 106733779721669 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 144689640749225 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 142784817021276 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 143165576533333 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 249707400930232 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 220934531687242 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 246271060550458 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 238609294222222 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 217356644534412 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 213892793625498 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 249707400930232 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 241833744144144 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 293372083060109 }
+      flops { key: "bf16xbf16->f32" value: 311229514202898 }
+      flops { key: "f16xf16->f16" value: 251432343753658 }
+      flops { key: "f16xf16->f32" value: 324393300302114 }
+      flops { key: "f32xf32->f32" value: 157209637481698 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 249707400930232 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 270429876337992 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 266437177171215 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 445536026556016 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 445536026556016 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 481498575784753 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 479349028571428 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 453055621940928 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 449170392804852 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 460833400858369 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 451152026890756 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 269767432698951 }
+      flops { key: "bf16xbf16->f32" value: 251756582415005 }
+      flops { key: "f16xf16->f16" value: 258732969638554 }
+      flops { key: "f16xf16->f32" value: 252037280441288 }
+      flops { key: "f32xf32->f32" value: 109117331775107 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 323879593997436 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 277094664258064 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 318594117350344 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 341955994904458 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 535532081795511 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 322444992192192 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 320999050523168 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 330382099692307 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 535465315546689 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 330382099692307 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 322420786427445 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 453055621940928 }
+      flops { key: "bf16xbf16->f32" value: 373784195291762 }
+      flops { key: "f16xf16->f16" value: 311443913998767 }
+      flops { key: "f16xf16->f32" value: 368034901113967 }
+      flops { key: "f32xf32->f32" value: 119038463879380 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 462794816658585 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 352032072128191 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 456401604165559 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 478281436080178 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 780903144727272 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 459846605567451 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 455433677535655 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 465831593926247 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 872960832520325 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 449734795392670 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 448326440083507 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 154273250574712 }
+      flops { key: "bf16xbf16->f32" value: 192392371259630 }
+      flops { key: "f16xf16->f16" value: 154273250574712 }
+      flops { key: "f16xf16->f32" value: 178362429235880 }
+      flops { key: "f32xf32->f32" value: 100537623970037 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 152066537884152 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 152954675783475 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 157879991765916 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 230416700429184 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 203360193939393 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 220029062295081 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 234441446288209 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 232411650216450 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 184491722336769 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 195225786181818 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 211366500787401 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 285569634042553 }
+      flops { key: "bf16xbf16->f32" value: 276026175835475 }
+      flops { key: "f16xf16->f16" value: 272523305583756 }
+      flops { key: "f16xf16->f32" value: 269784377889447 }
+      flops { key: "f32xf32->f32" value: 151231242816901 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 251432343753658 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 251461785480093 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 264468429556650 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 456911414468085 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 481498575784753 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 483667488288288 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 466844271304347 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 412977624615384 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 443694968595041 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 477218588444444 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 409825123664122 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 418612796881091 }
+      flops { key: "bf16xbf16->f32" value: 409825123664122 }
+      flops { key: "f16xf16->f16" value: 410608728107074 }
+      flops { key: "f16xf16->f32" value: 404422532580037 }
+      flops { key: "f32xf32->f32" value: 202592796981132 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 378078107042253 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 382795659180035 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 360316048322147 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 740511602758620 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 825955249230769 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 748252142160278 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 699506074267101 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 764229056227758 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 778073785507246 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 764229056227758 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 671088640000000 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 612691483024251 }
+      flops { key: "bf16xbf16->f32" value: 626042897164929 }
+      flops { key: "f16xf16->f16" value: 622459028405797 }
+      flops { key: "f16xf16->f32" value: 637235503857566 }
+      flops { key: "f32xf32->f32" value: 223341426171966 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 686097012140575 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 627002524963503 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 700647193474714 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1095654922448979 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1244918056811594 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1148386977540107 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1206451487640449 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1189741633240997 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1109810670801033 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1193046471111111 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1170290816348773 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 536870912000000 }
+      flops { key: "bf16xbf16->f32" value: 510682476264082 }
+      flops { key: "f16xf16->f16" value: 520602096484848 }
+      flops { key: "f16xf16->f32" value: 493390843882825 }
+      flops { key: "f32xf32->f32" value: 118382252063780 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 564737161303047 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 409619922843995 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 547809992793597 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 566226201641343 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1051399582864137 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 479616671803461 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 549562367934487 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 565127275789473 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1130180197618577 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 493674401839080 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 482025453382340 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 30093660986547 }
+      flops { key: "bf16xbf16->f32" value: 27962026666666 }
+      flops { key: "f16xf16->f16" value: 28079022594142 }
+      flops { key: "f16xf16->f32" value: 29433712280701 }
+      flops { key: "f32xf32->f32" value: 20776738080495 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 32263876923076 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 23546969824561 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 34952533333333 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 31213425116279 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 22982487671232 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 32896501960784 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 35320454736842 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 30504029090909 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 23882158007117 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 37282702222222 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 31797613835583 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 54109142511590 }
+      flops { key: "bf16xbf16->f32" value: 43570111345560 }
+      flops { key: "f16xf16->f16" value: 65472062439024 }
+      flops { key: "f16xf16->f32" value: 53040003161430 }
+      flops { key: "f32xf32->f32" value: 37701608988764 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 61851487557603 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 43436157928802 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 71014670899470 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 65776882136731 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 43436157928802 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 63913203809523 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 71774186096256 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 60732003619909 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 45039506040268 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 63610297630331 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 62137837037037 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 78033562790697 }
+      flops { key: "bf16xbf16->f32" value: 81840078048780 }
+      flops { key: "f16xf16->f16" value: 77136625287356 }
+      flops { key: "f16xf16->f32" value: 78033562790697 }
+      flops { key: "f32xf32->f32" value: 56745683542965 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 104857600000000 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 78489899415204 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 109120104065040 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 113719744122008 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 79654437982195 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 88592559735973 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 100915584962406 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 102066713307984 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 77358921037463 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 120347660165882 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 95189878014184 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 186413511111111 }
+      flops { key: "bf16xbf16->f32" value: 156979798830409 }
+      flops { key: "f16xf16->f16" value: 161222496096096 }
+      flops { key: "f16xf16->f32" value: 154717842074927 }
+      flops { key: "f32xf32->f32" value: 76477337891737 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 192426850179211 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 169359909148264 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 170435210158730 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 208089500775193 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 187063035540069 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 187717102097902 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 187717102097902 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 204912561832061 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 90534723777403 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 181990139661016 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 188375758596491 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 270463935516372 }
+      flops { key: "bf16xbf16->f32" value: 208493558058252 }
+      flops { key: "f16xf16->f16" value: 267099956218905 }
+      flops { key: "f16xf16->f32" value: 203746076660341 }
+      flops { key: "f32xf32->f32" value: 91460121294718 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 323416212048192 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 256262965155131 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 263818629975429 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 319566019047619 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 309435684149855 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 265121438024691 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 261888249756097 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 322444992192192 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 297435408310249 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 273913730612244 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 259357928502415 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 55450414377194 }
+      flops { key: "bf16xbf16->f32" value: 53261003174603 }
+      flops { key: "f16xf16->f16" value: 55692003319502 }
+      flops { key: "f16xf16->f32" value: 51622203076923 }
+      flops { key: "f32xf32->f32" value: 33218098750154 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 58342850684633 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 26789965668662 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 58355533913043 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 65472062439024 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 27616816460905 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 56394003361344 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 57358003418803 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 59388375221238 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 28020402505219 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 59388375221238 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 59652323555555 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 95869805714285 }
+      flops { key: "bf16xbf16->f32" value: 93858551048951 }
+      flops { key: "f16xf16->f16" value: 89181214617940 }
+      flops { key: "f16xf16->f32" value: 94519526760563 }
+      flops { key: "f32xf32->f32" value: 57977420302375 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 125437128971962 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 52629243407509 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 105268806274509 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 116711067826086 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 54560052032520 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 117220723144104 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 117220723144104 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 115208350214592 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 53902702008032 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 109565492244897 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 110923742148760 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 168827330817610 }
+      flops { key: "bf16xbf16->f32" value: 175448010457516 }
+      flops { key: "f16xf16->f16" value: 183859901369863 }
+      flops { key: "f16xf16->f32" value: 153831206876790 }
+      flops { key: "f32xf32->f32" value: 80605196606861 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 231409875862068 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 187717102097902 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 218240208130081 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 227439488244016 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 183232393174061 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 199580264684014 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 213044012698412 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 242928014479638 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 163182648024316 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 216480206451612 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 214748364800000 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 234954447264770 }
+      flops { key: "bf16xbf16->f32" value: 239674514285714 }
+      flops { key: "f16xf16->f16" value: 265777679207920 }
+      flops { key: "f16xf16->f32" value: 239140718040089 }
+      flops { key: "f32xf32->f32" value: 95869805714285 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 332427809287925 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 281084247120418 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 301612871910112 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 356724858471760 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 313044263556851 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 313044263556851 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 302462485633802 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 315806418823529 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 321479588023952 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 307662413753581 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 322444992192192 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 384165232200357 }
+      flops { key: "bf16xbf16->f32" value: 306783378285714 }
+      flops { key: "f16xf16->f16" value: 358511460434056 }
+      flops { key: "f16xf16->f32" value: 308546501149425 }
+      flops { key: "f32xf32->f32" value: 109283918882471 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 538216453132832 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 383479222857142 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 466793532876861 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 568117367195767 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 547827461224489 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 476160454101995 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 485856028959276 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 536870912000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 511305630476190 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 473014019383259 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 457885639232409 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 101680096969696 }
+      flops { key: "bf16xbf16->f32" value: 95869805714285 }
+      flops { key: "f16xf16->f16" value: 93858551048951 }
+      flops { key: "f16xf16->f32" value: 106946396812749 }
+      flops { key: "f32xf32->f32" value: 76477337891737 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 70827297097625 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 73949161432506 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 71014670899470 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 73543960547945 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 73343020765027 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 67615983879093 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 67446094472361 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 71014670899470 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 71203038726790 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 71014670899470 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 73746004395604 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 118514550110375 }
+      flops { key: "bf16xbf16->f32" value: 117993607032967 }
+      flops { key: "f16xf16->f16" value: 125730892740046 }
+      flops { key: "f16xf16->f32" value: 112551553878406 }
+      flops { key: "f32xf32->f32" value: 77136625287356 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 144709140700808 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 172627302893890 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 144709140700808 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 153831206876790 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 177771825165562 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 147087921095890 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 143165576533333 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 147492008791208 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 155165003468208 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 146286352043596 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 143548372192513 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 241833744144144 }
+      flops { key: "bf16xbf16->f32" value: 213022879476242 }
+      flops { key: "f16xf16->f16" value: 232915796963123 }
+      flops { key: "f16xf16->f32" value: 223231148440748 }
+      flops { key: "f32xf32->f32" value: 95609440719469 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 275283123702089 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 245707511212814 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 278893980259740 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 280350345691906 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 315806418823529 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 274614277237851 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 276737583505154 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 287866440750670 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 303316899435028 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 280350345691906 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 276026175835475 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 340870420317460 }
+      flops { key: "bf16xbf16->f32" value: 325376310303030 }
+      flops { key: "f16xf16->f16" value: 336569806128046 }
+      flops { key: "f16xf16->f32" value: 320042272429210 }
+      flops { key: "f32xf32->f32" value: 109786746146570 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 427742983368190 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 380725759773069 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 434713289068825 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 425244286732673 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 512525930310262 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 432089265191146 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 414572132818532 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 429496729600000 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 565127275789473 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 419430400000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 412184961228406 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 516222030769230 }
+      flops { key: "bf16xbf16->f32" value: 426088025396825 }
+      flops { key: "f16xf16->f16" value: 502894127510098 }
+      flops { key: "f16xf16->f32" value: 423149487290640 }
+      flops { key: "f32xf32->f32" value: 117379300528825 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 778073785507246 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 530898306056860 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 655720197862595 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 760171202831858 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 892924593762993 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 674249183045525 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 670041699843993 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 692680799290379 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 862443232128514 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 676372802519685 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 619764400577200 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 186413511111111 }
+      flops { key: "bf16xbf16->f32" value: 163680156097560 }
+      flops { key: "f16xf16->f16" value: 195938289051094 }
+      flops { key: "f16xf16->f32" value: 178362429235880 }
+      flops { key: "f32xf32->f32" value: 113743837288135 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 190379756028368 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 213044012698412 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 195938289051094 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 232411650216450 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 184491722336769 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 189039053521126 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 188375758596491 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 204912561832061 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 223696213333333 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 206488812307692 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 230416700429184 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 272488725796218 }
+      flops { key: "bf16xbf16->f32" value: 263172015686274 }
+      flops { key: "f16xf16->f16" value: 292572704087193 }
+      flops { key: "f16xf16->f32" value: 274614277237851 }
+      flops { key: "f32xf32->f32" value: 139266125032425 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 254411047032342 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 259985913801452 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 255045563895486 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 434713289068825 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 494811900460829 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 479349028571428 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 481498575784753 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 436480416260162 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 365218307482993 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 432960412903225 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 449264361506276 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 277452667700258 }
+      flops { key: "bf16xbf16->f32" value: 269445878042659 }
+      flops { key: "f16xf16->f16" value: 281084247120418 }
+      flops { key: "f16xf16->f32" value: 264468429556650 }
+      flops { key: "f32xf32->f32" value: 106943733871168 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 326862046879756 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 357318410648918 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 323904019306184 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 337654661635220 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 523776499512195 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 336596183072100 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 323391860251487 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 329343401272908 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 534199912437810 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 324393300302114 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 316738001179941 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 404422532580037 }
+      flops { key: "bf16xbf16->f32" value: 385873707021247 }
+      flops { key: "f16xf16->f16" value: 395831279295885 }
+      flops { key: "f16xf16->f32" value: 374778996160558 }
+      flops { key: "f32xf32->f32" value: 115796964074358 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 517465939277108 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 529589062392108 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 480421397762863 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 475633144629014 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 799807690130353 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 511884547523985 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 483123430371203 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 495382617762399 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 881923469404517 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 498256066821345 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 512525930310262 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 593207043403197 }
+      flops { key: "bf16xbf16->f32" value: 524400023930893 }
+      flops { key: "f16xf16->f16" value: 597332122805187 }
+      flops { key: "f16xf16->f32" value: 542636424005053 }
+      flops { key: "f32xf32->f32" value: 123064083953553 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 934704525788901 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 646832424096385 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 853022303078450 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 924593357946289 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1191391760332871 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 866794610696266 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 846257287030195 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 911882653078556 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1359166865822784 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 841325621155729 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 853022303078450 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 283309188390501 }
+      flops { key: "bf16xbf16->f32" value: 287058367597914 }
+      flops { key: "f16xf16->f16" value: 287096744385026 }
+      flops { key: "f16xf16->f32" value: 288640275268817 }
+      flops { key: "f32xf32->f32" value: 148923970041608 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 270463935516372 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 274614277237851 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 274614277237851 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 422733001574803 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 348617475324675 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 426088025396825 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 346368330322580 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 363980279322033 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 353204547368421 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 368983444673539 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 353204547368421 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 441869063374485 }
+      flops { key: "bf16xbf16->f32" value: 457885639232409 }
+      flops { key: "f16xf16->f16" value: 449264361506276 }
+      flops { key: "f16xf16->f32" value: 377413646397188 }
+      flops { key: "f32xf32->f32" value: 196108273412172 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 367688322575122 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 368350539965694 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 369618528055077 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 819650247328244 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 688296041025641 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 686097012140575 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 819650247328244 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 816533706463878 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 720632096644295 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 810371187924528 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 732804520730250 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 622459028405797 }
+      flops { key: "bf16xbf16->f32" value: 619764400577200 }
+      flops { key: "f16xf16->f16" value: 631612837647058 }
+      flops { key: "f16xf16->f32" value: 628838549926793 }
+      flops { key: "f32xf32->f32" value: 232909481630107 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 690509211575562 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 605778179971791 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 681740840634920 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1354879273186119 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1614649359398496 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1309441248780487 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1346384732288401 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1389957053721682 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1394469901298701 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1255838390643274 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1408185998688524 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 557769851108730 }
+      flops { key: "bf16xbf16->f32" value: 514968651539222 }
+      flops { key: "f16xf16->f16" value: 518074520792497 }
+      flops { key: "f16xf16->f32" value: 527945336160535 }
+      flops { key: "f32xf32->f32" value: 123772490194665 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 519641546958652 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 629737516366702 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 528936859113300 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 566992382310231 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1139248619628647 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 514968651539222 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 512831915940298 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 519641546958652 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1149847345157620 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 546416118571292 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 518074520792497 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 741774537855400 }
+      flops { key: "bf16xbf16->f32" value: 638656846988847 }
+      flops { key: "f16xf16->f16" value: 651727743555698 }
+      flops { key: "f16xf16->f32" value: 685809432306740 }
+      flops { key: "f32xf32->f32" value: 126777942713349 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1018337878782490 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 731058263148936 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 994205392592592 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1036180288540410 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1823765306157112 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 993056022196531 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 987916571822886 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1027504137799043 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1839287959316953 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 983927675839752 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 991308339863246 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 40184948502994 }
+      flops { key: "bf16xbf16->f32" value: 59652323555555 }
+      flops { key: "f16xf16->f16" value: 57852468965517 }
+      flops { key: "f16xf16->f32" value: 57852468965517 }
+      flops { key: "f32xf32->f32" value: 35887093048128 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 61851487557603 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 45497534915254 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 65472062439024 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 61286633789954 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 45964975342465 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 63610297630331 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 71774186096256 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 69905066666666 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 43436157928802 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 61008058181818 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 62426850232558 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 75192004481792 }
+      flops { key: "bf16xbf16->f32" value: 74773107520891 }
+      flops { key: "f16xf16->f16" value: 75818516028809 }
+      flops { key: "f16xf16->f32" value: 71573245167311 }
+      flops { key: "f32xf32->f32" value: 50743942533081 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 110467265843621 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 77582501734104 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 113263905485232 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 119304647111111 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 79418773964497 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 99053673800738 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 109120104065040 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 110923742148760 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 77358921037463 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 120374643946188 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 106946396812749 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 174876518566775 }
+      flops { key: "bf16xbf16->f32" value: 137659208205128 }
+      flops { key: "f16xf16->f16" value: 176602273684210 }
+      flops { key: "f16xf16->f32" value: 150806435955056 }
+      flops { key: "f32xf32->f32" value: 75615621408450 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 232361355550746 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 174876518566775 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 185127900689655 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 208858553588795 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 93037156572220 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 197379011764705 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 187684290159063 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 193119033093525 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 179555488963210 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 182609153741496 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 187717102097902 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 247977326558891 }
+      flops { key: "bf16xbf16->f32" value: 195563577816228 }
+      flops { key: "f16xf16->f16" value: 283309188390501 }
+      flops { key: "f16xf16->f32" value: 197360871978678 }
+      flops { key: "f32xf32->f32" value: 89777744481605 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 314880300293255 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 306783378285714 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 256876034449760 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 372827022222222 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 316738001179941 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 283309188390501 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 285569634042553 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 353204547368421 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 247405950230414 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 281084247120418 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 294984017582417 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 363980279322033 }
+      flops { key: "bf16xbf16->f32" value: 299509574337517 }
+      flops { key: "f16xf16->f16" value: 360316048322147 }
+      flops { key: "f16xf16->f32" value: 299927883798882 }
+      flops { key: "f32xf32->f32" value: 104599675994252 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 459846605567451 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 454013456236786 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 389742948820326 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 454975349152542 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 523776499512195 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 374778996160558 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 377413646397188 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 458815008652921 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 434713289068825 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 359712503852596 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 382795659180035 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 110467265843621 }
+      flops { key: "bf16xbf16->f32" value: 102456280916030 }
+      flops { key: "f16xf16->f16" value: 97259223188405 }
+      flops { key: "f16xf16->f32" value: 97595148518451 }
+      flops { key: "f32xf32->f32" value: 45961040321890 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 119837257142857 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 53579931337325 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 117734849122807 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 131586007843137 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 54449382555780 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 109565492244897 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 138368791752577 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 122573267579908 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 53687091200000 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 100915584962406 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 101296398490566 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 187684290159063 }
+      flops { key: "bf16xbf16->f32" value: 164180707033639 }
+      flops { key: "f16xf16->f16" value: 180764616835016 }
+      flops { key: "f16xf16->f32" value: 169895858227848 }
+      flops { key: "f32xf32->f32" value: 79418773964497 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 211366500787401 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 177771825165562 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 212201941501976 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 215610808032128 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 197379011764705 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 206488812307692 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 223696213333333 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 221847484297520 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 182609153741496 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 205697667432950 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 204873463842778 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 271112693851786 }
+      flops { key: "bf16xbf16->f32" value: 242352290712109 }
+      flops { key: "f16xf16->f16" value: 275318416410256 }
+      flops { key: "f16xf16->f32" value: 209306398440545 }
+      flops { key: "f32xf32->f32" value: 96908106859205 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 357913941333333 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 319566019047619 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 349753037133550 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 382114528113879 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 328361414067278 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 341955994904458 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 352046499672131 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 366464786348122 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 325376310303030 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 362689351123121 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 331401797530864 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 388333390235081 }
+      flops { key: "bf16xbf16->f32" value: 330356687639412 }
+      flops { key: "f16xf16->f16" value: 390451572363636 }
+      flops { key: "f16xf16->f32" value: 326862046879756 }
+      flops { key: "f32xf32->f32" value: 109506827872823 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 551981402904511 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 504104142723004 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 513752068899521 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 581973888346883 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 527637259950859 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 522502104136253 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 504104142723004 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 550636832820512 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 530242876049382 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 516222030769230 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 523776499512195 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 526989852269938 }
+      flops { key: "bf16xbf16->f32" value: 439607706857727 }
+      flops { key: "f16xf16->f16" value: 517465939277108 }
+      flops { key: "f16xf16->f32" value: 423128643515097 }
+      flops { key: "f32xf32->f32" value: 116804702030160 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 727898872298957 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 678509841390205 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 617093002298850 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 721782589026132 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 950108902997456 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 599855767597765 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 619719687757016 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 701792041830065 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 878316420449897 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 610037255308571 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 629760600586510 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 126322567529411 }
+      flops { key: "bf16xbf16->f32" value: 129055507692307 }
+      flops { key: "f16xf16->f16" value: 128116194248896 }
+      flops { key: "f16xf16->f32" value: 119837257142857 }
+      flops { key: "f32xf32->f32" value: 77358921037463 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 144709140700808 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 160739794011976 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 145869015622877 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 162688155151515 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 196656011721611 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 150806435955056 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 150384008963585 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 157440150146627 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 180158024161073 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 160259973731343 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 154273250574712 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 208089500775193 }
+      flops { key: "bf16xbf16->f32" value: 203746076660341 }
+      flops { key: "f16xf16->f16" value: 217797530223123 }
+      flops { key: "f16xf16->f32" value: 204522252190476 }
+      flops { key: "f32xf32->f32" value: 94349266200957 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 276026175835475 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 320472115803611 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 276026175835475 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 278893980259740 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 304996967476210 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 269074507956396 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 276026175835475 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 266437177171215 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 308546501149425 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 276737583505154 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 276026175835475 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 362750616216216 }
+      flops { key: "bf16xbf16->f32" value: 335544320000000 }
+      flops { key: "f16xf16->f16" value: 362138895109612 }
+      flops { key: "f16xf16->f32" value: 341955994904458 }
+      flops { key: "f32xf32->f32" value: 110070919938493 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 501748515887850 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 466844271304347 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 479349028571428 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 526344031372549 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 583555339130434 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 485801074086641 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 471922568508955 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 491415022425629 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 549228554475703 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 478281436080178 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 463819362419006 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 525699791432068 }
+      flops { key: "bf16xbf16->f32" value: 435131684919710 }
+      flops { key: "f16xf16->f16" value: 510091127790973 }
+      flops { key: "f16xf16->f32" value: 427359929950248 }
+      flops { key: "f32xf32->f32" value: 119007129287891 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 750868408391608 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 702940637643207 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 727960558644067 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 785185977330895 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 876434505866748 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 720632096644295 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 729196484889643 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 753503034385964 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 894784853333333 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 718221955852842 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 717022920868113 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 673165988166607 }
+      flops { key: "bf16xbf16->f32" value: 639607936857781 }
+      flops { key: "f16xf16->f16" value: 682255239426551 }
+      flops { key: "f16xf16->f32" value: 633920120438360 }
+      flops { key: "f32xf32->f32" value: 124219961996211 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1038686165900846 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 920629611703552 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 927638724838013 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1063110716831683 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1383242285346215 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 873804444534866 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 933688542608695 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1067072620124223 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1327656042040185 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 931663187852494 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 928641577513513 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 289418281401617 }
+      flops { key: "bf16xbf16->f32" value: 279620266666666 }
+      flops { key: "f16xf16->f16" value: 292572704087193 }
+      flops { key: "f16xf16->f32" value: 239140718040089 }
+      flops { key: "f32xf32->f32" value: 152726239101059 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 367719802739726 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 367719802739726 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 389036892753623 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 345254605787781 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 348617475324675 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 427785587250996 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 346368330322580 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 349753037133550 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 361468380407338 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 417798375097276 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 356724858471760 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 248264005549132 }
+      flops { key: "bf16xbf16->f32" value: 221847484297520 }
+      flops { key: "f16xf16->f16" value: 244588114806378 }
+      flops { key: "f16xf16->f32" value: 226767016684266 }
+      flops { key: "f32xf32->f32" value: 107965292375757 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 331914010510046 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 450206215513626 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 304607609645390 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 327360312195121 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 553403852080917 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 297003478044395 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 319091180980683 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 326365296048632 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 508882381042654 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 326862046879756 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 303745919094766 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 493107611481056 }
+      flops { key: "bf16xbf16->f32" value: 416562465059890 }
+      flops { key: "f16xf16->f16" value: 424403883003952 }
+      flops { key: "f16xf16->f32" value: 412957770876400 }
+      flops { key: "f32xf32->f32" value: 116424751521394 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 608352308215297 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 628838549926793 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 582724007326504 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 604074162587904 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 832358003100775 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 589927518164961 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 590779545529573 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 610904956404238 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 906111243881856 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 598184860167130 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 599019148675034 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 633920120438360 }
+      flops { key: "bf16xbf16->f32" value: 618871368299711 }
+      flops { key: "f16xf16->f16" value: 659723865596559 }
+      flops { key: "f16xf16->f32" value: 605351274982382 }
+      flops { key: "f32xf32->f32" value: 124113170573829 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 916748622411953 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 901309961911757 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 894784853333333 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 927638724838013 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1359166865822784 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 883738126748971 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 891951050516587 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 921666801716738 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1278264076190476 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 900412431027253 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 894738252382688 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 872074577868020 }
+      flops { key: "bf16xbf16->f32" value: 739539363509179 }
+      flops { key: "f16xf16->f16" value: 794610170162577 }
+      flops { key: "f16xf16->f32" value: 784827281132937 }
+      flops { key: "f32xf32->f32" value: 128053645673311 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1319447731193118 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1136197161734069 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1243116438784370 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1315457058499234 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1947830973242630 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1222722976691221 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1224465926659777 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1322545741647421 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2014052659320047 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1224509564076978 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1239528801154401 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 449264361506276 }
+      flops { key: "bf16xbf16->f32" value: 422733001574803 }
+      flops { key: "f16xf16->f16" value: 445536026556016 }
+      flops { key: "f16xf16->f32" value: 445489813919717 }
+      flops { key: "f32xf32->f32" value: 202966178157932 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 502923570960187 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 528871727127201 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 547827461224489 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 869426578137651 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 789370942106230 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 852176050793650 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 862270085524995 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 756156214084507 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 662803595061728 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 694978526860841 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 725501232432432 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 607491838189533 }
+      flops { key: "bf16xbf16->f32" value: 600694726713286 }
+      flops { key: "f16xf16->f16" value: 646832424096385 }
+      flops { key: "f16xf16->f32" value: 609215219290780 }
+      flops { key: "f32xf32->f32" value: 224274420824521 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 640036852097459 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 651740105614567 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 641039894925373 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1501736816783216 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1684300900392156 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1441264193288590 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1522768053891154 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1512312428169014 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1367823979617834 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1399012148534202 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1544952264748201 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 551343683697047 }
+      flops { key: "bf16xbf16->f32" value: 504089351368797 }
+      flops { key: "f16xf16->f16" value: 539213118985593 }
+      flops { key: "f16xf16->f32" value: 1004670712514619 }
+      flops { key: "f32xf32->f32" value: 122677424354296 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 665370611309062 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 833933750012135 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 661782326040061 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 679583432911392 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1346384732288401 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 662803595061728 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 668971970873408 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 670564761280249 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1213267597740113 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 663289802864754 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 652234972817008 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 744345624401551 }
+      flops { key: "bf16xbf16->f32" value: 711381746749482 }
+      flops { key: "f16xf16->f16" value: 713138755276976 }
+      flops { key: "f16xf16->f32" value: 688296041025641 }
+      flops { key: "f32xf32->f32" value: 126984567960913 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1053301197633426 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1119173263672193 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1056572520541205 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1063768989721362 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1990714853302433 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1044368947355623 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1052043428291488 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1061108006794107 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1963413621028571 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1036805623657211 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1048192140573520 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1083202924544064 }
+      flops { key: "bf16xbf16->f32" value: 881459662343992 }
+      flops { key: "f16xf16->f16" value: 995920011825915 }
+      flops { key: "f16xf16->f32" value: 874504991486491 }
+      flops { key: "f32xf32->f32" value: 129961735009938 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1506973021117958 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1305932550426635 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1476568043317576 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1497776350471873 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2853680359453511 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1458392969779287 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1454072719763013 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1493252427987831 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2846705747141673 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1432849806839032 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1477171099847380 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 80369897005988 }
+      flops { key: "bf16xbf16->f32" value: 77136625287356 }
+      flops { key: "f16xf16->f16" value: 78720075073313 }
+      flops { key: "f16xf16->f32" value: 77136625287356 }
+      flops { key: "f32xf32->f32" value: 48984572262773 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 107783760690624 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 84413665408805 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 96559516546762 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 112316090376569 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 79891504761904 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 106100970750988 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 106100970750988 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 111384006639004 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 79891504761904 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 114227853617021 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 92563950344827 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 152088077053824 }
+      flops { key: "bf16xbf16->f32" value: 151231242816901 }
+      flops { key: "f16xf16->f16" value: 167745949695360 }
+      flops { key: "f16xf16->f32" value: 150384008963585 }
+      flops { key: "f32xf32->f32" value: 76363119550529 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 201831169924812 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 176602273684210 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 179525467981942 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 226527810970464 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 167249505295950 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 175448010457516 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 163680156097560 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 202592796981132 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 173156236736010 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 181375308108108 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 181375308108108 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 282563637894736 }
+      flops { key: "bf16xbf16->f32" value: 199209985899814 }
+      flops { key: "f16xf16->f16" value: 285531664406328 }
+      flops { key: "f16xf16->f32" value: 209715200000000 }
+      flops { key: "f32xf32->f32" value: 90075233756973 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 355484795232577 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 261856316059017 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 263818629975429 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 328361414067278 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 293372083060109 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 287866440750670 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 265121438024691 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 368920056347706 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 293372083060109 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 271833373164556 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 262528563325183 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 361498804477737 }
+      flops { key: "bf16xbf16->f32" value: 292971848294679 }
+      flops { key: "f16xf16->f16" value: 350323596737357 }
+      flops { key: "f16xf16->f32" value: 286713437650200 }
+      flops { key: "f32xf32->f32" value: 104246779029126 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 465831593926247 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 514984088249400 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 402867207203827 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 470939396491228 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 488064465454545 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 404422532580037 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 400649934328358 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 445489813919717 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 508882381042654 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 400649934328358 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 412977624615384 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 484759288487584 }
+      flops { key: "bf16xbf16->f32" value: 410608728107074 }
+      flops { key: "f16xf16->f16" value: 489734013226909 }
+      flops { key: "f16xf16->f32" value: 413375100673724 }
+      flops { key: "f32xf32->f32" value: 115672218149499 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 591593291460055 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 625177190101892 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 498256066821345 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 645859743759398 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 708740477887788 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 491977926231386 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 491977926231386 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 643923132833583 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 705249145484400 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 495954653117782 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 495954653117782 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 185127900689655 }
+      flops { key: "bf16xbf16->f32" value: 169359909148264 }
+      flops { key: "f16xf16->f16" value: 187063035540069 }
+      flops { key: "f16xf16->f32" value: 172074010256410 }
+      flops { key: "f32xf32->f32" value: 74773107520891 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 242928014479638 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 165700898765432 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 208899187548638 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 215610808032128 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 201831169924812 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 217356644534412 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 209715200000000 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 234441446288209 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 193781235156109 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 204912561832061 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 222768013278008 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 253839674704491 }
+      flops { key: "bf16xbf16->f32" value: 224163220041753 }
+      flops { key: "f16xf16->f16" value: 240210698881431 }
+      flops { key: "f16xf16->f32" value: 233930680610021 }
+      flops { key: "f32xf32->f32" value: 97083347558770 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 368983444673539 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 309435684149855 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 333460193788819 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 371536963321799 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 329368657668711 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 343048506070287 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 319566019047619 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 366464786348122 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 312134251162790 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 324393300302114 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 333460193788819 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 379380557901245 }
+      flops { key: "bf16xbf16->f32" value: 320999050523168 }
+      flops { key: "f16xf16->f16" value: 389742948820326 }
+      flops { key: "f16xf16->f32" value: 317675095857988 }
+      flops { key: "f32xf32->f32" value: 109117331775107 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 546433498218829 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 511305630476190 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 497102696296296 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 550636832820512 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 552052351670951 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 494811900460829 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 481498575784753 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 560700691383812 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 508882381042654 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 502923570960187 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 500520603193101 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 519343082950423 }
+      flops { key: "bf16xbf16->f32" value: 476134060861371 }
+      flops { key: "f16xf16->f16" value: 508852235768023 }
+      flops { key: "f16xf16->f32" value: 432524400402819 }
+      flops { key: "f32xf32->f32" value: 118643866686924 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 737966889347079 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 833893271721192 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 679583432911392 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 748252142160278 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 881923469404517 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 654720624390243 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 691621142673107 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 689400850080256 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 881923469404517 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 671088640000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 687194767360000 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 701792041830065 }
+      flops { key: "bf16xbf16->f32" value: 529572737708455 }
+      flops { key: "f16xf16->f16" value: 663828021020092 }
+      flops { key: "f16xf16->f32" value: 521233895145631 }
+      flops { key: "f32xf32->f32" value: 120678199675472 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 967280512583750 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 977239430261661 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 829144265637065 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 951266289258028 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1272582902518518 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 798283963756331 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 806566628356807 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 930653801950162 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1178236690487621 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 808084157290686 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 805809999249531 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 228942819616204 }
+      flops { key: "bf16xbf16->f32" value: 217797530223123 }
+      flops { key: "f16xf16->f16" value: 230416700429184 }
+      flops { key: "f16xf16->f32" value: 223207945951564 }
+      flops { key: "f32xf32->f32" value: 93690661314951 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 285569634042553 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 275318416410256 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 296572800441927 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 282563637894736 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 288640275268817 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 281084247120418 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 287096744385026 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 290986944173441 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 276737583505154 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 286292980669244 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 273216749109414 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 357288686132601 }
+      flops { key: "bf16xbf16->f32" value: 311229514202898 }
+      flops { key: "f16xf16->f16" value: 316738001179941 }
+      flops { key: "f16xf16->f32" value: 308546501149425 }
+      flops { key: "f32xf32->f32" value: 112316090376569 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 478281436080178 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 543666746329113 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 481444602174644 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 486957743310657 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 534133477925631 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 465831593926247 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 455941326539278 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 474058200441501 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 538216453132832 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 468882892576419 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 449217372241397 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 491949750415211 }
+      flops { key: "bf16xbf16->f32" value: 422317334906588 }
+      flops { key: "f16xf16->f16" value: 485279622168239 }
+      flops { key: "f16xf16->f32" value: 422733001574803 }
+      flops { key: "f32xf32->f32" value: 116868268350090 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 715768235313723 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 788067393761467 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 704092999344262 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 724277790219224 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 919693211134903 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 688296041025641 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 707572865897858 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 741790551986183 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 852091517904969 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 688296041025641 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 682770415070344 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 751525336132983 }
+      flops { key: "bf16xbf16->f32" value: 613983388156248 }
+      flops { key: "f16xf16->f16" value: 686097012140575 }
+      flops { key: "f16xf16->f32" value: 610948406258890 }
+      flops { key: "f32xf32->f32" value: 124851885757474 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1084587701010101 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1124336988481675 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1014100063986777 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1094259183694267 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1438850015410385 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1011770858892815 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 996512133642691 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1079137511557789 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1315457058499234 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 994205392592592 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1014159928217237 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 836390018938195 }
+      flops { key: "bf16xbf16->f32" value: 707267004960787 }
+      flops { key: "f16xf16->f16" value: 818069530915930 }
+      flops { key: "f16xf16->f32" value: 697234950649350 }
+      flops { key: "f32xf32->f32" value: 128880272346043 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1298504907902195 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1331772804961240 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1188096070816044 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1345330398120595 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1845313553598281 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1182372276944253 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1201347448271039 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1330741222618125 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1706044606156901 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1167904091366417 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1200507961566681 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 264468429556650 }
+      flops { key: "bf16xbf16->f32" value: 244032232727272 }
+      flops { key: "f16xf16->f16" value: 260616947572815 }
+      flops { key: "f16xf16->f32" value: 256876034449760 }
+      flops { key: "f32xf32->f32" value: 106680757476403 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 337124591522762 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 495954653117782 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 324393300302114 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 338719818296529 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 549228554475703 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 330891163020030 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 328361414067278 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 311681226124818 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 492542121100917 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 329368657668711 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 324859488389683 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 484212772942502 }
+      flops { key: "bf16xbf16->f32" value: 361514018433567 }
+      flops { key: "f16xf16->f16" value: 380742635166880 }
+      flops { key: "f16xf16->f32" value: 383821921000893 }
+      flops { key: "f32xf32->f32" value: 119369305484915 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 519343082950423 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 734182443760683 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 552762843758043 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 568117367195767 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 850488573465346 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 540927871032745 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 556342913989637 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 552727275722283 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 948116400883002 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 556342913989637 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 531555358415841 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 592818122291235 }
+      flops { key: "bf16xbf16->f32" value: 558513302470741 }
+      flops { key: "f16xf16->f16" value: 648786600604229 }
+      flops { key: "f16xf16->f32" value: 559604859413680 }
+      flops { key: "f32xf32->f32" value: 123986873630576 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 894738252382688 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1020182255581947 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 850488573465346 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 895717892805005 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1201389453426573 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 878316420449897 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 842935537216034 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 904156054102415 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1325607190123456 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 849647338476755 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 863310009246231 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 867648250498724 }
+      flops { key: "bf16xbf16->f32" value: 802403922561360 }
+      flops { key: "f16xf16->f16" value: 808084157290686 }
+      flops { key: "f16xf16->f32" value: 789860885221029 }
+      flops { key: "f32xf32->f32" value: 128054122912023 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1379853755592145 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1490014673373807 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1325556049843756 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1388833402101859 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1954367690575052 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1304469945634016 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1303480211229135 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1354825849453886 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2028319856434474 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1284908506338581 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1326630825019305 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 1136967898214788 }
+      flops { key: "bf16xbf16->f32" value: 839260350215556 }
+      flops { key: "f16xf16->f16" value: 955485556874904 }
+      flops { key: "f16xf16->f32" value: 821011418453781 }
+      flops { key: "f32xf32->f32" value: 130713483327817 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1649531366682669 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1772902575681742 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1616928864376470 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1696777203358024 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2718333731645569 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1598833827412112 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1568185955044385 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1638518758607534 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2746581803996802 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1587751593909567 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1587018238285490 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 645859743759398 }
+      flops { key: "bf16xbf16->f32" value: 649718976779366 }
+      flops { key: "f16xf16->f16" value: 636291451259259 }
+      flops { key: "f16xf16->f32" value: 610080581818181 }
+      flops { key: "f32xf32->f32" value: 221732952813629 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1003379814507651 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 998829603720930 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1092866996437659 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1481023205517241 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1690932006299212 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1389957053721682 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1436443911705685 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1431417195800700 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1363265289953975 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1690932006299212 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1426899433887043 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 555264033096315 }
+      flops { key: "bf16xbf16->f32" value: 514044139433290 }
+      flops { key: "f16xf16->f16" value: 549562367934487 }
+      flops { key: "f16xf16->f32" value: 521550369884638 }
+      flops { key: "f32xf32->f32" value: 122659906640677 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 610926680559012 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1065682599342472 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 597332122805187 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 610080581818181 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1203072071708683 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 608352308215297 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 603649655094870 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 616207646484935 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1321426750557649 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 604477998099996 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 592409282206896 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 717007958264643 }
+      flops { key: "bf16xbf16->f32" value: 714027937241537 }
+      flops { key: "f16xf16->f16" value: 702064493328701 }
+      flops { key: "f16xf16->f32" value: 680377385952753 }
+      flops { key: "f32xf32->f32" value: 126451343345981 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 982268106575185 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1352745605039370 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 957095776267409 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 981146155568246 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2006994063551401 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 957602585435188 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 958136648950112 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 976101200761342 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1981530471049596 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 948090239452553 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 958698057142857 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1074396534388142 }
+      flops { key: "bf16xbf16->f32" value: 975297711268805 }
+      flops { key: "f16xf16->f16" value: 995631427188826 }
+      flops { key: "f16xf16->f32" value: 870076052924121 }
+      flops { key: "f32xf32->f32" value: 129853925949441 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1570336069468248 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1841357897534833 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1555443113082843 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1607849245109967 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3019309171177504 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1528458112455516 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1562516524238290 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1591465417693376 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2987673437502717 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1535939669117811 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1552631647898780 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1239953749228631 }
+      flops { key: "bf16xbf16->f32" value: 1032901853074905 }
+      flops { key: "f16xf16->f16" value: 1029489846384323 }
+      flops { key: "f16xf16->f32" value: 1158053550880090 }
+      flops { key: "f32xf32->f32" value: 131847182610313 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1919511647490956 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 2090612456032004 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1887353283695637 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1935187528646456 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3694496209026639 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1852252038004878 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1886317144590384 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1919002422116727 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 3726652751409978 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1865830676640284 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1880124122405986 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 15462871889400 }
+      flops { key: "bf16xbf16->f32" value: 19065018181818 }
+      flops { key: "f16xf16->f16" value: 17476266666666 }
+      flops { key: "f16xf16->f32" value: 18641351111111 }
+      flops { key: "f32xf32->f32" value: 9986438095238 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 16128061523672 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 11650844444444 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 18957306214689 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 18538360220994 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 11773484912280 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 18538360220994 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 19508390697674 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 16861523618090 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 11610530103806 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 18040017204301 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 15606712558139 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 31956601904761 }
+      flops { key: "bf16xbf16->f32" value: 30925743778801 }
+      flops { key: "f16xf16->f16" value: 32419741062801 }
+      flops { key: "f16xf16->f32" value: 30504029090909 }
+      flops { key: "f32xf32->f32" value: 19508390697674 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 34592197938144 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 23061465292096 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 33387494527363 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 37076720441988 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 22295303654485 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 30366001809954 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 32109504306220 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 32419741062801 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 21440531629392 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 34065413197969 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 31068918518518 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 50448309716218 }
+      flops { key: "bf16xbf16->f32" value: 52214638397198 }
+      flops { key: "f16xf16->f16" value: 59388375221238 }
+      flops { key: "f16xf16->f32" value: 48806446545454 }
+      flops { key: "f32xf32->f32" value: 35043793211488 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 59375239106392 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 41812376323987 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 68478432653061 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 69905066666666 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 41682524223602 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 54120051612903 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 64823824197053 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 64839482125603 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 43436157928802 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 53902702008032 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 57604175107296 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 84413665408805 }
+      flops { key: "bf16xbf16->f32" value: 79891504761904 }
+      flops { key: "f16xf16->f16" value: 86037005128205 }
+      flops { key: "f16xf16->f32" value: 83106952321981 }
+      flops { key: "f32xf32->f32" value: 56992665817409 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 118253504845814 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 62718564485981 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 93531517770034 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 96908106859205 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 63310249056603 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 95869805714285 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 93858551048951 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 113743837288135 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 62572367365967 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 90995069830508 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 94171358007367 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 184460028173853 }
+      flops { key: "bf16xbf16->f32" value: 161708106024096 }
+      flops { key: "f16xf16->f16" value: 178362429235880 }
+      flops { key: "f16xf16->f32" value: 162688155151515 }
+      flops { key: "f32xf32->f32" value: 74148320143636 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 223696213333333 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 75509270323488 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 176023249836065 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 209715200000000 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 172627302893890 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 185768481660899 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 197379011764705 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 228455707234042 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 162196650151057 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 184491722336769 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 195225786181818 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 32736031219512 }
+      flops { key: "bf16xbf16->f32" value: 35135530890052 }
+      flops { key: "f16xf16->f16" value: 34952533333333 }
+      flops { key: "f16xf16->f32" value: 32109504306220 }
+      flops { key: "f32xf32->f32" value: 20092474251497 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 30229218018018 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 24947533085501 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 18538360220994 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 27391373061224 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 26951351004016 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 26317201568627 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 26736599203187 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 24492286131386 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 25324099622641 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 26630501587301 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 24947533085501 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 49344752941176 }
+      flops { key: "bf16xbf16->f32" value: 47093939649122 }
+      flops { key: "f16xf16->f16" value: 52022375193798 }
+      flops { key: "f16xf16->f32" value: 45191154208754 }
+      flops { key: "f32xf32->f32" value: 33387494527363 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 53050485375494 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 26368905304518 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 53050485375494 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 58867424561403 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 26263130417767 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 57852468965517 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 59918628571428 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 62703914038775 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 25565281523809 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 58355533913043 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 59652323555555 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 99053673800738 }
+      flops { key: "bf16xbf16->f32" value: 95869805714285 }
+      flops { key: "f16xf16->f16" value: 95189878014184 }
+      flops { key: "f16xf16->f32" value: 93858551048951 }
+      flops { key: "f32xf32->f32" value: 55341811359653 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 115704937931034 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 50552816572504 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 119837257142857 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 117220723144104 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 50739146772516 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 122016116363636 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 107374182400000 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 118776750442477 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 50840048484848 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 104044750387596 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 111848106666666 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 181375308108108 }
+      flops { key: "bf16xbf16->f32" value: 166730096894409 }
+      flops { key: "f16xf16->f16" value: 184491722336769 }
+      flops { key: "f16xf16->f32" value: 168271716658830 }
+      flops { key: "f32xf32->f32" value: 75615621408450 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 189039053521126 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 74461985020804 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 194518446376811 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 200324967164179 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 169895858227848 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 201075247940074 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 187063035540069 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 183859901369863 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 169895858227848 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 187063035540069 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 189707036042402 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 244588114806378 }
+      flops { key: "bf16xbf16->f32" value: 227970663269639 }
+      flops { key: "f16xf16->f16" value: 229432013675213 }
+      flops { key: "f16xf16->f32" value: 227487674576271 }
+      flops { key: "f32xf32->f32" value: 97431316546436 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 325376310303030 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 167249505295950 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 296613763535911 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 331401797530864 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 322444992192192 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 295796645730027 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 284812154907161 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 314880300293255 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 298261617777777 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 305040290909090 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 297435408310249 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 57358003418803 }
+      flops { key: "bf16xbf16->f32" value: 64512246094688 }
+      flops { key: "f16xf16->f16" value: 57852468965517 }
+      flops { key: "f16xf16->f32" value: 54782746122448 }
+      flops { key: "f32xf32->f32" value: 44296279867986 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 49164002930402 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 50457792481203 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 46281975172413 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 50457792481203 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 54782746122448 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 51228140458015 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 48454053429602 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 52841625196850 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 46765758885017 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 48454053429602 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 48106712544802 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 107374182400000 }
+      flops { key: "bf16xbf16->f32" value: 99420539259259 }
+      flops { key: "f16xf16->f16" value: 97969144525547 }
+      flops { key: "f16xf16->f32" value: 109565492244897 }
+      flops { key: "f32xf32->f32" value: 56275776939203 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 67786731313131 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 68644791203170 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 61851487557603 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 73343020765027 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 72160068817204 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 69542864248704 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 70640909473684 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 73133212368887 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 60052674720357 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 66941510224438 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 70271061780104 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 120916872072072 }
+      flops { key: "bf16xbf16->f32" value: 116457898481561 }
+      flops { key: "f16xf16->f16" value: 124839184280897 }
+      flops { key: "f16xf16->f32" value: 120361150543661 }
+      flops { key: "f32xf32->f32" value: 74981970949720 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 149963941899441 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 95698914795008 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 147492008791208 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 152954675783475 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 188375758596491 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 139085728497409 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 147492008791208 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 143933220375335 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 177771825165562 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 142406077453580 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 137307138618925 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 219130984489795 }
+      flops { key: "bf16xbf16->f32" value: 207286066409266 }
+      flops { key: "f16xf16->f16" value: 215157163410479 }
+      flops { key: "f16xf16->f32" value: 207286066409266 }
+      flops { key: "f32xf32->f32" value: 96995648057813 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 260616947572815 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 161222496096096 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 269108226566416 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 265121438024691 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 304176154107648 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 255652815238095 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 263172015686274 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 277452667700258 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 297394217975349 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 248551348148148 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 249128033410672 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 272869586785260 }
+      flops { key: "bf16xbf16->f32" value: 266420649835618 }
+      flops { key: "f16xf16->f16" value: 302462485633802 }
+      flops { key: "f16xf16->f32" value: 263172015686274 }
+      flops { key: "f32xf32->f32" value: 108349326337033 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 424403883003952 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 190202705637482 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 408266853231939 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 429496729600000 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 543597936463738 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 399903845065176 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 402150495880149 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 432089265191146 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 513752068899521 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 397682157037037 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 377380484667428 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 109120104065040 }
+      flops { key: "bf16xbf16->f32" value: 105683250393700 }
+      flops { key: "f16xf16->f16" value: 111360902717278 }
+      flops { key: "f16xf16->f32" value: 96213425089605 }
+      flops { key: "f32xf32->f32" value: 49618383733826 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 71203038726790 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 61709300229885 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 67786731313131 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 71582788266666 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 70455500262467 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 68829604102564 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 72746736043360 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 71014670899470 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 67949742057967 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 72160068817204 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 68653569309462 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 180158024161073 }
+      flops { key: "bf16xbf16->f32" value: 178956970666666 }
+      flops { key: "f16xf16->f16" value: 194518446376811 }
+      flops { key: "f16xf16->f32" value: 191057264056939 }
+      flops { key: "f32xf32->f32" value: 100915584962406 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 95189878014184 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 97083347558770 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 98319002289167 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 100162483582089 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 101296398490566 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 99236767467652 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 95021400353982 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 100915584962406 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 98328005860805 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 90079012080536 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 98319002289167 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 249128033410672 }
+      flops { key: "bf16xbf16->f32" value: 245707511212814 }
+      flops { key: "f16xf16->f16" value: 298261617777777 }
+      flops { key: "f16xf16->f32" value: 287096744385026 }
+      flops { key: "f32xf32->f32" value: 121326759774011 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 130625526034063 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 132071565067650 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 128591835209580 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 477218588444444 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 393312023443223 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 440058124590163 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 462819751724137 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 447299239325140 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 436480416260162 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 451152026890756 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 393312023443223 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 268100330586766 }
+      flops { key: "bf16xbf16->f32" value: 256262965155131 }
+      flops { key: "f16xf16->f16" value: 268418679832510 }
+      flops { key: "f16xf16->f32" value: 252348254759106 }
+      flops { key: "f32xf32->f32" value: 103991847558170 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 317675095857988 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 181674518675182 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 307662413753581 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 314419274963396 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 517465939277108 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 313044263556851 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 301189852454417 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 311658609389739 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 452054235975160 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 304176154107648 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 304586007800865 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 426088025396825 }
+      flops { key: "bf16xbf16->f32" value: 373800460922541 }
+      flops { key: "f16xf16->f16" value: 361514018433567 }
+      flops { key: "f16xf16->f32" value: 365824904901835 }
+      flops { key: "f32xf32->f32" value: 117604285154913 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 508250079403585 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 212511679374582 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 494783399112954 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 505290270117647 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 685002758532695 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 486930139561249 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 485307039096045 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 500578938927738 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 732929572696245 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 479884614078212 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 474032039732906 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 179525467981942 }
+      flops { key: "bf16xbf16->f32" value: 204873463842778 }
+      flops { key: "f16xf16->f16" value: 179555488963210 }
+      flops { key: "f16xf16->f32" value: 174876518566775 }
+      flops { key: "f32xf32->f32" value: 99975961266294 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 99780859027971 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 104857600000000 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 105475621218074 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 103046240307101 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 108898765111561 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 99411334506064 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 103046240307101 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 105268806274509 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 103234479761561 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 103244406153846 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 102261126095238 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 295796645730027 }
+      flops { key: "bf16xbf16->f32" value: 283309188390501 }
+      flops { key: "f16xf16->f16" value: 288640275268817 }
+      flops { key: "f16xf16->f32" value: 309435684149855 }
+      flops { key: "f32xf32->f32" value: 120916872072072 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 126471357361601 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 133218588585607 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 135916686582278 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 383479222857142 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 453055621940928 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 440058124590163 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 429496729600000 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 412977624615384 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 434713289068825 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 451152026890756 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 391876578102189 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 397645338024257 }
+      flops { key: "bf16xbf16->f32" value: 394758023529411 }
+      flops { key: "f16xf16->f16" value: 395485018047882 }
+      flops { key: "f16xf16->f32" value: 397682157037037 }
+      flops { key: "f32xf32->f32" value: 147385721011633 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 169219782356881 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 559240533333333 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 743073926643598 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 872960832520325 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 732929572696245 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 852176050793650 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 753503034385964 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 816533706463878 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 727960558644067 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 737966889347079 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 756156214084507 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 581973888346883 }
+      flops { key: "bf16xbf16->f32" value: 479322280676301 }
+      flops { key: "f16xf16->f16" value: 486957743310657 }
+      flops { key: "f16xf16->f32" value: 491977926231386 }
+      flops { key: "f32xf32->f32" value: 160796963591097 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1359166865822784 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1321528398769230 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1385473321290322 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1350618646540880 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1367823979617834 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1455921117288135 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1451002464864864 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1350618646540880 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1367823979617834 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1412818189473684 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1381018423151125 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 504104142723004 }
+      flops { key: "bf16xbf16->f32" value: 499110112547572 }
+      flops { key: "f16xf16->f16" value: 511001462938726 }
+      flops { key: "f16xf16->f32" value: 485293330244908 }
+      flops { key: "f32xf32->f32" value: 126320709871913 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 527313357397176 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 232220018437166 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 518715857004830 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 502629291515506 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 953377868146503 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 521550369884638 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 519971827602905 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 523122596266861 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 965161190112359 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 497967222724637 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 496528011098265 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 28802087553648 }
+      flops { key: "bf16xbf16->f32" value: 27497997951239 }
+      flops { key: "f16xf16->f16" value: 33058553694581 }
+      flops { key: "f16xf16->f32" value: 29694187610619 }
+      flops { key: "f32xf32->f32" value: 20274581268882 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 27391373061224 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 23061465292096 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 33554432000000 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 30504029090909 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 22595577104377 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 31956601904761 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 35696204255319 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 31956601904761 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 22365893684385 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 36873002197802 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 32109504306220 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 59652323555555 }
+      flops { key: "bf16xbf16->f32" value: 58610361572052 }
+      flops { key: "f16xf16->f16" value: 60732003619909 }
+      flops { key: "f16xf16->f32" value: 54782746122448 }
+      flops { key: "f32xf32->f32" value: 35696204255319 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 64839482125603 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 42881063258785 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 69184395876288 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 69905066666666 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 44590607308970 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 62718564485981 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 60458436036036 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 46281975172413 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 42744499363057 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 61286633789954 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 61008058181818 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 80854053012048 }
+      flops { key: "bf16xbf16->f32" value: 77136625287356 }
+      flops { key: "f16xf16->f16" value: 82090353516819 }
+      flops { key: "f16xf16->f32" value: 83106952321981 }
+      flops { key: "f32xf32->f32" value: 57852468965517 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 111848106666666 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 70827297097625 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 104024590583220 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 108240103225806 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 67615983879093 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 98689505882352 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 108678322267206 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 113743837288135 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 67607469084498 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 104857600000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 103244406153846 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 189039053521126 }
+      flops { key: "bf16xbf16->f32" value: 158369000589970 }
+      flops { key: "f16xf16->f16" value: 173716522245591 }
+      flops { key: "f16xf16->f32" value: 163182648024316 }
+      flops { key: "f32xf32->f32" value: 74461985020804 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 219130984489795 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 160715734770243 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 185127900689655 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 226527810970464 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 187030451837658 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 175994398295361 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 189005777856011 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 221847484297520 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 162196650151057 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 177771825165562 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 180158024161073 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 269784377889447 }
+      flops { key: "bf16xbf16->f32" value: 222768013278008 }
+      flops { key: "f16xf16->f16" value: 279620266666666 }
+      flops { key: "f16xf16->f32" value: 219108626466687 }
+      flops { key: "f32xf32->f32" value: 91851310863986 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 320519947462686 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 210125601565557 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 285569634042553 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 328311213575905 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 295755908001652 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 282563637894736 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 281822001049868 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 324393300302114 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 263172015686274 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 278857764965588 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 284058683597883 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 53473198406374 }
+      flops { key: "bf16xbf16->f32" value: 51622203076923 }
+      flops { key: "f16xf16->f16" value: 51821516602316 }
+      flops { key: "f16xf16->f32" value: 51228140458015 }
+      flops { key: "f32xf32->f32" value: 32656381508515 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 60732003619909 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 26112398443579 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 57852468965517 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 59113731777141 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 26897340280561 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 58355533913043 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 60187321973094 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 58102912554112 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 26736599203187 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 62426850232558 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 52214638397198 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 92245861168384 }
+      flops { key: "bf16xbf16->f32" value: 95869805714285 }
+      flops { key: "f16xf16->f16" value: 100915584962406 }
+      flops { key: "f16xf16->f32" value: 97969144525547 }
+      flops { key: "f32xf32->f32" value: 56986616282772 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 111384006639004 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 51617239880780 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 112788006722689 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 117220723144104 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 51721667822736 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 119304647111111 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 114716006837606 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 117220723144104 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 50363124953095 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 115704937931034 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 119837257142857 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 170435210158730 }
+      flops { key: "bf16xbf16->f32" value: 163680156097560 }
+      flops { key: "f16xf16->f16" value: 185768481660899 }
+      flops { key: "f16xf16->f32" value: 168298091536050 }
+      flops { key: "f32xf32->f32" value: 77694777424023 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 204133426615969 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 133549978109452 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 211366500787401 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 202592796981132 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 209715200000000 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 194518446376811 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 212201941501976 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 205658269297069 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 160259973731343 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 191057264056939 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 210537612549019 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 234954447264770 }
+      flops { key: "bf16xbf16->f32" value: 224632180753138 }
+      flops { key: "f16xf16->f16" value: 231409875862068 }
+      flops { key: "f16xf16->f32" value: 222768013278008 }
+      flops { key: "f32xf32->f32" value: 95017196053271 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 321479588023952 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 211783397238658 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 300768017927170 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 335544320000000 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 321479588023952 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 324393300302114 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 314880300293255 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 335544320000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 317628109451264 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 306783378285714 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 299927883798882 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 395485018047882 }
+      flops { key: "bf16xbf16->f32" value: 318594117350344 }
+      flops { key: "f16xf16->f16" value: 372827022222222 }
+      flops { key: "f16xf16->f32" value: 322929871879699 }
+      flops { key: "f32xf32->f32" value: 108568435187057 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 557787960519480 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 308546501149425 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 495954653117782 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 574193488770053 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 470887764060958 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 483667488288288 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 489176229612756 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 556342913989637 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 531555358415841 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 481498575784753 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 500578938927738 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 98689505882352 }
+      flops { key: "bf16xbf16->f32" value: 96908106859205 }
+      flops { key: "f16xf16->f16" value: 101680096969696 }
+      flops { key: "f16xf16->f32" value: 101680096969696 }
+      flops { key: "f32xf32->f32" value: 55227951033844 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 71382916101582 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 67786731313131 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 68653569309462 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 69363166925064 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 72150371186668 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 68122181449054 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 71014670899470 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 67958343291139 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 69184395876288 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 71014670899470 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 68130826395939 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 120374643946188 }
+      flops { key: "bf16xbf16->f32" value: 121189822121896 }
+      flops { key: "f16xf16->f16" value: 121189822121896 }
+      flops { key: "f16xf16->f32" value: 121176145356054 }
+      flops { key: "f32xf32->f32" value: 77358921037463 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 144320137634408 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 137659208205128 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 147492008791208 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 155614757101449 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 199580264684014 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 145080640994460 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 143146490334622 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 152520145454545 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 180764616835016 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 147087921095890 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 142029341798941 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 239674514285714 }
+      flops { key: "bf16xbf16->f32" value: 212201941501976 }
+      flops { key: "f16xf16->f16" value: 235469698245614 }
+      flops { key: "f16xf16->f32" value: 217775443464151 }
+      flops { key: "f32xf32->f32" value: 91929950684931 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 284058683597883 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 196296494332723 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 261888249756097 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 290986944173441 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 326365296048632 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 269784377889447 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 272523305583756 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 267099956218905 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 298261617777777 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 263172015686274 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 267099956218905 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 279602063407330 }
+      flops { key: "bf16xbf16->f32" value: 266090533176383 }
+      flops { key: "f16xf16->f16" value: 284058683597883 }
+      flops { key: "f16xf16->f32" value: 265121438024691 }
+      flops { key: "f32xf32->f32" value: 112607621614535 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 424403883003952 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 294175842191780 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 398419971799628 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 417798375097276 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 534199912437810 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 405185593962264 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 396214695202952 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 405951540264650 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 559240533333333 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 399866613536914 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 409825123664122 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 514367340838323 }
+      flops { key: "bf16xbf16->f32" value: 412977624615384 }
+      flops { key: "f16xf16->f16" value: 502923570960187 }
+      flops { key: "f16xf16->f32" value: 404784628057113 }
+      flops { key: "f32xf32->f32" value: 119902494270040 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 760171202831858 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 357899028873796 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 697234950649350 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 750802778778078 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 765591318360071 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 686097012140575 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 708740477887788 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 758828144169611 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 869426578137651 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 682824689348171 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 692736660645161 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 188375758596491 }
+      flops { key: "bf16xbf16->f32" value: 189707036042402 }
+      flops { key: "f16xf16->f16" value: 162196650151057 }
+      flops { key: "f16xf16->f32" value: 165700898765432 }
+      flops { key: "f32xf32->f32" value: 78835669897209 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 86175106260032 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 99420539259259 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 117993607032967 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 108022316297786 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 111848106666666 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 106733779721669 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 107589361122244 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 105268806274509 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 99790132342007 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 104857600000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 102066713307984 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 265744790001237 }
+      flops { key: "bf16xbf16->f32" value: 279620266666666 }
+      flops { key: "f16xf16->f16" value: 253240996226415 }
+      flops { key: "f16xf16->f32" value: 292572704087193 }
+      flops { key: "f32xf32->f32" value: 120105349440715 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 335544320000000 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 328361414067278 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 359110977926421 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 508882381042654 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 477218588444444 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 481390640663528 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 497102696296296 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 483667488288288 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 429496729600000 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 382114528113879 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 470836142951107 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 270804999747793 }
+      flops { key: "bf16xbf16->f32" value: 255652815238095 }
+      flops { key: "f16xf16->f16" value: 269428975346590 }
+      flops { key: "f16xf16->f32" value: 251461785480093 }
+      flops { key: "f32xf32->f32" value: 106519364499888 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 320519947462686 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 242928014479638 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 316248236212355 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 335544320000000 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 518715857004830 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 319091180980683 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 320975061355653 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 320496029848518 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 506481992452830 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 316248236212355 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 325870052807283 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 454975349152542 }
+      flops { key: "bf16xbf16->f32" value: 375106314061135 }
+      flops { key: "f16xf16->f16" value: 382437762877877 }
+      flops { key: "f16xf16->f32" value: 378061467012895 }
+      flops { key: "f32xf32->f32" value: 121737710519975 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 504074560882577 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 358795981454408 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 449711250301031 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 505855638183852 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 845466003149606 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 457398008093716 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 456425855047821 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 501163045040840 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 782325554826958 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 444153805170630 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 458864027350427 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 614862359400164 }
+      flops { key: "bf16xbf16->f32" value: 562150099276856 }
+      flops { key: "f16xf16->f16" value: 610514185643212 }
+      flops { key: "f16xf16->f32" value: 586343658156996 }
+      flops { key: "f32xf32->f32" value: 123951091499401 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 910867355071311 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 401024023902894 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 869426578137651 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 913822828936170 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1223637406267806 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 858135323876123 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 876523937959183 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 901357249947534 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1252177054227405 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 846257287030195 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 870263369839420 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 290986944173441 }
+      flops { key: "bf16xbf16->f32" value: 285569634042553 }
+      flops { key: "f16xf16->f16" value: 284774386420899 }
+      flops { key: "f16xf16->f32" value: 275990701452255 }
+      flops { key: "f32xf32->f32" value: 117342421069886 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 370255801379310 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 353204547368421 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 400649934328358 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 422733001574803 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 434713289068825 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 424403883003952 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 397682157037037 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 432960412903225 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 368983444673539 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 379414072084805 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 396214695202952 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 385544640574506 }
+      flops { key: "bf16xbf16->f32" value: 453055621940928 }
+      flops { key: "f16xf16->f16" value: 436480416260162 }
+      flops { key: "f16xf16->f32" value: 431221616064257 }
+      flops { key: "f32xf32->f32" value: 148923970041608 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 673192366144200 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 633476002359882 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 743073926643598 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 750868408391608 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 807324679699248 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 715827882666666 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 838860800000000 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 727837196407388 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 761519024113475 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 819650247328244 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 735439605479452 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 517434768507921 }
+      flops { key: "bf16xbf16->f32" value: 522502104136253 }
+      flops { key: "f16xf16->f16" value: 523106667803422 }
+      flops { key: "f16xf16->f32" value: 513107615554626 }
+      flops { key: "f32xf32->f32" value: 991909306235565 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1329505431357375 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1270700383431952 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1263225675294117 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1501736816783216 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1626881551515151 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1451002464864864 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1394469901298701 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1422174601324503 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1422174601324503 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1512312428169014 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1436443911705685 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 514984088249400 }
+      flops { key: "bf16xbf16->f32" value: 509470928620147 }
+      flops { key: "f16xf16->f16" value: 524416031257631 }
+      flops { key: "f16xf16->f32" value: 509184030349733 }
+      flops { key: "f32xf32->f32" value: 124077315518449 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 561433633464052 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 396937898477391 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 539551810056216 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 564755725969756 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1213267597740113 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 546086115193897 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 549579948304542 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 559586631836096 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1111246389650711 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 545046611167512 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 549931792061459 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 700918756614512 }
+      flops { key: "bf16xbf16->f32" value: 680646943761019 }
+      flops { key: "f16xf16->f16" value: 688834192738718 }
+      flops { key: "f16xf16->f32" value: 672138856964006 }
+      flops { key: "f32xf32->f32" value: 126172274085280 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 949137824038010 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 435810534721781 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 935213346978769 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 958136648950112 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1567506312408759 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 933156035088672 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 933688542608695 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 941362695013698 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1599540913737721 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 925141043834141 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 939817789059081 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 53687091200000 }
+      flops { key: "bf16xbf16->f32" value: 56871918644067 }
+      flops { key: "f16xf16->f16" value: 57358003418803 }
+      flops { key: "f16xf16->f32" value: 54560052032520 }
+      flops { key: "f32xf32->f32" value: 36873002197802 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 57852468965517 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 46281975172413 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 66444419801980 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 63013017840375 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 43149888442372 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 65154236893203 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 65793003921568 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 58610361572052 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 42881063258785 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 62718564485981 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 62718564485981 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 76915603438395 }
+      flops { key: "bf16xbf16->f32" value: 85217605079365 }
+      flops { key: "f16xf16->f16" value: 77571292009825 }
+      flops { key: "f16xf16->f32" value: 73746004395604 }
+      flops { key: "f32xf32->f32" value: 55347516701030 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 111384006639004 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 80611248048048 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 115208350214592 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 104857600000000 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 77136625287356 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 101680096969696 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 116711067826086 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 106522006349206 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 75403217977528 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 105248169378553 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 109565492244897 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 178332805846204 }
+      flops { key: "bf16xbf16->f32" value: 127220595260663 }
+      flops { key: "f16xf16->f16" value: 175419347165495 }
+      flops { key: "f16xf16->f32" value: 134892188944723 }
+      flops { key: "f32xf32->f32" value: 76363119550529 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 204912561832061 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 183232393174061 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 191739611428571 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 209715200000000 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 187717102097902 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 180158024161073 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 173184165161290 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 199580264684014 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 186413511111111 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 179555488963210 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 200324967164179 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 267766040897755 }
+      flops { key: "bf16xbf16->f32" value: 218240208130081 }
+      flops { key: "f16xf16->f16" value: 273216749109414 }
+      flops { key: "f16xf16->f32" value: 213467559443339 }
+      flops { key: "f32xf32->f32" value: 91149560611205 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 322444992192192 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 259985913801452 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 271833373164556 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 328361414067278 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 267766040897755 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 273216749109414 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 264435863563600 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 333460193788819 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 292572704087193 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 255622384001904 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 250874257943925 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 358511460434056 }
+      flops { key: "bf16xbf16->f32" value: 301591692718208 }
+      flops { key: "f16xf16->f16" value: 361529233670033 }
+      flops { key: "f16xf16->f32" value: 287866440750670 }
+      flops { key: "f32xf32->f32" value: 105165702644466 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 438217252933374 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 345226854432923 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 390451572363636 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 448326440083507 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 522502104136253 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 382795659180035 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 389036892753623 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 427785587250996 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 492485643389519 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 382795659180035 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 377413646397188 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 100162483582089 }
+      flops { key: "bf16xbf16->f32" value: 98689505882352 }
+      flops { key: "f16xf16->f16" value: 108240103225806 }
+      flops { key: "f16xf16->f32" value: 106946396812749 }
+      flops { key: "f32xf32->f32" value: 55576698964803 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 118776750442477 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 52224796887159 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 119304647111111 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 120374643946188 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 50931686936723 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 126026035680751 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 113743837288135 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 115208350214592 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 51523120153550 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 116711067826086 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 119837257142857 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 174308737662337 }
+      flops { key: "bf16xbf16->f32" value: 171524253035143 }
+      flops { key: "f16xf16->f16" value: 181375308108108 }
+      flops { key: "f16xf16->f32" value: 153831206876790 }
+      flops { key: "f32xf32->f32" value: 78829882093825 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 205697667432950 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 173184165161290 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 217356644534412 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 219130984489795 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 188375758596491 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 222768013278008 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 214748364800000 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 214748364800000 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 176602273684210 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 199580264684014 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 213044012698412 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 266404124550303 }
+      flops { key: "bf16xbf16->f32" value: 208473317930298 }
+      flops { key: "f16xf16->f16" value: 258111015384615 }
+      flops { key: "f16xf16->f32" value: 237029100220750 }
+      flops { key: "f32xf32->f32" value: 96995648057813 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 349753037133550 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 252052071361502 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 344148020512820 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 303316899435028 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 311229514202898 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 335544320000000 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 352046499672131 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 332427809287925 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 306783378285714 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 352046499672131 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 323416212048192 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 363949436149478 }
+      flops { key: "bf16xbf16->f32" value: 320999050523168 }
+      flops { key: "f16xf16->f16" value: 371536963321799 }
+      flops { key: "f16xf16->f32" value: 315342679588839 }
+      flops { key: "f32xf32->f32" value: 109398046255731 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 559240533333333 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 389036892753623 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 484759288487584 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 554905335400516 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 514984088249400 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 488064465454545 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 468882892576419 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 538149015912792 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 532874354342431 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 479349028571428 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 478281436080178 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 574193488770053 }
+      flops { key: "bf16xbf16->f32" value: 448794910762800 }
+      flops { key: "f16xf16->f16" value: 505885429446407 }
+      flops { key: "f16xf16->f32" value: 440058124590163 }
+      flops { key: "f32xf32->f32" value: 118840837730523 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 729196484889643 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 538857950693181 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 599855767597765 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 727960558644067 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 862356650135528 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 591593291460055 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 594048035408022 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 730436614965986 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 825955249230769 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 582763540841248 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 584349291972789 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 127522781947743 }
+      flops { key: "bf16xbf16->f32" value: 125730892740046 }
+      flops { key: "f16xf16->f16" value: 130625526034063 }
+      flops { key: "f16xf16->f32" value: 119570359020044 }
+      flops { key: "f32xf32->f32" value: 76915603438395 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 157903209411764 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 178956970666666 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 168298091536050 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 161222496096096 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 177771825165562 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 153831206876790 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 156067125581395 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 156522131778425 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 179555488963210 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 153831206876790 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 157440150146627 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 217356644534412 }
+      flops { key: "bf16xbf16->f32" value: 208473317930298 }
+      flops { key: "f16xf16->f16" value: 208899187548638 }
+      flops { key: "f16xf16->f32" value: 197016848440366 }
+      flops { key: "f32xf32->f32" value: 97879838103919 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 267732657773344 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 256876034449760 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 271146925252525 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 269108226566416 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 324393300302114 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 271146925252525 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 273913730612244 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 273913730612244 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 328361414067278 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 277452667700258 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 268435456000000 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 354341002887550 }
+      flops { key: "bf16xbf16->f32" value: 332402081572633 }
+      flops { key: "f16xf16->f16" value: 342501379266347 }
+      flops { key: "f16xf16->f32" value: 320496029848518 }
+      flops { key: "f32xf32->f32" value: 113201214938984 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 424403883003952 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 380759512056737 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 437369378411405 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 436480416260162 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 596523235555555 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 441869063374485 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 444613591718426 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 436480416260162 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 546433498218829 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 440961734702258 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 429496729600000 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 499414801860465 }
+      flops { key: "bf16xbf16->f32" value: 441869063374485 }
+      flops { key: "f16xf16->f16" value: 457861232983316 }
+      flops { key: "f16xf16->f32" value: 411789769511025 }
+      flops { key: "f32xf32->f32" value: 119269860068591 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 694922303373513 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 525057126650366 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 685002758532695 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 749557992321116 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 923648880860215 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 678509841390205 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 680606496474130 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 764229056227758 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 904203641263157 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 668998021183800 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 688240893518147 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 790242372769089 }
+      flops { key: "bf16xbf16->f32" value: 682824689348171 }
+      flops { key: "f16xf16->f16" value: 734810486911890 }
+      flops { key: "f16xf16->f32" value: 665344842724913 }
+      flops { key: "f32xf32->f32" value: 125252396319680 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1014159928217237 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 639584125088418 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 925639503448275 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1008208285446009 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1255838390643274 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 902304053781512 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 894784853333333 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1048832062515262 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1458392969779287 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 803548605425631 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 906111243881856 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 297435408310249 }
+      flops { key: "bf16xbf16->f32" value: 293372083060109 }
+      flops { key: "f16xf16->f16" value: 287866440750670 }
+      flops { key: "f16xf16->f32" value: 308546501149425 }
+      flops { key: "f32xf32->f32" value: 117993607032967 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 384853700358422 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 365218307482993 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 361529233670033 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 380759512056737 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 384853700358422 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 431221616064257 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 367719802739726 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 456911414468085 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 383479222857142 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 451152026890756 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 386238066187050 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 253839674704491 }
+      flops { key: "bf16xbf16->f32" value: 230169737191854 }
+      flops { key: "f16xf16->f16" value: 254441190521327 }
+      flops { key: "f16xf16->f32" value: 233930680610021 }
+      flops { key: "f32xf32->f32" value: 107965292375757 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 309435684149855 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 337628118544139 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 314419274963396 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 321479588023952 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 569624309814323 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 309882200288600 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 308990452949640 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 316738001179941 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 528871727127201 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 312588595050946 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 305474203129445 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 387614935788096 }
+      flops { key: "bf16xbf16->f32" value: 382795659180035 }
+      flops { key: "f16xf16->f16" value: 390789072016741 }
+      flops { key: "f16xf16->f32" value: 362138895109612 }
+      flops { key: "f32xf32->f32" value: 121875889842652 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 514984088249400 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 448303042221178 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 492542121100917 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 508882381042654 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 933587065753722 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 493107611481056 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 518715857004830 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 498256066821345 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 917728054700854 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 527637259950859 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 491949750415211 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 635350191715976 }
+      flops { key: "bf16xbf16->f32" value: 606633798870056 }
+      flops { key: "f16xf16->f16" value: 631148757678177 }
+      flops { key: "f16xf16->f32" value: 601936483795241 }
+      flops { key: "f32xf32->f32" value: 126136145725802 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 922656776799140 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 638158656216336 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 747568390583525 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 925639503448275 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1274471007715133 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 861534987412868 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 855571174501992 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 911834254232790 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1337891845183397 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 855571174501992 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 854719859900497 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 906087349173281 }
+      flops { key: "bf16xbf16->f32" value: 783020860235637 }
+      flops { key: "f16xf16->f16" value: 851753553991075 }
+      flops { key: "f16xf16->f32" value: 771418207224804 }
+      flops { key: "f32xf32->f32" value: 128831465592812 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1256757072713972 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 732601402272872 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1175093651436388 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1251219488292487 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1963413621028571 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1171088560599863 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1179936070329670 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1239528801154401 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1932385038411787 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1188918282629757 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1180706448850555 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 439158210224948 }
+      flops { key: "bf16xbf16->f32" value: 411395334865900 }
+      flops { key: "f16xf16->f16" value: 439113311113383 }
+      flops { key: "f16xf16->f32" value: 447392426666666 }
+      flops { key: "f32xf32->f32" value: 148301760850799 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 610080581818181 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 662803595061728 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 642862939080975 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 697234950649350 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 704092999344262 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 727960558644067 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 750868408391608 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 692736660645161 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 688296041025641 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 720632096644295 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 688296041025641 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 584349291972789 }
+      flops { key: "bf16xbf16->f32" value: 574193488770053 }
+      flops { key: "f16xf16->f16" value: 562168494240837 }
+      flops { key: "f16xf16->f32" value: 578797560272218 }
+      flops { key: "f32xf32->f32" value: 1022611260952381 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1244918056811594 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1289779968768768 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1266952004719764 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1465859145392491 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1426899433887043 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1465859145392491 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1372194024281150 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1475933778694158 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1394469901298701 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1475933778694158 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1385473321290322 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 561800823544800 }
+      flops { key: "bf16xbf16->f32" value: 543305688751146 }
+      flops { key: "f16xf16->f16" value: 533867905034182 }
+      flops { key: "f16xf16->f32" value: 524720356250572 }
+      flops { key: "f32xf32->f32" value: 126283568192175 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 533536310062111 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 588331536043286 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 530570388634959 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 522502104136253 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1244918056811594 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 526344031372549 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 529915767550894 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 547478304142766 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1179936070329670 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 513444984578601 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 527637259950859 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 681727314299319 }
+      flops { key: "bf16xbf16->f32" value: 663046609829991 }
+      flops { key: "f16xf16->f16" value: 684443305272803 }
+      flops { key: "f16xf16->f32" value: 664855618575851 }
+      flops { key: "f32xf32->f32" value: 128532667851251 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1018337878782490 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 734480630341377 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 987916571822886 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1029937303078444 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1814136133474128 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 993056022196531 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 987348803678160 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1015328695014922 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1823765306157112 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 994781076085697 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 993056022196531 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 947580379972697 }
+      flops { key: "bf16xbf16->f32" value: 908975764024285 }
+      flops { key: "f16xf16->f16" value: 973625717062665 }
+      flops { key: "f16xf16->f32" value: 922396702540905 }
+      flops { key: "f32xf32->f32" value: 131007531724577 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1396141418012637 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 800916967587790 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1367279680382013 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1400123810354312 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2456021327233738 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1345304060922848 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1356457170920432 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1391617762621251 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2426535195480226 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1347969335739505 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1356992885922474 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 76260072727272 }
+      flops { key: "bf16xbf16->f32" value: 76695844571428 }
+      flops { key: "f16xf16->f16" value: 79172822887479 }
+      flops { key: "f16xf16->f32" value: 80369897005988 }
+      flops { key: "f32xf32->f32" value: 55924053333333 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 106100970750988 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 78489899415204 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 98328005860805 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 106946396812749 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 75615621408450 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 104449593774319 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 109543136502754 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 111384006639004 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 77136625287356 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 104857600000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 103244406153846 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 168827330817610 }
+      flops { key: "bf16xbf16->f32" value: 151658449717514 }
+      flops { key: "f16xf16->f16" value: 170435210158730 }
+      flops { key: "f16xf16->f32" value: 154717842074927 }
+      flops { key: "f32xf32->f32" value: 75716932797404 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 176602273684210 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 182609153741496 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 173744631715210 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 203360193939393 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 187717102097902 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 184491722336769 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 172627302893890 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 201075247940074 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 156979798830409 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 179555488963210 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 173184165161290 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 278893980259740 }
+      flops { key: "bf16xbf16->f32" value: 211366500787401 }
+      flops { key: "f16xf16->f16" value: 276737583505154 }
+      flops { key: "f16xf16->f32" value: 197742509023941 }
+      flops { key: "f32xf32->f32" value: 92004783342616 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 339791716455696 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 258732969638554 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 276026175835475 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 293372083060109 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 277452667700258 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 262528563325183 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 275318416410256 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 338719818296529 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 289418281401617 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 269108226566416 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 265121438024691 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 363980279322033 }
+      flops { key: "bf16xbf16->f32" value: 277452667700258 }
+      flops { key: "f16xf16->f16" value: 349184333008130 }
+      flops { key: "f16xf16->f32" value: 279620266666666 }
+      flops { key: "f32xf32->f32" value: 33569643244595 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 393997550316484 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 402904999624765 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 399903845065176 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 462769884279711 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 514922346960796 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 391876578102189 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 398419971799628 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 451152026890756 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 502923570960187 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 391876578102189 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 395485018047882 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 468371569901853 }
+      flops { key: "bf16xbf16->f32" value: 414972685603864 }
+      flops { key: "f16xf16->f16" value: 479884614078212 }
+      flops { key: "f16xf16->f32" value: 395103012372935 }
+      flops { key: "f32xf32->f32" value: 115672218149499 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 613566756571428 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 483667488288288 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 468882892576419 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 620615171736146 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 671088640000000 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 450678624973767 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 467861361220043 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 609215219290780 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 627919195321637 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 468857299929043 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 472493651925192 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 177185119471947 }
+      flops { key: "bf16xbf16->f32" value: 170977997452229 }
+      flops { key: "f16xf16->f16" value: 179555488963210 }
+      flops { key: "f16xf16->f32" value: 174308737662337 }
+      flops { key: "f32xf32->f32" value: 73746004395604 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 223696213333333 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 178362429235880 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 199580264684014 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 221801657508779 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 170950775991084 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 222768013278008 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 229432013675213 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 213892793625498 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 174308737662337 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 198107347601476 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 210537612549019 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 242928014479638 }
+      flops { key: "bf16xbf16->f32" value: 224632180753138 }
+      flops { key: "f16xf16->f16" value: 235987214065934 }
+      flops { key: "f16xf16->f32" value: 219556655556691 }
+      flops { key: "f32xf32->f32" value: 94270572783143 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 349753037133550 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 322444992192192 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 339791716455696 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 329368657668711 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 331401797530864 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 344148020512820 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 322444992192192 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 353204547368421 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 291777669565217 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 336596183072100 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 325376310303030 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 368350539965694 }
+      flops { key: "bf16xbf16->f32" value: 310756623688589 }
+      flops { key: "f16xf16->f16" value: 377380484667428 }
+      flops { key: "f16xf16->f32" value: 313936649075360 }
+      flops { key: "f32xf32->f32" value: 109674607287862 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 518653217727327 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 446462296881496 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 512525930310262 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 560700691383812 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 547827461224489 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 511244768003809 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 519971827602905 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 550636832820512 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 536870912000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 477218588444444 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 485856028959276 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 593227527071823 }
+      flops { key: "bf16xbf16->f32" value: 432938591401643 }
+      flops { key: "f16xf16->f16" value: 513138267144563 }
+      flops { key: "f16xf16->f32" value: 448794910762800 }
+      flops { key: "f32xf32->f32" value: 117507757650374 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 730436614965986 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 626088527113702 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 671088640000000 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 741790551986183 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 865920825806451 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 641950122711307 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 672138856964006 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 730436614965986 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 880116249180327 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 665886402480620 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 666920387577639 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 743073926643598 }
+      flops { key: "bf16xbf16->f32" value: 567741876536682 }
+      flops { key: "f16xf16->f16" value: 733524152854276 }
+      flops { key: "f16xf16->f32" value: 581186372936400 }
+      flops { key: "f32xf32->f32" value: 123541964921868 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 936743139803707 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 790933621104000 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 783753156204379 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 928591383384681 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1124336988481675 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 774565788277727 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 754164582265144 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 948116400883002 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1106950334020618 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 753503034385964 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 783003016453215 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 223207945951564 }
+      flops { key: "bf16xbf16->f32" value: 205697667432950 }
+      flops { key: "f16xf16->f16" value: 222744906959858 }
+      flops { key: "f16xf16->f32" value: 215178722244488 }
+      flops { key: "f32xf32->f32" value: 93772483647002 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 278893980259740 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 316691291549918 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 270463935516372 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 283309188390501 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 326365296048632 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 266437177171215 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 264468429556650 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 270463935516372 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 328361414067278 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 273913730612244 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 257492044124700 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 374778996160558 }
+      flops { key: "bf16xbf16->f32" value: 293372083060109 }
+      flops { key: "f16xf16->f16" value: 312134251162790 }
+      flops { key: "f16xf16->f32" value: 295796645730027 }
+      flops { key: "f32xf32->f32" value: 111961817887959 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 447392426666666 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 471974428131868 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 452101820631578 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 461824440430107 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 580400985945946 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 442780133608247 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 452101820631578 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 460833400858369 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 545046611167512 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 450206215513626 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 445536026556016 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 492542121100917 }
+      flops { key: "bf16xbf16->f32" value: 412957770876400 }
+      flops { key: "f16xf16->f16" value: 528286260270602 }
+      flops { key: "f16xf16->f32" value: 405568205476864 }
+      flops { key: "f32xf32->f32" value: 120442156365675 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 745654044444444 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 623362452249637 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 696104910210696 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 743009652452210 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 911882653078556 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 718221955852842 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 713449716943521 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 764229056227758 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 900412431027253 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 682824689348171 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 694978526860841 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 810371187924528 }
+      flops { key: "bf16xbf16->f32" value: 692736660645161 }
+      flops { key: "f16xf16->f16" value: 724277790219224 }
+      flops { key: "f16xf16->f32" value: 674778836763550 }
+      flops { key: "f32xf32->f32" value: 125600365428199 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1022611260952381 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 921666801716738 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 940795640107332 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1042467790291262 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1378801700160513 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 975020952553916 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 957575897887520 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1055274519901719 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1272582902518518 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 969518576975169 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 983899500830422 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 1030555123361626 }
+      flops { key: "bf16xbf16->f32" value: 728562548885731 }
+      flops { key: "f16xf16->f16" value: 957602585435188 }
+      flops { key: "f16xf16->f32" value: 717906821169637 }
+      flops { key: "f32xf32->f32" value: 128571144493962 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1269714288755035 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1034900706846179 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1155298690965334 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1244918056811594 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1763756396899543 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1146853750600801 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1146050444214669 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1347387881573271 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1751260875025484 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1136949087323384 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1146815472380761 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 255045563895486 }
+      flops { key: "bf16xbf16->f32" value: 252942714723203 }
+      flops { key: "f16xf16->f16" value: 303316899435028 }
+      flops { key: "f16xf16->f32" value: 273913730612244 }
+      flops { key: "f32xf32->f32" value: 106255839687291 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 321479588023952 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 431221616064257 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 313044263556851 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 325376310303030 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 547827461224489 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 321479588023952 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 320999050523168 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 314419274963396 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 499414801860465 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 324368801147949 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 320999050523168 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 463319017907227 }
+      flops { key: "bf16xbf16->f32" value: 385891041868823 }
+      flops { key: "f16xf16->f16" value: 398419971799628 }
+      flops { key: "f16xf16->f32" value: 383137136128456 }
+      flops { key: "f32xf32->f32" value: 120609575715027 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 545012029185965 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 585903730441306 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 542979430594184 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 545012029185965 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 908026912473573 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 532214039157373 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 538182732410250 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 531555358415841 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 750868408391608 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 529556414031194 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 517434768507921 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 643440793408239 }
+      flops { key: "bf16xbf16->f32" value: 616207646484935 }
+      flops { key: "f16xf16->f16" value: 645350256714623 }
+      flops { key: "f16xf16->f32" value: 606184297801771 }
+      flops { key: "f32xf32->f32" value: 123719901080937 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 910867355071311 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 786624046886446 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 744975030744547 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 917679033384968 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1363481681269841 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 868547481496461 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 871190120892494 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 904156054102415 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1475806991151963 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 847927998815458 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 858993459200000 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 969491221128072 }
+      flops { key: "bf16xbf16->f32" value: 869404579033931 }
+      flops { key: "f16xf16->f16" value: 876523937959183 }
+      flops { key: "f16xf16->f32" value: 856851330872818 }
+      flops { key: "f32xf32->f32" value: 129044359779616 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1282989371868115 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1140723693370074 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1238635125018024 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1291719487518797 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2100228506601467 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1254921050693937 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1259521201173020 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1333840775155279 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1997659207441860 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1231531841146953 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1221896812517781 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 1265062806943907 }
+      flops { key: "bf16xbf16->f32" value: 1012053971752993 }
+      flops { key: "f16xf16->f16" value: 1121749183591518 }
+      flops { key: "f16xf16->f32" value: 977795628002276 }
+      flops { key: "f32xf32->f32" value: 131383488487606 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1673594815908039 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1225798268600274 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1552631647898780 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1716227784920456 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2604983955117513 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1533882652976496 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1551895321605203 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1698412711895405 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2604983955117513 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1535287684003574 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1544257904179775 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 602337465254891 }
+      flops { key: "bf16xbf16->f32" value: 589927518164961 }
+      flops { key: "f16xf16->f16" value: 547094745048086 }
+      flops { key: "f16xf16->f32" value: 597352892350486 }
+      flops { key: "f32xf32->f32" value: 159246854748706 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 832358003100775 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 850404375012375 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 845466003149606 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1412818189473684 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1446116934680134 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1431655765333333 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1325607190123456 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1337996042367601 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1282079789850746 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1333840775155279 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1376592082051282 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 566226201641343 }
+      flops { key: "bf16xbf16->f32" value: 508867307958887 }
+      flops { key: "f16xf16->f16" value: 539551810056216 }
+      flops { key: "f16xf16->f32" value: 482309634587310 }
+      flops { key: "f32xf32->f32" value: 126061175973349 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 602802427508771 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 827546685163776 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 560334937508153 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 601115086913925 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1265086096023564 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 565499314812376 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 567741876536682 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 571880735794414 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1214983676379066 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 561782452633988 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 561433633464052 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 726099160372773 }
+      flops { key: "bf16xbf16->f32" value: 700061905177156 }
+      flops { key: "f16xf16->f16" value: 721237161376994 }
+      flops { key: "f16xf16->f32" value: 689400850080256 }
+      flops { key: "f32xf32->f32" value: 126993954686910 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 794977866500081 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1027504137799043 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1004054188013208 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 789879042942528 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1917289122705206 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 989623800921659 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1001128707438594 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 793894139741220 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1915258548940914 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 785185977330895 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 781951670831342 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 923388247080797 }
+      flops { key: "bf16xbf16->f32" value: 954954443879323 }
+      flops { key: "f16xf16->f16" value: 973074251794791 }
+      flops { key: "f16xf16->f32" value: 897343684934905 }
+      flops { key: "f32xf32->f32" value: 131232696776066 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1467110946541417 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1300003343410075 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1462116526297872 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1505685292199824 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2839530463038717 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1470879210958904 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1473370569584700 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1504333896718548 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2832508006100325 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1454657537647382 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1470218367942491 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1404717383019388 }
+      flops { key: "bf16xbf16->f32" value: 1180736879167704 }
+      flops { key: "f16xf16->f16" value: 1204960095668107 }
+      flops { key: "f16xf16->f32" value: 1144361441386832 }
+      flops { key: "f32xf32->f32" value: 133243256565993 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1921685591051454 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1400994418731715 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1812222487763713 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1921121503361708 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3393554406716049 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1794710805327761 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1811243308232627 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1908847842002194 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 3332580525981426 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1789080504966090 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1819877298658651 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 177771825165562 }
+      flops { key: "bf16xbf16->f32" value: 156067125581395 }
+      flops { key: "f16xf16->f16" value: 184491722336769 }
+      flops { key: "f16xf16->f32" value: 153831206876790 }
+      flops { key: "f32xf32->f32" value: 74981970949720 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 224632180753138 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 173744631715210 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 179555488963210 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 223696213333333 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 158837547928994 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 181990139661016 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 181990139661016 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 183859901369863 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 154717842074927 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 178362429235880 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 181990139661016 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 268435456000000 }
+      flops { key: "bf16xbf16->f32" value: 224163220041753 }
+      flops { key: "f16xf16->f16" value: 248551348148148 }
+      flops { key: "f16xf16->f32" value: 210125601565557 }
+      flops { key: "f32xf32->f32" value: 90611124388185 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 326365296048632 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 295796645730027 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 303316899435028 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 328361414067278 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 278893980259740 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 286331153066666 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 294175842191780 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 317675095857988 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 263818629975429 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 289418281401617 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 284812154907161 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 377413646397188 }
+      flops { key: "bf16xbf16->f32" value: 295776275463122 }
+      flops { key: "f16xf16->f16" value: 347489263430420 }
+      flops { key: "f16xf16->f32" value: 289028754777927 }
+      flops { key: "f32xf32->f32" value: 103590537999565 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 458864027350427 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 469908894529540 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 376091707180385 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 466844271304347 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 477218588444444 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 412937919046245 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 394758023529411 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 452101820631578 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 493674401839080 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 430357444488977 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 396214695202952 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 483667488288288 }
+      flops { key: "bf16xbf16->f32" value: 417392351409135 }
+      flops { key: "f16xf16->f16" value: 476662482215193 }
+      flops { key: "f16xf16->f32" value: 411001655119617 }
+      flops { key: "f32xf32->f32" value: 116047264857270 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 613566756571428 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 586744166120218 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 503513164830011 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 622459028405797 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 645859743759398 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 497102696296296 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 508280153372781 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 601536035854341 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 610080581818181 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 500578938927738 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 491977926231386 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 538874852859069 }
+      flops { key: "bf16xbf16->f32" value: 420035431505342 }
+      flops { key: "f16xf16->f16" value: 533188578380559 }
+      flops { key: "f16xf16->f32" value: 433386372291314 }
+      flops { key: "f32xf32->f32" value: 114485140701843 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 716992996285630 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 680094579945370 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 548509600076625 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 713449716943521 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 825161824399615 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 544338556572985 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 553475167010309 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 700076168867155 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 765591318360071 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 539568755778894 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 545029319628184 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 247405950230414 }
+      flops { key: "bf16xbf16->f32" value: 229432013675213 }
+      flops { key: "f16xf16->f16" value: 246271060550458 }
+      flops { key: "f16xf16->f32" value: 226527810970464 }
+      flops { key: "f32xf32->f32" value: 91926015495911 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 355543650331125 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 319518471656003 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 316738001179941 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 349753037133550 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 339791716455696 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 312134251162790 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 317675095857988 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 354370238943894 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 271146925252525 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 318617751928783 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 310330006936416 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 362138895109612 }
+      flops { key: "bf16xbf16->f32" value: 307662413753581 }
+      flops { key: "f16xf16->f16" value: 377413646397188 }
+      flops { key: "f16xf16->f32" value: 315806418823529 }
+      flops { key: "f32xf32->f32" value: 108620603828937 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 556342913989637 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 531555358415841 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 505290270117647 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 581973888346883 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 544977451592437 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 485856028959276 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 510091127790973 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 583555339130434 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 473014019383259 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 506481992452830 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 513752068899521 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 595695880166435 }
+      flops { key: "bf16xbf16->f32" value: 494242496662830 }
+      flops { key: "f16xf16->f16" value: 547094745048086 }
+      flops { key: "f16xf16->f32" value: 447835597309837 }
+      flops { key: "f32xf32->f32" value: 119269860068591 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 724216726414299 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 761451519546139 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 623317218779479 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 680660427258320 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 821217456214149 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 663828021020092 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 641039894925373 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 690509211575562 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 892924593762993 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 658737315337423 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 604074162587904 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 780903144727272 }
+      flops { key: "bf16xbf16->f32" value: 588331536043286 }
+      flops { key: "f16xf16->f16" value: 734182443760683 }
+      flops { key: "f16xf16->f32" value: 583139376939004 }
+      flops { key: "f32xf32->f32" value: 123879589160813 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 869382581043469 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 905108750013171 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 811098115480855 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 888307610341261 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1068399824875621 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 775930137934149 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 799063682976744 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 878316420449897 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1055274519901719 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 785904354254345 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 808084157290686 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 835170228433922 }
+      flops { key: "bf16xbf16->f32" value: 581579864048747 }
+      flops { key: "f16xf16->f16" value: 808845065160075 }
+      flops { key: "f16xf16->f32" value: 579031654330974 }
+      flops { key: "f32xf32->f32" value: 123391121115268 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1043702754108319 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1106201937091529 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 872960832520325 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1041172642283567 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1322545741647421 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 867232164765270 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 869426578137651 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1050756525015290 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1317474630674846 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 862443232128514 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 871190120892494 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 365840485178875 }
+      flops { key: "bf16xbf16->f32" value: 298261617777777 }
+      flops { key: "f16xf16->f16" value: 319067476116187 }
+      flops { key: "f16xf16->f32" value: 295389772764786 }
+      flops { key: "f32xf32->f32" value: 110464424680435 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 484759288487584 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 534199912437810 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 428639450698602 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 484759288487584 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 556342913989637 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 439158210224948 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 453055621940928 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 471974428131868 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 519908884638663 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 445536026556016 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 441869063374485 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 497102696296296 }
+      flops { key: "bf16xbf16->f32" value: 476662482215193 }
+      flops { key: "f16xf16->f16" value: 500549769360759 }
+      flops { key: "f16xf16->f32" value: 486406262287655 }
+      flops { key: "f32xf32->f32" value: 120305522219576 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 766958445714285 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 758828144169611 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 701792041830065 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 754827292794376 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 896652880167014 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 725501232432432 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 715827882666666 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 782325554826958 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 883738126748971 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 705249145484400 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 708682005775101 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 796064556044668 }
+      flops { key: "bf16xbf16->f32" value: 687717432608782 }
+      flops { key: "f16xf16->f16" value: 735408123967295 }
+      flops { key: "f16xf16->f32" value: 674778836763550 }
+      flops { key: "f32xf32->f32" value: 124617326031292 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1008208285446009 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1057873718226601 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 908026912473573 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1032382019349798 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1403584083660130 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 916748622411953 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 927588639058366 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1011770858892815 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1232415292969871 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 842976898135426 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 923648880860215 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 1038058560966767 }
+      flops { key: "bf16xbf16->f32" value: 742736611141134 }
+      flops { key: "f16xf16->f16" value: 958136648950112 }
+      flops { key: "f16xf16->f32" value: 725485913895399 }
+      flops { key: "f32xf32->f32" value: 128263496020665 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1206409127769390 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1336954800311284 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1143038535196274 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1187233971459175 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1714472250286911 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1122830573118525 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1144561571219187 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1276364723922734 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1833497244823906 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1101273665641025 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1110528066192630 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 1105152325244045 }
+      flops { key: "bf16xbf16->f32" value: 734645521600154 }
+      flops { key: "f16xf16->f16" value: 1014144961497026 }
+      flops { key: "f16xf16->f32" value: 747592788764265 }
+      flops { key: "f32xf32->f32" value: 129219069991688 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1382657828534637 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1438217633285197 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1245820825525743 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1399582010916497 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2118356249568434 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1233300013208901 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1250331630356070 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1383242285346215 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2163643359340071 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1231509771079371 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1246724904499274 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 378728212689034 }
+      flops { key: "bf16xbf16->f32" value: 383804771547294 }
+      flops { key: "f16xf16->f16" value: 401398812710280 }
+      flops { key: "f16xf16->f32" value: 389019274127077 }
+      flops { key: "f32xf32->f32" value: 120711268700552 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 537542840550688 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 748252142160278 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 542979430594184 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 540247458616352 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 810371187924528 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 527637259950859 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 521835525909726 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 544321309929662 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 830748026305609 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 519971827602905 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 525699791432068 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 640084544858420 }
+      flops { key: "bf16xbf16->f32" value: 607470357625260 }
+      flops { key: "f16xf16->f16" value: 636763127650111 }
+      flops { key: "f16xf16->f32" value: 602802427508771 }
+      flops { key: "f32xf32->f32" value: 123523311312750 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 926588058033547 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1036117796514082 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 903252848790746 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 923648880860215 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1396737332032520 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 886474158101135 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 891951050516587 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 935671759925930 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1239528801154401 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 887389937190082 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 881878198449771 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 963537250925406 }
+      flops { key: "bf16xbf16->f32" value: 873826666870120 }
+      flops { key: "f16xf16->f16" value: 892901389464930 }
+      flops { key: "f16xf16->f32" value: 846278130292357 }
+      flops { key: "f32xf32->f32" value: 128196977005704 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1162333424714996 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1353758258855049 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1171887393178717 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1178277095024176 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2299848619009371 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1168698583945578 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1173488332240437 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1177469530447894 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2290649224533333 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1156893547744107 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1175897959206023 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 1244895504356805 }
+      flops { key: "bf16xbf16->f32" value: 1030879775820944 }
+      flops { key: "f16xf16->f16" value: 1124318593216734 }
+      flops { key: "f16xf16->f32" value: 851742996938560 }
+      flops { key: "f32xf32->f32" value: 131489324516287 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1636139061831861 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1761089586017785 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1511647090541135 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1635360337355132 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2628901175822494 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1502393457280279 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1489368806588643 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1608564329861192 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2718226206874728 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1493869192756679 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1503017797860939 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 1299032650655475 }
+      flops { key: "bf16xbf16->f32" value: 1041827711069503 }
+      flops { key: "f16xf16->f16" value: 1140941495355343 }
+      flops { key: "f16xf16->f32" value: 1014152444801912 }
+      flops { key: "f32xf32->f32" value: 131574670411748 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1717128354222888 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1848763851333719 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1598499109932542 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1703485993877121 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3071879338235623 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 3507885489331291 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 3672874224265099 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 4137235203853100 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 3058208617342738 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 3665038759253333 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 3682715795069667 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 557064500129701 }
+      flops { key: "bf16xbf16->f32" value: 504978371711589 }
+      flops { key: "f16xf16->f16" value: 514675529778310 }
+      flops { key: "f16xf16->f32" value: 499110112547572 }
+      flops { key: "f32xf32->f32" value: 126246448347320 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 563644002099737 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1043734458323207 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 563644002099737 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 568493354864328 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1216704616430595 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1148386977540107 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 556703473233959 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 563995574143987 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1162372745872801 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 557425995587281 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 553475167010309 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 703501942384472 }
+      flops { key: "bf16xbf16->f32" value: 687469755262104 }
+      flops { key: "f16xf16->f16" value: 709897282452841 }
+      flops { key: "f16xf16->f32" value: 681186700660177 }
+      flops { key: "f32xf32->f32" value: 128628902670305 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1027504137799043 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1361266921595816 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 999963283024359 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1007616960938416 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2188518367388535 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 998800568820673 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 990736667570139 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1004641337036928 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2018786038072855 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1871343519851860 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1003497031775700 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1004068858374366 }
+      flops { key: "bf16xbf16->f32" value: 963794010406586 }
+      flops { key: "f16xf16->f16" value: 950463710543422 }
+      flops { key: "f16xf16->f32" value: 949675608905349 }
+      flops { key: "f32xf32->f32" value: 130977817723690 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1319979960738364 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1745877308401717 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1289779968768768 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1318460442739011 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3067833782857143 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1299044928846881 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1298063406422365 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1310415070955931 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 3019176518430649 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1294127732735730 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 3193284234944238 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1357006284219152 }
+      flops { key: "bf16xbf16->f32" value: 1187049398628457 }
+      flops { key: "f16xf16->f16" value: 1202219657560728 }
+      flops { key: "f16xf16->f32" value: 1154939483466525 }
+      flops { key: "f32xf32->f32" value: 132679731502987 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1843803456782173 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 2065477727596519 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1747675556923233 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1844793405081811 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3730699062757872 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 4107437119990436 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 4195200191447147 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 4652638912389980 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 3686568318231807 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 4134745892659446 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 4162168119439145 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1360229545154937 }
+      flops { key: "bf16xbf16->f32" value: 1217124834813719 }
+      flops { key: "f16xf16->f16" value: 1264725211620395 }
+      flops { key: "f16xf16->f32" value: 1123500612861825 }
+      flops { key: "f32xf32->f32" value: 93050226769001 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1925980808318327 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 2113453740506377 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1882196827904492 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 4367300714076898 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3976821570370370 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 4331446194418619 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 4353398060594542 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 4970577511148081 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 3901135478406494 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 4354777442435956 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 4357538830139027 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 28556963404255 }
+      flops { key: "bf16xbf16->f32" value: 28197001680672 }
+      flops { key: "f16xf16->f16" value: 28197001680672 }
+      flops { key: "f16xf16->f32" value: 29177766956521 }
+      flops { key: "f32xf32->f32" value: 19622474853801 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 34065413197969 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 22002906229508 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 36275061621621 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 31213425116279 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 23464637762237 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 33723047236180 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 36275061621621 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 36472208695652 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 22519753020134 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 36671510382513 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 29694187610619 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 44150568421052 }
+      flops { key: "bf16xbf16->f32" value: 54339161133603 }
+      flops { key: "f16xf16->f16" value: 58355533913043 }
+      flops { key: "f16xf16->f32" value: 56871918644067 }
+      flops { key: "f32xf32->f32" value: 33807991939546 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 60732003619909 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 41943040000000 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 64527753846153 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 70271061780104 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 43018502564102 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 63610297630331 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 62426850232558 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 64839482125603 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 41045176758409 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 61008058181818 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 62718564485981 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 83106952321981 }
+      flops { key: "bf16xbf16->f32" value: 82595524923076 }
+      flops { key: "f16xf16->f16" value: 85762126517571 }
+      flops { key: "f16xf16->f32" value: 81591324012158 }
+      flops { key: "f32xf32->f32" value: 57358003418803 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 104857600000000 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 57235704904051 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 87438259283387 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 91929950684931 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 56751682029598 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 89181214617940 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 91616196587030 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 91616196587030 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 56394003361344 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 91616196587030 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 84149045768025 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 185768481660899 }
+      flops { key: "bf16xbf16->f32" value: 160259973731343 }
+      flops { key: "f16xf16->f16" value: 183232393174061 }
+      flops { key: "f16xf16->f32" value: 139085728497409 }
+      flops { key: "f32xf32->f32" value: 75086840839160 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 202592796981132 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 74051160275862 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 193816213718411 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 208089500775193 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 170977997452229 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 191057264056939 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 186413511111111 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 209715200000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 182609153741496 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 190346006736394 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 179555488963210 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 277452667700258 }
+      flops { key: "bf16xbf16->f32" value: 206072703963151 }
+      flops { key: "f16xf16->f16" value: 214319725349301 }
+      flops { key: "f16xf16->f32" value: 232411650216450 }
+      flops { key: "f32xf32->f32" value: 89325886943138 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 321431469540487 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 175161798368678 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 281822001049868 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 325376310303030 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 280350345691906 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 278171456994818 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 279620266666666 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 341955994904458 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 276737583505154 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 281822001049868 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 266437177171215 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 57113926808510 }
+      flops { key: "bf16xbf16->f32" value: 53902702008032 }
+      flops { key: "f16xf16->f16" value: 53473198406374 }
+      flops { key: "f16xf16->f32" value: 51821516602316 }
+      flops { key: "f32xf32->f32" value: 25860833911368 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 58867424561403 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 26789965668662 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 65793003921568 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 60458436036036 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 27616816460905 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 52841625196850 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 64219008612440 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 65793003921568 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 25960875822050 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 55007265573770 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 62718564485981 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 100143800037306 }
+      flops { key: "bf16xbf16->f32" value: 88885912582781 }
+      flops { key: "f16xf16->f16" value: 98328005860805 }
+      flops { key: "f16xf16->f32" value: 91929950684931 }
+      flops { key: "f32xf32->f32" value: 58096625040580 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 119837257142857 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 52326599610136 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 115704937931034 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 116711067826086 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 94853518021201 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 125437128971962 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 123135530275229 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 119278140857587 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 105248169378553 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 115680006895065 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 110923742148760 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 171524253035143 }
+      flops { key: "bf16xbf16->f32" value: 162196650151057 }
+      flops { key: "f16xf16->f16" value: 180734190203669 }
+      flops { key: "f16xf16->f32" value: 167249505295950 }
+      flops { key: "f32xf32->f32" value: 76477337891737 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 208089500775193 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 68741474007682 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 174876518566775 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 193816213718411 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 192426850179211 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 183232393174061 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 189039053521126 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 187030451837658 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 188375758596491 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 182578103043700 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 188375758596491 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 231384942139855 }
+      flops { key: "bf16xbf16->f32" value: 221367245438614 }
+      flops { key: "f16xf16->f16" value: 240749287892376 }
+      flops { key: "f16xf16->f32" value: 217356644534412 }
+      flops { key: "f32xf32->f32" value: 94101207133780 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 313959597660818 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 163431023439878 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 267766040897755 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 319566019047619 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 325376310303030 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 288640275268817 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 294984017582417 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 319566019047619 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 305909351566951 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 301612871910112 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 284812154907161 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 360316048322147 }
+      flops { key: "bf16xbf16->f32" value: 311229514202898 }
+      flops { key: "f16xf16->f16" value: 363980279322033 }
+      flops { key: "f16xf16->f32" value: 317651600917091 }
+      flops { key: "f32xf32->f32" value: 106890502874492 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 550636832820512 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 201443051264012 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 482580595056179 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 557787960519480 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 494754901048266 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 505290270117647 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 502923570960187 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 547827461224489 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 483667488288288 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 482580595056179 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 488064465454545 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 99053673800738 }
+      flops { key: "bf16xbf16->f32" value: 105683250393700 }
+      flops { key: "f16xf16->f16" value: 99420539259259 }
+      flops { key: "f16xf16->f32" value: 110014531147540 }
+      flops { key: "f32xf32->f32" value: 57113926808510 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 72160068817204 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 68829604102564 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 68829604102564 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 67277056641604 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 73343020765027 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 73343020765027 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 71193596605224 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 63013017840375 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 67958343291139 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 63761390973871 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 50081241791044 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 120105349440715 }
+      flops { key: "bf16xbf16->f32" value: 117734849122807 }
+      flops { key: "f16xf16->f16" value: 119040113525498 }
+      flops { key: "f16xf16->f32" value: 120091916340454 }
+      flops { key: "f32xf32->f32" value: 76044038526912 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 144709140700808 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 98689505882352 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 149963941899441 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 142784817021276 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 169359909148264 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 151231242816901 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 148697108987674 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 149963941899441 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 183232393174061 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 150806435955056 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 142029341798941 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 234954447264770 }
+      flops { key: "bf16xbf16->f32" value: 213467559443339 }
+      flops { key: "f16xf16->f16" value: 226050910315789 }
+      flops { key: "f16xf16->f32" value: 214726892110788 }
+      flops { key: "f32xf32->f32" value: 95101352818741 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 253839674704491 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 141654594195250 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 259985913801452 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 263139768165665 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 294984017582417 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 257492044124700 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 259357928502415 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 250289469463869 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 346312473472020 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 242928014479638 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 251461785480093 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 266768155031055 }
+      flops { key: "bf16xbf16->f32" value: 264468429556650 }
+      flops { key: "f16xf16->f16" value: 272852251826440 }
+      flops { key: "f16xf16->f32" value: 263172015686274 }
+      flops { key: "f32xf32->f32" value: 111326264800414 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 424403883003952 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 185760447039487 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 394758023529411 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 413733483864752 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 510091127790973 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 400649934328358 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 375434204195804 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 440058124590163 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 514984088249400 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 398419971799628 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 412145407926302 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 483667488288288 }
+      flops { key: "bf16xbf16->f32" value: 401380056632867 }
+      flops { key: "f16xf16->f16" value: 478281436080178 }
+      flops { key: "f16xf16->f32" value: 397314273450508 }
+      flops { key: "f32xf32->f32" value: 119535416874243 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 720632096644295 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 211673802814124 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 686097012140575 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 740511602758620 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 697178361496631 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 683911989808917 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 687194767360000 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 723058467340067 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 670041699843993 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 666920387577639 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 690509211575562 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 174308737662337 }
+      flops { key: "bf16xbf16->f32" value: 179555488963210 }
+      flops { key: "f16xf16->f16" value: 188375758596491 }
+      flops { key: "f16xf16->f32" value: 173156236736010 }
+      flops { key: "f32xf32->f32" value: 97259223188405 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 102848833716475 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 105062800782778 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 106723171056555 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 112788006722689 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 102848833716475 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 105062800782778 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 110014531147540 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 107159862674650 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 103843503288201 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 101286843128006 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 106100970750988 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 292572704087193 }
+      flops { key: "bf16xbf16->f32" value: 287096744385026 }
+      flops { key: "f16xf16->f16" value: 287866440750670 }
+      flops { key: "f16xf16->f32" value: 284812154907161 }
+      flops { key: "f32xf32->f32" value: 119837257142857 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 131586007843137 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 124564016705336 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 134050165293383 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 460833400858369 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 456911414468085 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 440058124590163 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 429496729600000 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 436480416260162 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 372827022222222 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 479349028571428 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 386238066187050 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 266090533176383 }
+      flops { key: "bf16xbf16->f32" value: 248839356662804 }
+      flops { key: "f16xf16->f16" value: 265761233587030 }
+      flops { key: "f16xf16->f32" value: 249402897392718 }
+      flops { key: "f32xf32->f32" value: 105784766286544 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 305474203129445 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 162319247770219 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 308546501149425 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 315806418823529 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 448326440083507 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 304176154107648 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 311681226124818 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 312588595050946 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 485856028959276 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 308103823242467 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 305018627654285 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 375106314061135 }
+      flops { key: "bf16xbf16->f32" value: 370575262812769 }
+      flops { key: "f16xf16->f16" value: 382778601310102 }
+      flops { key: "f16xf16->f32" value: 371215842350907 }
+      flops { key: "f32xf32->f32" value: 121565426359660 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 497102696296296 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 215173332130958 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 480959383650615 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 504104142723004 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 731680970357751 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 480959383650615 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 484759288487584 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 503483652306429 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 676372802519685 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 486406262287655 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 479349028571428 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 606184297801771 }
+      flops { key: "bf16xbf16->f32" value: 564737161303047 }
+      flops { key: "f16xf16->f16" value: 589138547512088 }
+      flops { key: "f16xf16->f32" value: 574942913021652 }
+      flops { key: "f32xf32->f32" value: 124400758749031 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 852176050793650 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 224805605579618 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 821217456214149 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 855571174501992 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 995357426651216 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 811864712631728 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 814984306641366 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 854719859900497 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 971712057918552 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 813440775757575 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 814211809668246 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 289418281401617 }
+      flops { key: "bf16xbf16->f32" value: 278171456994818 }
+      flops { key: "f16xf16->f16" value: 287866440750670 }
+      flops { key: "f16xf16->f32" value: 293372083060109 }
+      flops { key: "f32xf32->f32" value: 113263905485232 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 135744857648546 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 135053370731400 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 133218588585607 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 367719802739726 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 387632427436823 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 393312023443223 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 387632427436823 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 371536963321799 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 367719802739726 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 382114528113879 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 399160529368029 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 399903845065176 }
+      flops { key: "bf16xbf16->f32" value: 409044504380952 }
+      flops { key: "f16xf16->f16" value: 389036892753623 }
+      flops { key: "f16xf16->f32" value: 409825123664122 }
+      flops { key: "f32xf32->f32" value: 149229258747090 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 656722828134556 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 635350191715976 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 679475920898592 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 732929572696245 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 810371187924528 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 713449716943521 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 780903144727272 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 732929572696245 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 708740477887788 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 732929572696245 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 715827882666666 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 486957743310657 }
+      flops { key: "bf16xbf16->f32" value: 494811900460829 }
+      flops { key: "f16xf16->f16" value: 554905335400516 }
+      flops { key: "f16xf16->f32" value: 494242496662830 }
+      flops { key: "f32xf32->f32" value: 156519279750733 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1342177280000000 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1354879273186119 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1376592082051282 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1507006068771929 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1376592082051282 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1486147853287197 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1321528398769230 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1446116934680134 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1293664848192771 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1446116934680134 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1282079789850746 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 493107611481056 }
+      flops { key: "bf16xbf16->f32" value: 499110112547572 }
+      flops { key: "f16xf16->f16" value: 506780801887905 }
+      flops { key: "f16xf16->f32" value: 509168939391245 }
+      flops { key: "f32xf32->f32" value: 126321638693833 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 529246455253997 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 231715750640662 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 518387169487945 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 525699791432068 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 859810278965016 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 519971827602905 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 520902009763197 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 526666743838136 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 955498842269188 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 522502104136253 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 518387169487945 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 673179176897004 }
+      flops { key: "bf16xbf16->f32" value: 656961403567809 }
+      flops { key: "f16xf16->f16" value: 671350886440015 }
+      flops { key: "f16xf16->f32" value: 655970568308514 }
+      flops { key: "f32xf32->f32" value: 127069098482999 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 918685018261543 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 240309819962092 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 927638724838013 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 929143817414818 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1203029948811316 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 916748622411953 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 911858453013455 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 917213591948960 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1228889068955651 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 908987787513227 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 921172610402144 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 53261003174603 }
+      flops { key: "bf16xbf16->f32" value: 56158045188284 }
+      flops { key: "f16xf16->f16" value: 53902702008032 }
+      flops { key: "f16xf16->f32" value: 52224796887159 }
+      flops { key: "f32xf32->f32" value: 35043793211488 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 62718564485981 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 43156825723472 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 68478432653061 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 63610297630331 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 43018502564102 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 68829604102564 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 66774989054726 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 61286633789954 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 42608802539682 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 66774989054726 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 61008058181818 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 72944417391304 }
+      flops { key: "bf16xbf16->f32" value: 78261065889212 }
+      flops { key: "f16xf16->f16" value: 78951604705882 }
+      flops { key: "f16xf16->f32" value: 76260072727272 }
+      flops { key: "f32xf32->f32" value: 58482670152505 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 104449593774319 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 67615983879093 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 94519526760563 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 108678322267206 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 64996478450363 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 99420539259259 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 100915584962406 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 103244406153846 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 64527753846153 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 102066713307984 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 97612893090909 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 178362429235880 }
+      flops { key: "bf16xbf16->f32" value: 158369000589970 }
+      flops { key: "f16xf16->f16" value: 182578103043700 }
+      flops { key: "f16xf16->f32" value: 160739794011976 }
+      flops { key: "f32xf32->f32" value: 76363119550529 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 218240208130081 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 141654594195250 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 185127900689655 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 203360193939393 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 190379756028368 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 193119033093525 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 188375758596491 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 209715200000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 165191049846153 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 184491722336769 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 180764616835016 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 279620266666666 }
+      flops { key: "bf16xbf16->f32" value: 217797530223123 }
+      flops { key: "f16xf16->f16" value: 273216749109414 }
+      flops { key: "f16xf16->f32" value: 224163220041753 }
+      flops { key: "f32xf32->f32" value: 86106000320769 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 327360312195121 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 206886671290944 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 284812154907161 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 321479588023952 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 261888249756097 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 280350345691906 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 232915796963123 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 322444992192192 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 305909351566951 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 283309188390501 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 298261617777777 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 358511460434056 }
+      flops { key: "bf16xbf16->f32" value: 305040290909090 }
+      flops { key: "f16xf16->f16" value: 365840485178875 }
+      flops { key: "f16xf16->f32" value: 280350345691906 }
+      flops { key: "f32xf32->f32" value: 104244248828911 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 454975349152542 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 312134251162790 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 382114528113879 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 467861361220043 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 501748515887850 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 392592988665447 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 397682157037037 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 445536026556016 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 391876578102189 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 380085601415929 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 386899134852716 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 96908106859205 }
+      flops { key: "bf16xbf16->f32" value: 98328005860805 }
+      flops { key: "f16xf16->f16" value: 102066713307984 }
+      flops { key: "f16xf16->f32" value: 104044750387596 }
+      flops { key: "f32xf32->f32" value: 58867424561403 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 120916872072072 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 51228140458015 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 127220595260663 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 132234214778325 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 51721667822736 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 111848106666666 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 126026035680751 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 127826407619047 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 51228140458015 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 114203554988300 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 115704937931034 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 171524253035143 }
+      flops { key: "bf16xbf16->f32" value: 164180707033639 }
+      flops { key: "f16xf16->f16" value: 181990139661016 }
+      flops { key: "f16xf16->f32" value: 160739794011976 }
+      flops { key: "f32xf32->f32" value: 77242056254945 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 206488812307692 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 128438017224880 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 217356644534412 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 222768013278008 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 191739611428571 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 203360193939393 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 214748364800000 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 231409875862068 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 192392371259630 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 213044012698412 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 195225786181818 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 237553500884955 }
+      flops { key: "bf16xbf16->f32" value: 222768013278008 }
+      flops { key: "f16xf16->f16" value: 233930680610021 }
+      flops { key: "f16xf16->f32" value: 223696213333333 }
+      flops { key: "f32xf32->f32" value: 96041308050089 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 334499010591900 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 192772320287253 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 301612871910112 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 343048506070287 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 307662413753581 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 314834136930068 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 300768017927170 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 328361414067278 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 314880300293255 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 304996967476210 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 306783378285714 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 367059849243654 }
+      flops { key: "bf16xbf16->f32" value: 320519947462686 }
+      flops { key: "f16xf16->f16" value: 368983444673539 }
+      flops { key: "f16xf16->f32" value: 315806418823529 }
+      flops { key: "f32xf32->f32" value: 108896004056692 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 549158329625367 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 304607609645390 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 510091127790973 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 572585961338488 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 449264361506276 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 505290270117647 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 517465939277108 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 578836562803234 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 507679349408983 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 498256066821345 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 495954653117782 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 578057509555854 }
+      flops { key: "bf16xbf16->f32" value: 446903625825919 }
+      flops { key: "f16xf16->f16" value: 507079964108618 }
+      flops { key: "f16xf16->f32" value: 443694968595041 }
+      flops { key: "f32xf32->f32" value: 115765752375304 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 737966889347079 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 353771862443886 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 586704090704186 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 721843243025210 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 758828144169611 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 579617718758434 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 585903730441306 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 718221955852842 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 723058467340067 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 587546825718194 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 623362452249637 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 127826407619047 }
+      flops { key: "bf16xbf16->f32" value: 122853755606407 }
+      flops { key: "f16xf16->f16" value: 128116194248896 }
+      flops { key: "f16xf16->f32" value: 128131482577565 }
+      flops { key: "f32xf32->f32" value: 78147148762736 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 158369000589970 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 132888839603960 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 154717842074927 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 158837547928994 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 174308737662337 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 155614757101449 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 158369000589970 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 152954675783475 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 168298091536050 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 161708106024096 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 150806435955056 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 226503918152093 }
+      flops { key: "bf16xbf16->f32" value: 201831169924812 }
+      flops { key: "f16xf16->f16" value: 227487674576271 }
+      flops { key: "f16xf16->f32" value: 199580264684014 }
+      flops { key: "f32xf32->f32" value: 96991267241768 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 263786223805429 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 199209985899814 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 260616947572815 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 272523305583756 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 346368330322580 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 276737583505154 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 268435456000000 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 269784377889447 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 334499010591900 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 267099956218905 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 273913730612244 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 359712503852596 }
+      flops { key: "bf16xbf16->f32" value: 264126886169362 }
+      flops { key: "f16xf16->f16" value: 284058683597883 }
+      flops { key: "f16xf16->f32" value: 268771420275344 }
+      flops { key: "f32xf32->f32" value: 104855040062498 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 432960412903225 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 274596719902819 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 392592988665447 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 413773342581888 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 488064465454545 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 393312023443223 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 388333390235081 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 419430400000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 538216453132832 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 389742948820326 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 410608728107074 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 514984088249400 }
+      flops { key: "bf16xbf16->f32" value: 411375632967769 }
+      flops { key: "f16xf16->f16" value: 494242496662830 }
+      flops { key: "f16xf16->f32" value: 407879135422602 }
+      flops { key: "f32xf32->f32" value: 117155175079445 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 775264854873646 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 351470318821603 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 682824689348171 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 746950834086956 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 789516047058823 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 683911989808917 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 705249145484400 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 743073926643598 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 756156214084507 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 681740840634920 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 691621142673107 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 762871633392540 }
+      flops { key: "bf16xbf16->f32" value: 677974316653512 }
+      flops { key: "f16xf16->f16" value: 715827882666666 }
+      flops { key: "f16xf16->f32" value: 662803595061728 }
+      flops { key: "f32xf32->f32" value: 124797469047376 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 966192519205893 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 394939521471264 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 897542927955697 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 969463866824671 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1156115019111709 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 903205361652910 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 912851710095642 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 976128930909090 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1162294106217441 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 888307610341261 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 919693211134903 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 293372083060109 }
+      flops { key: "bf16xbf16->f32" value: 299050779557164 }
+      flops { key: "f16xf16->f16" value: 298261617777777 }
+      flops { key: "f16xf16->f32" value: 297435408310249 }
+      flops { key: "f32xf32->f32" value: 119304647111111 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 356665611692409 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 362750616216216 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 391876578102189 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 432960412903225 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 431221616064257 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 402150495880149 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 384853700358422 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 365218307482993 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 384853700358422 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 445536026556016 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 408266853231939 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 254743018742586 }
+      flops { key: "bf16xbf16->f32" value: 221150676896143 }
+      flops { key: "f16xf16->f16" value: 257183670419161 }
+      flops { key: "f16xf16->f32" value: 218018644467005 }
+      flops { key: "f32xf32->f32" value: 112078685211763 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 315806418823529 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 245988963115693 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 310779109696092 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 318617751928783 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 512464776995585 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 317651600917091 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 307662413753581 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 317675095857988 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 499414801860465 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 301189852454417 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 312134251162790 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 450206215513626 }
+      flops { key: "bf16xbf16->f32" value: 384853700358422 }
+      flops { key: "f16xf16->f16" value: 387982592231255 }
+      flops { key: "f16xf16->f32" value: 380085601415929 }
+      flops { key: "f32xf32->f32" value: 120915170000422 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 499996192782305 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 319554130873107 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 440509466256410 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 457885639232409 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 858993459200000 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 450678624973767 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 444153805170630 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 505290270117647 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 880116249180327 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 457398008093716 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 451152026890756 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 617980905899280 }
+      flops { key: "bf16xbf16->f32" value: 589947775969231 }
+      flops { key: "f16xf16->f16" value: 614444534477825 }
+      flops { key: "f16xf16->f32" value: 582763540841248 }
+      flops { key: "f32xf32->f32" value: 123399984082861 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 898481731290204 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 396022894446877 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 874738756822810 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 906111243881856 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1227133513142857 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 860714888977955 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 881878198449771 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 905156437513171 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1145324612266666 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 867670160808080 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 884602707584573 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 876501578225045 }
+      flops { key: "bf16xbf16->f32" value: 790951828180750 }
+      flops { key: "f16xf16->f16" value: 842542810818763 }
+      flops { key: "f16xf16->f32" value: 774548327765379 }
+      flops { key: "f32xf32->f32" value: 128263974824830 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1180747022955326 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 433605138285252 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1118481066666666 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1184777710009999 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1674451187524366 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1151427176301062 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1159979013807771 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1179895551938463 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1614649359398496 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1146853750600801 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1149924309504685 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 422691398090739 }
+      flops { key: "bf16xbf16->f32" value: 396214695202952 }
+      flops { key: "f16xf16->f16" value: 421075225098039 }
+      flops { key: "f16xf16->f32" value: 439158210224948 }
+      flops { key: "f32xf32->f32" value: 146485924147339 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 644889984384384 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 624268502325581 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 646832424096385 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 745654044444444 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 711087300662251 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 701792041830065 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 745654044444444 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 692736660645161 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 694978526860841 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 692736660645161 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 697234950649350 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 553475167010309 }
+      flops { key: "bf16xbf16->f32" value: 554905335400516 }
+      flops { key: "f16xf16->f16" value: 528286260270602 }
+      flops { key: "f16xf16->f32" value: 557028376369885 }
+      flops { key: "f32xf32->f32" value: 697234950649350 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1151465763002681 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1095515188368830 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1213267597740113 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1470879210958904 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1523038048226950 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1363481681269841 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1441264193288590 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1350618646540880 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1403584083660130 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1512312428169014 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1403584083660130 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 531538912286129 }
+      flops { key: "bf16xbf16->f32" value: 527313357397176 }
+      flops { key: "f16xf16->f16" value: 539890926872191 }
+      flops { key: "f16xf16->f32" value: 517154400481637 }
+      flops { key: "f32xf32->f32" value: 126694266148479 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 541592925317612 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 370575262812769 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 537879435942392 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 556685434172580 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1208148325175808 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 545046611167512 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 541609999495586 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 545029319628184 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1160801971891892 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 538874852859069 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 541951709274447 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 693561663430290 }
+      flops { key: "bf16xbf16->f32" value: 673179176897004 }
+      flops { key: "f16xf16->f16" value: 690786859026940 }
+      flops { key: "f16xf16->f32" value: 660510157016532 }
+      flops { key: "f32xf32->f32" value: 128889457947431 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 938277945603495 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 440052488672020 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 935722722440087 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 943922924315266 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1505685292199824 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 924618238691100 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 930124749411223 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 937254183524277 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1546273271589937 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 928114809648577 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 924120878082891 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 986201069674660 }
+      flops { key: "bf16xbf16->f32" value: 849007014195525 }
+      flops { key: "f16xf16->f16" value: 929382571726106 }
+      flops { key: "f16xf16->f32" value: 897109394603203 }
+      flops { key: "f32xf32->f32" value: 130440804320220 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1197182570617236 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 460827220235780 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1191784338391633 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1195121334539130 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1978108138629821 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1196348892533208 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1196348892533208 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1183166211601040 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1967911704925544 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1179915810786216 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1186455054143646 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 82850449382716 }
+      flops { key: "bf16xbf16->f32" value: 77358921037463 }
+      flops { key: "f16xf16->f16" value: 94502888928005 }
+      flops { key: "f16xf16->f32" value: 79184500294985 }
+      flops { key: "f32xf32->f32" value: 57113926808510 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 110014531147540 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 69006543958868 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 105268806274509 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 104429276794397 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 69184395876288 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 108240103225806 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 107805404016064 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 115208350214592 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 73143176021798 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 102848833716475 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 103643033204633 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 165191049846153 }
+      flops { key: "bf16xbf16->f32" value: 152954675783475 }
+      flops { key: "f16xf16->f16" value: 168827330817610 }
+      flops { key: "f16xf16->f32" value: 153831206876790 }
+      flops { key: "f32xf32->f32" value: 75823870065673 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 189707036042402 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 169359909148264 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 188375758596491 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 184491722336769 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 176602273684210 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 181990139661016 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 177771825165562 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 193816213718411 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 167772160000000 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 173184165161290 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 169895858227848 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 269108226566416 }
+      flops { key: "bf16xbf16->f32" value: 224632180753138 }
+      flops { key: "f16xf16->f16" value: 260616947572815 }
+      flops { key: "f16xf16->f32" value: 210125601565557 }
+      flops { key: "f32xf32->f32" value: 92563950344827 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 338719818296529 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 261888249756097 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 276737583505154 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 362689351123121 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 326315703996353 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 273216749109414 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 253240996226415 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 363980279322033 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 299092430083565 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 287096744385026 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 276026175835475 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 356133274958540 }
+      flops { key: "bf16xbf16->f32" value: 292572704087193 }
+      flops { key: "f16xf16->f16" value: 353786432948929 }
+      flops { key: "f16xf16->f32" value: 288640275268817 }
+      flops { key: "f32xf32->f32" value: 105163127641340 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 447392426666666 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 350323596737357 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 380759512056737 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 454013456236786 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 513752068899521 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 386238066187050 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 380759512056737 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 444613591718426 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 491358802882965 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 383479222857142 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 376091707180385 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 490853405257142 }
+      flops { key: "bf16xbf16->f32" value: 379397314252904 }
+      flops { key: "f16xf16->f16" value: 476688934073251 }
+      flops { key: "f16xf16->f32" value: 376734993728345 }
+      flops { key: "f32xf32->f32" value: 113441906366793 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 639132038095238 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 452578218756585 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 465831593926247 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 611818703133903 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 641039894925373 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 465326900975081 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 465831593926247 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 644889984384384 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 594048035408022 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 460339474383708 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 471456344237102 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 183859901369863 }
+      flops { key: "bf16xbf16->f32" value: 155614757101449 }
+      flops { key: "f16xf16->f16" value: 176023249836065 }
+      flops { key: "f16xf16->f32" value: 170408161244246 }
+      flops { key: "f32xf32->f32" value: 76915603438395 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 220029062295081 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 162196650151057 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 219130984489795 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 234441446288209 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 172627302893890 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 220934531687242 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 199580264684014 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 219130984489795 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 177771825165562 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 204912561832061 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 210537612549019 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 219130984489795 }
+      flops { key: "bf16xbf16->f32" value: 230912220215053 }
+      flops { key: "f16xf16->f16" value: 221824568536308 }
+      flops { key: "f16xf16->f32" value: 223231148440748 }
+      flops { key: "f32xf32->f32" value: 96903733947024 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 350896020915032 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 244560260562578 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 344148020512820 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 360316048322147 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 329368657668711 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 314880300293255 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 331401797530864 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 339791716455696 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 299927883798882 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 330382099692307 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 339737960449296 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 381435816696270 }
+      flops { key: "bf16xbf16->f32" value: 314419274963396 }
+      flops { key: "f16xf16->f16" value: 357913941333333 }
+      flops { key: "f16xf16->f32" value: 305474203129445 }
+      flops { key: "f32xf32->f32" value: 107859550376695 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 522502104136253 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 352624572742200 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 480367665361816 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 553475167010309 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 563644002099737 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 493674401839080 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 493674401839080 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 525057126650366 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 539568755778894 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 510091127790973 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 483667488288288 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 511305630476190 }
+      flops { key: "bf16xbf16->f32" value: 440035581783720 }
+      flops { key: "f16xf16->f16" value: 511275197428724 }
+      flops { key: "f16xf16->f32" value: 432089265191146 }
+      flops { key: "f32xf32->f32" value: 118578354688643 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 717022920868113 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 520570546754742 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 601536035854341 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 654720624390243 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 887389937190082 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 592409282206896 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 589927518164961 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 696048504335143 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 847050053446405 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 581934461892825 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 589158751165980 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 780903144727272 }
+      flops { key: "bf16xbf16->f32" value: 576892853727333 }
+      flops { key: "f16xf16->f16" value: 702911876928112 }
+      flops { key: "f16xf16->f32" value: 578836562803234 }
+      flops { key: "f32xf32->f32" value: 123470046312400 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1010521097817775 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 593637497719419 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 778073785507246 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1009393019036427 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1010580540235294 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 764229056227758 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 758158392939099 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 997611589570872 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1118481066666666 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 769707400716845 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 764229056227758 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 227006728118393 }
+      flops { key: "bf16xbf16->f32" value: 216917540202020 }
+      flops { key: "f16xf16->f16" value: 220934531687242 }
+      flops { key: "f16xf16->f32" value: 212180975002470 }
+      flops { key: "f32xf32->f32" value: 92166680171673 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 270463935516372 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 260616947572815 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 271146925252525 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 274614277237851 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 326365296048632 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 277452667700258 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 278135429089496 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 278171456994818 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 277452667700258 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 265777679207920 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 259357928502415 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 372827022222222 }
+      flops { key: "bf16xbf16->f32" value: 290200492972973 }
+      flops { key: "f16xf16->f16" value: 323416212048192 }
+      flops { key: "f16xf16->f32" value: 301591692718208 }
+      flops { key: "f32xf32->f32" value: 106627787884806 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 480421397762863 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 356724858471760 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 440058124590163 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 434713289068825 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 525057126650366 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 452101820631578 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 446462296881496 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 463819362419006 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 568117367195767 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 456911414468085 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 444613591718426 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 446462296881496 }
+      flops { key: "bf16xbf16->f32" value: 403662339849624 }
+      flops { key: "f16xf16->f16" value: 451626424395373 }
+      flops { key: "f16xf16->f32" value: 478254807193363 }
+      flops { key: "f32xf32->f32" value: 119502157621624 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 752183414360770 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 493107611481056 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 687194767360000 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 685002758532695 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 889227183436853 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 671088640000000 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 698368666016260 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 720571646002852 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 814984306641366 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 663828021020092 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 686097012140575 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 783717402673235 }
+      flops { key: "bf16xbf16->f32" value: 691036932705844 }
+      flops { key: "f16xf16->f16" value: 723058467340067 }
+      flops { key: "f16xf16->f32" value: 667412656229361 }
+      flops { key: "f32xf32->f32" value: 124761217585801 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 964023858593793 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 625177190101892 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 856424186640079 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1003497031775700 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1191391760332871 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 905156437513171 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 905108750013171 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 961864911483119 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1171887393178717 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 908987787513227 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 855571174501992 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 1019546552565205 }
+      flops { key: "bf16xbf16->f32" value: 813806834703109 }
+      flops { key: "f16xf16->f16" value: 949662484950664 }
+      flops { key: "f16xf16->f32" value: 792411115241807 }
+      flops { key: "f32xf32->f32" value: 128754706057812 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1385473321290322 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 690509211575562 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1154522306642922 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1401237240243057 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1726533258027234 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1158414698358113 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1164736893830508 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1401294386949429 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1694267177909270 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1150655984997153 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1151465763002681 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 253240996226415 }
+      flops { key: "bf16xbf16->f32" value: 254441190521327 }
+      flops { key: "f16xf16->f16" value: 308524337044752 }
+      flops { key: "f16xf16->f32" value: 247977326558891 }
+      flops { key: "f32xf32->f32" value: 103991847558170 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 327360312195121 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 350867355281431 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 318594117350344 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 318145725629629 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 572662306133333 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 320999050523168 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 320042272429210 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 320519947462686 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 489176229612756 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 310779109696092 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 320042272429210 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 462794816658585 }
+      flops { key: "bf16xbf16->f32" value: 379079196469549 }
+      flops { key: "f16xf16->f16" value: 397314273450508 }
+      flops { key: "f16xf16->f32" value: 375746231223481 }
+      flops { key: "f32xf32->f32" value: 118676649839046 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 513138267144563 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 453031727862454 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 523138525700365 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 554153576672472 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 913822828936170 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 521233895145631 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 523138525700365 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 517465939277108 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 825955249230769 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 518090144270205 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 519311685629647 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 648296950339622 }
+      flops { key: "bf16xbf16->f32" value: 617536634938892 }
+      flops { key: "f16xf16->f16" value: 634857144377517 }
+      flops { key: "f16xf16->f32" value: 602379704908835 }
+      flops { key: "f32xf32->f32" value: 124058499906124 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 745007336686903 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 571899773102530 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 853022303078450 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 747600921845082 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1295616077224736 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 865920825806451 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 862443232128514 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 897542927955697 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1230649655014326 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 866750879572170 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 847969851135241 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 958671308501436 }
+      flops { key: "bf16xbf16->f32" value: 847530607730445 }
+      flops { key: "f16xf16->f16" value: 858564177111444 }
+      flops { key: "f16xf16->f32" value: 829925324702301 }
+      flops { key: "f32xf32->f32" value: 128908800336155 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1227133513142857 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 740495643800780 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1167904091366417 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1213267597740113 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1915151795775040 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1160762756933887 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1170290816348773 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1209807343685081 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1934669953153153 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1162372745872801 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1174250311609309 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 1213674727327316 }
+      flops { key: "bf16xbf16->f32" value: 826939227397985 }
+      flops { key: "f16xf16->f16" value: 1113749805286786 }
+      flops { key: "f16xf16->f32" value: 994478759149650 }
+      flops { key: "f32xf32->f32" value: 131675263823900 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1693390422512998 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 783208269064633 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1512279147377918 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1713702661745636 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2384354350508310 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1514979645855379 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1502393457280279 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1705155622341877 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2407745935180967 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1503017797860939 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1521655338367175 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 587546825718194 }
+      flops { key: "bf16xbf16->f32" value: 558513302470741 }
+      flops { key: "f16xf16->f16" value: 582763540841248 }
+      flops { key: "f16xf16->f32" value: 583555339130434 }
+      flops { key: "f32xf32->f32" value: 160736786212832 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 837144000779651 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 830748026305609 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 864178530382293 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1350618646540880 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1441264193288590 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1309441248780487 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1470879210958904 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1372194024281150 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1274471007715133 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1491308088888889 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1333840775155279 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 545721838061052 }
+      flops { key: "bf16xbf16->f32" value: 514044139433290 }
+      flops { key: "f16xf16->f16" value: 525041080162586 }
+      flops { key: "f16xf16->f32" value: 508882381042654 }
+      flops { key: "f32xf32->f32" value: 123541076527016 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 564366124108932 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 584727176883019 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 557787960519480 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 566244864337508 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1232415292969871 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 566244864337508 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 561048600111034 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 568851004403827 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1268729723358688 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 552052351670951 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 565108686687937 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 692178452215954 }
+      flops { key: "bf16xbf16->f32" value: 661005720705642 }
+      flops { key: "f16xf16->f16" value: 693561663430290 }
+      flops { key: "f16xf16->f32" value: 657728529249617 }
+      flops { key: "f32xf32->f32" value: 128725281702963 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 798673633062922 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 674235952355723 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 793509119142745 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 800161579096900 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1797057446025104 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 995357426651216 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 987348803678160 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1005847141920374 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1804608107563025 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 796470523133982 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1004670712514619 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1062436832083610 }
+      flops { key: "bf16xbf16->f32" value: 936219898039536 }
+      flops { key: "f16xf16->f16" value: 978338530715678 }
+      flops { key: "f16xf16->f32" value: 925128589222008 }
+      flops { key: "f32xf32->f32" value: 130912943250940 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1380990670123188 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 816718089112323 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1280169089716840 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 2520798090165438 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2533904009439528 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 2643056797538461 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 2636971478741366 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1368341465442743 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2526358469762141 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 2616887918354912 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1345857358715237 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1338243575739282 }
+      flops { key: "bf16xbf16->f32" value: 1191588017027769 }
+      flops { key: "f16xf16->f16" value: 1183176397172889 }
+      flops { key: "f16xf16->f32" value: 1148761323225315 }
+      flops { key: "f32xf32->f32" value: 133207097201020 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1929211457896436 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 838952970126112 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1823281420429822 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1941200738294656 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3031295841905602 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1790502259927045 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1802241718751639 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1915231859533730 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 3084357124596050 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1782583280009338 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1786290189521841 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 173744631715210 }
+      flops { key: "bf16xbf16->f32" value: 158837547928994 }
+      flops { key: "f16xf16->f16" value: 167249505295950 }
+      flops { key: "f16xf16->f32" value: 156499318466695 }
+      flops { key: "f32xf32->f32" value: 76368550782361 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 213044012698412 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 174876518566775 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 178956970666666 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 197379011764705 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 167745949695360 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 176602273684210 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 177185119471947 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 202554579136012 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 150384008963585 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 183232393174061 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 177155885827421 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 273913730612244 }
+      flops { key: "bf16xbf16->f32" value: 213446342113110 }
+      flops { key: "f16xf16->f16" value: 270463935516372 }
+      flops { key: "f16xf16->f32" value: 214319725349301 }
+      flops { key: "f32xf32->f32" value: 91538092412617 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 319566019047619 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 284812154907161 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 287096744385026 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 316738001179941 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 294175842191780 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 284812154907161 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 272523305583756 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 329368657668711 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 274579164812683 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 296613763535911 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 278893980259740 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 375434204195804 }
+      flops { key: "bf16xbf16->f32" value: 296613763535911 }
+      flops { key: "f16xf16->f16" value: 376751517192982 }
+      flops { key: "f16xf16->f32" value: 285569634042553 }
+      flops { key: "f32xf32->f32" value: 104857600000000 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 473014019383259 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 427785587250996 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 413733483864752 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 461824440430107 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 434713289068825 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 380085601415929 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 378078107042253 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 447392426666666 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 490293070319634 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 389742948820326 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 387632427436823 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 482580595056179 }
+      flops { key: "bf16xbf16->f32" value: 408247449836034 }
+      flops { key: "f16xf16->f16" value: 473014019383259 }
+      flops { key: "f16xf16->f32" value: 395485018047882 }
+      flops { key: "f32xf32->f32" value: 116015918099431 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 577280550537634 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 504666858116444 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 503483652306429 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 594870816620498 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 679583432911392 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 491949750415211 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 507079964108618 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 596523235555555 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 646832424096385 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 491977926231386 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 505260548908887 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 539213118985593 }
+      flops { key: "bf16xbf16->f32" value: 421685014702633 }
+      flops { key: "f16xf16->f16" value: 533851315496721 }
+      flops { key: "f16xf16->f32" value: 432949501877472 }
+      flops { key: "f32xf32->f32" value: 115021686801194 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 634411712850812 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 671088640000000 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 537879435942392 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 660764199384615 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 816533706463878 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 526989852269938 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 532857826494215 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 641518640179238 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 822790669731800 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 534865167621419 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 534183302260501 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 244588114806378 }
+      flops { key: "bf16xbf16->f32" value: 222306795859213 }
+      flops { key: "f16xf16->f16" value: 249128033410672 }
+      flops { key: "f16xf16->f32" value: 221390066804123 }
+      flops { key: "f32xf32->f32" value: 96991267241768 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 349753037133550 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 318617751928783 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 341955994904458 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 349753037133550 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 299092430083565 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 330382099692307 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 338666400883141 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 331401797530864 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 289418281401617 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 336543433317661 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 262528563325183 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 368983444673539 }
+      flops { key: "bf16xbf16->f32" value: 335544320000000 }
+      flops { key: "f16xf16->f16" value: 374093484539674 }
+      flops { key: "f16xf16->f32" value: 303745919094766 }
+      flops { key: "f32xf32->f32" value: 106519364499888 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 566618376781002 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 444613591718426 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 521233895145631 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 550636832820512 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 538149015912792 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 516222030769230 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 505290270117647 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 563644002099737 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 511305630476190 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 512525930310262 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 492542121100917 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 592409282206896 }
+      flops { key: "bf16xbf16->f32" value: 484185479510737 }
+      flops { key: "f16xf16->f16" value: 514367340838323 }
+      flops { key: "f16xf16->f32" value: 483640256291875 }
+      flops { key: "f32xf32->f32" value: 117959580230977 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 723058467340067 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 571139268085106 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 630685359177679 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 726728814890016 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 987348803678160 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 648786600604229 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 667957588802488 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 701792041830065 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 762871633392540 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 664855618575851 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 653724093759513 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 772476132374100 }
+      flops { key: "bf16xbf16->f32" value: 591572920491718 }
+      flops { key: "f16xf16->f16" value: 737301797519419 }
+      flops { key: "f16xf16->f32" value: 583535517951156 }
+      flops { key: "f32xf32->f32" value: 124040585579991 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 897589821525600 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 766240095624637 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 782325554826958 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 848807766007905 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1044940647405875 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 778779201450589 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 783003016453215 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 865048800805639 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1039943655205811 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 785185977330895 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 791699040737327 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 828324735854969 }
+      flops { key: "bf16xbf16->f32" value: 583545428372480 }
+      flops { key: "f16xf16->f16" value: 804282164930596 }
+      flops { key: "f16xf16->f32" value: 584339354228669 }
+      flops { key: "f32xf32->f32" value: 125207210649253 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 953880746453457 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 861124742938773 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 846695211256499 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 936743139803707 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1382073865411689 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 840481846530173 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 839680800782013 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 935697240489093 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1326579605729508 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 835576429756085 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 844634669813176 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 357288686132601 }
+      flops { key: "bf16xbf16->f32" value: 294984017582417 }
+      flops { key: "f16xf16->f16" value: 312111568636000 }
+      flops { key: "f16xf16->f32" value: 290986944173441 }
+      flops { key: "f32xf32->f32" value: 110920877456677 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 466844271304347 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 453055621940928 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 443694968595041 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 477218588444444 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 534133477925631 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 439158210224948 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 446462296881496 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 446462296881496 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 531555358415841 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 422733001574803 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 440058124590163 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 488036736094540 }
+      flops { key: "bf16xbf16->f32" value: 472987973789989 }
+      flops { key: "f16xf16->f16" value: 488064465454545 }
+      flops { key: "f16xf16->f32" value: 471974428131868 }
+      flops { key: "f32xf32->f32" value: 117477223632385 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 758761115802491 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 624268502325581 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 721843243025210 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 764229056227758 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 908026912473573 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 725501232432432 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 723058467340067 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 778003314192555 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 842067894520145 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 692736660645161 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 707572865897858 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 775264854873646 }
+      flops { key: "bf16xbf16->f32" value: 688296041025641 }
+      flops { key: "f16xf16->f16" value: 732929572696245 }
+      flops { key: "f16xf16->f32" value: 679046212806324 }
+      flops { key: "f32xf32->f32" value: 125162057569156 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 974965619658362 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 872960832520325 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 914747307598104 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1002326090081680 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1533916891428571 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 910915651325556 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 917728054700854 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1015358698817966 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1282079789850746 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 913822828936170 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 914747307598104 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 1036180288540410 }
+      flops { key: "bf16xbf16->f32" value: 788429058467186 }
+      flops { key: "f16xf16->f16" value: 958136648950112 }
+      flops { key: "f16xf16->f32" value: 723957320073323 }
+      flops { key: "f32xf32->f32" value: 128821805273635 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1174290443198906 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 981146155568246 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1136986709728656 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1188096070816044 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1681004812524461 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1099828378348964 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1146088671380920 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1308394134572179 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1620742375849056 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1085272848010107 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1121401382767624 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 1078781757523429 }
+      flops { key: "bf16xbf16->f32" value: 732757637243820 }
+      flops { key: "f16xf16->f16" value: 1009674802544776 }
+      flops { key: "f16xf16->f32" value: 725800073256514 }
+      flops { key: "f32xf32->f32" value: 129102301457672 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1381545942703202 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1100198151422487 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1222744732940695 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1308419046400487 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2012872780785003 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1206854054828682 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1219706372552847 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1290724756033883 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2073611247314423 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1208148325175808 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1228867093506911 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 469883189759859 }
+      flops { key: "bf16xbf16->f32" value: 387282894138863 }
+      flops { key: "f16xf16->f16" value: 401755511528927 }
+      flops { key: "f16xf16->f32" value: 373150937966985 }
+      flops { key: "f32xf32->f32" value: 117797816705750 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 540927871032745 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 656722828134556 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 528936859113300 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 544355804309252 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 919693211134903 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 529589062392108 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 540213482925602 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 534199912437810 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 860714888977955 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 536200661173533 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 541609999495586 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 632519759360848 }
+      flops { key: "bf16xbf16->f32" value: 607470357625260 }
+      flops { key: "f16xf16->f16" value: 633009181429624 }
+      flops { key: "f16xf16->f32" value: 594459141314878 }
+      flops { key: "f32xf32->f32" value: 125215880118365 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 912803208331119 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 798283963756331 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 898528723012552 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 918709582032085 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1431655765333333 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 885560267216494 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 878316420449897 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 905156437513171 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1333840775155279 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 881878198449771 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 884648258702368 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 962970162495445 }
+      flops { key: "bf16xbf16->f32" value: 855976143294885 }
+      flops { key: "f16xf16->f16" value: 888284645381453 }
+      flops { key: "f16xf16->f32" value: 845445199872050 }
+      flops { key: "f32xf32->f32" value: 128561523173802 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1187233971459175 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1028088278866580 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1163947776693767 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1186455054143646 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2134145240248447 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1163159728097495 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1160801971891892 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1198038297350069 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2185733992875318 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1152972664273011 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1156893547744107 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 1239059460449685 }
+      flops { key: "bf16xbf16->f32" value: 1017448316370797 }
+      flops { key: "f16xf16->f16" value: 1120286215353515 }
+      flops { key: "f16xf16->f32" value: 994191009042114 }
+      flops { key: "f32xf32->f32" value: 131433745633983 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1625303960076630 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1227133513142857 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1529819161531611 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1651910498461538 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2632930143141762 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1497123738829219 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1440629687763359 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1619940047052167 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2614896375038052 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1511613839026858 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1440629687763359 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 1303467849053025 }
+      flops { key: "bf16xbf16->f32" value: 1042926602054908 }
+      flops { key: "f16xf16->f16" value: 1138107116304104 }
+      flops { key: "f16xf16->f32" value: 954821757874699 }
+      flops { key: "f32xf32->f32" value: 132146359622749 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1730075823214712 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1278965889690213 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1560033524086265 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1745034960284408 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2874029264799983 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 3343932105593538 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 3430827595406889 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 3755162663169399 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2857299296729797 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 3386864304386397 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 3451418936541021 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 484759288487584 }
+      flops { key: "bf16xbf16->f32" value: 475633144629014 }
+      flops { key: "f16xf16->f16" value: 478268121266111 }
+      flops { key: "f16xf16->f32" value: 469639134632732 }
+      flops { key: "f32xf32->f32" value: 122084615544232 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 553475167010309 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 811098115480855 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 549931792061459 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 555264033096315 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1168698583945578 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 529589062392108 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 548527113154533 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 553475167010309 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1374279592352611 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 547129591847133 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 526650598816713 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 704078571504682 }
+      flops { key: "bf16xbf16->f32" value: 687744963330664 }
+      flops { key: "f16xf16->f16" value: 697503874626986 }
+      flops { key: "f16xf16->f32" value: 681997943034080 }
+      flops { key: "f32xf32->f32" value: 128532667851251 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1029937303078444 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1053301197633426 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 991909306235565 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 994205392592592 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1904641816407982 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 990165654246275 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 994176625907815 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1008770686944012 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1869409051577802 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 994205392592592 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 999410656428155 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1073054398525944 }
+      flops { key: "bf16xbf16->f32" value: 854709229188691 }
+      flops { key: "f16xf16->f16" value: 974454087945434 }
+      flops { key: "f16xf16->f32" value: 930137338909868 }
+      flops { key: "f32xf32->f32" value: 130435852548662 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1340580104484891 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1224073329818311 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1321528398769230 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 2931718290784983 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2882528386577181 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 2977446998960138 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 2929094102382677 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1324559602474894 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2877700030820770 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 2964602102502157 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 3035312576678445 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1316200318633225 }
+      flops { key: "bf16xbf16->f32" value: 1184389733648161 }
+      flops { key: "f16xf16->f16" value: 1196984466883235 }
+      flops { key: "f16xf16->f32" value: 1147993697613618 }
+      flops { key: "f32xf32->f32" value: 133263798659982 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1883731767272926 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1414257452300346 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1794687369869811 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1892551100535657 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3467090978330516 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 3740853387915079 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1790502259927045 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 4192640659894451 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 3361927386120692 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1772925445646986 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1790945563284294 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1411780542385068 }
+      flops { key: "bf16xbf16->f32" value: 1193440140601934 }
+      flops { key: "f16xf16->f16" value: 1231846425583594 }
+      flops { key: "f16xf16->f32" value: 1151157141785044 }
+      flops { key: "f32xf32->f32" value: 132079941908984 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1925427683445174 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1425249565463567 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1845301165701089 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1938476505412514 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3680693977638221 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1826176460055407 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 4085520532453441 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 4563046264010624 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 3651358336685219 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 4048215887011973 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 4063776510459632 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 268435456000000 }
+      flops { key: "bf16xbf16->f32" value: 210951242436149 }
+      flops { key: "f16xf16->f16" value: 272523305583756 }
+      flops { key: "f16xf16->f32" value: 213892793625498 }
+      flops { key: "f32xf32->f32" value: 87225168480909 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 312134251162790 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 275283123702089 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 292572704087193 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 329368657668711 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 278171456994818 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 290200492972973 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 283309188390501 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 331401797530864 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 287866440750670 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 291777669565217 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 281822001049868 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 372827022222222 }
+      flops { key: "bf16xbf16->f32" value: 323904019306184 }
+      flops { key: "f16xf16->f16" value: 372180874870017 }
+      flops { key: "f16xf16->f32" value: 320519947462686 }
+      flops { key: "f32xf32->f32" value: 103043768047791 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 481498575784753 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 492542121100917 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 419430400000000 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 483667488288288 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 499414801860465 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 427785587250996 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 416179001550387 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 475107001769911 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 444613591718426 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 412184961228406 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 423566794477317 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 475080725181129 }
+      flops { key: "bf16xbf16->f32" value: 411001655119617 }
+      flops { key: "f16xf16->f16" value: 474058200441501 }
+      flops { key: "f16xf16->f32" value: 400276542031686 }
+      flops { key: "f32xf32->f32" value: 115054039539244 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 635350191715976 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 574193488770053 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 511275197428724 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 633476002359882 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 665886402480620 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 512525930310262 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 510697657074910 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 627919195321637 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 641998101046337 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 506452130888508 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 518058898257041 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 545046611167512 }
+      flops { key: "bf16xbf16->f32" value: 424813164461808 }
+      flops { key: "f16xf16->f16" value: 570002295421367 }
+      flops { key: "f16xf16->f32" value: 431644159292480 }
+      flops { key: "f32xf32->f32" value: 118907463154324 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 640537980835912 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 742431684701815 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 552407369260450 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 636739527222860 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 753503034385964 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 544011057124762 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 540910839835017 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 642959176047904 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 753469987456690 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 529899422719842 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 533536310062111 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 564746443483834 }
+      flops { key: "bf16xbf16->f32" value: 447736390821073 }
+      flops { key: "f16xf16->f16" value: 557236151992345 }
+      flops { key: "f16xf16->f32" value: 449728908888627 }
+      flops { key: "f32xf32->f32" value: 119752054090978 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 745637863067207 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 770035148651980 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 572853257219073 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 744345624401551 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 855124022995943 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 597145261870003 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 597134884134790 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 735109183971245 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 860714888977955 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 568483949107394 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 573618336694490 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 358481537100409 }
+      flops { key: "bf16xbf16->f32" value: 313501262481751 }
+      flops { key: "f16xf16->f16" value: 356724858471760 }
+      flops { key: "f16xf16->f32" value: 309859843878508 }
+      flops { key: "f32xf32->f32" value: 106625140785978 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 557787960519480 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 504104142723004 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 525057126650366 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 547827461224489 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 489176229612756 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 499414801860465 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 512525930310262 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 538216453132832 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 511244768003809 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 505290270117647 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 516222030769230 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 546433498218829 }
+      flops { key: "bf16xbf16->f32" value: 475606809811195 }
+      flops { key: "f16xf16->f16" value: 525667620831038 }
+      flops { key: "f16xf16->f32" value: 472493651925192 }
+      flops { key: "f32xf32->f32" value: 117700971376111 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 714577372265202 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 722997608955475 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 659749200614439 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 700647193474714 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 788067393761467 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 671036215295680 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 672138856964006 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 712207494569272 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 798321058736059 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 652730592097264 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 653724093759513 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 764875525755754 }
+      flops { key: "bf16xbf16->f32" value: 588351684383561 }
+      flops { key: "f16xf16->f16" value: 736669490330603 }
+      flops { key: "f16xf16->f32" value: 569605423692848 }
+      flops { key: "f32xf32->f32" value: 124058499906124 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 948116400883002 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 863266629013617 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 822790669731800 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 960842795525727 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1149924309504685 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 825955249230769 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 830748026305609 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 953377868146503 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1007026329660023 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 817271737024879 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 727344165283657 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 800907633108785 }
+      flops { key: "bf16xbf16->f32" value: 600894324478410 }
+      flops { key: "f16xf16->f16" value: 810734488756754 }
+      flops { key: "f16xf16->f32" value: 595479079530684 }
+      flops { key: "f32xf32->f32" value: 125197630001020 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 961353581824795 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1101944721721561 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 845861460032987 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 980586140639269 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1366681451334473 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 844219615921375 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 824369922456813 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 966763410371120 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1335915177604976 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 848367654329522 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 838840320499987 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 868975818919841 }
+      flops { key: "bf16xbf16->f32" value: 627792994244578 }
+      flops { key: "f16xf16->f16" value: 849636833570307 }
+      flops { key: "f16xf16->f32" value: 622791861012678 }
+      flops { key: "f32xf32->f32" value: 126525846186704 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1096686563189224 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1140364028741640 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 891997361578400 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1091114411266890 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1445478150144086 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 2069801413692358 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 2118290950833821 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1097755219424920 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1417451717910109 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 902055325291083 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 886245508589115 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 484759288487584 }
+      flops { key: "bf16xbf16->f32" value: 468346033040728 }
+      flops { key: "f16xf16->f16" value: 485307039096045 }
+      flops { key: "f16xf16->f32" value: 407879135422602 }
+      flops { key: "f32xf32->f32" value: 120271833102308 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 758761115802491 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 725501232432432 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 724277790219224 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 769707400716845 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 911882653078556 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 699506074267101 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 705249145484400 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 749557992321116 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 869426578137651 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 691565461073987 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 699506074267101 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 777369646334841 }
+      flops { key: "bf16xbf16->f32" value: 691621142673107 }
+      flops { key: "f16xf16->f16" value: 725470596005236 }
+      flops { key: "f16xf16->f32" value: 674249183045525 }
+      flops { key: "f32xf32->f32" value: 125253309497597 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1033686473164861 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 964077956453423 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 941878792982456 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 946028038766519 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1556147571014492 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 943948856263736 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 951213619622390 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1024990703657299 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1465859145392491 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 954437176888888 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 949164043314917 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 1038654767630966 }
+      flops { key: "bf16xbf16->f32" value: 750523980865424 }
+      flops { key: "f16xf16->f16" value: 958671308501436 }
+      flops { key: "f16xf16->f32" value: 726099160372773 }
+      flops { key: "f32xf32->f32" value: 128610125571750 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1316414634228573 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1203915149544499 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1181518461125821 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1313445656269113 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1963413621028571 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1170290816348773 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1168698583945578 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1300519998788796 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1847297761720430 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1177469530447894 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1178317502331961 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 1092154872554473 }
+      flops { key: "bf16xbf16->f32" value: 748896336526411 }
+      flops { key: "f16xf16->f16" value: 1014144961497026 }
+      flops { key: "f16xf16->f32" value: 760667656280094 }
+      flops { key: "f32xf32->f32" value: 128460826320462 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1267395967171391 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1404731740310711 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1165902796627135 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1291209799440070 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1983818612471131 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1152238040509725 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1166694567766251 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1273974837989655 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1971242268896474 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 2595146402416918 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1160782364081687 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 1138295636709982 }
+      flops { key: "bf16xbf16->f32" value: 827830803394710 }
+      flops { key: "f16xf16->f16" value: 1052833214383110 }
+      flops { key: "f16xf16->f32" value: 818561630655795 }
+      flops { key: "f32xf32->f32" value: 130116762764207 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1413384821957816 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1501047961730849 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1274222874551506 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1440041004096771 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2185004268167437 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 3051418784485247 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 3080209625100851 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1417480955775577 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2191274907479153 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 3063662278415550 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 3046076096453900 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 610492490814114 }
+      flops { key: "bf16xbf16->f32" value: 578836562803234 }
+      flops { key: "f16xf16->f16" value: 620660013872832 }
+      flops { key: "f16xf16->f32" value: 583159171215207 }
+      flops { key: "f32xf32->f32" value: 123239761151203 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 916699705672055 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 980530174305119 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 880973754371570 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 926588058033547 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1394469901298701 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 861578193781344 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 871190120892494 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 913822828936170 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1307448187519026 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 854719859900497 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 884648258702368 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 944441834144196 }
+      flops { key: "bf16xbf16->f32" value: 811883896127218 }
+      flops { key: "f16xf16->f16" value: 868964830631496 }
+      flops { key: "f16xf16->f32" value: 770397721255605 }
+      flops { key: "f32xf32->f32" value: 129015287331548 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1317474630674846 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1375489926661329 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1230605578883277 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1312442260045836 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2372910108287293 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1219251920371881 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1217566915946137 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1301455943638498 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2296773955080214 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1206451487640449 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1232415292969871 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 1244444626790532 }
+      flops { key: "bf16xbf16->f32" value: 1039298811814703 }
+      flops { key: "f16xf16->f16" value: 1119191490952916 }
+      flops { key: "f16xf16->f32" value: 1007897753567709 }
+      flops { key: "f32xf32->f32" value: 131745947584958 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1604845323120037 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1637737767778837 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1467737649209739 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1601815266217570 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2813950155030506 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 1472108068293310 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 1468992662163317 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 1576821934696312 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2802474480486114 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 1456538294531581 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 1464609478601875 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 1289283904203525 }
+      flops { key: "bf16xbf16->f32" value: 1059333236771722 }
+      flops { key: "f16xf16->f16" value: 1133601285637696 }
+      flops { key: "f16xf16->f32" value: 1027496456156876 }
+      flops { key: "f32xf32->f32" value: 132482900641887 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1680984252540942 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1869383624705866 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1556482412113113 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 3732725515263444 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3106596900431726 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 3581004519854090 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 3690627107196563 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 4100207442482100 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 3108072217819991 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 3676706173510607 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 3641731676523582 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 1330728337951801 }
+      flops { key: "bf16xbf16->f32" value: 1058024375946390 }
+      flops { key: "f16xf16->f16" value: 1164825736471425 }
+      flops { key: "f16xf16->f32" value: 1030188203205870 }
+      flops { key: "f32xf32->f32" value: 131332077532765 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1696965755108592 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1912313862739232 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1614829585914781 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 4006908163787700 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 2933564283668264 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 3897871624276801 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 3953883099264970 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 4385416511550734 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2905041237611101 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 3893454772577903 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 3942597632587493 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 666648655788595 }
+      flops { key: "bf16xbf16->f32" value: 643911065534753 }
+      flops { key: "f16xf16->f16" value: 655470018466234 }
+      flops { key: "f16xf16->f32" value: 638644976264381 }
+      flops { key: "f32xf32->f32" value: 129063748691886 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 983927675839752 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1302491977558756 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 969518576975169 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 990765235524798 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 1995223179141745 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 972261979852858 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 968971753186689 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 985084242201834 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 1806410723305820 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 971162757716223 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 972784982531638 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 977781715342695 }
+      flops { key: "bf16xbf16->f32" value: 915271196920659 }
+      flops { key: "f16xf16->f16" value: 969518576975169 }
+      flops { key: "f16xf16->f32" value: 921160262409351 }
+      flops { key: "f32xf32->f32" value: 130848133012176 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1327117605608234 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1730097601611279 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1412789143644250 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 2630914116998468 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3037862019185712 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 3135012624817518 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 3172644355309326 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 3202063125483435 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 2995487412754457 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 2956948224440619 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 3172497887262822 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1306938441741710 }
+      flops { key: "bf16xbf16->f32" value: 1196974042187037 }
+      flops { key: "f16xf16->f16" value: 1204115554200506 }
+      flops { key: "f16xf16->f32" value: 1155716429158853 }
+      flops { key: "f32xf32->f32" value: 133054797881794 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1745012804205127 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 1976372981004012 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1685540268236448 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 1764277139856998 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3633932298775812 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 3990678091521486 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 4028105318640094 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 4494259621071907 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 3581004519854090 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 3986048534570765 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 3985932933267596 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1387417383955340 }
+      flops { key: "bf16xbf16->f32" value: 1204954813604941 }
+      flops { key: "f16xf16->f16" value: 1229422214318620 }
+      flops { key: "f16xf16->f32" value: 1167299016247526 }
+      flops { key: "f32xf32->f32" value: 132105904173469 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1851004747033710 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 2154519500744619 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1784446393778279 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 4371398466054929 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 3987147081475464 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 4360303722085627 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 4392354020293699 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 4972375806226371 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 3939151157822330 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 4358920837665118 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 4413511455243172 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 1426436641683424 }
+      flops { key: "bf16xbf16->f32" value: 1200114855917884 }
+      flops { key: "f16xf16->f16" value: 1250507963332469 }
+      flops { key: "f16xf16->f32" value: 1156051809684026 }
+      flops { key: "f32xf32->f32" value: 129785196000840 }
+      flops { key: "f8e4m3fnxf8e4m3fn->bf16" value: 1938332976831921 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f32" value: 2157571982621868 }
+      flops { key: "f8e4m3fnxf8e4m3fn->f8e4m3fn" value: 1888273811020052 }
+      flops { key: "f8e4m3fnxf8e5m2->bf16" value: 4526937474889041 }
+      flops { key: "f8e4m3fnxf8e5m2->f32" value: 4136550344524537 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e4m3fn" value: 4554691459789066 }
+      flops { key: "f8e4m3fnxf8e5m2->f8e5m2" value: 4624421176537882 }
+      flops { key: "f8e5m2xf8e4m3fn->bf16" value: 5234722711533884 }
+      flops { key: "f8e5m2xf8e4m3fn->f32" value: 4022770314047168 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e4m3fn" value: 4551674633328090 }
+      flops { key: "f8e5m2xf8e4m3fn->f8e5m2" value: 4593509528563431 }
+    }
+  }
+}

--- a/xla/service/gpu/model/matmul_interpolator_test.cc
+++ b/xla/service/gpu/model/matmul_interpolator_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -331,6 +332,12 @@ class MatmulInterpolatorDefaultTableTest
   std::unique_ptr<MatmulInterpolator> GetMatmulInterpolatorB200() {
     return GetMatmulInterpolator(TestGpuDeviceInfo::B200SXMDeviceInfo());
   }
+
+  std::unique_ptr<MatmulInterpolator> GetMatmulInterpolatorGfx950() {
+    se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI210DeviceInfo();
+    device_info.set_rocm_compute_capability("gfx950");
+    return GetMatmulInterpolator(device_info);
+  }
 };
 
 using H100BF16Test = MatmulInterpolatorDefaultTableTest;
@@ -640,6 +647,105 @@ INSTANTIATE_TEST_SUITE_P(
     }),
     [](const TestParamInfo<MatmulInterpolatorDefaultTableTest::ParamType>&
            info) { return info.param.test_name; });
+
+using Gfx950DefaultTableTest = MatmulInterpolatorDefaultTableTest;
+
+TEST_P(Gfx950DefaultTableTest, EstimatesExactRuntime) {
+  const auto& [_, spec, expected_duration] = GetParam();
+  ASSERT_OK_AND_ASSIGN(DotContext context,
+                       Dot(spec.b, spec.m, spec.n, spec.k, spec.lhs_type,
+                           spec.rhs_type, spec.result_type));
+  std::unique_ptr<MatmulInterpolator> interpolator =
+      GetMatmulInterpolatorGfx950();
+  std::optional<absl::Duration> runtime =
+      interpolator->EstimatedRuntime(*context.dot);
+  ASSERT_TRUE(runtime.has_value());
+  EXPECT_NEAR(absl::ToDoubleNanoseconds(*runtime),
+              absl::ToDoubleNanoseconds(expected_duration), 1.0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MatmulInterpolatorDefaultTableTestInstantiationGfx950,
+    Gfx950DefaultTableTest,
+    ValuesIn<ParametrizedTestCase>({
+        {
+            /*test_name=*/"bf16_bf16_bf16",
+            /*spec=*/
+            {/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/512,
+             /*lhs_type=*/"bf16",
+             /*rhs_type=*/"bf16",
+             /*result_type=*/"bf16",
+             /*clock_cycles=*/0},
+            /*expected_duration=*/absl::Nanoseconds(11180),
+        },
+        {
+            /*test_name=*/"f16_f16_f16",
+            /*spec=*/
+            {/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/512,
+             /*lhs_type=*/"f16",
+             /*rhs_type=*/"f16",
+             /*result_type=*/"f16",
+             /*clock_cycles=*/0},
+            /*expected_duration=*/absl::Nanoseconds(11980),
+        },
+        {
+            /*test_name=*/"f32_f32_f32",
+            /*spec=*/
+            {/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/512,
+             /*lhs_type=*/"f32",
+             /*rhs_type=*/"f32",
+             /*result_type=*/"f32",
+             /*clock_cycles=*/0},
+            /*expected_duration=*/absl::Nanoseconds(39301),
+        },
+        {
+            /*test_name=*/"f8e4m3fn_f8e4m3fn_bf16",
+            /*spec=*/
+            {/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/512,
+             /*lhs_type=*/"f8e4m3fn",
+             /*rhs_type=*/"f8e4m3fn",
+             /*result_type=*/"bf16",
+             /*clock_cycles=*/0},
+            /*expected_duration=*/absl::Nanoseconds(7980),
+        },
+        {
+            /*test_name=*/"f8e4m3fn_f8e4m3fn_f8e4m3fn",
+            /*spec=*/
+            {/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/512,
+             /*lhs_type=*/"f8e4m3fn",
+             /*rhs_type=*/"f8e4m3fn",
+             /*result_type=*/"f8e4m3fn",
+             /*clock_cycles=*/0},
+            /*expected_duration=*/absl::Nanoseconds(9201),
+        },
+        {
+            /*test_name=*/"f8e5m2_f8e4m3fn_f32",
+            /*spec=*/
+            {/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/512,
+             /*lhs_type=*/"f8e5m2",
+             /*rhs_type=*/"f8e4m3fn",
+             /*result_type=*/"f32",
+             /*clock_cycles=*/0},
+            /*expected_duration=*/absl::Nanoseconds(8400),
+        },
+    }),
+    [](const TestParamInfo<MatmulInterpolatorDefaultTableTest::ParamType>&
+           info) { return info.param.test_name; });
+
+TEST(DefaultMatmulPerfTableTest, Gfx950InterpolatesBetweenGridPoints) {
+  se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI210DeviceInfo();
+  device_info.set_rocm_compute_capability("gfx950");
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<MatmulInterpolator> interpolator,
+                       MatmulInterpolator::Create(device_info));
+  ASSERT_OK_AND_ASSIGN(
+      DotContext context,
+      Dot(/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/768, /*lhs_type=*/"bf16",
+          /*rhs_type=*/"bf16", /*result_type=*/"bf16"));
+  ASSERT_TRUE(interpolator->EstimatedRuntime(*context.dot).has_value());
+  absl::Duration runtime = *interpolator->EstimatedRuntime(*context.dot);
+  EXPECT_GT(runtime, absl::Nanoseconds(11180));
+  EXPECT_LT(runtime, absl::Nanoseconds(16640));
+}
 
 class MatmulInterpolatorTest : public Test {
  public:

--- a/xla/service/gpu/model/sol_latency_estimator.cc
+++ b/xla/service/gpu/model/sol_latency_estimator.cc
@@ -439,12 +439,14 @@ SolLatencyEstimator::Create(
 
 /*static*/ bool SolLatencyEstimator::IsSupportedForModule(
     const HloModule& module, const se::DeviceDescription& gpu_device_info) {
+  const se::GpuComputeCapability& cc = gpu_device_info.gpu_compute_capability();
   bool is_supported_device =
       gpu_device_info.cuda_compute_capability().IsHopper() ||
-      gpu_device_info.cuda_compute_capability().IsBlackwell();
+      gpu_device_info.cuda_compute_capability().IsBlackwell() ||
+      (cc.IsRocm() && cc.rocm_compute_capability()->gfx9_mi350());
   if (IsPassEnabledAtOptimizationEffort<LatencyHidingScheduler>(module)) {
     // If the user enabled opt effort we turn the estimator on if we're
-    // compiling for Hopper/Blackwell.
+    // compiling for a supported device.
     return is_supported_device;
   }
   // If this flag is on by default then we provide users an escape hatch in case
@@ -454,8 +456,9 @@ SolLatencyEstimator::Create(
            .xla_gpu_enable_analytical_sol_latency_estimator()) {
     return false;
   }
-  // Otherwise we are more conservative and we turn it on only for
-  // Hopper/Blackwell and if `module` contains only supported collectives.
+  // Otherwise we are more conservative and we turn it on only for supported
+  // devices (Hopper/Blackwell/gfx950) and if `module` contains only supported
+  // collectives.
   return is_supported_device && HasOnlySupportedCollectives(module);
 }
 

--- a/xla/service/gpu/model/sol_latency_estimator.h
+++ b/xla/service/gpu/model/sol_latency_estimator.h
@@ -36,18 +36,18 @@ namespace gpu {
 
 // Static analytical latency estimator for GPU. It uses empirical data and
 // interpolation techniques to estimate the runtime of matrix multiplications
-// and ICI (NVLINK) collectives, it also uses the GPU performance model to
+// and ICI (NVLink/XGMI) collectives, it also uses the GPU performance model to
 // estimate runtime of fusion operations and DCN collectives.
 //
 // The rationale for this mix is that we do not have proper analytical solutions
 // to estimate the runtime of GEMMs and we have not yet developed a good enough
-// set of parameters to reconstruct a bandwidth derating curve for NVLINK.
+// set of parameters to reconstruct a bandwidth derating curve for ICI links.
 // Interpolation/collection happens at the level of the HLO instruction,
 // therefore in the case of algorithmic improvements at lower levels of
 // abstractions performance tables need to be updated.
 //
-// Currently this estimator supports H100s and standard DP collectives, that is:
-// All-Reduce, All-Gather, Reduce-Scatter.
+// The estimator is enabled for Hopper, Blackwell, and ROCm gfx950 when a module
+// contains only supported collective operations.
 class SolLatencyEstimator : public LatencyEstimator {
  public:
   TimeCost GetLatencyBetween(const HloGraphNode& from,

--- a/xla/service/gpu/model/sol_latency_estimator_test.cc
+++ b/xla/service/gpu/model/sol_latency_estimator_test.cc
@@ -879,6 +879,123 @@ TEST_F(IsSolLatencyEstimatorEnabledTest, DisabledForHopperWithHostOffloaded) {
       SolLatencyEstimator::IsSupportedForModule(*module, gpu_device_info_));
 }
 
+TEST_F(IsSolLatencyEstimatorEnabledTest, EnabledBySolEstimatorFlagOnGfx950) {
+  HloModuleConfig config;
+  config.mutable_debug_options()
+      .set_xla_gpu_enable_analytical_sol_latency_estimator(true);
+  gpu_device_info_.set_rocm_compute_capability("gfx950");
+
+  auto module = CreateTestModule(config);
+  AddAllReduce(module.get());
+
+  EXPECT_TRUE(
+      SolLatencyEstimator::IsSupportedForModule(*module, gpu_device_info_));
+}
+
+TEST_F(IsSolLatencyEstimatorEnabledTest, DisabledIfFlagIsOffOnGfx950) {
+  HloModuleConfig config;
+  config.mutable_debug_options()
+      .set_xla_gpu_enable_analytical_sol_latency_estimator(false);
+  gpu_device_info_.set_rocm_compute_capability("gfx950");
+
+  auto module = CreateTestModule(config);
+  AddAllReduce(module.get());
+
+  EXPECT_FALSE(
+      SolLatencyEstimator::IsSupportedForModule(*module, gpu_device_info_));
+}
+
+TEST_F(IsSolLatencyEstimatorEnabledTest, DisabledForUnsupportedRocmArch) {
+  HloModuleConfig config;
+  config.mutable_debug_options()
+      .set_xla_gpu_enable_analytical_sol_latency_estimator(true);
+  auto module = CreateTestModule(config);
+  AddAllReduce(module.get());
+
+  for (absl::string_view architecture : {"gfx942", "gfx90a"}) {
+    gpu_device_info_.set_rocm_compute_capability(std::string(architecture));
+    EXPECT_FALSE(
+        SolLatencyEstimator::IsSupportedForModule(*module, gpu_device_info_));
+  }
+}
+
+TEST_F(IsSolLatencyEstimatorEnabledTest,
+       DisabledForGfx950WithUnsupportedCollective) {
+  HloModuleConfig config;
+  config.mutable_debug_options()
+      .set_xla_gpu_enable_analytical_sol_latency_estimator(true);
+  gpu_device_info_.set_rocm_compute_capability("gfx950");
+
+  auto module = CreateTestModule(config);
+  AddCollectiveBcast(module.get());
+
+  EXPECT_FALSE(
+      SolLatencyEstimator::IsSupportedForModule(*module, gpu_device_info_));
+}
+
+TEST_F(IsSolLatencyEstimatorEnabledTest, DisabledForGfx950WithHostOffloaded) {
+  HloModuleConfig config;
+  config.mutable_debug_options()
+      .set_xla_gpu_enable_analytical_sol_latency_estimator(true);
+  gpu_device_info_.set_rocm_compute_capability("gfx950");
+
+  auto module = CreateTestModule(config);
+  ASSERT_OK(AddHostOffloaded(module.get()));
+
+  EXPECT_FALSE(
+      SolLatencyEstimator::IsSupportedForModule(*module, gpu_device_info_));
+}
+
+TEST_F(IsSolLatencyEstimatorEnabledTest, CreatesEstimatorWithGfx950Profiles) {
+  constexpr absl::string_view kHlo = R"(
+    HloModule m, num_partitions=8
+
+    add {
+      x = f32[] parameter(0)
+      y = f32[] parameter(1)
+      ROOT sum = f32[] add(x, y)
+    }
+
+    ENTRY main {
+      lhs = f32[256,256] parameter(0)
+      rhs = f32[256,256] parameter(1)
+      dot = f32[256,256] dot(lhs, rhs),
+        lhs_contracting_dims={1}, rhs_contracting_dims={0}
+      p = f32[256] parameter(2)
+      ar-start = f32[256] all-reduce-start(p), to_apply=add,
+        replica_groups=[1,8]<=[8], channel_id=1, use_global_device_ids=true
+      ar-done = f32[256] all-reduce-done(ar-start)
+      ROOT result = (f32[256,256], f32[256]) tuple(dot, ar-done)
+    }
+  )";
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  gpu_device_info_ = TestGpuDeviceInfo::AMDMI210DeviceInfo();
+  gpu_device_info_.set_rocm_compute_capability("gfx950");
+
+  SchedulerConfig scheduler_config;
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<SolLatencyEstimator> estimator,
+      SolLatencyEstimator::Create(
+          scheduler_config, std::make_unique<DummyLatencyEstimator>(),
+          gpu_device_info_, HloCostAnalysis::DefaultShapeSize,
+          module->entry_computation()));
+
+  HloInstruction* dot =
+      module->entry_computation()->GetInstructionWithName("dot");
+  HloInstruction* all_reduce_start =
+      module->entry_computation()->GetInstructionWithName("ar-start");
+  HloInstruction* all_reduce_done =
+      module->entry_computation()->GetInstructionWithName("ar-done");
+  ASSERT_NE(dot, nullptr);
+  ASSERT_NE(all_reduce_start, nullptr);
+  ASSERT_NE(all_reduce_done, nullptr);
+  EXPECT_GT(estimator->NodeCost(dot), 0);
+  EXPECT_GT(estimator->GetLatencyBetween(
+                HloGraphNode(all_reduce_start, /*original_position=*/-1),
+                HloGraphNode(all_reduce_done, /*original_position=*/-1)),
+            0);
+}
+
 // ---- Triton collective scheduler integration tests -----------------------
 //
 // These tests verify that SolLatencyEstimator correctly uses the NVLink-based


### PR DESCRIPTION
This PR enables the SoL latency estimator for gfx950 on ROCm. The SoL estimator supplies per-instruction latency and node cost, which are fed into the latency-hiding scheduler (LHS) to drive compute/communication overlap. Before this PR it was gated to NVIDIA Hopper and Blackwell only.

Key changes:
1. interpolator data (collective & matmul)
```
xla/service/gpu/model/default_collective_perf_table.txtpb
xla/service/gpu/model/default_matmul_perf_table.txtpb
xla/service/gpu/model/collective_interpolator_test.cc
xla/service/gpu/model/matmul_interpolator_test.cc
```
2. the enablement for the SoL estimator (gfx950 only)
```
xla/service/gpu/model/sol_latency_estimator.h
xla/service/gpu/model/sol_latency_estimator.cc
xla/service/gpu/model/sol_latency_estimator_test.cc
xla/service/gpu/gpu_hlo_schedule_test.cc
xla/backends/gpu/transforms/collectives/collective_ops_utils.cc
```

Correctness is covered by unit tests that schedule a module with the SoL estimator enabled.

A performance comparison across the four estimators on typical LLM models (single node multiple gpus) is provided below:

### Experiment 1: llama3.1-8b_seq4096_pdbs16_fsdp8_high_steps30

#### Throughput
| Estimator  | Mean 8-GPU tokens/s | TPS std    | TPS CV (%) | Mean run-median step (s) | Step std (s) | Step CV (%) |
| ---------- | ------------------- | ---------- | ---------- | ------------------------ | ------------ | ----------- |
| T-shirt    | 180,692.42          | 493.85     | 0.273      | 2.901564                 | 0.007918     | 0.273       |
| Analytical | 180,884.52          | 425.12     | 0.235      | 2.898479                 | 0.006806     | 0.235       |
| SoL        | 180,656.12          | 178.03     | 0.099      | 2.902134                 | 0.002860     | 0.099       |
| **PGLE**   | **181,628.38**      | **329.60** | **0.181**  | **2.886604**             | **0.005243** | **0.182**   |

#### Overlap
| Estimator  | Total compute active (% trace) | Total communication active (% trace) | Exposed comm (% trace) | Hidden comm (% trace) | Comm overlap ratio (%) | Idle (% trace) | RCCL kernels |
| ---------- | ------------------------------ | ------------------------------------ | ---------------------- | --------------------- | ---------------------- | -------------- | ------------ |
| T-shirt    | 94.990                         | 6.517                                | 3.229                  | 3.289                 | 50.459                 | 1.782          | 864          |
| Analytical | 93.676                         | 7.045                                | 4.562                  | 2.483                 | 35.240                 | 1.762          | 864          |
| SoL        | 94.454                         | 6.463                                | 3.774                  | 2.690                 | 41.616                 | 1.772          | 864          |
| **PGLE**   | **95.521**                     | **6.827**                            | **2.814**              | **4.013**             | **58.774**             | **1.665**      | **864**      |

### Experiment 2: qwen3-14b_seq4096_pdbs48_fsdp8_high_steps30
#### Throughput
| Estimator  | Mean 8-GPU tokens/s | TPS std   | TPS CV (%) | Mean run-median step (s) | Step std (s) | Step CV (%) |
| ---------- | ------------------- | --------- | ---------- | ------------------------ | ------------ | ----------- |
| T-shirt    | 85,348.18           | 52.34     | 0.061      | 18.428798                | 0.011301     | 0.061       |
| Analytical | 85,405.46           | 55.96     | 0.066      | 18.416439                | 0.012070     | 0.066       |
| SoL        | 85,359.54           | 115.25    | 0.135      | 18.426364                | 0.024883     | 0.135       |
| **PGLE**   | **85,613.03**       | **30.34** | **0.035**  | **18.371785**            | **0.006509** | **0.035**   |

#### Overlap
| Estimator  | Total compute active (% trace) | Total communication active (% trace) | Exposed comm (% trace) | Hidden comm (% trace) | Comm overlap ratio (%) | Idle (% trace) | RCCL kernels |
| ---------- | ------------------------------ | ------------------------------------ | ---------------------- | --------------------- | ---------------------- | -------------- | ------------ |
| T-shirt    | 97.748                         | 2.923                                | 2.147                  | 0.776                 | 26.536                 | 0.105          | 2928         |
| Analytical | 98.149                         | 3.014                                | 1.746                  | 1.267                 | 42.055                 | 0.105          | 2928         |
| SoL        | 98.108                         | 3.074                                | 1.782                  | 1.291                 | 42.011                 | 0.109          | 2928         |
| **PGLE**   | **98.490**                     | **2.719**                            | **1.407**              | **1.312**             | **48.265**             | **0.104**      | **2928**     |

### Experiment 3: llama3.1-70b_seq4096_pdbs8_fsdp8_high_steps30
#### Throughput
| Estimator   | Mean 8-GPU tokens/s | TPS std   | TPS CV (%) | Mean run-median step (s) | Step std (s) | Step CV (%) |
| ----------- | ------------------- | --------- | ---------- | ------------------------ | ------------ | ----------- |
| **T-shirt** | **17,948.61**       | **11.32** | **0.063**  | **14.605257**            | **0.009209** | **0.063**   |
| Analytical  | 17,944.37           | 7.42      | 0.041      | 14.608703                | 0.006044     | 0.041       |
| SoL         | 17,947.95           | 2.30      | 0.013      | 14.605789                | 0.001871     | 0.013       |
| PGLE        | 17,938.59           | 6.68      | 0.037      | 14.613410                | 0.005440     | 0.037       |

#### Overlap
| Estimator  | Total compute active (% trace) | Total communication active (% trace) | Exposed comm (% trace) | Hidden comm (% trace) | Comm overlap ratio (%) | Idle (% trace) | RCCL kernels |
| ---------- | ------------------------------ | ------------------------------------ | ---------------------- | --------------------- | ---------------------- | -------------- | ------------ |
| T-shirt    | 92.223                         | 8.270                                | 7.608                  | 0.662                 | 8.008                  | 0.169          | 5808         |
| Analytical | 92.358                         | 8.227                                | 7.475                  | 0.752                 | 9.138                  | 0.167          | 5808         |
| SoL        | 92.289                         | 8.231                                | 7.542                  | 0.689                 | 8.369                  | 0.169          | 5808         |
| **PGLE**   | **92.526**                     | **8.057**                            | **7.308**              | **0.749**             | **9.292**              | **0.166**      | **5808**     |

### Experiment 4: llama3.1-70b_seq4096_pdbs2_fsdp8_low_steps30
#### Throughput
| Estimator  | Mean 8-GPU tokens/s | TPS std   | TPS CV (%) | Mean run-median step (s) | Step std (s) | Step CV (%) |
| ---------- | ------------------- | --------- | ---------- | ------------------------ | ------------ | ----------- |
| T-shirt    | 14,120.01           | 14.15     | 0.100      | 4.641360                 | 0.004648     | 0.100       |
| Analytical | 14,132.92           | 17.11     | 0.121      | 4.637122                 | 0.005616     | 0.121       |
| SoL        | 14,104.89           | 11.12     | 0.079      | 4.646334                 | 0.003663     | 0.079       |
| **PGLE**   | **14,148.33**       | **18.33** | **0.130**  | **4.632070**             | **0.005998** | **0.129**   |

#### Overlap
| Estimator      | Total compute active (% trace) | Total communication active (% trace) | Exposed comm (% trace) | Hidden comm (% trace) | Comm overlap ratio (%) | Idle (% trace) | RCCL kernels |
| -------------- | ------------------------------ | ------------------------------------ | ---------------------- | --------------------- | ---------------------- | -------------- | ------------ |
| T-shirt        | 78.893                         | 21.731                               | 20.624                 | 1.107                 | 5.096                  | 0.483          | 5808         |
| **Analytical** | **78.986**                     | **21.736**                           | **20.515**             | **1.221**             | **5.616**              | **0.499**      | **5808**     |
| SoL            | 78.809                         | 21.676                               | 20.675                 | 1.000                 | 4.616                  | 0.516          | 5808         |
| PGLE           | 78.714                         | 21.966                               | 20.790                 | 1.176                 | 5.354                  | 0.497          | 5808         |

### Experiment 5: deepseek2-16b_seq4096_pdbs16_ep8_high_steps30
#### Throughput
| Estimator  | Mean 8-GPU tokens/s | TPS std   | TPS CV (%) | Mean run-median step (s) | Step std (s) | Step CV (%) |
| ---------- | ------------------- | --------- | ---------- | ------------------------ | ------------ | ----------- |
| T-shirt    | 151,322.73          | 49.25     | 0.033      | 3.464701                 | 0.001127     | 0.033       |
| Analytical | 150,161.35          | 66.99     | 0.045      | 3.491498                 | 0.001557     | 0.045       |
| SoL        | 149,902.45          | 77.84     | 0.052      | 3.497529                 | 0.001816     | 0.052       |
| **PGLE**   | **152,286.11**      | **60.73** | **0.040**  | **3.442783**             | **0.001373** | **0.040**   |

#### Overlap
| Estimator   | Total compute active (% trace) | Total communication active (% trace) | Exposed comm (% trace) | Hidden comm (% trace) | Comm overlap ratio (%) | Idle (% trace) | RCCL kernels |
| ----------- | ------------------------------ | ------------------------------------ | ---------------------- | --------------------- | ---------------------- | -------------- | ------------ |
| **T-shirt** | **96.524**                     | **8.141**                            | **2.842**              | **5.298**             | **65.085**             | **0.634**      | **5040**     |
| Analytical  | 94.150                         | 11.744                               | 5.245                  | 6.499                 | 55.336                 | 0.605          | 5040         |
| SoL         | 93.808                         | 11.680                               | 5.543                  | 6.137                 | 52.540                 | 0.649          | 5040         |
| PGLE        | 96.502                         | 9.967                                | 2.879                  | 7.088                 | 71.116                 | 0.619          | 5040         |

### Experiment 6: qwen3-30b-a3b_seq4096_pdbs48_ep8_high_steps30
#### Throughput
| Estimator  | Mean 8-GPU tokens/s | TPS std   | TPS CV (%) | Mean run-median step (s) | Step std (s) | Step CV (%) |
| ---------- | ------------------- | --------- | ---------- | ------------------------ | ------------ | ----------- |
| T-shirt    | 83,686.68           | 33.09     | 0.040      | 18.794678                | 0.007432     | 0.040       |
| Analytical | 83,719.66           | 65.86     | 0.079      | 18.787280                | 0.014776     | 0.079       |
| SoL        | 83,402.98           | 12.91     | 0.015      | 18.858608                | 0.002918     | 0.015       |
| **PGLE**   | **83,756.85**       | **62.54** | **0.075**  | **18.778937**            | **0.014021** | **0.075**   |

#### Overlap
| Estimator   | Total compute active (% trace) | Total communication active (% trace) | Exposed comm (% trace) | Hidden comm (% trace) | Comm overlap ratio (%) | Idle (% trace) | RCCL kernels |
| ----------- | ------------------------------ | ------------------------------------ | ---------------------- | --------------------- | ---------------------- | -------------- | ------------ |
| **T-shirt** | **98.386**                     | **5.069**                            | **1.465**              | **3.604**             | **71.101**             | **0.149**      | **8211**     |
| Analytical  | 98.068                         | 8.945                                | 1.779                  | 7.166                 | 80.108                 | 0.152          | 8292         |
| SoL         | 97.975                         | 8.982                                | 1.873                  | 7.109                 | 79.151                 | 0.152          | 8180         |
| PGLE        | 98.188                         | 5.747                                | 1.669                  | 4.078                 | 70.957                 | 0.143          | 8208         |

### Experiment 7: qwen3-30b-a3b_seq4096_pdbs12_ep8_low_steps30
#### Throughput
| Estimator      | Mean 8-GPU tokens/s | TPS std   | TPS CV (%) | Mean run-median step (s) | Step std (s) | Step CV (%) |
| -------------- | ------------------- | --------- | ---------- | ------------------------ | ------------ | ----------- |
| T-shirt        | 76,226.52           | 14.26     | 0.019      | 5.158520                 | 0.000965     | 0.019       |
| **Analytical** | **76,297.07**       | **19.45** | **0.025**  | **5.153750**             | **0.001314** | **0.025**   |
| SoL            | 76,292.20           | 36.75     | 0.048      | 5.154080                 | 0.002483     | 0.048       |
| PGLE           | 76,164.60           | 9.37      | 0.012      | 5.162713                 | 0.000635     | 0.012       |

#### Overlap
| Estimator   | Total compute active (% trace) | Total communication active (% trace) | Exposed comm (% trace) | Hidden comm (% trace) | Comm overlap ratio (%) | Idle (% trace) | RCCL kernels |
| ----------- | ------------------------------ | ------------------------------------ | ---------------------- | --------------------- | ---------------------- | -------------- | ------------ |
| **T-shirt** | **91.762**                     | **11.054**                           | **7.701**              | **3.353**             | **30.329**             | **0.537**      | **8990**     |
| Analytical  | 91.644                         | 14.410                               | 7.797                  | 6.613                 | 45.892                 | 0.559          | 8896         |
| SoL         | 91.495                         | 14.494                               | 7.934                  | 6.560                 | 45.260                 | 0.571          | 8896         |
| PGLE        | 91.648                         | 9.653                                | 7.799                  | 1.853                 | 19.200                 | 0.553          | 8984         |

### Experiment 8: mixtral-8x7b_seq4096_pdbs16_ep8_high_steps30
#### Throughput
| Estimator  | Mean 8-GPU tokens/s | TPS std   | TPS CV (%) | Mean run-median step (s) | Step std (s) | Step CV (%) |
| ---------- | ------------------- | --------- | ---------- | ------------------------ | ------------ | ----------- |
| T-shirt    | 68,503.26           | 34.38     | 0.050      | 7.653476                 | 0.003842     | 0.050       |
| Analytical | 68,544.21           | 23.68     | 0.035      | 7.648903                 | 0.002642     | 0.035       |
| **SoL**    | **68,569.99**       | **81.17** | **0.118**  | **7.646034**             | **0.009056** | **0.118**   |
| PGLE       | 68,543.88           | 32.10     | 0.047      | 7.648940                 | 0.003581     | 0.047       |

#### Overlap
| Estimator      | Total compute active (% trace) | Total communication active (% trace) | Exposed comm (% trace) | Hidden comm (% trace) | Comm overlap ratio (%) | Idle (% trace) | RCCL kernels |
| -------------- | ------------------------------ | ------------------------------------ | ---------------------- | --------------------- | ---------------------- | -------------- | ------------ |
| T-shirt        | 90.174                         | 10.028                               | 9.590                  | 0.438                 | 4.364                  | 0.235          | 2352         |
| **Analytical** | **90.394**                     | **9.978**                            | **9.372**              | **0.606**             | **6.075**              | **0.234**      | **2352**     |
| SoL            | 90.268                         | 10.109                               | 9.503                  | 0.606                 | 5.996                  | 0.229          | 2352         |
| PGLE           | 90.185                         | 10.108                               | 9.575                  | 0.533                 | 5.273                  | 0.240          | 2352         |