### PR TITLE
[tsl:concurrency] Add rvalue-optimized casts to AsyncValue

### DIFF
--- a/xla/tsl/concurrency/async_value_ref.h
+++ b/xla/tsl/concurrency/async_value_ref.h
@@ -218,7 +218,7 @@ class AsyncValueRef {
     //
     //   struct A {};
     //   struct B : public A {};
-    //   struct C : public C {}
+    //   struct C : public B {}
     //
     //   AsyncValueRef<A> ref = MakeUnconstructedAsyncValueRef<C>();
     //
@@ -234,21 +234,40 @@ class AsyncValueRef {
   }
 
   template <typename Derived, internal::DerivedFrom<Derived, T>* = nullptr>
-  AsyncValueRef<Derived> Cast() const {
+  AsyncValueRef<Derived> Cast() const& {
     DCHECK(DynCast<Derived>()) << "Illegal async value cast";
     return AsyncValueRef<Derived>(value_);
   }
 
   template <typename Derived, internal::DerivedFrom<Derived, T>* = nullptr>
-  AsyncValueRef<Derived> DynCast() const {
+  AsyncValueRef<Derived> Cast() && {
+    DCHECK(Isa<Derived>()) << "Illegal async value cast";
+    return AsyncValueRef<Derived>(std::move(value_));
+  }
+
+  template <typename Derived, internal::DerivedFrom<Derived, T>* = nullptr>
+  AsyncValueRef<Derived> DynCast() const& {
     DCHECK(value_) << "Async value must be not null";
     return Isa<Derived>() ? AsyncValueRef<Derived>(value_)
                           : AsyncValueRef<Derived>(nullptr);
   }
 
   template <typename Derived, internal::DerivedFrom<Derived, T>* = nullptr>
-  AsyncValueRef<Derived> DynCastOrNull() const {
-    return value_ ? DynCast<Derived>(value_) : AsyncValueRef<Derived>(nullptr);
+  AsyncValueRef<Derived> DynCast() && {
+    DCHECK(value_) << "Async value must be not null";
+    return Isa<Derived>() ? AsyncValueRef<Derived>(std::move(value_))
+                          : AsyncValueRef<Derived>(nullptr);
+  }
+
+  template <typename Derived, internal::DerivedFrom<Derived, T>* = nullptr>
+  AsyncValueRef<Derived> DynCastOrNull() const& {
+    return value_ ? DynCast<Derived>() : AsyncValueRef<Derived>(nullptr);
+  }
+
+  template <typename Derived, internal::DerivedFrom<Derived, T>* = nullptr>
+  AsyncValueRef<Derived> DynCastOrNull() && {
+    return value_ ? std::move(*this).template DynCast<Derived>()
+                  : AsyncValueRef<Derived>(nullptr);
   }
 
   T* operator->() const { return &get(); }
@@ -1001,8 +1020,8 @@ bool Isa(const AsyncValueRef<T>& ref) {
 
 template <typename Derived, typename T,
           internal::DerivedFrom<Derived, T>* = nullptr>
-AsyncValueRef<Derived> Cast(const AsyncValueRef<T>& ref) {
-  return ref.template Cast<Derived>();
+AsyncValueRef<Derived> Cast(AsyncValueRef<T> ref) {
+  return std::move(ref).template Cast<Derived>();
 }
 
 template <typename Derived, typename T,
@@ -1013,8 +1032,20 @@ AsyncValueRef<Derived> DynCast(const AsyncValueRef<T>& ref) {
 
 template <typename Derived, typename T,
           internal::DerivedFrom<Derived, T>* = nullptr>
+AsyncValueRef<Derived> DynCast(AsyncValueRef<T>&& ref) {
+  return std::move(ref).template DynCast<Derived>();
+}
+
+template <typename Derived, typename T,
+          internal::DerivedFrom<Derived, T>* = nullptr>
 AsyncValueRef<Derived> DynCastOrNull(const AsyncValueRef<T>& ref) {
   return ref.template DynCastOrNull<Derived>();
+}
+
+template <typename Derived, typename T,
+          internal::DerivedFrom<Derived, T>* = nullptr>
+AsyncValueRef<Derived> DynCastOrNull(AsyncValueRef<T>&& ref) {
+  return std::move(ref).template DynCastOrNull<Derived>();
 }
 
 template <typename Derived, typename T,

--- a/xla/tsl/concurrency/async_value_ref_test.cc
+++ b/xla/tsl/concurrency/async_value_ref_test.cc
@@ -827,6 +827,22 @@ TEST(AsyncValueRefTest, DynCast) {
   typed_indirect->ForwardTo(c_ref.CopyRCRef());
   EXPECT_TRUE(DynCast<A>(c_typed_indirect));
   EXPECT_TRUE(DynCast<C>(c_typed_indirect));
+
+  // Casting an rvalue transfers ownership without changing the refcount.
+  AsyncValueRef<A> moved_ref = MakeAvailableAsyncValueRef<C>();
+  EXPECT_TRUE(moved_ref.IsUnique());
+  AsyncValueRef<C> moved_cast = DynCast<C>(std::move(moved_ref));
+  EXPECT_TRUE(moved_cast.IsUnique());
+}
+
+TEST(AsyncValueRefTest, DynCastOrNull) {
+  AsyncValueRef<A> null_ref;
+  EXPECT_FALSE(DynCastOrNull<C>(null_ref));
+
+  AsyncValueRef<A> moved_ref = MakeAvailableAsyncValueRef<C>();
+  EXPECT_TRUE(moved_ref.IsUnique());
+  AsyncValueRef<C> moved_cast = DynCastOrNull<C>(std::move(moved_ref));
+  EXPECT_TRUE(moved_cast.IsUnique());
 }
 
 TEST(AsyncValueRefTest, Cast) {
@@ -881,6 +897,12 @@ TEST(AsyncValueRefTest, Cast) {
   typed_indirect->ForwardTo(c_ref.CopyRCRef());
   EXPECT_TRUE(Cast<A>(c_typed_indirect));
   EXPECT_TRUE(Cast<C>(c_typed_indirect));
+
+  // Casting an rvalue transfers ownership without changing the refcount.
+  AsyncValueRef<A> moved_ref = MakeAvailableAsyncValueRef<C>();
+  EXPECT_TRUE(moved_ref.IsUnique());
+  AsyncValueRef<C> moved_cast = Cast<C>(std::move(moved_ref));
+  EXPECT_TRUE(moved_cast.IsUnique());
 }
 
 TEST(AsyncValueRefTest, RecursiveOwnership) {


### PR DESCRIPTION
Add a fast path for casting `tsl::AsyncValue` rvalues without having to increment/decrement reference count (saves two atomic operations on a hot path).