### PR TITLE
[oneAPI] Version-gate Highway ICX workaround for oneAPI 2026.x

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ bazel_dep(name = "google_benchmark", version = "1.8.5", repo_name = "com_google_
 bazel_dep(name = "googletest", version = "1.17.0", repo_name = "com_google_googletest")
 bazel_dep(name = "grpc", version = "1.81.0")
 bazel_dep(name = "gutil", version = "20260309.0.bcr.1", repo_name = "com_google_gutil")
-bazel_dep(name = "highway", version = "1.3.0")
+bazel_dep(name = "highway", version = "1.4.0")
 bazel_dep(name = "jsoncpp", version = "1.9.6", repo_name = "jsoncpp_git")
 bazel_dep(name = "or-tools", version = "9.12", repo_name = "com_google_ortools")
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/third_party/highway/workspace.bzl
+++ b/third_party/highway/workspace.bzl
@@ -20,8 +20,8 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 def repo():
     """Imports highway."""
 
-    HIGHWAY_VERSION = "1.3.0"
-    HIGHWAY_SHA256 = "07b3c1ba2c1096878a85a31a5b9b3757427af963b1141ca904db2f9f4afe0bc2"
+    HIGHWAY_VERSION = "1.4.0"
+    HIGHWAY_SHA256 = "e72241ac9524bb653ae52ced768b508045d4438726a303f10181a38f764a453c"
 
     tf_http_archive(
         name = "highway",


### PR DESCRIPTION
This change fixes XLA build failures with oneAPI 2026.x caused by Highway using the "evex512" and "avx10.2-512" target attributes, which are rejected by newer ICX compilers. ICX 2025.1 requires these older feature spellings, while ICX 2026.x instead accepts avx10.2, so the workaround is now gated on the ICX version rather than applied to all ICX compilers. This preserves the existing Highway behavior for oneAPI 2025.1 and other compilers while using the compatible target attributes for oneAPI 2026.x.