### PR TITLE
[ROCM][NFC] remove dead tracing API from stream executor

### DIFF
--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -182,11 +182,9 @@ cc_library(
         "//xla/stream_executor:platform",
         "//xla/stream_executor:stream_executor_common",
         "//xla/stream_executor:stream_executor_h",
-        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
-        "@com_google_absl//absl/synchronization",
     ],
 )
 

--- a/xla/stream_executor/gpu/gpu_executor.h
+++ b/xla/stream_executor/gpu/gpu_executor.h
@@ -19,15 +19,10 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <utility>
-#include <variant>
-#include <vector>
 
-#include "absl/base/thread_annotations.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
-#include "absl/synchronization/mutex.h"
 #include "xla/stream_executor/device_address.h"
 #include "xla/stream_executor/gpu/multicast_memory.h"
 #include "xla/stream_executor/platform.h"
@@ -46,28 +41,6 @@ class GpuExecutor : public StreamExecutorCommon {
       : StreamExecutorCommon(platform), device_ordinal_(device_ordinal) {}
 
   int device_ordinal() const override { return device_ordinal_; };
-
-  absl::StatusOr<std::vector<ApiTrace>> ExtractApiTrace() override {
-    absl::MutexLock lock(logger_mu_);
-    return std::move(argument_logs_);
-  }
-
-  absl::Status RecordApiTrace(ApiTrace call) override {
-    absl::MutexLock lock(logger_mu_);
-    if (std::holds_alternative<GemmCallTrace>(call) &&
-        (argument_logging_mode_ & kLogGemm)) {
-      argument_logs_.push_back(call);
-    }
-    return absl::OkStatus();
-  }
-
-  bool SetArgumentLoggingMode(uint64_t mode) override {
-    absl::MutexLock lock(logger_mu_);
-    argument_logging_mode_ = mode;
-    return true;
-  }
-
-  uint64_t GetArgumentLoggingMode() const { return argument_logging_mode_; }
 
   virtual absl::StatusOr<std::unique_ptr<MulticastMemory>>
   CreateMulticastMemory(uint64_t size, int num_devices) const {
@@ -103,12 +76,6 @@ class GpuExecutor : public StreamExecutorCommon {
   // The device ordinal value that this executor was initialized with; recorded
   // for use in getting device metadata. Immutable post-initialization.
   int device_ordinal_;
-
-  absl::Mutex logger_mu_;
-
-  mutable std::vector<ApiTrace> argument_logs_ ABSL_GUARDED_BY(logger_mu_);
-
-  uint64_t argument_logging_mode_ = 0;
 
   GpuExecutor(const GpuExecutor&) = delete;
   void operator=(const GpuExecutor&) = delete;

--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -652,11 +652,6 @@ absl::Status BlasLt::RegularMatmulPlan::ExecuteOnStream(
     std::swap(a_scale, b_scale);
   }
 
-  absl::Status status =
-      blas_lt_.executor_->RecordApiTrace(StreamExecutor::GemmCallTrace{
-          StreamExecutor::GemmCallTrace::GemmType::kBlasLt, 0, a.size(),
-          b.size()});
-
   std::unique_ptr<EventBasedTimer> timer;
   if (profile_result != nullptr) {
     ABSL_ASSIGN_OR_RETURN(timer, stream->CreateEventBasedTimer(
@@ -991,11 +986,6 @@ absl::Status BlasLt::GroupedMatmulPlan::ExecuteOnStream(
                                 (cfg_.group_count * cfg_.batch_count))
           : static_cast<size_t>(args.group_sizes.size() / cfg_.group_count);
 
-  absl::Status status =
-      blas_lt_.executor_->RecordApiTrace(StreamExecutor::GemmCallTrace{
-          StreamExecutor::GemmCallTrace::GemmType::kBlasLt, 0,
-          cfg_.m * cfg_.k * cfg_.batch_count,
-          cfg_.k * cfg_.n * cfg_.batch_count * cfg_.group_count});
   std::unique_ptr<EventBasedTimer> timer;
 
   if (profile_result != nullptr) {

--- a/xla/stream_executor/rocm/rocm_blas.cc
+++ b/xla/stream_executor/rocm/rocm_blas.cc
@@ -503,16 +503,6 @@ Impl_DoBlasScal(wrap::rocblas_sscal, float, float)
      *floats.)
      *
      **/
-    using GemmCallTrace = StreamExecutor::GemmCallTrace;
-
-// Log the GEMM operation if the logging mode is enabled.
-void ROCMBlas::MaybeLogGemmOp(GemmCallTrace::GemmType op,
-                              blas::CallContext context, uint64_t size1,
-                              uint64_t size2) {
-  auto status =
-      parent_->RecordApiTrace(GemmCallTrace{op, (int)context, size1, size2});
-}
-
 absl::Status ROCMBlas::DoBlasGemm(Stream* stream, blas::Transpose transa,
                                   blas::Transpose transb, uint64_t m,
                                   uint64_t n, uint64_t k, blas::DataType dtype,
@@ -521,9 +511,6 @@ absl::Status ROCMBlas::DoBlasGemm(Stream* stream, blas::Transpose transa,
                                   const void* beta, DeviceAddressBase* c,
                                   int ldc, const EngineOptions& engine_options,
                                   blas::CallContext context) {
-  MaybeLogGemmOp(GemmCallTrace::GemmType::kPlain, context,
-                 m * k * DtypeSize(dtype), n * k * DtypeSize(dtype));
-
   VLOG(1) << absl::StreamFormat(
       "doing rocBLAS GEMM: at=%d bt=%d m=%u n=%u "
       "k=%llu alpha=%p a=%p lda=%d b=%p ldb=%d beta=%p "
@@ -627,8 +614,6 @@ absl::Status ROCMBlas::DoBlasGemmWithAlgorithm(
                                context));
 
   } else {
-    MaybeLogGemmOp(GemmCallTrace::GemmType::kPlain, context,
-                   m * k * DtypeSize(type_a), n * k * DtypeSize(type_a));
     CheckPreconditions(transa, transb, m, n, k, type_a, lda, ldb);
     ABSL_ASSIGN_OR_RETURN(auto roc_type_a, AsRocBlasType(type_a));
     ABSL_ASSIGN_OR_RETURN(auto roc_type_c, AsRocBlasType(type_c));
@@ -689,8 +674,6 @@ absl::Status ROCMBlas::DoBlasGemmStridedBatchedWithAlgorithm(
         ldb, stride_b, beta, c, ldc, stride_c, batch_count, engine_options,
         context));
   } else {
-    MaybeLogGemmOp(GemmCallTrace::GemmType::kStridedBatched, context, a.size(),
-                   b.size());
     VLOG(1) << absl::StreamFormat(
         "doing rocBLAS GEMM strided batched with Algorithm: at=%d bt=%d m=%u "
         "n=%u "
@@ -1120,8 +1103,6 @@ bool ROCMBlas::DoBlasGemmBatched(
     DeviceAddressSlice<Eigen::half> c, int ldc, int batch_count,
     const EngineOptions& engine_options, ScratchAllocator* scratch_allocator,
     blas::CallContext context) {
-  MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a.size(),
-                 b.size());
   const Eigen::half alpha_half(alpha);
   const Eigen::half beta_half(beta);
   absl::Status status;
@@ -1156,8 +1137,6 @@ bool ROCMBlas::DoBlasGemmBatched(
     DeviceAddressSlice<Eigen::bfloat16> c_array, int ldc, int batch_count,
     const EngineOptions& engine_options, ScratchAllocator* scratch_allocator,
     blas::CallContext context) {
-  MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a_array.size(),
-                 b_array.size());
   const Eigen::bfloat16 alpha_bf16(alpha);
   const Eigen::bfloat16 beta_bf16(beta);
 
@@ -1179,8 +1158,6 @@ bool ROCMBlas::DoBlasGemmBatched(
       int ldb, T beta, DeviceAddressSlice<T> c_array, int ldc,                 \
       int batch_count, const EngineOptions& engine_options,                    \
       ScratchAllocator* scratch_allocator, blas::CallContext context) {        \
-    MaybeLogGemmOp(GemmCallTrace::GemmType::kBatched, context, a_array.size(), \
-                   b_array.size());                                            \
     absl::Status status = DoBlasGemmBatchedInternal(                           \
         Fun, stream, transa, transb, m, n, k, alpha, a_array, lda, b_array,    \
         ldb, beta, c_array, ldc, batch_count, scratch_allocator);              \
@@ -1248,8 +1225,6 @@ IMPL_DoBlasGemmBatched(float, wrap::rocblas_sgemm_strided_batched)
       static_cast<int>(transa), static_cast<int>(transb), m, n, k, alpha,
       a.opaque(), lda, b.opaque(), ldb, beta, c->opaque(), ldc, stride_a,
       stride_b, stride_c, batch_count);
-  MaybeLogGemmOp(GemmCallTrace::GemmType::kStridedBatched, context, a.size(),
-                 b.size());
 
   absl::Status status;
   auto call_gemm = [&](auto func, auto type) {

--- a/xla/stream_executor/rocm/rocm_blas.h
+++ b/xla/stream_executor/rocm/rocm_blas.h
@@ -185,10 +185,6 @@ class ROCMBlas : public blas::BlasSupport {
   // container holding solutions vector (to avoid reallocating it each time)
   std::vector<rocblas_int> solutions_;
 
-  void MaybeLogGemmOp(StreamExecutor::GemmCallTrace::GemmType op,
-                      blas::CallContext context, uint64_t size1,
-                      uint64_t size2);
-
   rocm::BlasLt blas_lt_;
 
   ROCMBlas(const ROCMBlas &) = delete;

--- a/xla/stream_executor/stream_executor.h
+++ b/xla/stream_executor/stream_executor.h
@@ -348,34 +348,6 @@ class StreamExecutor {
   // of arguments passed to other class methods.
   // Used for testing/debugging purposes.
 
-  struct GemmCallTrace {
-    enum class GemmType {
-      kPlain = 0,
-      kStridedBatched = 1,
-      kBatched = 2,
-      kBlasLt = 3
-    };
-    GemmType op;
-    int flags;
-    uint64_t size1, size2;
-  };
-  // This may be expanded as necessary to trace other calls
-  using ApiTrace = std::variant<GemmCallTrace>;
-
-  // Retrieves and clears internal argument logs.
-  virtual absl::StatusOr<std::vector<ApiTrace>> ExtractApiTrace() {
-    return absl::UnimplementedError("Not implemented");
-  }
-  virtual absl::Status RecordApiTrace(ApiTrace call) {
-    return absl::UnimplementedError("Not implemented");
-  }
-
-  static constexpr uint64_t kLogGemm = 1 << 0;
-
-  // Sets the argument logging mode. Returns true if 'mode' is valid.
-  // The mode is a bitmask of the kLog* constants.
-  virtual bool SetArgumentLoggingMode(uint64_t mode) { return false; }
-
   // Creates, allocates, and copies a CUtensorMap object for the given TMA
   // descriptor. Returns a TensorMap, which is 128 bytes of storage, to be
   // passed by value to the kernel.


### PR DESCRIPTION

Removing half-backed RecordApiTrace which was only partly implemented on ROCM but never really used.
Cleaning up StreamExecutor interface.