### PR TITLE
Stabilize ROCm BLASLt algorithm ordering

### DIFF
--- a/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -301,6 +301,13 @@ auto BlasLt::RegularMatmulPlan::GetAlgorithms(size_t max_algorithm_count,
     results.resize(found_algorithm_count);
   }  // end mutex block
 
+  // XLA persists an algorithm's position in this vector. Canonicalize the
+  // order because hipBLASLt can reorder equal-ranked results between processes.
+  std::sort(results.begin(), results.end(), [](auto lhs, auto rhs) {
+    return hipblaslt_ext::getIndexFromAlgo(lhs.algo) <
+           hipblaslt_ext::getIndexFromAlgo(rhs.algo);
+  });
+
   std::vector<MatmulAlgorithm> algorithms;
   algorithms.reserve(results.size());
   for (const hipblasLtMatmulHeuristicResult_t& result : results) {


### PR DESCRIPTION
#ai-generated

## Summary of Changes

Canonicalize regular ROCm hipBLASLt heuristic results by native solution ID
before exposing them as XLA `MatmulAlgorithm`s.

## Justification

hipBLASLt can return the same heuristic candidate set in different orders
across processes. XLA persists a `MatmulAlgorithm`'s vector ordinal and later
reconstructs the vector in another process, so an order change can make one
serialized ordinal select a different native solution and produce different
output bytes.

Sorting gives persisted ordinals a stable meaning without changing the
candidate set or algorithm descriptors.

## Kind of Contribution

Bug Fix

## Benchmark

Not applicable; this does not change the candidate set selected by autotuning.

## Unit Tests

No new hermetic unit test: the observed defect is process-to-process ordering
inside the native hipBLASLt API. Existing focused target
`//xla/backends/gpu/runtime:thunk_replay_main_test` passes.

## Execution Tests

On gfx1151, an interposer forced one four-result set into ascending and
descending orders. Before this change, the two orders selected native solutions
2797 and 2796 and produced different output hashes. After this change, both
orders selected 2797 and produced the same hash. Sixteen additional unforced
replay processes agreed.

A fresh XLA compilation under the change was then captured and replayed: one
four-launch replay and eight independent one-launch processes all matched the
captured output exactly.
