### PR TITLE
[XLA:GPU][oneAPI] Add XPU target check in Triton ThreadDim extraction

### DIFF
--- a/xla/backends/gpu/codegen/triton/lowering_util.cc
+++ b/xla/backends/gpu/codegen/triton/lowering_util.cc
@@ -73,7 +73,7 @@ absl::StatusOr<stream_executor::ThreadDim> ExtractThreadDims(
   if (!num_warps_attr) {
     return absl::InternalError("ttg.num-warps attribute not found.");
   }
-  // AMD/ROCm Triton backend does not support warp specialization.
+  // AMD/ROCm and Intel XPU Triton backends do not support warp specialization.
   // Consequently, `ttg.total-num-warps` and  `nvvm.reqntid` are not added
   // to triton module/function.
   // ThreadDim is therefore calculated from the Module attributes and not
@@ -82,7 +82,8 @@ absl::StatusOr<stream_executor::ThreadDim> ExtractThreadDims(
   if (!target) {
     return absl::InternalError("ttg.target attribute not found.");
   }
-  if (target.getValue().find("gfx") != std::string::npos) {
+  if (target.getValue().find("gfx") != std::string::npos ||
+      target.getValue().find("xpu") != std::string::npos) {
     stream_executor::ThreadDim thread_dims(
         num_warps_attr.getInt() * threads_per_warp_attr.getInt(), 1, 1);
     return thread_dims;


### PR DESCRIPTION
Like ROCm, Intel-XPU Triton targets do not support warp specialization and do not annotate functions with `ttg.total-num-warps` attribute. Hence, this PR (like ROCm) computes `ThreadDim` from the other launch information attributes.