### PR TITLE
Preserve chlo.erfc as a stablehlo.composite

### DIFF
--- a/xla/mlir_hlo/stablehlo_ext/transforms/chlo_preserve_high_level_ops.cpp
+++ b/xla/mlir_hlo/stablehlo_ext/transforms/chlo_preserve_high_level_ops.cpp
@@ -235,6 +235,7 @@ struct ChloPreserveHighLevelOpsPass
                  ChloOpToCompositePattern<chlo::CoshOp>,
                  ChloOpToCompositePattern<chlo::SinhOp>,
                  ChloOpToCompositePattern<chlo::ErfOp>,
+                 ChloOpToCompositePattern<chlo::ErfcOp>,
                  ChloOpToCompositePattern<chlo::MulhiOp>,
                  ChloOpToCompositePattern<chlo::RaggedDotOp>,
                  ChloOpToCompositePattern<chlo::TopKOp>,

--- a/xla/mlir_hlo/stablehlo_ext/transforms/chlo_recompose_ops.cpp
+++ b/xla/mlir_hlo/stablehlo_ext/transforms/chlo_recompose_ops.cpp
@@ -483,6 +483,7 @@ struct ChloRecomposeOpsPass
       ChloOpRecomposePattern<chlo::CoshOp>,
       ChloOpRecomposePattern<chlo::SinhOp>,
       ChloOpRecomposePattern<chlo::ErfOp>,
+      ChloOpRecomposePattern<chlo::ErfcOp>,
       ChloOpRecomposePattern<chlo::MulhiOp>,
       ChloOpRecomposePattern<chlo::RaggedDotOp>,
       ChloOpRecomposePattern<chlo::ScanOp>,

--- a/xla/mlir_hlo/tests/stablehlo_ext/chlo_preserve_high_level_ops.mlir
+++ b/xla/mlir_hlo/tests/stablehlo_ext/chlo_preserve_high_level_ops.mlir
@@ -80,6 +80,15 @@ func.func @erf_preserve(%arg0: tensor<3x20x20xbf16>) -> tensor<?x20x20xbf16> {
 
 // -----
 
+// CHECK-LABEL: func @erfc_preserve
+func.func @erfc_preserve(%arg0: tensor<3x20x20xbf16>) -> tensor<?x20x20xbf16> {
+  // CHECK: stablehlo.composite "chlo.erfc" %arg0 {decomposition = @chlo.erfc.impl, version = 1 : i32}
+  %0 = chlo.erfc %arg0 : tensor<3x20x20xbf16> -> tensor<?x20x20xbf16>
+  return %0 : tensor<?x20x20xbf16>
+}
+
+// -----
+
 // CHECK-LABEL: func @acosh_preserve
 func.func @acosh_preserve(%arg0: tensor<3x20x20xbf16>) -> tensor<?x20x20xbf16> {
   // CHECK: stablehlo.composite "chlo.acosh" %arg0 {decomposition = @chlo.acosh.impl, version = 1 : i32}

--- a/xla/mlir_hlo/tests/stablehlo_ext/chlo_recompose_ops.mlir
+++ b/xla/mlir_hlo/tests/stablehlo_ext/chlo_recompose_ops.mlir
@@ -32,6 +32,21 @@ func.func private @chlo.erf.impl(%arg0: tensor<3x20x20xbf16>) -> tensor<?x20x20x
 
 // -----
 
+// CHECK-LABEL: func @erfc_recompose_composite
+func.func @erfc_recompose_composite(%arg0: tensor<3x20x20xbf16>) -> tensor<?x20x20xbf16> {
+  // CHECK-NEXT: chlo.erfc
+  // CHECK-NOT: stablehlo.composite
+  %0 = stablehlo.composite "chlo.erfc" %arg0 {decomposition = @chlo.erfc.impl, version = 1 : i32} : (tensor<3x20x20xbf16>) -> tensor<?x20x20xbf16>
+  return %0 : tensor<?x20x20xbf16>
+}
+// CHECK-NOT: @chlo.erfc.impl
+func.func private @chlo.erfc.impl(%arg0: tensor<3x20x20xbf16>) -> tensor<?x20x20xbf16> {
+  %0 = chlo.erfc %arg0 : tensor<3x20x20xbf16> -> tensor<?x20x20xbf16>
+  return %0 : tensor<?x20x20xbf16>
+}
+
+// -----
+
 // CHECK-LABEL: func @acosh_recompose_composite
 func.func @acosh_recompose_composite(%arg0: tensor<3x20x20xbf16>) -> tensor<?x20x20xbf16> {
   // CHECK-NEXT: chlo.acosh


### PR DESCRIPTION
#ai-generated

`chlo.erf` and `chlo.top_k` already survive StableHLO serialization as `stablehlo.composite` ops. `chlo.erfc` does not, so it is expanded into its full polynomial approximation at export time and downstream StableHLO consumers cannot recognize it.

Where I hit this: exporting `jax.nn.gelu(x, approximate=False)` (which lowers through `chlo.erfc`) via `jax.export`. With jax/jaxlib 0.9.1:

```
jax.scipy.special.erf          -> stablehlo.composite "chlo.erf" ...
jax.nn.gelu(approximate=False) -> ~90 StableHLO ops, no composite
```

This blocks the stablehlo-coreml converter (and any other StableHLO consumer) from recognizing erfc; it has to match a ~70-op polynomial or give up.

This adds `chlo::ErfcOp` to `ChloPreserveHighLevelOpsPass` and `ChloRecomposeOpsPass` so erfc round-trips exactly like erf. `chlo.erfc` has no attributes, so the existing builtin-attribute passthrough covers it.

On the compile path there is no `MHLO_ErfcOp`, so the recomposed `chlo.erfc` is left alone by `ChloLegalizeToHighLevelMhloPass` and expanded by `ChloLegalizeToStablehloPass` — the same path `chlo.acosh`/`cosh`/`sinh` already take. Verified end to end: the composite lowers to the identical 92-op expansion produced today, so numerics are unchanged.

Tests: erfc cases added to `chlo_preserve_high_level_ops.mlir` and `chlo_recompose_ops.mlir`, mirroring the existing erf cases. The preserve test's `preserve | recompose | diff` RUN line covers the round trip.
