### PR TITLE
[XLA:GPU][oneAPI] oneCCL Build Fix

### DIFF
--- a/xla/backends/gpu/collectives/BUILD
+++ b/xla/backends/gpu/collectives/BUILD
@@ -1038,6 +1038,7 @@ cc_library(
         "@oneccl//:libs",
         "@tsl//tsl/platform:casts",
     ],
+    alwayslink = True,  # registers collectives implementation
 )
 
 cc_library(


### PR DESCRIPTION
📝 Summary of Changes
This PR forces the linker to include the oneCCL object files in `jaxlib`. This ensures oneCCL's static registration runs, preventing `Unimplemented: XLA compiled without GPU collective support` at runtime when using JAX with oneAPI backend.

🚀 Kind of Contribution
🐛 Bug Fix
