### PR TITLE
[XLA:GPU][oneAPI] Add an HLO pass to resize matmul workspace size with oneDNN

### DIFF
--- a/xla/backends/gpu/transforms/BUILD
+++ b/xla/backends/gpu/transforms/BUILD
@@ -2100,6 +2100,32 @@ cc_library(
 )
 
 cc_library(
+    name = "sycl_gemm_workspace_pass",
+    srcs = ["sycl_gemm_workspace_pass.cc"],
+    hdrs = ["sycl_gemm_workspace_pass.h"],
+    tags = [
+        "gpu",
+        "oneapi-only",
+    ],
+    deps = [
+        "//xla:shape_util",
+        "//xla:xla_data_proto_cc",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
+        "//xla/service/gpu:backend_configs_cc",
+        "//xla/service/gpu:cublas_cudnn",
+        "//xla/service/gpu:matmul_utils",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/sycl:sycl_matmul_utils",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status:status_macros",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
+cc_library(
     name = "gemm_rewriter_test_lib",
     testonly = True,
     srcs = ["gemm_rewriter_test_lib.cc"],

--- a/xla/backends/gpu/transforms/sycl_gemm_workspace_pass.cc
+++ b/xla/backends/gpu/transforms/sycl_gemm_workspace_pass.cc
@@ -45,14 +45,12 @@ absl::StatusOr<size_t> ComputeOneDnnScratchpadSize(
     const se::GpuComputeCapability& gpu_version) {
   ABSL_ASSIGN_OR_RETURN(GemmConfig gemm_config,
                         GemmConfig::For(matmul_instr, gpu_version));
-  ABSL_ASSIGN_OR_RETURN(
-      GpuBackendConfig gpu_config,
-      matmul_instr->backend_config<GpuBackendConfig>());
+  ABSL_ASSIGN_OR_RETURN(GpuBackendConfig gpu_config,
+                        matmul_instr->backend_config<GpuBackendConfig>());
   const GemmBackendConfig& config = gpu_config.gemm_backend_config();
   ABSL_ASSIGN_OR_RETURN(
-      auto prim_desc,
-      stream_executor::sycl::CreateMatMulPrimDescFromGemmConfig(
-          gemm_config, config.epilogue()));
+      auto prim_desc, stream_executor::sycl::CreateMatMulPrimDescFromGemmConfig(
+                          gemm_config, config.epilogue()));
   return prim_desc->scratchpad_desc().get_size();
 }
 
@@ -64,8 +62,7 @@ absl::StatusOr<bool> SyclGemmWorkspacePass::RunImpl(
   // Resizes the trailing S8 workspace element of the matmul custom call's
   // tuple shape in place. As the workspace is consumed only by the custom
   // call at runtime, downstream get-tuple-element users require no update.
-  auto resize_workspace = [](HloInstruction* matmul_instr,
-                             int64_t new_bytes) {
+  auto resize_workspace = [](HloInstruction* matmul_instr, int64_t new_bytes) {
     Shape* shape = matmul_instr->mutable_shape();
     *shape->mutable_tuple_shapes(shape->tuple_shapes().size() - 1) =
         ShapeUtil::MakeShape(S8, {new_bytes});

--- a/xla/backends/gpu/transforms/sycl_gemm_workspace_pass.cc
+++ b/xla/backends/gpu/transforms/sycl_gemm_workspace_pass.cc
@@ -1,0 +1,102 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/gpu/transforms/sycl_gemm_workspace_pass.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/log/log.h"
+#include "absl/status/status_macros.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/primitive_util.h"
+#include "xla/service/gpu/backend_configs.pb.h"
+#include "xla/service/gpu/cublas_cudnn.h"
+#include "xla/service/gpu/matmul_utils.h"
+#include "xla/shape.h"
+#include "xla/shape_util.h"
+#include "xla/stream_executor/sycl/sycl_matmul_utils.h"
+#include "xla/xla_data.pb.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+absl::StatusOr<size_t> ComputeOneDnnScratchpadSize(
+    const HloInstruction* matmul_instr,
+    const se::GpuComputeCapability& gpu_version) {
+  ABSL_ASSIGN_OR_RETURN(GemmConfig gemm_config,
+                        GemmConfig::For(matmul_instr, gpu_version));
+  ABSL_ASSIGN_OR_RETURN(
+      GpuBackendConfig gpu_config,
+      matmul_instr->backend_config<GpuBackendConfig>());
+  const GemmBackendConfig& config = gpu_config.gemm_backend_config();
+  ABSL_ASSIGN_OR_RETURN(
+      auto prim_desc,
+      stream_executor::sycl::CreateMatMulPrimDescFromGemmConfig(
+          gemm_config, config.epilogue()));
+  return prim_desc->scratchpad_desc().get_size();
+}
+
+}  // namespace
+
+absl::StatusOr<bool> SyclGemmWorkspacePass::RunImpl(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  // Resizes the trailing S8 workspace element of the matmul custom call's
+  // tuple shape in place. As the workspace is consumed only by the custom
+  // call at runtime, downstream get-tuple-element users require no update.
+  auto resize_workspace = [](HloInstruction* matmul_instr,
+                             int64_t new_bytes) {
+    Shape* shape = matmul_instr->mutable_shape();
+    *shape->mutable_tuple_shapes(shape->tuple_shapes().size() - 1) =
+        ShapeUtil::MakeShape(S8, {new_bytes});
+  };
+
+  bool changed = false;
+  for (HloComputation* computation :
+       module->MakeNonfusionComputations(execution_threads)) {
+    for (HloInstruction* matmul_instr : computation->instructions()) {
+      if (!IsCublasLtMatmul(*matmul_instr)) {
+        continue;
+      }
+      // oneDNN's matmul primitive does not support complex element types.
+      if (primitive_util::IsComplexType(
+              matmul_instr->shape().tuple_shapes(0).element_type())) {
+        continue;
+      }
+      auto scratchpad_or =
+          ComputeOneDnnScratchpadSize(matmul_instr, gpu_version_);
+      if (!scratchpad_or.ok()) {
+        VLOG(1) << "Failed to compute OneDNN scratchpad size for "
+                << matmul_instr->custom_call_target() << ": "
+                << scratchpad_or.status().message();
+        continue;
+      }
+      resize_workspace(matmul_instr, static_cast<int64_t>(*scratchpad_or));
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/xla/backends/gpu/transforms/sycl_gemm_workspace_pass.cc
+++ b/xla/backends/gpu/transforms/sycl_gemm_workspace_pass.cc
@@ -75,6 +75,10 @@ absl::StatusOr<bool> SyclGemmWorkspacePass::RunImpl(
       if (!IsCublasLtMatmul(*matmul_instr)) {
         continue;
       }
+      const Shape& matmul_shape = matmul_instr->shape();
+      if (!matmul_shape.IsTuple() || matmul_shape.tuple_shapes().size() != 2) {
+        continue;
+      }
       // oneDNN's matmul primitive does not support complex element types.
       if (primitive_util::IsComplexType(
               matmul_instr->shape().tuple_shapes(0).element_type())) {

--- a/xla/backends/gpu/transforms/sycl_gemm_workspace_pass.h
+++ b/xla/backends/gpu/transforms/sycl_gemm_workspace_pass.h
@@ -1,0 +1,52 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_GPU_TRANSFORMS_SYCL_GEMM_WORKSPACE_PASS_H_
+#define XLA_BACKENDS_GPU_TRANSFORMS_SYCL_GEMM_WORKSPACE_PASS_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+#include "xla/stream_executor/device_description.h"
+
+namespace xla {
+namespace gpu {
+
+// Resizes the cuBLASLt matmul workspace to the size oneDNN's matmul primitive
+// requires for its scratchpad (oneDNN's term for workspace).
+// Added only by IntelGpuCompiler, after the generic GPU post-layout-assignment
+// pipeline.
+class SyclGemmWorkspacePass : public HloModulePass {
+ public:
+  explicit SyclGemmWorkspacePass(se::GpuComputeCapability gpu_version)
+      : gpu_version_(gpu_version) {}
+
+  absl::string_view name() const override { return "sycl-gemm-workspace"; }
+
+ protected:
+  absl::StatusOr<bool> RunImpl(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  se::GpuComputeCapability gpu_version_;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_GPU_TRANSFORMS_SYCL_GEMM_WORKSPACE_PASS_H_

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3875,7 +3875,7 @@ cc_library(
         ":target_constants",
         "//xla/backends/gpu/transforms:sycl_gemm_workspace_pass",
         "//xla/hlo/ir:hlo",
-        "//xla/hlo/pass:hlo_pass",
+        "//xla/hlo/pass:hlo_pass_pipeline",
         "//xla/service:dump",
         "//xla/service:gpu_topology",
         "//xla/service/gpu/llvm_gpu_backend:spirv_backend",

--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -3873,8 +3873,11 @@ cc_library(
     deps = [
         ":gpu_compiler",
         ":target_constants",
+        "//xla/backends/gpu/transforms:sycl_gemm_workspace_pass",
         "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
         "//xla/service:dump",
+        "//xla/service:gpu_topology",
         "//xla/service/gpu/llvm_gpu_backend:spirv_backend",
         "//xla/stream_executor:semantic_version",
         "//xla/stream_executor:stream_executor_h",
@@ -3898,11 +3901,12 @@ xla_test(
         "nobuilder",
         "manual",
     ]),
-    use_legacy_runtime = True,
     deps = [
         ":intel_gpu_compiler",
+        ":matmul_utils",
+        "//xla/backends/gpu/tests:hlo_pjrt_gpu_test_base",
         "//xla/stream_executor/sycl:sycl_platform_id",
-        "//xla/tests/restricted:hlo_test_base_legacy",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/xla/service/gpu/intel_gpu_compiler.cc
+++ b/xla/service/gpu/intel_gpu_compiler.cc
@@ -16,9 +16,12 @@ limitations under the License.
 #include "xla/service/gpu/intel_gpu_compiler.h"
 
 #include "absl/status/status_macros.h"
+#include "xla/backends/gpu/transforms/sycl_gemm_workspace_pass.h"
+#include "xla/hlo/pass/hlo_pass_pipeline.h"
 #include "xla/service/dump.h"
 #include "xla/service/gpu/llvm_gpu_backend/spirv_backend.h"
 #include "xla/service/gpu/target_constants.h"
+#include "xla/service/gpu_topology.h"
 #include "xla/stream_executor/sycl/sycl_platform_id.h"
 
 namespace xla {
@@ -35,6 +38,23 @@ absl::Status IntelGpuCompiler::OptimizeHloConvolutionCanonicalization(
     CompilationStats* compilation_stats) {
   // Return OkStatus as a stub.
   return absl::OkStatus();
+}
+
+absl::Status IntelGpuCompiler::OptimizeHloPostLayoutAssignment(
+    HloModule* hlo_module, se::StreamExecutor* stream_exec,
+    const CompileOptions& options, const GpuTopology& gpu_topology,
+    const GpuAliasInfo* alias_info, tsl::thread::ThreadPool* thread_pool,
+    CompilationStats* compilation_stats, mlir::MLIRContext* mlir_context) {
+  ABSL_RETURN_IF_ERROR(GpuCompiler::OptimizeHloPostLayoutAssignment(
+      hlo_module, stream_exec, options, gpu_topology, alias_info, thread_pool,
+      compilation_stats, mlir_context));
+
+  HloPassPipeline post_pipeline("Intel GPU post-layout_assignment",
+                                compilation_stats);
+  post_pipeline.AddPass<SyclGemmWorkspacePass>(
+      gpu_topology.gpu_target_config()
+          .device_description.gpu_compute_capability());
+  return post_pipeline.Run(hlo_module).status();
 }
 
 void IntelGpuCompiler::AddPaddingForGpublasGemms(

--- a/xla/service/gpu/intel_gpu_compiler.h
+++ b/xla/service/gpu/intel_gpu_compiler.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "llvm/IR/Module.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/service/gpu/gpu_compiler.h"
+#include "xla/service/gpu_topology.h"
 #include "xla/stream_executor/semantic_version.h"
 #include "xla/stream_executor/stream_executor.h"
 
@@ -38,6 +39,13 @@ class IntelGpuCompiler : public GpuCompiler {
       se::dnn::VersionInfo dnn_version,
       const se::SemanticVersion& toolkit_version,
       CompilationStats* compilation_stats) override;
+
+  absl::Status OptimizeHloPostLayoutAssignment(
+      HloModule* hlo_module, se::StreamExecutor* stream_exec,
+      const CompileOptions& options, const GpuTopology& gpu_topology,
+      const GpuAliasInfo* alias_info, tsl::thread::ThreadPool* thread_pool,
+      CompilationStats* compilation_stats,
+      mlir::MLIRContext* mlir_context) override;
 
   absl::Status AddConfigAssignerPass(
       HloPassPipeline* pipeline, HloModule* hlo_module,

--- a/xla/service/gpu/intel_gpu_compiler_test.cc
+++ b/xla/service/gpu/intel_gpu_compiler_test.cc
@@ -14,18 +14,64 @@ limitations under the License.
 ==============================================================================*/
 
 #include <gtest/gtest.h>
+#include "absl/strings/substitute.h"
+#include "xla/backends/gpu/tests/hlo_pjrt_gpu_test_base.h"
+#include "xla/service/gpu/matmul_utils.h"
 #include "xla/stream_executor/sycl/sycl_platform_id.h"
-#include "xla/tests/restricted/hlo_test_base_legacy.h"
 
 namespace xla {
 namespace gpu {
 namespace {
 
-using IntelGpuCompilerTest = HloTestBaseLegacy;
+using IntelGpuCompilerTest = HloPjRtGpuTestBase;
 
 TEST_F(IntelGpuCompilerTest, CheckCompiler) {
-  auto compiler = backend().compiler();
-  EXPECT_EQ(compiler->PlatformId(), stream_executor::sycl::kSyclPlatformId);
+  EXPECT_EQ(stream_executor_platform_id(),
+            stream_executor::sycl::kSyclPlatformId);
+}
+
+// Checks that SyclGemmWorkspacePass rewrites the cuBLASLt matmul workspace
+// from the 4 MiB default to the oneDNN scratchpad size (0 for a tiny matmul).
+TEST_F(IntelGpuCompilerTest, ResizesMatmulWorkspace) {
+  const char* hlo_text = R"(
+    HloModule matmul
+
+    ENTRY main {
+      a = bf16[8,8] parameter(0)
+      b = bf16[8,8] parameter(1)
+      ROOT dot = bf16[8,8] dot(a, b),
+        lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    }
+  )";
+
+  const char* check_pattern = R"(
+    CHECK: (bf16[8,8]{{.*}}, s8[0]{0}) custom-call
+    CHECK-SAME: custom_call_target="__cublas$lt$matmul"
+  )";
+  MatchOptimizedHlo(hlo_text, check_pattern);
+}
+
+// Complex-typed matmuls are skipped because oneDNN's matmul primitive does
+// not support complex element types; the 4 MiB default workspace from
+// GemmRewriter is retained.
+TEST_F(IntelGpuCompilerTest, SkipsWorkspaceResizeForComplexMatmul) {
+  const char* hlo_text = R"(
+    HloModule complex_matmul
+
+    ENTRY main {
+      a = c64[8,8] parameter(0)
+      b = c64[8,8] parameter(1)
+      ROOT dot = c64[8,8] dot(a, b),
+        lhs_contracting_dims={1}, rhs_contracting_dims={0}
+    }
+  )";
+
+  const char* check_pattern = R"(
+    CHECK: (c64[8,8]{{.*}}, s8[$0]{0}) custom-call
+    CHECK-SAME: custom_call_target="__cublas$$lt$$matmul"
+  )";
+  MatchOptimizedHlo(
+      hlo_text, absl::Substitute(check_pattern, GemmConfig::kDefaultWorkspace));
 }
 
 }  // namespace


### PR DESCRIPTION
This PR is a follow up of https://github.com/openxla/xla/pull/46181.  It adds `SyclGemmWorkspacePass`, an Intel-GPU-only HLO pass that resizes the `cuBLASLt` matmul workspace to the size required by oneDNN's matmul primitive scratchpad. Without this pass, every `__cublas$lt$matmul` custom call carries GemmRewriter's 4 MiB default `(GemmConfig::kDefaultWorkspace)`, which is not optimal for oneDNN-backed matmul.