### PR TITLE
Fix XLA Digamma pole behavior for zero and negative integers

### DIFF
--- a/xla/hlo/builder/lib/math.cc
+++ b/xla/hlo/builder/lib/math.cc
@@ -712,10 +712,18 @@ XlaOp Digamma(XlaOp input) {
         y - pi * Cos(pi * reduced_input) / Sin(pi * reduced_input);
     XlaOp real_result = Select(need_to_reflect, reflection, y);
 
-    // Digamma has poles at negative integers and zero; return nan for those.
-    return Select(And(Le(input, zero), Eq(input, Floor(input))),
+    // Digamma has poles at zero and at the negative integers. The two one-sided
+    // limits agree at zero, so return -inf there; at the negative integers they
+    // disagree, so return nan. This matches the eager CPU kernel in
+    // tensorflow/core/kernels/cwise_ops.h.
+    XlaOp is_negative_integer = And(Lt(input, zero), Eq(input, Floor(input)));
+    XlaOp result =
+        Select(Eq(input, zero),
+               FullLike(input, -std::numeric_limits<float>::infinity()),
+               real_result);
+    return Select(is_negative_integer,
                   FullLike(input, std::numeric_limits<float>::quiet_NaN()),
-                  real_result);
+                  result);
   };
 
   auto& b = *input.builder();

--- a/xla/hlo/builder/lib/math_test.cc
+++ b/xla/hlo/builder/lib/math_test.cc
@@ -483,6 +483,27 @@ TEST_F(MathTest, Digamma) {
   ComputeAndCompareR1<float>(&builder, expected, {}, kErrorSpec);
 }
 
+TEST_F(MathTest, DigammaPoles) {
+  // digamma has a pole at zero and at every negative integer. The two one-sided
+  // limits agree at zero, so return -inf there (for -0.0 as well); at the
+  // negative integers they disagree, so return nan.
+  XlaBuilder builder(TestName());
+  auto x = ConstantR1<float>(&builder, {0.0, -0.0, -1.0, -2.0, -10.0, -1.5});
+  Digamma(x);
+
+  constexpr double euler_mascheroni =
+      0.57721566490153286060651209008240243104215933593992;
+  std::vector<float> expected = {
+      -std::numeric_limits<float>::infinity(),
+      -std::numeric_limits<float>::infinity(),
+      std::numeric_limits<float>::quiet_NaN(),
+      std::numeric_limits<float>::quiet_NaN(),
+      std::numeric_limits<float>::quiet_NaN(),
+      // digamma(-1.5) = 2/3 + 2 - 2 * log(2) - euler_mascheroni.
+      static_cast<float>(2 / 3.0 + 2 - 2 * std::log(2) - euler_mascheroni)};
+  ComputeAndCompareR1<float>(&builder, expected, {}, kErrorSpec);
+}
+
 TEST_F(MathTest, PolygammaNegativeInputs) {
   // Regression test for https://github.com/jax-ml/jax/issues/37635.
   // Polygamma for n >= 1 and x < 0 (non-integer) previously produced

--- a/xla/hlo/builder/tests/math_igamma_grad_a.hlo
+++ b/xla/hlo/builder/tests/math_igamma_grad_a.hlo
@@ -318,12 +318,15 @@
 // CHECK-NEXT:  %[[exponential_1:[^ ]+]] = f32[] exponential(%[[subtract_68]])
 // CHECK-NEXT:  %[[log_10:[^ ]+]] = f32[] log(%[[arg1_1]])
 // CHECK-NEXT:  %[[constant_212:[^ ]+]] = f32[] constant(0)
-// CHECK-NEXT:  %[[compare_44:[^ ]+]] = pred[] compare(%[[arg0_1]], %[[constant_212]]), direction=LE
+// CHECK-NEXT:  %[[compare_44:[^ ]+]] = pred[] compare(%[[arg0_1]], %[[constant_212]]), direction=LT
 // CHECK-NEXT:  %[[floor_7:[^ ]+]] = f32[] floor(%[[arg0_1]])
 // CHECK-NEXT:  %[[compare_45:[^ ]+]] = pred[] compare(%[[arg0_1]], %[[floor_7]]), direction=EQ
 // CHECK-NEXT:  %[[and_16:[^ ]+]] = pred[] and(%[[compare_44]], %[[compare_45]])
 // CHECK-NEXT:  %[[constant_237:[^ ]+]] = f32[] constant(nan)
 // CHECK-NEXT:  %[[broadcast_26:[^ ]+]] = f32[] broadcast(%[[constant_237]]), dimensions={}
+// CHECK-NEXT:  %[[compare_49:[^ ]+]] = pred[] compare(%[[arg0_1]], %[[constant_212]]), direction=EQ
+// CHECK-NEXT:  %[[constant_271:[^ ]+]] = f32[] constant(-inf)
+// CHECK-NEXT:  %[[broadcast_34:[^ ]+]] = f32[] broadcast(%[[constant_271]]), dimensions={}
 // CHECK-NEXT:  %[[constant_213:[^ ]+]] = f32[] constant(0.5)
 // CHECK-NEXT:  %[[compare_43:[^ ]+]] = pred[] compare(%[[arg0_1]], %[[constant_213]]), direction=LT
 // CHECK-NEXT:  %[[constant_218:[^ ]+]] = f32[] constant(2.01490307)
@@ -460,7 +463,8 @@
 // CHECK-NEXT:  %[[divide_108:[^ ]+]] = f32[] divide(%[[multiply_120]], %[[sine_4]])
 // CHECK-NEXT:  %[[subtract_81:[^ ]+]] = f32[] subtract(%[[subtract_80]], %[[divide_108]])
 // CHECK-NEXT:  %[[select_113:[^ ]+]] = f32[] select(%[[compare_43]], %[[subtract_81]], %[[subtract_80]])
-// CHECK-NEXT:  %[[select_114:[^ ]+]] = f32[] select(%[[and_16]], %[[broadcast_26]], %[[select_113]])
+// CHECK-NEXT:  %[[select_121:[^ ]+]] = f32[] select(%[[compare_49]], %[[broadcast_34]], %[[select_113]])
+// CHECK-NEXT:  %[[select_114:[^ ]+]] = f32[] select(%[[and_16]], %[[broadcast_26]], %[[select_121]])
 // CHECK-NEXT:  %[[subtract_82:[^ ]+]] = f32[] subtract(%[[log_10]], %[[select_114]])
 // CHECK-NEXT:  %[[multiply_122:[^ ]+]] = f32[] multiply(%[[while_2]]#1, %[[subtract_82]])
 // CHECK-NEXT:  %[[add_277:[^ ]+]] = f32[] add(%[[multiply_122]], %[[while_2]]#14)
@@ -470,12 +474,15 @@
 // CHECK-NEXT:  %[[constant_242:[^ ]+]] = f32[] constant(1)
 // CHECK-NEXT:  %[[add_278:[^ ]+]] = f32[] add(%[[arg0_1]], %[[constant_242]])
 // CHECK-NEXT:  %[[constant_243:[^ ]+]] = f32[] constant(0)
-// CHECK-NEXT:  %[[compare_47:[^ ]+]] = pred[] compare(%[[add_278]], %[[constant_243]]), direction=LE
+// CHECK-NEXT:  %[[compare_47:[^ ]+]] = pred[] compare(%[[add_278]], %[[constant_243]]), direction=LT
 // CHECK-NEXT:  %[[floor_9:[^ ]+]] = f32[] floor(%[[add_278]])
 // CHECK-NEXT:  %[[compare_48:[^ ]+]] = pred[] compare(%[[add_278]], %[[floor_9]]), direction=EQ
 // CHECK-NEXT:  %[[and_18:[^ ]+]] = pred[] and(%[[compare_47]], %[[compare_48]])
 // CHECK-NEXT:  %[[constant_268:[^ ]+]] = f32[] constant(nan)
 // CHECK-NEXT:  %[[broadcast_31:[^ ]+]] = f32[] broadcast(%[[constant_268]]), dimensions={}
+// CHECK-NEXT:  %[[compare_50:[^ ]+]] = pred[] compare(%[[add_278]], %[[constant_243]]), direction=EQ
+// CHECK-NEXT:  %[[constant_272:[^ ]+]] = f32[] constant(-inf)
+// CHECK-NEXT:  %[[broadcast_35:[^ ]+]] = f32[] broadcast(%[[constant_272]]), dimensions={}
 // CHECK-NEXT:  %[[constant_244:[^ ]+]] = f32[] constant(0.5)
 // CHECK-NEXT:  %[[compare_46:[^ ]+]] = pred[] compare(%[[add_278]], %[[constant_244]]), direction=LT
 // CHECK-NEXT:  %[[constant_249:[^ ]+]] = f32[] constant(2.01490307)
@@ -612,7 +619,8 @@
 // CHECK-NEXT:  %[[divide_128:[^ ]+]] = f32[] divide(%[[multiply_133]], %[[sine_5]])
 // CHECK-NEXT:  %[[subtract_93:[^ ]+]] = f32[] subtract(%[[subtract_92]], %[[divide_128]])
 // CHECK-NEXT:  %[[select_116:[^ ]+]] = f32[] select(%[[compare_46]], %[[subtract_93]], %[[subtract_92]])
-// CHECK-NEXT:  %[[select_117:[^ ]+]] = f32[] select(%[[and_18]], %[[broadcast_31]], %[[select_116]])
+// CHECK-NEXT:  %[[select_122:[^ ]+]] = f32[] select(%[[compare_50]], %[[broadcast_35]], %[[select_116]])
+// CHECK-NEXT:  %[[select_117:[^ ]+]] = f32[] select(%[[and_18]], %[[broadcast_31]], %[[select_122]])
 // CHECK-NEXT:  %[[subtract_94:[^ ]+]] = f32[] subtract(%[[log_11]], %[[select_117]])
 // CHECK-NEXT:  %[[multiply_135:[^ ]+]] = f32[] multiply(%[[while_3]]#3, %[[subtract_94]])
 // CHECK-NEXT:  %[[add_340:[^ ]+]] = f32[] add(%[[multiply_135]], %[[while_3]]#6)

--- a/xla/hlo/builder/tests/math_polygamma.hlo
+++ b/xla/hlo/builder/tests/math_polygamma.hlo
@@ -19,12 +19,15 @@
 // CHECK-NEXT:  %[[compare_56:[^ ]+]] = pred[] compare(%[[arg0_1]], %[[constant_337]]), direction=EQ
 // CHECK-NEXT:  %[[arg1_1:[^ ]+]] = f32[] parameter(1)
 // CHECK-NEXT:  %[[constant_338:[^ ]+]] = f32[] constant(0)
-// CHECK-NEXT:  %[[compare_58:[^ ]+]] = pred[] compare(%[[arg1_1]], %[[constant_338]]), direction=LE
+// CHECK-NEXT:  %[[compare_58:[^ ]+]] = pred[] compare(%[[arg1_1]], %[[constant_338]]), direction=LT
 // CHECK-NEXT:  %[[floor_20:[^ ]+]] = f32[] floor(%[[arg1_1]])
 // CHECK-NEXT:  %[[compare_59:[^ ]+]] = pred[] compare(%[[arg1_1]], %[[floor_20]]), direction=EQ
 // CHECK-NEXT:  %[[and_16:[^ ]+]] = pred[] and(%[[compare_58]], %[[compare_59]])
 // CHECK-NEXT:  %[[constant_363:[^ ]+]] = f32[] constant(nan)
 // CHECK-NEXT:  %[[broadcast_4:[^ ]+]] = f32[] broadcast(%[[constant_363]]), dimensions={}
+// CHECK-NEXT:  %[[compare_74:[^ ]+]] = pred[] compare(%[[arg1_1]], %[[constant_338]]), direction=EQ
+// CHECK-NEXT:  %[[constant_456:[^ ]+]] = f32[] constant(-inf)
+// CHECK-NEXT:  %[[broadcast_6:[^ ]+]] = f32[] broadcast(%[[constant_456]]), dimensions={}
 // CHECK-NEXT:  %[[constant_339:[^ ]+]] = f32[] constant(0.5)
 // CHECK-NEXT:  %[[compare_57:[^ ]+]] = pred[] compare(%[[arg1_1]], %[[constant_339]]), direction=LT
 // CHECK-NEXT:  %[[constant_344:[^ ]+]] = f32[] constant(2.01490307)
@@ -161,7 +164,8 @@
 // CHECK-NEXT:  %[[divide_86:[^ ]+]] = f32[] divide(%[[multiply_182]], %[[sine_6]])
 // CHECK-NEXT:  %[[subtract_48:[^ ]+]] = f32[] subtract(%[[subtract_47]], %[[divide_86]])
 // CHECK-NEXT:  %[[select_46:[^ ]+]] = f32[] select(%[[compare_57]], %[[subtract_48]], %[[subtract_47]])
-// CHECK-NEXT:  %[[select_47:[^ ]+]] = f32[] select(%[[and_16]], %[[broadcast_4]], %[[select_46]])
+// CHECK-NEXT:  %[[select_62:[^ ]+]] = f32[] select(%[[compare_74]], %[[broadcast_6]], %[[select_46]])
+// CHECK-NEXT:  %[[select_47:[^ ]+]] = f32[] select(%[[and_16]], %[[broadcast_4]], %[[select_62]])
 // CHECK-NEXT:  %[[constant_334:[^ ]+]] = f32[] constant(0)
 // CHECK-NEXT:  %[[compare_52:[^ ]+]] = pred[] compare(%[[arg1_1]], %[[constant_334]]), direction=LT
 // CHECK-NEXT:  %[[floor_18:[^ ]+]] = f32[] floor(%[[arg1_1]])

--- a/xla/hlo/builder/tests/math_random_gamma_grad.hlo
+++ b/xla/hlo/builder/tests/math_random_gamma_grad.hlo
@@ -318,12 +318,15 @@
 // CHECK-NEXT:  %[[broadcast_32:[^ ]+]] = f32[] broadcast(%[[constant_269]]), dimensions={}
 // CHECK-NEXT:  %[[log_10:[^ ]+]] = f32[] log(%[[arg1_1]])
 // CHECK-NEXT:  %[[constant_212:[^ ]+]] = f32[] constant(0)
-// CHECK-NEXT:  %[[compare_44:[^ ]+]] = pred[] compare(%[[arg0_1]], %[[constant_212]]), direction=LE
+// CHECK-NEXT:  %[[compare_44:[^ ]+]] = pred[] compare(%[[arg0_1]], %[[constant_212]]), direction=LT
 // CHECK-NEXT:  %[[floor_7:[^ ]+]] = f32[] floor(%[[arg0_1]])
 // CHECK-NEXT:  %[[compare_45:[^ ]+]] = pred[] compare(%[[arg0_1]], %[[floor_7]]), direction=EQ
 // CHECK-NEXT:  %[[and_16:[^ ]+]] = pred[] and(%[[compare_44]], %[[compare_45]])
 // CHECK-NEXT:  %[[constant_237:[^ ]+]] = f32[] constant(nan)
 // CHECK-NEXT:  %[[broadcast_26:[^ ]+]] = f32[] broadcast(%[[constant_237]]), dimensions={}
+// CHECK-NEXT:  %[[compare_49:[^ ]+]] = pred[] compare(%[[arg0_1]], %[[constant_212]]), direction=EQ
+// CHECK-NEXT:  %[[constant_271:[^ ]+]] = f32[] constant(-inf)
+// CHECK-NEXT:  %[[broadcast_34:[^ ]+]] = f32[] broadcast(%[[constant_271]]), dimensions={}
 // CHECK-NEXT:  %[[constant_213:[^ ]+]] = f32[] constant(0.5)
 // CHECK-NEXT:  %[[compare_43:[^ ]+]] = pred[] compare(%[[arg0_1]], %[[constant_213]]), direction=LT
 // CHECK-NEXT:  %[[constant_218:[^ ]+]] = f32[] constant(2.01490307)
@@ -460,7 +463,8 @@
 // CHECK-NEXT:  %[[divide_108:[^ ]+]] = f32[] divide(%[[multiply_120]], %[[sine_4]])
 // CHECK-NEXT:  %[[subtract_81:[^ ]+]] = f32[] subtract(%[[subtract_80]], %[[divide_108]])
 // CHECK-NEXT:  %[[select_113:[^ ]+]] = f32[] select(%[[compare_43]], %[[subtract_81]], %[[subtract_80]])
-// CHECK-NEXT:  %[[select_114:[^ ]+]] = f32[] select(%[[and_16]], %[[broadcast_26]], %[[select_113]])
+// CHECK-NEXT:  %[[select_121:[^ ]+]] = f32[] select(%[[compare_49]], %[[broadcast_34]], %[[select_113]])
+// CHECK-NEXT:  %[[select_114:[^ ]+]] = f32[] select(%[[and_16]], %[[broadcast_26]], %[[select_121]])
 // CHECK-NEXT:  %[[subtract_82:[^ ]+]] = f32[] subtract(%[[log_10]], %[[select_114]])
 // CHECK-NEXT:  %[[multiply_122:[^ ]+]] = f32[] multiply(%[[while_2]]#1, %[[subtract_82]])
 // CHECK-NEXT:  %[[add_277:[^ ]+]] = f32[] add(%[[while_2]]#14, %[[multiply_122]])
@@ -471,12 +475,15 @@
 // CHECK-NEXT:  %[[constant_242:[^ ]+]] = f32[] constant(1)
 // CHECK-NEXT:  %[[add_278:[^ ]+]] = f32[] add(%[[arg0_1]], %[[constant_242]])
 // CHECK-NEXT:  %[[constant_243:[^ ]+]] = f32[] constant(0)
-// CHECK-NEXT:  %[[compare_47:[^ ]+]] = pred[] compare(%[[add_278]], %[[constant_243]]), direction=LE
+// CHECK-NEXT:  %[[compare_47:[^ ]+]] = pred[] compare(%[[add_278]], %[[constant_243]]), direction=LT
 // CHECK-NEXT:  %[[floor_9:[^ ]+]] = f32[] floor(%[[add_278]])
 // CHECK-NEXT:  %[[compare_48:[^ ]+]] = pred[] compare(%[[add_278]], %[[floor_9]]), direction=EQ
 // CHECK-NEXT:  %[[and_18:[^ ]+]] = pred[] and(%[[compare_47]], %[[compare_48]])
 // CHECK-NEXT:  %[[constant_268:[^ ]+]] = f32[] constant(nan)
 // CHECK-NEXT:  %[[broadcast_31:[^ ]+]] = f32[] broadcast(%[[constant_268]]), dimensions={}
+// CHECK-NEXT:  %[[compare_50:[^ ]+]] = pred[] compare(%[[add_278]], %[[constant_243]]), direction=EQ
+// CHECK-NEXT:  %[[constant_272:[^ ]+]] = f32[] constant(-inf)
+// CHECK-NEXT:  %[[broadcast_35:[^ ]+]] = f32[] broadcast(%[[constant_272]]), dimensions={}
 // CHECK-NEXT:  %[[constant_244:[^ ]+]] = f32[] constant(0.5)
 // CHECK-NEXT:  %[[compare_46:[^ ]+]] = pred[] compare(%[[add_278]], %[[constant_244]]), direction=LT
 // CHECK-NEXT:  %[[constant_249:[^ ]+]] = f32[] constant(2.01490307)
@@ -613,7 +620,8 @@
 // CHECK-NEXT:  %[[divide_128:[^ ]+]] = f32[] divide(%[[multiply_133]], %[[sine_5]])
 // CHECK-NEXT:  %[[subtract_93:[^ ]+]] = f32[] subtract(%[[subtract_92]], %[[divide_128]])
 // CHECK-NEXT:  %[[select_116:[^ ]+]] = f32[] select(%[[compare_46]], %[[subtract_93]], %[[subtract_92]])
-// CHECK-NEXT:  %[[select_117:[^ ]+]] = f32[] select(%[[and_18]], %[[broadcast_31]], %[[select_116]])
+// CHECK-NEXT:  %[[select_122:[^ ]+]] = f32[] select(%[[compare_50]], %[[broadcast_35]], %[[select_116]])
+// CHECK-NEXT:  %[[select_117:[^ ]+]] = f32[] select(%[[and_18]], %[[broadcast_31]], %[[select_122]])
 // CHECK-NEXT:  %[[subtract_94:[^ ]+]] = f32[] subtract(%[[log_11]], %[[select_117]])
 // CHECK-NEXT:  %[[multiply_135:[^ ]+]] = f32[] multiply(%[[while_3]]#3, %[[subtract_94]])
 // CHECK-NEXT:  %[[add_340:[^ ]+]] = f32[] add(%[[while_3]]#6, %[[multiply_135]])

--- a/xla/tests/exhaustive/exhaustive_unary_test_ops.inc
+++ b/xla/tests/exhaustive/exhaustive_unary_test_ops.inc
@@ -112,6 +112,13 @@ NativeRefT HostDigamma(NativeRefT x) {
   if (x <= 0) {
     double floor = std::floor(x);
     if (x == floor) {
+      // digamma has a pole at zero and at every negative integer. The two
+      // one-sided limits agree at zero, so the value there is -inf (this also
+      // covers -0.0); at the negative integers they disagree, so the value is
+      // nan. This matches Digamma in xla/hlo/builder/lib/math.cc.
+      if (x == 0) {
+        return -std::numeric_limits<double>::infinity();
+      }
       return std::numeric_limits<double>::quiet_NaN();
     }
     // Compute reflection term, pi * cot(pi * x).


### PR DESCRIPTION


This PR updates the pole behavior of `Digamma` in XLA HLO to correctly handle zero and negative integers, keeping it in sync with the CPU kernels.
* **Input `0.0`:** Now correctly returns `-inf` instead of `NaN`.
* **Negative integers:** Explicitly return `NaN`.

*Note: This PR is a companion to the CPU-side fixes being made in TensorFlow (decoupling of PR [tensorflow/tensorflow#112118](https://github.com/tensorflow/tensorflow/pull/112118)), ensuring consistency between TensorFlow's `tf.raw_ops.Digamma` and the underlying XLA implementation.*

### Motivation and Context
The XLA implementation previously returned `NaN` for `0.0`, causing test mismatches when compared against CPU references in `DTensorSPMDTest`.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
