### PR TITLE
Fix false shape-mismatch in XLA Igamma/Igammac/Zeta/Polygamma for ope…

### DIFF
--- a/xla/hlo/builder/lib/math.cc
+++ b/xla/hlo/builder/lib/math.cc
@@ -40,6 +40,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/primitive_util.h"
 #include "xla/shape.h"
+#include "xla/shape_util.h"
 #include "xla/status_macros.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
@@ -968,7 +969,7 @@ XlaOp Igamma(XlaOp a, XlaOp x) {
   return b.ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     ABSL_ASSIGN_OR_RETURN(auto a_shape, b.GetShape(a));
     ABSL_ASSIGN_OR_RETURN(auto x_shape, b.GetShape(x));
-    if (a_shape != x_shape) {
+    if (!ShapeUtil::Compatible(a_shape, x_shape)) {
       return InvalidArgument(
           "Arguments to Igamma must have equal shapes and types; got %s and %s",
           a_shape.ToString(), x_shape.ToString());
@@ -1022,7 +1023,7 @@ XlaOp IgammaGradA(XlaOp a, XlaOp x) {
   return b.ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     ABSL_ASSIGN_OR_RETURN(auto a_shape, b.GetShape(a));
     ABSL_ASSIGN_OR_RETURN(auto x_shape, b.GetShape(x));
-    if (a_shape != x_shape) {
+    if (!ShapeUtil::Compatible(a_shape, x_shape)) {
       return InvalidArgument(
           "Arguments to IgammaGradA must have equal shapes and types; got %s "
           "and %s",
@@ -1076,7 +1077,7 @@ XlaOp RandomGammaGrad(XlaOp a, XlaOp x) {
   return b.ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     ABSL_ASSIGN_OR_RETURN(auto a_shape, b.GetShape(a));
     ABSL_ASSIGN_OR_RETURN(auto x_shape, b.GetShape(x));
-    if (a_shape != x_shape) {
+    if (!ShapeUtil::Compatible(a_shape, x_shape)) {
       return InvalidArgument(
           "Arguments to RandomGammaGrad must have equal shapes and types; got "
           "%s and %s",
@@ -1121,7 +1122,7 @@ XlaOp Igammac(XlaOp a, XlaOp x) {
   return b.ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     ABSL_ASSIGN_OR_RETURN(auto a_shape, b.GetShape(a));
     ABSL_ASSIGN_OR_RETURN(auto x_shape, b.GetShape(x));
-    if (a_shape != x_shape) {
+    if (!ShapeUtil::Compatible(a_shape, x_shape)) {
       return InvalidArgument(
           "Arguments to Igammac must have equal shapes and types; "
           "got %s and %s",
@@ -2051,7 +2052,7 @@ XlaOp Polygamma(XlaOp n, XlaOp x) {
   return builder.ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     ABSL_ASSIGN_OR_RETURN(auto n_shape, builder.GetShape(n));
     ABSL_ASSIGN_OR_RETURN(auto x_shape, builder.GetShape(x));
-    if (n_shape != x_shape) {
+    if (!ShapeUtil::Compatible(n_shape, x_shape)) {
       return InvalidArgument(
           "Arguments to Polygamma must have equal shapes and types; "
           "got %s and %s",
@@ -2170,7 +2171,7 @@ XlaOp Zeta(XlaOp x, XlaOp q) {
   return builder.ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     ABSL_ASSIGN_OR_RETURN(auto x_shape, builder.GetShape(x));
     ABSL_ASSIGN_OR_RETURN(auto q_shape, builder.GetShape(q));
-    if (x_shape != q_shape) {
+    if (!ShapeUtil::Compatible(x_shape, q_shape)) {
       return InvalidArgument(
           "Arguments to Zeta must have equal shapes and types; got %s and %s",
           x_shape.ToString(), q_shape.ToString());

--- a/xla/hlo/builder/lib/math_test.cc
+++ b/xla/hlo/builder/lib/math_test.cc
@@ -842,5 +842,74 @@ TEST_F(MathTest, ZetaF64) {
                               ErrorSpec{0.00000000000001});
 }
 
+TEST_F(MathTest, IgammaDynamicDimensionMismatch) {
+  XlaBuilder builder(TestName());
+  // Logical shape is identical, but one operand carries a dynamic-dimension bit.
+  Shape shape_a = ShapeUtil::MakeShape(F32, {2, 2});
+  Shape shape_x = ShapeUtil::MakeShape(F32, {2, 2});
+  shape_x.set_dynamic_dimension(0, true);
+  XlaOp a = Parameter(&builder, 0, shape_a, "a");
+  XlaOp x = Parameter(&builder, 1, shape_x, "x");
+  Igamma(a, x);
+  EXPECT_OK(builder.Build().status());
+}
+
+TEST_F(MathTest, IgammacDynamicDimensionMismatch) {
+  XlaBuilder builder(TestName());
+  Shape shape_a = ShapeUtil::MakeShape(F32, {2, 2});
+  Shape shape_x = ShapeUtil::MakeShape(F32, {2, 2});
+  shape_x.set_dynamic_dimension(0, true);
+  XlaOp a = Parameter(&builder, 0, shape_a, "a");
+  XlaOp x = Parameter(&builder, 1, shape_x, "x");
+  Igammac(a, x);
+  EXPECT_OK(builder.Build().status());
+}
+
+TEST_F(MathTest, IgammaGradADynamicDimensionMismatch) {
+  XlaBuilder builder(TestName());
+  Shape shape_a = ShapeUtil::MakeShape(F32, {2, 2});
+  Shape shape_x = ShapeUtil::MakeShape(F32, {2, 2});
+  shape_x.set_dynamic_dimension(0, true);
+  XlaOp a = Parameter(&builder, 0, shape_a, "a");
+  XlaOp x = Parameter(&builder, 1, shape_x, "x");
+  IgammaGradA(a, x);
+  EXPECT_OK(builder.Build().status());
+}
+
+TEST_F(MathTest, RandomGammaGradDynamicDimensionMismatch) {
+  XlaBuilder builder(TestName());
+  Shape shape_a = ShapeUtil::MakeShape(F32, {2, 2});
+  Shape shape_x = ShapeUtil::MakeShape(F32, {2, 2});
+  shape_x.set_dynamic_dimension(0, true);
+  XlaOp a = Parameter(&builder, 0, shape_a, "a");
+  XlaOp x = Parameter(&builder, 1, shape_x, "x");
+  RandomGammaGrad(a, x);
+  EXPECT_OK(builder.Build().status());
+}
+
+TEST_F(MathTest, ZetaDynamicDimensionMismatch) {
+  XlaBuilder builder(TestName());
+  // x is static; q carries a dynamic-dimension bit.
+  Shape shape_x = ShapeUtil::MakeShape(F32, {2, 2});
+  Shape shape_q = ShapeUtil::MakeShape(F32, {2, 2});
+  shape_q.set_dynamic_dimension(0, true);
+  XlaOp x = Parameter(&builder, 0, shape_x, "x");
+  XlaOp q = Parameter(&builder, 1, shape_q, "q");
+  Zeta(x, q);
+  EXPECT_OK(builder.Build().status());
+}
+
+TEST_F(MathTest, PolygammaDynamicDimensionMismatch) {
+  XlaBuilder builder(TestName());
+  // n is static; x carries a dynamic-dimension bit.
+  Shape shape_n = ShapeUtil::MakeShape(F32, {2, 2});
+  Shape shape_x = ShapeUtil::MakeShape(F32, {2, 2});
+  shape_x.set_dynamic_dimension(0, true);
+  XlaOp n = Parameter(&builder, 0, shape_n, "n");
+  XlaOp x = Parameter(&builder, 1, shape_x, "x");
+  Polygamma(n, x);
+  EXPECT_OK(builder.Build().status());
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
Fixes tensorflow/tensorflow#122047.

The shape equality check in XLA operations `Igamma`, `IgammaGradA`, `RandomGammaGrad`, `Igammac`, `Zeta`, and `Polygamma` was using `operator!=` (`Shape::Equal()`). This strict equality check inappropriately compares dynamic-dimension bits and layouts in addition to logical dimensions and element types.

When one operand originates from a path that propagates a dynamic-dimension bit while the other operand does not, the two `xla::Shape` objects compare as unequal. This triggers a failure even though their printed representation and logical semantics are identical. The check would confusingly fire with: `"must have equal shapes and types; got f64[6,32,32] and f64[6,32,32]"`.

**The Fix:**
Replaced `operator!=` with `!ShapeUtil::Compatible()`, which is defined as `Shape::Equal().IgnoreDynamicDimension().IgnoreLayout()`. This safely accepts any pair of shapes that share the same rank, bounded dimensions, and element type, correctly validating the op constraints without falsely failing on dynamic dimension metadata.

*Note: This PR ports the C++ side fixes originally authored in tensorflow/tensorflow#125398 to OpenXLA so that they can be synced via Copybara.*
