### PR TITLE
[XLA] Fix transpose folding for sparse convolutions

### DIFF
--- a/xla/service/BUILD
+++ b/xla/service/BUILD
@@ -4942,6 +4942,7 @@ xla_cc_test(
     name = "transpose_folding_test",
     srcs = ["transpose_folding_test.cc"],
     deps = [
+        ":hlo_proto_cc",
         ":shape_inference",
         ":transpose_folding",
         "//xla:literal_util",

--- a/xla/service/transpose_folding.cc
+++ b/xla/service/transpose_folding.cc
@@ -48,12 +48,30 @@ TransposeFolding::OperandIndices CanFoldOperandsIntoConvolution(
     return {};
   }
 
-  TransposeFolding::OperandIndices operand_set;
-  for (int64_t i = 0; i < convolution.operand_count(); ++i) {
-    auto& operand = *convolution.operand(i);
-    if (operand.opcode() == HloOpcode::kTranspose) {
-      operand_set.push_back(i);
+  const SparsityConfig& sparsity_config = convolution.sparsity_config();
+  auto is_sparsity_metadata = [&](int64_t index) {
+    return (sparsity_config.has_lhs() &&
+            sparsity_config.lhs().idx() == index) ||
+           (sparsity_config.has_rhs() && sparsity_config.rhs().idx() == index);
+  };
+  // Extra operands, such as block scales, may need to be transformed with the
+  // lhs or rhs. Only sparsity metadata can be preserved unchanged here.
+  for (int64_t i = 2; i < convolution.operand_count(); ++i) {
+    if (!is_sparsity_metadata(i)) {
+      return {};
     }
+  }
+
+  TransposeFolding::OperandIndices operand_set;
+  // Do not fold a transpose into a sparse operand, since its sparsity
+  // descriptor would no longer match the operand.
+  if (!sparsity_config.has_lhs() &&
+      convolution.operand(0)->opcode() == HloOpcode::kTranspose) {
+    operand_set.push_back(0);
+  }
+  if (!sparsity_config.has_rhs() &&
+      convolution.operand(1)->opcode() == HloOpcode::kTranspose) {
+    operand_set.push_back(1);
   }
 
   return transposable_conv_operands(convolution, operand_set);
@@ -173,10 +191,18 @@ bool FoldTransposeIntoConvolution(InstructionOperandsPair& pair) {
     new_rhs = convolution.mutable_operand(kRhsIdx);
   }
 
-  auto new_conv = HloInstruction::CreateConvolve(
-      convolution.shape(), {new_lhs, new_rhs},
-      convolution.feature_group_count(), convolution.batch_group_count(),
-      convolution.window(), new_dnums, convolution.precision_config());
+  // Replace the lhs and rhs while preserving auxiliary operands such as
+  // sparsity metadata.
+  std::vector<HloInstruction*> new_operands(convolution.operands().begin(),
+                                            convolution.operands().end());
+  new_operands[kLhsIdx] = new_lhs;
+  new_operands[kRhsIdx] = new_rhs;
+
+  // Clone the convolution to preserve all of its attributes without copying
+  // them individually.
+  auto new_conv =
+      convolution.CloneWithNewOperands(convolution.shape(), new_operands);
+  new_conv->set_convolution_dimension_numbers(new_dnums);
   CHECK_OK(convolution.parent()->ReplaceWithNewInstruction(
       &convolution, std::move(new_conv)));
 

--- a/xla/service/transpose_folding_test.cc
+++ b/xla/service/transpose_folding_test.cc
@@ -25,8 +25,10 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "xla/hlo/builder/xla_builder.h"
+#include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/hlo/testlib/hlo_hardware_independent_test_base.h"
@@ -34,6 +36,7 @@ limitations under the License.
 #include "xla/hlo/testlib/test_helpers.h"
 #include "xla/hlo/utils/hlo_matchers.h"
 #include "xla/literal_util.h"
+#include "xla/service/hlo.pb.h"
 #include "xla/service/shape_inference.h"
 #include "xla/shape.h"
 #include "xla/shape_util.h"
@@ -600,6 +603,140 @@ ENTRY entry_computation {
               absl_testing::IsOkAndHolds(true));
   EXPECT_TRUE(
       module->entry_computation()->root_instruction()->has_backend_config());
+}
+
+TEST_F(TransposeFoldingTest, FoldConvTransposePreservesConvAttributes) {
+  constexpr absl::string_view kHloString = R"(
+HloModule FoldConvTransposePreservesConvAttributes
+
+ENTRY entry_computation {
+  input = f32[1,4] parameter(0)
+  filter = f32[2,4] parameter(1)
+  filter_t = f32[4,2] transpose(filter), dimensions={1,0}
+  ROOT conv = f32[1,2] convolution(input, filter_t), dim_labels=bf_io->bf,
+      convolution_kind=fprop, backend_config="fake_conv_config"
+}
+)";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloString));
+
+  EXPECT_THAT(TransposeFolding().Run(module.get()),
+              absl_testing::IsOkAndHolds(true));
+
+  HloInstruction* root = module->entry_computation()->root_instruction();
+  ASSERT_THAT(root, op::Convolution(op::Parameter(0), op::Parameter(1)));
+  const HloConvolutionInstruction* conv = Cast<HloConvolutionInstruction>(root);
+  EXPECT_EQ(conv->convolution_kind(), CONVOLUTION_KIND_FPROP);
+  EXPECT_EQ(conv->raw_backend_config_string(), "fake_conv_config");
+}
+
+TEST_F(TransposeFoldingTest, DoNotFoldTransposeIntoSparseConvOperand) {
+  constexpr absl::string_view kHloString = R"(
+HloModule DoNotFoldTransposeIntoSparseConvOperand
+
+ENTRY entry_computation {
+  input = f32[1,8] parameter(0)
+  filter = f32[3,2] parameter(1)
+  filter_t = f32[2,3] transpose(filter), dimensions={1,0}
+  meta = s32[2,3] parameter(2)
+  ROOT conv = f32[1,3] convolution(input, filter_t, meta), dim_labels=bf_io->bf,
+      sparsity_config={rhs={sparsity=1x4 dimension=0 stride=1 idx=2}}
+}
+)";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloString));
+
+  EXPECT_THAT(TransposeFolding().Run(module.get()),
+              absl_testing::IsOkAndHolds(false));
+
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::Convolution(op::Parameter(0), op::Transpose(op::Parameter(1)),
+                              op::Parameter(2)));
+}
+
+TEST_F(TransposeFoldingTest, DoNotFoldTransposeIntoConvMetadataOperand) {
+  constexpr absl::string_view kHloString = R"(
+HloModule DoNotFoldTransposeIntoConvMetadataOperand
+
+ENTRY entry_computation {
+  input = f32[1,8] parameter(0)
+  filter = f32[2,3] parameter(1)
+  meta_input = s32[3,2] parameter(2)
+  meta = s32[2,3] transpose(meta_input), dimensions={1,0}
+  ROOT conv = f32[1,3] convolution(input, filter, meta), dim_labels=bf_io->bf,
+      sparsity_config={rhs={sparsity=1x4 dimension=0 stride=1 idx=2}}
+}
+)";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloString));
+
+  EXPECT_THAT(TransposeFolding().Run(module.get()),
+              absl_testing::IsOkAndHolds(false));
+
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::Convolution(op::Parameter(0), op::Parameter(1),
+                              op::Transpose(op::Parameter(2))));
+}
+
+TEST_F(TransposeFoldingTest, DoNotFoldConvWithNonSparsityAdditionalOperand) {
+  constexpr absl::string_view kHloString = R"(
+HloModule DoNotFoldConvWithNonSparsityAdditionalOperand
+
+ENTRY entry_computation {
+  input = f32[8,1] parameter(0)
+  input_t = f32[1,8] transpose(input), dimensions={1,0}
+  filter = f32[8,3] parameter(1)
+  extra = f32[] parameter(2)
+  ROOT conv = f32[1,3] convolution(input_t, filter, extra), dim_labels=bf_io->bf
+}
+)";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloString));
+
+  EXPECT_THAT(TransposeFolding().Run(module.get()),
+              absl_testing::IsOkAndHolds(false));
+
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              op::Convolution(op::Transpose(op::Parameter(0)), op::Parameter(1),
+                              op::Parameter(2)));
+}
+
+TEST_F(TransposeFoldingTest, FoldConvActivationsTransposeKeepsSparsity) {
+  constexpr absl::string_view kHloString = R"(
+HloModule FoldConvActivationsTransposeKeepsSparsity
+
+ENTRY entry_computation {
+  input = f32[8,1] parameter(0)
+  input_t = f32[1,8] transpose(input), dimensions={1,0}
+  filter = f32[2,3] parameter(1)
+  meta = s32[2,3] parameter(2)
+  ROOT conv = f32[1,3] convolution(input_t, filter, meta), dim_labels=bf_io->bf,
+      sparsity_config={rhs={sparsity=1x4 dimension=0 stride=1 idx=2}},
+      convolution_kind=fprop
+}
+)";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(kHloString));
+
+  EXPECT_THAT(TransposeFolding().Run(module.get()),
+              absl_testing::IsOkAndHolds(true));
+
+  HloInstruction* root = module->entry_computation()->root_instruction();
+  ASSERT_THAT(root, op::Convolution(op::Parameter(0), op::Parameter(1),
+                                    op::Parameter(2)));
+  const HloConvolutionInstruction* conv = Cast<HloConvolutionInstruction>(root);
+  EXPECT_FALSE(conv->sparsity_config().has_lhs());
+  EXPECT_TRUE(conv->sparsity_config().has_rhs());
+  EXPECT_EQ(conv->sparsity_config().rhs().num_non_zero(), 1);
+  EXPECT_EQ(conv->sparsity_config().rhs().block_size(), 4);
+  EXPECT_EQ(conv->sparsity_config().rhs().dimension(), 0);
+  EXPECT_EQ(conv->sparsity_config().rhs().stride(), 1);
+  EXPECT_EQ(conv->sparsity_config().rhs().idx(), 2);
+  EXPECT_EQ(conv->convolution_kind(), CONVOLUTION_KIND_FPROP);
+  const ConvolutionDimensionNumbers& dnums =
+      conv->convolution_dimension_numbers();
+  EXPECT_EQ(dnums.input_batch_dimension(), 1);
+  EXPECT_EQ(dnums.input_feature_dimension(), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
📝 Summary of Changes
Transpose folding rebuilt convolutions with only the lhs and rhs, which dropped sparsity metadata and other convolution attributes.

Limit folding to the lhs and rhs, leave sparse operands unchanged, and reject convolutions with unknown auxiliary operands. Clone the original convolution when folding so all operands and attributes are preserved.

🎯 Justification
Without this fix, folding a transpose in a sparse convolution can produce an invalid or semantically different HLO.

🚀 Kind of Contribution
🐛 Bug Fix

📊 Benchmark (for Performance Improvements)
Not applicable; this is a correctness fix.

🧪 Unit Tests:
Added tests for attribute preservation, sparse operands, metadata operands, unknown auxiliary operands,
and folding the dense side of a sparse convolution.

bazel test //xla/service:transpose_folding_test

🧪 Execution Tests:
None. The pass is hardware-independent and is covered by verified HLO unit tests.