### PR TITLE
enable sol estimator for mi300

### DIFF
--- a/xla/backends/gpu/transforms/collectives/collective_ops_utils.cc
+++ b/xla/backends/gpu/transforms/collectives/collective_ops_utils.cc
@@ -268,10 +268,10 @@ absl::StatusOr<GPUCommunicationType> CommunicationType(
     const se::GpuComputeCapability& gpu_version) {
   const bool is_supported_rocm =
       gpu_version.IsRocm() &&
-      gpu_version.rocm_compute_capability()->gfx9_mi350();
+      gpu_version.rocm_compute_capability()->gfx9_mi300_series();
   if (!gpu_version.IsCuda() && !is_supported_rocm) {
     return absl::FailedPreconditionError(
-        "Only CUDA and ROCm gfx950 (MI350) are supported.");
+        "Only CUDA and ROCm gfx942 (MI300) and gfx950 (MI350) are supported.");
   }
 
   if (const auto* collective = DynCast<HloCollectiveInstruction>(&instr)) {

--- a/xla/service/gpu/model/collective_interpolator_test.cc
+++ b/xla/service/gpu/model/collective_interpolator_test.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "absl/time/time.h"
 #include "xla/backends/gpu/transforms/collectives/collective_ops_utils.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_module.h"
 #include "xla/hlo/ir/hlo_opcode.h"

--- a/xla/service/gpu/model/collective_interpolator_test.cc
+++ b/xla/service/gpu/model/collective_interpolator_test.cc
@@ -1081,6 +1081,56 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.test_name;
     });
 
+TEST(DefaultCollectivePerfTableTest, EstimatesGfx942DefaultProfile) {
+  se::DeviceDescription device_info = TestGpuDeviceInfo::RTXA6000DeviceInfo();
+  device_info.set_rocm_compute_capability("gfx942");
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<CollectiveInterpolator> interpolator,
+      CollectiveInterpolator::Create(kNumGpusPerHost, device_info));
+
+  absl::string_view kAllReduceHlo = R"(
+    HloModule m, num_partitions=8
+
+    wrapped_add {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT _ = f32[] add(a,b)
+    }
+
+    ENTRY main {
+      p = f32[256] parameter(0)
+      ROOT _ = f32[256] all-reduce(p), to_apply=wrapped_add,
+          replica_groups=[1,8]<=[8], use_global_device_ids=true, channel_id=1
+    }
+  )";
+  ASSERT_OK_AND_ASSIGN(auto all_reduce_module,
+                       ParseAndReturnUnverifiedModule(kAllReduceHlo));
+  HloInstruction* all_reduce =
+      all_reduce_module->entry_computation()->root_instruction();
+  ASSERT_OK_AND_ASSIGN(absl::Duration all_reduce_runtime,
+                       interpolator->EstimatedRuntime(*all_reduce));
+  EXPECT_NEAR(absl::ToDoubleMicroseconds(all_reduce_runtime),
+              1e6 * 1024.0 / 18206710.0, 0.01);
+
+  absl::string_view kCollectivePermuteHlo = R"(
+    HloModule m, num_partitions=8
+
+    ENTRY main {
+      p = f32[256] parameter(0)
+      ROOT _ = f32[256] collective-permute(p),
+          source_target_pairs={{0,4},{1,5},{2,6},{3,7}}, channel_id=1
+    }
+  )";
+  ASSERT_OK_AND_ASSIGN(auto collective_permute_module,
+                       ParseAndReturnUnverifiedModule(kCollectivePermuteHlo));
+  HloInstruction* collective_permute =
+      collective_permute_module->entry_computation()->root_instruction();
+  ASSERT_OK_AND_ASSIGN(absl::Duration collective_permute_runtime,
+                       interpolator->EstimatedRuntime(*collective_permute));
+  EXPECT_NEAR(absl::ToDoubleMicroseconds(collective_permute_runtime),
+              1e6 * 1024.0 / 6772889.0, 0.01);
+}
+
 TEST(DefaultCollectivePerfTableTest, EstimatesGfx950DefaultProfile) {
   se::DeviceDescription device_info = TestGpuDeviceInfo::RTXA6000DeviceInfo();
   device_info.set_rocm_compute_capability("gfx950");

--- a/xla/service/gpu/model/default_collective_perf_table.txtpb
+++ b/xla/service/gpu/model/default_collective_perf_table.txtpb
@@ -77750,6 +77750,16139 @@ entries {
   }
 }
 entries {
+  key: "gfx942"
+  value {
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 64
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f8b5ec938cad8a87a80fc1dcd768c66b"
+      network_throughput_bytes_per_sec: 65712635
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2eb056e21ce0ddec3c4acf722189b700"
+      network_throughput_bytes_per_sec: 211253803
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ea0954193cc480c6593f553bd3438c9e"
+      network_throughput_bytes_per_sec: 3886148007
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5771f9afffba4af7a205f96eef84981b"
+      network_throughput_bytes_per_sec: 291397585757
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ce91af68036c36a9df8e3bbf567eee09"
+      network_throughput_bytes_per_sec: 970328694
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2c6f6210ff747b61044161f5f2d82027"
+      network_throughput_bytes_per_sec: 331378273764
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c899fb206acc512aabad1c825500db25"
+      network_throughput_bytes_per_sec: 1635986919
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bb0c837eadcc79bc10233ea7ef4010a9"
+      network_throughput_bytes_per_sec: 44582786806
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8eaf5a05d48989b38e5eaea491d6f0fb"
+      network_throughput_bytes_per_sec: 66806896826
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2d717ad201d941580b9e0106406fd7d5"
+      network_throughput_bytes_per_sec: 612302862
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8ba146534a3ced22d98ec89e13791de1"
+      network_throughput_bytes_per_sec: 53843726
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "184135279c70089f7c6ca507b1582d55"
+      network_throughput_bytes_per_sec: 16838643371
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ef16ed48f2ab9a546f3605e4c3340419"
+      network_throughput_bytes_per_sec: 178797245127
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9bb2cf7ea4be08f4379c34a8776dd615"
+      network_throughput_bytes_per_sec: 44943947365
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "33661ac19032bfe68c3d9b02871f9ed9"
+      network_throughput_bytes_per_sec: 176597395
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "cbd1ef2c36141930a966889cfc48d322"
+      network_throughput_bytes_per_sec: 88663212318
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "921e6393a965bcd40b2ee3799112ec42"
+      network_throughput_bytes_per_sec: 282843628
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 536870912
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "19badbe16d051a71a5719fc1cbd40c7f"
+      network_throughput_bytes_per_sec: 168232855159
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "d3b910fdeb6b07245ce93ccb67ea88bd"
+      network_throughput_bytes_per_sec: 211221122
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fbda4473b6de260c6512121cc16e8f04"
+      network_throughput_bytes_per_sec: 339875179474
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3064d5d2f82d8e6ced1ab7e947ef7391"
+      network_throughput_bytes_per_sec: 428272689
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "96f8309cce55a9949e1f2f0f3e0ec690"
+      network_throughput_bytes_per_sec: 771960822
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "184920561f3c0de7e3083fe2fc0bd31c"
+      network_throughput_bytes_per_sec: 45450589848
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "89e6821bfad18005a5bee029eeb23f19"
+      network_throughput_bytes_per_sec: 213624528878
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "057eed0f675dbf7448cc6f9f13963459"
+      network_throughput_bytes_per_sec: 14772004958
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "132109fb8819d2dd18efd21168ba46cf"
+      network_throughput_bytes_per_sec: 2420088626
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1a7304fb341d7f07c57c9bf104fa240c"
+      network_throughput_bytes_per_sec: 17662309661
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "869218e49384a9020f9fbb1c8eb247de"
+      network_throughput_bytes_per_sec: 53758924
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "59d80d26dc690f4b5ca94bf13c0a4edb"
+      network_throughput_bytes_per_sec: 98407019848
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "122edd8939058bb037abb5816debfc87"
+      network_throughput_bytes_per_sec: 23454927750
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0828705e9e274be716d9bed985b9d04f"
+      network_throughput_bytes_per_sec: 149950538499
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0e252d37f4f95b65b0c309bd36d90e08"
+      network_throughput_bytes_per_sec: 68010961391
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "adf9fe649eb56b23ae6e148efc55dbac"
+      network_throughput_bytes_per_sec: 38692841328
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c5cd6dc54b5be0e57e2f5ff3b8b297a9"
+      network_throughput_bytes_per_sec: 77817463
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f2b280da4c9e108e14768760ebb4c392"
+      network_throughput_bytes_per_sec: 796480396
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "61c8e423ccee51351146a02330cbd321"
+      network_throughput_bytes_per_sec: 267696613347
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3b8d159ab132a6a4de22cf70abec0b16"
+      network_throughput_bytes_per_sec: 157344174814
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4cde049d4af2588421f1cd37e1a1d96d"
+      network_throughput_bytes_per_sec: 46648503726
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3a6a7362223de42b37d4ea61ae462272"
+      network_throughput_bytes_per_sec: 70295205054
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9553913f2f28f76f48cad5808ac047a8"
+      network_throughput_bytes_per_sec: 152544413884
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fbc3523926dbdd757c935102891781d6"
+      network_throughput_bytes_per_sec: 161038341740
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "68055875bc25bbe6685e1b9b85eab565"
+      network_throughput_bytes_per_sec: 8241448692
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e116b749dc6fb00963e1e1c912a89c03"
+      network_throughput_bytes_per_sec: 328029171676
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "863b7bb32c372a2dd7cae3096429baa4"
+      network_throughput_bytes_per_sec: 27175319
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "e7ff1ad5ce23298c66709c1a761fc80c"
+      network_throughput_bytes_per_sec: 2995058582
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "dab6356615fe22377f82fa76542aacfd"
+      network_throughput_bytes_per_sec: 3265533908
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9b4cd34c3b54a338ab91020d2c23470e"
+      network_throughput_bytes_per_sec: 142743512515
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a25e0b6606b5a56f34374dda554164b2"
+      network_throughput_bytes_per_sec: 46782352764
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1463d8954f4946d066311dc7f75d49dc"
+      network_throughput_bytes_per_sec: 309441391426
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "956a8ba9e3cb2a85b1f2051634580fa9"
+      network_throughput_bytes_per_sec: 32132319790
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "d650b9830fd51944cce5307dad5a78b6"
+      network_throughput_bytes_per_sec: 46145721972
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4bd1e1be2e4f6abd94d41b47a4e4a20b"
+      network_throughput_bytes_per_sec: 324879343355
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "725a4a0ae76c1f2dc1f7c1877ad92a3d"
+      network_throughput_bytes_per_sec: 89525844505
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e2f8ceafe05d7294298b62da832dd887"
+      network_throughput_bytes_per_sec: 46732443700
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "833cc5cec9d7cfba5770633083f5fb7e"
+      network_throughput_bytes_per_sec: 160275473
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1e90f0394d981c53e9ef82dacccbd73d"
+      network_throughput_bytes_per_sec: 104497793
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "be5aa918f7da473d687285a4e6e7e13f"
+      network_throughput_bytes_per_sec: 101085883
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "586bac400ee3830fcb0bfb33c5e1dec6"
+      network_throughput_bytes_per_sec: 2034773969
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "10afb3a674511ddbd597cb56dbb5c8fd"
+      network_throughput_bytes_per_sec: 11110385895
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fd1abf3e9a2d65d8c9875426308088db"
+      network_throughput_bytes_per_sec: 4876190476
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d2b7c2d576d861a8c7c91e1bf57c188f"
+      network_throughput_bytes_per_sec: 10200949490
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4fb0e0f55c14066295dd304d8371b0ee"
+      network_throughput_bytes_per_sec: 8582222949
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "44ae733809312994206ebe478f6f6d88"
+      network_throughput_bytes_per_sec: 77185598218
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f569c9c702eb778090e38c0661443be4"
+      network_throughput_bytes_per_sec: 156316504935
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "6162dcdb0d5f77647fc11bc90b514c9e"
+      network_throughput_bytes_per_sec: 14826827
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e48d6a945ecb9b02cc16939023bc2d96"
+      network_throughput_bytes_per_sec: 4659260970
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b1ee9be4f8941e8c5707b526de55ebcd"
+      network_throughput_bytes_per_sec: 37880712402
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fdd21857630c37298563cd2c4a3d9d0b"
+      network_throughput_bytes_per_sec: 1230030030
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ed727b57d6a3ae32b3e8b3c460375593"
+      network_throughput_bytes_per_sec: 89224848829
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fdfd9b0e1d6925288b99fa31fb770d0f"
+      network_throughput_bytes_per_sec: 197970033
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d3ad67df0aff5eb378644f9090463629"
+      network_throughput_bytes_per_sec: 17485592315
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7d3fc6383c3bfc8d9b3e2269bf971b44"
+      network_throughput_bytes_per_sec: 24870167449
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "b52cca147cee2cf2afd9b52e23b0e447"
+      network_throughput_bytes_per_sec: 5965410522
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "56fca87b103de1eb73c7e89c61448474"
+      network_throughput_bytes_per_sec: 9708317902
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4a3d963f9237ede18f970c615082a65b"
+      network_throughput_bytes_per_sec: 9216792068
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7d0d5395979bcdd88ab169ef67df3d5e"
+      network_throughput_bytes_per_sec: 99126352
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "5fb3ea880a0b624efd5aaa39e8e94119"
+      network_throughput_bytes_per_sec: 45318060035
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9dc805264207f639505e60a61756f2ff"
+      network_throughput_bytes_per_sec: 129742143033
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0763253379412eb8c92d451a4989af92"
+      network_throughput_bytes_per_sec: 4883457526
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9599ceb31c1d43d9bd34666de402264a"
+      network_throughput_bytes_per_sec: 10240800062
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "75e40f7ad44a713cbbbd71adca9ca1c5"
+      network_throughput_bytes_per_sec: 183445766270
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "47b532f58d2079ddc96d356ceefa38b8"
+      network_throughput_bytes_per_sec: 83130378
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a4ff2d7f7e21480824c17556c4ea5f1e"
+      network_throughput_bytes_per_sec: 63302604968
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "46ba65401185eae7cf33ea01a44d150f"
+      network_throughput_bytes_per_sec: 349577536
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7d103ef6ef882da52bf468af2e2c89af"
+      network_throughput_bytes_per_sec: 51074866
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "66750fce8728e0f48633bfce62ae1980"
+      network_throughput_bytes_per_sec: 13661872003
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "460a0e15a081f4490055616ae5d0fa4c"
+      network_throughput_bytes_per_sec: 11067933291
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c52376a097b88c64ce5161577dba2070"
+      network_throughput_bytes_per_sec: 17419113
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0b3c62ead25a10854182eb972d21a33d"
+      network_throughput_bytes_per_sec: 9101590167
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "72c4414d2ea15a15319031a9404c518d"
+      network_throughput_bytes_per_sec: 4841965275
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3067ba1a1aa9f8fd0f9c70c28fd2aae5"
+      network_throughput_bytes_per_sec: 100544945
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "21b95933b3a9fcf0834be1a9a56d565f"
+      network_throughput_bytes_per_sec: 19148575602
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "62a78b2d792f227e3319cbc6d0f7397a"
+      network_throughput_bytes_per_sec: 165414996302
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "26a9264b3431e346ef5fef61c3213c53"
+      network_throughput_bytes_per_sec: 171179051063
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "dbc9494722e22aa9d9bbc19961fa2bd5"
+      network_throughput_bytes_per_sec: 7936630
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0655eca561666269145633dca1fd0bad"
+      network_throughput_bytes_per_sec: 704566956
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "62deed7a65e09eb425eac9e48ddd5a47"
+      network_throughput_bytes_per_sec: 78805119894
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "44189885145704c5e0202393bb9877c9"
+      network_throughput_bytes_per_sec: 1410346905
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5e2663d7fceff11b5312332fa4e92638"
+      network_throughput_bytes_per_sec: 919106922
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5f3fc5e4e7b3cece8395d7709beadc90"
+      network_throughput_bytes_per_sec: 137653560879
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c057bfe7ad7cd11029ee0025cf8c22e6"
+      network_throughput_bytes_per_sec: 95651767
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 128
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7a54c034380c02751b62ec1327003385"
+      network_throughput_bytes_per_sec: 108543565
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "30970b3a64dad66be798dd9a326d7629"
+      network_throughput_bytes_per_sec: 2816995852
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c3b34f754c1e17af82ed0baa3ab2e457"
+      network_throughput_bytes_per_sec: 322063217
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "364cc6f929827da70719a1a88a21eee6"
+      network_throughput_bytes_per_sec: 310460651649
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "58357e0bd8b0689ff1fe2c58de3ccb19"
+      network_throughput_bytes_per_sec: 93277555811
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a275e77e76f7666c635ad7320b1e2e59"
+      network_throughput_bytes_per_sec: 47446844282
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "04fd9fed92d16e173fc5208523f53283"
+      network_throughput_bytes_per_sec: 1713090757
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4928da39d79385e5f104ae32acf39251"
+      network_throughput_bytes_per_sec: 27817007335
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "273eb0c88e187b9a6a76c5d5bbda9095"
+      network_throughput_bytes_per_sec: 53720784876
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7ea858b3ed721e1f90bd0ad4e02171de"
+      network_throughput_bytes_per_sec: 46043375226
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bdc2c7412dbec535a96e650e8b71faba"
+      network_throughput_bytes_per_sec: 62027565808
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ef4fee03912d152ba48c7a9651d5e2ec"
+      network_throughput_bytes_per_sec: 70459346861
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f91111ab5af2a4c95a894ac69a514d2d"
+      network_throughput_bytes_per_sec: 31955628018
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5c4855fe511cdd5117be76e7385d1cf7"
+      network_throughput_bytes_per_sec: 2663361306
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4c90e212c6c2ead3940ec3f3968d901f"
+      network_throughput_bytes_per_sec: 2578431758
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e05052a696f34e30c1714e84b65c4039"
+      network_throughput_bytes_per_sec: 166260642929
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1b6ab3ab54b060fef16d0df721e84115"
+      network_throughput_bytes_per_sec: 47417133165
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "06470add083211b0654aff4cb202e57c"
+      network_throughput_bytes_per_sec: 170816646441
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "dced792a6bb96b549cd4ed3e96bb281d"
+      network_throughput_bytes_per_sec: 1560223072
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "0de26ff26de5e012abea2cc8bcc34581"
+      network_throughput_bytes_per_sec: 2936381609
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "52b2577f0bfaf38305363f115bd77596"
+      network_throughput_bytes_per_sec: 382241093
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e75477358c94574e1c6b9b50b78af270"
+      network_throughput_bytes_per_sec: 102968903
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a35c1aa8de7b8a1b684b1b36ab4b04fd"
+      network_throughput_bytes_per_sec: 71371756257
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7ce0f5f18004ff9348daed57054665a7"
+      network_throughput_bytes_per_sec: 341581125936
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "8e2053ca4b68a7a30436f17d2fb23d82"
+      network_throughput_bytes_per_sec: 47688811557
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6b536595b1c234076e742dbd7dc69fab"
+      network_throughput_bytes_per_sec: 308213251
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "35b276d0339cf8c94aba45efe9bec4c7"
+      network_throughput_bytes_per_sec: 21996559681
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 128
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ee756f40fb626c4aa03d562de5e5d7e4"
+      network_throughput_bytes_per_sec: 65044781
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "43520b1b002bd615e25c415898cef7db"
+      network_throughput_bytes_per_sec: 96938763305
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "45bfdb58c636e6b400334106497f5f53"
+      network_throughput_bytes_per_sec: 762702790
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "28126f4b484edf49b2dcf198458b4937"
+      network_throughput_bytes_per_sec: 2463944657
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2184b39554ab974feabcadff2e7fb123"
+      network_throughput_bytes_per_sec: 79986727056
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "343586e8809857f6fca34bd73bbeed71"
+      network_throughput_bytes_per_sec: 3131049639
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e5db97fda4f5b604f27655ea77479506"
+      network_throughput_bytes_per_sec: 12018338529
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "efe3f776e8fbfab41dbe68168e3aa2e7"
+      network_throughput_bytes_per_sec: 65628404
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6335d98ead54a01eaf5ba646d0d77e2d"
+      network_throughput_bytes_per_sec: 173573193079
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "71aee88e910b8b7555921506479bc0c9"
+      network_throughput_bytes_per_sec: 18206710
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "edb08e654b739c98c5c485d7a96dd456"
+      network_throughput_bytes_per_sec: 3132546245
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e5806ec9f07cc39cc732e915835ae9bd"
+      network_throughput_bytes_per_sec: 7970810021
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fcfc7148888759b910ebf6b82fb52f3d"
+      network_throughput_bytes_per_sec: 85305998342
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b7fbaf6afe0c082466ed59153b00a307"
+      network_throughput_bytes_per_sec: 452947030
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "75dfdcaad56647e9bf10057076c42406"
+      network_throughput_bytes_per_sec: 36998553332
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c25a500ce3140b364a6832b1b1362e4b"
+      network_throughput_bytes_per_sec: 56504162737
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "aa8ffa9987c29072b26beb5ec031d86a"
+      network_throughput_bytes_per_sec: 41157750127
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "ad849cba863d23a00310bcc3ee950a88"
+      network_throughput_bytes_per_sec: 225184859
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f99414bac0801687d5d0b26afffa8232"
+      network_throughput_bytes_per_sec: 353194791
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "922a53422acacfe04e053f1e422ba8fd"
+      network_throughput_bytes_per_sec: 389863176
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "522194310113ca1bf37c3e0f09ab8db8"
+      network_throughput_bytes_per_sec: 376782264
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6c8096ed8c910cfc7ac8df0127fb2d87"
+      network_throughput_bytes_per_sec: 1531823387
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a976ae7da30669c0a2326985521dd531"
+      network_throughput_bytes_per_sec: 10420320387
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1e2b9985be63b818f1261076e2da88b4"
+      network_throughput_bytes_per_sec: 90298577009
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "3dd676703d6ef499f65d3872b7be00c1"
+      network_throughput_bytes_per_sec: 32510897221
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f6d023ca703280822f935c8b9b234a39"
+      network_throughput_bytes_per_sec: 1217236255
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "33b97af27dc242fd69140fc6a5441d85"
+      network_throughput_bytes_per_sec: 141498760
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "af4f3c69b95e67b20c2ec30b01c7411a"
+      network_throughput_bytes_per_sec: 87179730207
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "063d71e21f991fc06c181d3f90af617b"
+      network_throughput_bytes_per_sec: 35468001623
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "dce7d2c5dcc9ed1735611e790b3ca454"
+      network_throughput_bytes_per_sec: 1519974951
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5f3eaa847e85cc2e010b81fbdc9f2856"
+      network_throughput_bytes_per_sec: 79117658709
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "ff47ecd6d22ac749c3efe918866b3b13"
+      network_throughput_bytes_per_sec: 752578029
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "af1dcdb3cca467fabadbfb453250b83e"
+      network_throughput_bytes_per_sec: 41589657875
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "60b6ca4ca57fed5c906e82faf7a25020"
+      network_throughput_bytes_per_sec: 87422341013
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "549a754e6dd1d745599a351bc6375098"
+      network_throughput_bytes_per_sec: 184261996383
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9f256fa6769acb746028a86f3a24c32b"
+      network_throughput_bytes_per_sec: 34503981572
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5b22cde9f2f97e685ff50ea81ec477f1"
+      network_throughput_bytes_per_sec: 14957434668
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4e85a8b0501a8cb5bebaede38fa82634"
+      network_throughput_bytes_per_sec: 113421759
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "85f5b62cb98aabd24d2b37c5dd910965"
+      network_throughput_bytes_per_sec: 161782131
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "76ba73613bb4d3e8a47d5731f98b069d"
+      network_throughput_bytes_per_sec: 186972155346
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c847e212ae13666202c7fac95f296bb2"
+      network_throughput_bytes_per_sec: 60452336340
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c654748a7104d2a0a9f9d067a746c65d"
+      network_throughput_bytes_per_sec: 89262945075
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fcc44e04fa5b43db434b13c1ff2715b0"
+      network_throughput_bytes_per_sec: 863770560
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9f89f8e474b2d2108395576f404592f0"
+      network_throughput_bytes_per_sec: 74635568
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c78e7b3217fa35a2d658c44700e18a84"
+      network_throughput_bytes_per_sec: 308687006959
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7d507fb5fef893d318380fcd6940e951"
+      network_throughput_bytes_per_sec: 89546779677
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1de71abe7c607c98ba5804bf7bfe52fd"
+      network_throughput_bytes_per_sec: 141348475912
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "f11a1d62b4764b85d44c1b9054a4ee0c"
+      network_throughput_bytes_per_sec: 53624497
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "815e0561d46aa81f847e03864d64d42c"
+      network_throughput_bytes_per_sec: 113780938
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "bfac5cabd46928be7a0f7846d91a4c68"
+      network_throughput_bytes_per_sec: 378505752
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "f2f94c05790a5d153abc20208696a019"
+      network_throughput_bytes_per_sec: 37820083587
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ac966f268b5c7c7311f92df25cfd603b"
+      network_throughput_bytes_per_sec: 795726080
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "582244bd08be612bf4fddfb765ebb9b2"
+      network_throughput_bytes_per_sec: 793414043
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c367cbc0001b4184f03992ff46f035c8"
+      network_throughput_bytes_per_sec: 166755058365
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "d2c52c9c7d7442d814395a7590d04e39"
+      network_throughput_bytes_per_sec: 26384082631
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "55594333fcb9e1747c94f550f2123a24"
+      network_throughput_bytes_per_sec: 103807843185
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "fa7774e70aad1ce38ac3bf38250e0a71"
+      network_throughput_bytes_per_sec: 46337580268
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "95a914bf79d60997a74f1dd9115ba2cf"
+      network_throughput_bytes_per_sec: 142807335
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "cb2bdec86e4c8f9a34f3e9f665f1a785"
+      network_throughput_bytes_per_sec: 44592266556
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "65316f05eec205fc5387382135f2e6eb"
+      network_throughput_bytes_per_sec: 111682816098
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "cb65fce6da1bd8410e8959d7b3b9b93d"
+      network_throughput_bytes_per_sec: 820040541
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e4b01b4ff61fcac06330fb733e0e9d49"
+      network_throughput_bytes_per_sec: 19332153392
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 64
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e1b4ad01f4943d5c7e83afcac9a37b2b"
+      network_throughput_bytes_per_sec: 52167711
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "dee38aee4309c8a7e6c8bffa59ecf6fc"
+      network_throughput_bytes_per_sec: 2784618653
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f72d81e32fb5cab52e1fbd4536ece85b"
+      network_throughput_bytes_per_sec: 42023936076
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "71252e403a93408fba96de8bd3825ccc"
+      network_throughput_bytes_per_sec: 169814497737
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "15094deb985f983ccfd5b2545123a183"
+      network_throughput_bytes_per_sec: 69224931712
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ed9bb4a33c886916d5e152a46eac4310"
+      network_throughput_bytes_per_sec: 92123567923
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c34ec0c1f1d1ba3d22754d726aa60897"
+      network_throughput_bytes_per_sec: 78546489634
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0b7a2190bebed5eef89ea66815a0363b"
+      network_throughput_bytes_per_sec: 90006152
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "99ed8a570257a0c3cc345f86a8001dfd"
+      network_throughput_bytes_per_sec: 93372394292
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0f61afe6ad7cda8a18c6818f6140079e"
+      network_throughput_bytes_per_sec: 87860907453
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6f02e702519475f50093c2ef72dac341"
+      network_throughput_bytes_per_sec: 90426395090
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "16ea64590ed40dc5483002a49f0d6285"
+      network_throughput_bytes_per_sec: 643115088
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b4ed48d632b88bc005d30df32b363ad9"
+      network_throughput_bytes_per_sec: 375229021
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "21edd922fde3970e62fbd7ba9f2ddc48"
+      network_throughput_bytes_per_sec: 200581232141
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f4b02e73323ebe8b582ef8eea7eed6ba"
+      network_throughput_bytes_per_sec: 3587868170
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "3095bedc178b27a02eb1a4143351df17"
+      network_throughput_bytes_per_sec: 1515143108
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0aabccd34a8a301bc3ddf7b1d46e2129"
+      network_throughput_bytes_per_sec: 81830897021
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "b2df91aa80c387f126f650e678c520b4"
+      network_throughput_bytes_per_sec: 5891505273
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "936f0c4ef7edb565c9896c0c4870960b"
+      network_throughput_bytes_per_sec: 93652123431
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1cff4402d5277799435921d310e21a35"
+      network_throughput_bytes_per_sec: 44649348644
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f650becd3ab75fdbc10bd51f46be4d0b"
+      network_throughput_bytes_per_sec: 46068661384
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "c41feadc1950e49d7e9eec9400f6e9d9"
+      network_throughput_bytes_per_sec: 30822283174
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "07adfd421c186a489807bf49b8eb6253"
+      network_throughput_bytes_per_sec: 187746806793
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b1c4513e7ed44592d1eb64d50a5cceb1"
+      network_throughput_bytes_per_sec: 167314971839
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "4b078f6cd0c4e1a6730911dfbea26461"
+      network_throughput_bytes_per_sec: 46113390975
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "34a00406559cb1523830491d95378f08"
+      network_throughput_bytes_per_sec: 23667750090
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f6900c72e82afa0a8c995380ea03dc9d"
+      network_throughput_bytes_per_sec: 386579208
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f0faf27f86b3a156830f2f3379c1a78a"
+      network_throughput_bytes_per_sec: 263188331
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "aefb2f182dc06d72825918161ea66565"
+      network_throughput_bytes_per_sec: 47598327434
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "84feeac9978d4c556ab80dddd4768654"
+      network_throughput_bytes_per_sec: 5294554855
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "07ffe12ee7d0bc4514d508fe7cc19f09"
+      network_throughput_bytes_per_sec: 91379669823
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8f0369c1d10b99cad34e0efd03d26027"
+      network_throughput_bytes_per_sec: 1652529124
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2bbf5f211c33a2ad2c630f148483dc2a"
+      network_throughput_bytes_per_sec: 945685425
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fdf5fd552cc8266498cf173283d68c43"
+      network_throughput_bytes_per_sec: 485164347
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3f30e55b4464b5fd1961a36ec3206917"
+      network_throughput_bytes_per_sec: 146131540210
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ed7f56a0e4cc2f90edd777cc7d0902f0"
+      network_throughput_bytes_per_sec: 13997810706
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "910aa36c56dc61f73860235229ece2c0"
+      network_throughput_bytes_per_sec: 6101622326
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8fe6f4a6145f5e93f984c0c9d228bffa"
+      network_throughput_bytes_per_sec: 14872574605
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "58234bff32af3126a5abb79263b6d567"
+      network_throughput_bytes_per_sec: 92912347619
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5a42dd2bf4274cd2ff01caeea3ab825e"
+      network_throughput_bytes_per_sec: 9126941020
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "30329f9a71a703dddba37a4140cf5ebd"
+      network_throughput_bytes_per_sec: 41859269137
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "a76344596468a7872eadbfd9a21739c6"
+      network_throughput_bytes_per_sec: 5274182271
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "30bac766dc6b8bee2436ed12933994f3"
+      network_throughput_bytes_per_sec: 1702410640
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "eac6121ff38a66212e2843295c8e1d87"
+      network_throughput_bytes_per_sec: 97945122947
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "aaf348636c4e381eafbb9006118444ae"
+      network_throughput_bytes_per_sec: 199809751
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ace313bb59b4ef2c1f109158e10e2bc6"
+      network_throughput_bytes_per_sec: 24935223057
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6b5eb7277c0289f2b7bb2e6260cd4d46"
+      network_throughput_bytes_per_sec: 826681467
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 128
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "17900cdf63a9ee0ed1755baffe233181"
+      network_throughput_bytes_per_sec: 125844905
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "abcc51b30fadae6e7deab4c52594727a"
+      network_throughput_bytes_per_sec: 27007068
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "00ea231f198010898c495c8f3aa69249"
+      network_throughput_bytes_per_sec: 27310308
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0d8ff69f1887cddd6d6c7a7cb6e757ad"
+      network_throughput_bytes_per_sec: 124165304914
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b48e2044f7d3c623aadb3f9db7443ff5"
+      network_throughput_bytes_per_sec: 468515870
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0b37b4cf262c1d9b92406e50696e59c4"
+      network_throughput_bytes_per_sec: 46058697
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8e275b21c1aefcc7d9d9fdd8dadee7e3"
+      network_throughput_bytes_per_sec: 254636210481
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "3a8645893cd88d826c0847a7ccfb1379"
+      network_throughput_bytes_per_sec: 10533529556
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7d24ed151e4cd5c7633745a7ba79ff0b"
+      network_throughput_bytes_per_sec: 137790356359
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "df69c417ad310e1b1bb927730e2f10c0"
+      network_throughput_bytes_per_sec: 881476300
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d4331b2f624a701455e129bb32031a61"
+      network_throughput_bytes_per_sec: 776088295
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "55ff80ff4a9a3beb6c7fbde2910fd13c"
+      network_throughput_bytes_per_sec: 2891698104
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "92c147798a31c7520d2ee0ded8ad804a"
+      network_throughput_bytes_per_sec: 355554952740
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9336904dbf1c1d1c5b645493ee702e0f"
+      network_throughput_bytes_per_sec: 1519745843
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "82f362e9d321c948d13b3b80b6127e69"
+      network_throughput_bytes_per_sec: 92037401198
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "8a1da081231362bd028addc1b51d9c9b"
+      network_throughput_bytes_per_sec: 24500512580
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e8636d435d0fae43c0c2a9e79a42691f"
+      network_throughput_bytes_per_sec: 89546779677
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "23433bd8d9f0851f4d638a12a250765c"
+      network_throughput_bytes_per_sec: 12382220962
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "258669441dfeae8366b3ddc732953015"
+      network_throughput_bytes_per_sec: 276364617
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c06280b5ee6c4fa8a084614ad718f48d"
+      network_throughput_bytes_per_sec: 38465737344
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "709c979785595ebfd212c19fbb0201e6"
+      network_throughput_bytes_per_sec: 121219155515
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "aa54856c98f8ee17f5ae47bd848f98ac"
+      network_throughput_bytes_per_sec: 86385982346
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "473de5e2e2797b06e199daa05c708a59"
+      network_throughput_bytes_per_sec: 68444350160
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "7442c7f9a88e07c2359930d71b9cb4f7"
+      network_throughput_bytes_per_sec: 48099922094
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8ced1638c13ee23a87f2ed048b266463"
+      network_throughput_bytes_per_sec: 1513463581
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e0693614b2f73e7073f66010f736214a"
+      network_throughput_bytes_per_sec: 182192960570
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f33c96d99b16c475e9426acbf66dd505"
+      network_throughput_bytes_per_sec: 342760280811
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3a85682307cc04bdf2d54b6e969ddf03"
+      network_throughput_bytes_per_sec: 19673464792
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "dc56556d1adadef6f24e57a9b7767495"
+      network_throughput_bytes_per_sec: 109885982
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ba06c43b0e9a16e6f70a35cf45d16045"
+      network_throughput_bytes_per_sec: 32637958135
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "fa424be17588fdb480397be00ca54b0c"
+      network_throughput_bytes_per_sec: 121004431
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "17aeda778598e4f09df04f7f7aa4003a"
+      network_throughput_bytes_per_sec: 10420320387
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "49b9e194815f26ce0fdea12d8d8145da"
+      network_throughput_bytes_per_sec: 160772140981
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c6c8164390d18c7b8227ed85b0d93966"
+      network_throughput_bytes_per_sec: 85033393055
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9a2fa6100fdf7452201647b34f24d846"
+      network_throughput_bytes_per_sec: 336486903939
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 128
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "feace905f214b6dc5980b277dfb00077"
+      network_throughput_bytes_per_sec: 82196179
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "94b441a1f24803f223f997cfc3551595"
+      network_throughput_bytes_per_sec: 367123353018
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "89bf703c6da6a800c76bc44e3eeb91c1"
+      network_throughput_bytes_per_sec: 229046745303
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0b17520ef1c4f5cd7dea5e25a264eb0f"
+      network_throughput_bytes_per_sec: 172314449665
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "971ba4331155d73cf505b7046e927999"
+      network_throughput_bytes_per_sec: 137484356305
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "e747471da878022b0e610cf02be16904"
+      network_throughput_bytes_per_sec: 14362959
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0ac522248afbce29ceb2768f3938161e"
+      network_throughput_bytes_per_sec: 27078485
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "85e994016d8e47f32a5448d4032a348e"
+      network_throughput_bytes_per_sec: 207613158
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8e977f1d0af1a26d296c1aaa638dd4e2"
+      network_throughput_bytes_per_sec: 139789164958
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a41f12bbaed25af2cec9dd82edd3f358"
+      network_throughput_bytes_per_sec: 298191377142
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0f9fab80196b5ca3a20c8b4d82429ffc"
+      network_throughput_bytes_per_sec: 172995098260
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ceb6ede44fdcea933bdbf9fb08da4047"
+      network_throughput_bytes_per_sec: 51046859
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "222e31563730a12c12652876f75aa032"
+      network_throughput_bytes_per_sec: 101959661
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "036547934bd0d0bb72c94bb8ac62df03"
+      network_throughput_bytes_per_sec: 286033519
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "b195ecd43415c6e2133f67d283c70392"
+      network_throughput_bytes_per_sec: 391488751
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "aba5522f4f72600896d0d38c2bace66e"
+      network_throughput_bytes_per_sec: 5010589089
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ef6169f1bb54bc4a3a7a051048934504"
+      network_throughput_bytes_per_sec: 163127908446
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "de1e3e1a4c273794678bc61b5d653b96"
+      network_throughput_bytes_per_sec: 5140481606
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9a00b4aca393f1e9d49eb3b5f09fc1c0"
+      network_throughput_bytes_per_sec: 169777980731
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bbc9ee9d4267db9c368730cb88915520"
+      network_throughput_bytes_per_sec: 94286830845
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 536870912
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0b4253423ad3baa463934639904af66a"
+      network_throughput_bytes_per_sec: 47650042817
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "29a32f0bb7a1457842de5659e9e37786"
+      network_throughput_bytes_per_sec: 25763142457
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "cf9f897c04f74b0a135ecb4c11a26855"
+      network_throughput_bytes_per_sec: 79140797765
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "04daaa08891c88599cf6b5e5432743e1"
+      network_throughput_bytes_per_sec: 38546159678
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "75cdf6eabbbdac74bc5568d6d46578eb"
+      network_throughput_bytes_per_sec: 211477398
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "70348095a69033348d06a2ac297b5377"
+      network_throughput_bytes_per_sec: 2905866181
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b2fae3c053c9425aa7b2455cd42ed715"
+      network_throughput_bytes_per_sec: 86437276207
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9c3c4a224e66a397bfac9accf9cc1a7f"
+      network_throughput_bytes_per_sec: 89635407052
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "34029e7be9d63c46e84a59f187976494"
+      network_throughput_bytes_per_sec: 178430718999
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "56d105d61538ea5d57669499dbb0cd31"
+      network_throughput_bytes_per_sec: 511233150
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "be83c13222556564f80565d69e4c5314"
+      network_throughput_bytes_per_sec: 16864235454
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5b3a40da645053c4c49583b44ff21960"
+      network_throughput_bytes_per_sec: 349824027481
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6ce7f2d96c09502b579b2cc31a252a14"
+      network_throughput_bytes_per_sec: 18657271983
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "32d57fabcd45bb4420ad3804d58b6daa"
+      network_throughput_bytes_per_sec: 13229546
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "d2314470d36c1fb289de20e57d81e109"
+      network_throughput_bytes_per_sec: 38864396806
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "4951da2d8f297b24121287ac7e845ede"
+      network_throughput_bytes_per_sec: 34151547
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d1a6a800b1ee86a32a33db83fcf204e3"
+      network_throughput_bytes_per_sec: 16730904855
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b00e61bfb66f71c42590fb44fafcd46c"
+      network_throughput_bytes_per_sec: 74682240660
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8fc7520997c9861590d3a11efee5e464"
+      network_throughput_bytes_per_sec: 3290125006
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7fd67d96daadd70a6f60920d4dcc86e5"
+      network_throughput_bytes_per_sec: 128780733
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 64
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f2247e58f9dfdee0211213f74e5f7feb"
+      network_throughput_bytes_per_sec: 84086056
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d32b95bcb7f76a67d13b3caf116bf903"
+      network_throughput_bytes_per_sec: 260011096474
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bd7b374fb5b1baf0fcab53db4ed3a18a"
+      network_throughput_bytes_per_sec: 88766342555
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "36827cb7d9d81ad5d39c6724b093541c"
+      network_throughput_bytes_per_sec: 1238912624
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1f8995887b89b71a8635d44959d3c644"
+      network_throughput_bytes_per_sec: 56382632074
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "fb36e95d966ca073a983033d1cd853ee"
+      network_throughput_bytes_per_sec: 7072116
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e6875d068a859fc9c823bbaa445bd205"
+      network_throughput_bytes_per_sec: 94213912089
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2898f1b237631f585973476ece15eb4c"
+      network_throughput_bytes_per_sec: 171205034957
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1841b260ab4a40af1b8ba495043826c7"
+      network_throughput_bytes_per_sec: 6809642560
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "52cb2f8abd5ba59c1eb59484cbdf0163"
+      network_throughput_bytes_per_sec: 1023136728
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f8236051598e374faf860e419eeb4ff9"
+      network_throughput_bytes_per_sec: 39871325905
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e45ba4475adc9a853d150aca5d1333d1"
+      network_throughput_bytes_per_sec: 2456371814
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e062c8ee9e86b399c11f6e70eeea5ab8"
+      network_throughput_bytes_per_sec: 67724342827
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "4ca4e3406755d17f747a07b8511cb33a"
+      network_throughput_bytes_per_sec: 11128249483
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "199effc00a48df62ad8aac2557ced496"
+      network_throughput_bytes_per_sec: 19681219264
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6f2128c1096979ddb9bb3d2d1ecbc018"
+      network_throughput_bytes_per_sec: 408588742
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f53f76968e917ef5f386872467c6ef38"
+      network_throughput_bytes_per_sec: 92277571674
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 128
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "26a483ffc11467c6c27c00096a99950b"
+      network_throughput_bytes_per_sec: 105741429
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "60532c3a26ca6a8fe1410171835f3cdc"
+      network_throughput_bytes_per_sec: 47651402539
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "048fd4ebffa26a0f555a13d497fffb5c"
+      network_throughput_bytes_per_sec: 21904658449
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b497a392f67a4f5b4072540892de137a"
+      network_throughput_bytes_per_sec: 86015611501
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9a97c97d215983128682ba3ef92d46a0"
+      network_throughput_bytes_per_sec: 182448425366
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2e50b732eb8b42bf4094cc1128021ee0"
+      network_throughput_bytes_per_sec: 138172986
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 536870912
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "15a31184e19613f6aefe5aa0d66bf174"
+      network_throughput_bytes_per_sec: 92391274239
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a16a4afaeeda93a334f1127435c9c469"
+      network_throughput_bytes_per_sec: 25942008906
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "96db7ac42e083786dd2e2ace91847307"
+      network_throughput_bytes_per_sec: 91569817880
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "3f17d3795d2154a17d98923926faec1e"
+      network_throughput_bytes_per_sec: 569640497
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "4d3e5e4cd088394f4ad45e10894ef7ff"
+      network_throughput_bytes_per_sec: 30733907
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "173b0bc7740214cfc9963e19610cf098"
+      network_throughput_bytes_per_sec: 16661121306
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8347a8a2df0cb35df36c10079023ab76"
+      network_throughput_bytes_per_sec: 5578837600
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b97f24bb846a88481c2900cac902f6f1"
+      network_throughput_bytes_per_sec: 422943879
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ab056536331bdda05cf9fb4e4e83c9ac"
+      network_throughput_bytes_per_sec: 95852689162
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bc9fc8450274035530c5644ee6a0cbc1"
+      network_throughput_bytes_per_sec: 203275434
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9eba46fe48d732fc74500cac8fb7c3fe"
+      network_throughput_bytes_per_sec: 42155080052
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a7d84fd4843073d498edbcd00f7ab6a4"
+      network_throughput_bytes_per_sec: 50493096
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "68ae89524d1d819c91d1823b6f3d6537"
+      network_throughput_bytes_per_sec: 754557962
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "94a2bd79958b89a1cd906d3f4f29d6e0"
+      network_throughput_bytes_per_sec: 2997592951
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c66e53fff207188081e98dfa77807537"
+      network_throughput_bytes_per_sec: 356192581318
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e258bb39ba3efefc2c6bba1c0f94e170"
+      network_throughput_bytes_per_sec: 94968957319
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "289bd78c54fef174d38cd7d0d2af0ed2"
+      network_throughput_bytes_per_sec: 70792927971
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f97af309039c11855739ecdeec9bbc9c"
+      network_throughput_bytes_per_sec: 2945041118
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c33b5cae9b992934b5065b3df33efc63"
+      network_throughput_bytes_per_sec: 97634203974
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "11b7ac8b9606f69c06dc08e59b9a053c"
+      network_throughput_bytes_per_sec: 10915389740
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "66a1b5078d8f0097738c1d90c3e06c06"
+      network_throughput_bytes_per_sec: 3026787363
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6dd504ab26947845d5c80bfc9586dd68"
+      network_throughput_bytes_per_sec: 46876285653
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a1b2a20ae014e046611855ab2efdfda5"
+      network_throughput_bytes_per_sec: 91083436201
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6011d5117ac63690f82029dc8471949a"
+      network_throughput_bytes_per_sec: 9840609632
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "dec343e95dd864ed86b8292ac32fc83d"
+      network_throughput_bytes_per_sec: 206462019
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7bf42174397e4f9e9e4164a352814b3d"
+      network_throughput_bytes_per_sec: 26805460401
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "9ce58729ac6905e5deb36d1567798b01"
+      network_throughput_bytes_per_sec: 47981800783
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1a63b72a7b77dfd3dbe86f522952c68a"
+      network_throughput_bytes_per_sec: 220363147
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "30502fd073c5c5ea768072632ec9c21b"
+      network_throughput_bytes_per_sec: 1322009965
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "49ee5c79563a6427d9cb86a3e99e129a"
+      network_throughput_bytes_per_sec: 43191295432
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "cfcef6f6eec1f07ea7bf67c6f7a8ae9a"
+      network_throughput_bytes_per_sec: 361886733898
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0eba5f28aff574f84c270f76a1796685"
+      network_throughput_bytes_per_sec: 52816174
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "df795aac25ae021df12f1fc1c95816a9"
+      network_throughput_bytes_per_sec: 17697485232
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "aa25b0c2ebe85af31775495126132917"
+      network_throughput_bytes_per_sec: 56534627308
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9673d884e9031593a3e8c06b1d1286f0"
+      network_throughput_bytes_per_sec: 1210044313
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 512
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c4bc78586046f9edb53d96b66049914a"
+      network_throughput_bytes_per_sec: 52382535
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "24af6415e6f60b5a9f415abb5457248e"
+      network_throughput_bytes_per_sec: 217676726263
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "24684b883922432b7bb22b93bef42919"
+      network_throughput_bytes_per_sec: 6365808644
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "12b21848edee6fc36f0071df662c6159"
+      network_throughput_bytes_per_sec: 269375036126
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e45127722646074a5d9b4c24ebc6b49a"
+      network_throughput_bytes_per_sec: 1426308000
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e8ee4f3c9505eedcf86568c849ec03be"
+      network_throughput_bytes_per_sec: 1956882651
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0dcf986269bf50a46e4297b6dc978284"
+      network_throughput_bytes_per_sec: 86742791184
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 4
+        }
+        source_target_pairs {
+          source: 1
+          target: 5
+        }
+        source_target_pairs {
+          source: 2
+          target: 6
+        }
+        source_target_pairs {
+          source: 3
+          target: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "38b551890d391b77a1f157e4b7184870"
+      network_throughput_bytes_per_sec: 6772889
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 1024
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2c386b081607aab3778a5f87110bb32f"
+      network_throughput_bytes_per_sec: 373177842
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 32
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5ad37bd1731c84de4e1fad9d11683e93"
+      network_throughput_bytes_per_sec: 44340521
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "318caa16d4196637a0b49daf3312b6ca"
+      network_throughput_bytes_per_sec: 92429576863
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "026c7aca115d50e9a725ad9cc129a53e"
+      network_throughput_bytes_per_sec: 47721549184
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "5ea2cbe7f5e685aaa702c3ac87eb2424"
+      network_throughput_bytes_per_sec: 335524293393
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f5c609ce87a73de10f144d4057f242ed"
+      network_throughput_bytes_per_sec: 18298158973
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "425885911c59969621fc807b50dc017d"
+      network_throughput_bytes_per_sec: 79758573805
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 4194304
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7c944feb506c3fd2ab7c35af07f3d758"
+      network_throughput_bytes_per_sec: 154771365313
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "173319bd44c6e326a43edec16eff8d2e"
+      network_throughput_bytes_per_sec: 5634112792
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d941f2611b4071dac72664214a7d5d29"
+      network_throughput_bytes_per_sec: 361213627823
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b4d98a0368b1e111b67f10765613016d"
+      network_throughput_bytes_per_sec: 25964805
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "44c3eecf750fab00b51b9c70c0fd2290"
+      network_throughput_bytes_per_sec: 7776676851
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c2aa34383cf2e341115876c717901bc4"
+      network_throughput_bytes_per_sec: 5593240590
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "58314732912345548ae7796528670d53"
+      network_throughput_bytes_per_sec: 53966810
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "512c78e43dde94eab5be4e2a23d40c2c"
+      network_throughput_bytes_per_sec: 611343283
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9324434db5366a8bec594bb1549c6777"
+      network_throughput_bytes_per_sec: 186095275267
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "9885b3b7a489530a5723707a6c245d21"
+      network_throughput_bytes_per_sec: 94483080910
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "20c467af3cb33d4f6820f682bdd18097"
+      network_throughput_bytes_per_sec: 90652373130
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "c389be608049d2735a7f0f2da2adad8c"
+      network_throughput_bytes_per_sec: 174005922161
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 16777216
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "daa2296a0f8546b3da95ed15254e621b"
+      network_throughput_bytes_per_sec: 172527447779
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "041681439796b2c7e6a1130c7a70276e"
+      network_throughput_bytes_per_sec: 6576948165
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 65536
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e4c3db92efad6de5e5840e659c4c13ad"
+      network_throughput_bytes_per_sec: 37991884057
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "847322655433140629869e9781d50b4f"
+      network_throughput_bytes_per_sec: 48608195809
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b2859bcf4713290fc071dba2107dd573"
+      network_throughput_bytes_per_sec: 32760833567
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "ff59d8600ca5d7625580430f6114aecd"
+      network_throughput_bytes_per_sec: 166326780279
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 16384
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "49048b9110f13a6c745074a7a718894f"
+      network_throughput_bytes_per_sec: 4079935254
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4c4aa30c982edd7cb519d3e0f5f1a555"
+      network_throughput_bytes_per_sec: 175292881985
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4ebf30811a22fe550c8a474736c86ebd"
+      network_throughput_bytes_per_sec: 122138699203
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "219e6eafb24f19ca46f775efb9e79f4a"
+      network_throughput_bytes_per_sec: 47802660212
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6482bf31e7c22102c12db681032fb503"
+      network_throughput_bytes_per_sec: 663400413
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+          target: 2
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 4
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 6
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "e1112f0402903c243e8cc21c4f38b20e"
+      network_throughput_bytes_per_sec: 54521011
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7534416b2a6d3452a3adf39b30eb8258"
+      network_throughput_bytes_per_sec: 8748631691
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "eebcf31aeb46f251deb8c25cfb0f09fc"
+      network_throughput_bytes_per_sec: 34261591243
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8ee9101aaefcb090d2a2098aa6d87667"
+      network_throughput_bytes_per_sec: 91237545204
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "2955d362c4784f9a6295fd859f6bf6dd"
+      network_throughput_bytes_per_sec: 17680178053
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "082a66d9bce9594529e3b56a01f55f6c"
+      network_throughput_bytes_per_sec: 32431021418
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8c69870b341e765e470f58443bad0c5d"
+      network_throughput_bytes_per_sec: 96991582647
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a931cd9a10313d6131a6be303bf5d394"
+      network_throughput_bytes_per_sec: 6092971364
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 134217728
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "a72278a0ffa1250acd42babc5e4a2c7a"
+      network_throughput_bytes_per_sec: 174570224588
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "6fc32835aa0f0e4084c95aec9cc07042"
+      network_throughput_bytes_per_sec: 368295643
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 4096
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bd1b66688dfceaa021489d8ae3cf3eda"
+      network_throughput_bytes_per_sec: 933774079
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-to-all"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "d46bc24d789e134da2ba22676a05d2a5"
+      network_throughput_bytes_per_sec: 61337272049
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 256
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "87a721da93ba6a8f0a6509223c6879d3"
+      network_throughput_bytes_per_sec: 80006250
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "0b11a13cda5a5f4706404093723fd1b0"
+      network_throughput_bytes_per_sec: 83938541588
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "34af34ffe43466899ab24789bd5af0c9"
+      network_throughput_bytes_per_sec: 81182859
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 8388608
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "417426246287e26b23b3f3fbb2db6735"
+      network_throughput_bytes_per_sec: 350358804082
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "421633cbe081af3cd0ad351606175269"
+      network_throughput_bytes_per_sec: 47763854948
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "71984575aa654cfc93c69a828b619b03"
+      network_throughput_bytes_per_sec: 24485708948
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 33554432
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "beaf14cc7bbcb59673df046c2e6aba77"
+      network_throughput_bytes_per_sec: 44158761033
+    }
+    entries {
+      instruction {
+        name: "collective-permute"
+        opcode: "collective-permute"
+        shape {
+          element_type: F32
+          dimensions: 268435456
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967299
+        operand_ids: 4294967298
+        source_target_pairs {
+          target: 1
+        }
+        source_target_pairs {
+          source: 1
+        }
+        source_target_pairs {
+          source: 2
+          target: 3
+        }
+        source_target_pairs {
+          source: 3
+          target: 2
+        }
+        source_target_pairs {
+          source: 4
+          target: 5
+        }
+        source_target_pairs {
+          source: 5
+          target: 4
+        }
+        source_target_pairs {
+          source: 6
+          target: 7
+        }
+        source_target_pairs {
+          source: 7
+          target: 6
+        }
+        frontend_attributes {
+        }
+        statistics_viz {
+        }
+      }
+      fingerprint: "e00ef2e375e79ce3a18a56da684651bd"
+      network_throughput_bytes_per_sec: 46443383948
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 524288
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "617df37ce5fbbeb886ad387486913bd2"
+      network_throughput_bytes_per_sec: 62734511950
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "76925d8a3b4a506d081fd885b24126eb"
+      network_throughput_bytes_per_sec: 27860984164
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 1048576
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "bcdb32b92ed02a87807bb1839f3142cf"
+      network_throughput_bytes_per_sec: 34033073140
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 32768
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "1ff7a5b620524694d519cb4f1cc2c428"
+      network_throughput_bytes_per_sec: 35564238230
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4526400ba6777f813b834e26ba34cbf0"
+      network_throughput_bytes_per_sec: 150166624897
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "b21eaf2dedc72a5542590064bb4f26bb"
+      network_throughput_bytes_per_sec: 1484595868
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 67108864
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "158a817bc197fa5908085609188b9810"
+      network_throughput_bytes_per_sec: 177174009550
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: BF16
+          dimensions: 8192
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "650508cd9199d62c5d16ff3e25f0dd9f"
+      network_throughput_bytes_per_sec: 3970675552
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: BF16
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "e6ae5e4e282b8bdb0243f76430a739a4"
+      network_throughput_bytes_per_sec: 5313873347
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "reduce-scatter"
+        shape {
+          element_type: F32
+          dimensions: 131072
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "4d2170351e894746020dfac2fcac1a4d"
+      network_throughput_bytes_per_sec: 96411916145
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 2097152
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 2
+          num_devices_per_group: 4
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "f950cb6fec3ae1196c4e2b9969e4649f"
+      network_throughput_bytes_per_sec: 122892001171
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-reduce"
+        shape {
+          element_type: F32
+          dimensions: 2048
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        channel_id: 1
+        id: 4294967297
+        operand_ids: 4294967296
+        called_computation_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 1
+          num_devices_per_group: 8
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "7db0a796043ec024eff5d858a1fb8cee"
+      network_throughput_bytes_per_sec: 197392833
+    }
+    entries {
+      instruction {
+        name: "_"
+        opcode: "all-gather"
+        shape {
+          element_type: F32
+          dimensions: 262144
+          layout {
+            minor_to_major: 0
+            tail_padding_alignment_in_elements: 1
+          }
+          is_dynamic_dimension: false
+        }
+        metadata {
+        }
+        dimensions: 0
+        channel_id: 1
+        id: 1
+        operand_ids: 0
+        frontend_attributes {
+        }
+        use_global_device_ids: true
+        statistics_viz {
+        }
+        iota_collective_device_list {
+          num_replica_groups: 4
+          num_devices_per_group: 2
+          iota_reshape_dims: 8
+          iota_transpose_perm: 0
+        }
+      }
+      fingerprint: "8b64b5d8f00d6d6ee4305d45a2ba83df"
+      network_throughput_bytes_per_sec: 40835579094
+    }
+  }
+}
+entries {
   key: "gfx950"
   value {
     entries {

--- a/xla/service/gpu/model/default_matmul_perf_table.txtpb
+++ b/xla/service/gpu/model/default_matmul_perf_table.txtpb
@@ -8276,6 +8276,8261 @@ entries {
   }
 }
 entries {
+  key: "gfx942"
+  value {
+    entries {
+      b: 1
+      m: 256
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 9103209983722 }
+      flops { key: "bf16xbf16->f32" value: 8957403096636 }
+      flops { key: "f16xf16->f16" value: 10947612398042 }
+      flops { key: "f16xf16->f32" value: 8546722363728 }
+      flops { key: "f32xf32->f32" value: 8015870043000 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 9103209983722 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 9305166943982 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 9253842250413 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 9005483628556 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 9056526855600 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 9628244476327 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 9740038316400 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 7939998106956 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 4898457226277 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 8376043934098 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 8212048947626 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 16424097895252 }
+      flops { key: "bf16xbf16->f32" value: 16031740086000 }
+      flops { key: "f16xf16->f16" value: 15512913546000 }
+      flops { key: "f16xf16->f32" value: 16752087868197 }
+      flops { key: "f32xf32->f32" value: 14824136072454 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 15300698586411 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 15227788518266 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 16586471576866 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 16752087868197 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 14758932043105 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 18010967257112 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 15805196420160 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 15509328403050 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 17449002600104 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 17637020762155 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 16108704752760 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 22714118801827 }
+      flops { key: "bf16xbf16->f32" value: 28037962815959 }
+      flops { key: "f16xf16->f16" value: 29779837585977 }
+      flops { key: "f16xf16->f32" value: 27690886734062 }
+      flops { key: "f32xf32->f32" value: 23346273786745 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 27235740259740 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 29517864086210 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 28274221192332 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 24192092285508 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 26379270440251 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 32529745031507 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 27464237364436 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 26379270440251 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 28508438402718 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 33172943153732 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 26588297939778 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 38623806618705 }
+      flops { key: "bf16xbf16->f32" value: 42140573940345 }
+      flops { key: "f16xf16->f16" value: 42949672960000 }
+      flops { key: "f16xf16->f32" value: 38623806618705 }
+      flops { key: "f32xf32->f32" value: 40494110122190 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 44524043124896 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 38402783404864 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 40488002413273 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 39187657810218 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 39768215703703 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 49820982925018 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 50193615557217 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 42008678560250 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 41361395377503 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 43797594387338 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 42676543084260 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 70344721174004 }
+      flops { key: "bf16xbf16->f32" value: 65209633426454 }
+      flops { key: "f16xf16->f16" value: 62332626494833 }
+      flops { key: "f16xf16->f32" value: 68548379979570 }
+      flops { key: "f32xf32->f32" value: 51647033381433 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 71668790815645 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 74451658854527 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 72053538048584 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 71089898305084 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 72043869028448 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 81965024732824 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 64582089738963 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 75286903940541 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 75711593851360 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 74866951889555 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 73433307618656 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 18610333887964 }
+      flops { key: "bf16xbf16->f32" value: 22943201367521 }
+      flops { key: "f16xf16->f16" value: 16752087868197 }
+      flops { key: "f16xf16->f32" value: 20554016539050 }
+      flops { key: "f32xf32->f32" value: 14257247503717 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 17540215368531 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 17725531959852 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 17540215368531 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 19367637518037 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 17358733574754 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 17632386757750 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 17819666489644 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 16186411963338 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 16921044881492 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 17914806193272 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 16836142498745 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 29779837585977 }
+      flops { key: "bf16xbf16->f32" value: 31454822591985 }
+      flops { key: "f16xf16->f16" value: 32680235695154 }
+      flops { key: "f16xf16->f32" value: 32209677945764 }
+      flops { key: "f32xf32->f32" value: 25870803392444 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 29260459559625 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 27799860811930 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 30462489332728 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 30594421700478 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 34361937532002 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 34717467149508 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 31602949846950 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 31162695147434 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 28514495007435 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 31308077443433 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 34186889454915 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 41624353543184 }
+      flops { key: "bf16xbf16->f32" value: 39417834948604 }
+      flops { key: "f16xf16->f16" value: 38735275036075 }
+      flops { key: "f16xf16->f32" value: 41234325038402 }
+      flops { key: "f32xf32->f32" value: 29007505511130 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 39181937819296 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 38729686336747 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 36026769024292 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 42541276703645 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 37962870315372 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 38397290230296 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 38847388712011 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 41624353543184 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 41747349300155 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 42956546007361 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 34993541389649 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 62917017696003 }
+      flops { key: "bf16xbf16->f32" value: 61901408047964 }
+      flops { key: "f16xf16->f16" value: 66675473422752 }
+      flops { key: "f16xf16->f32" value: 62623458765892 }
+      flops { key: "f32xf32->f32" value: 51941845201238 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 59692118301089 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 63663098778607 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 61476114966220 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 58906178626289 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 60642822997853 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 64902189555125 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 61617228509124 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 62188221012394 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 55836808320332 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 64119301564552 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 63362553050867 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 95384367415830 }
+      flops { key: "bf16xbf16->f32" value: 91320107501275 }
+      flops { key: "f16xf16->f16" value: 96585573805882 }
+      flops { key: "f16xf16->f32" value: 91320107501275 }
+      flops { key: "f32xf32->f32" value: 63142712378712 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 108294687241553 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 80732467969924 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 114789589908060 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 113816178079287 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 81221015431164 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 117812357252578 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 106574870868486 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 117297555604107 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 80369897005988 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 113563386991010 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 110535497632283 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 29786446515756 }
+      flops { key: "bf16xbf16->f32" value: 27577096363262 }
+      flops { key: "f16xf16->f16" value: 42676543084260 }
+      flops { key: "f16xf16->f32" value: 27805620053863 }
+      flops { key: "f32xf32->f32" value: 25003302533532 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 25870803392444 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 26071819735819 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 26908125100240 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 26488598381685 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 28882661502044 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 25575024390243 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 23592499208999 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 33172943153732 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 35264773515501 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 35274041524310 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 33172943153732 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 54693450692746 }
+      flops { key: "bf16xbf16->f32" value: 54917237315875 }
+      flops { key: "f16xf16->f16" value: 54693450692746 }
+      flops { key: "f16xf16->f32" value: 50571864355689 }
+      flops { key: "f32xf32->f32" value: 45737852445050 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 47184998417999 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 48735558460421 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 47359819336626 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 48913166180758 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 56075925631919 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 52551968676585 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 45274996795412 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 49453842299189 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 49092073152889 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 48210390804597 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 49820982925018 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 87580899184339 }
+      flops { key: "bf16xbf16->f32" value: 76357689091167 }
+      flops { key: "f16xf16->f16" value: 75498651666432 }
+      flops { key: "f16xf16->f32" value: 82216066156202 }
+      flops { key: "f32xf32->f32" value: 66841498007968 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 77236500071932 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 87027218674015 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 77683535233685 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 77920306531204 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 82978502627511 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 86731972859450 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 73837286755604 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 85082553407290 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 80249762630792 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 75498651666432 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 79067881001472 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 90549993590824 }
+      flops { key: "bf16xbf16->f32" value: 92747846937894 }
+      flops { key: "f16xf16->f16" value: 93393217708967 }
+      flops { key: "f16xf16->f32" value: 96239295868064 }
+      flops { key: "f32xf32->f32" value: 60849020967924 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 81467513201820 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 98725802133137 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 84420302225017 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 80860141878153 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 110308385453051 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 84553258051815 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 80369897005988 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 82729164342399 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 111453375960141 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 84820430049766 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 83242253197922 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 156067125581395 }
+      flops { key: "bf16xbf16->f32" value: 155165003468208 }
+      flops { key: "f16xf16->f16" value: 148707405858320 }
+      flops { key: "f16xf16->f32" value: 149535801685119 }
+      flops { key: "f32xf32->f32" value: 87168519564864 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 145080640994460 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 292931884872459 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 140523730401779 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 141440008430481 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 264729246548323 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 140330892504737 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 140698660027517 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 145671119793786 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 262144000000000 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 140147728773738 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 140514535627821 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 43094470380478 }
+      flops { key: "bf16xbf16->f32" value: 50006605067064 }
+      flops { key: "f16xf16->f16" value: 53612034351907 }
+      flops { key: "f16xf16->f32" value: 48201733884000 }
+      flops { key: "f32xf32->f32" value: 41747349300155 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 54928474728872 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 55611240107727 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 48735558460421 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 58266866941610 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 47359819336626 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 47857988233196 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 54043780148983 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 51941845201238 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 50193615557217 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 49083096727006 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 51345726090283 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 77014906326208 }
+      flops { key: "bf16xbf16->f32" value: 77470550072150 }
+      flops { key: "f16xf16->f16" value: 75286903940541 }
+      flops { key: "f16xf16->f32" value: 69086464032942 }
+      flops { key: "f32xf32->f32" value: 69624032161846 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 81715511719939 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 78604818740849 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 75498651666432 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 80249762630792 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 80976004826546 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 80490391604197 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 85096039308923 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 74451658854527 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 84813730173775 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 79998645805394 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 81221015431164 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 120740112897784 }
+      flops { key: "bf16xbf16->f32" value: 126129663338423 }
+      flops { key: "f16xf16->f16" value: 127948263107721 }
+      flops { key: "f16xf16->f32" value: 128854173046921 }
+      flops { key: "f32xf32->f32" value: 103693078126508 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 105735285475135 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 109856949457745 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 105735285475135 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 111210960538581 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 117041838238500 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 113816178079287 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 106574870868486 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 111453375960141 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 111441808406850 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 111453375960141 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 111685232369461 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 208980502919423 }
+      flops { key: "bf16xbf16->f32" value: 211034163522012 }
+      flops { key: "f16xf16->f16" value: 202287457422758 }
+      flops { key: "f16xf16->f32" value: 204211073411943 }
+      flops { key: "f32xf32->f32" value: 142387193210449 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 357377874521551 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 350380755098711 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 338239667349188 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 225244771134885 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 217027149873673 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 217027149873673 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 234083676477000 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 363425900829243 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 344700425040128 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 368476947151681 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 376223484232655 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 194580133919267 }
+      flops { key: "bf16xbf16->f32" value: 194580133919267 }
+      flops { key: "f16xf16->f16" value: 194756599827687 }
+      flops { key: "f16xf16->f32" value: 191962424957540 }
+      flops { key: "f32xf32->f32" value: 98271760576593 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 362811902010474 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 360982290805177 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 369046854786045 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 400799486375513 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 376190531312954 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 155383933142795 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 392019650967506 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 370959344964588 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 399308971364819 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 160021136214605 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 369682156653468 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 80976004826546 }
+      flops { key: "bf16xbf16->f32" value: 77014906326208 }
+      flops { key: "f16xf16->f16" value: 78593311667398 }
+      flops { key: "f16xf16->f32" value: 75711593851360 }
+      flops { key: "f32xf32->f32" value: 61617228509124 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 80249762630792 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 88753663746073 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 87296083252032 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 88753663746073 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 85096039308923 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 78604818740849 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 95038221278102 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 85899345920000 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 89642830522624 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 89048086249792 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 87027218674015 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 114057980029742 }
+      flops { key: "bf16xbf16->f32" value: 146067449870765 }
+      flops { key: "f16xf16->f16" value: 151423187702721 }
+      flops { key: "f16xf16->f32" value: 156750631240875 }
+      flops { key: "f32xf32->f32" value: 104898576006252 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 119119350343909 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 105943939220522 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 107643290626566 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 124088966138911 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 113816178079287 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 121560265368504 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 118855636927164 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 119119350343909 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 106999683507722 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 82729164342399 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 118593088579633 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 220594108680020 }
+      flops { key: "bf16xbf16->f32" value: 206171625192012 }
+      flops { key: "f16xf16->f16" value: 201528120120120 }
+      flops { key: "f16xf16->f32" value: 210228453059226 }
+      flops { key: "f32xf32->f32" value: 141626567829585 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 342556013399266 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 362199974363299 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 341466631896962 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 346983947002746 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 349184333008130 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 339308523937430 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 351527852021607 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 352682484480210 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 357377874521551 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 348052455105348 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 362199974363299 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 344175598685792 }
+      flops { key: "bf16xbf16->f32" value: 354428725532266 }
+      flops { key: "f16xf16->f16" value: 327360312195121 }
+      flops { key: "f16xf16->f32" value: 340357183295031 }
+      flops { key: "f32xf32->f32" value: 212516936961900 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 425454907974244 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 500987670127143 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 402301170475833 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 409981605192821 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 519217516441005 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 431438201506780 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 514182604573207 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 426299483473945 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 519217516441005 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 417961005838847 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 529393232589670 }
+    }
+    entries {
+      b: 1
+      m: 256
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 495782903843934 }
+      flops { key: "bf16xbf16->f32" value: 465150516705474 }
+      flops { key: "f16xf16->f16" value: 465629585429314 }
+      flops { key: "f16xf16->f32" value: 453342547603968 }
+      flops { key: "f32xf32->f32" value: 239989232307993 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 590698294044835 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 628792518263670 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 607448878580015 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 611775129406737 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 610037255308571 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 614400585938058 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 580322563977840 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 630685359177679 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 640084544858420 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 600652723026361 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 615280752954659 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 15367269063430 }
+      flops { key: "bf16xbf16->f32" value: 15727411295992 }
+      flops { key: "f16xf16->f16" value: 15158993449288 }
+      flops { key: "f16xf16->f32" value: 17006807906741 }
+      flops { key: "f32xf32->f32" value: 13620634057235 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 16344097418412 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 18206419967444 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 17819666489644 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 16027911153570 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 19825366026587 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 16504885391047 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 17180968766001 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 16836142498745 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 16424097895252 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 16752087868197 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 16420079275752 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 23848210376687 }
+      flops { key: "bf16xbf16->f32" value: 29517864086210 }
+      flops { key: "f16xf16->f16" value: 25771453149001 }
+      flops { key: "f16xf16->f32" value: 26275984338292 }
+      flops { key: "f32xf32->f32" value: 22410707630656 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 29260459559625 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 27021890074491 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 26800664536741 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 31454822591985 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 27125652384801 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 31752478826590 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 27235740259740 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 27346725346373 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 26694058870326 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 30594421700478 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 27577096363262 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 41114329300045 }
+      flops { key: "bf16xbf16->f32" value: 43372993375343 }
+      flops { key: "f16xf16->f16" value: 40366233984962 }
+      flops { key: "f16xf16->f32" value: 38287755812294 }
+      flops { key: "f32xf32->f32" value: 35644065329969 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 49820982925018 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 39533940500736 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 46210269581683 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 45737852445050 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 38287755812294 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 48559235890014 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 47351465161404 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 46051716589466 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 34898005200208 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 47857988233196 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 48029246018965 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 60918065584931 }
+      flops { key: "bf16xbf16->f32" value: 66345886307464 }
+      flops { key: "f16xf16->f16" value: 56667818450496 }
+      flops { key: "f16xf16->f32" value: 71288130659938 }
+      flops { key: "f32xf32->f32" value: 50287646309479 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 54704596698593 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 74877393584379 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 74451658854527 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 73232971218114 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 72825679869777 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 75286903940541 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 73433307618656 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 82722790755007 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 75076340651657 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 76357689091167 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 76575511624589 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 104095184100824 }
+      flops { key: "bf16xbf16->f32" value: 107213362356465 }
+      flops { key: "f16xf16->f16" value: 103284130819545 }
+      flops { key: "f16xf16->f32" value: 109621421541602 }
+      flops { key: "f32xf32->f32" value: 81344077575757 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 112622385567442 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 102105536705971 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 125834035392007 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 103483213569776 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 104297408839242 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 122099365931316 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 113816178079287 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 114300811581860 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 102105536705971 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 120726537440971 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 114544679325794 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 30875943869335 }
+      flops { key: "bf16xbf16->f32" value: 33337736711376 }
+      flops { key: "f16xf16->f16" value: 36611491543917 }
+      flops { key: "f16xf16->f32" value: 32217409505520 }
+      flops { key: "f32xf32->f32" value: 26908125100240 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 29260459559625 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 35274041524310 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 33842089762985 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 33009770782095 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 34361937532002 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 29007505511130 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 29912575885892 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 31602949846950 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 34178183855360 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 32055822307141 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 33337736711376 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 43940981502700 }
+      flops { key: "bf16xbf16->f32" value: 46377929509329 }
+      flops { key: "f16xf16->f16" value: 43094470380478 }
+      flops { key: "f16xf16->f32" value: 42819501674908 }
+      flops { key: "f32xf32->f32" value: 33588020020020 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 40366233984962 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 40610507715582 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 42140573940345 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 40857755859969 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 38397290230296 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 41617900155038 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 39417834948604 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 41495664863193 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 40366233984962 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 40982512366412 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 40124881315396 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 57272339662897 }
+      flops { key: "bf16xbf16->f32" value: 63370032105760 }
+      flops { key: "f16xf16->f16" value: 56193312957923 }
+      flops { key: "f16xf16->f32" value: 63064831669211 }
+      flops { key: "f32xf32->f32" value: 50859313376278 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 60780132684252 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 57641283229546 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 57272339662897 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 58520919119250 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 63663098778607 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 62188221012394 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 63370032105760 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 65857570166830 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 63822029481692 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 70160861474124 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 59958779539870 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 109175579461108 }
+      flops { key: "bf16xbf16->f32" value: 109175579461108 }
+      flops { key: "f16xf16->f16" value: 100764060060060 }
+      flops { key: "f16xf16->f32" value: 102691452180566 }
+      flops { key: "f32xf32->f32" value: 64046634297643 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 108733349265822 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 90094128545057 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 102300097560975 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 110297054340010 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 89642830522624 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 116030022044521 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 113575399196107 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 110752122124806 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 92420539163367 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 110981067080103 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 113335636900992 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 166213904643962 }
+      flops { key: "bf16xbf16->f32" value: 175763926010803 }
+      flops { key: "f16xf16->f16" value: 190768734831660 }
+      flops { key: "f16xf16->f32" value: 172377881521913 }
+      flops { key: "f32xf32->f32" value: 102794679431334 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 176052110837842 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 309837490693983 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 176037679154029 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 182020990676385 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 193886208739617 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 175476683118156 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 182036420106806 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 171551657453267 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 306302046498359 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 174606362143263 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 169373266661408 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 46855551754232 }
+      flops { key: "bf16xbf16->f32" value: 51345726090283 }
+      flops { key: "f16xf16->f16" value: 50763134644478 }
+      flops { key: "f16xf16->f32" value: 49453842299189 }
+      flops { key: "f32xf32->f32" value: 37020473865673 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 52966743488555 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 52551968676585 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 59296544289816 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 46855551754232 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 53388117740652 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 56299382550335 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 54693450692746 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 51941845201238 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 49453842299189 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 57272339662897 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 63205899693901 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 85082553407290 }
+      flops { key: "bf16xbf16->f32" value: 79772795245170 }
+      flops { key: "f16xf16->f16" value: 81221015431164 }
+      flops { key: "f16xf16->f32" value: 85913092014722 }
+      flops { key: "f32xf32->f32" value: 62477704177819 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 93061347200554 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 89048086249792 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 100387231114435 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 92420539163367 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 88170621120052 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 87881963005401 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 86745986750686 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 90245572701294 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 92420539163367 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 94055871058163 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 104287278943278 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 80010568107302 }
+      flops { key: "bf16xbf16->f32" value: 94378291641030 }
+      flops { key: "f16xf16->f16" value: 100764060060060 }
+      flops { key: "f16xf16->f32" value: 95554135801370 }
+      flops { key: "f32xf32->f32" value: 63441171285081 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 87310280045535 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 101718626752557 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 89344468630387 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 82595524923076 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 95046633973621 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 88026055418921 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 84023931763048 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 88170621120052 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 96585573805882 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 87310280045535 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 89943191824426 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 157659764187651 }
+      flops { key: "bf16xbf16->f32" value: 151862219645003 }
+      flops { key: "f16xf16->f16" value: 155603481486848 }
+      flops { key: "f16xf16->f32" value: 159783009523809 }
+      flops { key: "f32xf32->f32" value: 89121997343957 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 153380733376187 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 292931884872459 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 152726239101059 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 150795846359104 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 307222267238912 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 154262168522376 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 155829304694869 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 152293003900432 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 253450212203469 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 152293003900432 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 151007921243231 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 233067467766442 }
+      flops { key: "bf16xbf16->f32" value: 231310173201206 }
+      flops { key: "f16xf16->f16" value: 226432269928300 }
+      flops { key: "f16xf16->f32" value: 214641044277861 }
+      flops { key: "f32xf32->f32" value: 121832675119847 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 235379366251986 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 441188217360041 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 231809547495682 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 233841525344367 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 474372354318533 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 230565132918187 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 229334007689021 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 480797861412739 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 494071930978948 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 236155896849397 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 232060044089042 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 77470550072150 }
+      flops { key: "bf16xbf16->f32" value: 69796010400416 }
+      flops { key: "f16xf16->f16" value: 74451658854527 }
+      flops { key: "f16xf16->f32" value: 85353086168521 }
+      flops { key: "f32xf32->f32" value: 61617228509124 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 89943191824426 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 96058492037931 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 89344468630387 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 88170621120052 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 96058492037931 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 89958262734584 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 95733044222539 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 89344468630387 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 98544587371512 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 89344468630387 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 91788495811249 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 144494929888305 }
+      flops { key: "bf16xbf16->f32" value: 124955408355638 }
+      flops { key: "f16xf16->f16" value: 122113251904924 }
+      flops { key: "f16xf16->f32" value: 121012264623013 }
+      flops { key: "f32xf32->f32" value: 98184146305779 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 118855636927164 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 110535497632283 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 116030022044521 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 121012264623013 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 122113251904924 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 106142924476077 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 123802816095929 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 115035550032140 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 115779795557472 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 116281332466969 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 115035550032140 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 217466698531645 }
+      flops { key: "bf16xbf16->f32" value: 214855792696348 }
+      flops { key: "f16xf16->f16" value: 225694550499211 }
+      flops { key: "f16xf16->f32" value: 218796092511462 }
+      flops { key: "f32xf32->f32" value: 153820188238664 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 472285825379371 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 474372354318533 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 450489542269771 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 299467807558220 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 296982941225280 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 339254920695102 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 351527852021607 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 478601214174281 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 462122584032709 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 460142200128562 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 480851690103000 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 191108271602740 }
+      flops { key: "bf16xbf16->f32" value: 192314838848341 }
+      flops { key: "f16xf16->f16" value: 193353770134605 }
+      flops { key: "f16xf16->f32" value: 192832905131773 }
+      flops { key: "f32xf32->f32" value: 97868686248148 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 480744044772778 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 436702317844433 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 458178717303179 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 443924268320413 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 435816062506341 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 182959203237486 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 440328818535985 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 438530457014498 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 403814149680330 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 178688937260775 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 455264712317150 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 297198719579282 }
+      flops { key: "bf16xbf16->f32" value: 285143056995850 }
+      flops { key: "f16xf16->f16" value: 281775777989175 }
+      flops { key: "f16xf16->f32" value: 272290062192918 }
+      flops { key: "f32xf32->f32" value: 134060625704252 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 648786600604229 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 635350191715976 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 606590960525386 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 594006956088790 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 638182361961367 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 274913095820265 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 581895040780382 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 604839782565835 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 634411712850812 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 273503823733562 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 646832424096385 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 145276934650250 }
+      flops { key: "bf16xbf16->f32" value: 144884877074618 }
+      flops { key: "f16xf16->f16" value: 152282204509998 }
+      flops { key: "f16xf16->f32" value: 150152681303314 }
+      flops { key: "f32xf32->f32" value: 102300097560975 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 244811177382580 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 266701893691008 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 276310299536798 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 119132566736935 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 110981067080103 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 116281332466969 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 109845710895140 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 128238603129105 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 103683065276168 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 115282566459093 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 114789589908060 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 222421921077162 }
+      flops { key: "bf16xbf16->f32" value: 229579179816121 }
+      flops { key: "f16xf16->f16" value: 220141839876986 }
+      flops { key: "f16xf16->f32" value: 217466698531645 }
+      flops { key: "f32xf32->f32" value: 133849641485913 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 316271524005891 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 387073476568132 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 341412344674085 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 335020849921996 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 339254920695102 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 338186401259842 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 365902819560402 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 339254920695102 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 356192344999170 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 353844726973142 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 348108874696060 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 359171039973239 }
+      flops { key: "bf16xbf16->f32" value: 355602524921344 }
+      flops { key: "f16xf16->f16" value: 339818600838673 }
+      flops { key: "f16xf16->f32" value: 355014654984294 }
+      flops { key: "f32xf32->f32" value: 216164240575771 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 696104910210696 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 757757109386026 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 736953894303363 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 659749200614439 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 752315168330705 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 785473170446232 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 834460325626578 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 680768314471390 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 837715485859176 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 806112480480480 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 812210154311649 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 483476928688017 }
+      flops { key: "bf16xbf16->f32" value: 498661011958667 }
+      flops { key: "f16xf16->f16" value: 454782644642100 }
+      flops { key: "f16xf16->f32" value: 462620346402412 }
+      flops { key: "f32xf32->f32" value: 246752113983683 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 932269871065769 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 959447625600357 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 955180094740353 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 904775078154624 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 990422528767439 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 955073892817433 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 922260531672750 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 916357434606358 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1001975340254286 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 916357434606358 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 813749014020462 }
+    }
+    entries {
+      b: 1
+      m: 512
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 327372788292236 }
+      flops { key: "bf16xbf16->f32" value: 330910283413910 }
+      flops { key: "f16xf16->f16" value: 309313117712721 }
+      flops { key: "f16xf16->f32" value: 301909693237733 }
+      flops { key: "f32xf32->f32" value: 144422048354013 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 742592141084936 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 686727792461126 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 697886386805865 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 691148134690429 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 699022223379582 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 307756107410923 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 730591927875824 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 688930873160364 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 657753711244687 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 302228365069312 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 684511482349191 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 24275226623259 }
+      flops { key: "bf16xbf16->f32" value: 30317986898576 }
+      flops { key: "f16xf16->f16" value: 25672863045141 }
+      flops { key: "f16xf16->f32" value: 25477928625664 }
+      flops { key: "f32xf32->f32" value: 18255947769314 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 26800664536741 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 28514495007435 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 34361937532002 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 26694058870326 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 27131135637760 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 31162695147434 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 31911014740846 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 26173503900156 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 27921308092365 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 34013615813482 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 33337736711376 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 37861136248236 }
+      flops { key: "bf16xbf16->f32" value: 37020473865673 }
+      flops { key: "f16xf16->f16" value: 41747349300155 }
+      flops { key: "f16xf16->f32" value: 40245195802098 }
+      flops { key: "f32xf32->f32" value: 34274189989785 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 54482536228942 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 41495664863193 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 41617900155038 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 41884140427523 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 35834395407822 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 59559675171954 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 54471480519480 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 36716653809328 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 46210269581683 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 45894247905624 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 39533940500736 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 68200065040650 }
+      flops { key: "bf16xbf16->f32" value: 69443915664209 }
+      flops { key: "f16xf16->f16" value: 62924391936240 }
+      flops { key: "f16xf16->f32" value: 76357689091167 }
+      flops { key: "f32xf32->f32" value: 52250210413625 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 75498651666432 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 61056625952462 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 64280521072796 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 74658727854262 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 67176040040040 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 77920306531204 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 66019541564190 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 66510271555996 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 70160861474124 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 71468438764643 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 65376389673648 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 108733349265822 }
+      flops { key: "bf16xbf16->f32" value: 109845710895140 }
+      flops { key: "f16xf16->f16" value: 104085093447072 }
+      flops { key: "f16xf16->f32" value: 116281332466969 }
+      flops { key: "f32xf32->f32" value: 82474984561026 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 118868794863279 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 112151851263839 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 117041838238500 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 115779795557472 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 169119833674594 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 108733349265822 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 113575399196107 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 124088966138911 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 166989397200622 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 117041838238500 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 122391636156388 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 174606362143263 }
+      flops { key: "bf16xbf16->f32" value: 170178591647515 }
+      flops { key: "f16xf16->f16" value: 184856989584230 }
+      flops { key: "f16xf16->f32" value: 156282923222472 }
+      flops { key: "f32xf32->f32" value: 91091565132555 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 159783009523809 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 269378279979929 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 148697108987674 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 154929921939254 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 209388031201248 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 157209637481698 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 156294297525473 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 158369000589970 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 282861386722866 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 159072862814814 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 155378311844294 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 34898005200208 }
+      flops { key: "bf16xbf16->f32" value: 42676543084260 }
+      flops { key: "f16xf16->f16" value: 34812016080923 }
+      flops { key: "f16xf16->f32" value: 42147190453760 }
+      flops { key: "f32xf32->f32" value: 30321411498926 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 43094470380478 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 39073574381368 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 48037841088045 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 48913166180758 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 50193615557217 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 47519110639051 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 41617900155038 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 42541276703645 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 50382030030030 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 52758540880503 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 53176595879556 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 57517775016070 }
+      flops { key: "bf16xbf16->f32" value: 57641283229546 }
+      flops { key: "f16xf16->f16" value: 57641283229546 }
+      flops { key: "f16xf16->f32" value: 57394794954030 }
+      flops { key: "f32xf32->f32" value: 49453842299189 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 71659224773091 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 66675473422752 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 68900271047227 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 64582089738963 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 67008351472790 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 69987082779298 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 64126960344003 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 68732673409294 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 71860649444518 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 69255793601651 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 72053538048584 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 107643290626566 }
+      flops { key: "bf16xbf16->f32" value: 97109688342226 }
+      flops { key: "f16xf16->f16" value: 101718626752557 }
+      flops { key: "f16xf16->f32" value: 102495401298205 }
+      flops { key: "f32xf32->f32" value: 64123130725589 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 119930953200044 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 89048086249792 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 113096884769328 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 121560265368504 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 89943191824426 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 118855636927164 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 116787233413095 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 114300811581860 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 89048086249792 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 114544679325794 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 119650303543570 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 182330077092885 }
+      flops { key: "bf16xbf16->f32" value: 179585519986619 }
+      flops { key: "f16xf16->f16" value: 155153792934036 }
+      flops { key: "f16xf16->f32" value: 172641180802315 }
+      flops { key: "f32xf32->f32" value: 103788296747378 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 181712950414621 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 185159824797378 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 182036420106806 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 180188257090115 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 190430402411989 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 180795053712746 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 179585519986619 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 188756583282060 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 183263666837344 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 178096172499585 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 182330077092885 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 233587170065807 }
+      flops { key: "bf16xbf16->f32" value: 252570849514848 }
+      flops { key: "f16xf16->f16" value: 273147245993385 }
+      flops { key: "f16xf16->f32" value: 242831870639452 }
+      flops { key: "f32xf32->f32" value: 112442529413304 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 222433440157439 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 482906149763885 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 224057973603213 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 222664072580227 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 486241061474017 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 223358848406053 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 223591404862304 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 281766535196483 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 403056240240240 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 218807239085027 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 218140448778505 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 70902127839408 }
+      flops { key: "bf16xbf16->f32" value: 69615004149377 }
+      flops { key: "f16xf16->f16" value: 68200065040650 }
+      flops { key: "f16xf16->f32" value: 74658727854262 }
+      flops { key: "f32xf32->f32" value: 59296544289816 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 80976004826546 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 93061347200554 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 86745986750686 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 93711103508465 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 90856475207310 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 91165038546442 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 79301464106351 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 93061347200554 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 84813730173775 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 79067881001472 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 91165038546442 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 98004912741876 }
+      flops { key: "bf16xbf16->f32" value: 97285659508924 }
+      flops { key: "f16xf16->f16" value: 73634743107941 }
+      flops { key: "f16xf16->f32" value: 97648401600582 }
+      flops { key: "f32xf32->f32" value: 58716127522283 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 86879344930819 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 154473000143864 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 88170621120052 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 90253158275195 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 172377881521913 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 88900631230336 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 89344468630387 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 88170621120052 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 141822985602958 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 88607181383066 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 91320107501275 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 161708106024096 }
+      flops { key: "bf16xbf16->f32" value: 159545590490341 }
+      flops { key: "f16xf16->f16" value: 129179718960538 }
+      flops { key: "f16xf16->f32" value: 146266424737774 }
+      flops { key: "f32xf32->f32" value: 84089734826533 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 158135762002945 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 184222668611134 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 153820188238664 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 161222496096096 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 185816703988924 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 161952009653092 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 159545590490341 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 156979798830409 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 176341242240105 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 159545590490341 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 156294297525473 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 252274143671071 }
+      flops { key: "bf16xbf16->f32" value: 254064909553386 }
+      flops { key: "f16xf16->f16" value: 238516537790859 }
+      flops { key: "f16xf16->f32" value: 239848511531803 }
+      flops { key: "f32xf32->f32" value: 121422800407101 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 384957183472259 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 409239380276322 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 239060853612378 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 239580927985719 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 412343250384024 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 236676436656196 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 232060044089042 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 238781747706677 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 428853449425861 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 234864510089134 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 235637641740275 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 336899815350825 }
+      flops { key: "bf16xbf16->f32" value: 320759320089619 }
+      flops { key: "f16xf16->f16" value: 321961566416791 }
+      flops { key: "f16xf16->f32" value: 295359302410342 }
+      flops { key: "f32xf32->f32" value: 124705069423071 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 524288000000000 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 725623804020949 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 783967745915852 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 772684590447063 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 537408320320320 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 299687213201688 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 721964581610354 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 754959974687994 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 733117230690449 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 302005224202791 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 791188596481532 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 141449324726649 }
+      flops { key: "bf16xbf16->f32" value: 136400130081300 }
+      flops { key: "f16xf16->f16" value: 132691772614928 }
+      flops { key: "f16xf16->f32" value: 129788688988275 }
+      flops { key: "f32xf32->f32" value: 96943104369808 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 234083676477000 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 220571451109285 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 204600195121951 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 233067467766442 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 230071100064281 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 227150798392214 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 232060044089042 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 111453375960141 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 120469182542353 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 108076680825364 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 112386625915846 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 211866973954222 }
+      flops { key: "bf16xbf16->f32" value: 228577290899414 }
+      flops { key: "f16xf16->f16" value: 198546934911242 }
+      flops { key: "f16xf16->f32" value: 206568261639091 }
+      flops { key: "f32xf32->f32" value: 136573622996692 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 288989859776611 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 268704160160160 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 325870052807283 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 301147615762165 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 280643445896497 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 297806635418111 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 409200390243902 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 300305362606628 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 310779109696092 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 345866266387502 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 365902819560402 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 206181522538524 }
+      flops { key: "bf16xbf16->f32" value: 199840279918109 }
+      flops { key: "f16xf16->f16" value: 198546934911242 }
+      flops { key: "f16xf16->f32" value: 196188895304220 }
+      flops { key: "f32xf32->f32" value: 94295409150785 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 186462068941564 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 360376514180231 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 460142200128562 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 427147418796618 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 397829501296776 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 188260160252476 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 186130760390032 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 183741916406417 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 387737410490204 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 188756583282060 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 189255631268176 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 293542514164644 }
+      flops { key: "bf16xbf16->f32" value: 293342027524502 }
+      flops { key: "f16xf16->f16" value: 292134899741531 }
+      flops { key: "f16xf16->f32" value: 289574386192017 }
+      flops { key: "f32xf32->f32" value: 135032140597981 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 516687795007518 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 568042229334744 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 548422051458852 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 546990231278655 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 581107738601001 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 287635098848111 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 584269799483063 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 560590915094955 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 545600520325203 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 292134899741531 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 549791000512032 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 395995509496588 }
+      flops { key: "bf16xbf16->f32" value: 385319813035482 }
+      flops { key: "f16xf16->f16" value: 359780301648133 }
+      flops { key: "f16xf16->f32" value: 361445565715007 }
+      flops { key: "f32xf32->f32" value: 138454656834538 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 727498165742113 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 791954509934080 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 734339353879034 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 978018284413070 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 748447729546048 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 362368048597342 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 903823084175084 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 745815896852615 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 753040641009906 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 360997461315402 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 759029300344614 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 203823429005315 }
+      flops { key: "bf16xbf16->f32" value: 210228453059226 }
+      flops { key: "f16xf16->f16" value: 203823429005315 }
+      flops { key: "f16xf16->f32" value: 217908031253170 }
+      flops { key: "f32xf32->f32" value: 133350946845504 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 450395060402684 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 376223484232655 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 400052840536512 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 458178717303179 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 423733947908445 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 427189904117764 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 385613871072005 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 378811721291233 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 376157584165352 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 377479987343997 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 430530001603849 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 355014654984294 }
+      flops { key: "bf16xbf16->f32" value: 327860098931297 }
+      flops { key: "f16xf16->f16" value: 349241120182143 }
+      flops { key: "f16xf16->f32" value: 315342679588839 }
+      flops { key: "f32xf32->f32" value: 182803460140455 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 831069523219814 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 731805639120804 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 719545534595409 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 752315168330705 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 670041699843993 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 714755749043102 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 741918689929176 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 754959974687994 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 616119250609668 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 726851801658487 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 741918689929176 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 508129819106773 }
+      flops { key: "bf16xbf16->f32" value: 505736508213129 }
+      flops { key: "f16xf16->f16" value: 485663741278905 }
+      flops { key: "f16xf16->f32" value: 482390890773291 }
+      flops { key: "f32xf32->f32" value: 251970742776685 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 906685095207937 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 610037255308571 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 836003366618004 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 574885195556150 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 407666204356698 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 528806611179512 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 542842175935288 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 559860170240500 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 435396350144457 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 509334989149125 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 491246402379046 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 339556659432750 }
+      flops { key: "bf16xbf16->f32" value: 344051531701846 }
+      flops { key: "f16xf16->f16" value: 313839155002648 }
+      flops { key: "f16xf16->f32" value: 327123446894398 }
+      flops { key: "f32xf32->f32" value: 144860443724914 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 651764831139269 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 666454697183645 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 688378778859638 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 670617112342883 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 641518640179238 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 318972691867805 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 698453843314225 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 679126741668972 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 627919195321637 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 319684949460364 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 680202287840994 }
+    }
+    entries {
+      b: 1
+      m: 1024
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 433851514173516 }
+      flops { key: "bf16xbf16->f32" value: 418709720427486 }
+      flops { key: "f16xf16->f16" value: 384285536259115 }
+      flops { key: "f16xf16->f32" value: 410099044781819 }
+      flops { key: "f32xf32->f32" value: 154127925214192 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1068134119870678 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1026583160083657 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1057580669395795 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1019274350875111 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 995617002347077 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 403439575986003 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1039031672200550 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1060878670124737 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1004935169138077 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 397737398342362 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1015658834407330 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 38507453163104 }
+      flops { key: "bf16xbf16->f32" value: 37538170325828 }
+      flops { key: "f16xf16->f16" value: 39187657810218 }
+      flops { key: "f16xf16->f32" value: 39181937819296 }
+      flops { key: "f32xf32->f32" value: 30253066155753 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 50571864355689 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 49272293685756 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 53398738014720 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 52143639471639 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 49627557034572 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 43655140022767 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 49272293685756 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 48735558460421 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 49272293685756 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 61766096640589 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 53388117740652 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 65857570166830 }
+      flops { key: "bf16xbf16->f32" value: 63213341810903 }
+      flops { key: "f16xf16->f16" value: 61901408047964 }
+      flops { key: "f16xf16->f32" value: 69086464032942 }
+      flops { key: "f32xf32->f32" value: 49362901066568 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 75498651666432 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 87027218674015 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 81715511719939 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 86466566596875 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 70902127839408 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 88461181743285 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 83235800310077 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 73232971218114 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 86452642834138 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 81965024732824 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 62332626494833 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 93393217708967 }
+      flops { key: "bf16xbf16->f32" value: 99090238464378 }
+      flops { key: "f16xf16->f16" value: 94047632828238 }
+      flops { key: "f16xf16->f32" value: 89493400900150 }
+      flops { key: "f32xf32->f32" value: 72053538048584 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 116533733883221 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 100199871593878 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 112151851263839 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 115530646008177 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 114057980029742 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 129491295706705 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 123503775477340 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 117825285196971 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 102888254503641 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 124955408355638 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 104500420827250 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 192495845105772 }
+      flops { key: "bf16xbf16->f32" value: 166471600620155 }
+      flops { key: "f16xf16->f16" value: 192134172676031 }
+      flops { key: "f16xf16->f32" value: 163930049465648 }
+      flops { key: "f32xf32->f32" value: 92747846937894 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 140147728773738 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 233067467766442 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 155153792934036 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 146866615237313 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 306345741512125 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 151862219645003 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 160499525261584 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 315342679588839 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 295349147022417 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 157209637481698 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 161708106024096 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 240398930706369 }
+      flops { key: "bf16xbf16->f32" value: 206578197104516 }
+      flops { key: "f16xf16->f16" value: 258966975942116 }
+      flops { key: "f16xf16->f32" value: 199654485682409 }
+      flops { key: "f32xf32->f32" value: 126882342570162 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 198363536670977 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 405338551906379 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 488453007619697 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 440283679753972 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 396360953857512 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 193179836099491 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 487344524679450 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 200399743187756 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 300305362606628 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 188425344213389 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 502159160060797 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 54147343620776 }
+      flops { key: "bf16xbf16->f32" value: 55611240107727 }
+      flops { key: "f16xf16->f16" value: 52867642737567 }
+      flops { key: "f16xf16->f32" value: 54810710770801 }
+      flops { key: "f32xf32->f32" value: 39709386982248 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 62477704177819 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 62332626494833 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 74658727854262 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 72247464944152 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 68900271047227 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 67008351472790 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 66345886307464 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 68909114619432 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 67684179525970 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 65696391581008 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 75936479773691 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 101334637976594 }
+      flops { key: "bf16xbf16->f32" value: 96412123911286 }
+      flops { key: "f16xf16->f16" value: 97109688342226 }
+      flops { key: "f16xf16->f32" value: 94544494496786 }
+      flops { key: "f32xf32->f32" value: 64276673091888 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 118084441218519 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 90245572701294 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 115779795557472 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 122377686801914 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 93222940093766 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 125834035392007 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 119663638025186 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 118868794863279 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 90101688680036 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 124955408355638 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 110992539177175 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 176341242240105 }
+      flops { key: "bf16xbf16->f32" value: 168575527749430 }
+      flops { key: "f16xf16->f16" value: 145473760195095 }
+      flops { key: "f16xf16->f32" value: 161222496096096 }
+      flops { key: "f32xf32->f32" value: 101048543572369 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 174620560091071 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 262144000000000 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 184222668611134 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 174890760485381 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 261473718251552 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 177507327492147 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 180188257090115 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 179886383648852 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 316271524005891 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 178392062468848 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 178096172499585 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 269716609897010 }
+      flops { key: "bf16xbf16->f32" value: 250801009985401 }
+      flops { key: "f16xf16->f16" value: 268368363909022 }
+      flops { key: "f16xf16->f32" value: 233080115916861 }
+      flops { key: "f32xf32->f32" value: 110133014410995 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 212097150419753 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 339818600838673 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 544217853015712 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 433178748966212 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 345866266387502 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 218584523181841 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 217687141206284 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 521740439261418 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 508099762924405 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 221744400640198 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 220832294513856 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 349795764629229 }
+      flops { key: "bf16xbf16->f32" value: 297404514489492 }
+      flops { key: "f16xf16->f16" value: 340370669730950 }
+      flops { key: "f16xf16->f32" value: 288020875536480 }
+      flops { key: "f32xf32->f32" value: 167067344639800 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 637235503857566 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 594788435950699 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 693967894005493 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 627873298150720 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 602337465254891 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 286665596262306 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 751065366092506 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 516687795007518 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 588271099301465 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 285522173574871 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 708798959650136 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 111685232369461 }
+      flops { key: "bf16xbf16->f32" value: 106153418091942 }
+      flops { key: "f16xf16->f16" value: 105735285475135 }
+      flops { key: "f16xf16->f32" value: 99641965850037 }
+      flops { key: "f32xf32->f32" value: 60707967659863 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 87452502361948 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 193536738284066 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 91327874797992 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 91953568896120 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 188078792082676 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 84686633330704 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 89792759993309 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 90397526856373 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 183576991622499 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 88900631230336 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 91475704890100 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 123234457018248 }
+      flops { key: "bf16xbf16->f32" value: 157903209411764 }
+      flops { key: "f16xf16->f16" value: 149744344745833 }
+      flops { key: "f16xf16->f32" value: 151220593479332 }
+      flops { key: "f32xf32->f32" value: 78144305083512 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 161708106024096 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 275601084188911 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 159545590490341 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 160021136214605 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 261505558694593 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 155378311844294 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 159783009523809 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 160259973731343 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 314419274963396 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 158591215419836 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 155378311844294 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 251963351871406 }
+      flops { key: "bf16xbf16->f32" value: 254969860255268 }
+      flops { key: "f16xf16->f16" value: 242571291991415 }
+      flops { key: "f16xf16->f32" value: 245904459864880 }
+      flops { key: "f32xf32->f32" value: 120740112897784 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 235121656320140 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 342528694154238 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 233828794425087 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 239313940825764 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 354399479825068 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 232575258352737 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 235896484648761 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 236676436656196 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 419635300048852 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 233067467766442 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 242010891756353 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 342269378491453 }
+      flops { key: "bf16xbf16->f32" value: 319566019047619 }
+      flops { key: "f16xf16->f16" value: 329128878194566 }
+      flops { key: "f16xf16->f32" value: 316504590714812 }
+      flops { key: "f32xf32->f32" value: 139241292765557 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 643923132833583 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 438956236496499 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 759029300344614 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 786912293147673 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 664907081972288 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 301168732627445 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 747145741671740 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 768536690704124 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 418388514538989 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 302015842486463 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 459158359632242 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 440080669706439 }
+      flops { key: "bf16xbf16->f32" value: 400052840536512 }
+      flops { key: "f16xf16->f16" value: 395986382021436 }
+      flops { key: "f16xf16->f32" value: 364057410129264 }
+      flops { key: "f32xf32->f32" value: 194805184079827 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 822357435450672 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 820002347572908 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 819963210385643 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 829504571676886 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 806907575219576 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 396727073341954 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 794922690357209 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 766513594074867 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 812978855953057 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 386359672198983 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 921271406263406 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 220616770906102 }
+      flops { key: "bf16xbf16->f32" value: 216153361650729 }
+      flops { key: "f16xf16->f16" value: 208574557886557 }
+      flops { key: "f16xf16->f32" value: 210640867876410 }
+      flops { key: "f32xf32->f32" value: 139049705257705 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 404574914845516 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 409200390243902 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 422068327044025 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 372245388802218 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 444889920861818 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 448607405055358 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 400052840536512 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 434010438156831 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 454301596784429 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 464120088178085 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 374844414033862 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 198730672589302 }
+      flops { key: "bf16xbf16->f32" value: 196368292611558 }
+      flops { key: "f16xf16->f16" value: 196000880573175 }
+      flops { key: "f16xf16->f32" value: 194580133919267 }
+      flops { key: "f32xf32->f32" value: 90898778751322 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 388438753368906 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 328864264624808 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 340897475672672 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 337681208900070 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 333486085565649 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 183115211937753 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 337681208900070 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 329899938244104 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 334525063945790 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 188425344213389 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 331401797530864 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 299061191101208 }
+      flops { key: "bf16xbf16->f32" value: 298240906603708 }
+      flops { key: "f16xf16->f16" value: 291936330614464 }
+      flops { key: "f16xf16->f32" value: 291540001086071 }
+      flops { key: "f32xf32->f32" value: 135117101204895 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 585863769744918 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 503336141568030 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 438956236496499 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 432306723301459 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 589077944863530 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 286102271249666 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 567254480089810 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 431438201506780 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 464145166261414 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 288601484746673 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 459649753424657 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 385665810263547 }
+      flops { key: "bf16xbf16->f32" value: 381715492790010 }
+      flops { key: "f16xf16->f16" value: 369865210962561 }
+      flops { key: "f16xf16->f32" value: 362215247396162 }
+      flops { key: "f32xf32->f32" value: 149403158396382 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 768571072518230 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 940486625280560 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 927238189982728 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 932269871065769 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 964835964506346 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 372430991003490 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 962673382494676 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 970230371265601 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 954066151163436 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 367334541769120 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 939458040356537 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 497232183844172 }
+      flops { key: "bf16xbf16->f32" value: 473613860726691 }
+      flops { key: "f16xf16->f16" value: 459532952187345 }
+      flops { key: "f16xf16->f32" value: 420760685859835 }
+      flops { key: "f32xf32->f32" value: 217309905308827 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1139059783457649 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 991565807687868 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1339143283498324 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1122647140037901 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1143647262947676 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 501440973234873 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1076196898173959 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1034651400764852 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 930275845891430 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 496944525295768 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 941001762830695 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 337681208900070 }
+      flops { key: "bf16xbf16->f32" value: 349212724286527 }
+      flops { key: "f16xf16->f16" value: 339281720199067 }
+      flops { key: "f16xf16->f32" value: 337681208900070 }
+      flops { key: "f32xf32->f32" value: 185327607162891 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 592327581850779 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 771366252873563 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 800105681073025 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 532082172447968 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 636291451259259 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 747210733472512 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 741918689929176 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 749688828067725 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 782610658892128 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 774007442061632 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 760440385269121 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 503336141568030 }
+      flops { key: "bf16xbf16->f32" value: 492372726814169 }
+      flops { key: "f16xf16->f16" value: 496930151104940 }
+      flops { key: "f16xf16->f32" value: 482390890773291 }
+      flops { key: "f32xf32->f32" value: 218024178075585 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 655720197862595 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 718342079946479 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 696217749392121 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 632543048011782 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 728145680427227 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 740639299189515 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 728083962705543 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 619764400577200 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 741982775503152 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 704208443351369 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 718342079946479 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 341996838475932 }
+      flops { key: "bf16xbf16->f32" value: 324890205639289 }
+      flops { key: "f16xf16->f16" value: 323178938354747 }
+      flops { key: "f16xf16->f32" value: 322209140906618 }
+      flops { key: "f32xf32->f32" value: 139624921238916 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 778320535677071 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 891580735066687 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 865484593652393 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 893481858955689 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 870792700288914 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 319566019047619 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 883329178055427 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 844178132966439 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 814520632656931 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 321846965735588 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 848346708014419 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 426834350339755 }
+      flops { key: "bf16xbf16->f32" value: 428965884318156 }
+      flops { key: "f16xf16->f16" value: 411277151776309 }
+      flops { key: "f16xf16->f32" value: 391474744992594 }
+      flops { key: "f32xf32->f32" value: 164820204386284 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1076196898173959 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1015658834407330 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1153630753693258 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1007882971106743 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1166160004344284 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 415861665250596 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1072133623564653 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1047904430388240 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1162215477202002 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 417382210927820 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1174973100160722 }
+    }
+    entries {
+      b: 1
+      m: 2048
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 483769635593101 }
+      flops { key: "bf16xbf16->f32" value: 477109250907778 }
+      flops { key: "f16xf16->f16" value: 456477396730502 }
+      flops { key: "f16xf16->f32" value: 448540058456859 }
+      flops { key: "f32xf32->f32" value: 220239909288156 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1439724219815214 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1389029909971095 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1437315193909351 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1354478697861437 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1375655137446450 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 578661092795311 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1451308906779303 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1415962184455617 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1369623245824530 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 577688193416053 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1420058619937179 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 63966509233885 }
+      flops { key: "bf16xbf16->f32" value: 63362553050867 }
+      flops { key: "f16xf16->f16" value: 62917017696003 }
+      flops { key: "f16xf16->f32" value: 61758991372368 }
+      flops { key: "f32xf32->f32" value: 43510082826809 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 72442438537309 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 85353086168521 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 72053538048584 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 65376389673648 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 83768280855047 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 71860649444518 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 85353086168521 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 82468650076804 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 75498651666432 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 87027218674015 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 90245572701294 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 124955408355638 }
+      flops { key: "bf16xbf16->f32" value: 112859136430523 }
+      flops { key: "f16xf16->f16" value: 120740112897784 }
+      flops { key: "f16xf16->f32" value: 113816178079287 }
+      flops { key: "f32xf32->f32" value: 60231212430582 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 110535497632283 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 108954015626585 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 115543078015710 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 110535497632283 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 107213362356465 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 108076680825364 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 105735285475135 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 115779795557472 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 105735285475135 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 111441808406850 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 104898576006252 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 178096172499585 }
+      flops { key: "bf16xbf16->f32" value: 153380733376187 }
+      flops { key: "f16xf16->f16" value: 166743042782824 }
+      flops { key: "f16xf16->f32" value: 154929921939254 }
+      flops { key: "f32xf32->f32" value: 85635588308011 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 132201652794878 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 267365992031872 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 136235719596523 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 135890884515598 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 291342239587572 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 152293003900432 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 155614757101449 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 139058709318137 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 273495115639327 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 145671119793786 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 150584366313722 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 245342585170798 }
+      flops { key: "bf16xbf16->f32" value: 216371148413098 }
+      flops { key: "f16xf16->f16" value: 254064909553386 }
+      flops { key: "f16xf16->f32" value: 205000586893227 }
+      flops { key: "f32xf32->f32" value: 117754216592641 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 467148933652382 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 397057159656096 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 446694466562662 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 486186019470228 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 390593606402328 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 168575527749430 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 500987670127143 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 438485686166411 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 389142638035698 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 166226770493072 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 465125329867879 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 299896470062493 }
+      flops { key: "bf16xbf16->f32" value: 252274143671071 }
+      flops { key: "f16xf16->f16" value: 310543168793608 }
+      flops { key: "f16xf16->f32" value: 239320608252305 }
+      flops { key: "f32xf32->f32" value: 128825186220549 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 526860561334641 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 490685170341597 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 519186134300392 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 562794640110070 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 426723029905613 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 199561718055942 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 641039894925373 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 609172015601730 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 524896705896730 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 200119620538626 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 577202969493347 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 127024940731101 }
+      flops { key: "bf16xbf16->f32" value: 122391636156388 }
+      flops { key: "f16xf16->f16" value: 119930953200044 }
+      flops { key: "f16xf16->f32" value: 118593088579633 }
+      flops { key: "f32xf32->f32" value: 68552756432356 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 127628886722928 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 92103433178932 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 139248064323693 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 121546504867557 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 93719282883826 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 134352080080080 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 137800542094455 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 118868794863279 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 183576991622499 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 134352080080080 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 134352080080080 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 185479672482294 }
+      flops { key: "bf16xbf16->f32" value: 180491145402588 }
+      flops { key: "f16xf16->f16" value: 184856989584230 }
+      flops { key: "f16xf16->f32" value: 175190377549355 }
+      flops { key: "f32xf32->f32" value: 84890842708621 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 166226770493072 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 289730659471127 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 172377881521913 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 176052110837842 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 279184041601664 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 178392062468848 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 154706696059361 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 176922363486571 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 233067467766442 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 171537954149692 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 169373266661408 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 255881280667262 }
+      flops { key: "bf16xbf16->f32" value: 248752884049577 }
+      flops { key: "f16xf16->f16" value: 263753825595676 }
+      flops { key: "f16xf16->f32" value: 246186363407084 }
+      flops { key: "f32xf32->f32" value: 112796893032539 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 490685170341597 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 441188217360041 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 440283679753972 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 495211264383719 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 503336141568030 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 211679019024149 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 450489542269771 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 473326790390125 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 489566544625555 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 207576593494756 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 467148933652382 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 339549948296308 }
+      flops { key: "bf16xbf16->f32" value: 306334816589993 }
+      flops { key: "f16xf16->f16" value: 335046984632186 }
+      flops { key: "f16xf16->f32" value: 282703129570511 }
+      flops { key: "f32xf32->f32" value: 150318218426809 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 645859743759398 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 512985045804717 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 693967894005493 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 578758562996900 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 517933951884232 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 269894573538190 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 683966445736125 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 553332555526926 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 524288000000000 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 270574687120042 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 692848410388772 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 423358038048299 }
+      flops { key: "bf16xbf16->f32" value: 354721448298645 }
+      flops { key: "f16xf16->f16" value: 393276009156670 }
+      flops { key: "f16xf16->f32" value: 334655391616019 }
+      flops { key: "f32xf32->f32" value: 173067274965497 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 775509826389202 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 606590960525386 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 995011536198308 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 650777271260275 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 708272970976253 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 304478044520062 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 858564177111444 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 663341024132205 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 699022223379582 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 306547993219492 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 967008284588539 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 155840613062409 }
+      flops { key: "bf16xbf16->f32" value: 161222496096096 }
+      flops { key: "f16xf16->f16" value: 150373478607940 }
+      flops { key: "f16xf16->f32" value: 159545590490341 }
+      flops { key: "f32xf32->f32" value: 81405748597422 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 155614757101449 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 292931884872459 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 166484506395844 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 149733903779110 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 323904019306184 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 172377881521913 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 170719743063836 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 153831206876790 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 305430756364670 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 166484506395844 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 168840604450035 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 243949068272179 }
+      flops { key: "bf16xbf16->f32" value: 249330505979333 }
+      flops { key: "f16xf16->f16" value: 242845600814203 }
+      flops { key: "f16xf16->f32" value: 239047548060332 }
+      flops { key: "f32xf32->f32" value: 99090238464378 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 224538231702216 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 466134935532884 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 227391322321050 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 225955771043771 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 433178748966212 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 229334007689021 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 224526493596110 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 225008764459346 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 473326790390125 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 226910782755705 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 230565132918187 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 340897475672672 }
+      flops { key: "bf16xbf16->f32" value: 325142306370415 }
+      flops { key: "f16xf16->f16" value: 325635338413131 }
+      flops { key: "f16xf16->f32" value: 304802164218295 }
+      flops { key: "f32xf32->f32" value: 123697631035525 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 562794640110070 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 543563538062393 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 502776388176763 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 633476002359882 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 638182361961367 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 290357442942130 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 503956268231152 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 512373074381151 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 652780195455581 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 290367257952202 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 506930338861020 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 422317334906588 }
+      flops { key: "bf16xbf16->f32" value: 414952639582628 }
+      flops { key: "f16xf16->f16" value: 403444313082685 }
+      flops { key: "f16xf16->f32" value: 375861319331408 }
+      flops { key: "f32xf32->f32" value: 169008363754414 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 854294837593237 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 675362417800141 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 672191454104390 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 912463840237943 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 679126741668972 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 391474744992594 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 834338749162255 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 711794381173351 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 691148134690429 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 388456319450097 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 697886386805865 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 502034429187183 }
+      flops { key: "bf16xbf16->f32" value: 464509103258077 }
+      flops { key: "f16xf16->f16" value: 444418066171715 }
+      flops { key: "f16xf16->f32" value: 418195009469097 }
+      flops { key: "f32xf32->f32" value: 200496801526494 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1101061922963532 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1025970091609435 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1110312750210043 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1066807574764033 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1006701777504321 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 432649664026593 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1110312750210043 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1088470186207115 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 884693814511560 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 428324192124060 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1139059783457649 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 189430922065893 }
+      flops { key: "bf16xbf16->f32" value: 191287012693181 }
+      flops { key: "f16xf16->f16" value: 188922639922582 }
+      flops { key: "f16xf16->f32" value: 182337817703247 }
+      flops { key: "f32xf32->f32" value: 92948565096952 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 438485686166411 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 462122584032709 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 459158359632242 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 469190222416430 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 444889920861818 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 195643752380084 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 437592185022924 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 473326790390125 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 438485686166411 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 188590818301571 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 457154581798829 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 299061191101208 }
+      flops { key: "bf16xbf16->f32" value: 293944310714163 }
+      flops { key: "f16xf16->f16" value: 284953875999336 }
+      flops { key: "f16xf16->f32" value: 280121786792760 }
+      flops { key: "f32xf32->f32" value: 112502908752766 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 617980905899280 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 504548287342143 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 547025064764694 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 514213384735109 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 528156332513526 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 271773170247097 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 571823631473838 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 574885195556150 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 504548287342143 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 270736718103883 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 530111984201431 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 383077333690101 }
+      flops { key: "bf16xbf16->f32" value: 385492734012475 }
+      flops { key: "f16xf16->f16" value: 366707276227881 }
+      flops { key: "f16xf16->f32" value: 362827226694825 }
+      flops { key: "f32xf32->f32" value: 135630189267922 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 749754263070611 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 723789567913717 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 668529425791890 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 687277240628875 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 692820469572932 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 356347497127211 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 699022223379582 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 681794951345344 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 688930873160364 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 353699027917318 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 669545546747729 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 493369590166994 }
+      flops { key: "bf16xbf16->f32" value: 482811150942866 }
+      flops { key: "f16xf16->f16" value: 437274754291968 }
+      flops { key: "f16xf16->f32" value: 424508751766740 }
+      flops { key: "f32xf32->f32" value: 185755425754028 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1218344031203460 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1090543002126511 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1193751115867004 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1176542198602931 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1124116285022574 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 488314171565004 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1079578294152763 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1048544000976532 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1149770391112301 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 490832369584160 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 821570904500023 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 543464666903920 }
+      flops { key: "bf16xbf16->f32" value: 531592365928940 }
+      flops { key: "f16xf16->f16" value: 488730916704597 }
+      flops { key: "f16xf16->f32" value: 468445003892376 }
+      flops { key: "f32xf32->f32" value: 220934531687242 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1596493744447542 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1336019067112528 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1407839808571662 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1394668007549773 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1336019067112528 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 507679349408983 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1439724219815214 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1391843249063253 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1382296269380858 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 507154809859778 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1437916694272980 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 469215851422953 }
+      flops { key: "bf16xbf16->f32" value: 458178717303179 }
+      flops { key: "f16xf16->f16" value: 468703802695476 }
+      flops { key: "f16xf16->f32" value: 453342547603968 }
+      flops { key: "f32xf32->f32" value: 212727453987122 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1194539645668196 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1429511498086204 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1336122972779592 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1283996202092675 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1520880770538243 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 1149770391112301 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1218430438581560 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1253822010217486 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1484093744298548 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1242936563738966 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1374389534720000 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 332962559528654 }
+      flops { key: "bf16xbf16->f32" value: 339020605505673 }
+      flops { key: "f16xf16->f16" value: 320286902887824 }
+      flops { key: "f16xf16->f32" value: 305996530065545 }
+      flops { key: "f32xf32->f32" value: 117641329425621 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 817660710294607 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 691148134690429 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 683422276394303 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 661807819407527 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 669050127891580 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 299587918458453 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 677493066645634 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 676426064414520 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 674302110997723 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 299478248160931 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 681281246143474 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 420863761688367 }
+      flops { key: "bf16xbf16->f32" value: 418806688866678 }
+      flops { key: "f16xf16->f16" value: 387934407063260 }
+      flops { key: "f16xf16->f32" value: 400430481988648 }
+      flops { key: "f32xf32->f32" value: 154516764333157 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1098948965905456 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1038403649792982 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1037776386118578 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1017463380752146 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1025357754938824 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 358429183284304 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1051110109455780 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 969163071333878 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1029073598131121 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 370587253340811 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1024135271773472 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 527665620357359 }
+      flops { key: "bf16xbf16->f32" value: 520858579876454 }
+      flops { key: "f16xf16->f16" value: 464512243127234 }
+      flops { key: "f16xf16->f32" value: 454064454490792 }
+      flops { key: "f32xf32->f32" value: 207957889828687 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1504103413062511 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1428323011639507 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1384524252246444 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1369077513965812 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1359301290396597 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 529866736082410 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1475648537353174 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1506741728117874 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1360916461748688 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 529621714778962 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1461183855751648 }
+    }
+    entries {
+      b: 1
+      m: 4096
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 587080012780535 }
+      flops { key: "bf16xbf16->f32" value: 573920147790574 }
+      flops { key: "f16xf16->f16" value: 514069134566400 }
+      flops { key: "f16xf16->f32" value: 497374338096978 }
+      flops { key: "f32xf32->f32" value: 233958953835992 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1869688792828089 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1674410388050973 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1762150823411757 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1741563332007045 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1717578993389070 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 573056282327433 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1785965219569878 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1780435700598492 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1726663401995025 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 578028335851151 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1777672264686861 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 16921044881492 }
+      flops { key: "bf16xbf16->f32" value: 17185368501920 }
+      flops { key: "f16xf16->f16" value: 16260931427186 }
+      flops { key: "f16xf16->f32" value: 16668868355688 }
+      flops { key: "f32xf32->f32" value: 15023251399149 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 19367637518037 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 20428877929984 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 17819666489644 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 17093444727457 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 19819510927347 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 18010967257112 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 17180968766001 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 18206419967444 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 19146608844507 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 19037975602836 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 17914806193272 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 28393849799026 }
+      flops { key: "bf16xbf16->f32" value: 27241268114471 }
+      flops { key: "f16xf16->f16" value: 28274221192332 }
+      flops { key: "f16xf16->f32" value: 29779837585977 }
+      flops { key: "f32xf32->f32" value: 19480076632801 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 28636169831448 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 30046502798298 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 28636169831448 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 29388598204510 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 31315382174521 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 31759992427827 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 28037962815959 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 28630061433447 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 29388598204510 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 32688194836824 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 29007505511130 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 45894247905624 }
+      flops { key: "bf16xbf16->f32" value: 44821415261312 }
+      flops { key: "f16xf16->f16" value: 47184998417999 }
+      flops { key: "f16xf16->f32" value: 45428237603655 }
+      flops { key: "f32xf32->f32" value: 39296655833699 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 51345726090283 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 44821415261312 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 51941845201238 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 44672234315193 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 42273300157480 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 52551968676585 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 53388117740652 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 49092073152889 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 42819501674908 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 55381773468124 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 51345726090283 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 65536000000000 }
+      flops { key: "bf16xbf16->f32" value: 70344721174004 }
+      flops { key: "f16xf16->f16" value: 68200065040650 }
+      flops { key: "f16xf16->f32" value: 66675473422752 }
+      flops { key: "f32xf32->f32" value: 51350637207077 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 79067881001472 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 80732467969924 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 76141102254999 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 87027218674015 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 77908998984182 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 84827130984357 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 78135775287439 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 74245735306320 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 80976004826546 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 87310280045535 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 77908998984182 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 129475681176896 }
+      flops { key: "bf16xbf16->f32" value: 125539790015199 }
+      flops { key: "f16xf16->f16" value: 105114226529613 }
+      flops { key: "f16xf16->f32" value: 100953537420082 }
+      flops { key: "f32xf32->f32" value: 78375315620437 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 118855636927164 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 121836131169862 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 104500420827250 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 111673616640665 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 115047875709846 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 103883690402476 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 104704224670892 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 108954015626585 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 116281332466969 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 125539790015199 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 119917559079740 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 39886397622585 }
+      flops { key: "bf16xbf16->f32" value: 33009770782095 }
+      flops { key: "f16xf16->f16" value: 31911014740846 }
+      flops { key: "f16xf16->f32" value: 41877606240249 }
+      flops { key: "f32xf32->f32" value: 26908125100240 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 37861136248236 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 32688194836824 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 32848195790504 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 33337736711376 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 33172943153732 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 32688194836824 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 35080430737062 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 34717467149508 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 34013615813482 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 32529745031507 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 32372823926676 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 37962870315372 }
+      flops { key: "bf16xbf16->f32" value: 37122867653160 }
+      flops { key: "f16xf16->f16" value: 39768215703703 }
+      flops { key: "f16xf16->f32" value: 42147190453760 }
+      flops { key: "f32xf32->f32" value: 28454044519821 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 43226321417069 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 45894247905624 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 44971595912213 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 43094470380478 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 46210269581683 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 45737852445050 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 38735275036075 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 45130372562205 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 47857988233196 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 44524043124896 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 46051716589466 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 59825151771785 }
+      flops { key: "bf16xbf16->f32" value: 60099732676592 }
+      flops { key: "f16xf16->f16" value: 65217554907677 }
+      flops { key: "f16xf16->f32" value: 62188221012394 }
+      flops { key: "f32xf32->f32" value: 49545119232189 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 62188221012394 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 60370056448892 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 59566283368467 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 59698755921272 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 59165848798765 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 64745647853352 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 62630764349043 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 61056625952462 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 61901408047964 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 65217554907677 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 66345886307464 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 91788495811249 }
+      flops { key: "bf16xbf16->f32" value: 91320107501275 }
+      flops { key: "f16xf16->f16" value: 108524542551041 }
+      flops { key: "f16xf16->f32" value: 90710638168454 }
+      flops { key: "f32xf32->f32" value: 72344820374612 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 101143728711379 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 80369897005988 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 102888254503641 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 106363726993561 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 81715511719939 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 111673616640665 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 109621421541602 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 108733349265822 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 81597524431947 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 107643290626566 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 110082204633996 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 185175790980425 }
+      flops { key: "bf16xbf16->f32" value: 176341242240105 }
+      flops { key: "f16xf16->f16" value: 175190377549355 }
+      flops { key: "f16xf16->f32" value: 166226770493072 }
+      flops { key: "f32xf32->f32" value: 104191142981902 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 182966997358779 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 234109195246920 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 175749541533677 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 177507327492147 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 273495115639327 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 175190377549355 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 171537954149692 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 182966997358779 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 299467807558220 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 175763926010803 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 178392062468848 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 48735558460421 }
+      flops { key: "bf16xbf16->f32" value: 47519110639051 }
+      flops { key: "f16xf16->f16" value: 48735558460421 }
+      flops { key: "f16xf16->f32" value: 47687947415171 }
+      flops { key: "f32xf32->f32" value: 37329363927131 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 55381773468124 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 51542906298003 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 59035728172421 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 50571864355689 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 52977196763370 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 56075925631919 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 51941845201238 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 52551968676585 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 56075925631919 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 54471480519480 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 55370349834983 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 73634743107941 }
+      flops { key: "bf16xbf16->f32" value: 81715511719939 }
+      flops { key: "f16xf16->f16" value: 80976004826546 }
+      flops { key: "f16xf16->f32" value: 70911492801479 }
+      flops { key: "f32xf32->f32" value: 69615004149377 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 82722790755007 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 88753663746073 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 74866951889555 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 76794580460592 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 76357689091167 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 93385095146982 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 74866951889555 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 66337688372667 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 47523316986810 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 72247464944152 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 65536000000000 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 99273467455621 }
+      flops { key: "bf16xbf16->f32" value: 101535869881796 }
+      flops { key: "f16xf16->f16" value: 98544587371512 }
+      flops { key: "f16xf16->f32" value: 91639653836306 }
+      flops { key: "f32xf32->f32" value: 58780414080035 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 81846316335086 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 113563386991010 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 83242253197922 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 80976004826546 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 110992539177175 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 82595524923076 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 81840078048780 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 80249762630792 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 123517982744737 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 82348479484623 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 81971282082601 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 146866615237313 }
+      flops { key: "bf16xbf16->f32" value: 144494929888305 }
+      flops { key: "f16xf16->f16" value: 148491470612640 }
+      flops { key: "f16xf16->f32" value: 137456547910132 }
+      flops { key: "f32xf32->f32" value: 87094279433832 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 138342050376860 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 263430280667320 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 135710543983822 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 139965042560125 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 288950975242195 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 136400130081300 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 135882286003543 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 136408794257765 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 291342239587572 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 137280805983507 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 136921936240754 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 221515668471813 }
+      flops { key: "bf16xbf16->f32" value: 225955771043771 }
+      flops { key: "f16xf16->f16" value: 222203285012157 }
+      flops { key: "f16xf16->f32" value: 218129370035551 }
+      flops { key: "f32xf32->f32" value: 118403465181672 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 230812945829750 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 394903208532548 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 229334007689021 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 231559591114945 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 398567863400148 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 225706411056808 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 225244771134885 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 229824876712328 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 403056240240240 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 228115960059485 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 224057973603213 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 81467513201820 }
+      flops { key: "bf16xbf16->f32" value: 81715511719939 }
+      flops { key: "f16xf16->f16" value: 78604818740849 }
+      flops { key: "f16xf16->f32" value: 78147148762736 }
+      flops { key: "f32xf32->f32" value: 56311192783721 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 92739836241147 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 93727463687150 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 93711103508465 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 96058492037931 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 94369996835999 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 90549993590824 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 93711103508465 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 93385095146982 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 85096039308923 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 91475704890100 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 93061347200554 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 133350946845504 }
+      flops { key: "bf16xbf16->f32" value: 121012264623013 }
+      flops { key: "f16xf16->f16" value: 125246917531785 }
+      flops { key: "f16xf16->f32" value: 130103213861626 }
+      flops { key: "f32xf32->f32" value: 100575292618958 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 110992539177175 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 106574870868486 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 110752122124806 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 106574870868486 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 74663919338015 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 108733349265822 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 108733349265822 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 113816178079287 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 105114226529613 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 119397511842544 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 108087560297966 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 181405951005237 }
+      flops { key: "bf16xbf16->f32" value: 178971884990415 }
+      flops { key: "f16xf16->f16" value: 168575527749430 }
+      flops { key: "f16xf16->f32" value: 177214362766133 }
+      flops { key: "f32xf32->f32" value: 139058709318137 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 158357322321362 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 157671339794419 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 159072862814814 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 158837547928994 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 160259973731343 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 149535801685119 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 154484112509891 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 150163180756590 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 159308875964391 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 161708106024096 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 159308875964391 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 191116775508387 }
+      flops { key: "bf16xbf16->f32" value: 189933546897802 }
+      flops { key: "f16xf16->f16" value: 186949042221641 }
+      flops { key: "f16xf16->f32" value: 179893918157068 }
+      flops { key: "f32xf32->f32" value: 93842145079531 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 369682156653468 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 392019650967506 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 367185371975720 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 386342295223531 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 376850688426779 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 152509313827142 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 367814275584482 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 385648495645146 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 406105077155824 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 153600146484514 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 393420105889896 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 275972967679753 }
+      flops { key: "bf16xbf16->f32" value: 275256660108309 }
+      flops { key: "f16xf16->f16" value: 271087025972796 }
+      flops { key: "f16xf16->f32" value: 265876395691469 }
+      flops { key: "f32xf32->f32" value: 131390773391253 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 489566544625555 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 441210878422106 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 265383545229856 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 275609926909872 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 436724520412832 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 267532533698766 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 441664589027713 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 270404337583026 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 433616082382635 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 266867608798309 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 269555797282455 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 117297555604107 }
+      flops { key: "bf16xbf16->f32" value: 118868794863279 }
+      flops { key: "f16xf16->f16" value: 112622385567442 }
+      flops { key: "f16xf16->f32" value: 114789589908060 }
+      flops { key: "f32xf32->f32" value: 93883170761563 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 124088966138911 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 114789589908060 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 117812357252578 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 127024940731101 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 115779795557472 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 122671292585399 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 120740112897784 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 125246917531785 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 111906391245440 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 127628886722928 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 118071456344842 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 167002383389066 }
+      flops { key: "bf16xbf16->f32" value: 172364045910586 }
+      flops { key: "f16xf16->f16" value: 168311282075397 }
+      flops { key: "f16xf16->f32" value: 162688155151515 }
+      flops { key: "f32xf32->f32" value: 135719120773557 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 159783009523809 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 161708106024096 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 161222496096096 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 157903209411764 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 159297058675172 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 159061080512554 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 160021136214605 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 160259973731343 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 158837547928994 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 158135762002945 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 159308875964391 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 270055790744466 }
+      flops { key: "bf16xbf16->f32" value: 289769754149237 }
+      flops { key: "f16xf16->f16" value: 270055790744466 }
+      flops { key: "f16xf16->f32" value: 273164618457037 }
+      flops { key: "f32xf32->f32" value: 206181522538524 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 323904019306184 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 348674078259457 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 323416212048192 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 314857216919580 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 340897475672672 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 334525063945790 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 319091180980683 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 321479588023952 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 330916657369597 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 337151055498861 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 325870052807283 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 349226921657112 }
+      flops { key: "bf16xbf16->f32" value: 358287157122002 }
+      flops { key: "f16xf16->f16" value: 337151055498861 }
+      flops { key: "f16xf16->f32" value: 336095727052195 }
+      flops { key: "f32xf32->f32" value: 243810586739327 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1307448187519026 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1315457058499234 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1265086096023564 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1303480211229135 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1235961811798561 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 1235784001150913 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1307448187519026 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1331979313381919 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1311440395725190 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1276364723922734 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1207978426662916 }
+    }
+    entries {
+      b: 2
+      m: 256
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 311223876089201 }
+      flops { key: "bf16xbf16->f32" value: 308197785982096 }
+      flops { key: "f16xf16->f16" value: 294852387052483 }
+      flops { key: "f16xf16->f32" value: 293136812735680 }
+      flops { key: "f32xf32->f32" value: 137323601646616 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 614862359400164 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 615721782811268 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 623339834693951 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 617936450039565 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 626065711307897 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 296378380153883 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 641039894925373 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 630685359177679 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 624699799425475 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 295867963765370 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 635820473131014 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 27921308092365 }
+      flops { key: "bf16xbf16->f32" value: 28758887508035 }
+      flops { key: "f16xf16->f16" value: 28037962815959 }
+      flops { key: "f16xf16->f32" value: 21070286970172 }
+      flops { key: "f32xf32->f32" value: 22561393175323 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 31025827092001 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 32529745031507 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 30875943869335 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 32063480172001 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 30883048320294 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 35080430737062 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 34717467149508 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 30883048320294 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 32848195790504 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 36021934514224 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 31454822591985 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 43513609337007 }
+      flops { key: "bf16xbf16->f32" value: 40488002413273 }
+      flops { key: "f16xf16->f16" value: 37329363927131 }
+      flops { key: "f16xf16->f32" value: 43940981502700 }
+      flops { key: "f32xf32->f32" value: 35362331181662 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 52347007800312 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 43513609337007 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 52966743488555 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 52143639471639 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 43933789852700 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 48210390804597 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 48550453246518 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 50955857251328 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 42548019654461 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 53601329073482 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 53176595879556 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 76586435378031 }
+      flops { key: "bf16xbf16->f32" value: 67513947686116 }
+      flops { key: "f16xf16->f16" value: 76805566809728 }
+      flops { key: "f16xf16->f32" value: 70715346680716 }
+      flops { key: "f32xf32->f32" value: 48913166180758 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 68900271047227 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 87310280045535 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 65696391581008 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 87310280045535 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 86466566596875 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 82481320018436 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 93061347200554 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 79772795245170 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 80010568107302 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 86175106260032 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 70911492801479 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 122391636156388 }
+      flops { key: "bf16xbf16->f32" value: 122671292585399 }
+      flops { key: "f16xf16->f16" value: 103095710417666 }
+      flops { key: "f16xf16->f32" value: 111918055451323 }
+      flops { key: "f32xf32->f32" value: 80490391604197 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 111222480215454 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 106564293767368 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 117554392818042 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 116030022044521 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 113096884769328 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 117041838238500 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 118084441218519 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 118084441218519 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 106786854699154 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 117041838238500 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 117297555604107 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 183592685987860 }
+      flops { key: "bf16xbf16->f32" value: 180795053712746 }
+      flops { key: "f16xf16->f16" value: 194219376684453 }
+      flops { key: "f16xf16->f32" value: 167262531972895 }
+      flops { key: "f32xf32->f32" value: 94212672106694 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 152943782351684 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 264078166256763 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 148081895462694 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 151862219645003 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 287442597778075 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 149953470288387 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 147674573511208 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 146866615237313 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 279911841501564 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 152077306706323 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 148697108987674 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 39886397622585 }
+      flops { key: "bf16xbf16->f32" value: 41753842899362 }
+      flops { key: "f16xf16->f16" value: 40610507715582 }
+      flops { key: "f16xf16->f32" value: 41495664863193 }
+      flops { key: "f32xf32->f32" value: 29717198715819 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 55611240107727 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 51150048780487 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 48913166180758 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 53827041507920 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 54928474728872 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 52357217866198 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 51941845201238 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 54471480519480 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 52551968676585 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 46855551754232 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 51150048780487 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 61188843400957 }
+      flops { key: "bf16xbf16->f32" value: 59427818463582 }
+      flops { key: "f16xf16->f16" value: 59831819012593 }
+      flops { key: "f16xf16->f32" value: 56311192783721 }
+      flops { key: "f32xf32->f32" value: 49182018321729 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 67344569994982 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 68027231626964 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 71668790815645 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 64745647853352 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 69077574884199 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 67344569994982 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 69805085424522 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 69255793601651 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 76586435378031 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 65857570166830 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 64427086523460 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 104694015600624 }
+      flops { key: "bf16xbf16->f32" value: 94544494496786 }
+      flops { key: "f16xf16->f16" value: 98184146305779 }
+      flops { key: "f16xf16->f32" value: 97826332361516 }
+      flops { key: "f32xf32->f32" value: 69891415999479 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 122391636156388 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 89642830522624 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 124955408355638 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 118855636927164 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 91165038546442 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 121285645995707 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 122671292585399 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 121285645995707 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 89344468630387 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 125554469597754 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 118331697597531 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 188756583282060 }
+      flops { key: "bf16xbf16->f32" value: 184856989584230 }
+      flops { key: "f16xf16->f16" value: 180188257090115 }
+      flops { key: "f16xf16->f32" value: 174890760485381 }
+      flops { key: "f32xf32->f32" value: 103488200472266 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 173758689861639 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 312543101149759 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 178688937260775 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 175190377549355 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 320999050523168 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 176341242240105 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 178406882778100 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 176341242240105 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 319091180980683 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 176922363486571 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 171812436834946 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 269040797795038 }
+      flops { key: "bf16xbf16->f32" value: 255576750728949 }
+      flops { key: "f16xf16->f16" value: 266371080129000 }
+      flops { key: "f16xf16->f32" value: 246186363407084 }
+      flops { key: "f32xf32->f32" value: 116410551456836 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 219254035223850 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 437592185022924 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 218807239085027 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 216382049272003 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 444843842154324 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 221515668471813 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 223824446088905 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 225244771134885 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 441188217360041 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 221973605664375 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 506900424406939 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 77683535233685 }
+      flops { key: "bf16xbf16->f32" value: 70715346680716 }
+      flops { key: "f16xf16->f16" value: 71668790815645 }
+      flops { key: "f16xf16->f32" value: 74245735306320 }
+      flops { key: "f32xf32->f32" value: 59296544289816 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 92103433178932 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 84546600314960 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 85899345920000 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 92420539163367 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 81727951286344 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 88170621120052 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 90856475207310 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 90245572701294 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 95733044222539 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 88170621120052 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 103085812596006 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 97109688342226 }
+      flops { key: "bf16xbf16->f32" value: 94878662543076 }
+      flops { key: "f16xf16->f16" value: 98364036643459 }
+      flops { key: "f16xf16->f32" value: 95384367415830 }
+      flops { key: "f32xf32->f32" value: 58844841562996 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 91172779485437 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 158602928212703 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 92111334305567 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 91945694810755 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 163431023439878 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 92103433178932 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 86182022955293 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 86886375141608 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 161464935939849 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 88607181383066 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 88607181383066 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 156510724291232 }
+      flops { key: "bf16xbf16->f32" value: 154929921939254 }
+      flops { key: "f16xf16->f16" value: 149744344745833 }
+      flops { key: "f16xf16->f32" value: 156522131778425 }
+      flops { key: "f32xf32->f32" value: 85909655078609 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 152726239101059 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 267365992031872 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 149327838676030 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 142189210620406 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 234083676477000 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 153820188238664 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 153820188238664 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 149953470288387 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 267365992031872 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 153611133619456 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 150785258250245 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 226193769538656 }
+      flops { key: "bf16xbf16->f32" value: 226910782755705 }
+      flops { key: "f16xf16->f16" value: 213573709398309 }
+      flops { key: "f16xf16->f32" value: 220379049515111 }
+      flops { key: "f32xf32->f32" value: 121491494003168 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 228358533390046 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 492937828072994 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 220605439211053 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 231809547495682 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 494071930978948 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 228358533390046 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 225955771043771 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 230812945829750 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 478601214174281 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 233587170065807 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 223126775209101 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 325882415569634 }
+      flops { key: "bf16xbf16->f32" value: 323172858991723 }
+      flops { key: "f16xf16->f16" value: 318145725629629 }
+      flops { key: "f16xf16->f32" value: 307431179700082 }
+      flops { key: "f32xf32->f32" value: 130910199978664 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 661833314739194 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 661833314739194 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 653724093759513 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 658737315337423 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 658787835876984 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 293532483324220 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 583476062491509 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 641998101046337 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 652730592097264 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 295969906350136 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 612647784894087 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 120998627901735 }
+      flops { key: "bf16xbf16->f32" value: 111918055451323 }
+      flops { key: "f16xf16->f16" value: 121822308146131 }
+      flops { key: "f16xf16->f32" value: 122391636156388 }
+      flops { key: "f32xf32->f32" value: 98364036643459 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 117297555604107 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 108954015626585 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 117567264206722 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 110524119814719 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 112859136430523 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 114544679325794 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 111441808406850 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 115282566459093 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 111673616640665 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 110070919938493 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 106574870868486 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 212306836183885 }
+      flops { key: "bf16xbf16->f32" value: 197451604266274 }
+      flops { key: "f16xf16->f16" value: 187438565767652 }
+      flops { key: "f16xf16->f32" value: 190093267947242 }
+      flops { key: "f32xf32->f32" value: 132039083128381 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 163182648024316 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 163182648024316 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 162935026403641 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 130593751398686 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 165957005255023 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 163942564165203 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 163182648024316 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 168311282075397 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 161708106024096 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 164180707033639 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 165445581510015 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 188425344213389 }
+      flops { key: "bf16xbf16->f32" value: 189757325086153 }
+      flops { key: "f16xf16->f16" value: 192314838848341 }
+      flops { key: "f16xf16->f32" value: 187438565767652 }
+      flops { key: "f32xf32->f32" value: 96897175318668 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 338746533322817 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 478654552100746 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 460142200128562 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 453342547603968 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 441188217360041 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 175047574828822 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 443924268320413 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 403056240240240 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 460142200128562 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 173765719788000 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 428853449425861 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 295562556928052 }
+      flops { key: "bf16xbf16->f32" value: 282889332850321 }
+      flops { key: "f16xf16->f16" value: 278297628199313 }
+      flops { key: "f16xf16->f32" value: 269725079034131 }
+      flops { key: "f32xf32->f32" value: 133020543111992 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 621513247377179 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 644889984384384 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 630685359177679 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 629760600586510 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 628838549926793 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 274737241476364 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 655770256660813 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 660815031310100 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 650752620606060 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 273329767142902 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 666972171131299 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 376355353662811 }
+      flops { key: "bf16xbf16->f32" value: 373086109798471 }
+      flops { key: "f16xf16->f16" value: 351671767460902 }
+      flops { key: "f16xf16->f32" value: 345157495559930 }
+      flops { key: "f32xf32->f32" value: 141281818947368 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 669050127891580 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 729351270812990 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 717142644180998 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 728114820258529 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 705944657462195 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 354436037713271 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 718372117248588 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 726267984950327 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 720783267631634 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 358279685178619 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 758392671345958 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 170991611434031 }
+      flops { key: "bf16xbf16->f32" value: 162208901578669 }
+      flops { key: "f16xf16->f16" value: 165957005255023 }
+      flops { key: "f16xf16->f32" value: 168311282075397 }
+      flops { key: "f32xf32->f32" value: 128399620209267 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 175476683118156 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 164444723792020 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 169106516103630 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 168311282075397 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 169106516103630 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 174905004723896 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 173198132752641 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 168047863526097 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 173758689861639 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 169373266661408 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 172655060942273 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 258966975942116 }
+      flops { key: "bf16xbf16->f32" value: 257414881390470 }
+      flops { key: "f16xf16->f16" value: 261808430112770 }
+      flops { key: "f16xf16->f32" value: 255881280667262 }
+      flops { key: "f32xf32->f32" value: 179743347813350 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 667957588802488 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 647808038612368 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 647808038612368 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 657728529249617 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 682824689348171 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 703055704043214 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 647808038612368 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 685002758532695 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 640084544858420 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 689511526087654 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 687304736117778 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 364985536095177 }
+      flops { key: "bf16xbf16->f32" value: 355308346790205 }
+      flops { key: "f16xf16->f16" value: 348943193402932 }
+      flops { key: "f16xf16->f32" value: 345852340942948 }
+      flops { key: "f32xf32->f32" value: 241473437494729 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1162215477202002 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1064164344895936 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1110958948784273 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1137589007018938 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1149770391112301 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 1168539598966127 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1165368958350291 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1191226541672445 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1140610090559022 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1122720506077636 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1128621021153593 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 320525927424019 }
+      flops { key: "bf16xbf16->f32" value: 318027937504627 }
+      flops { key: "f16xf16->f16" value: 306766944342267 }
+      flops { key: "f16xf16->f32" value: 302654308787259 }
+      flops { key: "f32xf32->f32" value: 144155443914882 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 726882554855087 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 693379714412560 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 693379714412560 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 679664089251097 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 673271512481874 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 301591692718208 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 721388586353138 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 651764831139269 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 721994922630804 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 304586007800865 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 717741860962566 }
+    }
+    entries {
+      b: 2
+      m: 512
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 420657660508563 }
+      flops { key: "bf16xbf16->f32" value: 420143289614947 }
+      flops { key: "f16xf16->f16" value: 403539078383012 }
+      flops { key: "f16xf16->f32" value: 399778216435710 }
+      flops { key: "f32xf32->f32" value: 154322446397693 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 971354942131003 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 964808872265745 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 958885339435715 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1002589313647106 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 958885339435715 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 394626541800181 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 971931952025345 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 985903944449226 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 953034098909938 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 399778216435710 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 991022421274263 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 40245195802098 }
+      flops { key: "bf16xbf16->f32" value: 36616485609057 }
+      flops { key: "f16xf16->f16" value: 38178844545583 }
+      flops { key: "f16xf16->f32" value: 41108033078101 }
+      flops { key: "f32xf32->f32" value: 31532415834605 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 51150048780487 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 47687947415171 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 57028990014871 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 48559235890014 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 47866522111269 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 52153770351661 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 47527524079320 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 50184231819031 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 42548019654461 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 54693450692746 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 57272339662897 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 60642822997853 }
+      flops { key: "bf16xbf16->f32" value: 62917017696003 }
+      flops { key: "f16xf16->f16" value: 72053538048584 }
+      flops { key: "f16xf16->f32" value: 61758991372368 }
+      flops { key: "f32xf32->f32" value: 51647033381433 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 66675473422752 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 71468438764643 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 90245572701294 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 82468650076804 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 72247464944152 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 87027218674015 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 80732467969924 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 87580899184339 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 74658727854262 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 87310280045535 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 84827130984357 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 94212672106694 }
+      flops { key: "bf16xbf16->f32" value: 101334637976594 }
+      flops { key: "f16xf16->f16" value: 91788495811249 }
+      flops { key: "f16xf16->f32" value: 93883170761563 }
+      flops { key: "f32xf32->f32" value: 78604818740849 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 126129663338423 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 103483213569776 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 121836131169862 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 117041838238500 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 102300097560975 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 117297555604107 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 118606188445819 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 117554392818042 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 107643290626566 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 120998627901735 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 115530646008177 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 198546934911242 }
+      flops { key: "bf16xbf16->f32" value: 176341242240105 }
+      flops { key: "f16xf16->f16" value: 167785268224080 }
+      flops { key: "f16xf16->f32" value: 163431023439878 }
+      flops { key: "f32xf32->f32" value: 91796342993930 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 146465942436229 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 269378279979929 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 152077306706323 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 142377752966916 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 267365992031872 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 156055784318000 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 155614757101449 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 157891599735313 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 286675163262581 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 153161946223521 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 147471751682461 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 256799240418535 }
+      flops { key: "bf16xbf16->f32" value: 199099170035230 }
+      flops { key: "f16xf16->f16" value: 251373480978578 }
+      flops { key: "f16xf16->f32" value: 193528017663227 }
+      flops { key: "f32xf32->f32" value: 119660304126152 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 198546934911242 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 303724439290007 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 502159160060797 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 502159160060797 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 400799486375513 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 184690057880025 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 485142583982830 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 488453007619697 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 384991690211545 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 184698000172013 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 495211264383719 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 54147343620776 }
+      flops { key: "bf16xbf16->f32" value: 56787699598053 }
+      flops { key: "f16xf16->f16" value: 57889897778736 }
+      flops { key: "f16xf16->f32" value: 57028990014871 }
+      flops { key: "f32xf32->f32" value: 43869170779539 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 70160861474124 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 64119301564552 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 69434934299017 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 68200065040650 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 70353939457476 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 74451658854527 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 68732673409294 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 72053538048584 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 79067881001472 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 74866951889555 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 72247464944152 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 101334637976594 }
+      flops { key: "bf16xbf16->f32" value: 104908825012213 }
+      flops { key: "f16xf16->f16" value: 101334637976594 }
+      flops { key: "f16xf16->f32" value: 97648401600582 }
+      flops { key: "f32xf32->f32" value: 62696591381525 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 112610574095437 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 90397526856373 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 116787233413095 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 118084441218519 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 89344468630387 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 121560265368504 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 118344739777361 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 126426683621806 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 93231034470782 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 120726537440971 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 118331697597531 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 185175790980425 }
+      flops { key: "bf16xbf16->f32" value: 166743042782824 }
+      flops { key: "f16xf16->f16" value: 151851481261490 }
+      flops { key: "f16xf16->f32" value: 169373266661408 }
+      flops { key: "f32xf32->f32" value: 100481173872356 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 184222668611134 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 294538972431765 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 182345558970875 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 179585519986619 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 282118188124014 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 176052110837842 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 177801262460672 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 172655060942273 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 255288117926771 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 175190377549355 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 176341242240105 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 264403305589756 }
+      flops { key: "bf16xbf16->f32" value: 247320470805021 }
+      flops { key: "f16xf16->f16" value: 259295296788215 }
+      flops { key: "f16xf16->f32" value: 240398930706369 }
+      flops { key: "f32xf32->f32" value: 110989670930563 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 217477710061268 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 504518653353694 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 218584523181841 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 218362260206416 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 350380755098711 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 217477710061268 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 218140448778505 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 217257691132581 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 453342547603968 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 212306836183885 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 521740439261418 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 332453540986144 }
+      flops { key: "bf16xbf16->f32" value: 284963329087048 }
+      flops { key: "f16xf16->f16" value: 326377696417037 }
+      flops { key: "f16xf16->f32" value: 281397320055035 }
+      flops { key: "f32xf32->f32" value: 158778827948244 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 710029309968589 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 636291451259259 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 712384689998341 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 681794951345344 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 630639056750605 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 266205980909879 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 704208443351369 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 715947207201200 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 635350191715976 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 279939207821411 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 782610658892128 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 106153418091942 }
+      flops { key: "bf16xbf16->f32" value: 103294066762866 }
+      flops { key: "f16xf16->f16" value: 94544494496786 }
+      flops { key: "f16xf16->f32" value: 99081094767924 }
+      flops { key: "f32xf32->f32" value: 60298861346661 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 91327874797992 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 148903317709055 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 91327874797992 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 90702975502618 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 162935026403641 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 99457375324194 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 88026055418921 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 93719282883826 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 156750631240875 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 97639522051468 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 89344468630387 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 163182648024316 }
+      flops { key: "bf16xbf16->f32" value: 124232537776235 }
+      flops { key: "f16xf16->f16" value: 153820188238664 }
+      flops { key: "f16xf16->f32" value: 144300742373336 }
+      flops { key: "f32xf32->f32" value: 77635792198402 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 155165003468208 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 277058914720681 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 155378311844294 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 153611133619456 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 281378884696016 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 156055784318000 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 149327838676030 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 159308875964391 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 271421087967644 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 153380733376187 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 150795846359104 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 243396083871698 }
+      flops { key: "bf16xbf16->f32" value: 252570849514848 }
+      flops { key: "f16xf16->f16" value: 237987881420734 }
+      flops { key: "f16xf16->f32" value: 239580927985719 }
+      flops { key: "f32xf32->f32" value: 120940706107622 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 233574466826191 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 352104221675684 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 236155896849397 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 237987881420734 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 360376514180231 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 234864510089134 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 235379366251986 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 235896484648761 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 359772767297704 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 243382291380971 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 231822059480757 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 336095727052195 }
+      flops { key: "bf16xbf16->f32" value: 315806418823529 }
+      flops { key: "f16xf16->f16" value: 317440302734663 }
+      flops { key: "f16xf16->f32" value: 293733230474627 }
+      flops { key: "f32xf32->f32" value: 127636472392273 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 507499385088030 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 513598480837070 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 471792969297522 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 739427958336920 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 718342079946479 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 296174002413543 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 792721907715024 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 721964581610354 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 487898136544359 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 296583040154680 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 741982775503152 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 419830140612399 }
+      flops { key: "bf16xbf16->f32" value: 399680559836218 }
+      flops { key: "f16xf16->f16" value: 396360953857512 }
+      flops { key: "f16xf16->f32" value: 363287569972510 }
+      flops { key: "f32xf32->f32" value: 186867703445875 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 774810318134668 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 797876146386773 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 978018284413070 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 891580735066687 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 733085947685086 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 373410476091114 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 945663520889525 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 976906015239395 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 840872653516714 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 378019873346975 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 926288304523642 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 159545590490341 }
+      flops { key: "bf16xbf16->f32" value: 161708106024096 }
+      flops { key: "f16xf16->f16" value: 157671339794419 }
+      flops { key: "f16xf16->f32" value: 159308875964391 }
+      flops { key: "f32xf32->f32" value: 135376892643257 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 173212102597193 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 174040331307237 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 169373266661408 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 169909300419336 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 173772750283217 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 168575527749430 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 175476683118156 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 176922363486571 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 175763926010803 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 172087799342896 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 173198132752641 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 194403987507355 }
+      flops { key: "bf16xbf16->f32" value: 197633319344745 }
+      flops { key: "f16xf16->f16" value: 192487218034329 }
+      flops { key: "f16xf16->f32" value: 194228159725048 }
+      flops { key: "f32xf32->f32" value: 90553811849040 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 400052840536512 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 348080662614474 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 341439486127673 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 335046984632186 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 335570536448160 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 183584838469758 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 325870052807283 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 343624873669893 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 344175598685792 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 184531355359828 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 408422146823887 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 299906940576775 }
+      flops { key: "bf16xbf16->f32" value: 299061191101208 }
+      flops { key: "f16xf16->f16" value: 286665596262306 }
+      flops { key: "f16xf16->f32" value: 288214152194336 }
+      flops { key: "f32xf32->f32" value: 134018793852874 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 625131692889891 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 486241061474017 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 582684479175145 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 601451798907716 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 575655715855783 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 287635098848111 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 580322563977840 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 584309543024284 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 486764582761942 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 282703129570511 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 497534583955980 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 378177977987144 }
+      flops { key: "bf16xbf16->f32" value: 373410476091114 }
+      flops { key: "f16xf16->f16" value: 360535333655117 }
+      flops { key: "f16xf16->f32" value: 352104221675684 }
+      flops { key: "f32xf32->f32" value: 137986483839876 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 765148050772725 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 695625751467789 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 784003522292703 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 779733544410656 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 759700591845759 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 362520978771892 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 763753409086867 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 796396680140923 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 794922690357209 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 352097005390117 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 681822009921816 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 474667251965131 }
+      flops { key: "bf16xbf16->f32" value: 471146039491004 }
+      flops { key: "f16xf16->f16" value: 424409125211526 }
+      flops { key: "f16xf16->f32" value: 410589101476984 }
+      flops { key: "f32xf32->f32" value: 206829384732070 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1051785795518550 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1021091779138187 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1057613222359024 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1105312306761886 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1035274891319413 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 470887764060958 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1116808761879997 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 964267346785283 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 989880394341851 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 467295058657128 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1081583302946361 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 284755505933832 }
+      flops { key: "bf16xbf16->f32" value: 267033529967669 }
+      flops { key: "f16xf16->f16" value: 280661785009475 }
+      flops { key: "f16xf16->f32" value: 262785566324033 }
+      flops { key: "f32xf32->f32" value: 182959203237486 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 329899938244104 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 319566019047619 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 328864264624808 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 324884061724659 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 322929871879699 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 330916657369597 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 330407515655050 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 341439486127673 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 321479588023952 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 337681208900070 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 322929871879699 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 330649162477385 }
+      flops { key: "bf16xbf16->f32" value: 331926836121952 }
+      flops { key: "f16xf16->f16" value: 323428389321887 }
+      flops { key: "f16xf16->f32" value: 316259879680424 }
+      flops { key: "f32xf32->f32" value: 213679964975124 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1016199525848811 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 916357434606358 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1048448015623092 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1088435706031424 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 891627007681129 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 1053721122669283 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1088435706031424 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1077513119919719 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 916357434606358 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1152856608777345 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1168539598966127 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 332447107688139 }
+      flops { key: "bf16xbf16->f32" value: 335177719369439 }
+      flops { key: "f16xf16->f16" value: 318735977439703 }
+      flops { key: "f16xf16->f32" value: 307866408329301 }
+      flops { key: "f32xf32->f32" value: 142573894869624 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 786912293147673 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 869866794126582 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 623792497875894 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 820785876642300 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 857706898851722 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 319929033762267 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 829544625012071 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 842563471505640 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 847551513764183 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 318381563825055 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 846674347444679 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 422733001574803 }
+      flops { key: "bf16xbf16->f32" value: 420554685597483 }
+      flops { key: "f16xf16->f16" value: 376606986003178 }
+      flops { key: "f16xf16->f32" value: 401365990725057 }
+      flops { key: "f32xf32->f32" value: 155751604072418 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1031514210987691 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 965893749978916 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1009066939825555 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1025970091609435 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 965893749978916 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 399401803691821 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 991594423479841 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1010283398059394 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1045353931303051 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 399035367252372 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 985310230786877 }
+    }
+    entries {
+      b: 2
+      m: 1024
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 514144134552365 }
+      flops { key: "bf16xbf16->f32" value: 506702330288082 }
+      flops { key: "f16xf16->f16" value: 446265142322778 }
+      flops { key: "f16xf16->f32" value: 443154187722884 }
+      flops { key: "f32xf32->f32" value: 222078337941687 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1352319677581864 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1313019025469553 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1351787645290738 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1326195587085319 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1346516640266483 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 528883938152740 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1295640504836064 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1342806720650304 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1288353301261741 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 532581137370089 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1329788430752559 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 66841498007968 }
+      flops { key: "bf16xbf16->f32" value: 62332626494833 }
+      flops { key: "f16xf16->f16" value: 64582089738963 }
+      flops { key: "f16xf16->f32" value: 61758991372368 }
+      flops { key: "f32xf32->f32" value: 44821415261312 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 76141102254999 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 78604818740849 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 87595188774677 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 73033724935382 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 72053538048584 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 87013113776337 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 87013113776337 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 68373778909831 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 74040947731347 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 96420781609195 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 90245572701294 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 135368359051941 }
+      flops { key: "bf16xbf16->f32" value: 125246917531785 }
+      flops { key: "f16xf16->f16" value: 120726537440971 }
+      flops { key: "f16xf16->f32" value: 118071456344842 }
+      flops { key: "f32xf32->f32" value: 61901408047964 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 115779795557472 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 110308385453051 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 110752122124806 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 113816178079287 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 111453375960141 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 114300811581860 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 110070919938493 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 115035550032140 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 111441808406850 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 114544679325794 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 111685232369461 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 174606362143263 }
+      flops { key: "bf16xbf16->f32" value: 162442030862329 }
+      flops { key: "f16xf16->f16" value: 174054437348030 }
+      flops { key: "f16xf16->f32" value: 166226770493072 }
+      flops { key: "f32xf32->f32" value: 86742482853334 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 140698660027517 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 240398930706369 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 152293003900432 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 264078166256763 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 247605632191859 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 152943782351684 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 151220593479332 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 142566795990174 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 316224951848034 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 151862219645003 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 151220593479332 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 246752113983683 }
+      flops { key: "bf16xbf16->f32" value: 224303702527679 }
+      flops { key: "f16xf16->f16" value: 258966975942116 }
+      flops { key: "f16xf16->f32" value: 204609942165690 }
+      flops { key: "f32xf32->f32" value: 119660304126152 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 454301596784429 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 374223864773024 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 432306723301459 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 479723812800178 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 394903208532548 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 178096172499585 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 450442296381751 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 436702317844433 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 386342295223531 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 167523492316093 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 492937828072994 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 295562556928052 }
+      flops { key: "bf16xbf16->f32" value: 253009766781538 }
+      flops { key: "f16xf16->f16" value: 292742207408922 }
+      flops { key: "f16xf16->f32" value: 239587610297604 }
+      flops { key: "f32xf32->f32" value: 143096413266921 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 514213384735109 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 418388514538989 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 619719687757016 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 616163445376945 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 542156942186316 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 207676964170011 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 649768123449319 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 604031684972927 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 536066811782326 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 208488497657823 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 607448878580015 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 87168519564864 }
+      flops { key: "bf16xbf16->f32" value: 129491295706705 }
+      flops { key: "f16xf16->f16" value: 125246917531785 }
+      flops { key: "f16xf16->f32" value: 122391636156388 }
+      flops { key: "f32xf32->f32" value: 66758382491917 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 113563386991010 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 90702975502618 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 137447750128008 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 121560265368504 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 89048086249792 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 142955907868459 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 126725106101734 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 120469182542353 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 91639653836306 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 134352080080080 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 135027895372233 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 189422567522272 }
+      flops { key: "bf16xbf16->f32" value: 183263666837344 }
+      flops { key: "f16xf16->f16" value: 195652664723032 }
+      flops { key: "f16xf16->f32" value: 174322887247341 }
+      flops { key: "f32xf32->f32" value: 87595188774677 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 173491973501373 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 253450212203469 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 179285661045249 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 174905004723896 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 264078166256763 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 174606362143263 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 175476683118156 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 172364045910586 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 262144000000000 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 171551657453267 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 173212102597193 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 255881280667262 }
+      flops { key: "bf16xbf16->f32" value: 243949068272179 }
+      flops { key: "f16xf16->f16" value: 260870219630709 }
+      flops { key: "f16xf16->f32" value: 243120530737008 }
+      flops { key: "f32xf32->f32" value: 106839982487562 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 445767233627400 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 330916657369597 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 346955916956135 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 355014654984294 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 329899938244104 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 212727453987122 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 339281720199067 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 346955916956135 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 329393917938492 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 210847682670594 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 351527852021607 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 337694484097967 }
+      flops { key: "bf16xbf16->f32" value: 314419274963396 }
+      flops { key: "f16xf16->f16" value: 330903909703763 }
+      flops { key: "f16xf16->f32" value: 284764945864412 }
+      flops { key: "f32xf32->f32" value: 153328714849258 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 667957588802488 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 501572731052201 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 725685105347638 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 538081595590077 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 518559287171747 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 266041086223984 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 691676833239391 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 551945935359506 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 524288000000000 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 270064281195963 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 752381062625908 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 428425665436409 }
+      flops { key: "bf16xbf16->f32" value: 325635338413131 }
+      flops { key: "f16xf16->f16" value: 404775090921942 }
+      flops { key: "f16xf16->f32" value: 321245146393911 }
+      flops { key: "f32xf32->f32" value: 166937472636815 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 696782494484101 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 618849075465581 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 970285167965661 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 789806417065097 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 626088527113702 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 327997807934629 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 942550566961101 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 836777029077979 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 614862359400164 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 320645573526941 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1024746148762302 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 156055784318000 }
+      flops { key: "bf16xbf16->f32" value: 158369000589970 }
+      flops { key: "f16xf16->f16" value: 154484112509891 }
+      flops { key: "f16xf16->f32" value: 147674573511208 }
+      flops { key: "f32xf32->f32" value: 80671812471825 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 150584366313722 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 296982941225280 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 159308875964391 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 150163180756590 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 249910816711276 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 169106516103630 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 163182648024316 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 156055784318000 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 255257773445857 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 168840604450035 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 163930049465648 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 241738464344008 }
+      flops { key: "bf16xbf16->f32" value: 246186363407084 }
+      flops { key: "f16xf16->f16" value: 233320691873098 }
+      flops { key: "f16xf16->f32" value: 232814792714657 }
+      flops { key: "f32xf32->f32" value: 99317083963463 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 228845231031543 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 334004766778132 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 226671273801984 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 231310173201206 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 442096479258878 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 200399743187756 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 477590047370176 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 226671273801984 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 339281720199067 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 228358533390046 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 336622564150795 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 337694484097967 }
+      flops { key: "bf16xbf16->f32" value: 326625901821362 }
+      flops { key: "f16xf16->f16" value: 322699372328036 }
+      flops { key: "f16xf16->f32" value: 313718804718600 }
+      flops { key: "f32xf32->f32" value: 127560656251856 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 577979719553223 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 649768123449319 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 445328145160454 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 670093969264373 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 656722828134556 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 295969906350136 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 644889984384384 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 427147418796618 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 540791651473180 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 292134899741531 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 681794951345344 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 405348115612391 }
+      flops { key: "bf16xbf16->f32" value: 397093869822485 }
+      flops { key: "f16xf16->f16" value: 395084840033115 }
+      flops { key: "f16xf16->f32" value: 357831938180833 }
+      flops { key: "f32xf32->f32" value: 170015232055735 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 906685095207937 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 741982775503152 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 727467360433604 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 811481233007415 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 743910504200225 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 389336653764220 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 749754263070611 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 779733544410656 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 692820469572932 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 387754913194601 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 908603193568859 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 503948876783854 }
+      flops { key: "bf16xbf16->f32" value: 439405319555987 }
+      flops { key: "f16xf16->f16" value: 470243312640280 }
+      flops { key: "f16xf16->f32" value: 396452420362763 }
+      flops { key: "f32xf32->f32" value: 194649579188878 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 900035057837384 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1106736403014881 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1266018362859248 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1009689637613870 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1010877857252133 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 435722109235705 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1235917354339772 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1101061922963532 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1124889126469143 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 439635830951314 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1288812391897974 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 199840279918109 }
+      flops { key: "bf16xbf16->f32" value: 189422567522272 }
+      flops { key: "f16xf16->f16" value: 190261685833259 }
+      flops { key: "f16xf16->f32" value: 188260160252476 }
+      flops { key: "f32xf32->f32" value: 91362843990640 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 408422146823887 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 456231920118971 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 456231920118971 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 418001683309002 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 440283679753972 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 180955015630924 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 430573162506265 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 439382843580562 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 472285825379371 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 185816703988924 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 460142200128562 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 295969906350136 }
+      flops { key: "bf16xbf16->f32" value: 292931884872459 }
+      flops { key: "f16xf16->f16" value: 283262476240725 }
+      flops { key: "f16xf16->f32" value: 281960761267027 }
+      flops { key: "f32xf32->f32" value: 111683780271215 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 592327581850779 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 545600520325203 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 530767090459713 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 553368201507440 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 586664020762191 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 267707625892105 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 522375005594745 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 534731984063745 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 592327581850779 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 270064281195963 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 587466460949254 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 387938787038500 }
+      flops { key: "bf16xbf16->f32" value: 382055044454822 }
+      flops { key: "f16xf16->f16" value: 373898084443283 }
+      flops { key: "f16xf16->f32" value: 359780301648133 }
+      flops { key: "f32xf32->f32" value: 147172343587503 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 823935023931705 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 769259355393364 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 717741860962566 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 763074939326641 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 781862703499749 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 350659669422162 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 722602279032597 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 742592141084936 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 730591927875824 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 347538469928994 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 767849699830160 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 484725095125908 }
+      flops { key: "bf16xbf16->f32" value: 478641216504610 }
+      flops { key: "f16xf16->f16" value: 439292962667484 }
+      flops { key: "f16xf16->f32" value: 420451761089560 }
+      flops { key: "f32xf32->f32" value: 192789626357841 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1074144628235588 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1118991023513319 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1340135667069698 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1149001416800428 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1148195100016708 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 480918992917728 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 940486625280560 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 787977029423231 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1040920305613620 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 484451721790623 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1223550258813474 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 544325621488035 }
+      flops { key: "bf16xbf16->f32" value: 508280153372781 }
+      flops { key: "f16xf16->f16" value: 489218019306888 }
+      flops { key: "f16xf16->f32" value: 438900165649030 }
+      flops { key: "f32xf32->f32" value: 216419529353224 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1390716546981563 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1343331705684572 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1416545941952506 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1444566579134346 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1323131423378323 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 548238290300448 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1418885793194582 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1294176476694476 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1342282145792640 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 540638486452465 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1447030464013476 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 333227348591822 }
+      flops { key: "bf16xbf16->f32" value: 329381287319299 }
+      flops { key: "f16xf16->f16" value: 330140842922479 }
+      flops { key: "f16xf16->f32" value: 314880300293255 }
+      flops { key: "f32xf32->f32" value: 211054903980343 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 924245168065418 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 803097848915482 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 812210154311649 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 912463840237943 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 806112480480480 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 804602340951667 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 869866794126582 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 876971372332822 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 827945502843373 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 834298231546231 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 812286959054373 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 329893603394972 }
+      flops { key: "bf16xbf16->f32" value: 334264712895945 }
+      flops { key: "f16xf16->f16" value: 313495541760186 }
+      flops { key: "f16xf16->f32" value: 311218238179776 }
+      flops { key: "f32xf32->f32" value: 118111231542401 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 845882283801083 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 691148134690429 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 664392806249516 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 704208443351369 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 687277240628875 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 299797036628566 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 613544844255562 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 676426064414520 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 711205049842689 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 297822123324954 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 707689453946284 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 417078225437595 }
+      flops { key: "bf16xbf16->f32" value: 413758394663005 }
+      flops { key: "f16xf16->f16" value: 384109402345365 }
+      flops { key: "f16xf16->f32" value: 402122256957610 }
+      flops { key: "f32xf32->f32" value: 153000990185775 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1078900316136527 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1042815817414792 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1011473016426258 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 995617002347077 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1024135271773472 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 358130311730003 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1036524129476002 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 963726428855916 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1031545179020685 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 356865648490891 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1047904430388240 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 522680941137098 }
+      flops { key: "bf16xbf16->f32" value: 517325700382426 }
+      flops { key: "f16xf16->f16" value: 462632804200888 }
+      flops { key: "f16xf16->f32" value: 449776005236081 }
+      flops { key: "f32xf32->f32" value: 211378853759293 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1386787414202974 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1344382908208780 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1352878762397873 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1413050599111696 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1329814163944577 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 527341682994022 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1491696551532517 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1392407284987741 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1322113179598668 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 522684916683146 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1352878762397873 }
+    }
+    entries {
+      b: 2
+      m: 2048
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 548987231763531 }
+      flops { key: "bf16xbf16->f32" value: 549821792503100 }
+      flops { key: "f16xf16->f16" value: 500495085584437 }
+      flops { key: "f16xf16->f32" value: 475194063735405 }
+      flops { key: "f32xf32->f32" value: 228118231791399 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1745101431898117 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1595381825138134 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1749566595447833 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1683042743439340 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1589477650367766 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 618067057332631 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1726663401995025 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1746010385080542 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1664272522728924 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 609234122831825 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1728400531602907 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 121822308146131 }
+      flops { key: "bf16xbf16->f32" value: 101911714502657 }
+      flops { key: "f16xf16->f16" value: 130419266852909 }
+      flops { key: "f16xf16->f32" value: 100387231114435 }
+      flops { key: "f32xf32->f32" value: 62627111344415 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 98716725567711 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 103095710417666 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 114057980029742 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 100575292618958 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 102115247170708 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 126129663338423 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 123802816095929 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 103294066762866 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 96594262684418 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 127933018467770 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 114057980029742 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 183592685987860 }
+      flops { key: "bf16xbf16->f32" value: 170448737836336 }
+      flops { key: "f16xf16->f16" value: 188425344213389 }
+      flops { key: "f16xf16->f32" value: 157209637481698 }
+      flops { key: "f32xf32->f32" value: 81968153288293 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 135539235546579 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 282898649453299 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 128553346183777 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 134520398897519 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 279948331117194 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 135882286003543 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 130752779347296 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 127333747287281 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 293733230474627 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 131392783162016 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 131064000488251 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 252570849514848 }
+      flops { key: "bf16xbf16->f32" value: 218362260206416 }
+      flops { key: "f16xf16->f16" value: 238251916347700 }
+      flops { key: "f16xf16->f32" value: 205786368453835 }
+      flops { key: "f32xf32->f32" value: 114179266695023 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 475422547708656 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 409981605192821 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 525571132648066 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 468167352954000 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 426299483473945 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 177360724149322 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 510515546891715 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 476530266947742 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 433178748966212 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 178251392239053 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 506900424406939 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 290161281988920 }
+      flops { key: "bf16xbf16->f32" value: 252126052010566 }
+      flops { key: "f16xf16->f16" value: 290750561603032 }
+      flops { key: "f16xf16->f32" value: 242017710309075 }
+      flops { key: "f32xf32->f32" value: 124092551385397 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 482390890773291 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 429711585392696 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 481876730169415 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 473875136095327 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 431005247967887 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 201438327322186 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 501572731052201 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 490685170341597 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 438060818603702 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 201911820793079 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 491808919729760 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 329261344730436 }
+      flops { key: "bf16xbf16->f32" value: 262865982985494 }
+      flops { key: "f16xf16->f16" value: 321605967614519 }
+      flops { key: "f16xf16->f32" value: 253017219204712 }
+      flops { key: "f32xf32->f32" value: 141118186839273 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 624699799425475 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 535749187139426 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 781187212804656 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 652259735904931 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 540468404819580 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 230015653822466 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 763787364246654 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 650777271260275 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 540451402541839 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 227873901528013 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 682363632839496 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 186462068941564 }
+      flops { key: "bf16xbf16->f32" value: 187111932386512 }
+      flops { key: "f16xf16->f16" value: 185816703988924 }
+      flops { key: "f16xf16->f32" value: 175763926010803 }
+      flops { key: "f32xf32->f32" value: 85295454104937 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 179285661045249 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 291342239587572 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 164949969122052 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 174054437348030 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 281378884696016 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 174054437348030 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 167785268224080 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 176922363486571 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 289769754149237 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 178986801800300 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 173212102597193 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 273147245993385 }
+      flops { key: "bf16xbf16->f32" value: 249041360083497 }
+      flops { key: "f16xf16->f16" value: 271078471093158 }
+      flops { key: "f16xf16->f32" value: 241466649575532 }
+      flops { key: "f32xf32->f32" value: 110700739625753 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 208584687290563 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 508099762924405 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 442096479258878 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 436746725238966 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 502159160060797 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 216600297342276 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 466134935532884 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 457203246327443 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 491752610029768 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 218140448778505 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 425454907974244 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 344741926877232 }
+      flops { key: "bf16xbf16->f32" value: 295969906350136 }
+      flops { key: "f16xf16->f16" value: 302654308787259 }
+      flops { key: "f16xf16->f32" value: 280854490501880 }
+      flops { key: "f32xf32->f32" value: 152185078874636 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 729320308371540 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 643923132833583 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 708857451064532 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 752381062625908 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 658787835876984 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 265219667531184 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 759029300344614 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 752381062625908 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 633429289285450 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 259444096529644 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 744555308312386 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 423566794477317 }
+      flops { key: "bf16xbf16->f32" value: 345018861388922 }
+      flops { key: "f16xf16->f16" value: 400052840536512 }
+      flops { key: "f16xf16->f32" value: 319209758156819 }
+      flops { key: "f32xf32->f32" value: 161469488650995 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 822357435450672 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 548772413722609 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 883374598107774 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 811442904968826 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 566898834647747 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 316971756162361 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 883329178055427 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 820002347572908 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 547356204288399 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 313381171157038 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 608740315498547 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 427790913333084 }
+      flops { key: "bf16xbf16->f32" value: 360312269879720 }
+      flops { key: "f16xf16->f16" value: 403733486493155 }
+      flops { key: "f16xf16->f32" value: 341110686773421 }
+      flops { key: "f32xf32->f32" value: 175529572912249 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 912463840237943 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 812613541328666 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1063505582765878 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 918832420590988 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 806131393097623 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 348808583923821 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1047904430388240 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 929772381761602 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 811462068535531 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 348529070020794 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 975796273088719 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 232562664933939 }
+      flops { key: "bf16xbf16->f32" value: 218140448778505 }
+      flops { key: "f16xf16->f16" value: 229824876712328 }
+      flops { key: "f16xf16->f32" value: 223824446088905 }
+      flops { key: "f32xf32->f32" value: 103738159895657 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 232575258352737 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 478601214174281 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 454301596784429 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 438485686166411 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 462122584032709 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 204609942165690 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 482960451591139 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 489566544625555 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 457203246327443 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 205196469160575 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 440328818535985 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 329899938244104 }
+      flops { key: "bf16xbf16->f32" value: 313718804718600 }
+      flops { key: "f16xf16->f16" value: 315574378839088 }
+      flops { key: "f16xf16->f32" value: 306105573088161 }
+      flops { key: "f32xf32->f32" value: 130472752282151 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 583476062491509 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 717142644180998 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 479188585964520 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 680714366590062 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 721964581610354 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 293934252395291 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 542191162784826 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 731805639120804 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 718342079946479 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 293743275040180 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 495782903843934 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 429078378181273 }
+      flops { key: "bf16xbf16->f32" value: 382403712415972 }
+      flops { key: "f16xf16->f16" value: 390762406095758 }
+      flops { key: "f16xf16->f32" value: 368437435587295 }
+      flops { key: "f32xf32->f32" value: 174832027517427 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 892507100836407 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 836777029077979 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 878810639111975 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 861146325012531 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 851795784818285 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 361301139516298 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 891580735066687 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 900931836173894 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 833529143855223 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 376025853265627 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 833529143855223 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 502916209774447 }
+      flops { key: "bf16xbf16->f32" value: 438956236496499 }
+      flops { key: "f16xf16->f16" value: 474012421096196 }
+      flops { key: "f16xf16->f32" value: 416370645015874 }
+      flops { key: "f32xf32->f32" value: 186521789276544 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1086405235020710 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1016259638213546 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1117535236063227 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1066145537048529 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1070797131887309 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 441329887200565 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1164578984815618 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1086405235020710 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1054367815392168 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 439186276832619 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1151311431711566 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 509565373731082 }
+      flops { key: "bf16xbf16->f32" value: 464829588711968 }
+      flops { key: "f16xf16->f16" value: 464955390032341 }
+      flops { key: "f16xf16->f32" value: 417030135001790 }
+      flops { key: "f32xf32->f32" value: 204232315242943 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1300569225481661 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1202966769995623 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1326195587085319 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1264597205351392 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1186741904742168 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 475853813271658 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1297132332968402 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1303035320565816 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1173368110098009 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 475985653383943 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1383437214100215 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 272290062192918 }
+      flops { key: "bf16xbf16->f32" value: 269894573538190 }
+      flops { key: "f16xf16->f16" value: 266205980909879 }
+      flops { key: "f16xf16->f32" value: 263591953848042 }
+      flops { key: "f32xf32->f32" value: 116442111861190 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 681794951345344 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 612647784894087 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 711205049842689 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 738093709572091 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 604882373917329 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 224063818034796 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 700761510197422 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 721964581610354 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 570305045279511 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 229089358651589 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 721964581610354 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 367012800341807 }
+      flops { key: "bf16xbf16->f32" value: 371955252100112 }
+      flops { key: "f16xf16->f16" value: 353699027917318 }
+      flops { key: "f16xf16->f32" value: 351527852021607 }
+      flops { key: "f32xf32->f32" value: 147502139432653 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 858564177111444 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 859423170785392 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 855997468061783 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 877016140895400 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 827108429252323 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 325019281546785 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 885149630789839 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 869030764530325 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 834379270713938 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 325142306370415 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 916357434606358 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 485279622168239 }
+      flops { key: "bf16xbf16->f32" value: 477835793010416 }
+      flops { key: "f16xf16->f16" value: 436164595859197 }
+      flops { key: "f16xf16->f32" value: 412066324090952 }
+      flops { key: "f32xf32->f32" value: 191862737627383 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1198790676435698 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1080936809639160 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1138305064369720 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1124153062915099 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1078223189129820 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 410785452250011 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1140572227983402 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1143609198468963 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1099617191026338 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 435280519502894 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1138305064369720 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 543722667173047 }
+      flops { key: "bf16xbf16->f32" value: 513069306216309 }
+      flops { key: "f16xf16->f16" value: 488314171565004 }
+      flops { key: "f16xf16->f32" value: 465585419423027 }
+      flops { key: "f32xf32->f32" value: 206967673812607 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1546134111866084 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1353411654081733 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1449472194389369 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1415378907892568 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1289320188671457 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 480045523192131 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1422410099685378 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1413631957870484 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1303035320565816 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 482750100007024 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1463673625899893 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 552969673631144 }
+      flops { key: "bf16xbf16->f32" value: 536959006837059 }
+      flops { key: "f16xf16->f16" value: 497774245028195 }
+      flops { key: "f16xf16->f32" value: 471893402478969 }
+      flops { key: "f32xf32->f32" value: 224623736803827 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1680573158459789 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1549987633747223 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1637269530544172 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1620264703471853 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1564473004803642 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 569112467119674 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1664272522728924 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1593550540563729 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1563778783146924 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 569395400025686 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1678930790877218 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 310094747193242 }
+      flops { key: "bf16xbf16->f32" value: 301269078193774 }
+      flops { key: "f16xf16->f16" value: 298028782791222 }
+      flops { key: "f16xf16->f32" value: 295257779947066 }
+      flops { key: "f32xf32->f32" value: 102097648313117 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 909565289284201 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 806150306602224 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 797876146386773 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 803135392641765 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 793454146683909 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 231568954750704 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 806150306602224 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 816883133659835 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 810677103812759 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 230385801045997 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 823145473815341 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 413658769464141 }
+      flops { key: "bf16xbf16->f32" value: 409025026998714 }
+      flops { key: "f16xf16->f16" value: 395353051674740 }
+      flops { key: "f16xf16->f32" value: 393087042306372 }
+      flops { key: "f32xf32->f32" value: 158808916513757 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1144370969791840 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1059570074256815 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1115358643381159 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1096809090177801 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1057613222359024 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 361986287062789 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1085718657945460 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1079578294152763 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1052397879506263 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 359934825405139 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1082298748480171 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 518496685700488 }
+      flops { key: "bf16xbf16->f32" value: 514918488621803 }
+      flops { key: "f16xf16->f16" value: 453581930087654 }
+      flops { key: "f16xf16->f32" value: 451552234030949 }
+      flops { key: "f32xf32->f32" value: 200122534446557 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1451308906779303 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1399211547573962 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1360377644976739 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1413050599111696 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1348075108600125 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 494295822593058 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1408994438120233 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1405536217295263 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1396936083101254 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 492023718816900 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1424178826494238 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 584580439850791 }
+      flops { key: "bf16xbf16->f32" value: 567889666725891 }
+      flops { key: "f16xf16->f16" value: 511311337075934 }
+      flops { key: "f16xf16->f32" value: 499912534543840 }
+      flops { key: "f32xf32->f32" value: 221048950672126 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1806671926596821 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1680162265400178 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1739799656594554 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1729292165934798 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1671966052796769 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 550795716200185 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1676473249557824 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1764413036420823 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1712442884561233 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 547105634195954 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1738919157761554 }
+    }
+    entries {
+      b: 2
+      m: 4096
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 563134769747665 }
+      flops { key: "bf16xbf16->f32" value: 555386320404258 }
+      flops { key: "f16xf16->f16" value: 507530307375013 }
+      flops { key: "f16xf16->f32" value: 497556198039300 }
+      flops { key: "f32xf32->f32" value: 234635561748512 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1865374848627153 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1832006417829674 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1865121707066183 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1831518149704828 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1790887221354251 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 647890490739300 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1875314046160038 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1863857029143329 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1790653891640120 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 648287776455993 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1904998211583375 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 23513967764540 }
+      flops { key: "bf16xbf16->f32" value: 22262021562448 }
+      flops { key: "f16xf16->f16" value: 25191015015015 }
+      flops { key: "f16xf16->f32" value: 21341664493560 }
+      flops { key: "f32xf32->f32" value: 18769085162914 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 30875943869335 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 30734538126860 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 32529745031507 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 29007505511130 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 31602949846950 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 35451063919704 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 33009770782095 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 28882661502044 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 31903429522224 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 34898005200208 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 34898005200208 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 40488002413273 }
+      flops { key: "bf16xbf16->f32" value: 42279958418648 }
+      flops { key: "f16xf16->f16" value: 49820982925018 }
+      flops { key: "f16xf16->f32" value: 42548019654461 }
+      flops { key: "f32xf32->f32" value: 31458508848001 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 45582519273221 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 46051716589466 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 52347007800312 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 48913166180758 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 38618250035966 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 52966743488555 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 45274996795412 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 39533940500736 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 40245195802098 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 52977196763370 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 42279958418648 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 69624032161846 }
+      flops { key: "bf16xbf16->f32" value: 69077574884199 }
+      flops { key: "f16xf16->f16" value: 70160861474124 }
+      flops { key: "f16xf16->f32" value: 66182311637080 }
+      flops { key: "f32xf32->f32" value: 50193615557217 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 77236500071932 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 80249762630792 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 82735538912004 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 77459372673495 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 80490391604197 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 88461181743285 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 79772795245170 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 84017357120500 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 73033724935382 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 77694777424023 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 80010568107302 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 100013210134128 }
+      flops { key: "bf16xbf16->f32" value: 102309845069080 }
+      flops { key: "f16xf16->f16" value: 121836131169862 }
+      flops { key: "f16xf16->f32" value: 100013210134128 }
+      flops { key: "f32xf32->f32" value: 52761133310402 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 105114226529613 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 119930953200044 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 117054597623460 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 117812357252578 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 122671292585399 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 121285645995707 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 118606188445819 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 105320433938205 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 118855636927164 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 120469182542353 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 118855636927164 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 174905004723896 }
+      flops { key: "bf16xbf16->f32" value: 176631324888962 }
+      flops { key: "f16xf16->f16" value: 183891389621510 }
+      flops { key: "f16xf16->f32" value: 166743042782824 }
+      flops { key: "f32xf32->f32" value: 89946959078534 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 148913643159281 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 258982591413410 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 148697108987674 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 148296640287272 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 264078166256763 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 146876660146364 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 148491470612640 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 149733903779110 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 258951362353792 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 149120453301854 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 146067449870765 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 34721957832104 }
+      flops { key: "bf16xbf16->f32" value: 37020473865673 }
+      flops { key: "f16xf16->f16" value: 36417779948446 }
+      flops { key: "f16xf16->f32" value: 38070551127499 }
+      flops { key: "f32xf32->f32" value: 29517864086210 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 45894247905624 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 44971595912213 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 39528118981004 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 48550453246518 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 45130372562205 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 52551968676585 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 43226321417069 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 43797594387338 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 52551968676585 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 47184998417999 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 43233283298437 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 61195818078194 }
+      flops { key: "bf16xbf16->f32" value: 64126960344003 }
+      flops { key: "f16xf16->f16" value: 67513947686116 }
+      flops { key: "f16xf16->f32" value: 63966509233885 }
+      flops { key: "f32xf32->f32" value: 50382030030030 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 63519984855655 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 62917017696003 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 66841498007968 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 61335646292699 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 63814443361464 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 66345886307464 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 65368429562888 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 62623458765892 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 66019541564190 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 65857570166830 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 65059490063015 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 89048086249792 }
+      flops { key: "bf16xbf16->f32" value: 91796342993930 }
+      flops { key: "f16xf16->f16" value: 118071456344842 }
+      flops { key: "f16xf16->f32" value: 90702975502618 }
+      flops { key: "f32xf32->f32" value: 67176040040040 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 111222480215454 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 79536431407407 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 111906391245440 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 110535497632283 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 79536431407407 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 112386625915846 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 111222480215454 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 104908825012213 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 79184500294985 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 113335636900992 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 110981067080103 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 177214362766133 }
+      flops { key: "bf16xbf16->f32" value: 174054437348030 }
+      flops { key: "f16xf16->f16" value: 171812436834946 }
+      flops { key: "f16xf16->f32" value: 168840604450035 }
+      flops { key: "f32xf32->f32" value: 100669587849240 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 176341242240105 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 255866036935541 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 172641180802315 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 175190377549355 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 277023174406604 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 171537954149692 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 170733315948481 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 170991611434031 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 228601623163721 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 174054437348030 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 174905004723896 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 256492522902358 }
+      flops { key: "bf16xbf16->f32" value: 232072583130707 }
+      flops { key: "f16xf16->f16" value: 247035965489474 }
+      flops { key: "f16xf16->f32" value: 227632356158575 }
+      flops { key: "f32xf32->f32" value: 97380507788232 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 219030409301851 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 292931884872459 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 212097150419753 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 218807239085027 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 374223864773024 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 218796092511462 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 213786326331508 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 215070971256885 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 303295480262693 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 215936012870789 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 215936012870789 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 74245735306320 }
+      flops { key: "bf16xbf16->f32" value: 71851032119914 }
+      flops { key: "f16xf16->f16" value: 69615004149377 }
+      flops { key: "f16xf16->f32" value: 53393427349577 }
+      flops { key: "f32xf32->f32" value: 62623458765892 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 91165038546442 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 90856475207310 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 88170621120052 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 89943191824426 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 85082553407290 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 87296083252032 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 91165038546442 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 85639003349816 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 85082553407290 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 89048086249792 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 95375894830342 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 101334637976594 }
+      flops { key: "bf16xbf16->f32" value: 93393217708967 }
+      flops { key: "f16xf16->f16" value: 96759648914120 }
+      flops { key: "f16xf16->f32" value: 94544494496786 }
+      flops { key: "f32xf32->f32" value: 57893019032727 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 78720075073313 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 100953537420082 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 78375315620437 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 80732467969924 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 163431023439878 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 82984915681273 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 81840078048780 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 80490391604197 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 105310104354648 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 83242253197922 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 84023931763048 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 144884877074618 }
+      flops { key: "bf16xbf16->f32" value: 154262168522376 }
+      flops { key: "f16xf16->f16" value: 143913928963945 }
+      flops { key: "f16xf16->f32" value: 141635908719166 }
+      flops { key: "f32xf32->f32" value: 84486727830671 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 135368359051941 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 275601084188911 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 136408794257765 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 136747557819663 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 273495115639327 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 137632740370441 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 132527996050357 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 138520521705476 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 270055790744466 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 139428882482794 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 136054463253928 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 230317851565851 }
+      flops { key: "bf16xbf16->f32" value: 223836110902647 }
+      flops { key: "f16xf16->f16" value: 215719100753390 }
+      flops { key: "f16xf16->f32" value: 212306836183885 }
+      flops { key: "f32xf32->f32" value: 117496506428845 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 221287407697459 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 391305329446064 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 225244771134885 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 225481273414531 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 306323892447043 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 221973605664375 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 221755849648905 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 232060044089042 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 380860804823978 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 223370464738922 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 225244771134885 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 308092772569133 }
+      flops { key: "bf16xbf16->f32" value: 296993209279811 }
+      flops { key: "f16xf16->f16" value: 299697669108924 }
+      flops { key: "f16xf16->f32" value: 287442597778075 }
+      flops { key: "f32xf32->f32" value: 126135219629667 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 288795541689080 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 449546503663387 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 285341967579059 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 293532483324220 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 433178748966212 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 286292980669244 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 283636605316163 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 289379281498450 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 440758099030222 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 285332489353927 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 286474390261797 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 126725106101734 }
+      flops { key: "bf16xbf16->f32" value: 125246917531785 }
+      flops { key: "f16xf16->f16" value: 120998627901735 }
+      flops { key: "f16xf16->f32" value: 123802816095929 }
+      flops { key: "f32xf32->f32" value: 92587895490212 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 126426683621806 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 110981067080103 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 112140138276762 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 130118980126030 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 117297555604107 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 110524119814719 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 110752122124806 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 124376442024788 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 108954015626585 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 110297054340010 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 119397511842544 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 162935026403641 }
+      flops { key: "bf16xbf16->f32" value: 164432132312404 }
+      flops { key: "f16xf16->f16" value: 158837547928994 }
+      flops { key: "f16xf16->f32" value: 161222496096096 }
+      flops { key: "f32xf32->f32" value: 140147728773738 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 166471600620155 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 160499525261584 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 164949969122052 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 171812436834946 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 156968324537680 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 159794899025225 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 155829304694869 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 162442030862329 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 157891599735313 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 156979798830409 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 157659764187651 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 190599418478743 }
+      flops { key: "bf16xbf16->f32" value: 188922639922582 }
+      flops { key: "f16xf16->f16" value: 184698000172013 }
+      flops { key: "f16xf16->f32" value: 185175790980425 }
+      flops { key: "f32xf32->f32" value: 90592012149335 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 353844726973142 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 379514650172307 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 378845135044544 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 372277654156193 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 344175598685792 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 154823809379618 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 354428725532266 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 357973603600600 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 372277654156193 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 155721956999383 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 356192344999170 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 270574687120042 }
+      flops { key: "bf16xbf16->f32" value: 268704160160160 }
+      flops { key: "f16xf16->f16" value: 265055992100715 }
+      flops { key: "f16xf16->f32" value: 258351667478721 }
+      flops { key: "f32xf32->f32" value: 128248176174621 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 461650700919009 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 444866880314879 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 263915896276268 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 266041086223984 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 450017528918692 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 266205980909879 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 262777527363945 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 266205980909879 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 449993954214469 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 268376748586246 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 266041086223984 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 344741926877232 }
+      flops { key: "bf16xbf16->f32" value: 340498844197800 }
+      flops { key: "f16xf16->f16" value: 335570536448160 }
+      flops { key: "f16xf16->f32" value: 326129867952465 }
+      flops { key: "f32xf32->f32" value: 136732320837909 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 344603626268704 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 624245818974601 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 343363896230563 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 345018861388922 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 635796942526183 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 338486241434341 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 345991645869416 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 345296241186638 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 616605742014212 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 343501203343063 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 341175040889683 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 161222496096096 }
+      flops { key: "bf16xbf16->f32" value: 167510424960998 }
+      flops { key: "f16xf16->f16" value: 164684328834355 }
+      flops { key: "f16xf16->f32" value: 168840604450035 }
+      flops { key: "f32xf32->f32" value: 128707440695235 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 164180707033639 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 167262531972895 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 172919208309847 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 168311282075397 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 159072862814814 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 165445581510015 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 103488200472266 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 174337039129728 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 168840604450035 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 169640860099533 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 168047863526097 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 268368363909022 }
+      flops { key: "bf16xbf16->f32" value: 279930085120250 }
+      flops { key: "f16xf16->f16" value: 270395825736590 }
+      flops { key: "f16xf16->f32" value: 273495115639327 }
+      flops { key: "f32xf32->f32" value: 193006214712623 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 313478380848113 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 325870052807283 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 327885128330406 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 319091180980683 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 323416212048192 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 313959597660818 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 328864264624808 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 313959597660818 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 351527852021607 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 311206962973697 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 327860098931297 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 350953366236313 }
+      flops { key: "bf16xbf16->f32" value: 347531439576000 }
+      flops { key: "f16xf16->f16" value: 346131063061611 }
+      flops { key: "f16xf16->f32" value: 345005004096714 }
+      flops { key: "f32xf32->f32" value: 229089358651589 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1250354380203784 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1257677099853587 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1280169089716840 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1323564652080123 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1194539645668196 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 1214811850091924 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1140610090559022 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1295616077224736 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1168539598966127 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1250354380203784 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1235961811798561 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 306329354421125 }
+      flops { key: "bf16xbf16->f32" value: 305457909144249 }
+      flops { key: "f16xf16->f16" value: 296174002413543 }
+      flops { key: "f16xf16->f32" value: 294751212709741 }
+      flops { key: "f32xf32->f32" value: 135909159967406 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 639607936857781 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 644889984384384 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 649276991080876 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 630199522541359 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 626088527113702 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 289476800970546 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 660789614369783 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 597706195734613 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 615280752954659 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 289769754149237 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 635820473131014 }
+    }
+    entries {
+      b: 4
+      m: 256
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 379690790196035 }
+      flops { key: "bf16xbf16->f32" value: 384888188547360 }
+      flops { key: "f16xf16->f16" value: 357831938180833 }
+      flops { key: "f16xf16->f32" value: 352537740786341 }
+      flops { key: "f32xf32->f32" value: 145871492723351 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 382399456534562 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 725961089541517 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 381380777285693 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 383081604673720 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 726267984950327 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 381465459882539 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 380110830010841 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 382740226660577 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 756023111424045 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 382574025386362 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 381550180093944 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 45122786350647 }
+      flops { key: "bf16xbf16->f32" value: 39768215703703 }
+      flops { key: "f16xf16->f16" value: 43233283298437 }
+      flops { key: "f16xf16->f32" value: 42819501674908 }
+      flops { key: "f32xf32->f32" value: 31606670905451 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 50763134644478 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 43648041626016 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 50382030030030 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 48037841088045 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 41617900155038 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 58520919119250 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 57272339662897 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 51542906298003 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 40245195802098 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 58520919119250 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 44230590871642 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 74451658854527 }
+      flops { key: "bf16xbf16->f32" value: 65059490063015 }
+      flops { key: "f16xf16->f16" value: 71668790815645 }
+      flops { key: "f16xf16->f32" value: 70353939457476 }
+      flops { key: "f32xf32->f32" value: 51052768352985 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 77920306531204 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 82468650076804 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 81965024732824 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 83235800310077 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 70911492801479 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 79067881001472 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 82216066156202 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 84813730173775 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 78593311667398 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 79289752178407 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 79067881001472 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 110992539177175 }
+      flops { key: "bf16xbf16->f32" value: 103683065276168 }
+      flops { key: "f16xf16->f16" value: 130103213861626 }
+      flops { key: "f16xf16->f32" value: 99457375324194 }
+      flops { key: "f32xf32->f32" value: 77920306531204 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 112151851263839 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 120998627901735 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 114544679325794 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 117297555604107 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 114544679325794 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 119917559079740 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 120469182542353 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 111685232369461 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 121012264623013 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 123234457018248 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 117812357252578 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 185175790980425 }
+      flops { key: "bf16xbf16->f32" value: 172641180802315 }
+      flops { key: "f16xf16->f16" value: 192134172676031 }
+      flops { key: "f16xf16->f32" value: 169909300419336 }
+      flops { key: "f32xf32->f32" value: 85772402763909 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 141822985602958 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 282898649453299 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 144107076097168 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 139601095234999 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 206171625192012 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 147888137731561 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 146465942436229 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 143529183798957 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 287442597778075 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 146666005190547 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 144689640749225 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 253749692544015 }
+      flops { key: "bf16xbf16->f32" value: 214426724712930 }
+      flops { key: "f16xf16->f16" value: 257106692367554 }
+      flops { key: "f16xf16->f32" value: 208797632280019 }
+      flops { key: "f32xf32->f32" value: 120128864598774 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 195643752380084 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 374223864773024 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 446740929477844 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 201150585237916 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 394903208532548 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 182337817703247 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 485142583982830 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 442141990529133 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 399308971364819 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 182337817703247 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 449546503663387 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 57517775016070 }
+      flops { key: "bf16xbf16->f32" value: 59296544289816 }
+      flops { key: "f16xf16->f16" value: 59296544289816 }
+      flops { key: "f16xf16->f32" value: 59566283368467 }
+      flops { key: "f32xf32->f32" value: 50104611479234 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 70724662363324 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 63064831669211 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 73232971218114 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 73644843895747 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 77247613237410 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 81715511719939 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 70538813822099 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 74451658854527 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 71477953934229 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 75936479773691 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 69987082779298 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 96943104369808 }
+      flops { key: "bf16xbf16->f32" value: 99827242841204 }
+      flops { key: "f16xf16->f16" value: 99827242841204 }
+      flops { key: "f16xf16->f32" value: 97118471780028 }
+      flops { key: "f32xf32->f32" value: 60776692364295 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 118868794863279 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 87445380242690 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 109175579461108 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 116787233413095 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 87738341559078 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 120740112897784 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 116281332466969 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 116030022044521 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 87310280045535 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 118855636927164 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 114789589908060 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 182655749595985 }
+      flops { key: "bf16xbf16->f32" value: 189422567522272 }
+      flops { key: "f16xf16->f16" value: 182036420106806 }
+      flops { key: "f16xf16->f32" value: 181405951005237 }
+      flops { key: "f32xf32->f32" value: 101435154125926 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 176341242240105 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 323904019306184 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 176631324888962 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 173198132752641 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 302889089985895 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 176341242240105 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 170719743063836 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 173212102597193 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 320042272429210 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 176341242240105 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 179285661045249 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 271421087967644 }
+      flops { key: "bf16xbf16->f32" value: 253166359917477 }
+      flops { key: "f16xf16->f16" value: 266041086223984 }
+      flops { key: "f16xf16->f32" value: 242297602166309 }
+      flops { key: "f32xf32->f32" value: 112859136430523 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 215936012870789 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 288214152194336 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 217919087523466 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 220153123994054 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 438485686166411 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 216153361650729 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 312588595050946 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 213786326331508 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 470217571272169 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 218362260206416 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 218140448778505 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 333227348591822 }
+      flops { key: "bf16xbf16->f32" value: 293332010381095 }
+      flops { key: "f16xf16->f16" value: 323172858991723 }
+      flops { key: "f16xf16->f32" value: 283075781578513 }
+      flops { key: "f32xf32->f32" value: 153657846484088 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 535398565943654 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 533403787382016 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 585065698951096 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 577202969493347 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 547722667346808 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 268200780317222 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 528806611179512 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 610037255308571 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 536736727818045 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 265219667531184 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 589077944863530 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 103085812596006 }
+      flops { key: "bf16xbf16->f32" value: 105103937353171 }
+      flops { key: "f16xf16->f16" value: 93719282883826 }
+      flops { key: "f16xf16->f32" value: 105943939220522 }
+      flops { key: "f32xf32->f32" value: 60366662393883 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 93719282883826 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 138887831328418 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 94047632828238 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 91483498679389 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 143721298889037 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 100199871593878 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 94711283761136 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 86459604154923 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 140321722948248 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 98004912741876 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 88607181383066 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 165713685315224 }
+      flops { key: "bf16xbf16->f32" value: 159545590490341 }
+      flops { key: "f16xf16->f16" value: 158135762002945 }
+      flops { key: "f16xf16->f32" value: 146465942436229 }
+      flops { key: "f32xf32->f32" value: 78087474928184 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 154262168522376 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 274930693637178 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 147067774825366 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 153820188238664 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 270089755753993 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 155378311844294 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 151423187702721 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 149744344745833 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 275601084188911 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 151220593479332 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 147674573511208 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 230825350459504 }
+      flops { key: "bf16xbf16->f32" value: 226432269928300 }
+      flops { key: "f16xf16->f16" value: 217698175072228 }
+      flops { key: "f16xf16->f32" value: 220832294513856 }
+      flops { key: "f32xf32->f32" value: 119258268895429 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 226193769538656 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 453294701424802 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 230565132918187 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 225943884265348 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 432306723301459 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 232072583130707 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 471249429010313 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 233574466826191 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 436702317844433 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 230071100064281 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 229579179816121 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 324896349786300 }
+      flops { key: "bf16xbf16->f32" value: 318381563825055 }
+      flops { key: "f16xf16->f16" value: 314880300293255 }
+      flops { key: "f16xf16->f32" value: 299687213201688 }
+      flops { key: "f32xf32->f32" value: 125104637091841 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 610037255308571 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 589077944863530 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 629714433839161 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 647808038612368 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 601493914431762 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 292941874705862 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 643923132833583 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 604031684972927 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 626956761696226 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 291540001086071 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 642959176047904 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 402122256957610 }
+      flops { key: "bf16xbf16->f32" value: 372924137883129 }
+      flops { key: "f16xf16->f16" value: 380531800208208 }
+      flops { key: "f16xf16->f32" value: 350659669422162 }
+      flops { key: "f32xf32->f32" value: 180269558388684 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 714161505819753 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 644889984384384 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 704786231703314 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 714755749043102 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 642959176047904 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 365918406474973 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 749100426615505 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 711205049842689 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 654246893788796 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 365451375962561 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 718973391253400 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 165700898765432 }
+      flops { key: "bf16xbf16->f32" value: 160739794011976 }
+      flops { key: "f16xf16->f16" value: 167002383389066 }
+      flops { key: "f16xf16->f32" value: 165700898765432 }
+      flops { key: "f32xf32->f32" value: 133350946845504 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 176052110837842 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 175749541533677 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 168575527749430 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 184206866357865 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 180188257090115 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 174905004723896 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 177214362766133 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 177507327492147 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 181099987181649 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 172087799342896 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 175190377549355 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 200774462228870 }
+      flops { key: "bf16xbf16->f32" value: 192142768129557 }
+      flops { key: "f16xf16->f16" value: 188756583282060 }
+      flops { key: "f16xf16->f32" value: 187766341523126 }
+      flops { key: "f32xf32->f32" value: 90020483662048 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 417189635356969 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 444889920861818 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 443970156708703 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 357377874521551 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 475475179453116 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 176776724399078 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 445813503840564 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 356784124937697 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 353262649777924 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 176776724399078 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 356784124937697 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 283075781578513 }
+      flops { key: "bf16xbf16->f32" value: 281406538640458 }
+      flops { key: "f16xf16->f16" value: 272462796713927 }
+      flops { key: "f16xf16->f32" value: 273852602799120 }
+      flops { key: "f32xf32->f32" value: 130391550927472 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 586664020762191 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 624223137272000 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 560590915094955 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 557679321690579 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 599772000558581 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 273164618457037 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 551237540396586 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 528806611179512 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 593186561149091 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 272117546551778 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 530767090459713 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 369865210962561 }
+      flops { key: "bf16xbf16->f32" value: 365295963937912 }
+      flops { key: "f16xf16->f16" value: 348242944560436 }
+      flops { key: "f16xf16->f32" value: 339288420736644 }
+      flops { key: "f32xf32->f32" value: 140932963503170 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 673245128301591 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 750409241897440 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 736227520205699 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 739427958336920 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 733712115481528 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 349802886893490 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 755690559690331 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 731836812949946 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 739427958336920 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 351527852021607 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 713568249875394 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 452739229810390 }
+      flops { key: "bf16xbf16->f32" value: 428644798063848 }
+      flops { key: "f16xf16->f16" value: 418098324040836 }
+      flops { key: "f16xf16->f32" value: 397553320312861 }
+      flops { key: "f32xf32->f32" value: 199191508023374 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 970806045489221 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 954596276268266 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1044718245249171 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1015028754482880 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 912948729089170 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 448712857732389 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 999672350760815 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 987008455934735 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 956722681071448 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 450720007975548 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1020485250014850 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 258655061487503 }
+      flops { key: "bf16xbf16->f32" value: 251094258754750 }
+      flops { key: "f16xf16->f16" value: 259279643585873 }
+      flops { key: "f16xf16->f32" value: 250508445377661 }
+      flops { key: "f32xf32->f32" value: 179136106773440 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 330407515655050 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 323904019306184 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 331939662725094 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 334004766778132 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 317205856425406 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 321479588023952 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 329874600307219 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 321961566416791 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 322444992192192 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 325870052807283 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 336095727052195 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 322699372328036 }
+      flops { key: "bf16xbf16->f32" value: 329899938244104 }
+      flops { key: "f16xf16->f16" value: 322942012556863 }
+      flops { key: "f16xf16->f32" value: 322457096437553 }
+      flops { key: "f32xf32->f32" value: 213044012698412 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1174932921898509 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1111102650627344 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1152856608777345 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1131594597813199 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1152856608777345 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 1143647262947676 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1143495020234291 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1178317502331961 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1125515538784067 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1122573783585990 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1194539645668196 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 326253735120969 }
+      flops { key: "bf16xbf16->f32" value: 330267776231304 }
+      flops { key: "f16xf16->f16" value: 309982844069142 }
+      flops { key: "f16xf16->f32" value: 309865432678606 }
+      flops { key: "f32xf32->f32" value: 137433456133754 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 691704681885896 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 659799876488209 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 663879325450189 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 686727792461126 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 693939862826675 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 299274787631739 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 642959176047904 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 690592482373276 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 658282978925588 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 298546688400382 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 664907081972288 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 413858067860713 }
+      flops { key: "bf16xbf16->f32" value: 414957650906368 }
+      flops { key: "f16xf16->f16" value: 376112291259372 }
+      flops { key: "f16xf16->f32" value: 390851306654533 }
+      flops { key: "f32xf32->f32" value: 150662280507590 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 978575369332422 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 937893772840180 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 967525648860980 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 963186117455778 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 942550566961101 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 390762406095758 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 944104477880969 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 988143861957897 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 939432354559125 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 388460711218640 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 979691445255474 }
+    }
+    entries {
+      b: 4
+      m: 512
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 488036736094540 }
+      flops { key: "bf16xbf16->f32" value: 473421354662257 }
+      flops { key: "f16xf16->f16" value: 439015126307249 }
+      flops { key: "f16xf16->f32" value: 431178325067764 }
+      flops { key: "f32xf32->f32" value: 211495953588718 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1187562242698648 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1099282976916801 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1194601942390265 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1168957026825658 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1136798622597187 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 508807024552050 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1177388834869615 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1177772237407236 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1091235696255597 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 511385534465950 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1192942917038451 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 62917017696003 }
+      flops { key: "bf16xbf16->f32" value: 62477704177819 }
+      flops { key: "f16xf16->f16" value: 67513947686116 }
+      flops { key: "f16xf16->f32" value: 63213341810903 }
+      flops { key: "f32xf32->f32" value: 46454175997231 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 73033724935382 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 75297463113604 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 83248707086369 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 81467513201820 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 70715346680716 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 89344468630387 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 94702930322808 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 78147148762736 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 62332626494833 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 88461181743285 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 82722790755007 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 136054463253928 }
+      flops { key: "bf16xbf16->f32" value: 121546504867557 }
+      flops { key: "f16xf16->f16" value: 118593088579633 }
+      flops { key: "f16xf16->f32" value: 118071456344842 }
+      flops { key: "f32xf32->f32" value: 62044483069455 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 104287278943278 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 97109688342226 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 106999683507722 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 105320433938205 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 110070919938493 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 106574870868486 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 109175579461108 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 105103937353171 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 107859550376695 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 99457375324194 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 103284130819545 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 195634840849048 }
+      flops { key: "bf16xbf16->f32" value: 158135762002945 }
+      flops { key: "f16xf16->f16" value: 186462068941564 }
+      flops { key: "f16xf16->f32" value: 173758689861639 }
+      flops { key: "f32xf32->f32" value: 86672464301570 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 138164038345235 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 233067467766442 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 146465942436229 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 249910816711276 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 234620741614771 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 152077306706323 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 145869015622877 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 227632356158575 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 247605632191859 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 151862219645003 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 144884877074618 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 243949068272179 }
+      flops { key: "bf16xbf16->f32" value: 205589358862668 }
+      flops { key: "f16xf16->f16" value: 257106692367554 }
+      flops { key: "f16xf16->f32" value: 203052538577912 }
+      flops { key: "f32xf32->f32" value: 118534174973781 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 457203246327443 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 369078568015811 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 499821633422553 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 461130265836375 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 373572870835870 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 184372925348787 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 514182604573207 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 479670236318963 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 367153983244999 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 182959203237486 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 502159160060797 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 292532849475548 }
+      flops { key: "bf16xbf16->f32" value: 242154162095114 }
+      flops { key: "f16xf16->f16" value: 290947520390191 }
+      flops { key: "f16xf16->f32" value: 234864510089134 }
+      flops { key: "f32xf32->f32" value: 141958925665179 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 578758562996900 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 521708751412086 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 507529370280649 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 483476928688017 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 385665810263547 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 210842507351316 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 650752620606060 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 595613270836222 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 379514650172307 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 210946062031875 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 641039894925373 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 128869638022083 }
+      flops { key: "bf16xbf16->f32" value: 123517982744737 }
+      flops { key: "f16xf16->f16" value: 120998627901735 }
+      flops { key: "f16xf16->f32" value: 125246917531785 }
+      flops { key: "f32xf32->f32" value: 65612088237091 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 118331697597531 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 169627460347551 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 122113251904924 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 124376442024788 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 175763926010803 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 135027895372233 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 132039083128381 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 117310370807385 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 88315662444481 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 138172928065885 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 138529457360340 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 193519297828241 }
+      flops { key: "bf16xbf16->f32" value: 183576991622499 }
+      flops { key: "f16xf16->f16" value: 186138827078096 }
+      flops { key: "f16xf16->f32" value: 177507327492147 }
+      flops { key: "f32xf32->f32" value: 92345028940012 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 174890760485381 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 242024529246027 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 149733903779110 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 174606362143263 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 239835118159481 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 156067125581395 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 150584366313722 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 175176086793376 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 222883616813700 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 155378311844294 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 146465942436229 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 257106692367554 }
+      flops { key: "bf16xbf16->f32" value: 257106692367554 }
+      flops { key: "f16xf16->f16" value: 263107528546924 }
+      flops { key: "f16xf16->f32" value: 247320470805021 }
+      flops { key: "f32xf32->f32" value: 103738159895657 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 364691117941750 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 478601214174281 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 340357183295031 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 335570536448160 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 325894779270050 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 209612849975597 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 359772767297704 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 343624873669893 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 429711585392696 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 213786326331508 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 341439486127673 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 332711077232938 }
+      flops { key: "bf16xbf16->f32" value: 283262476240725 }
+      flops { key: "f16xf16->f16" value: 327372788292236 }
+      flops { key: "f16xf16->f32" value: 268368363909022 }
+      flops { key: "f32xf32->f32" value: 156288610167024 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 643923132833583 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 625177190101892 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 720813509440295 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 725623804020949 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 612647784894087 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 274377442488900 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 614400585938058 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 730560860010205 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 638182361961367 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 276505974119616 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 604882373917329 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 377521462280528 }
+      flops { key: "bf16xbf16->f32" value: 317675095857988 }
+      flops { key: "f16xf16->f16" value: 384276940613326 }
+      flops { key: "f16xf16->f32" value: 301798316802810 }
+      flops { key: "f32xf32->f32" value: 165232357935637 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 787633833852925 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 753040641009906 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 868108599494694 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 763074939326641 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 741310428651564 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 325382472849864 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 747796168886567 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 753701376853558 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 728732521060445 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 322814580957928 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 922260531672750 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 154262168522376 }
+      flops { key: "bf16xbf16->f32" value: 155603481486848 }
+      flops { key: "f16xf16->f16" value: 143337581631290 }
+      flops { key: "f16xf16->f32" value: 145473760195095 }
+      flops { key: "f32xf32->f32" value: 79654437982195 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 148707405858320 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 321961566416791 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 164684328834355 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 150795846359104 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 325870052807283 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 161952009653092 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 163182648024316 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 148501739022197 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 308103823242467 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 165458328684798 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 166743042782824 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 238781747706677 }
+      flops { key: "bf16xbf16->f32" value: 240938365084707 }
+      flops { key: "f16xf16->f16" value: 236676436656196 }
+      flops { key: "f16xf16->f32" value: 229824876712328 }
+      flops { key: "f32xf32->f32" value: 100342669812863 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 502159160060797 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 333486085565649 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 462122584032709 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 329874600307219 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 427998734030891 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 196000880573175 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 431438201506780 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 420456906118453 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 321961566416791 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 197451604266274 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 334525063945790 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 326377696417037 }
+      flops { key: "bf16xbf16->f32" value: 320042272429210 }
+      flops { key: "f16xf16->f16" value: 318145725629629 }
+      flops { key: "f16xf16->f32" value: 318145725629629 }
+      flops { key: "f32xf32->f32" value: 127371509371293 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 665886402480620 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 597269822834098 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 532082172447968 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 521708751412086 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 591511816003305 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 282145987584168 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 452840665928620 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 454301596784429 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 729320308371540 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 286474390261797 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 457227582477244 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 429722333825258 }
+      flops { key: "bf16xbf16->f32" value: 403633888212766 }
+      flops { key: "f16xf16->f16" value: 394169305586784 }
+      flops { key: "f16xf16->f32" value: 363895473173624 }
+      flops { key: "f32xf32->f32" value: 180003239496238 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 840050324385115 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 696782494484101 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 757022525072706 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 892507100836407 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 801598972751026 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 366394446117426 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 901877746023413 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 935315177700348 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 814520632656931 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 364211769853720 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 900931836173894 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 492097709465362 }
+      flops { key: "bf16xbf16->f32" value: 409605273505394 }
+      flops { key: "f16xf16->f16" value: 461266456812995 }
+      flops { key: "f16xf16->f32" value: 395171173538511 }
+      flops { key: "f32xf32->f32" value: 180819791224174 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1016861153240603 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 942033732741130 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1039660454718751 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1014459355417773 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 917826113046265 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 443952947451385 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1044718245249171 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1006112218324500 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 930779855560070 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 451193496881278 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1007292028026149 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 187930659665704 }
+      flops { key: "bf16xbf16->f32" value: 189088988993572 }
+      flops { key: "f16xf16->f16" value: 181874541435528 }
+      flops { key: "f16xf16->f32" value: 178986801800300 }
+      flops { key: "f32xf32->f32" value: 90898778751322 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 427998734030891 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 440328818535985 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 403814149680330 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 421281735752820 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 425454907974244 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 187930659665704 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 460142200128562 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 436702317844433 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 440328818535985 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 185969573327560 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 445813503840564 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 287442597778075 }
+      flops { key: "bf16xbf16->f32" value: 290750561603032 }
+      flops { key: "f16xf16->f16" value: 277937442308936 }
+      flops { key: "f16xf16->f32" value: 269040797795038 }
+      flops { key: "f32xf32->f32" value: 113876532400042 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 655770256660813 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 567291942411834 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 542156942186316 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 567291942411834 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 604031684972927 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 222785346162823 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 568756842481626 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 595654572637126 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 616163445376945 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 222900967693385 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 602337465254891 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 380194949520879 }
+      flops { key: "bf16xbf16->f32" value: 376520320504953 }
+      flops { key: "f16xf16->f16" value: 364985536095177 }
+      flops { key: "f16xf16->f32" value: 361141644783586 }
+      flops { key: "f32xf32->f32" value: 141841720475561 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 741342417536894 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 770639626070964 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 678027831083747 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 718342079946479 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 733712115481528 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 347531439576000 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 740671230178917 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 705336009524982 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 810677103812759 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 344880338539366 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 682878972255346 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 474005881911488 }
+      flops { key: "bf16xbf16->f32" value: 468953286765207 }
+      flops { key: "f16xf16->f16" value: 422213545932661 }
+      flops { key: "f16xf16->f32" value: 410785452250011 }
+      flops { key: "f32xf32->f32" value: 200097477611158 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1175737009581166 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1010253693452118 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1088470186207115 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1094015294934250 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 964808872265745 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 450123645662483 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1102475080793172 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1088470186207115 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1016861153240603 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 455264712317150 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1064823923639519 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 542003002934031 }
+      flops { key: "bf16xbf16->f32" value: 456538048909469 }
+      flops { key: "f16xf16->f16" value: 497228586056944 }
+      flops { key: "f16xf16->f32" value: 428324192124060 }
+      flops { key: "f32xf32->f32" value: 201946829087382 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1289320188671457 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1304519471809863 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1356617841002862 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1300052530997559 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1297597702675654 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 549557973017713 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1366328198349736 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1316011274579646 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1309990406344123 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 546055740192455 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1368504963377476 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 323672127510456 }
+      flops { key: "bf16xbf16->f32" value: 323659931876412 }
+      flops { key: "f16xf16->f16" value: 329128878194566 }
+      flops { key: "f16xf16->f32" value: 321720396704119 }
+      flops { key: "f32xf32->f32" value: 210429303348766 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1307448187519026 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1295811523910092 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1287846265667166 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1280169089716840 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1261370718355359 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 1239349962775934 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1361320854516640 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1344277713928012 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1323768622592079 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1361536628942780 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1323564652080123 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 326377696417037 }
+      flops { key: "bf16xbf16->f32" value: 334909822874632 }
+      flops { key: "f16xf16->f16" value: 311669917346975 }
+      flops { key: "f16xf16->f32" value: 310992889178523 }
+      flops { key: "f32xf32->f32" value: 120212922525750 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 826312788418065 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 759700591845759 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 605735462379239 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 729971072190354 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 773415080538423 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 242773534713488 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 619742043360629 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 754363273206287 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 767163936054300 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 243465069780624 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 788320524205020 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 414657185571364 }
+      flops { key: "bf16xbf16->f32" value: 411770029816403 }
+      flops { key: "f16xf16->f16" value: 398383016046748 }
+      flops { key: "f16xf16->f32" value: 374386967921896 }
+      flops { key: "f32xf32->f32" value: 155342485625285 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1071498374278853 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1059537400721576 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1101026640433236 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1085718657945460 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1047904430388240 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 355091702076206 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1075489494428446 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1117535236063227 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1096809090177801 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 355088032408747 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1045353931303051 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 509482260184903 }
+      flops { key: "bf16xbf16->f32" value: 498820277692285 }
+      flops { key: "f16xf16->f16" value: 443037049422990 }
+      flops { key: "f16xf16->f32" value: 441213711218547 }
+      flops { key: "f32xf32->f32" value: 212162632713800 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1326707661370349 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1323131423378323 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1302541353652526 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1322113179598668 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1332883541245611 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 518731519188381 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1363076003887731 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1290773243975281 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1318536335546260 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 522601442914179 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1353411654081733 }
+    }
+    entries {
+      b: 4
+      m: 1024
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 565825251016879 }
+      flops { key: "bf16xbf16->f32" value: 514259561888227 }
+      flops { key: "f16xf16->f16" value: 503393291720538 }
+      flops { key: "f16xf16->f32" value: 459350185232099 }
+      flops { key: "f32xf32->f32" value: 216487026229404 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1514061729242633 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1524490909687867 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1555249498953276 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1513061633423240 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1451293581609486 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 619404087052535 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1547178420749279 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1512062857934980 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1451922179083034 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 621591952674711 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1555249498953276 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 88900631230336 }
+      flops { key: "bf16xbf16->f32" value: 100764060060060 }
+      flops { key: "f16xf16->f16" value: 120199465353184 }
+      flops { key: "f16xf16->f32" value: 109621421541602 }
+      flops { key: "f32xf32->f32" value: 65217554907677 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 101526269288956 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 97826332361516 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 123234457018248 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 105114226529613 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 98004912741876 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 116799937343631 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 123234457018248 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 101143728711379 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 96239295868064 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 116787233413095 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 117297555604107 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 192478591736129 }
+      flops { key: "bf16xbf16->f32" value: 172087799342896 }
+      flops { key: "f16xf16->f16" value: 191125280170879 }
+      flops { key: "f16xf16->f32" value: 159783009523809 }
+      flops { key: "f32xf32->f32" value: 80671812471825 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 131707062128181 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 293733230474627 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 133350946845504 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 131224176474182 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 285911815736919 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 136573622996692 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 134360486016392 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 304564409019997 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 292134899741531 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 132527996050357 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 133185540064500 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 247334713273826 }
+      flops { key: "bf16xbf16->f32" value: 221515668471813 }
+      flops { key: "f16xf16->f16" value: 253465169430510 }
+      flops { key: "f16xf16->f32" value: 204220783414958 }
+      flops { key: "f32xf32->f32" value: 117303962855738 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 478601214174281 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 398567863400148 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 517902724707584 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 479723812800178 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 443054187744996 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 175047574828822 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 513015682752030 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 477536946408716 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 339818600838673 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 174755555844895 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 514182604573207 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 286866637456585 }
+      flops { key: "bf16xbf16->f32" value: 247605632191859 }
+      flops { key: "f16xf16->f16" value: 301803618579158 }
+      flops { key: "f16xf16->f32" value: 239187330270375 }
+      flops { key: "f32xf32->f32" value: 123697631035525 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 512373074381151 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 435838175046932 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 499240648145995 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 478121707224757 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 438060818603702 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 202101842034679 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 491246402379046 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 483476928688017 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 436280897557011 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 191885238618594 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 475975762841469 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 303402606385984 }
+      flops { key: "bf16xbf16->f32" value: 261262970999285 }
+      flops { key: "f16xf16->f16" value: 320042272429210 }
+      flops { key: "f16xf16->f32" value: 254365845188036 }
+      flops { key: "f32xf32->f32" value: 143097605170877 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 645884025113726 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 597290588047143 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 686727792461126 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 661807819407527 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 502776388176763 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 223946987303490 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 693379714412560 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 668529425791890 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 501587375083939 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 223949906586888 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 782575009520338 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 179585519986619 }
+      flops { key: "bf16xbf16->f32" value: 166484506395844 }
+      flops { key: "f16xf16->f16" value: 177801262460672 }
+      flops { key: "f16xf16->f32" value: 164180707033639 }
+      flops { key: "f32xf32->f32" value: 88900631230336 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 177507327492147 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 307178321842368 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 162442030862329 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 174620560091071 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 306302046498359 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 170178591647515 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 168047863526097 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 176341242240105 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 284397251754734 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 135368359051941 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 162935026403641 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 272800260162601 }
+      flops { key: "bf16xbf16->f32" value: 239861906400089 }
+      flops { key: "f16xf16->f16" value: 260537900879587 }
+      flops { key: "f16xf16->f32" value: 232060044089042 }
+      flops { key: "f32xf32->f32" value: 108683822460650 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 468167352954000 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 512954412516421 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 441233541812204 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 436702317844433 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 486241061474017 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 203446890057316 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 418001683309002 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 405338551906379 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 486241061474017 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 217477710061268 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 409200390243902 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 337946911322684 }
+      flops { key: "bf16xbf16->f32" value: 295766091381744 }
+      flops { key: "f16xf16->f16" value: 324160707649345 }
+      flops { key: "f16xf16->f32" value: 281960761267027 }
+      flops { key: "f32xf32->f32" value: 152783284278676 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 703055704043214 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 624268502325581 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 728083962705543 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 710029309968589 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 662854741260899 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 266701893691008 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 712384689998341 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 689456183642346 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 621513247377179 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 263260737135676 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 747145741671740 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 398383016046748 }
+      flops { key: "bf16xbf16->f32" value: 326625901821362 }
+      flops { key: "f16xf16->f16" value: 395630738393515 }
+      flops { key: "f16xf16->f32" value: 321726421543474 }
+      flops { key: "f32xf32->f32" value: 155301060213518 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 688378778859638 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 587466460949254 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1015058740561299 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 850067747847600 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 759700591845759 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 306323892447043 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 955126990826708 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 855145305326032 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 593575966002142 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 309871021680314 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 969190408665237 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 425454907974244 }
+      flops { key: "bf16xbf16->f32" value: 346064825888585 }
+      flops { key: "f16xf16->f16" value: 397461345178604 }
+      flops { key: "f16xf16->f32" value: 327313535298880 }
+      flops { key: "f32xf32->f32" value: 176504296381531 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 876121637207404 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 731525194123908 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 930275845891430 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 974136379224313 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 796766032093497 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 338886856376368 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1007912536462305 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 830707856680044 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 793454146683909 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 342675586352711 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1033406669914884 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 227150798392214 }
+      flops { key: "bf16xbf16->f32" value: 229334007689021 }
+      flops { key: "f16xf16->f16" value: 226193769538656 }
+      flops { key: "f16xf16->f32" value: 220832294513856 }
+      flops { key: "f32xf32->f32" value: 106786854699154 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 231809547495682 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 464120088178085 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 404574914845516 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 233080115916861 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 427147418796618 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 198730672589302 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 469190222416430 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 402301170475833 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 477590047370176 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 199469036596693 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 496355864555645 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 327372788292236 }
+      flops { key: "bf16xbf16->f32" value: 318381563825055 }
+      flops { key: "f16xf16->f16" value: 316738001179941 }
+      flops { key: "f16xf16->f32" value: 305235398763414 }
+      flops { key: "f32xf32->f32" value: 129526442172562 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 704208443351369 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 700761510197422 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 734370743951440 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 734307966489998 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 718342079946479 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 288407688423314 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 711205049842689 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 725623804020949 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 704208443351369 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 289379281498450 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 515447620282028 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 421488449067713 }
+      flops { key: "bf16xbf16->f32" value: 401183223594797 }
+      flops { key: "f16xf16->f16" value: 388640859269313 }
+      flops { key: "f16xf16->f32" value: 362980544770758 }
+      flops { key: "f32xf32->f32" value: 184775473332114 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 968043567025412 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 990422528767439 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 973584335486795 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 933282767492394 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 880612495976216 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 361597718086337 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 931309653819049 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 900979084539542 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 885149630789839 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 366074348689537 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 923251783319002 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 483361305029190 }
+      flops { key: "bf16xbf16->f32" value: 440532057643981 }
+      flops { key: "f16xf16->f16" value: 474143242689776 }
+      flops { key: "f16xf16->f32" value: 395717310668094 }
+      flops { key: "f32xf32->f32" value: 188884213359426 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1102475080793172 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1031514210987691 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1211470924758479 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1088470186207115 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1013860677722041 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 428864154971417 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1234097348179010 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1106736403014881 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1009066939825555 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 429073019992757 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1241275183989017 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 498530779257711 }
+      flops { key: "bf16xbf16->f32" value: 434952667118163 }
+      flops { key: "f16xf16->f16" value: 460398072745057 }
+      flops { key: "f16xf16->f32" value: 400197285812455 }
+      flops { key: "f32xf32->f32" value: 196107713769594 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1327220131255190 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1252154238005867 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1304024379217427 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1283540535609555 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1194186753601529 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 469344038465741 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1291768050227452 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1268355052344038 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1187993374293370 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 468317307400314 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1288836563626474 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 265383545229856 }
+      flops { key: "bf16xbf16->f32" value: 270745251426230 }
+      flops { key: "f16xf16->f16" value: 263915896276268 }
+      flops { key: "f16xf16->f32" value: 257422595582726 }
+      flops { key: "f32xf32->f32" value: 113274360660925 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 709970625010331 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 708857451064532 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 733117230690449 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 691676833239391 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 699563041941526 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 215508030607892 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 738157136031623 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 723180214850985 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 706525299555848 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 216158800976370 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 693967894005493 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 367334541769120 }
+      flops { key: "bf16xbf16->f32" value: 366550794427020 }
+      flops { key: "f16xf16->f16" value: 353699027917318 }
+      flops { key: "f16xf16->f32" value: 343913784361612 }
+      flops { key: "f32xf32->f32" value: 144422048354013 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 896231894412854 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 892507100836407 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 929244330592817 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 925240692804825 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 899093007326774 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 321005048375343 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 946705746624786 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 936385740666049 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 904727430828374 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 319447177091855 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 939406670166229 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 483905899133863 }
+      flops { key: "bf16xbf16->f32" value: 468058935116947 }
+      flops { key: "f16xf16->f16" value: 428757123561855 }
+      flops { key: "f16xf16->f32" value: 412665149802433 }
+      flops { key: "f32xf32->f32" value: 201036424192425 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1244872952719104 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1110312750210043 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 992138437514437 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1243071465142361 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1219208656873181 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 440086306346461 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1308493787577592 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1214039232845735 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1233255747029898 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 431016061215785 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1285918352095808 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 547190584428200 }
+      flops { key: "bf16xbf16->f32" value: 510019198123780 }
+      flops { key: "f16xf16->f16" value: 488730916704597 }
+      flops { key: "f16xf16->f32" value: 450188519424026 }
+      flops { key: "f32xf32->f32" value: 207668805429891 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1479460843850244 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1350724835600283 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1426543982728556 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1396368372909597 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1341234224685767 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 491531015871880 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1396936083101254 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1347572835297578 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1342806720650304 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 494434523880103 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1437315193909351 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 530853193378189 }
+      flops { key: "bf16xbf16->f32" value: 485928176100806 }
+      flops { key: "f16xf16->f16" value: 488558923171533 }
+      flops { key: "f16xf16->f32" value: 455239076769182 }
+      flops { key: "f32xf32->f32" value: 216624194938041 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1534721935300883 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1512412279331822 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1608846775281819 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1607717588311673 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1541279252141928 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 552300816048350 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1624842804624878 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1615294566344639 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1540950919621935 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 554981519879182 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1629871965277201 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 317440302734663 }
+      flops { key: "bf16xbf16->f32" value: 315336891466749 }
+      flops { key: "f16xf16->f16" value: 298132220112798 }
+      flops { key: "f16xf16->f32" value: 293036812117283 }
+      flops { key: "f32xf32->f32" value: 94028072814843 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 934348680263229 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 835962687168507 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 860283885027541 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 835149928734626 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 826312788418065 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 228604665061010 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 862876403013561 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 848388601679012 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 875228956340109 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 228361568821363 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 860326965997295 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 409020157942979 }
+      flops { key: "bf16xbf16->f32" value: 407661367598030 }
+      flops { key: "f16xf16->f16" value: 393541769668648 }
+      flops { key: "f16xf16->f32" value: 387234882600218 }
+      flops { key: "f32xf32->f32" value: 155738190903116 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1159079016596950 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1091963972796033 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1162215477202002 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1100321464373779 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1084348103891185 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 355238550996143 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1143609198468963 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1137551344744247 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1118991023513319 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 352393115851657 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1162215477202002 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 511690159539534 }
+      flops { key: "bf16xbf16->f32" value: 507604348766435 }
+      flops { key: "f16xf16->f16" value: 448130558380666 }
+      flops { key: "f16xf16->f32" value: 448598619569545 }
+      flops { key: "f32xf32->f32" value: 209981778429647 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1504762125251817 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1417714902129064 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1501474321272504 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1399810085879573 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1428946720509035 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 492305707093067 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1453150279890040 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1482045305728088 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1411889314924391 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 491460710277700 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1491049226176011 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 554086554397168 }
+      flops { key: "bf16xbf16->f32" value: 515809367775930 }
+      flops { key: "f16xf16->f16" value: 508846583926634 }
+      flops { key: "f16xf16->f32" value: 476315573503011 }
+      flops { key: "f32xf32->f32" value: 220863523609950 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1663466794219457 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1678930790877218 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1673207697398376 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1709460981753504 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1679341081756088 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 566107255866446 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1681395547791194 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1728400531602907 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1674838881709947 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 567090640589541 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1661455882014458 }
+    }
+    entries {
+      b: 4
+      m: 2048
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 549273551709599 }
+      flops { key: "bf16xbf16->f32" value: 500879035815091 }
+      flops { key: "f16xf16->f16" value: 485379023273225 }
+      flops { key: "f16xf16->f32" value: 469792442286427 }
+      flops { key: "f32xf32->f32" value: 219675795874494 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1768954932389471 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1714803813820595 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1763507454571117 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1733425236916285 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1726457349772320 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 639020601745882 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1750457912680218 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1778822653137295 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1719964878009711 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 621454231482611 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1758982197234291 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 256
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 182020990676385 }
+      flops { key: "bf16xbf16->f32" value: 170719743063836 }
+      flops { key: "f16xf16->f16" value: 190430402411989 }
+      flops { key: "f16xf16->f32" value: 172933133193751 }
+      flops { key: "f32xf32->f32" value: 83696455218645 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 134352080080080 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 279948331117194 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 187766341523126 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 297806635418111 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 285911815736919 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 184856989584230 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 183592685987860 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 133849641485913 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 272800260162601 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 190093267947242 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 148092107302944 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 512
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 257414881390470 }
+      flops { key: "bf16xbf16->f32" value: 214212832718204 }
+      flops { key: "f16xf16->f16" value: 248767291977990 }
+      flops { key: "f16xf16->f32" value: 207176079108581 }
+      flops { key: "f32xf32->f32" value: 129020616299678 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 208797632280019 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 430573162506265 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 504577924812030 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 488453007619697 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 417189635356969 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 189757325086153 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 510515546891715 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 210434458402743 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 422068327044025 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 191962424957540 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 514244168582375 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 1024
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 295349147022417 }
+      flops { key: "bf16xbf16->f32" value: 260387844190487 }
+      flops { key: "f16xf16->f16" value: 294145621751189 }
+      flops { key: "f16xf16->f32" value: 250940217697408 }
+      flops { key: "f32xf32->f32" value: 142193918093030 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 562794640110070 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 511762561334524 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 618826784237446 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 594006956088790 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 514213384735109 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 208084459969477 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 610037255308571 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 580322563977840 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 491246402379046 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 211783397238658 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 618871368299711 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 2048
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 330655526377581 }
+      flops { key: "bf16xbf16->f32" value: 260155203658555 }
+      flops { key: "f16xf16->f16" value: 317675095857988 }
+      flops { key: "f16xf16->f32" value: 254064909553386 }
+      flops { key: "f32xf32->f32" value: 131633394251913 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 592756760307766 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 477298138134133 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 699050666666666 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 629760600586510 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 487344524679450 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 221404332547200 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 657753711244687 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 627919195321637 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 491541563445967 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 220266028821990 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 699050666666666 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 4096
+      k: 256
+      flops { key: "bf16xbf16->bf16" value: 336033274667240 }
+      flops { key: "bf16xbf16->f32" value: 276061659339246 }
+      flops { key: "f16xf16->f16" value: 331936455981374 }
+      flops { key: "f16xf16->f32" value: 259836492089899 }
+      flops { key: "f32xf32->f32" value: 147097366560352 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 736243295720928 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 591735927530740 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 800105681073025 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 742287333232517 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 593176320552438 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 246472450023671 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 790515089566317 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 745508437327778 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 600012893879332 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 242843884457449 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 803849390978850 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 256
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 251963351871406 }
+      flops { key: "bf16xbf16->f32" value: 241466649575532 }
+      flops { key: "f16xf16->f16" value: 256186537190575 }
+      flops { key: "f16xf16->f32" value: 228358533390046 }
+      flops { key: "f32xf32->f32" value: 104294876180762 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 490685170341597 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 443924268320413 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 250493835063571 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 492937828072994 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 455216459565447 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 244783272312777 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 249620324072997 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 478601214174281 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 466185530880277 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 252853367243612 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 244504571103267 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 512
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 335570536448160 }
+      flops { key: "bf16xbf16->f32" value: 299687213201688 }
+      flops { key: "f16xf16->f16" value: 322215184065418 }
+      flops { key: "f16xf16->f32" value: 281029071255643 }
+      flops { key: "f32xf32->f32" value: 163686394146118 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 707689453946284 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 682878972255346 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 785473170446232 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 769914366944519 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 706525299555848 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 277757698764793 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 804602340951667 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 723241103982487 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 674302110997723 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 281222281617285 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 785473170446232 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 1024
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 415363970503614 }
+      flops { key: "bf16xbf16->f32" value: 346556980291691 }
+      flops { key: "f16xf16->f16" value: 381893682123327 }
+      flops { key: "f16xf16->f32" value: 335964275344180 }
+      flops { key: "f32xf32->f32" value: 162601926856969 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 750409241897440 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 831109727831261 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1012665439669908 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 940486625280560 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 822357435450672 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 317088763086009 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 983617839459521 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 758359194137900 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 646345717983446 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 317910236565507 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 984745453628338 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 2048
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 425560296854099 }
+      flops { key: "bf16xbf16->f32" value: 350663248129815 }
+      flops { key: "f16xf16->f16" value: 402404824772210 }
+      flops { key: "f16xf16->f32" value: 332579040082080 }
+      flops { key: "f32xf32->f32" value: 166612866374105 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 943585938595045 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 758375932372481 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1031545179020685 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 923773043903750 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 792703619056407 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 339623785390926 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1040920305613620 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 878810639111975 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 820393925027458 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 331420976985550 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1035899133769483 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 4096
+      k: 512
+      flops { key: "bf16xbf16->bf16" value: 432211558451523 }
+      flops { key: "bf16xbf16->f32" value: 382784997833170 }
+      flops { key: "f16xf16->f16" value: 415010277114472 }
+      flops { key: "f16xf16->f32" value: 351597996080819 }
+      flops { key: "f32xf32->f32" value: 185293626670405 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1073506994344987 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 907403432313949 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1068150722561591 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1013546654710107 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 916870937104736 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 369350335846927 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1118280853623212 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1098931392001023 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 857075752204442 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 369270946215642 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1073171701533560 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 256
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 306761466752374 }
+      flops { key: "bf16xbf16->f32" value: 287818213838163 }
+      flops { key: "f16xf16->f16" value: 292144835288916 }
+      flops { key: "f16xf16->f32" value: 287818213838163 }
+      flops { key: "f32xf32->f32" value: 116633417860391 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 711205049842689 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 719545534595409 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 809149829691032 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 763074939326641 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 720753028360463 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 295359302410342 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 624268502325581 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 755026333128241 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 733117230690449 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 299061191101208 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 803097848915482 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 512
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 394531385555172 }
+      flops { key: "bf16xbf16->f32" value: 373735406891750 }
+      flops { key: "f16xf16->f16" value: 375532683046253 }
+      flops { key: "f16xf16->f32" value: 360089481953468 }
+      flops { key: "f32xf32->f32" value: 184574971357356 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 998481296291991 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 967008284588539 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1061534180919426 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1048512003906011 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 968098116984109 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 378853489403929 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1044686481240498 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1025970091609435 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 995011536198308 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 382055044454822 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1039628997518910 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 1024
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 495933177951301 }
+      flops { key: "bf16xbf16->f32" value: 441216544051364 }
+      flops { key: "f16xf16->f16" value: 445455160733269 }
+      flops { key: "f16xf16->f32" value: 410099044781819 }
+      flops { key: "f32xf32->f32" value: 179854369028799 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1178196288722010 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1129325829679539 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1240378988772968 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1196286413480955 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1116119485723566 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 415464418853232 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1275417162880475 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1200424077420256 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1149770391112301 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 416976995315647 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1205520257104764 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 2048
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 499912534543840 }
+      flops { key: "bf16xbf16->f32" value: 454181493787342 }
+      flops { key: "f16xf16->f16" value: 458368196368778 }
+      flops { key: "f16xf16->f32" value: 417994055680249 }
+      flops { key: "f32xf32->f32" value: 192628043784530 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1267887024649446 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1172967547468678 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1300569225481661 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1225754539286160 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1152064187765092 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 463509646874726 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1331876051166757 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1308493787577592 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1155551240747280 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 466914054654907 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1328246259659431 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 4096
+      k: 1024
+      flops { key: "bf16xbf16->bf16" value: 509374630667225 }
+      flops { key: "bf16xbf16->f32" value: 470921646566227 }
+      flops { key: "f16xf16->f16" value: 465934243485041 }
+      flops { key: "f16xf16->f32" value: 423594209043361 }
+      flops { key: "f32xf32->f32" value: 213324424268011 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1446421316270259 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1288353301261741 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1454072719763013 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1404659956788798 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1298100186744996 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 473194789694576 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1454380460021164 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1417714902129064 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1280896872030494 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 495543369287903 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1400937296488456 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 256
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 341046356930162 }
+      flops { key: "bf16xbf16->f32" value: 333745224648379 }
+      flops { key: "f16xf16->f16" value: 329387602507812 }
+      flops { key: "f16xf16->f32" value: 321125052505654 }
+      flops { key: "f32xf32->f32" value: 131593063231024 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 995011536198308 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 968098116984109 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1015058740561299 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1023525122669049 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 973529165523885 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 329387602507812 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1006731273600937 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1061534180919426 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 976906015239395 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 331171817102320 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 995011536198308 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 512
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 438284330425021 }
+      flops { key: "bf16xbf16->f32" value: 427471582975652 }
+      flops { key: "f16xf16->f16" value: 417179504723051 }
+      flops { key: "f16xf16->f32" value: 404489185694441 }
+      flops { key: "f32xf32->f32" value: 191477825339240 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1323615638815054 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1192922208381071 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1263225675294117 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1242172675174433 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1197078297320837 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 450365542946272 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1258598475018315 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1229724718800329 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1206366770872832 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 451549266923370 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1249399598850950 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 1024
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 542949400207005 }
+      flops { key: "bf16xbf16->f32" value: 490828863813952 }
+      flops { key: "f16xf16->f16" value: 480045523192131 }
+      flops { key: "f16xf16->f32" value: 457818528307417 }
+      flops { key: "f32xf32->f32" value: 194022515863268 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1632950995318774 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1398072889467580 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1448250300021074 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1441566535263268 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1387319351071991 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 494150092301497 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1487144857841546 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1476282556789619 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1408994438120233 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 494363385292721 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1496862853383868 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 2048
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 540001231639661 }
+      flops { key: "bf16xbf16->f32" value: 525808396287482 }
+      flops { key: "f16xf16->f16" value: 494829715470747 }
+      flops { key: "f16xf16->f32" value: 466979098829485 }
+      flops { key: "f32xf32->f32" value: 215427297391936 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1669528843711280 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1525167604057083 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1620245602433216 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1582504732029154 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1497874291294302 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 556151556791097 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1623307507996126 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1595030040177794 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1510069257507004 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 556151556791097 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1632194685256220 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 4096
+      k: 2048
+      flops { key: "bf16xbf16->bf16" value: 545387261920020 }
+      flops { key: "bf16xbf16->f32" value: 537336883828945 }
+      flops { key: "f16xf16->f16" value: 491955913599226 }
+      flops { key: "f16xf16->f32" value: 470970058604418 }
+      flops { key: "f32xf32->f32" value: 234210926868171 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1681807044358243 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1636879537325520 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1794394478278182 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1726663401995025 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1632020251644619 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 594299770269218 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1731688906875653 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1772833969326023 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1655841130953887 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 594325469496480 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1797221940711100 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 256
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 385579252715683 }
+      flops { key: "bf16xbf16->f32" value: 379187966186240 }
+      flops { key: "f16xf16->f16" value: 379774723876472 }
+      flops { key: "f16xf16->f32" value: 375126790414323 }
+      flops { key: "f32xf32->f32" value: 139569339875865 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1101732720941417 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1108164173643810 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1119720340481001 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1095410411196480 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1120450608752364 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 347749512863591 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1107449828144137 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1106736403014881 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1133049904962902 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 349305027834821 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1114671155490673 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 512
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 460401157282594 }
+      flops { key: "bf16xbf16->f32" value: 455750825597050 }
+      flops { key: "f16xf16->f16" value: 436222738956282 }
+      flops { key: "f16xf16->f32" value: 427631188539994 }
+      flops { key: "f32xf32->f32" value: 204963900595330 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1485890778758000 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1439724219815214 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1438518698289757 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1425389988508846 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1433118740714479 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 500203640450419 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1461805503850244 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1466171895370172 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1437946782506800 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 500054406333682 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1475648537353174 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 1024
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 538391447220078 }
+      flops { key: "bf16xbf16->f32" value: 529907595009330 }
+      flops { key: "f16xf16->f16" value: 503692158599736 }
+      flops { key: "f16xf16->f32" value: 486547460234071 }
+      flops { key: "f32xf32->f32" value: 205985608282650 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1749099017167873 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1659429789696099 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1746431928434375 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1725362844560496 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1687609939489194 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 559185925332812 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1745101431898117 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1722335816336249 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1685519597159711 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 558958506743017 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1745123590228046 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 2048
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 570271916350630 }
+      flops { key: "bf16xbf16->f32" value: 553348150078308 }
+      flops { key: "f16xf16->f16" value: 503581425794088 }
+      flops { key: "f16xf16->f32" value: 496529804919815 }
+      flops { key: "f32xf32->f32" value: 226286315076127 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1819865249922207 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1757171850669939 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1850531216803554 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1809311938495563 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1751573337139652 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 621369942501141 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1839866580170146 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1830054905687008 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1775135176488062 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 622074457918904 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1842579865693352 }
+    }
+    entries {
+      b: 4
+      m: 4096
+      n: 4096
+      k: 4096
+      flops { key: "bf16xbf16->bf16" value: 588276135222360 }
+      flops { key: "bf16xbf16->f32" value: 579017627741154 }
+      flops { key: "f16xf16->f16" value: 511549701343740 }
+      flops { key: "f16xf16->f32" value: 492900703536474 }
+      flops { key: "f32xf32->f32" value: 244524907867903 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->bf16" value: 1857044750633364 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f32" value: 1807634281024561 }
+      flops { key: "f8e4m3fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 1894736200669311 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->bf16" value: 1853913541900195 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f32" value: 1797692091507200 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e4m3fnuz" value: 656710276332638 }
+      flops { key: "f8e4m3fnuzxf8e5m2fnuz->f8e5m2fnuz" value: 1899850065964446 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->bf16" value: 1892381721414065 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f32" value: 1813729145677448 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e4m3fnuz" value: 657322735638890 }
+      flops { key: "f8e5m2fnuzxf8e4m3fnuz->f8e5m2fnuz" value: 1902091548152940 }
+    }
+  }
+}
+entries {
   key: "gfx950"
   value {
     entries {

--- a/xla/service/gpu/model/matmul_interpolator_test.cc
+++ b/xla/service/gpu/model/matmul_interpolator_test.cc
@@ -333,6 +333,12 @@ class MatmulInterpolatorDefaultTableTest
     return GetMatmulInterpolator(TestGpuDeviceInfo::B200SXMDeviceInfo());
   }
 
+  std::unique_ptr<MatmulInterpolator> GetMatmulInterpolatorGfx942() {
+    se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI210DeviceInfo();
+    device_info.set_rocm_compute_capability("gfx942");
+    return GetMatmulInterpolator(device_info);
+  }
+
   std::unique_ptr<MatmulInterpolator> GetMatmulInterpolatorGfx950() {
     se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI210DeviceInfo();
     device_info.set_rocm_compute_capability("gfx950");
@@ -647,6 +653,105 @@ INSTANTIATE_TEST_SUITE_P(
     }),
     [](const TestParamInfo<MatmulInterpolatorDefaultTableTest::ParamType>&
            info) { return info.param.test_name; });
+
+using Gfx942DefaultTableTest = MatmulInterpolatorDefaultTableTest;
+
+TEST_P(Gfx942DefaultTableTest, EstimatesExactRuntime) {
+  const auto& [_, spec, expected_duration] = GetParam();
+  ASSERT_OK_AND_ASSIGN(DotContext context,
+                       Dot(spec.b, spec.m, spec.n, spec.k, spec.lhs_type,
+                           spec.rhs_type, spec.result_type));
+  std::unique_ptr<MatmulInterpolator> interpolator =
+      GetMatmulInterpolatorGfx942();
+  std::optional<absl::Duration> runtime =
+      interpolator->EstimatedRuntime(*context.dot);
+  ASSERT_TRUE(runtime.has_value());
+  EXPECT_NEAR(absl::ToDoubleNanoseconds(*runtime),
+              absl::ToDoubleNanoseconds(expected_duration), 1.0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MatmulInterpolatorDefaultTableTestInstantiationGfx942,
+    Gfx942DefaultTableTest,
+    ValuesIn<ParametrizedTestCase>({
+        {
+            /*test_name=*/"bf16_bf16_bf16",
+            /*spec=*/
+            {/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/512,
+             /*lhs_type=*/"bf16",
+             /*rhs_type=*/"bf16",
+             /*result_type=*/"bf16",
+             /*clock_cycles=*/0},
+            /*expected_duration=*/absl::Nanoseconds(18387),
+        },
+        {
+            /*test_name=*/"f16_f16_f16",
+            /*spec=*/
+            {/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/512,
+             /*lhs_type=*/"f16",
+             /*rhs_type=*/"f16",
+             /*result_type=*/"f16",
+             /*clock_cycles=*/0},
+            /*expected_duration=*/absl::Nanoseconds(15724),
+        },
+        {
+            /*test_name=*/"f32_f32_f32",
+            /*spec=*/
+            {/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/512,
+             /*lhs_type=*/"f32",
+             /*rhs_type=*/"f32",
+             /*result_type=*/"f32",
+             /*clock_cycles=*/0},
+            /*expected_duration=*/absl::Nanoseconds(38197),
+        },
+        {
+            /*test_name=*/"f8e4m3fnuz_f8e4m3fnuz_bf16",
+            /*spec=*/
+            {/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/512,
+             /*lhs_type=*/"f8e4m3fnuz",
+             /*rhs_type=*/"f8e4m3fnuz",
+             /*result_type=*/"bf16",
+             /*clock_cycles=*/0},
+            /*expected_duration=*/absl::Nanoseconds(19309),
+        },
+        {
+            /*test_name=*/"f8e4m3fnuz_f8e4m3fnuz_f8e4m3fnuz",
+            /*spec=*/
+            {/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/512,
+             /*lhs_type=*/"f8e4m3fnuz",
+             /*rhs_type=*/"f8e4m3fnuz",
+             /*result_type=*/"f8e4m3fnuz",
+             /*clock_cycles=*/0},
+            /*expected_duration=*/absl::Nanoseconds(19169),
+        },
+        {
+            /*test_name=*/"f8e5m2fnuz_f8e4m3fnuz_f32",
+            /*spec=*/
+            {/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/512,
+             /*lhs_type=*/"f8e5m2fnuz",
+             /*rhs_type=*/"f8e4m3fnuz",
+             /*result_type=*/"f32",
+             /*clock_cycles=*/0},
+            /*expected_duration=*/absl::Nanoseconds(10656),
+        },
+    }),
+    [](const TestParamInfo<MatmulInterpolatorDefaultTableTest::ParamType>&
+           info) { return info.param.test_name; });
+
+TEST(DefaultMatmulPerfTableTest, Gfx942InterpolatesBetweenGridPoints) {
+  se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI210DeviceInfo();
+  device_info.set_rocm_compute_capability("gfx942");
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<MatmulInterpolator> interpolator,
+                       MatmulInterpolator::Create(device_info));
+  ASSERT_OK_AND_ASSIGN(
+      DotContext context,
+      Dot(/*b=*/1, /*m=*/1024, /*n=*/4096, /*k=*/768, /*lhs_type=*/"bf16",
+          /*rhs_type=*/"bf16", /*result_type=*/"bf16"));
+  ASSERT_TRUE(interpolator->EstimatedRuntime(*context.dot).has_value());
+  absl::Duration runtime = *interpolator->EstimatedRuntime(*context.dot);
+  EXPECT_GT(runtime, absl::Nanoseconds(18387));
+  EXPECT_LT(runtime, absl::Nanoseconds(25497));
+}
 
 using Gfx950DefaultTableTest = MatmulInterpolatorDefaultTableTest;
 

--- a/xla/service/gpu/model/sol_latency_estimator.cc
+++ b/xla/service/gpu/model/sol_latency_estimator.cc
@@ -443,7 +443,7 @@ SolLatencyEstimator::Create(
   bool is_supported_device =
       gpu_device_info.cuda_compute_capability().IsHopper() ||
       gpu_device_info.cuda_compute_capability().IsBlackwell() ||
-      (cc.IsRocm() && cc.rocm_compute_capability()->gfx9_mi350());
+      (cc.IsRocm() && cc.rocm_compute_capability()->gfx9_mi300_series());
   if (IsPassEnabledAtOptimizationEffort<LatencyHidingScheduler>(module)) {
     // If the user enabled opt effort we turn the estimator on if we're
     // compiling for a supported device.
@@ -457,8 +457,8 @@ SolLatencyEstimator::Create(
     return false;
   }
   // Otherwise we are more conservative and we turn it on only for supported
-  // devices (Hopper/Blackwell/gfx950) and if `module` contains only supported
-  // collectives.
+  // devices (Hopper/Blackwell/gfx942/gfx950) and if `module` contains only
+  // supported collectives.
   return is_supported_device && HasOnlySupportedCollectives(module);
 }
 

--- a/xla/service/gpu/model/sol_latency_estimator.h
+++ b/xla/service/gpu/model/sol_latency_estimator.h
@@ -46,8 +46,8 @@ namespace gpu {
 // therefore in the case of algorithmic improvements at lower levels of
 // abstractions performance tables need to be updated.
 //
-// The estimator is enabled for Hopper, Blackwell, and ROCm gfx950 when a module
-// contains only supported collective operations.
+// The estimator is enabled for Hopper, Blackwell, and ROCm gfx942/gfx950 when a
+// module contains only supported collective operations.
 class SolLatencyEstimator : public LatencyEstimator {
  public:
   TimeCost GetLatencyBetween(const HloGraphNode& from,

--- a/xla/service/gpu/model/sol_latency_estimator_test.cc
+++ b/xla/service/gpu/model/sol_latency_estimator_test.cc
@@ -892,6 +892,19 @@ TEST_F(IsSolLatencyEstimatorEnabledTest, EnabledBySolEstimatorFlagOnGfx950) {
       SolLatencyEstimator::IsSupportedForModule(*module, gpu_device_info_));
 }
 
+TEST_F(IsSolLatencyEstimatorEnabledTest, EnabledBySolEstimatorFlagOnGfx942) {
+  HloModuleConfig config;
+  config.mutable_debug_options()
+      .set_xla_gpu_enable_analytical_sol_latency_estimator(true);
+  gpu_device_info_.set_rocm_compute_capability("gfx942");
+
+  auto module = CreateTestModule(config);
+  AddAllReduce(module.get());
+
+  EXPECT_TRUE(
+      SolLatencyEstimator::IsSupportedForModule(*module, gpu_device_info_));
+}
+
 TEST_F(IsSolLatencyEstimatorEnabledTest, DisabledIfFlagIsOffOnGfx950) {
   HloModuleConfig config;
   config.mutable_debug_options()
@@ -912,11 +925,9 @@ TEST_F(IsSolLatencyEstimatorEnabledTest, DisabledForUnsupportedRocmArch) {
   auto module = CreateTestModule(config);
   AddAllReduce(module.get());
 
-  for (absl::string_view architecture : {"gfx942", "gfx90a"}) {
-    gpu_device_info_.set_rocm_compute_capability(std::string(architecture));
-    EXPECT_FALSE(
-        SolLatencyEstimator::IsSupportedForModule(*module, gpu_device_info_));
-  }
+  gpu_device_info_.set_rocm_compute_capability("gfx90a");
+  EXPECT_FALSE(
+      SolLatencyEstimator::IsSupportedForModule(*module, gpu_device_info_));
 }
 
 TEST_F(IsSolLatencyEstimatorEnabledTest,
@@ -971,6 +982,56 @@ TEST_F(IsSolLatencyEstimatorEnabledTest, CreatesEstimatorWithGfx950Profiles) {
   ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
   gpu_device_info_ = TestGpuDeviceInfo::AMDMI210DeviceInfo();
   gpu_device_info_.set_rocm_compute_capability("gfx950");
+
+  SchedulerConfig scheduler_config;
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<SolLatencyEstimator> estimator,
+      SolLatencyEstimator::Create(
+          scheduler_config, std::make_unique<DummyLatencyEstimator>(),
+          gpu_device_info_, HloCostAnalysis::DefaultShapeSize,
+          module->entry_computation()));
+
+  HloInstruction* dot =
+      module->entry_computation()->GetInstructionWithName("dot");
+  HloInstruction* all_reduce_start =
+      module->entry_computation()->GetInstructionWithName("ar-start");
+  HloInstruction* all_reduce_done =
+      module->entry_computation()->GetInstructionWithName("ar-done");
+  ASSERT_NE(dot, nullptr);
+  ASSERT_NE(all_reduce_start, nullptr);
+  ASSERT_NE(all_reduce_done, nullptr);
+  EXPECT_GT(estimator->NodeCost(dot), 0);
+  EXPECT_GT(estimator->GetLatencyBetween(
+                HloGraphNode(all_reduce_start, /*original_position=*/-1),
+                HloGraphNode(all_reduce_done, /*original_position=*/-1)),
+            0);
+}
+
+TEST_F(IsSolLatencyEstimatorEnabledTest, CreatesEstimatorWithGfx942Profiles) {
+  constexpr absl::string_view kHlo = R"(
+    HloModule m, num_partitions=8
+
+    add {
+      x = f32[] parameter(0)
+      y = f32[] parameter(1)
+      ROOT sum = f32[] add(x, y)
+    }
+
+    ENTRY main {
+      lhs = f32[256,256] parameter(0)
+      rhs = f32[256,256] parameter(1)
+      dot = f32[256,256] dot(lhs, rhs),
+        lhs_contracting_dims={1}, rhs_contracting_dims={0}
+      p = f32[256] parameter(2)
+      ar-start = f32[256] all-reduce-start(p), to_apply=add,
+        replica_groups=[1,8]<=[8], channel_id=1, use_global_device_ids=true
+      ar-done = f32[256] all-reduce-done(ar-start)
+      ROOT result = (f32[256,256], f32[256]) tuple(dot, ar-done)
+    }
+  )";
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
+  gpu_device_info_ = TestGpuDeviceInfo::AMDMI210DeviceInfo();
+  gpu_device_info_.set_rocm_compute_capability("gfx942");
 
   SchedulerConfig scheduler_config;
   ASSERT_OK_AND_ASSIGN(


### PR DESCRIPTION
This PR is a follow-up to #47515 and enables the SoL latency estimator for gfx942 (MI300).

Key changes:

1. Interpolator data (collective & matmul)

```
xla/service/gpu/model/default_collective_perf_table.txtpb
xla/service/gpu/model/default_matmul_perf_table.txtpb
xla/service/gpu/model/collective_interpolator_test.cc
xla/service/gpu/model/matmul_interpolator_test.cc
```

2. Enablement for the SoL estimator (gfx942)

```
xla/service/gpu/model/sol_latency_estimator.h
xla/service/gpu/model/sol_latency_estimator.cc
xla/service/gpu/model/sol_latency_estimator_test.cc
xla/backends/gpu/transforms/collectives/collective_ops_utils.cc
```

Unlike gfx950, gfx942 uses native FNUZ (NANOO) FP8 types (`f8e4m3fnuz` and `f8e5m2fnuz`) instead of OCP FP8.