### PR TITLE
[XLA] Support non-tuple while state in dynamic dimension inference

### DIFF
--- a/xla/service/dynamic_dimension_inference.cc
+++ b/xla/service/dynamic_dimension_inference.cc
@@ -44,6 +44,7 @@ limitations under the License.
 #include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
 #include "xla/hlo/ir/dynamic_parameter_binding.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
+#include "xla/hlo/ir/hlo_clone_context.h"
 #include "xla/hlo/ir/hlo_computation.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
@@ -238,6 +239,13 @@ class DynamicDimensionInferenceVisitor : public DfsHloRewriteVisitor {
 
   void SetDynamicSizes(HloInstruction* inst, const ShapeIndex& index,
                        absl::Span<HloInstruction* const> sizes);
+
+  // Canonicalizes a while whose loop state is a bare array into the
+  // equivalent single-element tuple form so the tuple-based while handling
+  // applies. Returns the get-tuple-element that took over the old while's
+  // uses.
+  absl::StatusOr<HloInstruction*> CanonicalizeNonTupleWhile(
+      HloInstruction* hlo);
 
   absl::Status HandleDynamicConvolutionForward(HloInstruction* hlo,
                                                int64_t operand_index,
@@ -2247,10 +2255,91 @@ absl::Status DynamicDimensionInferenceVisitor::HandleScatter(
       });
 }
 
+absl::StatusOr<HloInstruction*>
+DynamicDimensionInferenceVisitor::CanonicalizeNonTupleWhile(
+    HloInstruction* hlo) {
+  const Shape element_shape = hlo->shape();
+  const Shape tuple_shape = ShapeUtil::MakeTupleShape({element_shape});
+  HloModule* module = hlo->GetModule();
+
+  // Rebuild the condition and body to take a single-element tuple: the new
+  // parameter feeds the old parameter's uses through a get-tuple-element,
+  // and the body root is wrapped in a tuple. The computations are cloned
+  // rather than mutated because HLO allows them to be shared with other
+  // callers.
+  for (bool is_body : {false, true}) {
+    HloComputation* computation =
+        is_body ? hlo->while_body() : hlo->while_condition();
+    HloCloneContext context(module);
+    HloComputation* clone = module->AddEmbeddedComputation(
+        computation->Clone("non_tuple", &context));
+    absl::flat_hash_map<HloInstruction*, HloInstruction*> instruction_map;
+    instruction_map.reserve(context.cloned_instructions().size());
+    for (const auto& [old_inst, new_inst] : context.cloned_instructions()) {
+      instruction_map[const_cast<HloInstruction*>(old_inst)] = new_inst;
+    }
+    for (const auto& [old_inst, new_inst] : instruction_map) {
+      parent_->CopyMapping(old_inst, new_inst, &instruction_map);
+    }
+
+    HloInstruction* old_param = clone->parameter_instruction(0);
+    HloInstruction* new_param = clone->ReplaceParameter(
+        0, HloInstruction::CreateParameter(0, tuple_shape, old_param->name()));
+    HloInstruction* element = clone->AddInstruction(
+        HloInstruction::CreateGetTupleElement(element_shape, new_param, 0));
+    ABSL_RETURN_IF_ERROR(new_param->ReplaceAllUsesWithDifferentShape(element));
+    if (is_body) {
+      HloInstruction* old_root = clone->root_instruction();
+      HloInstruction* new_root =
+          clone->AddInstruction(HloInstruction::CreateTuple({old_root}));
+      ABSL_RETURN_IF_ERROR(ForEachDynamicDimension(
+          old_root,
+          [&](ShapeIndex index, int64_t dimension,
+              HloInstruction* dynamic_size) -> absl::Status {
+            SetDynamicSize(new_root, {0}, dimension, dynamic_size);
+            return absl::OkStatus();
+          }));
+      clone->set_root_instruction(new_root, /*accept_different_shape=*/true);
+      hlo->set_while_body(clone);
+    } else {
+      hlo->set_while_condition(clone);
+    }
+  }
+
+  // Wrap the init value and the while itself, and route the old uses
+  // through a get-tuple-element of the new tuple-shaped while.
+  HloInstruction* old_init = hlo->mutable_operand(0);
+  HloInstruction* new_init =
+      hlo->parent()->AddInstruction(HloInstruction::CreateTuple({old_init}));
+  ABSL_RETURN_IF_ERROR(ForEachDynamicDimension(
+      old_init,
+      [&](ShapeIndex index, int64_t dimension,
+          HloInstruction* dynamic_size) -> absl::Status {
+        SetDynamicSize(new_init, {0}, dimension, dynamic_size);
+        return absl::OkStatus();
+      }));
+  ABSL_RETURN_IF_ERROR(hlo->ReplaceOperandWithDifferentShape(0, new_init));
+  *hlo->mutable_shape() = tuple_shape;
+  HloInstruction* element = hlo->parent()->AddInstruction(
+      HloInstruction::CreateGetTupleElement(element_shape, hlo, 0));
+  ABSL_RETURN_IF_ERROR(hlo->ReplaceAllUsesWithDifferentShape(element));
+  MarkAsChanged();
+  return element;
+}
+
 absl::Status DynamicDimensionInferenceVisitor::HandleWhile(
     HloInstruction* hlo) {
   if (!CanInfer(hlo)) {
     return absl::OkStatus();
+  }
+  // The logic below (in particular WhileUtil::MakeInstructionsLiveIn)
+  // requires tuple-shaped while state; HLO also allows a bare array.
+  HloInstruction* array_state_replacement = nullptr;
+  if (!hlo->shape().IsTuple() &&
+      parent_->HasDynamicDimension(hlo->mutable_operand(0))) {
+    ABSL_ASSIGN_OR_RETURN(array_state_replacement,
+                          CanonicalizeNonTupleWhile(hlo));
+    hlo = array_state_replacement->mutable_operand(0);
   }
   // If the output of the kWhile contains dynamic dimension, we send
   // dynamic dimension size into the while body by adding additional root/body
@@ -2404,6 +2493,12 @@ absl::Status DynamicDimensionInferenceVisitor::HandleWhile(
               HloInstruction::CreateGetTupleElement(hlo, output_index));
           SetDynamicSize(result.replacement_instr, index, dimension,
                          dynamic_size);
+          if (array_state_replacement != nullptr) {
+            // The old array-shaped while's uses read the state through this
+            // get-tuple-element; record the same dynamic size for it.
+            SetDynamicSize(array_state_replacement, {}, dimension,
+                           dynamic_size);
+          }
           ShapeUtil::GetMutableSubshape(hlo->mutable_shape(), index)
               ->set_dynamic_dimension(dimension, false);
           TF_RET_CHECK(!index.empty());

--- a/xla/service/dynamic_padder_test.cc
+++ b/xla/service/dynamic_padder_test.cc
@@ -1836,6 +1836,62 @@ ENTRY entry {
   EXPECT_EQ(result, expected);
 }
 
+TEST_F(ExecutionTest, NonTupleWhileLoopStack) {
+  // Regression test for https://github.com/openxla/xla/issues/47375: same
+  // stack loop as WhileLoopStack, but the loop state is the bare array
+  // instead of a single-element tuple. This used to hit a CHECK in
+  // WhileUtil::MakeInstructionsLiveIn during DynamicDimensionInference.
+  const std::string hlo_text = R"(
+HloModule module
+
+update_s32 (lhs: s32[], rhs: s32[]) -> s32[] {
+  lhs = s32[] parameter(0)
+  rhs = s32[] parameter(1)
+  ROOT add = s32[] add(lhs, rhs)
+}
+
+body {
+  stack_buffer = s32[<=4, 2] parameter(0)
+  stack_size = s32[] get-dimension-size(stack_buffer), dimensions={0}
+  zero = s32[] constant(0)
+  one = s32[] constant(1)
+  // content of the stack is the stack index broadcasted.
+  new_data = s32[1, 2] broadcast(s32[] stack_size), dimensions={}
+  new_stack_size = s32[] add(stack_size, one)
+  new_stack_buffer = s32[<=4, 2] set-dimension-size(stack_buffer, new_stack_size), dimensions={0}
+  ROOT new_stack = s32[<=4, 2] dynamic-update-slice(new_stack_buffer, new_data, stack_size, zero)
+}
+
+condition {
+  stack_buffer = s32[<=4, 2] parameter(0)
+  stack_size = s32[] get-dimension-size(stack_buffer), dimensions={0}
+  three = s32[] constant(3)
+  ROOT less-than = pred[] compare(s32[] stack_size, s32[] three), direction=LT
+}
+
+ENTRY entry {
+  zero = s32[] constant(0)
+  pad = s32[] constant(-1)
+  stack_buffer_input = s32[4, 2] broadcast(s32[] pad), dimensions={}
+  stack_buffer_input_dynamic = s32[<=4, 2] set-dimension-size(stack_buffer_input, zero), dimensions={0}
+  while = s32[<=4, 2] while(stack_buffer_input_dynamic), body=body, condition=condition
+  ROOT reduce = s32[2] reduce(while, zero),
+    dimensions={0},
+    to_apply=update_s32
+}
+)";
+
+  auto module = GetHloModule(hlo_text);
+
+  TF_ASSERT_OK_AND_ASSIGN(Literal result, PadAndExecute(std::move(module), {}));
+
+  // As in WhileLoopStack, three items are pushed before the loop exits, so
+  // reducing along the major dimension gives us [3, 3].
+  Literal expected = LiteralUtil::CreateR1<int32_t>({{3, 3}});
+
+  EXPECT_EQ(result, expected);
+}
+
 TEST_F(ExecutionTest, DynamicAddWithImplicitBroadcast) {
   const std::string hlo_text = R"(
 HloModule module


### PR DESCRIPTION
## 📝 Summary of Changes

HLO allows a while loop whose loop-carried state is a bare array instead of a tuple. `DynamicDimensionInference::HandleWhile` assumed tuple state: it passed the loop to `WhileUtil::MakeInstructionsLiveIn`, which starts with `CHECK(while_instr->shape().IsTuple())`. So any bare-array while that carries a bounded dynamic dimension crashed the whole process at compile time, on CPU, GPU and the interpreter.

This change canonicalizes such a while into the equivalent single-element tuple form before the existing tuple-based handling runs. The condition and body are cloned rather than mutated, since HLO allows them to be shared with other callers, and the analysis' dynamic-size mappings are copied onto the clones and wrapper tuples. The rewrite only triggers when the loop state actually carries a recorded dynamic dimension, so fully static non-tuple whiles are untouched (verified against pass dumps). The canonicalization lives in the analysis rather than in DynamicPadder because the interpreter and the service compile path invoke the analysis directly.

## 🎯 Justification

Fixes #47375. The compiler must not abort on valid HLO. The two other callers of `MakeInstructionsLiveIn` (the while-loop invariant code motion passes) already guard against non-tuple state; the analysis could not simply skip the loop because dropping the size mapping would miscompile the module (padded garbage would leak into consumers).

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

Added `NonTupleWhileLoopStack` to `dynamic_padder_test.cc`, a bare-array-state twin of the existing `WhileLoopStack` test. Before the fix it aborts with the exact `while_util.cc:230` CHECK from the issue; after it passes and asserts the computed values, so a fix that stopped the crash but leaked padded rows into the reduce would still fail. `//xla/service:dynamic_padder_test`, `//xla/service:dynamic_dimension_inference_test` and `//xla/service:while_util_test` all pass.

## 🧪 Execution Tests:

The issue's original StableHLO module and the reduced HLO repro compile and run correctly with `run_hlo_module` on CPU and on a single NVIDIA RTX 2070 (sm_75) after the change; the new regression test also runs on the GPU configs of `dynamic_padder_test`.