### PR TITLE
Reject transpose tiles exceeding shared memory during Triton tile selection

### DIFF
--- a/xla/service/gpu/model/triton_emitter_constraints.cc
+++ b/xla/service/gpu/model/triton_emitter_constraints.cc
@@ -48,6 +48,7 @@ limitations under the License.
 #include "xla/hlo/utils/hlo_traversal.h"
 #include "xla/service/decision.h"
 #include "xla/shape.h"
+#include "xla/shape_util.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/util.h"
 
@@ -73,6 +74,19 @@ llvm::SmallVector<int64_t> GetPaddedTileSizes(
     result.push_back(llvm::PowerOf2Ceil(value));
   }
   return result;
+}
+
+// Returns a conservative estimate (in bytes) of the memory required to stage a
+// tile whose sizes are `tile_sizes` for an instruction whose element type
+// occupies `element_byte_size` bytes.
+int64_t GetPaddedTileSizeInBytes(absl::Span<const int64_t> tile_sizes,
+                                 int64_t element_byte_size) {
+  int64_t padded_tile_elements = 1;
+  for (int64_t size : tile_sizes) {
+    CHECK_GT(size, 0) << "Encountered non-positive tile size " << size;
+    padded_tile_elements *= llvm::PowerOf2Ceil(size);
+  }
+  return padded_tile_elements * element_byte_size;
 }
 
 }  // namespace
@@ -120,6 +134,7 @@ TritonEmitterConstraints::GetBuilder(
              const HloFusionAdaptor& fusion_adaptor) {
     absl::flat_hash_set<SymbolicMap> unique_tile_size_maps;
     llvm::SmallVector<RootTileInfo, 2> root_infos;
+    llvm::SmallVector<TransposeTileInfo, 2> transpose_infos;
     auto roots = fusion_adaptor.GetRoots();
     for (const auto& tiled_hlo_instruction : instructions) {
       unique_tile_size_maps.insert(
@@ -133,6 +148,17 @@ TritonEmitterConstraints::GetBuilder(
             RootTileInfo{tiled_hlo_instruction->symbolic_tile().size_map(),
                          shape.IsArray() ? SpanToVector(shape.dimensions())
                                          : std::vector<int64_t>()});
+      }
+      // A transpose stages its operand tile in shared memory to perform the
+      // layout conversion, so record the info needed to estimate that usage.
+      const HloInstruction* hlo = tiled_hlo_instruction->hlo();
+      if (hlo->opcode() == HloOpcode::kTranspose &&
+          fusion_adaptor.ContainsInstruction(hlo)) {
+        const auto& operand = tiled_hlo_instruction->operands().front();
+        transpose_infos.push_back(
+            TransposeTileInfo{operand->symbolic_tile().size_map(),
+                              ShapeUtil::ByteSizeOfPrimitiveType(
+                                  operand->hlo()->shape().element_type())});
       }
     }
 
@@ -148,7 +174,7 @@ TritonEmitterConstraints::GetBuilder(
     return std::unique_ptr<TritonEmitterConstraints>(
         absl::WrapUnique(new TritonEmitterConstraints(
             std::move(tile_size_maps), std::move(root_infos),
-            std::move(custom_constraints),
+            std::move(transpose_infos), std::move(custom_constraints),
             /*root_shape=*/instructions.back()->hlo()->shape(),
             device_description, std::move(tiled_emitter_constraints))));
   };
@@ -258,6 +284,27 @@ absl::StatusOr<bool> TritonEmitterConstraints::ParametersSatisfyConstraints(
     }
   }
 
+  // Verify that no transpose op would require more shared memory than the
+  // device provides. A transpose stages its (padded) operand tile in shared
+  // memory to perform the layout conversion, so estimate that usage and reject
+  // tiles that would exceed the device shared memory limit. This lets the tile
+  // search fall back to a smaller tile instead of failing later with a
+  // RESOURCE_EXHAUSTED error during Triton compilation.
+  const int64_t shared_memory_limit =
+      device_info_.shared_memory_per_block_optin();
+  for (const auto& transpose : transposes_) {
+    llvm::SmallVector<int64_t> operand_tile_sizes =
+        transpose.operand_size_map.Evaluate(tile_parameters);
+    if (GetPaddedTileSizeInBytes(operand_tile_sizes,
+                                 transpose.element_byte_size) >
+        shared_memory_limit) {
+      VLOG(2) << "Found a transpose whose operand tile would exceed the shared "
+                 "memory limit of "
+              << shared_memory_limit << " bytes. Bailing out.";
+      return false;
+    }
+  }
+
   return tiled_emitter_constraints_->ParametersSatisfyConstraints(
       tile_parameters);
 }
@@ -346,6 +393,44 @@ Decision VerifyTritonConstraints(const TiledHloComputation& tiled_computation,
           }
         }
       }
+    }
+  }
+
+  // 3. Transpose Shared Memory Limit.
+  // A transpose op stages its (padded) operand tile in shared memory to perform
+  // the layout conversion (the classic shared-memory transpose that avoids
+  // uncoalesced global memory accesses). Estimate that shared-memory usage as
+  // the product of the power-of-2-padded operand tile sizes multiplied by the
+  // element byte size, and reject tiles that would exceed the device shared
+  // memory limit. This lets the tile search fall back to a smaller tile instead
+  // of failing later with a RESOURCE_EXHAUSTED error during Triton compilation.
+  const int64_t shared_memory_limit =
+      device_info.shared_memory_per_block_optin();
+  for (const TiledHloInstruction* inst : all_instructions) {
+    if (inst->hlo()->opcode() != HloOpcode::kTranspose) {
+      continue;
+    }
+    // The transposed operand (operand 0) is the tile that is staged in shared
+    // memory.
+    CHECK_EQ(inst->operands().size(), 1)
+        << "Transpose " << inst->hlo()->name() << " should have exactly one "
+        << "operand, but has " << inst->operands().size() << ".";
+    const TiledHloInstruction* operand = inst->operands().front();
+    auto operand_tile_sizes_or = operand->tile().GetStaticTileSizes();
+    if (!operand_tile_sizes_or.ok()) {
+      return Decision(operand_tile_sizes_or.status());
+    }
+
+    const int64_t shared_memory_bytes = GetPaddedTileSizeInBytes(
+        *operand_tile_sizes_or, ShapeUtil::ByteSizeOfPrimitiveType(
+                                    operand->hlo()->shape().element_type()));
+    if (shared_memory_bytes > shared_memory_limit) {
+      return Decision::Forbid(absl::StrCat(
+          "Transpose instruction ", inst->hlo()->name(),
+          " has an operand tile that requires an estimated ",
+          shared_memory_bytes,
+          " bytes of shared memory, which exceeds the device limit of ",
+          shared_memory_limit, " bytes."));
     }
   }
 

--- a/xla/service/gpu/model/triton_emitter_constraints.cc
+++ b/xla/service/gpu/model/triton_emitter_constraints.cc
@@ -83,7 +83,6 @@ int64_t GetPaddedTileSizeInBytes(absl::Span<const int64_t> tile_sizes,
                                  int64_t element_byte_size) {
   int64_t padded_tile_elements = 1;
   for (int64_t size : tile_sizes) {
-    CHECK_GT(size, 0) << "Encountered non-positive tile size " << size;
     padded_tile_elements *= llvm::PowerOf2Ceil(size);
   }
   return padded_tile_elements * element_byte_size;

--- a/xla/service/gpu/model/triton_emitter_constraints.h
+++ b/xla/service/gpu/model/triton_emitter_constraints.h
@@ -66,14 +66,23 @@ class TritonEmitterConstraints : public EmitterSpecificConstraints {
     std::vector<int64_t> dim_sizes;
   };
 
+  // Holds the info needed to estimate the shared memory required to stage the
+  // operand tile of a transpose instruction.
+  struct TransposeTileInfo {
+    SymbolicMap operand_size_map;
+    int64_t element_byte_size;
+  };
+
   explicit TritonEmitterConstraints(
       llvm::SmallVector<SymbolicMap, 4> tile_size_maps,
       llvm::SmallVector<RootTileInfo, 2> roots,
+      llvm::SmallVector<TransposeTileInfo, 2> transposes,
       std::vector<CustomConstraints> custom_constraints,
       const Shape& root_shape, const se::DeviceDescription& device_info,
       std::unique_ptr<TiledEmitterConstraints> tiled_emitter_constraints)
       : tile_size_maps_(std::move(tile_size_maps)),
         roots_(std::move(roots)),
+        transposes_(std::move(transposes)),
         custom_constraints_(std::move(custom_constraints)),
         root_shape_(root_shape),
         device_info_(device_info),
@@ -111,6 +120,10 @@ class TritonEmitterConstraints : public EmitterSpecificConstraints {
   // Holds the info for all fusion roots necessary to check whether the tile
   // sizes evaluate to powers of 2 or have the same size as the dimension.
   llvm::SmallVector<RootTileInfo, 2> roots_;
+
+  // Holds the info for all transpose instructions necessary to estimate the
+  // shared memory required to stage their operand tiles.
+  llvm::SmallVector<TransposeTileInfo, 2> transposes_;
 
   // Custom emitter-specific constraints to check in
   // `ParametersSatisfyConstraints`.

--- a/xla/service/gpu/model/triton_emitter_constraints_test.cc
+++ b/xla/service/gpu/model/triton_emitter_constraints_test.cc
@@ -177,6 +177,77 @@ ENTRY entry_computation {
               absl_testing::IsOkAndHolds(false));
 }
 
+TEST_F(TritonEmitterConstraintsTest,
+       TransposeSharedMemoryConstraintIsEnforced) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                       ParseAndReturnVerifiedModule(R"(
+HloModule m
+
+fused_computation {
+  param_0 = f32[1024,1024] parameter(0)
+  ROOT transpose = f32[1024,1024] transpose(param_0), dimensions={1,0}
+}
+
+ENTRY entry_computation {
+  param_0 = f32[1024,1024] parameter(0)
+  ROOT fusion = f32[1024,1024] fusion(param_0), kind=kCustom,
+    calls=fused_computation, backend_config={"fusion_backend_config":{"kind":"__triton"}}
+}
+)"));
+
+  std::optional<SymbolicTileAnalysis> analysis = TryAnalyzeModule(module.get());
+  ASSERT_TRUE(analysis.has_value());
+  const HloInstruction* fusion_root =
+      module->entry_computation()->root_instruction()->fused_expression_root();
+
+  // The RTX A6000 test device has 99 * 1024 = 101376 bytes of opt-in shared
+  // memory. A [128, 128] f32 transpose operand tile requires
+  // 128 * 128 * 4 = 65536 bytes, which fits.
+  EXPECT_THAT(analysis->ParametersSatisfyConstraints(
+                  Tiling({{fusion_root, FlatTiling({128, 128})}})),
+              absl_testing::IsOkAndHolds(true));
+
+  // A [256, 128] f32 transpose operand tile requires
+  // 256 * 128 * 4 = 131072 bytes, which exceeds the shared memory limit. The
+  // tile is otherwise valid (32768 elements is below the tensor size limit,
+  // tile sizes are powers of 2, and the number of blocks fits on the grid), so
+  // it is the transpose shared memory constraint that rejects it.
+  EXPECT_THAT(analysis->ParametersSatisfyConstraints(
+                  Tiling({{fusion_root, FlatTiling({256, 128})}})),
+              absl_testing::IsOkAndHolds(false));
+}
+
+TEST_F(TritonEmitterConstraintsTest, NonTransposeIsNotChargedToSharedMemory) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                       ParseAndReturnVerifiedModule(R"(
+HloModule m
+
+fused_computation {
+  param_0 = f32[1024,1024] parameter(0)
+  ROOT log = f32[1024,1024] log(param_0)
+}
+
+ENTRY entry_computation {
+  param_0 = f32[1024,1024] parameter(0)
+  ROOT fusion = f32[1024,1024] fusion(param_0), kind=kCustom,
+    calls=fused_computation, backend_config={"fusion_backend_config":{"kind":"__triton"}}
+}
+)"));
+
+  std::optional<SymbolicTileAnalysis> analysis = TryAnalyzeModule(module.get());
+  ASSERT_TRUE(analysis.has_value());
+  const HloInstruction* fusion_root =
+      module->entry_computation()->root_instruction()->fused_expression_root();
+
+  // A [256, 128] f32 tile requires 256 * 128 * 4 = 131072 bytes, which would
+  // exceed the shared memory limit if it were charged to shared memory. Because
+  // there is no transpose op, the shared memory constraint does not apply and
+  // the tiling is accepted.
+  EXPECT_THAT(analysis->ParametersSatisfyConstraints(
+                  Tiling({{fusion_root, FlatTiling({256, 128})}})),
+              absl_testing::IsOkAndHolds(true));
+}
+
 TEST_F(TritonEmitterConstraintsTest, TooManyBlocksConstraintIsEnforced) {
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
                        ParseAndReturnVerifiedModule(R"(
@@ -426,6 +497,63 @@ ENTRY entry_computation {
   EXPECT_OK(CheckTiling(module.get(), {4, 4, 4}));
   EXPECT_THAT(CheckTiling(module.get(), {512, 4, 4}),
               StatusIs(_, HasSubstr("exceeds the maximum MMA dimension size")));
+}
+
+TEST_F(VerifyTritonConstraintsTest, TransposeSharedMemoryConstraintIsEnforced) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                       ParseAndReturnVerifiedModule(R"hlo(
+HloModule m
+
+fused_computation {
+  param_0 = f32[1024,1024] parameter(0)
+  ROOT transpose = f32[1024,1024] transpose(param_0), dimensions={1,0}
+}
+
+ENTRY entry_computation {
+  param_0 = f32[1024,1024] parameter(0)
+  ROOT fusion = f32[1024,1024] fusion(param_0), kind=kCustom,
+    calls=fused_computation,
+    backend_config={"fusion_backend_config":{"kind":"__triton"}}
+}
+)hlo"));
+
+  // The RTX A6000 test device has 99 * 1024 = 101376 bytes of opt-in shared
+  // memory. A [128, 128] f32 transpose operand tile requires
+  // 128 * 128 * 4 = 65536 bytes, which fits.
+  EXPECT_OK(CheckTiling(module.get(), {128, 128}));
+
+  // A [256, 128] f32 transpose operand tile requires
+  // 256 * 128 * 4 = 131072 bytes, which exceeds the shared memory limit. The
+  // tile is otherwise valid (32768 elements is below the tensor size limit,
+  // tile sizes are powers of 2, and the number of blocks fits on the grid), so
+  // it is the transpose shared memory constraint that rejects it.
+  EXPECT_THAT(CheckTiling(module.get(), {256, 128}),
+              StatusIs(_, HasSubstr("exceeds the device limit")));
+}
+
+TEST_F(VerifyTritonConstraintsTest, NonTransposeIsNotChargedToSharedMemory) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                       ParseAndReturnVerifiedModule(R"hlo(
+HloModule m
+
+fused_computation {
+  param_0 = f32[1024,1024] parameter(0)
+  ROOT log = f32[1024,1024] log(param_0)
+}
+
+ENTRY entry_computation {
+  param_0 = f32[1024,1024] parameter(0)
+  ROOT fusion = f32[1024,1024] fusion(param_0), kind=kCustom,
+    calls=fused_computation,
+    backend_config={"fusion_backend_config":{"kind":"__triton"}}
+}
+)hlo"));
+
+  // A [256, 128] f32 tile requires 256 * 128 * 4 = 131072 bytes, which would
+  // exceed the shared memory limit if it were charged to shared memory. Because
+  // there is no transpose op, the shared memory constraint does not apply and
+  // the tiling is accepted.
+  EXPECT_OK(CheckTiling(module.get(), {256, 128}));
 }
 
 TEST_F(VerifyTritonConstraintsTest, TooManyBlocksConstraintIsEnforced) {


### PR DESCRIPTION
📝 Summary of Changes
Add a shared-memory constraint to the Triton tile-selection search for transpose ops so that tiles requiring more shared memory than the device provides are rejected before compilation, letting the search fall back to a smaller tile instead of failing later with a RESOURCE_EXHAUSTED error.

A transpose stages its (padded) operand tile in shared memory to perform the layout conversion. The estimate is `product(power-of-2-padded operand tile sizes) * element_byte_size`, compared against `shared_memory_per_block_optin()`.

🎯 Justification
The Triton tile selection process did not take into account the amount of shared memory required when choosing the tile size.
As a result, some merged kernels failed with a RESOURCE_EXHAUSTED error.

Example of kernel failing on gfx1201:

```
HloModule transpose_shared_memory_repro, entry_computation_layout={(bf16[1024,2080]{0,1})->bf16[1024,16,128]{2,1,0}}

transpose_fusion {
  param_0 = bf16[1024,2080]{0,1} parameter(0)
  bitcast_0 = bf16[2080,1024]{1,0} bitcast(param_0)
  slice = bf16[2048,1024]{1,0} slice(bitcast_0), slice={[32:2080], [0:1024]}
  transpose = bf16[1024,2048]{1,0} transpose(slice), dimensions={1,0}
  ROOT bitcast_1 = bf16[1024,16,128]{2,1,0} bitcast(transpose)
}

ENTRY main {
  param_0 = bf16[1024,2080]{0,1} parameter(0)
  ROOT fusion = bf16[1024,16,128]{2,1,0} fusion(param_0), kind=kCustom,
    calls=transpose_fusion,
    backend_config={"fusion_backend_config":{"kind":"__triton","block_level_fusion_config":{"output_tiles":[{"sizes":["32","16","128"]}],"num_warps":"8","num_ctas":1,"num_stages":1,"is_tma_allowed":false,"is_warp_specialization_allowed":false,"waves_per_eu":0}}}
}
```

```
RESOURCE_EXHAUSTED: Shared memory size limit exceeded: requested 131072, available: 65536, context: [Fusion: fusion = bf16[1024,16,128]{2,1,0} fusion(param_0.1), kind=kCustom, calls=transpose_fusion, backend_config={"fusion_backend_config":{"kind":"__triton","block_level_fusion_config":{"output_tiles":[{"sizes":["32","16","128"]}],"num_warps":"8","num_ctas":1,"num_stages":1,"is_tma_allowed":false,"is_warp_specialization_allowed":false,"waves_per_eu":0}}}Computation: transpose_fusion {
  param_0 = bf16[1024,2080]{0,1} parameter(0)
  bitcast_0 = bf16[2080,1024]{1,0} bitcast(param_0)
  slice = bf16[2048,1024]{1,0} slice(bitcast_0), slice={[32:2080], [0:1024]}
  transpose = bf16[1024,2048]{1,0} transpose(slice), dimensions={1,0}
  ROOT bitcast_1 = bf16[1024,16,128]{2,1,0} bitcast(transpose)
```

the tile selection must therefore take into consideration the use of shared memory when selecting the tile sizes to reject incompatible tile sizes cleanly instead of failing with a RESOURCE_EXHAUSTED error.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix,

🧪 Unit Tests:
New tests included in this PR
