### PR TITLE
[XLA:GPU] Determine compiler PTX support from LLVM

### DIFF
--- a/xla/service/gpu/llvm_gpu_backend/BUILD
+++ b/xla/service/gpu/llvm_gpu_backend/BUILD
@@ -290,6 +290,8 @@ xla_cc_test(
         "//xla/stream_executor/cuda:cuda_compute_capability",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//llvm:TargetParser",
     ],
 )
 

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "absl/base/call_once.h"
@@ -27,9 +28,10 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/status_macros.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include "third_party/gpus/cuda/include/cuda.h"
+#include "absl/strings/strip.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/Analysis/CGSCCPassManager.h"
 #include "llvm/Analysis/LazyCallGraph.h"
@@ -47,6 +49,7 @@ limitations under the License.
 #include "llvm/IR/Verifier.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Linker/Linker.h"
+#include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/PassRegistry.h"
 #include "llvm/Passes/PassBuilder.h"
@@ -146,28 +149,26 @@ absl::Status NVPTXTargetModuleLinker(llvm::Module* module,
   return absl::OkStatus();
 }
 
-std::unique_ptr<llvm::TargetMachine> NVPTXGetTargetMachine(
+absl::StatusOr<std::unique_ptr<llvm::TargetMachine>> NVPTXGetTargetMachine(
     llvm::Triple target_triple, se::CudaComputeCapability compute_capability,
     const DebugOptions& debug_options) {
+  ABSL_ASSIGN_OR_RETURN(int llvm_max_ptx_version,
+                        GetMaxPtxVersionSupportedByLlvm(target_triple));
+
   absl::StatusOr<stream_executor::SemanticVersion> runtime_cuda_version =
       stream_executor::GetAsmCompilerVersion(
           debug_options.xla_gpu_cuda_data_dir());
 
-  constexpr stream_executor::SemanticVersion kCompileTimeCudaVersion{
-      CUDA_VERSION / 1000, (CUDA_VERSION / 10) % 100, CUDA_VERSION % 10};
-
-  auto highest_supported_cuda_version = [&] {
-    if (runtime_cuda_version.ok()) {
-      return std::min(runtime_cuda_version.value(), kCompileTimeCudaVersion);
-    }
-
-    return kCompileTimeCudaVersion;
-  }();
-
-  auto ptx_version = nvptx::DetermineHighestSupportedPtxVersionFromCudaVersion(
-      highest_supported_cuda_version, compute_capability.major);
-  int highest_supported_ptx_version =
-      ptx_version.major_version() * 10 + ptx_version.minor_version();
+  int highest_supported_ptx_version = llvm_max_ptx_version;
+  if (runtime_cuda_version.ok()) {
+    auto ptx_version =
+        nvptx::DetermineHighestSupportedPtxVersionFromCudaVersion(
+            *runtime_cuda_version, compute_capability.major);
+    int runtime_max_ptx_version =
+        ptx_version.major_version() * 10 + ptx_version.minor_version();
+    highest_supported_ptx_version =
+        std::min(runtime_max_ptx_version, llvm_max_ptx_version);
+  }
 
   VLOG(1) << "Targeting PTX version: " << highest_supported_ptx_version;
   std::string feature_str =
@@ -193,6 +194,45 @@ void NVPTXBackendInit() {
 }
 
 }  // namespace
+
+absl::StatusOr<int> GetMaxPtxVersionSupportedByLlvm(
+    const llvm::Triple& target_triple) {
+  std::string error;
+  const llvm::Target* target =
+      llvm::TargetRegistry::lookupTarget(target_triple, error);
+  if (target == nullptr) {
+    return Internal("Failed to look up LLVM target for triple %s: %s",
+                    target_triple.str(), error);
+  }
+
+  std::unique_ptr<const llvm::MCSubtargetInfo> subtarget_info{
+      target->createMCSubtargetInfo(target_triple, "", "")};
+  if (subtarget_info == nullptr) {
+    return Internal("Failed to get LLVM subtarget info for triple %s",
+                    target_triple.str());
+  }
+
+  int max_ptx_version = 0;
+  for (const llvm::SubtargetFeatureKV& feature :
+       subtarget_info->getAllProcessorFeatures()) {
+    std::string_view version_string = feature.key();
+    if (!absl::ConsumePrefix(&version_string, "ptx")) {
+      continue;
+    }
+
+    int ptx_version;
+    if (!absl::SimpleAtoi(version_string, &ptx_version)) {
+      return Internal("Failed to parse LLVM PTX feature: %s", version_string);
+    }
+    max_ptx_version = std::max(max_ptx_version, ptx_version);
+  }
+
+  if (max_ptx_version == 0) {
+    return Internal("LLVM target %s does not define any PTX features",
+                    target_triple.str());
+  }
+  return max_ptx_version;
+}
 
 std::vector<std::string> GetNVPTXBackendOptions(
     const DebugOptions& debug_options) {
@@ -341,8 +381,10 @@ absl::StatusOr<std::string> CompileToPtx(
 
     llvm::Triple default_target_triple("nvptx64-unknown-unknown");
     // Construct LLVM TargetMachine for NVPTX.
-    std::unique_ptr<llvm::TargetMachine> target_machine = NVPTXGetTargetMachine(
-        default_target_triple, *compute_capability, debug_options);
+    ABSL_ASSIGN_OR_RETURN(
+        std::unique_ptr<llvm::TargetMachine> target_machine,
+        NVPTXGetTargetMachine(default_target_triple, *compute_capability,
+                              debug_options));
 
     // Apply target machine configuration from call-back if available.
     if (configure_target) {

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend.h
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend.h
@@ -24,11 +24,18 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Target/TargetMachine.h"
+#include "llvm/TargetParser/Triple.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/device_description.h"
 #include "xla/xla.pb.h"
 
 namespace xla::gpu::nvptx {
+
+// Returns the maximum PTX ISA version advertised by LLVM's NVPTX target,
+// encoded as major * 10 + minor. Returns an error if the target or its MC
+// subtarget information is not registered.
+absl::StatusOr<int> GetMaxPtxVersionSupportedByLlvm(
+    const llvm::Triple& target_triple);
 
 // Resolves the compute capability that XLA actually compiles for given the
 // compute capability of the target device. If the device's compute capability

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
@@ -19,6 +19,8 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "absl/strings/str_cat.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/TargetParser/Triple.h"
 #include "xla/service/gpu/llvm_gpu_backend/ptx_version_util.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/semantic_version.h"
@@ -27,6 +29,17 @@ namespace xla {
 namespace gpu {
 namespace {
 namespace se = ::stream_executor;
+
+TEST(UtilsTest, LlvmSupportsMinimumPtxVersionForSm107a) {
+  LLVMInitializeNVPTXTargetInfo();
+  LLVMInitializeNVPTXTargetMC();
+
+  auto max_ptx_version = nvptx::GetMaxPtxVersionSupportedByLlvm(
+      llvm::Triple("nvptx64-unknown-unknown"));
+
+  ASSERT_TRUE(max_ptx_version.ok()) << max_ptx_version.status();
+  EXPECT_GE(*max_ptx_version, 94);
+}
 
 TEST(UtilsTest, TestGetSmName) {
   using FeatureExtension = se::CudaComputeCapability::FeatureExtension;


### PR DESCRIPTION
📝 Summary of Changes
Determine the maximum supported compiler PTX version from LLVM instead of deriving it from the build-time CUDA_VERSION.

🎯 Justification
The CUDA version used to build XLA does not represent the PTX capability of the bundled LLVM and unnecessary restricts supported PTX version to the lower value. Follows an approach to query PTX version from JAX https://github.com/jax-ml/jax/blob/c3ca80f83f09e89994830e2397783fb65adb3d12/jaxlib/mosaic/gpu/target.cc#L80. 

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
Added UtilsTest.LlvmSupportsMinimumPtxVersionForSm107a in xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
