### PR TITLE
Fix ragged all to all 46982

### DIFF
--- a/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
+++ b/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
@@ -447,11 +447,20 @@ absl::Status RunNcclFallbackRaggedAllToAll(
     int64_t element_byte_width = primitive_util::ByteWidth(element_type);
     se::DeviceAddressBase input_buffer = buffers[0].source_buffer;
 
+    // Track the actual number of puts issued per peer so we can pass the
+    // correct op_cnt to WaitSignal below. Skipping zero-size puts saves
+    // ~12 us of NCCL overhead per skipped slot (see issue #46982).
+    std::vector<int> puts_per_peer(num_ranks, 0);
+
     Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
       for (int peer = 0; peer < num_ranks; ++peer) {
         for (int64_t i = 0; i < num_updates_per_replica; ++i) {
           const int64_t idx = peer * num_updates_per_replica + i;
           const int64_t send_count = send_sizes[idx] * ragged_row_element_size;
+
+          // Skip zero-size sends: NCCL still pays ~12 us per LaunchPut even
+          // at count=0, causing O(n_devices) cost for sparse neighbor patterns.
+          if (send_count == 0) continue;
 
           const se::DeviceAddressBase send_slice = GpuCollectives::Slice(
               input_buffer, element_type,
@@ -466,6 +475,7 @@ absl::Status RunNcclFallbackRaggedAllToAll(
           ABSL_RETURN_IF_ERROR(gpu_comm->LaunchPut(
               send_slice, output_symmetric_memory, byte_offset, byte_count,
               RankId(peer), GpuCollectives::On(stream)));
+          ++puts_per_peer[peer];
         }
       }
       return absl::OkStatus();
@@ -474,8 +484,11 @@ absl::Status RunNcclFallbackRaggedAllToAll(
 
     GpuSignalDesc signal_desc(/*sig_idx=*/0, /*ctx=*/0);
     for (int peer = 0; peer < num_ranks; ++peer) {
+      // Wait only for the puts we actually issued to this peer. If we issued
+      // zero puts (all slots were zero-size), WaitSignal is skipped entirely.
+      if (puts_per_peer[peer] == 0) continue;
       ABSL_RETURN_IF_ERROR(comm.WaitSignal(RankId(peer),
-                                      /*op_cnt=*/num_updates_per_replica,
+                                      /*op_cnt=*/puts_per_peer[peer],
                                       signal_desc, GpuCollectives::On(stream))
                           .Await());
     }
@@ -496,6 +509,15 @@ absl::Status RunNcclFallbackRaggedAllToAll(
     for (int64_t i = 0; i < num_updates_per_replica; ++i) {
       for (int peer = 0; peer < num_ranks; ++peer) {
         int64_t idx = peer * num_updates_per_replica + i;
+
+        // Skip zero-size peer slots. NCCL pays ~12 us overhead per
+        // LaunchSend/LaunchRecv even at count=0, causing O(n_devices) cost
+        // for sparse neighbor patterns (issue #46982). Both sides apply the
+        // same condition using their local metadata so sends and recvs remain
+        // paired: if send_size[idx]==0 here, the matching recv_size on the
+        // remote rank for the same slot is also 0 by RaggedAllToAll semantics.
+        if (send_sizes[idx] == 0 && recv_sizes[idx] == 0) continue;
+
         se::DeviceAddressBase send_slice =
             GpuCollectives::Slice(input_buffer, element_type,
                                   input_offsets[idx] * ragged_row_element_size,

--- a/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
+++ b/xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc
@@ -439,6 +439,7 @@ absl::Status RunNcclFallbackRaggedAllToAll(
   const int64_t* input_offsets = ragged_metadata_allocs[0];
   const int64_t* send_sizes = ragged_metadata_allocs[1];
   const int64_t* output_offsets = ragged_metadata_allocs[2];
+  const int64_t* recv_sizes = ragged_metadata_allocs[3];
 
   if (use_put_path) {
     XLA_VLOG_DEVICE(3, device_ordinal)
@@ -447,10 +448,15 @@ absl::Status RunNcclFallbackRaggedAllToAll(
     int64_t element_byte_width = primitive_util::ByteWidth(element_type);
     se::DeviceAddressBase input_buffer = buffers[0].source_buffer;
 
-    // Track the actual number of puts issued per peer so we can pass the
-    // correct op_cnt to WaitSignal below. Skipping zero-size puts saves
-    // ~12 us of NCCL overhead per skipped slot (see issue #46982).
-    std::vector<int> puts_per_peer(num_ranks, 0);
+    // WaitSignal observes puts sent by `peer` to this rank, so its op_cnt must
+    // be the number of nonzero receives expected from that peer.
+    std::vector<int> puts_from_peer(num_ranks, 0);
+    for (int peer = 0; peer < num_ranks; ++peer) {
+      for (int64_t i = 0; i < num_updates_per_replica; ++i) {
+        const int64_t idx = peer * num_updates_per_replica + i;
+        puts_from_peer[peer] += recv_sizes[idx] != 0;
+      }
+    }
 
     Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
       for (int peer = 0; peer < num_ranks; ++peer) {
@@ -475,7 +481,6 @@ absl::Status RunNcclFallbackRaggedAllToAll(
           ABSL_RETURN_IF_ERROR(gpu_comm->LaunchPut(
               send_slice, output_symmetric_memory, byte_offset, byte_count,
               RankId(peer), GpuCollectives::On(stream)));
-          ++puts_per_peer[peer];
         }
       }
       return absl::OkStatus();
@@ -484,11 +489,9 @@ absl::Status RunNcclFallbackRaggedAllToAll(
 
     GpuSignalDesc signal_desc(/*sig_idx=*/0, /*ctx=*/0);
     for (int peer = 0; peer < num_ranks; ++peer) {
-      // Wait only for the puts we actually issued to this peer. If we issued
-      // zero puts (all slots were zero-size), WaitSignal is skipped entirely.
-      if (puts_per_peer[peer] == 0) continue;
+      if (puts_from_peer[peer] == 0) continue;
       ABSL_RETURN_IF_ERROR(comm.WaitSignal(RankId(peer),
-                                      /*op_cnt=*/puts_per_peer[peer],
+                                      /*op_cnt=*/puts_from_peer[peer],
                                       signal_desc, GpuCollectives::On(stream))
                           .Await());
     }
@@ -498,7 +501,6 @@ absl::Status RunNcclFallbackRaggedAllToAll(
 
   XLA_VLOG_DEVICE(3, device_ordinal)
       << "RunFallbackNcclRaggedAllToAll: using Send/Recv path";
-  const int64_t* recv_sizes = ragged_metadata_allocs[3];
 
   Future<> future = gpu_comm->GroupExecute([&]() -> absl::Status {
     PrimitiveType element_type = buffers[0].element_type;
@@ -510,31 +512,31 @@ absl::Status RunNcclFallbackRaggedAllToAll(
       for (int peer = 0; peer < num_ranks; ++peer) {
         int64_t idx = peer * num_updates_per_replica + i;
 
-        // Skip zero-size peer slots. NCCL pays ~12 us overhead per
-        // LaunchSend/LaunchRecv even at count=0, causing O(n_devices) cost
-        // for sparse neighbor patterns (issue #46982). Both sides apply the
-        // same condition using their local metadata so sends and recvs remain
-        // paired: if send_size[idx]==0 here, the matching recv_size on the
-        // remote rank for the same slot is also 0 by RaggedAllToAll semantics.
-        if (send_sizes[idx] == 0 && recv_sizes[idx] == 0) continue;
+        // Send and receive refer to different slots. Skip each zero-size
+        // operation independently: NCCL pays ~12 us per LaunchSend/LaunchRecv
+        // even at count=0, causing O(n_devices) cost for sparse neighbor
+        // patterns (issue #46982).
+        if (send_sizes[idx] != 0) {
+          se::DeviceAddressBase send_slice = GpuCollectives::Slice(
+              input_buffer, element_type,
+              input_offsets[idx] * ragged_row_element_size,
+              send_sizes[idx] * ragged_row_element_size);
+          ABSL_RETURN_IF_ERROR(gpu_comm->LaunchSend(
+              send_slice, element_type,
+              send_sizes[idx] * ragged_row_element_size, RankId(peer),
+              GpuCollectives::On(stream)));
+        }
 
-        se::DeviceAddressBase send_slice =
-            GpuCollectives::Slice(input_buffer, element_type,
-                                  input_offsets[idx] * ragged_row_element_size,
-                                  send_sizes[idx] * ragged_row_element_size);
-
-        se::DeviceAddressBase recv_slice =
-            GpuCollectives::Slice(output_buffer, element_type,
-                                  output_offsets[idx] * ragged_row_element_size,
-                                  recv_sizes[idx] * ragged_row_element_size);
-
-        ABSL_RETURN_IF_ERROR(gpu_comm->LaunchSend(
-            send_slice, element_type, send_sizes[idx] * ragged_row_element_size,
-            RankId(peer), GpuCollectives::On(stream)));
-
-        ABSL_RETURN_IF_ERROR(gpu_comm->LaunchRecv(
-            recv_slice, element_type, recv_sizes[idx] * ragged_row_element_size,
-            RankId(peer), GpuCollectives::On(stream)));
+        if (recv_sizes[idx] != 0) {
+          se::DeviceAddressBase recv_slice = GpuCollectives::Slice(
+              output_buffer, element_type,
+              output_offsets[idx] * ragged_row_element_size,
+              recv_sizes[idx] * ragged_row_element_size);
+          ABSL_RETURN_IF_ERROR(gpu_comm->LaunchRecv(
+              recv_slice, element_type,
+              recv_sizes[idx] * ragged_row_element_size, RankId(peer),
+              GpuCollectives::On(stream)));
+        }
       }
     }
 

--- a/xla/backends/gpu/tests/ragged_all_to_all_e2e_test.cc
+++ b/xla/backends/gpu/tests/ragged_all_to_all_e2e_test.cc
@@ -891,6 +891,53 @@ TEST_P(RaggedAllToAllTest, RaggedAllToAll_2GPUs_PreservesInitialData) {
   EXPECT_TRUE(LiteralTestUtil::Equal(expected_outputs_[1], results[1]));
 }
 
+// Regression test for issue #46982: zero-size peer slices must be skipped so
+// that the collective's cost is O(actual_neighbors) not O(n_devices).
+//
+// Pattern: replica_0 sends 3 rows to replica_1; replica_1 sends 0 rows to
+// replica_0. This creates one direction with all-zero sizes per peer, which
+// previously caused ~12 us of unnecessary NCCL overhead for every zero-size
+// slot in the Send/Recv or Put+Signal paths.
+TEST_P(RaggedAllToAllTest, RaggedAllToAll_2GPUs_SparseNeighbors) {
+  absl::string_view kModuleReplicatedStr = R"(
+  HloModule module, num_partitions=1
+
+  ENTRY entry {
+    input = f32[4] parameter(0)
+    output = f32[4] parameter(1)
+    input_offsets = s32[2] parameter(2)
+    send_sizes = s32[2] parameter(3)
+    output_offsets = s32[2] parameter(4)
+    recv_sizes = s32[2] parameter(5)
+    ROOT ra2a = f32[4] ragged-all-to-all(input, output, input_offsets,
+    send_sizes, output_offsets, recv_sizes), replica_groups={{0,1}}
+  })";
+
+  const int64_t kNumReplicas = 2;
+  ASSERT_GE(device_count(), kNumReplicas)
+      << "Test requires at least " << kNumReplicas << " devices ("
+      << device_count() << " available)";
+
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(
+                                        kModuleReplicatedStr, kNumReplicas));
+
+  // Sparse pattern: replica_0 sends 3 rows to replica_1, and 1 row to itself.
+  // replica_1 sends 0 rows to replica_0 (zero-size slot), and 1 row to itself.
+  // The zero-size slot for replica_1->replica_0 must be skipped without hangs.
+  ASSERT_OK(CreateRandomTestData(module.get(),
+                                 /*input_sizes=*/{/*replica_0=*/{1, 3},
+                                                  /*replica_1=*/{0, 1}}));
+
+  ASSERT_OK_AND_ASSIGN(
+      ExecutionResult execution_result,
+      ExecuteReplicated(std::move(module), GetInputLiteralPtrs()));
+
+  const std::vector<Literal>& results = execution_result.results;
+  ASSERT_EQ(results.size(), kNumReplicas);
+  EXPECT_TRUE(LiteralTestUtil::Equal(expected_outputs_[0], results[0]));
+  EXPECT_TRUE(LiteralTestUtil::Equal(expected_outputs_[1], results[1]));
+}
+
 TEST_P(RaggedAllToAllTest, RaggedAllToAll_8GPUs) {
   absl::string_view kModuleReplicatedStr = R"(
   HloModule module, num_partitions=1


### PR DESCRIPTION
📝 **Summary of Changes**
Modified the `RaggedAllToAll` GPU collective in `xla/backends/gpu/runtime/ragged_all_to_all_thunk.cc` to explicitly skip `LaunchSend`, `LaunchRecv`, and `LaunchPut` calls for zero-size peer slices in the NCCL fallback path. In the Put+Signal path, it now tracks the actual number of puts issued per peer and passes this correct `op_cnt` to `WaitSignal`.

🎯 **Justification**
This change resolves issue #46982 by eliminating an O(n_devices) cost scaling bottleneck during ragged-all-to-all operations with sparse neighbor exchange patterns. Previously, NCCL enqueued work for zero-count operations, resulting in ~12 µs overhead for every zero-size slot. By skipping these slots, this change significantly improves performance for sparse communication on a large number of GPUs (e.g., eliminating the +625 µs scaling overhead from 16 to 64 devices on a fixed degree-10 neighbor graph).

🚀 **Kind of Contribution**
🐛 Bug Fix, ⚡️ Performance Improvement

📊 **Benchmark (for Performance Improvements)**
Eliminates the ~12 µs per zero-size slot NCCL overhead reported in #46982 (cost is now constant O(actual_neighbors) rather than linear O(n_devices)).

🧪 **Unit Tests:**
Existing tests in `ragged_all_to_all_thunk_test.cc` continue to validate thunk initialization and command buffer logic. 

🧪 **Execution Tests:**
Added `RaggedAllToAll_2GPUs_SparseNeighbors` end-to-end test to `xla/backends/gpu/tests/ragged_all_to_all_e2e_test.cc`. This 2-GPU test verifies the collective's correctness under a sparse pattern where one replica sends zero rows in one direction, ensuring that skipping zero-size slots works correctly without deadlocks and produces the expected data.
