### PR TITLE
Fix duplicate cupti_driver_cbid.h inclusion causing redefinition error

### DIFF
--- a/xla/backends/profiler/gpu/cupti_tracer.cc
+++ b/xla/backends/profiler/gpu/cupti_tracer.cc
@@ -47,7 +47,6 @@ limitations under the License.
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_activity.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_callbacks.h"
-#include "third_party/gpus/cuda/extras/CUPTI/include/cupti_driver_cbid.h"
 #include "third_party/gpus/cuda/extras/CUPTI/include/cupti_result.h"
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/backends/profiler/gpu/cuda_version_variants.h"


### PR DESCRIPTION
Redirected from [tensorflow/tensorflow#125963](https://github.com/tensorflow/tensorflow/pull/125963) per reviewer feedback (`dmiltr3`) -- `xla/backends/profiler/gpu/cupti_tracer.cc` is vendored into TensorFlow from this repo, so the fix belongs here.

## Problem

`cupti_tracer.cc` includes `cupti_driver_cbid.h` twice:

- Transitively, via `cupti.h` (included one line above, whose own `cupti.h:77` does `#include <cupti_driver_cbid.h>`).
- Directly, via the line this PR removes.

`cupti_driver_cbid.h` (vendored from the CUPTI redistributable, not part of this repo) has no include guards. With the CUDA 12.4.127 CUPTI package (reachable via `HERMETIC_CUDA_VERSION=12.4.1`), bazel's virtual-include resolution treats the transitive angle-bracket path and this file's quoted relative path as distinct, so the preprocessor processes the header twice and the enum gets defined twice:

```
error: redefinition of 'CUpti_driver_api_trace_cbid_enum'
```

This didn't surface with the default hermetic CUDA version (12.5.1) in CI, but is reproducible with 12.4.1 -- which is a real, useful thing to build against for GPUs whose installed driver doesn't support 12.5+ (`CUDA_ERROR_UNSUPPORTED_PTX_VERSION` at runtime otherwise, see tensorflow/tensorflow#62864, #97387).

## Fix

Remove the redundant direct include. `cupti_driver_cbid.h` is already available transitively via `cupti.h`, included one line above -- nothing else in this file needs the direct include path.

## Testing

Built TensorFlow 2.20.0 from source (Spack recipe, AOCC 5.0.0, `cuda_arch=80`, `HERMETIC_CUDA_VERSION=12.4.1`) on an NVIDIA A100 (driver 550.144.03). Before this fix: build fails at the error above. After: build completes, and a real GPU test (elementwise add + matmul) runs without `CUDA_ERROR_UNSUPPORTED_PTX_VERSION` / `CUDA_ERROR_INVALID_HANDLE`.
