### PR TITLE
[XLA] Clamp out-of-bound set-dimension-size sizes in the HLO evaluator

### DIFF
--- a/xla/hlo/evaluator/hlo_evaluator.cc
+++ b/xla/hlo/evaluator/hlo_evaluator.cc
@@ -1419,8 +1419,12 @@ absl::Status HloEvaluator::HandleSetDimensionSize(
          operand_literal.total_size_bytes());
   const Literal& size_literal =
       GetEvaluatedLiteralFor(set_dimension_size->operand(1));
-  result.SetDynamicSize(set_dimension_size->dimension(),
-                        size_literal.Get<int32_t>({}));
+  const int64_t dimension = set_dimension_size->dimension();
+  // Nothing validates the size operand against the bound; clamp to [0, bound]
+  // so an out-of-contract runtime size cannot trip internal CHECKs.
+  const int32_t size = static_cast<int32_t>(std::clamp<int64_t>(
+      size_literal.Get<int32_t>({}), 0, result.shape().dimensions(dimension)));
+  result.SetDynamicSize(dimension, size);
   SetEvaluatedLiteralFor(set_dimension_size, std::move(result));
   return absl::OkStatus();
 }

--- a/xla/hlo/evaluator/hlo_evaluator_test.cc
+++ b/xla/hlo/evaluator/hlo_evaluator_test.cc
@@ -6278,6 +6278,45 @@ ENTRY main {
   EXPECT_EQ(actual.GetFirstElement<int32_t>(), static_cast<int32_t>(3));
 }
 
+// An out-of-contract size operand of set-dimension-size must not crash the
+// evaluator; it is clamped to [0, bound].
+constexpr absl::string_view kSetDimensionSizeHlo = R"(
+HloModule Test
+
+ENTRY main {
+  data = s32[4] parameter(0)
+  size = s32[] parameter(1)
+  ROOT sds = s32[<=4] set-dimension-size(data, size), dimensions={0}
+}
+)";
+
+TEST_F(HloEvaluatorTest, SetDimensionSizeClampsOversizedSize) {
+  TF_ASSERT_OK_AND_ASSIGN(m_,
+                          ParseAndReturnVerifiedModule(kSetDimensionSizeHlo));
+  Literal data_arg = LiteralUtil::CreateR1<int32_t>({1, 2, 3, 4});
+  Literal size_arg = LiteralUtil::CreateR0<int32_t>(1851888704);
+  TF_ASSERT_OK_AND_ASSIGN(Literal result, Evaluate({&data_arg, &size_arg}));
+  EXPECT_EQ(result.GetDynamicSize(0), 4);
+}
+
+TEST_F(HloEvaluatorTest, SetDimensionSizeClampsNegativeSize) {
+  TF_ASSERT_OK_AND_ASSIGN(m_,
+                          ParseAndReturnVerifiedModule(kSetDimensionSizeHlo));
+  Literal data_arg = LiteralUtil::CreateR1<int32_t>({1, 2, 3, 4});
+  Literal size_arg = LiteralUtil::CreateR0<int32_t>(-3);
+  TF_ASSERT_OK_AND_ASSIGN(Literal result, Evaluate({&data_arg, &size_arg}));
+  EXPECT_EQ(result.GetDynamicSize(0), 0);
+}
+
+TEST_F(HloEvaluatorTest, SetDimensionSizeKeepsSizeEqualToBound) {
+  TF_ASSERT_OK_AND_ASSIGN(m_,
+                          ParseAndReturnVerifiedModule(kSetDimensionSizeHlo));
+  Literal data_arg = LiteralUtil::CreateR1<int32_t>({1, 2, 3, 4});
+  Literal size_arg = LiteralUtil::CreateR0<int32_t>(4);
+  TF_ASSERT_OK_AND_ASSIGN(Literal result, Evaluate({&data_arg, &size_arg}));
+  EXPECT_EQ(result.GetDynamicSize(0), 4);
+}
+
 // Check that we get a useful error if we pass inputs of the wrong shape.
 TEST_F(HloEvaluatorTest, EvaluateWithWrongInputShapes) {
   const absl::string_view hlo_text = R"(


### PR DESCRIPTION
## 📝 Summary of Changes

Fixes #47368.

`HloEvaluator::HandleSetDimensionSize` passes the raw runtime value of the
size operand straight into `MutableLiteralBase::SetDynamicSize`. Nothing
validates that value against the dimension bound, so a size larger than the
bound trips the fatal `CHECK_GE(bound, size)` in `literal.cc` and aborts the
whole process, and a negative size is silently stored and aborts later in
`LiteralBase::ToStatic` (`Shape::set_dimensions` CHECK). On the Interpreter
platform the evaluator executes the module directly, so a program whose
set-dimension-size size operand comes from input data can kill the process,
which is how the fuzzed module in the issue crashes `run_hlo_module`.

This change clamps the size to [0, bound] in `HandleSetDimensionSize` before
storing it. The evaluator is the only place a runtime program value becomes a
literal dynamic size, so this single site covers the crash class. In-contract
programs are unaffected (the clamp is the identity for sizes in [0, bound]).

Clamping (rather than erroring) matches the direction of #46625, which gives
the compiled CPU path the same [0, bound] clamp where the dynamic padder
materializes dynamic tensors, and keeps interpreter-vs-backend comparisons in
`run_hlo_module` executable for such modules (CPU/GPU execute them without
complaint today). Note that `get-dimension-size` still observes the raw size
value: it forwards the size-producing instruction's result, mirroring how the
dynamic padder forwards the raw size tensor on compiled backends, so only the
literal's stored dynamic size is clamped.

## 🎯 Justification

An out-of-contract runtime value in input data must not be able to abort the
process. The CHECKs themselves guard correct internal invariants (the literal
data buffer is sized to the bound); the evaluator is the boundary layer that
has to enforce the contract on program-provided sizes.

## 🚀 Kind of Contribution

- 🐛 Bug Fix

## 🧪 Unit Tests:

Three regression tests in `hlo_evaluator_test.cc` next to the existing
`GetDimensionSize` test: `SetDimensionSizeClampsOversizedSize` (size
1851888704, the issue's value, expects dynamic size clamped to the bound 4),
`SetDimensionSizeClampsNegativeSize` (size -3, expects 0), and
`SetDimensionSizeKeepsSizeEqualToBound` (size 4, expects 4). Without the
fix the first aborts at `literal.cc` exactly like the issue and the second
observes the stored -3; with the fix all pass.
`bazel test //xla/hlo/evaluator/...` passes (331 tests in
`hlo_evaluator_test` plus the other evaluator targets).

## 🧪 Execution Tests:

The issue's StableHLO module and three minimal HLO variants (parameter size,
constant oversize, constant negative) now run cleanly under
`run_hlo_module --platform=Interpreter`; before the fix all four SIGABRT.