### PR TITLE
[PJRT:CPU] Support dynamic-shaped literals in BufferFromHostLiteral

### DIFF
--- a/xla/pjrt/cpu/cpu_client.cc
+++ b/xla/pjrt/cpu/cpu_client.cc
@@ -1109,6 +1109,12 @@ absl::StatusOr<PjRtDeviceEventRef> PjRtCpuClient::LinearizeInto(
   if (device_shape.IsToken()) {
     return PjRtDeviceEventRef(tsl::MakeAvailableAsyncValueRef<CpuEvent>());
   }
+  // CopyFromLiteral does not write runtime shape metadata; delegate dynamic
+  // shapes to the base implementation, which does.
+  if (RequiresRuntimeShapeMetadata(device_shape, raw_buffer->memory_space())) {
+    return CommonPjRtClient::LinearizeInto(literal, device_shape,
+                                           host_buffer_semantics, raw_buffer);
+  }
   auto* cpp_buf = raw_buffer->down_cast<CpuRawBuffer>();
   if (cpp_buf == nullptr) {
     return absl::InvalidArgumentError("Not a CPU raw buffer");

--- a/xla/pjrt/cpu/cpu_client_test.cc
+++ b/xla/pjrt/cpu/cpu_client_test.cc
@@ -613,6 +613,34 @@ TEST(PjRtCpuClientTest, AsyncTransferLiteralInt4) {
               ElementsAreArray(literal.data<s4>()));
 }
 
+TEST(PjRtCpuClientTest, BufferFromHostLiteralDynamicShape) {
+  TF_ASSERT_OK_AND_ASSIGN(auto client, GetPjRtCpuClient(CpuClientOptions()));
+  Literal literal(ShapeUtil::MakeShape(F32, {10}, {true}));
+  absl::Span<float> data = literal.data<float>();
+  std::iota(data.begin(), data.end(), 0.0f);
+  literal.SetDynamicSize(0, 3);
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto buffer,
+      client->BufferFromHostLiteral(literal, client->memory_spaces()[0]));
+  TF_ASSERT_OK_AND_ASSIGN(auto received, buffer->ToLiteral().Await());
+  EXPECT_EQ(received->GetDynamicSize(0), 3);
+  EXPECT_THAT(received->data<float>().subspan(0, 3), ElementsAre(0, 1, 2));
+}
+
+TEST(PjRtCpuClientTest, BufferFromHostLiteralDynamicShapeMixedDims) {
+  TF_ASSERT_OK_AND_ASSIGN(auto client, GetPjRtCpuClient(CpuClientOptions()));
+  Literal literal(ShapeUtil::MakeShape(F32, {2, 3}, {false, true}));
+  absl::Span<float> data = literal.data<float>();
+  std::iota(data.begin(), data.end(), 0.0f);
+  literal.SetDynamicSize(1, 2);
+  TF_ASSERT_OK_AND_ASSIGN(
+      auto buffer,
+      client->BufferFromHostLiteral(literal, client->memory_spaces()[0]));
+  TF_ASSERT_OK_AND_ASSIGN(auto received, buffer->ToLiteral().Await());
+  EXPECT_EQ(received->shape().dimensions(1), 2);
+  EXPECT_THAT(received->data<float>(), ElementsAre(0, 1, 3, 4));
+}
+
 TEST(PjRtCpuClientTest, ToLiteralWithLayout) {
   TF_ASSERT_OK_AND_ASSIGN(auto client, GetPjRtCpuClient(CpuClientOptions()));
   Literal literal = LiteralUtil::CreateR2<int8_t>({{1, 2}, {3, 4}});


### PR DESCRIPTION
## 📝 Summary of Changes

Fixes #47379.

On CPU, a buffer for a bounded-dynamic shape holds the array data padded to
the bound followed by one int32 runtime size per dynamic dimension (suffix
metadata), and `CommonPjRtClient::BufferFromHostLiteral` sizes the allocation
accordingly. But `PjRtCpuClient::LinearizeInto` routes every literal to
`CpuRawBuffer::CopyFromLiteral`, which knows nothing about the metadata: it
bulk-copies with `CHECK(literal.size_bytes() == size)` in `PackOrCopy`, and a
literal's `size_bytes()` counts only the data. For any dynamic-shaped literal
the sizes differ by the metadata bytes and the process aborts
(`abstract_cpu_buffer.cc: Check failed: literal.size_bytes() == size
(40 vs. 44)` for the issue's `f32[<=10]` input).

The base `CommonPjRtClient::LinearizeInto` already handles this case: it
collects the literal's dynamic sizes and writes the data and metadata regions
separately. This change makes the CPU override delegate to the base
implementation when the device shape requires runtime shape metadata, keeping
the existing fast path for static shapes untouched.

Note the D2H direction already works on CPU (dynamic outputs are read via the
shape-metadata helpers), so with this change a dynamic literal round-trips
through `BufferFromHostLiteral` + `ToLiteral`.

## 🎯 Justification

Transferring a well-formed dynamic-shaped literal must not abort the
process. The buffer sizing, the D2H direction, and the generic linearization
path all support dynamic shapes already; the CPU override just bypassed the
support.

## 🚀 Kind of Contribution

- 🐛 Bug Fix

## 🧪 Unit Tests:

`PjRtCpuClientTest.BufferFromHostLiteralDynamicShape`: round-trips an
`f32[<=10]` literal with dynamic size 3 through `BufferFromHostLiteral` and
`ToLiteral`, checking the dynamic size and data survive.
`PjRtCpuClientTest.BufferFromHostLiteralDynamicShapeMixedDims`: `f32[2,<=3]`
with dynamic size 2, checking the compacted data placement the CPU runtime
expects. Without the fix both abort on the `PackOrCopy` CHECK exactly like
the issue; with it the whole `cpu_client_test` suite (48 tests) passes.

## 🧪 Execution Tests:

The issue's module needs one more fix to run end-to-end with `run_hlo_module`:
the fake-argument generator leaves dynamic-dimension sizes uninitialized
(garbage metadata), which is a separate defect in `MakeFakeLiteral` and will
be addressed in a follow-up PR. With both changes applied locally, the
issue's module runs cleanly on CPU, Interpreter, and GPU with identical
results.