### PR TITLE
Fix while loop range analysis for nonconstant steps

### DIFF
--- a/xla/hlo/analysis/while_loop_analysis.cc
+++ b/xla/hlo/analysis/while_loop_analysis.cc
@@ -774,7 +774,7 @@ optional<Range> MatchLoopRangeWithKnownValues(
   int64_t trip_count_step = 0;
   if (!Match(while_body_indvar_update,
              m::AddAnyOrder(m::Op().Is(while_body_indvar),
-                            m::Op(&trip_count_increase_step_instr)))) {
+                            m::Constant(&trip_count_increase_step_instr)))) {
     if (trip_count_increase_step_instr == nullptr) {
       VLOG(2) << "Pattern-match failed: induction variable is not getting "
                  "updated by an add operation: "

--- a/xla/hlo/analysis/while_loop_analysis_test.cc
+++ b/xla/hlo/analysis/while_loop_analysis_test.cc
@@ -1066,7 +1066,7 @@ TEST_F(WhileLoopAnalysisTest, GetIndvarIndexShouldWorkWhenParamIsCopied) {
 }
 
 TEST_F(WhileLoopAnalysisTest,
-       MatchTrivialLoopCountFailsWhenIndvarIsNotIncrementedByConstant) {
+       MatchTrivialLoopFailsWhenIndvarIsNotIncrementedByConstant) {
   absl::string_view hlo_with_constant = R"(
   HloModule test
   body {
@@ -1125,6 +1125,7 @@ TEST_F(WhileLoopAnalysisTest,
       MatchTrivialLoopTripCount(while_op_without_constant, 0,
                                 LiteralUtil::CreateR0<int32_t>(0));
   EXPECT_EQ(trip_count_without_constant, std::nullopt);
+  EXPECT_EQ(MatchTrivialLoopRange(while_op_without_constant), std::nullopt);
 }
 
 TEST_F(WhileLoopAnalysisTest,


### PR DESCRIPTION
## Summary

- require the while-loop induction-variable step to be an HLO constant before reading its literal
- keep `MatchLoopRangeWithKnownValues` consistent with `MatchTrivialLoopTripCount`
- add a regression assertion that a nonconstant induction-variable update returns `std::nullopt` instead of crashing

## Test

```bash
TMPDIR=/export/home/lishuo121/.cache/xla-tmp /tmp/xla-tools/bazel-8.7.0 test \
  --config=clang_local \
  --repo_env=CC=/usr/bin/clang \
  --repo_env=CXX=/usr/bin/clang++ \
  --action_env=CC=/usr/bin/clang \
  --action_env=CXX=/usr/bin/clang++ \
  --distdir=/export/home/lishuo121/.cache/xla-distdir \
  --experimental_downloader_config=/tmp/xla-tools/downloader.cfg \
  //xla/hlo/analysis:while_loop_analysis_test \
  --test_output=errors
```

Result: `1 test passes`.

Fixes #47384
