### PR TITLE
Fix system hwloc

### DIFF
--- a/third_party/hwloc/BUILD.system
+++ b/third_party/hwloc/BUILD.system
@@ -2,11 +2,6 @@
 
 licenses(["notice"])
 
-config_setting(
-    name = "with_numa_support",
-    define_values = {"with_numa_support": "true"},
-)
-
 filegroup(
     name = "COPYING",
     visibility = ["//visibility:public"],
@@ -14,9 +9,6 @@ filegroup(
 
 cc_library(
     name = "hwloc",
-    linkopts = select({
-        ":with_numa_support": ["-lhwloc"],
-        "//conditions:default": [],
-    }),
+    linkopts = ["-lhwloc"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
📝 Summary of Changes
The `with_numa_support` in hwloc is never used so the linkopts stays empty. The actual hwloc library has no similar condition and users conditionally depend on the hwloc target, see https://github.com/openxla/xla/blob/b25f0b0368801956b81bbff6c49b30fc2e3d0e07/xla/tsl/platform/default/BUILD#L398-L401

So the condition and config can be removed.

🎯 Justification

The condition was likely moved without updating the system build file which is since broken.

🚀 Kind of Contribution
🐛 Bug Fix

🧪 Unit Tests:
🧪 Execution Tests:

Build change only. Passes locally with `TF_SYSTEM_LIBS=hwloc`