### PR TITLE
[XLA] Skip TopK custom calls without a comparator in TopK passes

### DIFF
--- a/xla/backends/gpu/transforms/topk_specializer.cc
+++ b/xla/backends/gpu/transforms/topk_specializer.cc
@@ -125,8 +125,10 @@ class SpecializeTopkVisitor : public DfsHloRewriteVisitor {
 
   absl::Status HandleCustomCall(HloInstruction* inst) override {
     HloCustomCallInstruction* topk = DynCast<HloCustomCallInstruction>(inst);
+    // Only specialize "TopK" custom calls created by TopkRewriter, which
+    // always attach a comparator computation. Skip foreign ones without it.
     if (topk == nullptr || topk->custom_call_target() != "TopK" ||
-        compute_capability_.IsOneAPI()) {
+        !topk->has_to_apply() || compute_capability_.IsOneAPI()) {
       return absl::OkStatus();
     }
     TF_RET_CHECK(topk->operand_count() == 1);

--- a/xla/backends/gpu/transforms/topk_specializer_test.cc
+++ b/xla/backends/gpu/transforms/topk_specializer_test.cc
@@ -207,5 +207,24 @@ TEST_F(TopkTest, PreservesBackendConfig) {
   EXPECT_EQ(custom_call->raw_backend_config_string(), "{is_stable = false}");
 }
 
+TEST_F(TopkTest, IgnoresTopKWithoutComparator) {
+  // A foreign "TopK" custom call carries no comparator computation; the
+  // specializer must leave it alone instead of CHECK-crashing (issue #47365).
+  constexpr absl::string_view hlo = R"(
+    ENTRY top_k {
+      arg = f32[1,1025] parameter(0)
+      ROOT result = (f32[1,4], s32[1,4]) custom-call(arg), custom_call_target="TopK"
+    }
+  )";
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnVerifiedModule(hlo));
+  ASSERT_OK_AND_ASSIGN(
+      bool changed,
+      TopkSpecializer(device_description().gpu_compute_capability())
+          .Run(module.get()));
+  EXPECT_FALSE(changed);
+}
+
 }  // namespace
 }  // namespace xla::gpu

--- a/xla/backends/gpu/transforms/topk_splitter.cc
+++ b/xla/backends/gpu/transforms/topk_splitter.cc
@@ -56,7 +56,10 @@ class TopkSplitterVisitor : public DfsHloRewriteVisitor {
 
   absl::Status HandleCustomCall(HloInstruction* inst) override {
     HloCustomCallInstruction* topk = DynCast<HloCustomCallInstruction>(inst);
-    if (topk == nullptr || topk->custom_call_target() != "TopK") {
+    // Only split "TopK" custom calls created by TopkRewriter, which always
+    // attach a comparator computation. Skip foreign ones without it.
+    if (topk == nullptr || topk->custom_call_target() != "TopK" ||
+        !topk->has_to_apply()) {
       return absl::OkStatus();
     }
     HloComputation* comp = inst->parent();

--- a/xla/backends/gpu/transforms/topk_splitter_test.cc
+++ b/xla/backends/gpu/transforms/topk_splitter_test.cc
@@ -160,6 +160,23 @@ ENTRY cluster {
               absl_testing::IsOkAndHolds(false));
 }
 
+TEST_F(HardwareIndependentTopkSplitterTest, IgnoresTopKWithoutComparator) {
+  // A foreign "TopK" custom call carries no comparator computation; the
+  // splitter must leave it alone instead of CHECK-crashing (issue #47365).
+  const std::string hlo_string = R"(
+HloModule module
+ENTRY cluster {
+  %arg.1 = f32[1,2097152] parameter(0)
+  ROOT %cc.2 = (f32[1,16], s32[1,16]) custom-call(%arg.1), custom_call_target="TopK"
+})";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+  EXPECT_THAT(RunHloPass(TopKSplitter(), module.get()),
+              absl_testing::IsOkAndHolds(false));
+  EXPECT_TRUE(Match(module->entry_computation()->root_instruction(),
+                    m::CustomCall(m::Parameter(0))));
+}
+
 TEST_F(TopkSplitterTest, Equivalent) {
   const std::string hlo_string = absl::Substitute(R"(
 HloModule module

--- a/xla/service/topk_rewriter.cc
+++ b/xla/service/topk_rewriter.cc
@@ -477,7 +477,10 @@ class TopkDecomposerVisitor : public DfsHloRewriteVisitor {
       return absl::OkStatus();
     }
     HloCustomCallInstruction* call = DynCast<HloCustomCallInstruction>(inst);
-    if (call == nullptr || call->custom_call_target() != "TopK") {
+    // Only decompose "TopK" custom calls created by TopkRewriter, which always
+    // attach a comparator computation. Skip foreign ones without it.
+    if (call == nullptr || call->custom_call_target() != "TopK" ||
+        !call->has_to_apply()) {
       return absl::OkStatus();
     }
     HloComputation* comparator = call->to_apply();

--- a/xla/service/topk_rewriter_test.cc
+++ b/xla/service/topk_rewriter_test.cc
@@ -855,6 +855,48 @@ ENTRY cluster {
                           m::Slice(m::GetTupleElement(sort_matcher, 1)))));
 }
 
+TEST_F(TopkRewriterTest, TopKCustomCallWithoutComparatorIsNotDecomposed) {
+  // A foreign "TopK" custom call carries no comparator computation; the
+  // decomposer must leave it alone instead of CHECK-crashing (issue #47365).
+  const std::string hlo_string = R"(
+HloModule module
+ENTRY cluster {
+  %arg = f32[8,5] parameter(0)
+  ROOT %cc = (f32[8,5], s32[8,5]) custom-call(%arg), custom_call_target="TopK"
+})";
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+
+  ASSERT_OK_AND_ASSIGN(bool decomposer_changed,
+                       TopkDecomposer().Run(module.get()));
+  EXPECT_FALSE(decomposer_changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              GmockMatch(m::CustomCall(m::Parameter(0))));
+}
+
+TEST_F(TopkRewriterTest, TopKCustomCallWithTwoComputationsIsNotDecomposed) {
+  // to_apply() also CHECK-fails on custom calls with more than one called
+  // computation; the decomposer must skip those too (issue #47365).
+  const std::string hlo_string = R"(
+HloModule module
+%c1 (p0: f32[]) -> f32[] {
+  ROOT %p0 = f32[] parameter(0)
+}
+%c2 (p1: f32[]) -> f32[] {
+  ROOT %p1 = f32[] parameter(0)
+}
+ENTRY cluster {
+  %arg = f32[8,5] parameter(0)
+  ROOT %cc = (f32[8,5], s32[8,5]) custom-call(%arg), custom_call_target="TopK", called_computations={%c1, %c2}
+})";
+  ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_string));
+
+  ASSERT_OK_AND_ASSIGN(bool decomposer_changed,
+                       TopkDecomposer().Run(module.get()));
+  EXPECT_FALSE(decomposer_changed);
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              GmockMatch(m::CustomCall(m::Parameter(0))));
+}
+
 TEST_F(TopkRewriterTest, TopKCustomCallUnstableConfig) {
   const std::string hlo_string = R"(
 HloModule module


### PR DESCRIPTION
## 📝 Summary of Changes

TopkDecomposer, TopKSplitter and TopkSpecializer recognize "TopK" custom
calls by the target string and then read the attached comparator with
`HloInstruction::to_apply()`. That accessor is a fatal CHECK when the custom
call has no called computation, so a module containing a plain custom call
named "TopK" (for example from `stablehlo.custom_call @TopK`) aborts the
whole process while compiling on the interpreter and on GPU.

This change makes all three passes skip TopK custom calls that do not have a
comparator attached (`!has_to_apply()`). Custom calls produced by
TopkRewriter always carry the comparator, so the rewrites themselves are
unchanged. A comparator-less "TopK" custom call now just flows through the
pipeline like any other unrecognized custom call and produces a normal
"not registered" error at execution time instead of a SIGABRT at compile
time. The CPU backend already handles this input fine (its pipeline only
runs the decomposer on the kTopK opcode, and its runtime executes the
custom call natively), so this aligns the interpreter and GPU behavior with
CPU.

Fixes #47365.

## 🎯 Justification

Reported in #47365 (StableHLO fuzzer): compiling the attached module
SIGABRTs with `hlo_instruction.cc: Invalid opcode for to_apply():
custom-call` from `TopkDecomposerVisitor::HandleCustomCall`. Custom call
targets are free-form strings, nothing reserves the name "TopK", and a
custom call may legally have zero called computations, so a compiler pass
must not abort on this input. While fixing the reported crash site the same
defect was confirmed in the two GPU TopK passes with different input
shapes: TopKSplitter crashes for shapes like `f32[1,2097152]` and
TopkSpecializer for shapes like `f32[1,1025]`. All three are one-line
guards of the same form.

## 🚀 Kind of Contribution

- 🐛 Bug Fix
- 🧪 Tests

## 🧪 Unit Tests:

- `//xla/service:topk_rewriter_test` -
  `TopKCustomCallWithoutComparatorIsNotDecomposed` and
  `TopKCustomCallWithTwoComputationsIsNotDecomposed` (new): TopK custom
  calls with zero (or two) called computations are left untouched by
  TopkDecomposer. Abort before this change, pass after.
- `//xla/backends/gpu/transforms:topk_splitter_test` -
  `IgnoresTopKWithoutComparator` (new): same for TopKSplitter with a
  `f32[1,2097152]` input. Aborts before, passes after.
- `//xla/backends/gpu/transforms:topk_specializer_test` -
  `IgnoresTopKWithoutComparator` (new): same for TopkSpecializer with a
  `f32[1,1025]` input. Aborts before, passes after.

## 🧪 Execution Tests:

Verified with `run_hlo_module` on a single RTX 2070 (sm_75): the issue's
module and the reduced repro no longer abort. The Interpreter compiles and
fails gracefully at execution with NOT_FOUND (custom call target not
registered); CUDA reports the same NOT_FOUND as a clean error from backend
compilation. CPU behavior is unchanged (still executes the custom call via
its native TopK runtime).

Note: TopK custom calls that do carry a comparator but have a malformed
shape (for example a non-tuple result) can still hit CHECKs further down in
these passes and in the CPU thunk emitter. That is a separate pre-existing
class not touched here to keep this change minimal.