### PR TITLE
Replace rocm-smi CLI with amd-smi in ROCm test scripts

### DIFF
--- a/build_tools/rocm/run_xla.sh
+++ b/build_tools/rocm/run_xla.sh
@@ -22,12 +22,13 @@ set -e
 set -x
 
 N_BUILD_JOBS=$(grep -c ^processor /proc/cpuinfo)
-# If rocm-smi exists locally (it should) use it to find
+# amd-smi replaces the deprecated rocm-smi CLI as of ROCm 7.14.
+# If amd-smi exists locally (it should) use it to find
 # out how many GPUs we have to test with.
-rocm-smi -i
+amd-smi list
 STATUS=$?
 if [ $STATUS -ne 0 ]; then TF_GPU_COUNT=1; else
-   TF_GPU_COUNT=$(rocm-smi -i|grep 'Device ID' |grep 'GPU' |wc -l)
+   TF_GPU_COUNT=$(amd-smi list|grep -c '^GPU:')
 fi
 TF_TESTS_PER_GPU=1
 N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})

--- a/build_tools/rocm/run_xla_multi_gpu.sh
+++ b/build_tools/rocm/run_xla_multi_gpu.sh
@@ -33,12 +33,13 @@ set -e
 set -x
 
 N_BUILD_JOBS=$(grep -c ^processor /proc/cpuinfo)
-# If rocm-smi exists locally (it should) use it to find
+# amd-smi replaces the deprecated rocm-smi CLI as of ROCm 7.14.
+# If amd-smi exists locally (it should) use it to find
 # out how many GPUs we have to test with.
-rocm-smi -i
+amd-smi list
 STATUS=$?
 if [ $STATUS -ne 0 ]; then TF_GPU_COUNT=1; else
-   TF_GPU_COUNT=$(rocm-smi -i|grep 'Device ID' |grep 'GPU' |wc -l)
+   TF_GPU_COUNT=$(amd-smi list|grep -c '^GPU:')
 fi
 if [[ $TF_GPU_COUNT -lt 4 ]]; then
     echo "Found only ${TF_GPU_COUNT} gpus, multi-gpu tests need atleast 4 gpus."


### PR DESCRIPTION
## Summary
- Replace `rocm-smi -i` GPU counting with `amd-smi list | grep -c ^GPU:` in `run_xla.sh` and `run_xla_multi_gpu.sh`.

## Context
ROCm SMI CLI is deprecated in favor of AMD SMI. Library usage in stream executor is tracked separately on ROCm/xla.

## Test plan
- [x] Both scripts pass `bash -n`
- [x] GPU count from `amd-smi list` matches `rocm-smi -i` on ROCm 7.14