### PR TITLE
[ROCm: XLA Profiler] Write VGPR and LDS kernel stats to kernel_info XStat for XProf

### DIFF
--- a/xla/backends/profiler/gpu/rocm_collector.h
+++ b/xla/backends/profiler/gpu/rocm_collector.h
@@ -50,8 +50,16 @@ inline std::string ToXStat(const KernelDetails& kernel_info,
            grid_z = kernel_info.workgroup_z != 0
                         ? kernel_info.grid_z / kernel_info.workgroup_z
                         : 0;
+  const uint32_t dynamic_group_segment_size =
+      kernel_info.group_segment_size > kernel_info.static_group_segment_size
+          ? kernel_info.group_segment_size -
+                kernel_info.static_group_segment_size
+          : 0;
 
-  return absl::StrCat(" grid:", grid_x, ",", grid_y, ",", grid_z,
+  return absl::StrCat("regs:", kernel_info.registers_per_work_item,
+                      " static_shared:", kernel_info.static_group_segment_size,
+                      " dynamic_shared:", dynamic_group_segment_size,
+                      " grid:", grid_x, ",", grid_y, ",", grid_z,
                       " block:", kernel_info.workgroup_x, ",",
                       kernel_info.workgroup_y, ",", kernel_info.workgroup_z,
                       " private_mem:", kernel_info.private_segment_size,

--- a/xla/backends/profiler/gpu/rocm_collector_test.cc
+++ b/xla/backends/profiler/gpu/rocm_collector_test.cc
@@ -33,6 +33,21 @@ namespace test {
 using tsl::profiler::FindOrAddMutablePlaneWithName;
 using tsl::profiler::XSpace;
 
+TEST(RocmCollectorTest, ToXStatDecomposesDispatchGroupMemory) {
+  KernelDetails kernel_info{};
+  kernel_info.group_segment_size = 1536;
+  kernel_info.static_group_segment_size = 1024;
+
+  EXPECT_NE(ToXStat(kernel_info, /*occupancy_pct=*/0)
+                .find("static_shared:1024 dynamic_shared:512"),
+            std::string::npos);
+
+  kernel_info.group_segment_size = 512;
+  EXPECT_NE(ToXStat(kernel_info, /*occupancy_pct=*/0)
+                .find("static_shared:1024 dynamic_shared:0"),
+            std::string::npos);
+}
+
 TEST(RocmCollectorTest, TestAddKernelEventAndExport) {
   RocmTraceCollectorOptions options;
   options.max_callback_api_events = 100;

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -337,7 +337,13 @@ void RocmTracer::KernelEvent(const rocprofiler_record_header_t* hdr,
   };
 
   auto it = kernel_info_.find(kinfo.kernel_id);
-  if (it != kernel_info_.end()) trace_event->name = it->second.name;
+  if (it != kernel_info_.end()) {
+    trace_event->name = it->second.name;
+    const auto& sym = it->second.data;
+    trace_event->kernel_info.registers_per_work_item =
+        sym.arch_vgpr_count + sym.accum_vgpr_count;
+    trace_event->kernel_info.static_group_segment_size = sym.group_segment_size;
+  }
 }
 
 void RocmTracer::TracingCallback(rocprofiler_context_id_t context,

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -58,11 +58,15 @@ struct MemsetDetails {
 };
 
 struct KernelDetails {
-  // The amount of private memory used by kernel,
-  // number of register per thread (register spillage if > 0)
+  // Total dispatch-time private-segment (scratch) bytes per work-item.
   uint32_t private_segment_size;
-  // The amount of shared memory (SMEM)
+  // Total dispatch-time group-segment (LDS) bytes per workgroup. Includes
+  // static and dynamic LDS allocation.
   uint32_t group_segment_size;
+  // Architecture and accumulator VGPRs allocated per work-item.
+  uint32_t registers_per_work_item;
+  // Static group-segment (LDS) bytes per workgroup from the kernel symbol.
+  uint32_t static_group_segment_size;
   // X-dimension of a workgroup (grid.x*block.x)
   uint32_t workgroup_x;
   // Y-dimension of a workgroup (grid.x*block.x)


### PR DESCRIPTION
## 📝 Summary of Changes

- Populate ROCm `kernel_details` XStat with:

  - Architecture + accumulator VGPRs per work-item.
  - Static LDS from kernel symbol metadata.
  - Dynamic LDS derived from dispatch total minus static LDS.
  - XProf-compatible `regs`, `static_shared`, and `dynamic_shared` keys.

- Adjust inline comments regarding existing `private_segment_size` and `group_segment_size` stats.

## 🎯 Justification

On AMD GPU traces, XProf Kernel Stats page reads 0 for "Registers per thread" and "Shared Mem Bytes". This is because XProf parses these fields on specific keys in the `kernel_info` XStat, `regs`, `static_shared` and `dynamic_shared`, none of which we were populating from `rocm_collector`.

### Implementation detail:

- Why do we need static/dynamic group segment size separately when we already have total group segment size?
  - XProf parses on static, dynamic group size separately. The group segment size stat provided by rocprofiler combines static and dynamic, so we need to manually decompose into static and dynamic attribution.

- Why not add dynamic mem member (eg. `dynamic_group_segment_size`) to KernelDetails struct if we are already adding `static_group_segment_size`?
  - The static LDS size is fixed by the compiled kernel symbol and does not vary between dispatches of that symbol. Rocprofiler provides the total LDS allocation at dispatch time. The dynamic size is derived as (dispatch total - static LDS) and can vary between dispatches due to runtime allocation and padding.

- Why not just change XProf to parse our `group_mem` instead of following this existing static + dynamic separation?
  - Would need to vendor gate in XProf as NVIDIA provides static, dynamic separately. Besides, adding separation for static vs dynamic LDS is a useful detail to have.

- Rationale for defining registers per work item as arch VGPR + accum VGPR
  - `registers_per_work_item` sums `arch_vgpr_count + accum_vgpr_count` because both are per-lane allocations consuming the VGPR budget. SGPRs are per-wavefront (not per work item/thread) scalar registers in a separate register file and so are excluded. 

### Evidence (XProf v2.23.1, profiled via JAX)

VIEWING AMD TRACE GENERATED BEFORE PR CHANGES:
<img width="1887" height="907" alt="image" src="https://github.com/user-attachments/assets/90a11231-29ec-4112-9276-3a9367579a78" />


VIEWING AMD TRACE AFTER PR CHANGES:
<img width="1885" height="906" alt="image" src="https://github.com/user-attachments/assets/917bfb08-d66d-4827-b585-0a5582e4507a" />



## 🚀 Kind of Contribution  
🐛 Bug Fix

## 📊 Benchmark (for Performance Improvements)  
N/A

## 🧪 Unit Tests:  
`TEST(RocmCollectorTest, ToXStatDecomposesDispatchGroupMemory)`

Verifies correct decomposition of total group-segment size into static and dynamic LDS, including underflow protection.

## 🧪 Execution Tests:  
N/A