### PR TITLE
[XLA:GPU] Balance ragged a2a device kernel CTAs by work

### DIFF
--- a/xla/stream_executor/gpu/ragged_all_to_all_device_kernel_lib.cu.h
+++ b/xla/stream_executor/gpu/ragged_all_to_all_device_kernel_lib.cu.h
@@ -81,42 +81,57 @@ __device__ void RaggedAllToAllCopy(
   using T = DeviceVec<kVectorSize>;
 
   if (lsa_size > 0) {
-    const int grid = static_cast<int>(gridDim.x);
-    const int64_t total_lsa_updates =
+    // Work-proportional CTA assignment: CTA k copies the global element range
+    // [total*k/grid, total*(k+1)/grid), walking update boundaries as needed.
+    // This keeps CTA work balanced regardless of how transferred bytes are
+    // distributed across updates. Every CTA scans the update-size array,
+    // then walks updates in peer-major order to locate its range.
+    const int64_t grid = static_cast<int64_t>(gridDim.x);
+    const int64_t num_lsa_updates =
         static_cast<int64_t>(lsa_size) * num_updates_per_replica;
-    const int ctas_per_unit =
-        max(1, grid / static_cast<int>(total_lsa_updates));
-    const int unit_step = grid / ctas_per_unit;
-    const int my_unit_start = static_cast<int>(blockIdx.x) / ctas_per_unit;
-    const int my_cta_in_unit = static_cast<int>(blockIdx.x) % ctas_per_unit;
-    if (my_unit_start < total_lsa_updates) {
-      const int unit_tid = my_cta_in_unit * static_cast<int>(blockDim.x) +
-                           static_cast<int>(threadIdx.x);
-      const int unit_nthreads = ctas_per_unit * static_cast<int>(blockDim.x);
+    const int64_t meta_base =
+        static_cast<int64_t>(start_lsa) * num_updates_per_replica;
 
-      for (int unit = my_unit_start; unit < total_lsa_updates;
-           unit += unit_step) {
-        const int64_t flat_idx =
-            static_cast<int64_t>(start_lsa) * num_updates_per_replica + unit;
-        RaggedAllToAllUpdateMetadata<kVectorSize> meta;
-        if (!LoadRaggedAllToAllUpdateMetadata<kVectorSize>(
-                flat_idx, num_updates_per_replica, num_row_elements,
-                input_buffer_offset_bytes, output_buffer_offset_bytes,
-                input_offsets_ptr, send_sizes_ptr, output_offsets_ptr, &meta)) {
-          continue;
-        }
+    int64_t total_elements = 0;
+    for (int64_t update = 0; update < num_lsa_updates; ++update) {
+      total_elements += send_sizes_ptr[meta_base + update] * num_row_elements;
+    }
 
-        const int lsa_peer = unit / num_updates_per_replica;
+    const int64_t cta_begin =
+        total_elements * static_cast<int64_t>(blockIdx.x) / grid;
+    const int64_t cta_end =
+        total_elements * (static_cast<int64_t>(blockIdx.x) + 1) / grid;
+
+    // Element offset of the current update within the concatenated element
+    // space that cta_begin/cta_end index into.
+    int64_t update_begin = 0;
+    for (int64_t update = 0;
+         update < num_lsa_updates && update_begin < cta_end; ++update) {
+      RaggedAllToAllUpdateMetadata<kVectorSize> meta;
+      if (!LoadRaggedAllToAllUpdateMetadata<kVectorSize>(
+              meta_base + update, num_updates_per_replica, num_row_elements,
+              input_buffer_offset_bytes, output_buffer_offset_bytes,
+              input_offsets_ptr, send_sizes_ptr, output_offsets_ptr, &meta)) {
+        continue;
+      }
+      const int64_t update_end = update_begin + meta.byte_count / kVectorSize;
+      if (update_end > cta_begin) {
+        const int64_t lo =
+            cta_begin > update_begin ? cta_begin - update_begin : 0;
+        const int64_t hi =
+            (cta_end < update_end ? cta_end : update_end) - update_begin;
+        const int lsa_peer =
+            static_cast<int>(update / num_updates_per_replica);
         const T* src = static_cast<const T*>(
             ncclGetLocalPointer(send_win, meta.src_byte_offset));
         T* dst = static_cast<T*>(
             ncclGetLsaPointer(recv_win, meta.dst_byte_offset, lsa_peer));
-
-        const int64_t num_elements = meta.byte_count / kVectorSize;
-        for (int64_t i = unit_tid; i < num_elements; i += unit_nthreads) {
+        for (int64_t i = lo + static_cast<int64_t>(threadIdx.x); i < hi;
+             i += static_cast<int64_t>(blockDim.x)) {
           dst[i] = src[i];
         }
       }
+      update_begin = update_end;
     }
   }
 


### PR DESCRIPTION
Fixes #47868.

The ragged all-to-all device kernel divides updates approximately evenly among CTAs (or CTAs among updates), regardless of update sizes. This can leave some CTAs copying substantially more data than others, particularly with uneven MoE routing or update counts that do not divide evenly across the grid.

This change divides the _total LSA copy payload_ approximately evenly among CTAs. Large updates can span CTAs, and a single CTA can process parts of multiple updates.

The 512-thread CTA width and launch bounds, update-count-dependent launch grid, and remote GIN update-assignment algorithm are unchanged.

## Microbenchmark

Rerunning the [microbenchmark](https://github.com/marin-community/marin/blob/research/mcwitt/8317-dk-native/autoresearch/loop-260824-dkperf/ragged_a2a_bench.py) from #47868 on 64 GB200 GPUs in one NVL72 domain with a uniform 3.2 GB/rank bf16 payload (6144-wide rows) gave the following median per-call times across six interleaved before/after pairs, each with 10 warmups and 50 timed calls using donated output buffers:

| Updates/peer | Before | After | Speedup |
|---|---:|---:|---:|
| 1 | 9.12 ms | 9.14 ms | 1.00x |
| 3 | 12.74 ms | 10.29 ms | 1.24x |
| 30 | 22.74 ms | 10.12 ms | 2.25x |
| 120 | 22.59 ms | 11.03 ms | 2.05x |

These matched builds compare fixed assignment against balanced assignment, both using 512-thread CTAs and the original grid calculation. The balanced build used an earlier revision with a launch-bounds hint; a separate matched six-pair ablation found no consistent microbenchmark benefit from the hint, so it is not part of this PR. All 48 cases passed bit-exact validation on every rank. All six pairs improved at 3, 30, and 120 updates/peer; at 1, the median was essentially unchanged, with one after run 4.5% slower than its paired control.

## Marin MoE benchmark

An initial ablation on 64 GB200 GPUs in one NVL72 domain, using MoE training at d6144/L48/E384-top8 restored from the same trained-router checkpoint with the latency-hiding scheduler enabled, measured:

| Configuration | Median MFU |
|---|---:|
| Fixed assignment | 21.794% |
| Balanced assignment | 22.700% |

These are single-run medians over 15 steps: a 0.906 percentage-point (4.2% relative) improvement. Both benchmark arms use identical launch bounds, so this comparison isolates assignment.
