### PR TITLE
Add introductory HLO add-zero pass

### DIFF
--- a/build_tools/dev_container/Dockerfile
+++ b/build_tools/dev_container/Dockerfile
@@ -1,0 +1,8 @@
+ARG XLA_BUILD_IMAGE=us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest
+FROM ${XLA_BUILD_IMAGE}
+
+WORKDIR /workspace/xla
+
+ENV USE_BAZEL_VERSION=8.7.0
+
+CMD ["/bin/bash"]

--- a/build_tools/dev_container/README.md
+++ b/build_tools/dev_container/README.md
@@ -1,0 +1,31 @@
+# XLA development container
+
+This directory provides a small wrapper around the same `ml-build` image used
+by XLA CI. The repository is mounted at `/workspace/xla`, while Bazel caches are
+kept under `${HOME}/.cache/xla-docker` on the host.
+
+Start an interactive development shell:
+
+```bash
+build_tools/dev_container/run.sh
+```
+
+Run the first HLO pass test directly:
+
+```bash
+build_tools/dev_container/run.sh \
+  bazel test --config=clang_local \
+  //xla/examples/first_hlo_pass:first_hlo_pass_test \
+  --test_output=errors
+```
+
+To expose NVIDIA GPUs to the container, set `XLA_DOCKER_GPUS`:
+
+```bash
+XLA_DOCKER_GPUS=all build_tools/dev_container/run.sh
+```
+
+Override the container image, its base image, or the cache location with
+`XLA_DEV_IMAGE`, `XLA_BUILD_IMAGE`, and `XLA_DOCKER_CACHE`, respectively. If a
+custom base image does not contain Bazel, set `XLA_BAZEL_BIN` to a host Bazel
+8.7.0 executable; the wrapper mounts it at `/usr/local/bin/bazel`.

--- a/build_tools/dev_container/run.sh
+++ b/build_tools/dev_container/run.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+image="${XLA_DEV_IMAGE:-xla-dev:latest}"
+build_image="${XLA_BUILD_IMAGE:-us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest}"
+cache_dir="${XLA_DOCKER_CACHE:-${HOME}/.cache/xla-docker}"
+
+mkdir -p "${cache_dir}"
+
+docker build \
+  --build-arg "XLA_BUILD_IMAGE=${build_image}" \
+  --tag "${image}" \
+  --file "${repo_root}/build_tools/dev_container/Dockerfile" \
+  "${repo_root}/build_tools/dev_container"
+
+docker_args=(
+  run
+  --rm
+  --user "$(id -u):$(id -g)"
+  --env HOME=/home/xla
+  --env USER=xla
+  --volume "${repo_root}:/workspace/xla"
+  --volume "${cache_dir}:/home/xla"
+  --workdir /workspace/xla
+)
+
+if [[ -n "${XLA_BAZEL_BIN:-}" ]]; then
+  docker_args+=(--volume "${XLA_BAZEL_BIN}:/usr/local/bin/bazel:ro")
+fi
+
+if [[ -t 0 && -t 1 ]]; then
+  docker_args+=(-it)
+fi
+
+if [[ -n "${XLA_DOCKER_GPUS:-}" ]]; then
+  docker_args+=(--gpus "${XLA_DOCKER_GPUS}")
+fi
+
+docker_args+=("${image}")
+
+if [[ $# -gt 0 ]]; then
+  docker_args+=("$@")
+fi
+
+exec docker "${docker_args[@]}"

--- a/xla/examples/first_hlo_pass/BUILD
+++ b/xla/examples/first_hlo_pass/BUILD
@@ -1,0 +1,32 @@
+load("//xla:xla.default.bzl", "xla_cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "add_zero_eliminator",
+    srcs = ["add_zero_eliminator.cc"],
+    hdrs = ["add_zero_eliminator.h"],
+    deps = [
+        "//xla:literal",
+        "//xla:shape_util",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/pass:hlo_pass",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status:status_macros",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+xla_cc_test(
+    name = "first_hlo_pass_test",
+    srcs = ["add_zero_eliminator_test.cc"],
+    deps = [
+        ":add_zero_eliminator",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/parser:hlo_parser",
+        "//xla/tests:xla_internal_test_main",
+        "//xla/tsl/platform:status_matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xla/examples/first_hlo_pass/README.md
+++ b/xla/examples/first_hlo_pass/README.md
@@ -1,0 +1,27 @@
+# First HLO pass: eliminate integer add-zero
+
+This example implements a small `HloModulePass` that rewrites:
+
+```text
+add(x, constant-zero) -> x
+```
+
+The pass deliberately handles only integer element types. For floating-point
+values, adding positive zero can change the sign of negative zero, so the same
+rewrite is not always valid under strict IEEE semantics.
+
+The implementation demonstrates four basic pieces of an HLO rewrite pass:
+
+1. Traverse computations and instructions in post-order.
+2. Match an HLO pattern with `hlo_matchers`.
+3. Check an additional semantic condition on a literal.
+4. Replace the matched instruction and report whether the module changed.
+
+Run the test in the development container:
+
+```bash
+build_tools/dev_container/run.sh \
+  bazel test --config=clang_local \
+  //xla/examples/first_hlo_pass:first_hlo_pass_test \
+  --test_output=errors
+```

--- a/xla/examples/first_hlo_pass/add_zero_eliminator.cc
+++ b/xla/examples/first_hlo_pass/add_zero_eliminator.cc
@@ -1,0 +1,53 @@
+#include "xla/examples/first_hlo_pass/add_zero_eliminator.h"
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status_macros.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_computation.h"
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/literal.h"
+#include "xla/primitive_util.h"
+
+namespace xla {
+namespace {
+
+bool IsIntegralZeroConstant(const HloInstruction* instruction) {
+  return instruction->IsConstant() &&
+         primitive_util::IsIntegralType(instruction->shape().element_type()) &&
+         instruction->literal().IsAll(0);
+}
+
+}  // namespace
+
+absl::StatusOr<bool> AddZeroEliminator::RunImpl(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  bool changed = false;
+  for (HloComputation* computation :
+       module->MakeComputationPostOrder(execution_threads)) {
+    for (HloInstruction* instruction :
+         computation->MakeInstructionPostOrder()) {
+      if (instruction->opcode() != HloOpcode::kAdd) {
+        continue;
+      }
+
+      HloInstruction* value = instruction->mutable_operand(0);
+      HloInstruction* zero = instruction->mutable_operand(1);
+      if (!IsIntegralZeroConstant(zero)) {
+        value = instruction->mutable_operand(1);
+        zero = instruction->mutable_operand(0);
+      }
+      if (!IsIntegralZeroConstant(zero)) {
+        continue;
+      }
+
+      ABSL_RETURN_IF_ERROR(computation->ReplaceInstruction(instruction, value));
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+}  // namespace xla

--- a/xla/examples/first_hlo_pass/add_zero_eliminator.h
+++ b/xla/examples/first_hlo_pass/add_zero_eliminator.h
@@ -1,0 +1,24 @@
+#ifndef XLA_EXAMPLES_FIRST_HLO_PASS_ADD_ZERO_ELIMINATOR_H_
+#define XLA_EXAMPLES_FIRST_HLO_PASS_ADD_ZERO_ELIMINATOR_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/pass/hlo_pass_interface.h"
+
+namespace xla {
+
+class AddZeroEliminator final : public HloModulePass {
+ public:
+  absl::string_view name() const override { return "add-zero-eliminator"; }
+
+  using HloModulePass::Run;
+  absl::StatusOr<bool> RunImpl(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace xla
+
+#endif  // XLA_EXAMPLES_FIRST_HLO_PASS_ADD_ZERO_ELIMINATOR_H_

--- a/xla/examples/first_hlo_pass/add_zero_eliminator_test.cc
+++ b/xla/examples/first_hlo_pass/add_zero_eliminator_test.cc
@@ -1,0 +1,93 @@
+#include "xla/examples/first_hlo_pass/add_zero_eliminator.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include "xla/hlo/ir/hlo_instruction.h"
+#include "xla/hlo/ir/hlo_opcode.h"
+#include "xla/hlo/parser/hlo_parser.h"
+#include "xla/tsl/platform/status_matchers.h"
+
+namespace xla {
+namespace {
+
+using ::tsl::testing::IsOkAndHolds;
+
+TEST(AddZeroEliminatorTest, EliminatesZeroOnRight) {
+  const char* hlo = R"(
+HloModule test
+
+ENTRY main {
+  value = s32[] parameter(0)
+  zero = s32[] constant(0)
+  ROOT add = s32[] add(value, zero)
+}
+)";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnUnverifiedModule(hlo));
+
+  AddZeroEliminator pass;
+  EXPECT_THAT(pass.Run(module.get()), IsOkAndHolds(true));
+  EXPECT_EQ(module->entry_computation()->root_instruction()->opcode(),
+            HloOpcode::kParameter);
+}
+
+TEST(AddZeroEliminatorTest, EliminatesZeroOnLeft) {
+  const char* hlo = R"(
+HloModule test
+
+ENTRY main {
+  value = s32[4]{0} parameter(0)
+  zero = s32[4]{0} constant({0, 0, 0, 0})
+  ROOT add = s32[4]{0} add(zero, value)
+}
+)";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnUnverifiedModule(hlo));
+
+  AddZeroEliminator pass;
+  EXPECT_THAT(pass.Run(module.get()), IsOkAndHolds(true));
+  EXPECT_EQ(module->entry_computation()->root_instruction()->opcode(),
+            HloOpcode::kParameter);
+}
+
+TEST(AddZeroEliminatorTest, KeepsNonzeroConstant) {
+  const char* hlo = R"(
+HloModule test
+
+ENTRY main {
+  value = s32[] parameter(0)
+  one = s32[] constant(1)
+  ROOT add = s32[] add(value, one)
+}
+)";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnUnverifiedModule(hlo));
+
+  AddZeroEliminator pass;
+  EXPECT_THAT(pass.Run(module.get()), IsOkAndHolds(false));
+  EXPECT_EQ(module->entry_computation()->root_instruction()->opcode(),
+            HloOpcode::kAdd);
+}
+
+TEST(AddZeroEliminatorTest, KeepsFloatingPointAddZero) {
+  const char* hlo = R"(
+HloModule test
+
+ENTRY main {
+  value = f32[] parameter(0)
+  zero = f32[] constant(0)
+  ROOT add = f32[] add(value, zero)
+}
+)";
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<HloModule> module,
+                       ParseAndReturnUnverifiedModule(hlo));
+
+  AddZeroEliminator pass;
+  EXPECT_THAT(pass.Run(module.get()), IsOkAndHolds(false));
+  EXPECT_EQ(module->entry_computation()->root_instruction()->opcode(),
+            HloOpcode::kAdd);
+}
+
+}  // namespace
+}  // namespace xla


### PR DESCRIPTION
## Summary
- add a small development container wrapper using XLA's CI build image
- add an educational HLO module pass that removes integer add-zero operations
- cover scalar/vector, operand order, nonzero, and floating-point behavior

## Testing
- `bazel test --config=clang_local //xla/examples/first_hlo_pass:first_hlo_pass_test --test_output=errors`
- repeated inside Docker; 963 compile actions completed and all tests passed
