### PR TITLE
Add specialized interleave kernels for transposes with a tiny stride-1 dimension

### DIFF
--- a/xla/pjrt/transpose.cc
+++ b/xla/pjrt/transpose.cc
@@ -480,11 +480,11 @@ void TransposePlan::ExecuteTyped(const char* a, char* b,
   tsl::profiler::TraceMe traceme([&]() {
     return tsl::profiler::TraceMeEncode(
         "TransposePlan::ExecuteTyped",
-        {{"inner_kernel_is_memcpy", inner_kernel_is_memcpy_},
+        {{"inner_kernel_is_memcpy", inner_kernel_is_memcpy()},
          {"inner_block_elems", inner_block_elems_}});
   });
 
-  CHECK(!inner_kernel_is_memcpy_);
+  CHECK(!inner_kernel_is_memcpy());
   std::unique_ptr<char[]> scratch;
   if (scratch_size_ > 0) {
     scratch.reset(new char[scratch_size_]);
@@ -587,7 +587,7 @@ void TransposePlan::ExecuteChunk(int chunk_id, const void* a, void* b,
     }
   }
 
-  if (inner_kernel_is_memcpy_) {
+  if (inner_kernel_is_memcpy()) {
     CHECK(transformation_ == Transformation::kNone);
     // Memcpy-based plans all assume element size 1 (i.e., bytes).
     TransposeConstStride1(ac, bc, nodes.data());
@@ -817,14 +817,14 @@ void TransposePlan::BuildPlanNodes(int chunk_id,
       // We've reached the end of the loop nest.
       // Transpose loops have a sentinel node, indicated by a negative `inc`
       // value, that describes the striding of the inner transpose kernel.
-      if (!inner_kernel_is_memcpy_) {
+      if (!inner_kernel_is_memcpy()) {
         Node node;
         node.end = node.inc = -1;
         node.lda = sentinel_lda_;
         node.ldb = sentinel_ldb_;
         nodes.push_back(node);
       }
-      DCHECK(!(inner_kernel_is_memcpy_ && agendum.parent_node_id >= 0));
+      DCHECK(!(inner_kernel_is_memcpy() && agendum.parent_node_id >= 0));
       continue;
     }
 
@@ -847,12 +847,12 @@ void TransposePlan::BuildPlanNodes(int chunk_id,
       int64_t actual_end = std::min<int64_t>(size, loop.end);
       node.end = std::max<int64_t>(0, actual_end - actual_start);
 
-      if (node.is_inner_dim_in_a && inner_kernel_is_memcpy_) {
+      if (node.is_inner_dim_in_a && inner_kernel_is_memcpy()) {
         node.end *= elem_size_in_bytes_;
       }
 
       if (!loop_has_trivial_iteration_space(node) ||
-          (inner_kernel_is_memcpy_ && node.is_inner_dim_in_a)) {
+          (inner_kernel_is_memcpy() && node.is_inner_dim_in_a)) {
         nodes.push_back(node);
       }
       Agendum new_agendum;
@@ -894,13 +894,13 @@ void TransposePlan::BuildPlanNodes(int chunk_id,
       node.end = std::max<int64_t>(
           0, std::min<int64_t>(num_tiles, loop.end) - loop.start);
 
-      if (node.is_inner_dim_in_a && inner_kernel_is_memcpy_) {
+      if (node.is_inner_dim_in_a && inner_kernel_is_memcpy()) {
         node.end *= elem_size_in_bytes_;
       }
 
       // If this loop has a trivial iteration space, drop it.
       if (!loop_has_trivial_iteration_space(node) ||
-          (inner_kernel_is_memcpy_ && node.is_inner_dim_in_a) ||
+          (inner_kernel_is_memcpy() && node.is_inner_dim_in_a) ||
           has_trailing_plan_node) {
         nodes.push_back(node);
       }
@@ -1186,13 +1186,13 @@ absl::Status TransposePlan::Initialize() {
   int64_t stride_pos1b =
       inner_stride(pos_stride1b_in_b, ldb_, ldb_tile_, b_tiling_);
 
-  inner_kernel_is_memcpy_ = (pos_stride1b_in_a == pos_stride1a_in_a) &&
-                            (stride_pos1a == elem_size_in_bytes_) &&
-                            (stride_pos1b == elem_size_in_bytes_);
-  inner_kernel_kind_ = inner_kernel_is_memcpy_ ? InnerKernelKind::kMemcpy
-                                               : InnerKernelKind::kDefault;
+  inner_kernel_kind_ = (pos_stride1b_in_a == pos_stride1a_in_a) &&
+                               (stride_pos1a == elem_size_in_bytes_) &&
+                               (stride_pos1b == elem_size_in_bytes_)
+                           ? InnerKernelKind::kMemcpy
+                           : InnerKernelKind::kDefault;
 
-  if (inner_kernel_is_memcpy_ && transformation_ != Transformation::kNone) {
+  if (inner_kernel_is_memcpy() && transformation_ != Transformation::kNone) {
     if (transformation_ == Transformation::kPackSubbyte) {
       transformation_ = Transformation::kNone;
       use_fallback_pack_ = true;
@@ -1203,7 +1203,7 @@ absl::Status TransposePlan::Initialize() {
   }
 
   // Calculate sentinel strides.
-  if (!inner_kernel_is_memcpy_) {
+  if (!inner_kernel_is_memcpy()) {
     int pos_stride1a_in_b = inverse_permutation[pos_stride1a_in_a];
     sentinel_lda_ = inner_stride(pos_stride1b_in_a, lda_, lda_tile_, a_tiling_);
     sentinel_ldb_ = inner_stride(pos_stride1a_in_b, ldb_, ldb_tile_, b_tiling_);
@@ -1290,7 +1290,7 @@ absl::Status TransposePlan::Initialize() {
   }
 
   int small_dim_in_a = -1;
-  if (!inner_kernel_is_memcpy_ && transformation_ == Transformation::kNone &&
+  if (!inner_kernel_is_memcpy() && transformation_ == Transformation::kNone &&
       !a_is_tiled_ && !b_is_tiled_ && original_a_strides_.empty() &&
       (elem_size_in_bytes_ == 1 || elem_size_in_bytes_ == 2 ||
        elem_size_in_bytes_ == 4 || elem_size_in_bytes_ == 8)) {
@@ -1306,7 +1306,7 @@ absl::Status TransposePlan::Initialize() {
   }
 
   constexpr int kMaxOuterBlockElems = 16;
-  if (inner_kernel_is_memcpy_) {
+  if (inner_kernel_is_memcpy()) {
     inner_block_elems_ = -1;
     outer_block_elems_a_ = -1;
     outer_block_elems_b_ = -1;
@@ -1371,7 +1371,7 @@ absl::Status TransposePlan::Initialize() {
   ChooseLoopOrder(loop_order);
 
   for (Loop& loop : loop_order) {
-    if (!inner_kernel_is_memcpy_ &&
+    if (!inner_kernel_is_memcpy() &&
         (loop.tile_interior || loop.tile_size == 1)) {
       if (small_dim_in_a >= 0 && loop.dim_in_a == small_dim_in_a) {
         loop.inc = loop.dim_size;
@@ -1389,7 +1389,7 @@ absl::Status TransposePlan::Initialize() {
   // both input and output.
 
   // The stride-1 loop must be innermost for a memcpy loop.
-  DCHECK(!inner_kernel_is_memcpy_ || loop_order.back().is_inner_dim_in_a)
+  DCHECK(!inner_kernel_is_memcpy() || loop_order.back().is_inner_dim_in_a)
       << ToString();
 
   int num_chunks = ChooseParallelizationStrategy(loop_order);
@@ -1412,13 +1412,13 @@ absl::Status TransposePlan::Initialize() {
     case Transformation::kF64ToEf57:
       scratch_size_ = sizeof(float) * inner_block_elems_ * inner_block_elems_ *
                       outer_block_elems_a_ * outer_block_elems_b_;
-      DCHECK(!inner_kernel_is_memcpy_);
+      DCHECK(!inner_kernel_is_memcpy());
       break;
     case Transformation::kPackSubbyte:
       scratch_size_ = sizeof(uint8_t) * inner_block_elems_ *
                       inner_block_elems_ * outer_block_elems_a_ *
                       outer_block_elems_b_;
-      DCHECK(!inner_kernel_is_memcpy_);
+      DCHECK(!inner_kernel_is_memcpy());
       break;
   }
 
@@ -1439,11 +1439,11 @@ void TransposePlan::ChooseLoopOrder(std::vector<Loop>& loop_order) const {
 
   auto soft_cost = [&](const Loop& l) {
     int64_t a_stride = std::abs(l.lda);
-    if (!inner_kernel_is_memcpy_ && l.is_inner_dim_in_a) {
+    if (!inner_kernel_is_memcpy() && l.is_inner_dim_in_a) {
       a_stride *= inner_block_elems_ * outer_block_elems_a_;
     }
     int64_t b_stride = std::abs(l.ldb);
-    if (!inner_kernel_is_memcpy_ && l.is_inner_dim_in_b) {
+    if (!inner_kernel_is_memcpy() && l.is_inner_dim_in_b) {
       b_stride *= inner_block_elems_ * outer_block_elems_b_;
     }
 
@@ -1471,7 +1471,7 @@ void TransposePlan::ChooseLoopOrder(std::vector<Loop>& loop_order) const {
       const Loop& l = remaining[i];
 
       // Hard constraint 1: memcpy kernel requirement.
-      if (inner_kernel_is_memcpy_ && l.is_inner_dim_in_a &&
+      if (inner_kernel_is_memcpy() && l.is_inner_dim_in_a &&
           remaining.size() > 1) {
         continue;
       }
@@ -1515,7 +1515,7 @@ int TransposePlan::ChooseParallelizationStrategy(
   // Estimate the number of bytes each iteration of each loop processes.
   absl::InlinedVector<int64_t, 4> work_in_bytes(loop_order.size());
   int64_t acc = elem_size_in_bytes_;
-  if (!inner_kernel_is_memcpy_) {
+  if (!inner_kernel_is_memcpy()) {
     acc *= inner_block_elems_ * inner_block_elems_ * outer_block_elems_a_ *
            outer_block_elems_b_;
   }
@@ -1558,7 +1558,7 @@ int TransposePlan::ChooseParallelizationStrategy(
       continue;
     }
 
-    int kMinBytesPerThread = inner_kernel_is_memcpy_ ? (1 << 20) : (1 << 26);
+    int kMinBytesPerThread = inner_kernel_is_memcpy() ? (1 << 20) : (1 << 26);
     int64_t min_iterations_per_thread =
         CeilOfRatio<int64_t>(kMinBytesPerThread, work_in_bytes[i]);
     int64_t parallel_work = CeilOfRatio(iterations, min_iterations_per_thread);

--- a/xla/pjrt/transpose.cc
+++ b/xla/pjrt/transpose.cc
@@ -187,13 +187,23 @@ struct TransposePlan::Node {
 };
 
 template <typename T, int inner_bs,
-          TransposePlan::Transformation transformation>
+          TransposePlan::Transformation transformation,
+          TransposePlan::InnerKernelKind kind =
+              TransposePlan::InnerKernelKind::kDefault>
 void MacroKernel(const char* __restrict a, int64_t lda, int outer_bs_a,
                  char* __restrict b, int64_t ldb, int outer_bs_b,
                  void* __restrict scratch, int bits_per_element) {
   DVLOG(10) << "MacroKernel lda=" << lda << " ldb=" << ldb
             << " outer_bs_a=" << outer_bs_a << " outer_bs_b=" << outer_bs_b
             << " inner_bs=" << inner_bs;
+
+  if constexpr (kind == TransposePlan::InnerKernelKind::kInterleave) {
+    InterleaveKernel<T, 3>(a, lda, b, outer_bs_a * inner_bs);
+    return;
+  } else if constexpr (kind == TransposePlan::InnerKernelKind::kDeinterleave) {
+    DeinterleaveKernel<T, 3>(a, b, ldb, outer_bs_b * inner_bs);
+    return;
+  }
 
   // TODO(phawkins): consider adding prefetching and streaming stores.
 
@@ -252,7 +262,9 @@ void MacroKernel(const char* __restrict a, int64_t lda, int outer_bs_a,
 // Transpose() is a driver function that implements a multidimensional loop nest
 // following by iterating over the linked Node data structure.
 template <typename T, int inner_bs,
-          TransposePlan::Transformation transformation>
+          TransposePlan::Transformation transformation,
+          TransposePlan::InnerKernelKind kind =
+              TransposePlan::InnerKernelKind::kDefault>
 void Transpose(const char* __restrict a, int outer_bs_a, char* __restrict b,
                int outer_bs_b, TransposePlan::Node const* __restrict node,
                void* __restrict scratch, int bits_per_element) {
@@ -288,7 +300,7 @@ void Transpose(const char* __restrict a, int outer_bs_a, char* __restrict b,
     const int64_t ldb_block = next_node->ldb;
     int64_t i;
     for (i = 0; i < stop; i += inc) {
-      MacroKernel<T, inner_bs, transformation>(
+      MacroKernel<T, inner_bs, transformation, kind>(
           a_offset(i), lda_block, outer_bs_a, b_offset(i), ldb_block,
           outer_bs_b, scratch, bits_per_element);
     }
@@ -300,7 +312,7 @@ void Transpose(const char* __restrict a, int outer_bs_a, char* __restrict b,
       if (node->is_inner_dim_in_a) {
         outer_bs_a = (end - i) / inner_bs;
         if (outer_bs_a > 0) {
-          MacroKernel<T, inner_bs, transformation>(
+          MacroKernel<T, inner_bs, transformation, kind>(
               a_offset(i), lda_block, outer_bs_a, b_offset(i), ldb_block,
               outer_bs_b, scratch, bits_per_element);
           i += outer_bs_a * inner_bs;
@@ -308,20 +320,20 @@ void Transpose(const char* __restrict a, int outer_bs_a, char* __restrict b,
         // If there are still trailing elements left over that don't fit in the
         // inner block size, handle them via an unvectorized transpose.
         if (i < end) {
-          MacroKernel<T, 1, transformation>(
+          MacroKernel<T, 1, transformation, kind>(
               a_offset(i), lda_block, end - i, b_offset(i), ldb_block,
               outer_bs_b * inner_bs, scratch, bits_per_element);
         }
       } else if (node->is_inner_dim_in_b) {
         outer_bs_b = (end - i) / inner_bs;
         if (outer_bs_b > 0) {
-          MacroKernel<T, inner_bs, transformation>(
+          MacroKernel<T, inner_bs, transformation, kind>(
               a_offset(i), lda_block, outer_bs_a, b_offset(i), ldb_block,
               outer_bs_b, scratch, bits_per_element);
           i += outer_bs_b * inner_bs;
         }
         if (i < end) {
-          MacroKernel<T, 1, transformation>(
+          MacroKernel<T, 1, transformation, kind>(
               a_offset(i), lda_block, outer_bs_a * inner_bs, b_offset(i),
               ldb_block, end - i, scratch, bits_per_element);
         }
@@ -337,11 +349,11 @@ void Transpose(const char* __restrict a, int outer_bs_a, char* __restrict b,
       if (trailing_next_node->inc < 0) {
         const int64_t lda_block = trailing_next_node->lda;
         const int64_t ldb_block = trailing_next_node->ldb;
-        MacroKernel<T, inner_bs, transformation>(
+        MacroKernel<T, inner_bs, transformation, kind>(
             a_offset(i), lda_block, outer_bs_a, b_offset(i), ldb_block,
             outer_bs_b, scratch, bits_per_element);
       } else {
-        Transpose<T, inner_bs, transformation>(
+        Transpose<T, inner_bs, transformation, kind>(
             a_offset(i), outer_bs_a, b_offset(i), outer_bs_b,
             trailing_next_node, scratch, bits_per_element);
       }
@@ -352,9 +364,9 @@ void Transpose(const char* __restrict a, int outer_bs_a, char* __restrict b,
     // but we call Transpose() recursively instead of MacroKernel().
     int64_t i;
     for (i = 0; i < stop; i += inc) {
-      Transpose<T, inner_bs, transformation>(a_offset(i), outer_bs_a,
-                                             b_offset(i), outer_bs_b, next_node,
-                                             scratch, bits_per_element);
+      Transpose<T, inner_bs, transformation, kind>(
+          a_offset(i), outer_bs_a, b_offset(i), outer_bs_b, next_node, scratch,
+          bits_per_element);
     }
     if (i < end) {
       DCHECK_EQ(node->trailing_tile_next_node_inc, 0);
@@ -362,28 +374,28 @@ void Transpose(const char* __restrict a, int outer_bs_a, char* __restrict b,
       if (node->is_inner_dim_in_a) {
         outer_bs_a = (end - i) / inner_bs;
         if (outer_bs_a > 0) {
-          Transpose<T, inner_bs, transformation>(
+          Transpose<T, inner_bs, transformation, kind>(
               a_offset(i), outer_bs_a, b_offset(i), outer_bs_b, next_node,
               scratch, bits_per_element);
           i += outer_bs_a * inner_bs;
         }
         if (i < end) {
-          Transpose<T, 1, transformation>(a_offset(i), end - i, b_offset(i),
-                                          outer_bs_b * inner_bs, next_node,
-                                          scratch, bits_per_element);
+          Transpose<T, 1, transformation, kind>(
+              a_offset(i), end - i, b_offset(i), outer_bs_b * inner_bs,
+              next_node, scratch, bits_per_element);
         }
       } else if (node->is_inner_dim_in_b) {
         outer_bs_b = (end - i) / inner_bs;
         if (outer_bs_b > 0) {
-          Transpose<T, inner_bs, transformation>(
+          Transpose<T, inner_bs, transformation, kind>(
               a_offset(i), outer_bs_a, b_offset(i), outer_bs_b, next_node,
               scratch, bits_per_element);
           i += outer_bs_b * inner_bs;
         }
         if (i < end) {
-          Transpose<T, 1, transformation>(a_offset(i), outer_bs_a * inner_bs,
-                                          b_offset(i), end - i, next_node,
-                                          scratch, bits_per_element);
+          Transpose<T, 1, transformation, kind>(
+              a_offset(i), outer_bs_a * inner_bs, b_offset(i), end - i,
+              next_node, scratch, bits_per_element);
         }
       }
     } else if (node->trailing_tile_next_node_inc) {
@@ -392,11 +404,11 @@ void Transpose(const char* __restrict a, int outer_bs_a, char* __restrict b,
       if (trailing_next_node->inc < 0) {
         const int64_t lda_block = trailing_next_node->lda;
         const int64_t ldb_block = trailing_next_node->ldb;
-        MacroKernel<T, inner_bs, transformation>(
+        MacroKernel<T, inner_bs, transformation, kind>(
             a_offset(i), lda_block, outer_bs_a, b_offset(i), ldb_block,
             outer_bs_b, scratch, bits_per_element);
       } else {
-        Transpose<T, inner_bs, transformation>(
+        Transpose<T, inner_bs, transformation, kind>(
             a_offset(i), outer_bs_a, b_offset(i), outer_bs_b,
             trailing_next_node, scratch, bits_per_element);
       }
@@ -478,35 +490,56 @@ void TransposePlan::ExecuteTyped(const char* a, char* b,
     scratch.reset(new char[scratch_size_]);
   }
   DCHECK_LE(sizeof(T) * inner_block_elems_, kMaxInnerBlockSizeBytes);
-  auto handle_inner_block_elems = [&](auto const_inner_block_elems) {
+  auto handle_inner_block_elems = [&](auto const_inner_block_elems,
+                                      auto const_kind) {
     if (nodes.size() > 1) {
-      Transpose<T, const_inner_block_elems, transformation>(
+      Transpose<T, const_inner_block_elems, transformation, const_kind>(
           a, outer_block_elems_a_, b, outer_block_elems_b_, nodes.data(),
           scratch.get(), bits_per_element);
     } else {
-      MacroKernel<T, const_inner_block_elems, transformation>(
+      MacroKernel<T, const_inner_block_elems, transformation, const_kind>(
           a, nodes.back().lda, outer_block_elems_a_, b, nodes.back().ldb,
           outer_block_elems_b_, scratch.get(), bits_per_element);
     }
   };
-  switch (inner_block_elems_) {
-    case 1:
-      handle_inner_block_elems(std::integral_constant<int, 1>{});
+  auto dispatch_inner_block_elems = [&](auto const_kind) {
+    switch (inner_block_elems_) {
+      case 1:
+        handle_inner_block_elems(std::integral_constant<int, 1>{}, const_kind);
+        break;
+      case 2:
+        handle_inner_block_elems(std::integral_constant<int, 2>{}, const_kind);
+        break;
+      case 4:
+        handle_inner_block_elems(std::integral_constant<int, 4>{}, const_kind);
+        break;
+      case 8:
+        handle_inner_block_elems(std::integral_constant<int, 8>{}, const_kind);
+        break;
+      case 16:
+        handle_inner_block_elems(std::integral_constant<int, 16>{}, const_kind);
+        break;
+      default:
+        LOG(FATAL) << "Invalid inner_block_elems_ " << inner_block_elems_;
+    }
+  };
+  switch (inner_kernel_kind_) {
+    case InnerKernelKind::kDefault:
+      dispatch_inner_block_elems(
+          std::integral_constant<InnerKernelKind, InnerKernelKind::kDefault>{});
       break;
-    case 2:
-      handle_inner_block_elems(std::integral_constant<int, 2>{});
+    case InnerKernelKind::kInterleave:
+      dispatch_inner_block_elems(
+          std::integral_constant<InnerKernelKind,
+                                 InnerKernelKind::kInterleave>{});
       break;
-    case 4:
-      handle_inner_block_elems(std::integral_constant<int, 4>{});
+    case InnerKernelKind::kDeinterleave:
+      dispatch_inner_block_elems(
+          std::integral_constant<InnerKernelKind,
+                                 InnerKernelKind::kDeinterleave>{});
       break;
-    case 8:
-      handle_inner_block_elems(std::integral_constant<int, 8>{});
-      break;
-    case 16:
-      handle_inner_block_elems(std::integral_constant<int, 16>{});
-      break;
-    default:
-      LOG(FATAL) << "Invalid inner_block_elems_ " << inner_block_elems_;
+    case InnerKernelKind::kMemcpy:
+      LOG(FATAL) << "Unreachable: memcpy plans do not call ExecuteTyped";
   }
 }
 
@@ -1156,6 +1189,8 @@ absl::Status TransposePlan::Initialize() {
   inner_kernel_is_memcpy_ = (pos_stride1b_in_a == pos_stride1a_in_a) &&
                             (stride_pos1a == elem_size_in_bytes_) &&
                             (stride_pos1b == elem_size_in_bytes_);
+  inner_kernel_kind_ = inner_kernel_is_memcpy_ ? InnerKernelKind::kMemcpy
+                                               : InnerKernelKind::kDefault;
 
   if (inner_kernel_is_memcpy_ && transformation_ != Transformation::kNone) {
     if (transformation_ == Transformation::kPackSubbyte) {
@@ -1254,6 +1289,22 @@ absl::Status TransposePlan::Initialize() {
     b_stride1_size = std::min(b_stride1_size, b_dims_[pos_stride1b_in_b]);
   }
 
+  int small_dim_in_a = -1;
+  if (!inner_kernel_is_memcpy_ && transformation_ == Transformation::kNone &&
+      !a_is_tiled_ && !b_is_tiled_ && original_a_strides_.empty() &&
+      (elem_size_in_bytes_ == 1 || elem_size_in_bytes_ == 2 ||
+       elem_size_in_bytes_ == 4 || elem_size_in_bytes_ == 8)) {
+    if (b_stride1_size == 3 && a_stride1_size >= 8 &&
+        sentinel_ldb_ == 3 * elem_size_in_bytes_) {
+      inner_kernel_kind_ = InnerKernelKind::kInterleave;
+      small_dim_in_a = pos_stride1b_in_a;
+    } else if (a_stride1_size == 3 && b_stride1_size >= 8 &&
+               sentinel_lda_ == 3 * elem_size_in_bytes_) {
+      inner_kernel_kind_ = InnerKernelKind::kDeinterleave;
+      small_dim_in_a = pos_stride1a_in_a;
+    }
+  }
+
   constexpr int kMaxOuterBlockElems = 16;
   if (inner_kernel_is_memcpy_) {
     inner_block_elems_ = -1;
@@ -1280,8 +1331,14 @@ absl::Status TransposePlan::Initialize() {
       default:
         LOG(FATAL) << "Unreachable: element size " << elem_size_in_bytes_;
     }
+    int64_t bound_stride1_size = std::min(a_stride1_size, b_stride1_size);
+    if (inner_kernel_kind_ == InnerKernelKind::kInterleave) {
+      bound_stride1_size = a_stride1_size;
+    } else if (inner_kernel_kind_ == InnerKernelKind::kDeinterleave) {
+      bound_stride1_size = b_stride1_size;
+    }
     inner_block_elems_ = max_inner_block_elems;
-    while (inner_block_elems_ > std::min(a_stride1_size, b_stride1_size)) {
+    while (inner_block_elems_ > bound_stride1_size) {
       inner_block_elems_ /= 2;
     }
     if (inner_block_elems_ < min_inner_block_elems) {
@@ -1297,6 +1354,13 @@ absl::Status TransposePlan::Initialize() {
         std::min<int64_t>(kMaxOuterBlockElems, b_stride1_size),
         inner_block_elems_);
     outer_block_elems_b_ = std::max<int64_t>(outer_block_elems_b_, 1);
+    if (inner_kernel_kind_ == InnerKernelKind::kInterleave) {
+      outer_block_elems_a_ = kMaxOuterBlockElems;
+      outer_block_elems_b_ = 1;
+    } else if (inner_kernel_kind_ == InnerKernelKind::kDeinterleave) {
+      outer_block_elems_a_ = 1;
+      outer_block_elems_b_ = kMaxOuterBlockElems;
+    }
   }
 
   // Identify contiguous loops for chunk scheduling.
@@ -1309,7 +1373,9 @@ absl::Status TransposePlan::Initialize() {
   for (Loop& loop : loop_order) {
     if (!inner_kernel_is_memcpy_ &&
         (loop.tile_interior || loop.tile_size == 1)) {
-      if (loop.is_inner_dim_in_a) {
+      if (small_dim_in_a >= 0 && loop.dim_in_a == small_dim_in_a) {
+        loop.inc = loop.dim_size;
+      } else if (loop.is_inner_dim_in_a) {
         loop.inc = inner_block_elems_ * outer_block_elems_a_;
       } else if (loop.is_inner_dim_in_b) {
         loop.inc = inner_block_elems_ * outer_block_elems_b_;

--- a/xla/pjrt/transpose.h
+++ b/xla/pjrt/transpose.h
@@ -207,7 +207,9 @@ class TransposePlan {
   // Returns the number of items of parallel work in the plan.
   int Parallelism() const { return nodes_.size(); }
 
-  bool inner_kernel_is_memcpy() const { return inner_kernel_is_memcpy_; }
+  bool inner_kernel_is_memcpy() const {
+    return inner_kernel_kind_ == InnerKernelKind::kMemcpy;
+  }
 
   struct Node;
 
@@ -282,7 +284,8 @@ class TransposePlan {
   void ChooseLoopOrder(std::vector<Loop>& loop_order) const;
 
   void set_inner_kernel_is_memcpy(bool is_memcpy) {
-    inner_kernel_is_memcpy_ = is_memcpy;
+    inner_kernel_kind_ =
+        is_memcpy ? InnerKernelKind::kMemcpy : InnerKernelKind::kDefault;
   }
 
  private:
@@ -386,10 +389,6 @@ class TransposePlan {
   // Root nodes of the plan, i.e., pointing to the outermost loops in the loop
   // nest. The outer vector is indexed on the thread ID.
   absl::InlinedVector<std::vector<Node>, 1> nodes_;
-
-  // Are the innermost (stride-1) dimensions the same dimension? This determines
-  // whether the inner kernel is a transpose or a memcpy.
-  bool inner_kernel_is_memcpy_ = false;
 
   InnerKernelKind inner_kernel_kind_ = InnerKernelKind::kDefault;
 

--- a/xla/pjrt/transpose.h
+++ b/xla/pjrt/transpose.h
@@ -97,6 +97,13 @@ class TransposePlan {
     kPackSubbyte = 2,
   };
 
+  enum class InnerKernelKind {
+    kDefault,
+    kMemcpy,
+    kInterleave,
+    kDeinterleave,
+  };
+
   // Requested contiguity of chunks.
   enum class ChunkContiguity {
     // We don't care about contiguity (default).
@@ -383,6 +390,8 @@ class TransposePlan {
   // Are the innermost (stride-1) dimensions the same dimension? This determines
   // whether the inner kernel is a transpose or a memcpy.
   bool inner_kernel_is_memcpy_ = false;
+
+  InnerKernelKind inner_kernel_kind_ = InnerKernelKind::kDefault;
 
   // Size of the inner (microkernel) block size. This is the unit of work for
   // our vectorized kernels.

--- a/xla/pjrt/transpose_kernels.h
+++ b/xla/pjrt/transpose_kernels.h
@@ -722,6 +722,30 @@ struct TransposeMicroKernel {
   }
 };
 
+template <typename T, int K>
+void InterleaveKernel(const char* __restrict a, int64_t lda, char* __restrict b,
+                      int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    for (int k = 0; k < K; ++k) {
+      T v;
+      std::memcpy(&v, a + k * lda + i * sizeof(T), sizeof(T));
+      std::memcpy(b + (i * K + k) * sizeof(T), &v, sizeof(T));
+    }
+  }
+}
+
+template <typename T, int K>
+void DeinterleaveKernel(const char* __restrict a, char* __restrict b,
+                        int64_t ldb, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    for (int k = 0; k < K; ++k) {
+      T v;
+      std::memcpy(&v, a + (i * K + k) * sizeof(T), sizeof(T));
+      std::memcpy(b + k * ldb + i * sizeof(T), &v, sizeof(T));
+    }
+  }
+}
+
 }  // namespace xla
 
 #endif  // XLA_PJRT_TRANSPOSE_KERNELS_H_

--- a/xla/pjrt/transpose_test.cc
+++ b/xla/pjrt/transpose_test.cc
@@ -682,7 +682,14 @@ std::vector<TransposeTestCase> GetTransposeTestCases() {
       TransposeTestCase(/*dims=*/{52, 44, 45, 96, 1, 5},
                         /*permutation=*/{5, 4, 2, 3, 1, 0},
                         /*input_tiling=*/{}, /*output_tiling=*/{},
-                        /*input_striding=*/{})};
+                        /*input_striding=*/{}),
+
+      // Small stride-1 dim of size 3 (SoA<->AoS interleave/deinterleave).
+      TransposeTestCase(/*dims=*/{3, 256, 256}, /*permutation=*/{1, 2, 0}),
+      TransposeTestCase(/*dims=*/{256, 256, 3}, /*permutation=*/{2, 0, 1}),
+      TransposeTestCase(/*dims=*/{256, 3}, /*permutation=*/{1, 0}),
+      TransposeTestCase(/*dims=*/{3, 257, 255}, /*permutation=*/{1, 2, 0}),
+      TransposeTestCase(/*dims=*/{5, 3, 64, 64}, /*permutation=*/{2, 3, 0, 1})};
   return cases;
 }
 
@@ -1113,6 +1120,12 @@ static std::vector<TransposeTestCase> BenchmarkCases() {
                         /*permutation=*/{1, 2, 3, 0}),
       TransposeTestCase(/*dims=*/{256, 64, 64, 3},
                         /*permutation=*/{1, 3, 2, 0}),
+      TransposeTestCase(/*dims=*/{256, 3},
+                        /*permutation=*/{1, 0}),
+      TransposeTestCase(/*dims=*/{3, 256, 256},
+                        /*permutation=*/{1, 2, 0}),
+      TransposeTestCase(/*dims=*/{256, 256, 3},
+                        /*permutation=*/{2, 0, 1}),
   };
 }
 


### PR DESCRIPTION
Transposes where one side has a stride-1 dimension of size 3 (RGB channels and similar) are interleave/deinterleave conversions. The existing microkernel clamps the inner block to 2x2 with a scalar residual for these shapes, so most of the work is unvectorized. This adds constant-K interleave and deinterleave kernels and routes eligible plans to them. With K known at compile time, clang emits st3/ld3 on NEON and shuffle sequences on x86.

Measured on M-series arm64: {3,256,256} perm (1,2,0) 7.96x, {256,3} perm (1,0) 3.26x, {256,256,3} perm (2,0,1) 2.72x, no change on the rest of the benchmark suite. Benchmark cases for these shapes are included.