### PR TITLE
Rename bundled hwloc symbols so they cannot interpose system PCI disc…

### DIFF
--- a/third_party/hwloc/hwloc.BUILD
+++ b/third_party/hwloc/hwloc.BUILD
@@ -50,9 +50,12 @@ _INCLUDE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS = {
     "#undef hwloc_pid_t": "#define hwloc_pid_t pid_t",
     "#undef hwloc_thread_t": "#define hwloc_thread_t pthread_t",
     "#  undef HWLOC_HAVE_STDINT_H": "#  define HWLOC_HAVE_STDINT_H 1",
-    "#undef HWLOC_SYM_TRANSFORM": "#define HWLOC_SYM_TRANSFORM 0",
-    "#undef HWLOC_SYM_PREFIX_CAPS": "#define HWLOC_SYM_PREFIX_CAPS HWLOC_",
-    "#undef HWLOC_SYM_PREFIX": "#define HWLOC_SYM_PREFIX hwloc_",
+    # Prefix bundled APIs (tf_hwloc_*) so they cannot interpose system hwloc
+    # (openxla/xla#39355, tensorflow#125854). Public symbols must stay visible
+    # across DSOs (libplatform_port.so vs libtensorflow_framework.so).
+    "#undef HWLOC_SYM_TRANSFORM": "#define HWLOC_SYM_TRANSFORM 1",
+    "#undef HWLOC_SYM_PREFIX_CAPS": "#define HWLOC_SYM_PREFIX_CAPS TF_",
+    "#undef HWLOC_SYM_PREFIX": "#define HWLOC_SYM_PREFIX tf_",
 }
 
 _INCLUDE_HWLOC_AUTOIGEN_CONFIG_H_LINUX_SUBS = dict(_INCLUDE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS)
@@ -176,9 +179,9 @@ _INCLUDE_PRIVATE_HWLOC_AUTOIGEN_CONFIG_H_COMMON_SUBS = {
     "#undef HWLOC_HAVE_X86_CPUID": "#define HWLOC_HAVE_X86_CPUID 1",
     "#undef HWLOC_SIZEOF_UNSIGNED_INT": "#define HWLOC_SIZEOF_UNSIGNED_INT 4",
     "#undef HWLOC_SIZEOF_UNSIGNED_LONG": "#define HWLOC_SIZEOF_UNSIGNED_LONG 8",
-    "#undef HWLOC_SYM_PREFIX_CAPS": "#define HWLOC_SYM_PREFIX_CAPS HWLOC_",
-    "#undef HWLOC_SYM_PREFIX": "#define HWLOC_SYM_PREFIX hwloc_",
-    "#undef HWLOC_SYM_TRANSFORM": "#define HWLOC_SYM_TRANSFORM 0",
+    "#undef HWLOC_SYM_PREFIX_CAPS": "#define HWLOC_SYM_PREFIX_CAPS TF_",
+    "#undef HWLOC_SYM_PREFIX": "#define HWLOC_SYM_PREFIX tf_",
+    "#undef HWLOC_SYM_TRANSFORM": "#define HWLOC_SYM_TRANSFORM 1",
     "#undef HWLOC_USE_NCURSES": "#define HWLOC_USE_NCURSES 1",
     "#undef HWLOC_VERSION_GREEK": "#define HWLOC_VERSION_GREEK \"\"",
     "#undef HWLOC_VERSION_MAJOR": "#define HWLOC_VERSION_MAJOR 2",


### PR DESCRIPTION
## Summary
Enable hwloc embed-mode renaming (`HWLOC_SYM_TRANSFORM=1`, prefix `tf_` / `TF_`) in `third_party/hwloc/hwloc.BUILD`. Bundled APIs become `tf_hwloc_*` (e.g. `hwloc_topology_init` → `tf_hwloc_topology_init`). Callers that include `hwloc.h` (`numa_hwloc.cc`) are renamed automatically. Prefixed symbols stay exported so split DSOs can still link.

## Justification
XLA/TF's bundled hwloc currently exports unprefixed `hwloc_*`. In-process libraries (aws-ofi-nccl, NIXL) bind that copy, which has no PCI backend, so PCI count is 0 and NCCL fails on AWS EFA. `-fvisibility=hidden` is already present and is not enough (`HWLOC_C_HAVE_VISIBILITY=1` still exports APIs). Hiding those APIs also breaks `libplatform_port.so` -> `libtensorflow_framework.so`.
Rename is hwloc's supported embed mode.

Fixes #39355
Related: tensorflow/tensorflow#125854, tensorflow/tensorflow#126200 (TF version-script follow-up after vendor)

## Kind of contribution
Bug fix

## Benchmark
N/A. Symbol naming, not a compiler pass.

## Unit tests
None. This is a third-party BUILD config change. `numa_hwloc.cc` still calls the `hwloc_*` names in source; `rename.h` maps them at compile time.

## Execution tests
None in this repo (no HLO). After vendor into TensorFlow: `nm -D` on `libtensorflow_framework.so.2` should show `tf_hwloc_topology_init` only, and the issue's `LD_PRELOAD` PCI repro should match system hwloc (not 0).