### PR TITLE
fix(gpu): force PTX 8.7 minimum for Blackwell sm_120 in NVPTX backend

### DIFF
--- a/xla/backends/gpu/codegen/emitters/mlir_kernel_emitter.cc
+++ b/xla/backends/gpu/codegen/emitters/mlir_kernel_emitter.cc
@@ -627,7 +627,7 @@ void AddLoweringPasses(mlir::OpPassManager& pm,
   if (auto* cc = device.gpu_compute_capability().cuda_compute_capability()) {
     se::SemanticVersion ptx_version =
         nvptx::DetermineHighestSupportedPtxVersionFromCudaVersion(
-            device.runtime_version());
+            device.runtime_version(), cc->major);
     ConvertFloatNvidiaPassOptions nv_options;
     nv_options.compute_capability_major_ = cc->major;
     nv_options.compute_capability_minor_ = cc->minor;

--- a/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
+++ b/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
@@ -165,7 +165,7 @@ std::unique_ptr<llvm::TargetMachine> NVPTXGetTargetMachine(
   }();
 
   auto ptx_version = nvptx::DetermineHighestSupportedPtxVersionFromCudaVersion(
-      highest_supported_cuda_version);
+      highest_supported_cuda_version, compute_capability.major);
   int highest_supported_ptx_version =
       ptx_version.major_version() * 10 + ptx_version.minor_version();
 

--- a/xla/service/gpu/llvm_gpu_backend/ptx_version_util.cc
+++ b/xla/service/gpu/llvm_gpu_backend/ptx_version_util.cc
@@ -24,32 +24,35 @@ constexpr stream_executor::SemanticVersion kMaxPtxVersion{9, 4, 0};
 
 stream_executor::SemanticVersion
 DetermineHighestSupportedPtxVersionFromCudaVersion(
-    stream_executor::SemanticVersion cuda_version) {
+    stream_executor::SemanticVersion cuda_version,
+    int compute_capability_major) {
+  stream_executor::SemanticVersion ptx_version = kMaxPtxVersion;
+
   if (cuda_version < stream_executor::SemanticVersion{11, 0, 0}) {
     // For everything below CUDA 11 we just fall back to PTX 6.5.
     // We don't support CUDA below 11 anymore.
-    return kFallbackPtxVersion;
-  }
-
-  // Mapping determined from
-  // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#release-notes
-  if (cuda_version >= stream_executor::SemanticVersion{12, 6, 0} &&
+    ptx_version = kFallbackPtxVersion;
+  } else if (cuda_version >= stream_executor::SemanticVersion{12, 6, 0} &&
       cuda_version < stream_executor::SemanticVersion{12, 10, 0}) {
     // Examples:
     // CUDA 12.6 -> PTX 8.5
     // CUDA 12.9 -> PTX 8.8
-    return {cuda_version.major_version() - 4, cuda_version.minor_version() - 1,
-            0};
-  }
-  if (cuda_version < stream_executor::SemanticVersion{13, 4, 0}) {
+    ptx_version = {cuda_version.major_version() - 4, cuda_version.minor_version() - 1, 0};
+  } else if (cuda_version < stream_executor::SemanticVersion{13, 4, 0}) {
     // Examples:
     // CUDA 11.0 -> PTX 7.0
     // CUDA 12.4 -> PTX 8.4
     // CUDA 13.0 -> PTX 9.0
-    return {cuda_version.major_version() - 4, cuda_version.minor_version(), 0};
+    ptx_version = {cuda_version.major_version() - 4, cuda_version.minor_version(), 0};
   }
 
-  // Return maximum known PTX version.
-  return kMaxPtxVersion;
+  // sm_120 (Blackwell) requires at least PTX 8.7
+  if (compute_capability_major >= 12) {
+    if (ptx_version < stream_executor::SemanticVersion{8, 7, 0}) {
+      ptx_version = {8, 7, 0};
+    }
+  }
+
+  return ptx_version;
 }
 }  // namespace xla::gpu::nvptx

--- a/xla/service/gpu/llvm_gpu_backend/ptx_version_util.h
+++ b/xla/service/gpu/llvm_gpu_backend/ptx_version_util.h
@@ -23,7 +23,8 @@ namespace xla::gpu::nvptx {
 // Determine PTX version from CUDA version.
 stream_executor::SemanticVersion
 DetermineHighestSupportedPtxVersionFromCudaVersion(
-    stream_executor::SemanticVersion cuda_version);
+    stream_executor::SemanticVersion cuda_version,
+    int compute_capability_major = 0);
 
 }  // namespace xla::gpu::nvptx
 


### PR DESCRIPTION
Fixes tensorflow/tensorflow#111958.

When targeting Blackwell sm_120, the compiler requires PTX version 8.7 or newer. However, the XLA GPU backend relies on the CUDA version to determine the maximum supported PTX version, which clamps it to 8.5 on CUDA 12.6, resulting in a fatal LLVM error:
LLVM ERROR: ptx87 is required for target sm_120

This PR patches nvptx_backend.cc to ensure that highest_supported_ptx_version is at least 87 if the compute capability is 12.0 (sm_120) or higher.