### PR TITLE
[oneDNN] Add HLO for keras vision transformer model with jax backend for BF16

### DIFF
--- a/xla/backends/cpu/benchmarks/hlo/hlo_files.bzl
+++ b/xla/backends/cpu/benchmarks/hlo/hlo_files.bzl
@@ -51,6 +51,7 @@ REGULAR_HLO_FILES = [
     "sort_full_1024x4096_bf16.hlo",
     "sum_axis_1x4096x1024_bf16.hlo",
     "topk_logits_k10_1x50000_bf16.hlo",
+    "vit_keras_jax_bf16.hlo",
     "xnn.parallel_dots.optimized.hlo",
     "xnn.sequential_dots.optimized.hlo",
     # go/keep-sorted end

--- a/xla/backends/cpu/benchmarks/hlo/vit_keras_jax_bf16.hlo
+++ b/xla/backends/cpu/benchmarks/hlo/vit_keras_jax_bf16.hlo
@@ -1,0 +1,2873 @@
+HloModule jit__unnamed_function, entry_computation_layout={(f32[1,224,224,3]{3,2,1,0})->bf16[1,1000]{1,0}}, allow_spmd_sharding_propagation_to_parameters={true}, allow_spmd_sharding_propagation_to_output={true}
+
+%_where.1 (Arg_0.2: pred[1,197], Arg_1.2: s32[1,197], Arg_2.1: s32[1,197]) -> s32[1,197] {
+  %Arg_0.2 = pred[1,197]{1,0} parameter(0)
+  %Arg_1.2 = s32[1,197]{1,0} parameter(1)
+  %Arg_2.1 = s32[1,197]{1,0} parameter(2)
+  ROOT %select_n.1 = s32[1,197]{1,0} select(%Arg_0.2, %Arg_1.2, %Arg_2.1), metadata={op_name="select_n"}
+}
+
+%region_0.2 (reduce_and.3: pred[], reduce_and.4: pred[]) -> pred[] {
+  %reduce_and.3 = pred[] parameter(0), metadata={op_name="reduce_and"}
+  %reduce_and.4 = pred[] parameter(1), metadata={op_name="reduce_and"}
+  ROOT %reduce_and.5 = pred[] and(%reduce_and.3, %reduce_and.4), metadata={op_name="reduce_and"}
+}
+
+%_take.3 (Arg_0.3: f32[197,768], Arg_1.3: s32[1,197]) -> f32[1,197,768] {
+  %Arg_1.3 = s32[1,197]{1,0} parameter(1)
+  %constant.249 = s32[] constant(0)
+  %lt.2 = s32[1,197]{1,0} broadcast(%constant.249), dimensions={}, metadata={op_name="lt"}
+  %lt.3 = pred[1,197]{1,0} compare(%Arg_1.3, %lt.2), direction=LT, metadata={op_name="lt"}
+  %constant.247 = s32[] constant(197)
+  %add.6 = s32[1,197]{1,0} broadcast(%constant.247), dimensions={}, metadata={op_name="add"}
+  %add.7 = s32[1,197]{1,0} add(%Arg_1.3, %add.6), metadata={op_name="add"}
+  %jit__where_.1 = s32[1,197]{1,0} call(%lt.3, %add.7, %Arg_1.3), to_apply=%_where.1, metadata={op_name="jit(_where)"}
+  %broadcast_in_dim.4 = s32[1,197,1]{2,1,0} reshape(%jit__where_.1), metadata={op_name="broadcast_in_dim"}
+  %constant.246 = s32[] constant(0)
+  %ge.2 = s32[1,197,1]{2,1,0} broadcast(%constant.246), dimensions={}, metadata={op_name="ge"}
+  %ge.3 = pred[1,197,1]{2,1,0} compare(%broadcast_in_dim.4, %ge.2), direction=GE, metadata={op_name="ge"}
+  %constant.245 = s32[] constant(196)
+  %le.2 = s32[1,197,1]{2,1,0} broadcast(%constant.245), dimensions={}, metadata={op_name="le"}
+  %le.3 = pred[1,197,1]{2,1,0} compare(%broadcast_in_dim.4, %le.2), direction=LE, metadata={op_name="le"}
+  %and.1 = pred[1,197,1]{2,1,0} and(%ge.3, %le.3), metadata={op_name="and"}
+  %constant.248 = pred[] constant(true)
+  %reduce_and.7 = pred[1,197]{1,0} reduce(%and.1, %constant.248), dimensions={2}, to_apply=%region_0.2, metadata={op_name="reduce_and"}
+  %broadcast_in_dim.5 = pred[1,197,768]{2,1,0} broadcast(%reduce_and.7), dimensions={0,1}, metadata={op_name="broadcast_in_dim"}
+  %Arg_0.3 = f32[197,768]{1,0} parameter(0)
+  %gather.1 = f32[1,197,768]{2,1,0} gather(%Arg_0.3, %broadcast_in_dim.4), offset_dims={2}, collapsed_slice_dims={0}, start_index_map={0}, index_vector_dim=2, slice_sizes={1,768}, metadata={op_name="gather"}
+  %constant.244 = f32[] constant(nan)
+  %broadcast_in_dim.3 = f32[1,197,768]{2,1,0} broadcast(%constant.244), dimensions={}, metadata={op_name="broadcast_in_dim"}
+  ROOT %select_n.3 = f32[1,197,768]{2,1,0} select(%broadcast_in_dim.5, %gather.1, %broadcast_in_dim.3), metadata={op_name="select_n"}
+}
+
+%region_1.4 (reduce_sum.3: f32[], reduce_sum.4: f32[]) -> f32[] {
+  %reduce_sum.3 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.4 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.5 = f32[] add(%reduce_sum.3, %reduce_sum.4), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/reduce_sum"}
+}
+
+%region_2.5 (reduce_sum.10: f32[], reduce_sum.11: f32[]) -> f32[] {
+  %reduce_sum.10 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.11 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.12 = f32[] add(%reduce_sum.10, %reduce_sum.11), metadata={op_name="reduce_sum"}
+}
+
+%region_3.6 (reduce_sum.17: f32[], reduce_sum.18: f32[]) -> f32[] {
+  %reduce_sum.17 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.18 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.19 = f32[] add(%reduce_sum.17, %reduce_sum.18), metadata={op_name="reduce_sum"}
+}
+
+%_where_0.7 (Arg_0.6: pred[], Arg_1.6: f32[1,197,1], Arg_2.3: f32[]) -> f32[1,197,1] {
+  %Arg_0.6 = pred[] parameter(0)
+  %select_n.6 = pred[1,197,1]{2,1,0} broadcast(%Arg_0.6), dimensions={}, metadata={op_name="select_n"}
+  %Arg_1.6 = f32[1,197,1]{2,1,0} parameter(1)
+  %Arg_2.3 = f32[] parameter(2)
+  %broadcast_in_dim.10 = f32[1,197,1]{2,1,0} broadcast(%Arg_2.3), dimensions={}, metadata={op_name="broadcast_in_dim"}
+  ROOT %select_n.7 = f32[1,197,1]{2,1,0} select(%select_n.6, %Arg_1.6, %broadcast_in_dim.10), metadata={op_name="select_n"}
+}
+
+%_var.8 (Arg_0.7: f32[1,197,768], Arg_1.7: s32[]) -> f32[1,197,1] {
+  %constant.256 = f32[] constant(768)
+  %Arg_1.7 = s32[] parameter(1)
+  %convert_element_type.5 = f32[] convert(%Arg_1.7), metadata={op_name="convert_element_type"}
+  %sub.9 = f32[] subtract(%constant.256, %convert_element_type.5), metadata={op_name="sub"}
+  %constant.257 = f32[] constant(0)
+  %gt.1 = pred[] compare(%sub.9, %constant.257), direction=GT, metadata={op_name="gt"}
+  %Arg_0.7 = f32[1,197,768]{2,1,0} parameter(0)
+  %reduce_sum.21 = f32[1,197]{1,0} reduce(%Arg_0.7, %constant.257), dimensions={2}, to_apply=%region_2.5, metadata={op_name="reduce_sum"}
+  %broadcast_in_dim.11 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.21), metadata={op_name="broadcast_in_dim"}
+  %constant.254 = f32[] constant(768)
+  %div.5 = f32[1,197,1]{2,1,0} broadcast(%constant.254), dimensions={}, metadata={op_name="div"}
+  %div.6 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.11, %div.5), metadata={op_name="div"}
+  %sub.5 = f32[1,197,1]{2,1,0} broadcast(%div.6), dimensions={0,1,2}, metadata={op_name="sub"}
+  %sub.6 = f32[1,197]{1,0} reshape(%sub.5), metadata={op_name="sub"}
+  %sub.7 = f32[1,197,768]{2,1,0} broadcast(%sub.6), dimensions={0,1}, metadata={op_name="sub"}
+  %sub.8 = f32[1,197,768]{2,1,0} subtract(%Arg_0.7, %sub.7), metadata={op_name="sub"}
+  %square.1 = f32[1,197,768]{2,1,0} multiply(%sub.8, %sub.8), metadata={op_name="square"}
+  %reduce_sum.22 = f32[1,197]{1,0} reduce(%square.1, %constant.257), dimensions={2}, to_apply=%region_3.6, metadata={op_name="reduce_sum"}
+  %broadcast_in_dim.12 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.22), metadata={op_name="broadcast_in_dim"}
+  %div.7 = f32[1,197,1]{2,1,0} broadcast(%sub.9), dimensions={}, metadata={op_name="div"}
+  %div.8 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.12, %div.7), metadata={op_name="div"}
+  %constant.255 = f32[] constant(nan)
+  ROOT %jit__where_.3 = f32[1,197,1]{2,1,0} call(%gt.1, %div.8, %constant.255), to_apply=%_where_0.7, metadata={op_name="jit(_where)"}
+}
+
+%region_4.9 (reduce_max.3: f32[], reduce_max.4: f32[]) -> f32[] {
+  %reduce_max.3 = f32[] parameter(0), metadata={op_name="reduce_max"}
+  %reduce_max.4 = f32[] parameter(1), metadata={op_name="reduce_max"}
+  ROOT %reduce_max.5 = f32[] maximum(%reduce_max.3, %reduce_max.4), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/reduce_max"}
+}
+
+%region_5.10 (reduce_sum.26: f32[], reduce_sum.27: f32[]) -> f32[] {
+  %reduce_sum.26 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.27 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.28 = f32[] add(%reduce_sum.26, %reduce_sum.27), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/reduce_sum"}
+}
+
+%region_6.11 (reduce_sum.33: f32[], reduce_sum.34: f32[]) -> f32[] {
+  %reduce_sum.33 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.34 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.35 = f32[] add(%reduce_sum.33, %reduce_sum.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/reduce_sum"}
+}
+
+%region_7.12 (reduce_sum.40: f32[], reduce_sum.41: f32[]) -> f32[] {
+  %reduce_sum.40 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.41 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.42 = f32[] add(%reduce_sum.40, %reduce_sum.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/reduce_sum"}
+}
+
+%region_8.13 (reduce_max.10: f32[], reduce_max.11: f32[]) -> f32[] {
+  %reduce_max.10 = f32[] parameter(0), metadata={op_name="reduce_max"}
+  %reduce_max.11 = f32[] parameter(1), metadata={op_name="reduce_max"}
+  ROOT %reduce_max.12 = f32[] maximum(%reduce_max.10, %reduce_max.11), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/reduce_max"}
+}
+
+%region_9.14 (reduce_sum.47: f32[], reduce_sum.48: f32[]) -> f32[] {
+  %reduce_sum.47 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.48 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.49 = f32[] add(%reduce_sum.47, %reduce_sum.48), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/reduce_sum"}
+}
+
+%region_10.15 (reduce_sum.54: f32[], reduce_sum.55: f32[]) -> f32[] {
+  %reduce_sum.54 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.55 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.56 = f32[] add(%reduce_sum.54, %reduce_sum.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/reduce_sum"}
+}
+
+%region_11.16 (reduce_sum.61: f32[], reduce_sum.62: f32[]) -> f32[] {
+  %reduce_sum.61 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.62 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.63 = f32[] add(%reduce_sum.61, %reduce_sum.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/reduce_sum"}
+}
+
+%region_12.17 (reduce_max.17: f32[], reduce_max.18: f32[]) -> f32[] {
+  %reduce_max.17 = f32[] parameter(0), metadata={op_name="reduce_max"}
+  %reduce_max.18 = f32[] parameter(1), metadata={op_name="reduce_max"}
+  ROOT %reduce_max.19 = f32[] maximum(%reduce_max.17, %reduce_max.18), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/reduce_max"}
+}
+
+%region_13.18 (reduce_sum.68: f32[], reduce_sum.69: f32[]) -> f32[] {
+  %reduce_sum.68 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.69 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.70 = f32[] add(%reduce_sum.68, %reduce_sum.69), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/reduce_sum"}
+}
+
+%region_14.19 (reduce_sum.75: f32[], reduce_sum.76: f32[]) -> f32[] {
+  %reduce_sum.75 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.76 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.77 = f32[] add(%reduce_sum.75, %reduce_sum.76), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/reduce_sum"}
+}
+
+%region_15.20 (reduce_sum.82: f32[], reduce_sum.83: f32[]) -> f32[] {
+  %reduce_sum.82 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.83 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.84 = f32[] add(%reduce_sum.82, %reduce_sum.83), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/reduce_sum"}
+}
+
+%region_16.21 (reduce_max.24: f32[], reduce_max.25: f32[]) -> f32[] {
+  %reduce_max.24 = f32[] parameter(0), metadata={op_name="reduce_max"}
+  %reduce_max.25 = f32[] parameter(1), metadata={op_name="reduce_max"}
+  ROOT %reduce_max.26 = f32[] maximum(%reduce_max.24, %reduce_max.25), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/reduce_max"}
+}
+
+%region_17.22 (reduce_sum.89: f32[], reduce_sum.90: f32[]) -> f32[] {
+  %reduce_sum.89 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.90 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.91 = f32[] add(%reduce_sum.89, %reduce_sum.90), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/reduce_sum"}
+}
+
+%region_18.23 (reduce_sum.96: f32[], reduce_sum.97: f32[]) -> f32[] {
+  %reduce_sum.96 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.97 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.98 = f32[] add(%reduce_sum.96, %reduce_sum.97), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/reduce_sum"}
+}
+
+%region_19.24 (reduce_sum.103: f32[], reduce_sum.104: f32[]) -> f32[] {
+  %reduce_sum.103 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.104 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.105 = f32[] add(%reduce_sum.103, %reduce_sum.104), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/reduce_sum"}
+}
+
+%region_20.25 (reduce_max.31: f32[], reduce_max.32: f32[]) -> f32[] {
+  %reduce_max.31 = f32[] parameter(0), metadata={op_name="reduce_max"}
+  %reduce_max.32 = f32[] parameter(1), metadata={op_name="reduce_max"}
+  ROOT %reduce_max.33 = f32[] maximum(%reduce_max.31, %reduce_max.32), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/reduce_max"}
+}
+
+%region_21.26 (reduce_sum.110: f32[], reduce_sum.111: f32[]) -> f32[] {
+  %reduce_sum.110 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.111 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.112 = f32[] add(%reduce_sum.110, %reduce_sum.111), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/reduce_sum"}
+}
+
+%region_22.27 (reduce_sum.117: f32[], reduce_sum.118: f32[]) -> f32[] {
+  %reduce_sum.117 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.118 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.119 = f32[] add(%reduce_sum.117, %reduce_sum.118), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/reduce_sum"}
+}
+
+%region_23.28 (reduce_sum.124: f32[], reduce_sum.125: f32[]) -> f32[] {
+  %reduce_sum.124 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.125 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.126 = f32[] add(%reduce_sum.124, %reduce_sum.125), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/reduce_sum"}
+}
+
+%region_24.29 (reduce_max.38: f32[], reduce_max.39: f32[]) -> f32[] {
+  %reduce_max.38 = f32[] parameter(0), metadata={op_name="reduce_max"}
+  %reduce_max.39 = f32[] parameter(1), metadata={op_name="reduce_max"}
+  ROOT %reduce_max.40 = f32[] maximum(%reduce_max.38, %reduce_max.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/reduce_max"}
+}
+
+%region_25.30 (reduce_sum.131: f32[], reduce_sum.132: f32[]) -> f32[] {
+  %reduce_sum.131 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.132 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.133 = f32[] add(%reduce_sum.131, %reduce_sum.132), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/reduce_sum"}
+}
+
+%region_26.31 (reduce_sum.138: f32[], reduce_sum.139: f32[]) -> f32[] {
+  %reduce_sum.138 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.139 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.140 = f32[] add(%reduce_sum.138, %reduce_sum.139), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/reduce_sum"}
+}
+
+%region_27.32 (reduce_sum.145: f32[], reduce_sum.146: f32[]) -> f32[] {
+  %reduce_sum.145 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.146 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.147 = f32[] add(%reduce_sum.145, %reduce_sum.146), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/reduce_sum"}
+}
+
+%region_28.33 (reduce_max.45: f32[], reduce_max.46: f32[]) -> f32[] {
+  %reduce_max.45 = f32[] parameter(0), metadata={op_name="reduce_max"}
+  %reduce_max.46 = f32[] parameter(1), metadata={op_name="reduce_max"}
+  ROOT %reduce_max.47 = f32[] maximum(%reduce_max.45, %reduce_max.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/reduce_max"}
+}
+
+%region_29.34 (reduce_sum.152: f32[], reduce_sum.153: f32[]) -> f32[] {
+  %reduce_sum.152 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.153 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.154 = f32[] add(%reduce_sum.152, %reduce_sum.153), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/reduce_sum"}
+}
+
+%region_30.35 (reduce_sum.159: f32[], reduce_sum.160: f32[]) -> f32[] {
+  %reduce_sum.159 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.160 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.161 = f32[] add(%reduce_sum.159, %reduce_sum.160), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/reduce_sum"}
+}
+
+%region_31.36 (reduce_sum.166: f32[], reduce_sum.167: f32[]) -> f32[] {
+  %reduce_sum.166 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.167 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.168 = f32[] add(%reduce_sum.166, %reduce_sum.167), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/reduce_sum"}
+}
+
+%region_32.37 (reduce_max.52: f32[], reduce_max.53: f32[]) -> f32[] {
+  %reduce_max.52 = f32[] parameter(0), metadata={op_name="reduce_max"}
+  %reduce_max.53 = f32[] parameter(1), metadata={op_name="reduce_max"}
+  ROOT %reduce_max.54 = f32[] maximum(%reduce_max.52, %reduce_max.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/reduce_max"}
+}
+
+%region_33.38 (reduce_sum.173: f32[], reduce_sum.174: f32[]) -> f32[] {
+  %reduce_sum.173 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.174 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.175 = f32[] add(%reduce_sum.173, %reduce_sum.174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/reduce_sum"}
+}
+
+%region_34.39 (reduce_sum.180: f32[], reduce_sum.181: f32[]) -> f32[] {
+  %reduce_sum.180 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.181 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.182 = f32[] add(%reduce_sum.180, %reduce_sum.181), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/reduce_sum"}
+}
+
+%region_35.40 (reduce_sum.187: f32[], reduce_sum.188: f32[]) -> f32[] {
+  %reduce_sum.187 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.188 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.189 = f32[] add(%reduce_sum.187, %reduce_sum.188), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/reduce_sum"}
+}
+
+%region_36.41 (reduce_max.59: f32[], reduce_max.60: f32[]) -> f32[] {
+  %reduce_max.59 = f32[] parameter(0), metadata={op_name="reduce_max"}
+  %reduce_max.60 = f32[] parameter(1), metadata={op_name="reduce_max"}
+  ROOT %reduce_max.61 = f32[] maximum(%reduce_max.59, %reduce_max.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/reduce_max"}
+}
+
+%region_37.42 (reduce_sum.194: f32[], reduce_sum.195: f32[]) -> f32[] {
+  %reduce_sum.194 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.195 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.196 = f32[] add(%reduce_sum.194, %reduce_sum.195), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/reduce_sum"}
+}
+
+%region_38.43 (reduce_sum.201: f32[], reduce_sum.202: f32[]) -> f32[] {
+  %reduce_sum.201 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.202 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.203 = f32[] add(%reduce_sum.201, %reduce_sum.202), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/reduce_sum"}
+}
+
+%region_39.44 (reduce_sum.208: f32[], reduce_sum.209: f32[]) -> f32[] {
+  %reduce_sum.208 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.209 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.210 = f32[] add(%reduce_sum.208, %reduce_sum.209), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/reduce_sum"}
+}
+
+%region_40.45 (reduce_max.66: f32[], reduce_max.67: f32[]) -> f32[] {
+  %reduce_max.66 = f32[] parameter(0), metadata={op_name="reduce_max"}
+  %reduce_max.67 = f32[] parameter(1), metadata={op_name="reduce_max"}
+  ROOT %reduce_max.68 = f32[] maximum(%reduce_max.66, %reduce_max.67), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/reduce_max"}
+}
+
+%region_41.46 (reduce_sum.215: f32[], reduce_sum.216: f32[]) -> f32[] {
+  %reduce_sum.215 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.216 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.217 = f32[] add(%reduce_sum.215, %reduce_sum.216), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/reduce_sum"}
+}
+
+%region_42.47 (reduce_sum.222: f32[], reduce_sum.223: f32[]) -> f32[] {
+  %reduce_sum.222 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.223 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.224 = f32[] add(%reduce_sum.222, %reduce_sum.223), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/reduce_sum"}
+}
+
+%region_43.48 (reduce_sum.229: f32[], reduce_sum.230: f32[]) -> f32[] {
+  %reduce_sum.229 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.230 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.231 = f32[] add(%reduce_sum.229, %reduce_sum.230), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/reduce_sum"}
+}
+
+%region_44.49 (reduce_max.73: f32[], reduce_max.74: f32[]) -> f32[] {
+  %reduce_max.73 = f32[] parameter(0), metadata={op_name="reduce_max"}
+  %reduce_max.74 = f32[] parameter(1), metadata={op_name="reduce_max"}
+  ROOT %reduce_max.75 = f32[] maximum(%reduce_max.73, %reduce_max.74), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/reduce_max"}
+}
+
+%region_45.50 (reduce_sum.236: f32[], reduce_sum.237: f32[]) -> f32[] {
+  %reduce_sum.236 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.237 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.238 = f32[] add(%reduce_sum.236, %reduce_sum.237), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/reduce_sum"}
+}
+
+%region_46.51 (reduce_sum.243: f32[], reduce_sum.244: f32[]) -> f32[] {
+  %reduce_sum.243 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.244 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.245 = f32[] add(%reduce_sum.243, %reduce_sum.244), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/reduce_sum"}
+}
+
+%region_47.52 (reduce_sum.250: f32[], reduce_sum.251: f32[]) -> f32[] {
+  %reduce_sum.250 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.251 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.252 = f32[] add(%reduce_sum.250, %reduce_sum.251), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/reduce_sum"}
+}
+
+%region_48.53 (reduce_max.80: f32[], reduce_max.81: f32[]) -> f32[] {
+  %reduce_max.80 = f32[] parameter(0), metadata={op_name="reduce_max"}
+  %reduce_max.81 = f32[] parameter(1), metadata={op_name="reduce_max"}
+  ROOT %reduce_max.82 = f32[] maximum(%reduce_max.80, %reduce_max.81), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/reduce_max"}
+}
+
+%region_49.54 (reduce_sum.257: f32[], reduce_sum.258: f32[]) -> f32[] {
+  %reduce_sum.257 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.258 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.259 = f32[] add(%reduce_sum.257, %reduce_sum.258), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/reduce_sum"}
+}
+
+%region_50.55 (reduce_sum.264: f32[], reduce_sum.265: f32[]) -> f32[] {
+  %reduce_sum.264 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.265 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.266 = f32[] add(%reduce_sum.264, %reduce_sum.265), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/reduce_sum"}
+}
+
+%region_51.56 (reduce_sum.271: f32[], reduce_sum.272: f32[]) -> f32[] {
+  %reduce_sum.271 = f32[] parameter(0), metadata={op_name="reduce_sum"}
+  %reduce_sum.272 = f32[] parameter(1), metadata={op_name="reduce_sum"}
+  ROOT %reduce_sum.273 = f32[] add(%reduce_sum.271, %reduce_sum.272), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/reduce_sum"}
+}
+
+ENTRY %main.57 (args_0_.1: f32[1,224,224,3]) -> bf16[1,1000] {
+  %constant.387 = bf16[1,1,768]{2,1,0} constant({...})
+  %args_0_.1 = f32[1,224,224,3]{3,2,1,0} parameter(0), metadata={op_name="args[0]"}
+  %convert_element_type.140 = bf16[1,224,224,3]{3,2,1,0} convert(%args_0_.1), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/convert_element_type"}
+  %constant.420 = f32[16,16,3,768]{3,2,1,0} constant({...})
+  %convert_element_type.141 = bf16[16,16,3,768]{3,2,1,0} convert(%constant.420), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_patching_and_embedding/patch_embedding/convert_element_type"}
+  %conv_general_dilated.1 = bf16[1,14,14,768]{3,2,1,0} convolution(%convert_element_type.140, %convert_element_type.141), window={size=16x16 stride=16x16}, dim_labels=b01f_01io->b01f, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_patching_and_embedding/patch_embedding/conv_general_dilated"}
+  %constant.388 = bf16[1,1,1,768]{3,2,1,0} constant({...})
+  %add.472 = bf16[1,1,1,768]{3,2,1,0} broadcast(%constant.388), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_patching_and_embedding/patch_embedding/add"}
+  %add.473 = bf16[1,768]{1,0} reshape(%add.472), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_patching_and_embedding/patch_embedding/add"}
+  %add.474 = bf16[1,14,14,768]{3,2,1,0} broadcast(%add.473), dimensions={0,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_patching_and_embedding/patch_embedding/add"}
+  %add.475 = bf16[1,14,14,768]{3,2,1,0} add(%conv_general_dilated.1, %add.474), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_patching_and_embedding/patch_embedding/add"}
+  %reshape.25 = bf16[1,196,768]{2,1,0} reshape(%add.475), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_patching_and_embedding/reshape"}
+  %concatenate.1 = bf16[1,197,768]{2,1,0} concatenate(%constant.387, %reshape.25), dimensions={1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_patching_and_embedding/concatenate"}
+  %constant.421 = f32[197,768]{1,0} constant({...})
+  %constant.422 = s32[1,197]{1,0} constant({...})
+  %jit__take_.1 = f32[1,197,768]{2,1,0} call(%constant.421, %constant.422), to_apply=%_take.3, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_patching_and_embedding/position_embedding/jit(_take)"}
+  %convert_element_type.142 = bf16[1,197,768]{2,1,0} convert(%jit__take_.1), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_patching_and_embedding/position_embedding/convert_element_type"}
+  %add.476 = bf16[1,197,768]{2,1,0} add(%concatenate.1, %convert_element_type.142), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_patching_and_embedding/add"}
+  %convert_element_type.143 = f32[1,197,768]{2,1,0} convert(%add.476), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/convert_element_type"}
+  %constant.418 = s32[] constant(0)
+  %jit__var_.25 = f32[1,197,1]{2,1,0} call(%convert_element_type.143, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/jit(_var)"}
+  %constant.383 = f32[] constant(1e-06)
+  %broadcast.38 = f32[1,197,1]{2,1,0} broadcast(%constant.383), dimensions={}
+  %add.477 = f32[1,197,1]{2,1,0} add(%jit__var_.25, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/add"}
+  %rsqrt.25 = f32[1,197,1]{2,1,0} rsqrt(%add.477), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/rsqrt"}
+  %mul.348 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.25), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/mul"}
+  %mul.349 = f32[1,197]{1,0} reshape(%mul.348), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/mul"}
+  %mul.350 = f32[1,197,768]{2,1,0} broadcast(%mul.349), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/mul"}
+  %constant.385 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.351 = f32[1,1,768]{2,1,0} broadcast(%constant.385), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/mul"}
+  %mul.352 = f32[1,768]{1,0} reshape(%mul.351), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/mul"}
+  %mul.353 = f32[1,197,768]{2,1,0} broadcast(%mul.352), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/mul"}
+  %mul.354 = f32[1,197,768]{2,1,0} multiply(%mul.350, %mul.353), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/mul"}
+  %mul.359 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.143, %mul.354), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/mul"}
+  %constant.419 = f32[] constant(0)
+  %reduce_sum.275 = f32[1,197]{1,0} reduce(%convert_element_type.143, %constant.419), dimensions={2}, to_apply=%region_1.4, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/reduce_sum"}
+  %broadcast_in_dim.49 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.275), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/broadcast_in_dim"}
+  %constant.386 = f32[] constant(768)
+  %broadcast.39 = f32[1,197,1]{2,1,0} broadcast(%constant.386), dimensions={}
+  %div.81 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.49, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/div"}
+  %neg.37 = f32[1,197,1]{2,1,0} negate(%div.81), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/neg"}
+  %mul.355 = f32[1,197,1]{2,1,0} broadcast(%neg.37), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/mul"}
+  %mul.356 = f32[1,197]{1,0} reshape(%mul.355), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/mul"}
+  %mul.357 = f32[1,197,768]{2,1,0} broadcast(%mul.356), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/mul"}
+  %mul.358 = f32[1,197,768]{2,1,0} multiply(%mul.357, %mul.354), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/mul"}
+  %constant.384 = f32[1,1,768]{2,1,0} constant({...})
+  %add.478 = f32[1,1,768]{2,1,0} broadcast(%constant.384), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/add"}
+  %add.479 = f32[1,768]{1,0} reshape(%add.478), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/add"}
+  %add.480 = f32[1,197,768]{2,1,0} broadcast(%add.479), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/add"}
+  %add.481 = f32[1,197,768]{2,1,0} add(%mul.358, %add.480), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/add"}
+  %add.482 = f32[1,197,768]{2,1,0} add(%mul.359, %add.481), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/add"}
+  %convert_element_type.144 = bf16[1,197,768]{2,1,0} convert(%add.482), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_1/convert_element_type"}
+  %constant.425 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.147 = bf16[768,12,64]{2,1,0} convert(%constant.425), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/value/convert_element_type"}
+  %dot_general.99 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.144, %convert_element_type.147), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/value/abc,cde->abde/dot_general"}
+  %constant.380 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.491 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.380), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/value/add"}
+  %add.492 = bf16[1,12,64]{2,1,0} reshape(%add.491), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/value/add"}
+  %add.493 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.492), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/value/add"}
+  %add.494 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.99, %add.493), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/value/add"}
+  %constant.423 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.145 = bf16[768,12,64]{2,1,0} convert(%constant.423), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/query/convert_element_type"}
+  %dot_general.97 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.144, %convert_element_type.145), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/query/abc,cde->abde/dot_general"}
+  %constant.382 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.483 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.382), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/query/add"}
+  %add.484 = bf16[1,12,64]{2,1,0} reshape(%add.483), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/query/add"}
+  %add.485 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.484), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/query/add"}
+  %add.486 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.97, %add.485), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/query/add"}
+  %reshape.26 = bf16[1,197,12,1,64]{4,3,2,1,0} reshape(%add.486), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/reshape"}
+  %constant.424 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.146 = bf16[768,12,64]{2,1,0} convert(%constant.424), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/key/convert_element_type"}
+  %dot_general.98 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.144, %convert_element_type.146), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/key/abc,cde->abde/dot_general"}
+  %constant.381 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.487 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.381), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/key/add"}
+  %add.488 = bf16[1,12,64]{2,1,0} reshape(%add.487), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/key/add"}
+  %add.489 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.488), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/key/add"}
+  %add.490 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.98, %add.489), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/key/add"}
+  %dot_general.100 = f32[1,12,197,1,197]{4,3,2,1,0} dot(%reshape.26, %add.490), lhs_batch_dims={0,2}, lhs_contracting_dims={4}, rhs_batch_dims={0,2}, rhs_contracting_dims={3}, algorithm=dot_bf16_bf16_f32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap(BTNH,BSNH->BNTS)/dot_general"}
+  %constant.379 = f32[] constant(0.125)
+  %broadcast.37 = f32[1,12,197,1,197]{4,3,2,1,0} broadcast(%constant.379), dimensions={}
+  %mul.360 = f32[1,12,197,1,197]{4,3,2,1,0} multiply(%dot_general.100, %broadcast.37), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/mul"}
+  %transpose.37 = f32[1,1,12,197,197]{4,3,2,1,0} reshape(%mul.360), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/transpose"}
+  %constant.417 = f32[] constant(-inf)
+  %reduce_max.84 = f32[1,12,197,1]{3,2,1,0} reduce(%mul.360, %constant.417), dimensions={4}, to_apply=%region_4.9, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/reduce_max"}
+  %constant.378 = f32[] constant(-inf)
+  %broadcast.36 = f32[1,12,197,1]{3,2,1,0} broadcast(%constant.378), dimensions={}
+  %max.12 = f32[1,12,197,1]{3,2,1,0} maximum(%reduce_max.84, %broadcast.36), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/max"}
+  %transpose.36 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%max.12), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/broadcast_in_dim;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/transpose"}
+  %sub.58 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%transpose.36), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/sub"}
+  %sub.59 = f32[1,1,12,197]{3,2,1,0} reshape(%sub.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/sub"}
+  %sub.60 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%sub.59), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/sub"}
+  %sub.61 = f32[1,1,12,197,197]{4,3,2,1,0} subtract(%transpose.37, %sub.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/sub"}
+  %exp.12 = f32[1,1,12,197,197]{4,3,2,1,0} exponential(%sub.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/exp"}
+  %reduce_sum.276 = f32[1,1,12,197]{3,2,1,0} reduce(%exp.12, %constant.419), dimensions={4}, to_apply=%region_5.10, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/reduce_sum"}
+  %broadcast_in_dim.50 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%reduce_sum.276), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/broadcast_in_dim"}
+  %div.82 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%broadcast_in_dim.50), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/div"}
+  %div.83 = f32[1,1,12,197]{3,2,1,0} reshape(%div.82), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/div"}
+  %div.84 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%div.83), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/div"}
+  %div.85 = f32[1,1,12,197,197]{4,3,2,1,0} divide(%exp.12, %div.84), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/div"}
+  %convert_element_type.148 = bf16[1,1,12,197,197]{4,3,2,1,0} convert(%div.85), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/convert_element_type"}
+  %dot_general.101 = bf16[1,12,64,1,197]{4,3,2,1,0} dot(%add.494, %convert_element_type.148), lhs_batch_dims={0,2}, lhs_contracting_dims={1}, rhs_batch_dims={1,2}, rhs_contracting_dims={4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap(BNTS,BSNH->BTNH)/dot_general"}
+  %transpose.38 = bf16[1,197,12,1,64]{1,3,4,2,0} transpose(%dot_general.101), dimensions={0,4,1,3,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap()/transpose;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/vmap(BNTS,BSNH->BTNH)/transpose"}
+  %reshape.27 = bf16[1,197,12,64]{3,2,1,0} reshape(%transpose.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/reshape"}
+  %constant.426 = f32[12,64,768]{2,1,0} constant({...})
+  %convert_element_type.149 = bf16[12,64,768]{2,1,0} convert(%constant.426), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/attention_output/convert_element_type"}
+  %dot_general.102 = bf16[1,197,768]{2,1,0} dot(%reshape.27, %convert_element_type.149), lhs_contracting_dims={2,3}, rhs_contracting_dims={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/attention_output/abcd,cde->abe/dot_general"}
+  %constant.377 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.495 = bf16[1,1,768]{2,1,0} broadcast(%constant.377), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/attention_output/add"}
+  %add.496 = bf16[1,768]{1,0} reshape(%add.495), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/attention_output/add"}
+  %add.497 = bf16[1,197,768]{2,1,0} broadcast(%add.496), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/attention_output/add"}
+  %add.498 = bf16[1,197,768]{2,1,0} add(%dot_general.102, %add.497), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mha/attention_output/add"}
+  %add.499 = bf16[1,197,768]{2,1,0} add(%add.498, %add.476), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/add"}
+  %convert_element_type.150 = f32[1,197,768]{2,1,0} convert(%add.499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/convert_element_type"}
+  %jit__var_.26 = f32[1,197,1]{2,1,0} call(%convert_element_type.150, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/jit(_var)"}
+  %add.500 = f32[1,197,1]{2,1,0} add(%jit__var_.26, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/add"}
+  %rsqrt.26 = f32[1,197,1]{2,1,0} rsqrt(%add.500), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/rsqrt"}
+  %mul.361 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.26), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/mul"}
+  %mul.362 = f32[1,197]{1,0} reshape(%mul.361), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/mul"}
+  %mul.363 = f32[1,197,768]{2,1,0} broadcast(%mul.362), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/mul"}
+  %constant.376 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.364 = f32[1,1,768]{2,1,0} broadcast(%constant.376), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/mul"}
+  %mul.365 = f32[1,768]{1,0} reshape(%mul.364), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/mul"}
+  %mul.366 = f32[1,197,768]{2,1,0} broadcast(%mul.365), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/mul"}
+  %mul.367 = f32[1,197,768]{2,1,0} multiply(%mul.363, %mul.366), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/mul"}
+  %mul.372 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.150, %mul.367), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/mul"}
+  %reduce_sum.277 = f32[1,197]{1,0} reduce(%convert_element_type.150, %constant.419), dimensions={2}, to_apply=%region_6.11, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/reduce_sum"}
+  %broadcast_in_dim.51 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.277), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/broadcast_in_dim"}
+  %div.86 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.51, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/div"}
+  %neg.38 = f32[1,197,1]{2,1,0} negate(%div.86), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/neg"}
+  %mul.368 = f32[1,197,1]{2,1,0} broadcast(%neg.38), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/mul"}
+  %mul.369 = f32[1,197]{1,0} reshape(%mul.368), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/mul"}
+  %mul.370 = f32[1,197,768]{2,1,0} broadcast(%mul.369), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/mul"}
+  %mul.371 = f32[1,197,768]{2,1,0} multiply(%mul.370, %mul.367), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/mul"}
+  %constant.375 = f32[1,1,768]{2,1,0} constant({...})
+  %add.501 = f32[1,1,768]{2,1,0} broadcast(%constant.375), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/add"}
+  %add.502 = f32[1,768]{1,0} reshape(%add.501), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/add"}
+  %add.503 = f32[1,197,768]{2,1,0} broadcast(%add.502), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/add"}
+  %add.504 = f32[1,197,768]{2,1,0} add(%mul.371, %add.503), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/add"}
+  %add.505 = f32[1,197,768]{2,1,0} add(%mul.372, %add.504), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/add"}
+  %convert_element_type.151 = bf16[1,197,768]{2,1,0} convert(%add.505), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/ln_2/convert_element_type"}
+  %constant.427 = f32[768,3072]{1,0} constant({...})
+  %convert_element_type.152 = bf16[768,3072]{1,0} convert(%constant.427), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/convert_element_type"}
+  %dot_general.103 = bf16[1,197,3072]{2,1,0} dot(%convert_element_type.151, %convert_element_type.152), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/dot_general"}
+  %constant.374 = bf16[1,1,3072]{2,1,0} constant({...})
+  %add.506 = bf16[1,1,3072]{2,1,0} broadcast(%constant.374), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/add"}
+  %add.507 = bf16[1,3072]{1,0} reshape(%add.506), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/add"}
+  %add.508 = bf16[1,197,3072]{2,1,0} broadcast(%add.507), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/add"}
+  %add.509 = bf16[1,197,3072]{2,1,0} add(%dot_general.103, %add.508), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/add"}
+  %constant.373 = bf16[] constant(0.5)
+  %broadcast.35 = bf16[1,197,3072]{2,1,0} broadcast(%constant.373), dimensions={}
+  %mul.373 = bf16[1,197,3072]{2,1,0} multiply(%add.509, %broadcast.35), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/mul"}
+  %neg.39 = bf16[1,197,3072]{2,1,0} negate(%add.509), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/neg"}
+  %constant.372 = bf16[] constant(0.707)
+  %broadcast.34 = bf16[1,197,3072]{2,1,0} broadcast(%constant.372), dimensions={}
+  %mul.374 = bf16[1,197,3072]{2,1,0} multiply(%neg.39, %broadcast.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/mul"}
+  %erfc.780 = f32[1,197,3072]{2,1,0} convert(%mul.374), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.841 = f32[1,197,3072]{2,1,0} abs(%erfc.780), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.416 = f32[] constant(1)
+  %broadcast.67 = f32[1,197,3072]{2,1,0} broadcast(%constant.416), dimensions={}
+  %erfc.842 = pred[1,197,3072]{2,1,0} compare(%erfc.841, %broadcast.67), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.826 = f32[1,197,3072]{2,1,0} multiply(%erfc.780, %erfc.780), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.395 = f32[] constant(7.85386146e-05)
+  %broadcast.46 = f32[1,197,3072]{2,1,0} broadcast(%constant.395), dimensions={}
+  %erfc.827 = f32[1,197,3072]{2,1,0} multiply(%erfc.826, %broadcast.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.394 = f32[] constant(-0.000801019371)
+  %broadcast.45 = f32[1,197,3072]{2,1,0} broadcast(%constant.394), dimensions={}
+  %erfc.828 = f32[1,197,3072]{2,1,0} add(%erfc.827, %broadcast.45), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.829 = f32[1,197,3072]{2,1,0} multiply(%erfc.828, %erfc.826), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.393 = f32[] constant(0.00518832775)
+  %broadcast.44 = f32[1,197,3072]{2,1,0} broadcast(%constant.393), dimensions={}
+  %erfc.830 = f32[1,197,3072]{2,1,0} add(%erfc.829, %broadcast.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.831 = f32[1,197,3072]{2,1,0} multiply(%erfc.830, %erfc.826), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.392 = f32[] constant(-0.0268538129)
+  %broadcast.43 = f32[1,197,3072]{2,1,0} broadcast(%constant.392), dimensions={}
+  %erfc.832 = f32[1,197,3072]{2,1,0} add(%erfc.831, %broadcast.43), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.833 = f32[1,197,3072]{2,1,0} multiply(%erfc.832, %erfc.826), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.391 = f32[] constant(0.112835854)
+  %broadcast.42 = f32[1,197,3072]{2,1,0} broadcast(%constant.391), dimensions={}
+  %erfc.834 = f32[1,197,3072]{2,1,0} add(%erfc.833, %broadcast.42), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.835 = f32[1,197,3072]{2,1,0} multiply(%erfc.834, %erfc.826), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.390 = f32[] constant(-0.37612626)
+  %broadcast.41 = f32[1,197,3072]{2,1,0} broadcast(%constant.390), dimensions={}
+  %erfc.836 = f32[1,197,3072]{2,1,0} add(%erfc.835, %broadcast.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.837 = f32[1,197,3072]{2,1,0} multiply(%erfc.836, %erfc.826), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.389 = f32[] constant(1.12837911)
+  %broadcast.40 = f32[1,197,3072]{2,1,0} broadcast(%constant.389), dimensions={}
+  %erfc.838 = f32[1,197,3072]{2,1,0} add(%erfc.837, %broadcast.40), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.839 = f32[1,197,3072]{2,1,0} multiply(%erfc.780, %erfc.838), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.840 = f32[1,197,3072]{2,1,0} subtract(%broadcast.67, %erfc.839), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.396 = f32[] constant(0)
+  %broadcast.47 = f32[1,197,3072]{2,1,0} broadcast(%constant.396), dimensions={}
+  %erfc.823 = pred[1,197,3072]{2,1,0} compare(%erfc.780, %broadcast.47), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.415 = f32[] constant(2)
+  %broadcast.66 = f32[1,197,3072]{2,1,0} broadcast(%constant.415), dimensions={}
+  %erfc.781 = f32[1,197,3072]{2,1,0} multiply(%erfc.780, %erfc.780), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.782 = f32[1,197,3072]{2,1,0} negate(%erfc.781), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.397 = f32[] constant(-88.7228394)
+  %broadcast.48 = f32[1,197,3072]{2,1,0} broadcast(%constant.397), dimensions={}
+  %erfc.821 = pred[1,197,3072]{2,1,0} compare(%erfc.782, %broadcast.48), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.785 = f32[1,197,3072]{2,1,0} exponential(%erfc.782), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.783 = f32[1,197,3072]{2,1,0} abs(%erfc.780), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.786 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.783), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.787 = f32[1,197,3072]{2,1,0} multiply(%erfc.785, %erfc.786), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.788 = pred[1,197,3072]{2,1,0} compare(%erfc.783, %broadcast.66), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.784 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.781), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.414 = f32[] constant(0.0232682)
+  %broadcast.65 = f32[1,197,3072]{2,1,0} broadcast(%constant.414), dimensions={}
+  %erfc.789 = f32[1,197,3072]{2,1,0} multiply(%erfc.784, %broadcast.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.413 = f32[] constant(-0.138703942)
+  %broadcast.64 = f32[1,197,3072]{2,1,0} broadcast(%constant.413), dimensions={}
+  %erfc.790 = f32[1,197,3072]{2,1,0} add(%erfc.789, %broadcast.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.791 = f32[1,197,3072]{2,1,0} multiply(%erfc.790, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.412 = f32[] constant(0.368742466)
+  %broadcast.63 = f32[1,197,3072]{2,1,0} broadcast(%constant.412), dimensions={}
+  %erfc.792 = f32[1,197,3072]{2,1,0} add(%erfc.791, %broadcast.63), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.793 = f32[1,197,3072]{2,1,0} multiply(%erfc.792, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.411 = f32[] constant(-0.582473278)
+  %broadcast.62 = f32[1,197,3072]{2,1,0} broadcast(%constant.411), dimensions={}
+  %erfc.794 = f32[1,197,3072]{2,1,0} add(%erfc.793, %broadcast.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.795 = f32[1,197,3072]{2,1,0} multiply(%erfc.794, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.410 = f32[] constant(0.621000469)
+  %broadcast.61 = f32[1,197,3072]{2,1,0} broadcast(%constant.410), dimensions={}
+  %erfc.796 = f32[1,197,3072]{2,1,0} add(%erfc.795, %broadcast.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.797 = f32[1,197,3072]{2,1,0} multiply(%erfc.796, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.409 = f32[] constant(-0.494451523)
+  %broadcast.60 = f32[1,197,3072]{2,1,0} broadcast(%constant.409), dimensions={}
+  %erfc.798 = f32[1,197,3072]{2,1,0} add(%erfc.797, %broadcast.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.799 = f32[1,197,3072]{2,1,0} multiply(%erfc.798, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.408 = f32[] constant(0.340488)
+  %broadcast.59 = f32[1,197,3072]{2,1,0} broadcast(%constant.408), dimensions={}
+  %erfc.800 = f32[1,197,3072]{2,1,0} add(%erfc.799, %broadcast.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.801 = f32[1,197,3072]{2,1,0} multiply(%erfc.800, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.407 = f32[] constant(-0.274112701)
+  %broadcast.58 = f32[1,197,3072]{2,1,0} broadcast(%constant.407), dimensions={}
+  %erfc.802 = f32[1,197,3072]{2,1,0} add(%erfc.801, %broadcast.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.803 = f32[1,197,3072]{2,1,0} multiply(%erfc.802, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.406 = f32[] constant(0.563825965)
+  %broadcast.57 = f32[1,197,3072]{2,1,0} broadcast(%constant.406), dimensions={}
+  %erfc.804 = f32[1,197,3072]{2,1,0} add(%erfc.803, %broadcast.57), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.405 = f32[] constant(-10.477664)
+  %broadcast.56 = f32[1,197,3072]{2,1,0} broadcast(%constant.405), dimensions={}
+  %erfc.805 = f32[1,197,3072]{2,1,0} multiply(%erfc.784, %broadcast.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.404 = f32[] constant(12.9772)
+  %broadcast.55 = f32[1,197,3072]{2,1,0} broadcast(%constant.404), dimensions={}
+  %erfc.806 = f32[1,197,3072]{2,1,0} add(%erfc.805, %broadcast.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.807 = f32[1,197,3072]{2,1,0} multiply(%erfc.806, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.403 = f32[] constant(-7.49551868)
+  %broadcast.54 = f32[1,197,3072]{2,1,0} broadcast(%constant.403), dimensions={}
+  %erfc.808 = f32[1,197,3072]{2,1,0} add(%erfc.807, %broadcast.54), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.809 = f32[1,197,3072]{2,1,0} multiply(%erfc.808, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.402 = f32[] constant(2.92101908)
+  %broadcast.53 = f32[1,197,3072]{2,1,0} broadcast(%constant.402), dimensions={}
+  %erfc.810 = f32[1,197,3072]{2,1,0} add(%erfc.809, %broadcast.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.811 = f32[1,197,3072]{2,1,0} multiply(%erfc.810, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.401 = f32[] constant(-1.01526523)
+  %broadcast.52 = f32[1,197,3072]{2,1,0} broadcast(%constant.401), dimensions={}
+  %erfc.812 = f32[1,197,3072]{2,1,0} add(%erfc.811, %broadcast.52), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.813 = f32[1,197,3072]{2,1,0} multiply(%erfc.812, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.400 = f32[] constant(0.42184633)
+  %broadcast.51 = f32[1,197,3072]{2,1,0} broadcast(%constant.400), dimensions={}
+  %erfc.814 = f32[1,197,3072]{2,1,0} add(%erfc.813, %broadcast.51), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.815 = f32[1,197,3072]{2,1,0} multiply(%erfc.814, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.399 = f32[] constant(-0.282076746)
+  %broadcast.50 = f32[1,197,3072]{2,1,0} broadcast(%constant.399), dimensions={}
+  %erfc.816 = f32[1,197,3072]{2,1,0} add(%erfc.815, %broadcast.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.817 = f32[1,197,3072]{2,1,0} multiply(%erfc.816, %erfc.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %constant.398 = f32[] constant(0.564189494)
+  %broadcast.49 = f32[1,197,3072]{2,1,0} broadcast(%constant.398), dimensions={}
+  %erfc.818 = f32[1,197,3072]{2,1,0} add(%erfc.817, %broadcast.49), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.819 = f32[1,197,3072]{2,1,0} select(%erfc.788, %erfc.804, %erfc.818), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.820 = f32[1,197,3072]{2,1,0} multiply(%erfc.787, %erfc.819), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.822 = f32[1,197,3072]{2,1,0} select(%erfc.821, %broadcast.47, %erfc.820), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.824 = f32[1,197,3072]{2,1,0} subtract(%broadcast.66, %erfc.822), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.825 = f32[1,197,3072]{2,1,0} select(%erfc.823, %erfc.824, %erfc.822), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.843 = f32[1,197,3072]{2,1,0} select(%erfc.842, %erfc.840, %erfc.825), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %erfc.844 = bf16[1,197,3072]{2,1,0} convert(%erfc.843), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/erfc"}
+  %mul.375 = bf16[1,197,3072]{2,1,0} multiply(%mul.373, %erfc.844), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_1/mul"}
+  %constant.428 = f32[3072,768]{1,0} constant({...})
+  %convert_element_type.153 = bf16[3072,768]{1,0} convert(%constant.428), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_2/convert_element_type"}
+  %dot_general.104 = bf16[1,197,768]{2,1,0} dot(%mul.375, %convert_element_type.153), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_2/dot_general"}
+  %constant.371 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.510 = bf16[1,1,768]{2,1,0} broadcast(%constant.371), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_2/add"}
+  %add.511 = bf16[1,768]{1,0} reshape(%add.510), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_2/add"}
+  %add.512 = bf16[1,197,768]{2,1,0} broadcast(%add.511), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_2/add"}
+  %add.513 = bf16[1,197,768]{2,1,0} add(%dot_general.104, %add.512), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/mlp/dense_2/add"}
+  %add.514 = bf16[1,197,768]{2,1,0} add(%add.499, %add.513), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_1/add"}
+  %convert_element_type.154 = f32[1,197,768]{2,1,0} convert(%add.514), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/convert_element_type"}
+  %jit__var_.27 = f32[1,197,1]{2,1,0} call(%convert_element_type.154, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/jit(_var)"}
+  %add.515 = f32[1,197,1]{2,1,0} add(%jit__var_.27, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/add"}
+  %rsqrt.27 = f32[1,197,1]{2,1,0} rsqrt(%add.515), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/rsqrt"}
+  %mul.376 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.27), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/mul"}
+  %mul.377 = f32[1,197]{1,0} reshape(%mul.376), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/mul"}
+  %mul.378 = f32[1,197,768]{2,1,0} broadcast(%mul.377), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/mul"}
+  %constant.370 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.379 = f32[1,1,768]{2,1,0} broadcast(%constant.370), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/mul"}
+  %mul.380 = f32[1,768]{1,0} reshape(%mul.379), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/mul"}
+  %mul.381 = f32[1,197,768]{2,1,0} broadcast(%mul.380), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/mul"}
+  %mul.382 = f32[1,197,768]{2,1,0} multiply(%mul.378, %mul.381), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/mul"}
+  %mul.387 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.154, %mul.382), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/mul"}
+  %reduce_sum.278 = f32[1,197]{1,0} reduce(%convert_element_type.154, %constant.419), dimensions={2}, to_apply=%region_7.12, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/reduce_sum"}
+  %broadcast_in_dim.52 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.278), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/broadcast_in_dim"}
+  %div.87 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.52, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/div"}
+  %neg.40 = f32[1,197,1]{2,1,0} negate(%div.87), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/neg"}
+  %mul.383 = f32[1,197,1]{2,1,0} broadcast(%neg.40), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/mul"}
+  %mul.384 = f32[1,197]{1,0} reshape(%mul.383), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/mul"}
+  %mul.385 = f32[1,197,768]{2,1,0} broadcast(%mul.384), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/mul"}
+  %mul.386 = f32[1,197,768]{2,1,0} multiply(%mul.385, %mul.382), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/mul"}
+  %constant.369 = f32[1,1,768]{2,1,0} constant({...})
+  %add.516 = f32[1,1,768]{2,1,0} broadcast(%constant.369), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/add"}
+  %add.517 = f32[1,768]{1,0} reshape(%add.516), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/add"}
+  %add.518 = f32[1,197,768]{2,1,0} broadcast(%add.517), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/add"}
+  %add.519 = f32[1,197,768]{2,1,0} add(%mul.386, %add.518), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/add"}
+  %add.520 = f32[1,197,768]{2,1,0} add(%mul.387, %add.519), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/add"}
+  %convert_element_type.155 = bf16[1,197,768]{2,1,0} convert(%add.520), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_1/convert_element_type"}
+  %constant.431 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.158 = bf16[768,12,64]{2,1,0} convert(%constant.431), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/value/convert_element_type"}
+  %dot_general.107 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.155, %convert_element_type.158), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/value/abc,cde->abde/dot_general"}
+  %constant.366 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.529 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.366), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/value/add"}
+  %add.530 = bf16[1,12,64]{2,1,0} reshape(%add.529), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/value/add"}
+  %add.531 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.530), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/value/add"}
+  %add.532 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.107, %add.531), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/value/add"}
+  %constant.429 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.156 = bf16[768,12,64]{2,1,0} convert(%constant.429), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/query/convert_element_type"}
+  %dot_general.105 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.155, %convert_element_type.156), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/query/abc,cde->abde/dot_general"}
+  %constant.368 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.521 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.368), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/query/add"}
+  %add.522 = bf16[1,12,64]{2,1,0} reshape(%add.521), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/query/add"}
+  %add.523 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.522), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/query/add"}
+  %add.524 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.105, %add.523), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/query/add"}
+  %reshape.28 = bf16[1,197,12,1,64]{4,3,2,1,0} reshape(%add.524), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/reshape"}
+  %constant.430 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.157 = bf16[768,12,64]{2,1,0} convert(%constant.430), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/key/convert_element_type"}
+  %dot_general.106 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.155, %convert_element_type.157), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/key/abc,cde->abde/dot_general"}
+  %constant.367 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.525 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.367), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/key/add"}
+  %add.526 = bf16[1,12,64]{2,1,0} reshape(%add.525), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/key/add"}
+  %add.527 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.526), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/key/add"}
+  %add.528 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.106, %add.527), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/key/add"}
+  %dot_general.108 = f32[1,12,197,1,197]{4,3,2,1,0} dot(%reshape.28, %add.528), lhs_batch_dims={0,2}, lhs_contracting_dims={4}, rhs_batch_dims={0,2}, rhs_contracting_dims={3}, algorithm=dot_bf16_bf16_f32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap(BTNH,BSNH->BNTS)/dot_general"}
+  %mul.388 = f32[1,12,197,1,197]{4,3,2,1,0} multiply(%dot_general.108, %broadcast.37), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/mul"}
+  %transpose.40 = f32[1,1,12,197,197]{4,3,2,1,0} reshape(%mul.388), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/transpose"}
+  %reduce_max.85 = f32[1,12,197,1]{3,2,1,0} reduce(%mul.388, %constant.417), dimensions={4}, to_apply=%region_8.13, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/reduce_max"}
+  %max.13 = f32[1,12,197,1]{3,2,1,0} maximum(%reduce_max.85, %broadcast.36), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/max"}
+  %transpose.39 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%max.13), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/broadcast_in_dim;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/transpose"}
+  %sub.62 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%transpose.39), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/sub"}
+  %sub.63 = f32[1,1,12,197]{3,2,1,0} reshape(%sub.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/sub"}
+  %sub.64 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%sub.63), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/sub"}
+  %sub.65 = f32[1,1,12,197,197]{4,3,2,1,0} subtract(%transpose.40, %sub.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/sub"}
+  %exp.13 = f32[1,1,12,197,197]{4,3,2,1,0} exponential(%sub.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/exp"}
+  %reduce_sum.279 = f32[1,1,12,197]{3,2,1,0} reduce(%exp.13, %constant.419), dimensions={4}, to_apply=%region_9.14, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/reduce_sum"}
+  %broadcast_in_dim.53 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%reduce_sum.279), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/broadcast_in_dim"}
+  %div.88 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%broadcast_in_dim.53), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/div"}
+  %div.89 = f32[1,1,12,197]{3,2,1,0} reshape(%div.88), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/div"}
+  %div.90 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%div.89), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/div"}
+  %div.91 = f32[1,1,12,197,197]{4,3,2,1,0} divide(%exp.13, %div.90), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/div"}
+  %convert_element_type.159 = bf16[1,1,12,197,197]{4,3,2,1,0} convert(%div.91), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/convert_element_type"}
+  %dot_general.109 = bf16[1,12,64,1,197]{4,3,2,1,0} dot(%add.532, %convert_element_type.159), lhs_batch_dims={0,2}, lhs_contracting_dims={1}, rhs_batch_dims={1,2}, rhs_contracting_dims={4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap(BNTS,BSNH->BTNH)/dot_general"}
+  %transpose.41 = bf16[1,197,12,1,64]{1,3,4,2,0} transpose(%dot_general.109), dimensions={0,4,1,3,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap()/transpose;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/vmap(BNTS,BSNH->BTNH)/transpose"}
+  %reshape.29 = bf16[1,197,12,64]{3,2,1,0} reshape(%transpose.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/reshape"}
+  %constant.432 = f32[12,64,768]{2,1,0} constant({...})
+  %convert_element_type.160 = bf16[12,64,768]{2,1,0} convert(%constant.432), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/attention_output/convert_element_type"}
+  %dot_general.110 = bf16[1,197,768]{2,1,0} dot(%reshape.29, %convert_element_type.160), lhs_contracting_dims={2,3}, rhs_contracting_dims={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/attention_output/abcd,cde->abe/dot_general"}
+  %constant.365 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.533 = bf16[1,1,768]{2,1,0} broadcast(%constant.365), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/attention_output/add"}
+  %add.534 = bf16[1,768]{1,0} reshape(%add.533), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/attention_output/add"}
+  %add.535 = bf16[1,197,768]{2,1,0} broadcast(%add.534), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/attention_output/add"}
+  %add.536 = bf16[1,197,768]{2,1,0} add(%dot_general.110, %add.535), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mha/attention_output/add"}
+  %add.537 = bf16[1,197,768]{2,1,0} add(%add.536, %add.514), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/add"}
+  %convert_element_type.161 = f32[1,197,768]{2,1,0} convert(%add.537), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/convert_element_type"}
+  %jit__var_.28 = f32[1,197,1]{2,1,0} call(%convert_element_type.161, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/jit(_var)"}
+  %add.538 = f32[1,197,1]{2,1,0} add(%jit__var_.28, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/add"}
+  %rsqrt.28 = f32[1,197,1]{2,1,0} rsqrt(%add.538), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/rsqrt"}
+  %mul.389 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.28), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/mul"}
+  %mul.390 = f32[1,197]{1,0} reshape(%mul.389), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/mul"}
+  %mul.391 = f32[1,197,768]{2,1,0} broadcast(%mul.390), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/mul"}
+  %constant.364 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.392 = f32[1,1,768]{2,1,0} broadcast(%constant.364), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/mul"}
+  %mul.393 = f32[1,768]{1,0} reshape(%mul.392), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/mul"}
+  %mul.394 = f32[1,197,768]{2,1,0} broadcast(%mul.393), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/mul"}
+  %mul.395 = f32[1,197,768]{2,1,0} multiply(%mul.391, %mul.394), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/mul"}
+  %mul.400 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.161, %mul.395), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/mul"}
+  %reduce_sum.280 = f32[1,197]{1,0} reduce(%convert_element_type.161, %constant.419), dimensions={2}, to_apply=%region_10.15, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/reduce_sum"}
+  %broadcast_in_dim.54 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.280), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/broadcast_in_dim"}
+  %div.92 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.54, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/div"}
+  %neg.41 = f32[1,197,1]{2,1,0} negate(%div.92), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/neg"}
+  %mul.396 = f32[1,197,1]{2,1,0} broadcast(%neg.41), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/mul"}
+  %mul.397 = f32[1,197]{1,0} reshape(%mul.396), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/mul"}
+  %mul.398 = f32[1,197,768]{2,1,0} broadcast(%mul.397), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/mul"}
+  %mul.399 = f32[1,197,768]{2,1,0} multiply(%mul.398, %mul.395), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/mul"}
+  %constant.363 = f32[1,1,768]{2,1,0} constant({...})
+  %add.539 = f32[1,1,768]{2,1,0} broadcast(%constant.363), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/add"}
+  %add.540 = f32[1,768]{1,0} reshape(%add.539), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/add"}
+  %add.541 = f32[1,197,768]{2,1,0} broadcast(%add.540), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/add"}
+  %add.542 = f32[1,197,768]{2,1,0} add(%mul.399, %add.541), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/add"}
+  %add.543 = f32[1,197,768]{2,1,0} add(%mul.400, %add.542), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/add"}
+  %convert_element_type.162 = bf16[1,197,768]{2,1,0} convert(%add.543), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/ln_2/convert_element_type"}
+  %constant.433 = f32[768,3072]{1,0} constant({...})
+  %convert_element_type.163 = bf16[768,3072]{1,0} convert(%constant.433), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/convert_element_type"}
+  %dot_general.111 = bf16[1,197,3072]{2,1,0} dot(%convert_element_type.162, %convert_element_type.163), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/dot_general"}
+  %constant.362 = bf16[1,1,3072]{2,1,0} constant({...})
+  %add.544 = bf16[1,1,3072]{2,1,0} broadcast(%constant.362), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/add"}
+  %add.545 = bf16[1,3072]{1,0} reshape(%add.544), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/add"}
+  %add.546 = bf16[1,197,3072]{2,1,0} broadcast(%add.545), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/add"}
+  %add.547 = bf16[1,197,3072]{2,1,0} add(%dot_general.111, %add.546), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/add"}
+  %mul.401 = bf16[1,197,3072]{2,1,0} multiply(%add.547, %broadcast.35), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/mul"}
+  %neg.42 = bf16[1,197,3072]{2,1,0} negate(%add.547), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/neg"}
+  %mul.402 = bf16[1,197,3072]{2,1,0} multiply(%neg.42, %broadcast.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/mul"}
+  %erfc.845 = f32[1,197,3072]{2,1,0} convert(%mul.402), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.906 = f32[1,197,3072]{2,1,0} abs(%erfc.845), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.907 = pred[1,197,3072]{2,1,0} compare(%erfc.906, %broadcast.67), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.891 = f32[1,197,3072]{2,1,0} multiply(%erfc.845, %erfc.845), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.892 = f32[1,197,3072]{2,1,0} multiply(%erfc.891, %broadcast.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.893 = f32[1,197,3072]{2,1,0} add(%erfc.892, %broadcast.45), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.894 = f32[1,197,3072]{2,1,0} multiply(%erfc.893, %erfc.891), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.895 = f32[1,197,3072]{2,1,0} add(%erfc.894, %broadcast.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.896 = f32[1,197,3072]{2,1,0} multiply(%erfc.895, %erfc.891), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.897 = f32[1,197,3072]{2,1,0} add(%erfc.896, %broadcast.43), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.898 = f32[1,197,3072]{2,1,0} multiply(%erfc.897, %erfc.891), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.899 = f32[1,197,3072]{2,1,0} add(%erfc.898, %broadcast.42), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.900 = f32[1,197,3072]{2,1,0} multiply(%erfc.899, %erfc.891), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.901 = f32[1,197,3072]{2,1,0} add(%erfc.900, %broadcast.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.902 = f32[1,197,3072]{2,1,0} multiply(%erfc.901, %erfc.891), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.903 = f32[1,197,3072]{2,1,0} add(%erfc.902, %broadcast.40), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.904 = f32[1,197,3072]{2,1,0} multiply(%erfc.845, %erfc.903), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.905 = f32[1,197,3072]{2,1,0} subtract(%broadcast.67, %erfc.904), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.888 = pred[1,197,3072]{2,1,0} compare(%erfc.845, %broadcast.47), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.846 = f32[1,197,3072]{2,1,0} multiply(%erfc.845, %erfc.845), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.847 = f32[1,197,3072]{2,1,0} negate(%erfc.846), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.886 = pred[1,197,3072]{2,1,0} compare(%erfc.847, %broadcast.48), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.850 = f32[1,197,3072]{2,1,0} exponential(%erfc.847), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.848 = f32[1,197,3072]{2,1,0} abs(%erfc.845), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.851 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.848), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.852 = f32[1,197,3072]{2,1,0} multiply(%erfc.850, %erfc.851), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.853 = pred[1,197,3072]{2,1,0} compare(%erfc.848, %broadcast.66), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.849 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.846), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.854 = f32[1,197,3072]{2,1,0} multiply(%erfc.849, %broadcast.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.855 = f32[1,197,3072]{2,1,0} add(%erfc.854, %broadcast.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.856 = f32[1,197,3072]{2,1,0} multiply(%erfc.855, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.857 = f32[1,197,3072]{2,1,0} add(%erfc.856, %broadcast.63), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.858 = f32[1,197,3072]{2,1,0} multiply(%erfc.857, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.859 = f32[1,197,3072]{2,1,0} add(%erfc.858, %broadcast.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.860 = f32[1,197,3072]{2,1,0} multiply(%erfc.859, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.861 = f32[1,197,3072]{2,1,0} add(%erfc.860, %broadcast.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.862 = f32[1,197,3072]{2,1,0} multiply(%erfc.861, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.863 = f32[1,197,3072]{2,1,0} add(%erfc.862, %broadcast.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.864 = f32[1,197,3072]{2,1,0} multiply(%erfc.863, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.865 = f32[1,197,3072]{2,1,0} add(%erfc.864, %broadcast.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.866 = f32[1,197,3072]{2,1,0} multiply(%erfc.865, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.867 = f32[1,197,3072]{2,1,0} add(%erfc.866, %broadcast.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.868 = f32[1,197,3072]{2,1,0} multiply(%erfc.867, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.869 = f32[1,197,3072]{2,1,0} add(%erfc.868, %broadcast.57), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.870 = f32[1,197,3072]{2,1,0} multiply(%erfc.849, %broadcast.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.871 = f32[1,197,3072]{2,1,0} add(%erfc.870, %broadcast.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.872 = f32[1,197,3072]{2,1,0} multiply(%erfc.871, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.873 = f32[1,197,3072]{2,1,0} add(%erfc.872, %broadcast.54), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.874 = f32[1,197,3072]{2,1,0} multiply(%erfc.873, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.875 = f32[1,197,3072]{2,1,0} add(%erfc.874, %broadcast.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.876 = f32[1,197,3072]{2,1,0} multiply(%erfc.875, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.877 = f32[1,197,3072]{2,1,0} add(%erfc.876, %broadcast.52), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.878 = f32[1,197,3072]{2,1,0} multiply(%erfc.877, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.879 = f32[1,197,3072]{2,1,0} add(%erfc.878, %broadcast.51), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.880 = f32[1,197,3072]{2,1,0} multiply(%erfc.879, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.881 = f32[1,197,3072]{2,1,0} add(%erfc.880, %broadcast.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.882 = f32[1,197,3072]{2,1,0} multiply(%erfc.881, %erfc.849), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.883 = f32[1,197,3072]{2,1,0} add(%erfc.882, %broadcast.49), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.884 = f32[1,197,3072]{2,1,0} select(%erfc.853, %erfc.869, %erfc.883), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.885 = f32[1,197,3072]{2,1,0} multiply(%erfc.852, %erfc.884), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.887 = f32[1,197,3072]{2,1,0} select(%erfc.886, %broadcast.47, %erfc.885), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.889 = f32[1,197,3072]{2,1,0} subtract(%broadcast.66, %erfc.887), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.890 = f32[1,197,3072]{2,1,0} select(%erfc.888, %erfc.889, %erfc.887), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.908 = f32[1,197,3072]{2,1,0} select(%erfc.907, %erfc.905, %erfc.890), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %erfc.909 = bf16[1,197,3072]{2,1,0} convert(%erfc.908), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/erfc"}
+  %mul.403 = bf16[1,197,3072]{2,1,0} multiply(%mul.401, %erfc.909), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_1/mul"}
+  %constant.434 = f32[3072,768]{1,0} constant({...})
+  %convert_element_type.164 = bf16[3072,768]{1,0} convert(%constant.434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_2/convert_element_type"}
+  %dot_general.112 = bf16[1,197,768]{2,1,0} dot(%mul.403, %convert_element_type.164), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_2/dot_general"}
+  %constant.361 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.548 = bf16[1,1,768]{2,1,0} broadcast(%constant.361), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_2/add"}
+  %add.549 = bf16[1,768]{1,0} reshape(%add.548), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_2/add"}
+  %add.550 = bf16[1,197,768]{2,1,0} broadcast(%add.549), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_2/add"}
+  %add.551 = bf16[1,197,768]{2,1,0} add(%dot_general.112, %add.550), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/mlp/dense_2/add"}
+  %add.552 = bf16[1,197,768]{2,1,0} add(%add.537, %add.551), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_2/add"}
+  %convert_element_type.165 = f32[1,197,768]{2,1,0} convert(%add.552), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/convert_element_type"}
+  %jit__var_.29 = f32[1,197,1]{2,1,0} call(%convert_element_type.165, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/jit(_var)"}
+  %add.553 = f32[1,197,1]{2,1,0} add(%jit__var_.29, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/add"}
+  %rsqrt.29 = f32[1,197,1]{2,1,0} rsqrt(%add.553), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/rsqrt"}
+  %mul.404 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.29), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/mul"}
+  %mul.405 = f32[1,197]{1,0} reshape(%mul.404), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/mul"}
+  %mul.406 = f32[1,197,768]{2,1,0} broadcast(%mul.405), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/mul"}
+  %constant.360 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.407 = f32[1,1,768]{2,1,0} broadcast(%constant.360), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/mul"}
+  %mul.408 = f32[1,768]{1,0} reshape(%mul.407), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/mul"}
+  %mul.409 = f32[1,197,768]{2,1,0} broadcast(%mul.408), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/mul"}
+  %mul.410 = f32[1,197,768]{2,1,0} multiply(%mul.406, %mul.409), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/mul"}
+  %mul.415 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.165, %mul.410), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/mul"}
+  %reduce_sum.281 = f32[1,197]{1,0} reduce(%convert_element_type.165, %constant.419), dimensions={2}, to_apply=%region_11.16, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/reduce_sum"}
+  %broadcast_in_dim.55 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.281), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/broadcast_in_dim"}
+  %div.93 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.55, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/div"}
+  %neg.43 = f32[1,197,1]{2,1,0} negate(%div.93), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/neg"}
+  %mul.411 = f32[1,197,1]{2,1,0} broadcast(%neg.43), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/mul"}
+  %mul.412 = f32[1,197]{1,0} reshape(%mul.411), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/mul"}
+  %mul.413 = f32[1,197,768]{2,1,0} broadcast(%mul.412), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/mul"}
+  %mul.414 = f32[1,197,768]{2,1,0} multiply(%mul.413, %mul.410), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/mul"}
+  %constant.359 = f32[1,1,768]{2,1,0} constant({...})
+  %add.554 = f32[1,1,768]{2,1,0} broadcast(%constant.359), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/add"}
+  %add.555 = f32[1,768]{1,0} reshape(%add.554), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/add"}
+  %add.556 = f32[1,197,768]{2,1,0} broadcast(%add.555), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/add"}
+  %add.557 = f32[1,197,768]{2,1,0} add(%mul.414, %add.556), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/add"}
+  %add.558 = f32[1,197,768]{2,1,0} add(%mul.415, %add.557), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/add"}
+  %convert_element_type.166 = bf16[1,197,768]{2,1,0} convert(%add.558), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_1/convert_element_type"}
+  %constant.437 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.169 = bf16[768,12,64]{2,1,0} convert(%constant.437), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/value/convert_element_type"}
+  %dot_general.115 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.166, %convert_element_type.169), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/value/abc,cde->abde/dot_general"}
+  %constant.356 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.567 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.356), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/value/add"}
+  %add.568 = bf16[1,12,64]{2,1,0} reshape(%add.567), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/value/add"}
+  %add.569 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.568), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/value/add"}
+  %add.570 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.115, %add.569), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/value/add"}
+  %constant.435 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.167 = bf16[768,12,64]{2,1,0} convert(%constant.435), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/query/convert_element_type"}
+  %dot_general.113 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.166, %convert_element_type.167), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/query/abc,cde->abde/dot_general"}
+  %constant.358 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.559 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.358), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/query/add"}
+  %add.560 = bf16[1,12,64]{2,1,0} reshape(%add.559), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/query/add"}
+  %add.561 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.560), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/query/add"}
+  %add.562 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.113, %add.561), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/query/add"}
+  %reshape.30 = bf16[1,197,12,1,64]{4,3,2,1,0} reshape(%add.562), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/reshape"}
+  %constant.436 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.168 = bf16[768,12,64]{2,1,0} convert(%constant.436), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/key/convert_element_type"}
+  %dot_general.114 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.166, %convert_element_type.168), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/key/abc,cde->abde/dot_general"}
+  %constant.357 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.563 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.357), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/key/add"}
+  %add.564 = bf16[1,12,64]{2,1,0} reshape(%add.563), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/key/add"}
+  %add.565 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.564), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/key/add"}
+  %add.566 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.114, %add.565), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/key/add"}
+  %dot_general.116 = f32[1,12,197,1,197]{4,3,2,1,0} dot(%reshape.30, %add.566), lhs_batch_dims={0,2}, lhs_contracting_dims={4}, rhs_batch_dims={0,2}, rhs_contracting_dims={3}, algorithm=dot_bf16_bf16_f32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap(BTNH,BSNH->BNTS)/dot_general"}
+  %mul.416 = f32[1,12,197,1,197]{4,3,2,1,0} multiply(%dot_general.116, %broadcast.37), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/mul"}
+  %transpose.43 = f32[1,1,12,197,197]{4,3,2,1,0} reshape(%mul.416), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/transpose"}
+  %reduce_max.86 = f32[1,12,197,1]{3,2,1,0} reduce(%mul.416, %constant.417), dimensions={4}, to_apply=%region_12.17, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/reduce_max"}
+  %max.14 = f32[1,12,197,1]{3,2,1,0} maximum(%reduce_max.86, %broadcast.36), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/max"}
+  %transpose.42 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%max.14), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/broadcast_in_dim;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/transpose"}
+  %sub.66 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%transpose.42), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/sub"}
+  %sub.67 = f32[1,1,12,197]{3,2,1,0} reshape(%sub.66), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/sub"}
+  %sub.68 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%sub.67), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/sub"}
+  %sub.69 = f32[1,1,12,197,197]{4,3,2,1,0} subtract(%transpose.43, %sub.68), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/sub"}
+  %exp.14 = f32[1,1,12,197,197]{4,3,2,1,0} exponential(%sub.69), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/exp"}
+  %reduce_sum.282 = f32[1,1,12,197]{3,2,1,0} reduce(%exp.14, %constant.419), dimensions={4}, to_apply=%region_13.18, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/reduce_sum"}
+  %broadcast_in_dim.56 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%reduce_sum.282), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/broadcast_in_dim"}
+  %div.94 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%broadcast_in_dim.56), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/div"}
+  %div.95 = f32[1,1,12,197]{3,2,1,0} reshape(%div.94), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/div"}
+  %div.96 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%div.95), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/div"}
+  %div.97 = f32[1,1,12,197,197]{4,3,2,1,0} divide(%exp.14, %div.96), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/div"}
+  %convert_element_type.170 = bf16[1,1,12,197,197]{4,3,2,1,0} convert(%div.97), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/convert_element_type"}
+  %dot_general.117 = bf16[1,12,64,1,197]{4,3,2,1,0} dot(%add.570, %convert_element_type.170), lhs_batch_dims={0,2}, lhs_contracting_dims={1}, rhs_batch_dims={1,2}, rhs_contracting_dims={4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap(BNTS,BSNH->BTNH)/dot_general"}
+  %transpose.44 = bf16[1,197,12,1,64]{1,3,4,2,0} transpose(%dot_general.117), dimensions={0,4,1,3,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap()/transpose;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/vmap(BNTS,BSNH->BTNH)/transpose"}
+  %reshape.31 = bf16[1,197,12,64]{3,2,1,0} reshape(%transpose.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/reshape"}
+  %constant.438 = f32[12,64,768]{2,1,0} constant({...})
+  %convert_element_type.171 = bf16[12,64,768]{2,1,0} convert(%constant.438), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/attention_output/convert_element_type"}
+  %dot_general.118 = bf16[1,197,768]{2,1,0} dot(%reshape.31, %convert_element_type.171), lhs_contracting_dims={2,3}, rhs_contracting_dims={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/attention_output/abcd,cde->abe/dot_general"}
+  %constant.355 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.571 = bf16[1,1,768]{2,1,0} broadcast(%constant.355), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/attention_output/add"}
+  %add.572 = bf16[1,768]{1,0} reshape(%add.571), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/attention_output/add"}
+  %add.573 = bf16[1,197,768]{2,1,0} broadcast(%add.572), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/attention_output/add"}
+  %add.574 = bf16[1,197,768]{2,1,0} add(%dot_general.118, %add.573), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mha/attention_output/add"}
+  %add.575 = bf16[1,197,768]{2,1,0} add(%add.574, %add.552), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/add"}
+  %convert_element_type.172 = f32[1,197,768]{2,1,0} convert(%add.575), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/convert_element_type"}
+  %jit__var_.30 = f32[1,197,1]{2,1,0} call(%convert_element_type.172, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/jit(_var)"}
+  %add.576 = f32[1,197,1]{2,1,0} add(%jit__var_.30, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/add"}
+  %rsqrt.30 = f32[1,197,1]{2,1,0} rsqrt(%add.576), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/rsqrt"}
+  %mul.417 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.30), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/mul"}
+  %mul.418 = f32[1,197]{1,0} reshape(%mul.417), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/mul"}
+  %mul.419 = f32[1,197,768]{2,1,0} broadcast(%mul.418), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/mul"}
+  %constant.354 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.420 = f32[1,1,768]{2,1,0} broadcast(%constant.354), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/mul"}
+  %mul.421 = f32[1,768]{1,0} reshape(%mul.420), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/mul"}
+  %mul.422 = f32[1,197,768]{2,1,0} broadcast(%mul.421), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/mul"}
+  %mul.423 = f32[1,197,768]{2,1,0} multiply(%mul.419, %mul.422), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/mul"}
+  %mul.428 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.172, %mul.423), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/mul"}
+  %reduce_sum.283 = f32[1,197]{1,0} reduce(%convert_element_type.172, %constant.419), dimensions={2}, to_apply=%region_14.19, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/reduce_sum"}
+  %broadcast_in_dim.57 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.283), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/broadcast_in_dim"}
+  %div.98 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.57, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/div"}
+  %neg.44 = f32[1,197,1]{2,1,0} negate(%div.98), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/neg"}
+  %mul.424 = f32[1,197,1]{2,1,0} broadcast(%neg.44), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/mul"}
+  %mul.425 = f32[1,197]{1,0} reshape(%mul.424), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/mul"}
+  %mul.426 = f32[1,197,768]{2,1,0} broadcast(%mul.425), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/mul"}
+  %mul.427 = f32[1,197,768]{2,1,0} multiply(%mul.426, %mul.423), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/mul"}
+  %constant.353 = f32[1,1,768]{2,1,0} constant({...})
+  %add.577 = f32[1,1,768]{2,1,0} broadcast(%constant.353), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/add"}
+  %add.578 = f32[1,768]{1,0} reshape(%add.577), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/add"}
+  %add.579 = f32[1,197,768]{2,1,0} broadcast(%add.578), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/add"}
+  %add.580 = f32[1,197,768]{2,1,0} add(%mul.427, %add.579), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/add"}
+  %add.581 = f32[1,197,768]{2,1,0} add(%mul.428, %add.580), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/add"}
+  %convert_element_type.173 = bf16[1,197,768]{2,1,0} convert(%add.581), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/ln_2/convert_element_type"}
+  %constant.439 = f32[768,3072]{1,0} constant({...})
+  %convert_element_type.174 = bf16[768,3072]{1,0} convert(%constant.439), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/convert_element_type"}
+  %dot_general.119 = bf16[1,197,3072]{2,1,0} dot(%convert_element_type.173, %convert_element_type.174), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/dot_general"}
+  %constant.352 = bf16[1,1,3072]{2,1,0} constant({...})
+  %add.582 = bf16[1,1,3072]{2,1,0} broadcast(%constant.352), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/add"}
+  %add.583 = bf16[1,3072]{1,0} reshape(%add.582), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/add"}
+  %add.584 = bf16[1,197,3072]{2,1,0} broadcast(%add.583), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/add"}
+  %add.585 = bf16[1,197,3072]{2,1,0} add(%dot_general.119, %add.584), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/add"}
+  %mul.429 = bf16[1,197,3072]{2,1,0} multiply(%add.585, %broadcast.35), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/mul"}
+  %neg.45 = bf16[1,197,3072]{2,1,0} negate(%add.585), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/neg"}
+  %mul.430 = bf16[1,197,3072]{2,1,0} multiply(%neg.45, %broadcast.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/mul"}
+  %erfc.910 = f32[1,197,3072]{2,1,0} convert(%mul.430), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.971 = f32[1,197,3072]{2,1,0} abs(%erfc.910), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.972 = pred[1,197,3072]{2,1,0} compare(%erfc.971, %broadcast.67), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.956 = f32[1,197,3072]{2,1,0} multiply(%erfc.910, %erfc.910), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.957 = f32[1,197,3072]{2,1,0} multiply(%erfc.956, %broadcast.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.958 = f32[1,197,3072]{2,1,0} add(%erfc.957, %broadcast.45), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.959 = f32[1,197,3072]{2,1,0} multiply(%erfc.958, %erfc.956), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.960 = f32[1,197,3072]{2,1,0} add(%erfc.959, %broadcast.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.961 = f32[1,197,3072]{2,1,0} multiply(%erfc.960, %erfc.956), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.962 = f32[1,197,3072]{2,1,0} add(%erfc.961, %broadcast.43), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.963 = f32[1,197,3072]{2,1,0} multiply(%erfc.962, %erfc.956), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.964 = f32[1,197,3072]{2,1,0} add(%erfc.963, %broadcast.42), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.965 = f32[1,197,3072]{2,1,0} multiply(%erfc.964, %erfc.956), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.966 = f32[1,197,3072]{2,1,0} add(%erfc.965, %broadcast.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.967 = f32[1,197,3072]{2,1,0} multiply(%erfc.966, %erfc.956), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.968 = f32[1,197,3072]{2,1,0} add(%erfc.967, %broadcast.40), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.969 = f32[1,197,3072]{2,1,0} multiply(%erfc.910, %erfc.968), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.970 = f32[1,197,3072]{2,1,0} subtract(%broadcast.67, %erfc.969), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.953 = pred[1,197,3072]{2,1,0} compare(%erfc.910, %broadcast.47), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.911 = f32[1,197,3072]{2,1,0} multiply(%erfc.910, %erfc.910), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.912 = f32[1,197,3072]{2,1,0} negate(%erfc.911), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.951 = pred[1,197,3072]{2,1,0} compare(%erfc.912, %broadcast.48), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.915 = f32[1,197,3072]{2,1,0} exponential(%erfc.912), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.913 = f32[1,197,3072]{2,1,0} abs(%erfc.910), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.916 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.913), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.917 = f32[1,197,3072]{2,1,0} multiply(%erfc.915, %erfc.916), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.918 = pred[1,197,3072]{2,1,0} compare(%erfc.913, %broadcast.66), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.914 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.911), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.919 = f32[1,197,3072]{2,1,0} multiply(%erfc.914, %broadcast.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.920 = f32[1,197,3072]{2,1,0} add(%erfc.919, %broadcast.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.921 = f32[1,197,3072]{2,1,0} multiply(%erfc.920, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.922 = f32[1,197,3072]{2,1,0} add(%erfc.921, %broadcast.63), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.923 = f32[1,197,3072]{2,1,0} multiply(%erfc.922, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.924 = f32[1,197,3072]{2,1,0} add(%erfc.923, %broadcast.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.925 = f32[1,197,3072]{2,1,0} multiply(%erfc.924, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.926 = f32[1,197,3072]{2,1,0} add(%erfc.925, %broadcast.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.927 = f32[1,197,3072]{2,1,0} multiply(%erfc.926, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.928 = f32[1,197,3072]{2,1,0} add(%erfc.927, %broadcast.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.929 = f32[1,197,3072]{2,1,0} multiply(%erfc.928, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.930 = f32[1,197,3072]{2,1,0} add(%erfc.929, %broadcast.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.931 = f32[1,197,3072]{2,1,0} multiply(%erfc.930, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.932 = f32[1,197,3072]{2,1,0} add(%erfc.931, %broadcast.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.933 = f32[1,197,3072]{2,1,0} multiply(%erfc.932, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.934 = f32[1,197,3072]{2,1,0} add(%erfc.933, %broadcast.57), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.935 = f32[1,197,3072]{2,1,0} multiply(%erfc.914, %broadcast.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.936 = f32[1,197,3072]{2,1,0} add(%erfc.935, %broadcast.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.937 = f32[1,197,3072]{2,1,0} multiply(%erfc.936, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.938 = f32[1,197,3072]{2,1,0} add(%erfc.937, %broadcast.54), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.939 = f32[1,197,3072]{2,1,0} multiply(%erfc.938, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.940 = f32[1,197,3072]{2,1,0} add(%erfc.939, %broadcast.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.941 = f32[1,197,3072]{2,1,0} multiply(%erfc.940, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.942 = f32[1,197,3072]{2,1,0} add(%erfc.941, %broadcast.52), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.943 = f32[1,197,3072]{2,1,0} multiply(%erfc.942, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.944 = f32[1,197,3072]{2,1,0} add(%erfc.943, %broadcast.51), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.945 = f32[1,197,3072]{2,1,0} multiply(%erfc.944, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.946 = f32[1,197,3072]{2,1,0} add(%erfc.945, %broadcast.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.947 = f32[1,197,3072]{2,1,0} multiply(%erfc.946, %erfc.914), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.948 = f32[1,197,3072]{2,1,0} add(%erfc.947, %broadcast.49), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.949 = f32[1,197,3072]{2,1,0} select(%erfc.918, %erfc.934, %erfc.948), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.950 = f32[1,197,3072]{2,1,0} multiply(%erfc.917, %erfc.949), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.952 = f32[1,197,3072]{2,1,0} select(%erfc.951, %broadcast.47, %erfc.950), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.954 = f32[1,197,3072]{2,1,0} subtract(%broadcast.66, %erfc.952), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.955 = f32[1,197,3072]{2,1,0} select(%erfc.953, %erfc.954, %erfc.952), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.973 = f32[1,197,3072]{2,1,0} select(%erfc.972, %erfc.970, %erfc.955), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %erfc.974 = bf16[1,197,3072]{2,1,0} convert(%erfc.973), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/erfc"}
+  %mul.431 = bf16[1,197,3072]{2,1,0} multiply(%mul.429, %erfc.974), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_1/mul"}
+  %constant.440 = f32[3072,768]{1,0} constant({...})
+  %convert_element_type.175 = bf16[3072,768]{1,0} convert(%constant.440), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_2/convert_element_type"}
+  %dot_general.120 = bf16[1,197,768]{2,1,0} dot(%mul.431, %convert_element_type.175), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_2/dot_general"}
+  %constant.351 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.586 = bf16[1,1,768]{2,1,0} broadcast(%constant.351), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_2/add"}
+  %add.587 = bf16[1,768]{1,0} reshape(%add.586), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_2/add"}
+  %add.588 = bf16[1,197,768]{2,1,0} broadcast(%add.587), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_2/add"}
+  %add.589 = bf16[1,197,768]{2,1,0} add(%dot_general.120, %add.588), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/mlp/dense_2/add"}
+  %add.590 = bf16[1,197,768]{2,1,0} add(%add.575, %add.589), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_3/add"}
+  %convert_element_type.176 = f32[1,197,768]{2,1,0} convert(%add.590), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/convert_element_type"}
+  %jit__var_.31 = f32[1,197,1]{2,1,0} call(%convert_element_type.176, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/jit(_var)"}
+  %add.591 = f32[1,197,1]{2,1,0} add(%jit__var_.31, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/add"}
+  %rsqrt.31 = f32[1,197,1]{2,1,0} rsqrt(%add.591), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/rsqrt"}
+  %mul.432 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.31), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/mul"}
+  %mul.433 = f32[1,197]{1,0} reshape(%mul.432), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/mul"}
+  %mul.434 = f32[1,197,768]{2,1,0} broadcast(%mul.433), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/mul"}
+  %constant.350 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.435 = f32[1,1,768]{2,1,0} broadcast(%constant.350), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/mul"}
+  %mul.436 = f32[1,768]{1,0} reshape(%mul.435), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/mul"}
+  %mul.437 = f32[1,197,768]{2,1,0} broadcast(%mul.436), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/mul"}
+  %mul.438 = f32[1,197,768]{2,1,0} multiply(%mul.434, %mul.437), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/mul"}
+  %mul.443 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.176, %mul.438), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/mul"}
+  %reduce_sum.284 = f32[1,197]{1,0} reduce(%convert_element_type.176, %constant.419), dimensions={2}, to_apply=%region_15.20, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/reduce_sum"}
+  %broadcast_in_dim.58 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.284), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/broadcast_in_dim"}
+  %div.99 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.58, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/div"}
+  %neg.46 = f32[1,197,1]{2,1,0} negate(%div.99), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/neg"}
+  %mul.439 = f32[1,197,1]{2,1,0} broadcast(%neg.46), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/mul"}
+  %mul.440 = f32[1,197]{1,0} reshape(%mul.439), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/mul"}
+  %mul.441 = f32[1,197,768]{2,1,0} broadcast(%mul.440), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/mul"}
+  %mul.442 = f32[1,197,768]{2,1,0} multiply(%mul.441, %mul.438), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/mul"}
+  %constant.349 = f32[1,1,768]{2,1,0} constant({...})
+  %add.592 = f32[1,1,768]{2,1,0} broadcast(%constant.349), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/add"}
+  %add.593 = f32[1,768]{1,0} reshape(%add.592), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/add"}
+  %add.594 = f32[1,197,768]{2,1,0} broadcast(%add.593), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/add"}
+  %add.595 = f32[1,197,768]{2,1,0} add(%mul.442, %add.594), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/add"}
+  %add.596 = f32[1,197,768]{2,1,0} add(%mul.443, %add.595), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/add"}
+  %convert_element_type.177 = bf16[1,197,768]{2,1,0} convert(%add.596), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_1/convert_element_type"}
+  %constant.443 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.180 = bf16[768,12,64]{2,1,0} convert(%constant.443), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/value/convert_element_type"}
+  %dot_general.123 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.177, %convert_element_type.180), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/value/abc,cde->abde/dot_general"}
+  %constant.346 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.605 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.346), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/value/add"}
+  %add.606 = bf16[1,12,64]{2,1,0} reshape(%add.605), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/value/add"}
+  %add.607 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.606), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/value/add"}
+  %add.608 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.123, %add.607), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/value/add"}
+  %constant.441 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.178 = bf16[768,12,64]{2,1,0} convert(%constant.441), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/query/convert_element_type"}
+  %dot_general.121 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.177, %convert_element_type.178), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/query/abc,cde->abde/dot_general"}
+  %constant.348 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.597 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.348), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/query/add"}
+  %add.598 = bf16[1,12,64]{2,1,0} reshape(%add.597), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/query/add"}
+  %add.599 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.598), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/query/add"}
+  %add.600 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.121, %add.599), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/query/add"}
+  %reshape.32 = bf16[1,197,12,1,64]{4,3,2,1,0} reshape(%add.600), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/reshape"}
+  %constant.442 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.179 = bf16[768,12,64]{2,1,0} convert(%constant.442), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/key/convert_element_type"}
+  %dot_general.122 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.177, %convert_element_type.179), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/key/abc,cde->abde/dot_general"}
+  %constant.347 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.601 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.347), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/key/add"}
+  %add.602 = bf16[1,12,64]{2,1,0} reshape(%add.601), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/key/add"}
+  %add.603 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.602), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/key/add"}
+  %add.604 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.122, %add.603), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/key/add"}
+  %dot_general.124 = f32[1,12,197,1,197]{4,3,2,1,0} dot(%reshape.32, %add.604), lhs_batch_dims={0,2}, lhs_contracting_dims={4}, rhs_batch_dims={0,2}, rhs_contracting_dims={3}, algorithm=dot_bf16_bf16_f32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap(BTNH,BSNH->BNTS)/dot_general"}
+  %mul.444 = f32[1,12,197,1,197]{4,3,2,1,0} multiply(%dot_general.124, %broadcast.37), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/mul"}
+  %transpose.46 = f32[1,1,12,197,197]{4,3,2,1,0} reshape(%mul.444), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/transpose"}
+  %reduce_max.87 = f32[1,12,197,1]{3,2,1,0} reduce(%mul.444, %constant.417), dimensions={4}, to_apply=%region_16.21, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/reduce_max"}
+  %max.15 = f32[1,12,197,1]{3,2,1,0} maximum(%reduce_max.87, %broadcast.36), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/max"}
+  %transpose.45 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%max.15), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/broadcast_in_dim;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/transpose"}
+  %sub.70 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%transpose.45), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/sub"}
+  %sub.71 = f32[1,1,12,197]{3,2,1,0} reshape(%sub.70), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/sub"}
+  %sub.72 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%sub.71), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/sub"}
+  %sub.73 = f32[1,1,12,197,197]{4,3,2,1,0} subtract(%transpose.46, %sub.72), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/sub"}
+  %exp.15 = f32[1,1,12,197,197]{4,3,2,1,0} exponential(%sub.73), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/exp"}
+  %reduce_sum.285 = f32[1,1,12,197]{3,2,1,0} reduce(%exp.15, %constant.419), dimensions={4}, to_apply=%region_17.22, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/reduce_sum"}
+  %broadcast_in_dim.59 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%reduce_sum.285), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/broadcast_in_dim"}
+  %div.100 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%broadcast_in_dim.59), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/div"}
+  %div.101 = f32[1,1,12,197]{3,2,1,0} reshape(%div.100), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/div"}
+  %div.102 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%div.101), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/div"}
+  %div.103 = f32[1,1,12,197,197]{4,3,2,1,0} divide(%exp.15, %div.102), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/div"}
+  %convert_element_type.181 = bf16[1,1,12,197,197]{4,3,2,1,0} convert(%div.103), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/convert_element_type"}
+  %dot_general.125 = bf16[1,12,64,1,197]{4,3,2,1,0} dot(%add.608, %convert_element_type.181), lhs_batch_dims={0,2}, lhs_contracting_dims={1}, rhs_batch_dims={1,2}, rhs_contracting_dims={4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap(BNTS,BSNH->BTNH)/dot_general"}
+  %transpose.47 = bf16[1,197,12,1,64]{1,3,4,2,0} transpose(%dot_general.125), dimensions={0,4,1,3,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap()/transpose;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/vmap(BNTS,BSNH->BTNH)/transpose"}
+  %reshape.33 = bf16[1,197,12,64]{3,2,1,0} reshape(%transpose.47), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/reshape"}
+  %constant.444 = f32[12,64,768]{2,1,0} constant({...})
+  %convert_element_type.182 = bf16[12,64,768]{2,1,0} convert(%constant.444), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/attention_output/convert_element_type"}
+  %dot_general.126 = bf16[1,197,768]{2,1,0} dot(%reshape.33, %convert_element_type.182), lhs_contracting_dims={2,3}, rhs_contracting_dims={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/attention_output/abcd,cde->abe/dot_general"}
+  %constant.345 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.609 = bf16[1,1,768]{2,1,0} broadcast(%constant.345), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/attention_output/add"}
+  %add.610 = bf16[1,768]{1,0} reshape(%add.609), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/attention_output/add"}
+  %add.611 = bf16[1,197,768]{2,1,0} broadcast(%add.610), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/attention_output/add"}
+  %add.612 = bf16[1,197,768]{2,1,0} add(%dot_general.126, %add.611), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mha/attention_output/add"}
+  %add.613 = bf16[1,197,768]{2,1,0} add(%add.612, %add.590), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/add"}
+  %convert_element_type.183 = f32[1,197,768]{2,1,0} convert(%add.613), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/convert_element_type"}
+  %jit__var_.32 = f32[1,197,1]{2,1,0} call(%convert_element_type.183, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/jit(_var)"}
+  %add.614 = f32[1,197,1]{2,1,0} add(%jit__var_.32, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/add"}
+  %rsqrt.32 = f32[1,197,1]{2,1,0} rsqrt(%add.614), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/rsqrt"}
+  %mul.445 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.32), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/mul"}
+  %mul.446 = f32[1,197]{1,0} reshape(%mul.445), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/mul"}
+  %mul.447 = f32[1,197,768]{2,1,0} broadcast(%mul.446), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/mul"}
+  %constant.344 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.448 = f32[1,1,768]{2,1,0} broadcast(%constant.344), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/mul"}
+  %mul.449 = f32[1,768]{1,0} reshape(%mul.448), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/mul"}
+  %mul.450 = f32[1,197,768]{2,1,0} broadcast(%mul.449), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/mul"}
+  %mul.451 = f32[1,197,768]{2,1,0} multiply(%mul.447, %mul.450), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/mul"}
+  %mul.456 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.183, %mul.451), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/mul"}
+  %reduce_sum.286 = f32[1,197]{1,0} reduce(%convert_element_type.183, %constant.419), dimensions={2}, to_apply=%region_18.23, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/reduce_sum"}
+  %broadcast_in_dim.60 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.286), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/broadcast_in_dim"}
+  %div.104 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.60, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/div"}
+  %neg.47 = f32[1,197,1]{2,1,0} negate(%div.104), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/neg"}
+  %mul.452 = f32[1,197,1]{2,1,0} broadcast(%neg.47), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/mul"}
+  %mul.453 = f32[1,197]{1,0} reshape(%mul.452), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/mul"}
+  %mul.454 = f32[1,197,768]{2,1,0} broadcast(%mul.453), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/mul"}
+  %mul.455 = f32[1,197,768]{2,1,0} multiply(%mul.454, %mul.451), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/mul"}
+  %constant.343 = f32[1,1,768]{2,1,0} constant({...})
+  %add.615 = f32[1,1,768]{2,1,0} broadcast(%constant.343), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/add"}
+  %add.616 = f32[1,768]{1,0} reshape(%add.615), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/add"}
+  %add.617 = f32[1,197,768]{2,1,0} broadcast(%add.616), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/add"}
+  %add.618 = f32[1,197,768]{2,1,0} add(%mul.455, %add.617), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/add"}
+  %add.619 = f32[1,197,768]{2,1,0} add(%mul.456, %add.618), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/add"}
+  %convert_element_type.184 = bf16[1,197,768]{2,1,0} convert(%add.619), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/ln_2/convert_element_type"}
+  %constant.445 = f32[768,3072]{1,0} constant({...})
+  %convert_element_type.185 = bf16[768,3072]{1,0} convert(%constant.445), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/convert_element_type"}
+  %dot_general.127 = bf16[1,197,3072]{2,1,0} dot(%convert_element_type.184, %convert_element_type.185), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/dot_general"}
+  %constant.342 = bf16[1,1,3072]{2,1,0} constant({...})
+  %add.620 = bf16[1,1,3072]{2,1,0} broadcast(%constant.342), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/add"}
+  %add.621 = bf16[1,3072]{1,0} reshape(%add.620), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/add"}
+  %add.622 = bf16[1,197,3072]{2,1,0} broadcast(%add.621), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/add"}
+  %add.623 = bf16[1,197,3072]{2,1,0} add(%dot_general.127, %add.622), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/add"}
+  %mul.457 = bf16[1,197,3072]{2,1,0} multiply(%add.623, %broadcast.35), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/mul"}
+  %neg.48 = bf16[1,197,3072]{2,1,0} negate(%add.623), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/neg"}
+  %mul.458 = bf16[1,197,3072]{2,1,0} multiply(%neg.48, %broadcast.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/mul"}
+  %erfc.975 = f32[1,197,3072]{2,1,0} convert(%mul.458), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1036 = f32[1,197,3072]{2,1,0} abs(%erfc.975), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1037 = pred[1,197,3072]{2,1,0} compare(%erfc.1036, %broadcast.67), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1021 = f32[1,197,3072]{2,1,0} multiply(%erfc.975, %erfc.975), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1022 = f32[1,197,3072]{2,1,0} multiply(%erfc.1021, %broadcast.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1023 = f32[1,197,3072]{2,1,0} add(%erfc.1022, %broadcast.45), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1024 = f32[1,197,3072]{2,1,0} multiply(%erfc.1023, %erfc.1021), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1025 = f32[1,197,3072]{2,1,0} add(%erfc.1024, %broadcast.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1026 = f32[1,197,3072]{2,1,0} multiply(%erfc.1025, %erfc.1021), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1027 = f32[1,197,3072]{2,1,0} add(%erfc.1026, %broadcast.43), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1028 = f32[1,197,3072]{2,1,0} multiply(%erfc.1027, %erfc.1021), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1029 = f32[1,197,3072]{2,1,0} add(%erfc.1028, %broadcast.42), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1030 = f32[1,197,3072]{2,1,0} multiply(%erfc.1029, %erfc.1021), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1031 = f32[1,197,3072]{2,1,0} add(%erfc.1030, %broadcast.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1032 = f32[1,197,3072]{2,1,0} multiply(%erfc.1031, %erfc.1021), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1033 = f32[1,197,3072]{2,1,0} add(%erfc.1032, %broadcast.40), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1034 = f32[1,197,3072]{2,1,0} multiply(%erfc.975, %erfc.1033), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1035 = f32[1,197,3072]{2,1,0} subtract(%broadcast.67, %erfc.1034), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1018 = pred[1,197,3072]{2,1,0} compare(%erfc.975, %broadcast.47), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.976 = f32[1,197,3072]{2,1,0} multiply(%erfc.975, %erfc.975), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.977 = f32[1,197,3072]{2,1,0} negate(%erfc.976), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1016 = pred[1,197,3072]{2,1,0} compare(%erfc.977, %broadcast.48), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.980 = f32[1,197,3072]{2,1,0} exponential(%erfc.977), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.978 = f32[1,197,3072]{2,1,0} abs(%erfc.975), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.981 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.978), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.982 = f32[1,197,3072]{2,1,0} multiply(%erfc.980, %erfc.981), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.983 = pred[1,197,3072]{2,1,0} compare(%erfc.978, %broadcast.66), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.979 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.976), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.984 = f32[1,197,3072]{2,1,0} multiply(%erfc.979, %broadcast.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.985 = f32[1,197,3072]{2,1,0} add(%erfc.984, %broadcast.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.986 = f32[1,197,3072]{2,1,0} multiply(%erfc.985, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.987 = f32[1,197,3072]{2,1,0} add(%erfc.986, %broadcast.63), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.988 = f32[1,197,3072]{2,1,0} multiply(%erfc.987, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.989 = f32[1,197,3072]{2,1,0} add(%erfc.988, %broadcast.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.990 = f32[1,197,3072]{2,1,0} multiply(%erfc.989, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.991 = f32[1,197,3072]{2,1,0} add(%erfc.990, %broadcast.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.992 = f32[1,197,3072]{2,1,0} multiply(%erfc.991, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.993 = f32[1,197,3072]{2,1,0} add(%erfc.992, %broadcast.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.994 = f32[1,197,3072]{2,1,0} multiply(%erfc.993, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.995 = f32[1,197,3072]{2,1,0} add(%erfc.994, %broadcast.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.996 = f32[1,197,3072]{2,1,0} multiply(%erfc.995, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.997 = f32[1,197,3072]{2,1,0} add(%erfc.996, %broadcast.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.998 = f32[1,197,3072]{2,1,0} multiply(%erfc.997, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.999 = f32[1,197,3072]{2,1,0} add(%erfc.998, %broadcast.57), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1000 = f32[1,197,3072]{2,1,0} multiply(%erfc.979, %broadcast.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1001 = f32[1,197,3072]{2,1,0} add(%erfc.1000, %broadcast.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1002 = f32[1,197,3072]{2,1,0} multiply(%erfc.1001, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1003 = f32[1,197,3072]{2,1,0} add(%erfc.1002, %broadcast.54), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1004 = f32[1,197,3072]{2,1,0} multiply(%erfc.1003, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1005 = f32[1,197,3072]{2,1,0} add(%erfc.1004, %broadcast.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1006 = f32[1,197,3072]{2,1,0} multiply(%erfc.1005, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1007 = f32[1,197,3072]{2,1,0} add(%erfc.1006, %broadcast.52), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1008 = f32[1,197,3072]{2,1,0} multiply(%erfc.1007, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1009 = f32[1,197,3072]{2,1,0} add(%erfc.1008, %broadcast.51), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1010 = f32[1,197,3072]{2,1,0} multiply(%erfc.1009, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1011 = f32[1,197,3072]{2,1,0} add(%erfc.1010, %broadcast.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1012 = f32[1,197,3072]{2,1,0} multiply(%erfc.1011, %erfc.979), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1013 = f32[1,197,3072]{2,1,0} add(%erfc.1012, %broadcast.49), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1014 = f32[1,197,3072]{2,1,0} select(%erfc.983, %erfc.999, %erfc.1013), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1015 = f32[1,197,3072]{2,1,0} multiply(%erfc.982, %erfc.1014), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1017 = f32[1,197,3072]{2,1,0} select(%erfc.1016, %broadcast.47, %erfc.1015), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1019 = f32[1,197,3072]{2,1,0} subtract(%broadcast.66, %erfc.1017), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1020 = f32[1,197,3072]{2,1,0} select(%erfc.1018, %erfc.1019, %erfc.1017), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1038 = f32[1,197,3072]{2,1,0} select(%erfc.1037, %erfc.1035, %erfc.1020), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %erfc.1039 = bf16[1,197,3072]{2,1,0} convert(%erfc.1038), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/erfc"}
+  %mul.459 = bf16[1,197,3072]{2,1,0} multiply(%mul.457, %erfc.1039), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_1/mul"}
+  %constant.446 = f32[3072,768]{1,0} constant({...})
+  %convert_element_type.186 = bf16[3072,768]{1,0} convert(%constant.446), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_2/convert_element_type"}
+  %dot_general.128 = bf16[1,197,768]{2,1,0} dot(%mul.459, %convert_element_type.186), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_2/dot_general"}
+  %constant.341 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.624 = bf16[1,1,768]{2,1,0} broadcast(%constant.341), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_2/add"}
+  %add.625 = bf16[1,768]{1,0} reshape(%add.624), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_2/add"}
+  %add.626 = bf16[1,197,768]{2,1,0} broadcast(%add.625), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_2/add"}
+  %add.627 = bf16[1,197,768]{2,1,0} add(%dot_general.128, %add.626), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/mlp/dense_2/add"}
+  %add.628 = bf16[1,197,768]{2,1,0} add(%add.613, %add.627), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_4/add"}
+  %convert_element_type.187 = f32[1,197,768]{2,1,0} convert(%add.628), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/convert_element_type"}
+  %jit__var_.33 = f32[1,197,1]{2,1,0} call(%convert_element_type.187, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/jit(_var)"}
+  %add.629 = f32[1,197,1]{2,1,0} add(%jit__var_.33, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/add"}
+  %rsqrt.33 = f32[1,197,1]{2,1,0} rsqrt(%add.629), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/rsqrt"}
+  %mul.460 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.33), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/mul"}
+  %mul.461 = f32[1,197]{1,0} reshape(%mul.460), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/mul"}
+  %mul.462 = f32[1,197,768]{2,1,0} broadcast(%mul.461), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/mul"}
+  %constant.340 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.463 = f32[1,1,768]{2,1,0} broadcast(%constant.340), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/mul"}
+  %mul.464 = f32[1,768]{1,0} reshape(%mul.463), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/mul"}
+  %mul.465 = f32[1,197,768]{2,1,0} broadcast(%mul.464), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/mul"}
+  %mul.466 = f32[1,197,768]{2,1,0} multiply(%mul.462, %mul.465), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/mul"}
+  %mul.471 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.187, %mul.466), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/mul"}
+  %reduce_sum.287 = f32[1,197]{1,0} reduce(%convert_element_type.187, %constant.419), dimensions={2}, to_apply=%region_19.24, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/reduce_sum"}
+  %broadcast_in_dim.61 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.287), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/broadcast_in_dim"}
+  %div.105 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.61, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/div"}
+  %neg.49 = f32[1,197,1]{2,1,0} negate(%div.105), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/neg"}
+  %mul.467 = f32[1,197,1]{2,1,0} broadcast(%neg.49), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/mul"}
+  %mul.468 = f32[1,197]{1,0} reshape(%mul.467), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/mul"}
+  %mul.469 = f32[1,197,768]{2,1,0} broadcast(%mul.468), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/mul"}
+  %mul.470 = f32[1,197,768]{2,1,0} multiply(%mul.469, %mul.466), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/mul"}
+  %constant.339 = f32[1,1,768]{2,1,0} constant({...})
+  %add.630 = f32[1,1,768]{2,1,0} broadcast(%constant.339), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/add"}
+  %add.631 = f32[1,768]{1,0} reshape(%add.630), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/add"}
+  %add.632 = f32[1,197,768]{2,1,0} broadcast(%add.631), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/add"}
+  %add.633 = f32[1,197,768]{2,1,0} add(%mul.470, %add.632), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/add"}
+  %add.634 = f32[1,197,768]{2,1,0} add(%mul.471, %add.633), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/add"}
+  %convert_element_type.188 = bf16[1,197,768]{2,1,0} convert(%add.634), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_1/convert_element_type"}
+  %constant.449 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.191 = bf16[768,12,64]{2,1,0} convert(%constant.449), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/value/convert_element_type"}
+  %dot_general.131 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.188, %convert_element_type.191), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/value/abc,cde->abde/dot_general"}
+  %constant.336 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.643 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.336), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/value/add"}
+  %add.644 = bf16[1,12,64]{2,1,0} reshape(%add.643), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/value/add"}
+  %add.645 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.644), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/value/add"}
+  %add.646 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.131, %add.645), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/value/add"}
+  %constant.447 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.189 = bf16[768,12,64]{2,1,0} convert(%constant.447), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/query/convert_element_type"}
+  %dot_general.129 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.188, %convert_element_type.189), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/query/abc,cde->abde/dot_general"}
+  %constant.338 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.635 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.338), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/query/add"}
+  %add.636 = bf16[1,12,64]{2,1,0} reshape(%add.635), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/query/add"}
+  %add.637 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.636), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/query/add"}
+  %add.638 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.129, %add.637), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/query/add"}
+  %reshape.34 = bf16[1,197,12,1,64]{4,3,2,1,0} reshape(%add.638), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/reshape"}
+  %constant.448 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.190 = bf16[768,12,64]{2,1,0} convert(%constant.448), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/key/convert_element_type"}
+  %dot_general.130 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.188, %convert_element_type.190), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/key/abc,cde->abde/dot_general"}
+  %constant.337 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.639 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.337), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/key/add"}
+  %add.640 = bf16[1,12,64]{2,1,0} reshape(%add.639), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/key/add"}
+  %add.641 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.640), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/key/add"}
+  %add.642 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.130, %add.641), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/key/add"}
+  %dot_general.132 = f32[1,12,197,1,197]{4,3,2,1,0} dot(%reshape.34, %add.642), lhs_batch_dims={0,2}, lhs_contracting_dims={4}, rhs_batch_dims={0,2}, rhs_contracting_dims={3}, algorithm=dot_bf16_bf16_f32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap(BTNH,BSNH->BNTS)/dot_general"}
+  %mul.472 = f32[1,12,197,1,197]{4,3,2,1,0} multiply(%dot_general.132, %broadcast.37), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/mul"}
+  %transpose.49 = f32[1,1,12,197,197]{4,3,2,1,0} reshape(%mul.472), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/transpose"}
+  %reduce_max.88 = f32[1,12,197,1]{3,2,1,0} reduce(%mul.472, %constant.417), dimensions={4}, to_apply=%region_20.25, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/reduce_max"}
+  %max.16 = f32[1,12,197,1]{3,2,1,0} maximum(%reduce_max.88, %broadcast.36), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/max"}
+  %transpose.48 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%max.16), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/broadcast_in_dim;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/transpose"}
+  %sub.74 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%transpose.48), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/sub"}
+  %sub.75 = f32[1,1,12,197]{3,2,1,0} reshape(%sub.74), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/sub"}
+  %sub.76 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%sub.75), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/sub"}
+  %sub.77 = f32[1,1,12,197,197]{4,3,2,1,0} subtract(%transpose.49, %sub.76), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/sub"}
+  %exp.16 = f32[1,1,12,197,197]{4,3,2,1,0} exponential(%sub.77), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/exp"}
+  %reduce_sum.288 = f32[1,1,12,197]{3,2,1,0} reduce(%exp.16, %constant.419), dimensions={4}, to_apply=%region_21.26, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/reduce_sum"}
+  %broadcast_in_dim.62 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%reduce_sum.288), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/broadcast_in_dim"}
+  %div.106 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%broadcast_in_dim.62), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/div"}
+  %div.107 = f32[1,1,12,197]{3,2,1,0} reshape(%div.106), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/div"}
+  %div.108 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%div.107), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/div"}
+  %div.109 = f32[1,1,12,197,197]{4,3,2,1,0} divide(%exp.16, %div.108), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/div"}
+  %convert_element_type.192 = bf16[1,1,12,197,197]{4,3,2,1,0} convert(%div.109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/convert_element_type"}
+  %dot_general.133 = bf16[1,12,64,1,197]{4,3,2,1,0} dot(%add.646, %convert_element_type.192), lhs_batch_dims={0,2}, lhs_contracting_dims={1}, rhs_batch_dims={1,2}, rhs_contracting_dims={4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap(BNTS,BSNH->BTNH)/dot_general"}
+  %transpose.50 = bf16[1,197,12,1,64]{1,3,4,2,0} transpose(%dot_general.133), dimensions={0,4,1,3,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap()/transpose;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/vmap(BNTS,BSNH->BTNH)/transpose"}
+  %reshape.35 = bf16[1,197,12,64]{3,2,1,0} reshape(%transpose.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/reshape"}
+  %constant.450 = f32[12,64,768]{2,1,0} constant({...})
+  %convert_element_type.193 = bf16[12,64,768]{2,1,0} convert(%constant.450), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/attention_output/convert_element_type"}
+  %dot_general.134 = bf16[1,197,768]{2,1,0} dot(%reshape.35, %convert_element_type.193), lhs_contracting_dims={2,3}, rhs_contracting_dims={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/attention_output/abcd,cde->abe/dot_general"}
+  %constant.335 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.647 = bf16[1,1,768]{2,1,0} broadcast(%constant.335), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/attention_output/add"}
+  %add.648 = bf16[1,768]{1,0} reshape(%add.647), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/attention_output/add"}
+  %add.649 = bf16[1,197,768]{2,1,0} broadcast(%add.648), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/attention_output/add"}
+  %add.650 = bf16[1,197,768]{2,1,0} add(%dot_general.134, %add.649), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mha/attention_output/add"}
+  %add.651 = bf16[1,197,768]{2,1,0} add(%add.650, %add.628), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/add"}
+  %convert_element_type.194 = f32[1,197,768]{2,1,0} convert(%add.651), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/convert_element_type"}
+  %jit__var_.34 = f32[1,197,1]{2,1,0} call(%convert_element_type.194, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/jit(_var)"}
+  %add.652 = f32[1,197,1]{2,1,0} add(%jit__var_.34, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/add"}
+  %rsqrt.34 = f32[1,197,1]{2,1,0} rsqrt(%add.652), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/rsqrt"}
+  %mul.473 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.34), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/mul"}
+  %mul.474 = f32[1,197]{1,0} reshape(%mul.473), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/mul"}
+  %mul.475 = f32[1,197,768]{2,1,0} broadcast(%mul.474), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/mul"}
+  %constant.334 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.476 = f32[1,1,768]{2,1,0} broadcast(%constant.334), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/mul"}
+  %mul.477 = f32[1,768]{1,0} reshape(%mul.476), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/mul"}
+  %mul.478 = f32[1,197,768]{2,1,0} broadcast(%mul.477), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/mul"}
+  %mul.479 = f32[1,197,768]{2,1,0} multiply(%mul.475, %mul.478), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/mul"}
+  %mul.484 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.194, %mul.479), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/mul"}
+  %reduce_sum.289 = f32[1,197]{1,0} reduce(%convert_element_type.194, %constant.419), dimensions={2}, to_apply=%region_22.27, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/reduce_sum"}
+  %broadcast_in_dim.63 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.289), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/broadcast_in_dim"}
+  %div.110 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.63, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/div"}
+  %neg.50 = f32[1,197,1]{2,1,0} negate(%div.110), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/neg"}
+  %mul.480 = f32[1,197,1]{2,1,0} broadcast(%neg.50), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/mul"}
+  %mul.481 = f32[1,197]{1,0} reshape(%mul.480), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/mul"}
+  %mul.482 = f32[1,197,768]{2,1,0} broadcast(%mul.481), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/mul"}
+  %mul.483 = f32[1,197,768]{2,1,0} multiply(%mul.482, %mul.479), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/mul"}
+  %constant.333 = f32[1,1,768]{2,1,0} constant({...})
+  %add.653 = f32[1,1,768]{2,1,0} broadcast(%constant.333), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/add"}
+  %add.654 = f32[1,768]{1,0} reshape(%add.653), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/add"}
+  %add.655 = f32[1,197,768]{2,1,0} broadcast(%add.654), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/add"}
+  %add.656 = f32[1,197,768]{2,1,0} add(%mul.483, %add.655), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/add"}
+  %add.657 = f32[1,197,768]{2,1,0} add(%mul.484, %add.656), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/add"}
+  %convert_element_type.195 = bf16[1,197,768]{2,1,0} convert(%add.657), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/ln_2/convert_element_type"}
+  %constant.451 = f32[768,3072]{1,0} constant({...})
+  %convert_element_type.196 = bf16[768,3072]{1,0} convert(%constant.451), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/convert_element_type"}
+  %dot_general.135 = bf16[1,197,3072]{2,1,0} dot(%convert_element_type.195, %convert_element_type.196), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/dot_general"}
+  %constant.332 = bf16[1,1,3072]{2,1,0} constant({...})
+  %add.658 = bf16[1,1,3072]{2,1,0} broadcast(%constant.332), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/add"}
+  %add.659 = bf16[1,3072]{1,0} reshape(%add.658), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/add"}
+  %add.660 = bf16[1,197,3072]{2,1,0} broadcast(%add.659), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/add"}
+  %add.661 = bf16[1,197,3072]{2,1,0} add(%dot_general.135, %add.660), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/add"}
+  %mul.485 = bf16[1,197,3072]{2,1,0} multiply(%add.661, %broadcast.35), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/mul"}
+  %neg.51 = bf16[1,197,3072]{2,1,0} negate(%add.661), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/neg"}
+  %mul.486 = bf16[1,197,3072]{2,1,0} multiply(%neg.51, %broadcast.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/mul"}
+  %erfc.1040 = f32[1,197,3072]{2,1,0} convert(%mul.486), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1101 = f32[1,197,3072]{2,1,0} abs(%erfc.1040), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1102 = pred[1,197,3072]{2,1,0} compare(%erfc.1101, %broadcast.67), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1086 = f32[1,197,3072]{2,1,0} multiply(%erfc.1040, %erfc.1040), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1087 = f32[1,197,3072]{2,1,0} multiply(%erfc.1086, %broadcast.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1088 = f32[1,197,3072]{2,1,0} add(%erfc.1087, %broadcast.45), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1089 = f32[1,197,3072]{2,1,0} multiply(%erfc.1088, %erfc.1086), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1090 = f32[1,197,3072]{2,1,0} add(%erfc.1089, %broadcast.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1091 = f32[1,197,3072]{2,1,0} multiply(%erfc.1090, %erfc.1086), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1092 = f32[1,197,3072]{2,1,0} add(%erfc.1091, %broadcast.43), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1093 = f32[1,197,3072]{2,1,0} multiply(%erfc.1092, %erfc.1086), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1094 = f32[1,197,3072]{2,1,0} add(%erfc.1093, %broadcast.42), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1095 = f32[1,197,3072]{2,1,0} multiply(%erfc.1094, %erfc.1086), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1096 = f32[1,197,3072]{2,1,0} add(%erfc.1095, %broadcast.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1097 = f32[1,197,3072]{2,1,0} multiply(%erfc.1096, %erfc.1086), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1098 = f32[1,197,3072]{2,1,0} add(%erfc.1097, %broadcast.40), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1099 = f32[1,197,3072]{2,1,0} multiply(%erfc.1040, %erfc.1098), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1100 = f32[1,197,3072]{2,1,0} subtract(%broadcast.67, %erfc.1099), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1083 = pred[1,197,3072]{2,1,0} compare(%erfc.1040, %broadcast.47), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1041 = f32[1,197,3072]{2,1,0} multiply(%erfc.1040, %erfc.1040), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1042 = f32[1,197,3072]{2,1,0} negate(%erfc.1041), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1081 = pred[1,197,3072]{2,1,0} compare(%erfc.1042, %broadcast.48), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1045 = f32[1,197,3072]{2,1,0} exponential(%erfc.1042), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1043 = f32[1,197,3072]{2,1,0} abs(%erfc.1040), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1046 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1043), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1047 = f32[1,197,3072]{2,1,0} multiply(%erfc.1045, %erfc.1046), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1048 = pred[1,197,3072]{2,1,0} compare(%erfc.1043, %broadcast.66), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1044 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1041), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1049 = f32[1,197,3072]{2,1,0} multiply(%erfc.1044, %broadcast.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1050 = f32[1,197,3072]{2,1,0} add(%erfc.1049, %broadcast.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1051 = f32[1,197,3072]{2,1,0} multiply(%erfc.1050, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1052 = f32[1,197,3072]{2,1,0} add(%erfc.1051, %broadcast.63), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1053 = f32[1,197,3072]{2,1,0} multiply(%erfc.1052, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1054 = f32[1,197,3072]{2,1,0} add(%erfc.1053, %broadcast.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1055 = f32[1,197,3072]{2,1,0} multiply(%erfc.1054, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1056 = f32[1,197,3072]{2,1,0} add(%erfc.1055, %broadcast.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1057 = f32[1,197,3072]{2,1,0} multiply(%erfc.1056, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1058 = f32[1,197,3072]{2,1,0} add(%erfc.1057, %broadcast.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1059 = f32[1,197,3072]{2,1,0} multiply(%erfc.1058, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1060 = f32[1,197,3072]{2,1,0} add(%erfc.1059, %broadcast.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1061 = f32[1,197,3072]{2,1,0} multiply(%erfc.1060, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1062 = f32[1,197,3072]{2,1,0} add(%erfc.1061, %broadcast.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1063 = f32[1,197,3072]{2,1,0} multiply(%erfc.1062, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1064 = f32[1,197,3072]{2,1,0} add(%erfc.1063, %broadcast.57), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1065 = f32[1,197,3072]{2,1,0} multiply(%erfc.1044, %broadcast.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1066 = f32[1,197,3072]{2,1,0} add(%erfc.1065, %broadcast.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1067 = f32[1,197,3072]{2,1,0} multiply(%erfc.1066, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1068 = f32[1,197,3072]{2,1,0} add(%erfc.1067, %broadcast.54), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1069 = f32[1,197,3072]{2,1,0} multiply(%erfc.1068, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1070 = f32[1,197,3072]{2,1,0} add(%erfc.1069, %broadcast.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1071 = f32[1,197,3072]{2,1,0} multiply(%erfc.1070, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1072 = f32[1,197,3072]{2,1,0} add(%erfc.1071, %broadcast.52), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1073 = f32[1,197,3072]{2,1,0} multiply(%erfc.1072, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1074 = f32[1,197,3072]{2,1,0} add(%erfc.1073, %broadcast.51), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1075 = f32[1,197,3072]{2,1,0} multiply(%erfc.1074, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1076 = f32[1,197,3072]{2,1,0} add(%erfc.1075, %broadcast.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1077 = f32[1,197,3072]{2,1,0} multiply(%erfc.1076, %erfc.1044), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1078 = f32[1,197,3072]{2,1,0} add(%erfc.1077, %broadcast.49), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1079 = f32[1,197,3072]{2,1,0} select(%erfc.1048, %erfc.1064, %erfc.1078), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1080 = f32[1,197,3072]{2,1,0} multiply(%erfc.1047, %erfc.1079), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1082 = f32[1,197,3072]{2,1,0} select(%erfc.1081, %broadcast.47, %erfc.1080), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1084 = f32[1,197,3072]{2,1,0} subtract(%broadcast.66, %erfc.1082), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1085 = f32[1,197,3072]{2,1,0} select(%erfc.1083, %erfc.1084, %erfc.1082), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1103 = f32[1,197,3072]{2,1,0} select(%erfc.1102, %erfc.1100, %erfc.1085), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %erfc.1104 = bf16[1,197,3072]{2,1,0} convert(%erfc.1103), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/erfc"}
+  %mul.487 = bf16[1,197,3072]{2,1,0} multiply(%mul.485, %erfc.1104), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_1/mul"}
+  %constant.452 = f32[3072,768]{1,0} constant({...})
+  %convert_element_type.197 = bf16[3072,768]{1,0} convert(%constant.452), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_2/convert_element_type"}
+  %dot_general.136 = bf16[1,197,768]{2,1,0} dot(%mul.487, %convert_element_type.197), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_2/dot_general"}
+  %constant.331 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.662 = bf16[1,1,768]{2,1,0} broadcast(%constant.331), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_2/add"}
+  %add.663 = bf16[1,768]{1,0} reshape(%add.662), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_2/add"}
+  %add.664 = bf16[1,197,768]{2,1,0} broadcast(%add.663), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_2/add"}
+  %add.665 = bf16[1,197,768]{2,1,0} add(%dot_general.136, %add.664), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/mlp/dense_2/add"}
+  %add.666 = bf16[1,197,768]{2,1,0} add(%add.651, %add.665), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_5/add"}
+  %convert_element_type.198 = f32[1,197,768]{2,1,0} convert(%add.666), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/convert_element_type"}
+  %jit__var_.35 = f32[1,197,1]{2,1,0} call(%convert_element_type.198, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/jit(_var)"}
+  %add.667 = f32[1,197,1]{2,1,0} add(%jit__var_.35, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/add"}
+  %rsqrt.35 = f32[1,197,1]{2,1,0} rsqrt(%add.667), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/rsqrt"}
+  %mul.488 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.35), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/mul"}
+  %mul.489 = f32[1,197]{1,0} reshape(%mul.488), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/mul"}
+  %mul.490 = f32[1,197,768]{2,1,0} broadcast(%mul.489), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/mul"}
+  %constant.330 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.491 = f32[1,1,768]{2,1,0} broadcast(%constant.330), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/mul"}
+  %mul.492 = f32[1,768]{1,0} reshape(%mul.491), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/mul"}
+  %mul.493 = f32[1,197,768]{2,1,0} broadcast(%mul.492), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/mul"}
+  %mul.494 = f32[1,197,768]{2,1,0} multiply(%mul.490, %mul.493), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/mul"}
+  %mul.499 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.198, %mul.494), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/mul"}
+  %reduce_sum.290 = f32[1,197]{1,0} reduce(%convert_element_type.198, %constant.419), dimensions={2}, to_apply=%region_23.28, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/reduce_sum"}
+  %broadcast_in_dim.64 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.290), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/broadcast_in_dim"}
+  %div.111 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.64, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/div"}
+  %neg.52 = f32[1,197,1]{2,1,0} negate(%div.111), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/neg"}
+  %mul.495 = f32[1,197,1]{2,1,0} broadcast(%neg.52), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/mul"}
+  %mul.496 = f32[1,197]{1,0} reshape(%mul.495), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/mul"}
+  %mul.497 = f32[1,197,768]{2,1,0} broadcast(%mul.496), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/mul"}
+  %mul.498 = f32[1,197,768]{2,1,0} multiply(%mul.497, %mul.494), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/mul"}
+  %constant.329 = f32[1,1,768]{2,1,0} constant({...})
+  %add.668 = f32[1,1,768]{2,1,0} broadcast(%constant.329), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/add"}
+  %add.669 = f32[1,768]{1,0} reshape(%add.668), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/add"}
+  %add.670 = f32[1,197,768]{2,1,0} broadcast(%add.669), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/add"}
+  %add.671 = f32[1,197,768]{2,1,0} add(%mul.498, %add.670), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/add"}
+  %add.672 = f32[1,197,768]{2,1,0} add(%mul.499, %add.671), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/add"}
+  %convert_element_type.199 = bf16[1,197,768]{2,1,0} convert(%add.672), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_1/convert_element_type"}
+  %constant.455 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.202 = bf16[768,12,64]{2,1,0} convert(%constant.455), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/value/convert_element_type"}
+  %dot_general.139 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.199, %convert_element_type.202), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/value/abc,cde->abde/dot_general"}
+  %constant.326 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.681 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.326), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/value/add"}
+  %add.682 = bf16[1,12,64]{2,1,0} reshape(%add.681), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/value/add"}
+  %add.683 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.682), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/value/add"}
+  %add.684 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.139, %add.683), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/value/add"}
+  %constant.453 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.200 = bf16[768,12,64]{2,1,0} convert(%constant.453), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/query/convert_element_type"}
+  %dot_general.137 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.199, %convert_element_type.200), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/query/abc,cde->abde/dot_general"}
+  %constant.328 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.673 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.328), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/query/add"}
+  %add.674 = bf16[1,12,64]{2,1,0} reshape(%add.673), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/query/add"}
+  %add.675 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.674), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/query/add"}
+  %add.676 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.137, %add.675), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/query/add"}
+  %reshape.36 = bf16[1,197,12,1,64]{4,3,2,1,0} reshape(%add.676), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/reshape"}
+  %constant.454 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.201 = bf16[768,12,64]{2,1,0} convert(%constant.454), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/key/convert_element_type"}
+  %dot_general.138 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.199, %convert_element_type.201), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/key/abc,cde->abde/dot_general"}
+  %constant.327 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.677 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.327), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/key/add"}
+  %add.678 = bf16[1,12,64]{2,1,0} reshape(%add.677), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/key/add"}
+  %add.679 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.678), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/key/add"}
+  %add.680 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.138, %add.679), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/key/add"}
+  %dot_general.140 = f32[1,12,197,1,197]{4,3,2,1,0} dot(%reshape.36, %add.680), lhs_batch_dims={0,2}, lhs_contracting_dims={4}, rhs_batch_dims={0,2}, rhs_contracting_dims={3}, algorithm=dot_bf16_bf16_f32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap(BTNH,BSNH->BNTS)/dot_general"}
+  %mul.500 = f32[1,12,197,1,197]{4,3,2,1,0} multiply(%dot_general.140, %broadcast.37), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/mul"}
+  %transpose.52 = f32[1,1,12,197,197]{4,3,2,1,0} reshape(%mul.500), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/transpose"}
+  %reduce_max.89 = f32[1,12,197,1]{3,2,1,0} reduce(%mul.500, %constant.417), dimensions={4}, to_apply=%region_24.29, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/reduce_max"}
+  %max.17 = f32[1,12,197,1]{3,2,1,0} maximum(%reduce_max.89, %broadcast.36), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/max"}
+  %transpose.51 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%max.17), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/broadcast_in_dim;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/transpose"}
+  %sub.78 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%transpose.51), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/sub"}
+  %sub.79 = f32[1,1,12,197]{3,2,1,0} reshape(%sub.78), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/sub"}
+  %sub.80 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%sub.79), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/sub"}
+  %sub.81 = f32[1,1,12,197,197]{4,3,2,1,0} subtract(%transpose.52, %sub.80), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/sub"}
+  %exp.17 = f32[1,1,12,197,197]{4,3,2,1,0} exponential(%sub.81), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/exp"}
+  %reduce_sum.291 = f32[1,1,12,197]{3,2,1,0} reduce(%exp.17, %constant.419), dimensions={4}, to_apply=%region_25.30, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/reduce_sum"}
+  %broadcast_in_dim.65 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%reduce_sum.291), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/broadcast_in_dim"}
+  %div.112 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%broadcast_in_dim.65), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/div"}
+  %div.113 = f32[1,1,12,197]{3,2,1,0} reshape(%div.112), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/div"}
+  %div.114 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%div.113), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/div"}
+  %div.115 = f32[1,1,12,197,197]{4,3,2,1,0} divide(%exp.17, %div.114), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/div"}
+  %convert_element_type.203 = bf16[1,1,12,197,197]{4,3,2,1,0} convert(%div.115), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/convert_element_type"}
+  %dot_general.141 = bf16[1,12,64,1,197]{4,3,2,1,0} dot(%add.684, %convert_element_type.203), lhs_batch_dims={0,2}, lhs_contracting_dims={1}, rhs_batch_dims={1,2}, rhs_contracting_dims={4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap(BNTS,BSNH->BTNH)/dot_general"}
+  %transpose.53 = bf16[1,197,12,1,64]{1,3,4,2,0} transpose(%dot_general.141), dimensions={0,4,1,3,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap()/transpose;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/vmap(BNTS,BSNH->BTNH)/transpose"}
+  %reshape.37 = bf16[1,197,12,64]{3,2,1,0} reshape(%transpose.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/reshape"}
+  %constant.456 = f32[12,64,768]{2,1,0} constant({...})
+  %convert_element_type.204 = bf16[12,64,768]{2,1,0} convert(%constant.456), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/attention_output/convert_element_type"}
+  %dot_general.142 = bf16[1,197,768]{2,1,0} dot(%reshape.37, %convert_element_type.204), lhs_contracting_dims={2,3}, rhs_contracting_dims={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/attention_output/abcd,cde->abe/dot_general"}
+  %constant.325 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.685 = bf16[1,1,768]{2,1,0} broadcast(%constant.325), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/attention_output/add"}
+  %add.686 = bf16[1,768]{1,0} reshape(%add.685), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/attention_output/add"}
+  %add.687 = bf16[1,197,768]{2,1,0} broadcast(%add.686), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/attention_output/add"}
+  %add.688 = bf16[1,197,768]{2,1,0} add(%dot_general.142, %add.687), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mha/attention_output/add"}
+  %add.689 = bf16[1,197,768]{2,1,0} add(%add.688, %add.666), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/add"}
+  %convert_element_type.205 = f32[1,197,768]{2,1,0} convert(%add.689), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/convert_element_type"}
+  %jit__var_.36 = f32[1,197,1]{2,1,0} call(%convert_element_type.205, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/jit(_var)"}
+  %add.690 = f32[1,197,1]{2,1,0} add(%jit__var_.36, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/add"}
+  %rsqrt.36 = f32[1,197,1]{2,1,0} rsqrt(%add.690), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/rsqrt"}
+  %mul.501 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.36), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/mul"}
+  %mul.502 = f32[1,197]{1,0} reshape(%mul.501), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/mul"}
+  %mul.503 = f32[1,197,768]{2,1,0} broadcast(%mul.502), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/mul"}
+  %constant.324 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.504 = f32[1,1,768]{2,1,0} broadcast(%constant.324), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/mul"}
+  %mul.505 = f32[1,768]{1,0} reshape(%mul.504), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/mul"}
+  %mul.506 = f32[1,197,768]{2,1,0} broadcast(%mul.505), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/mul"}
+  %mul.507 = f32[1,197,768]{2,1,0} multiply(%mul.503, %mul.506), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/mul"}
+  %mul.512 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.205, %mul.507), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/mul"}
+  %reduce_sum.292 = f32[1,197]{1,0} reduce(%convert_element_type.205, %constant.419), dimensions={2}, to_apply=%region_26.31, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/reduce_sum"}
+  %broadcast_in_dim.66 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.292), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/broadcast_in_dim"}
+  %div.116 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.66, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/div"}
+  %neg.53 = f32[1,197,1]{2,1,0} negate(%div.116), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/neg"}
+  %mul.508 = f32[1,197,1]{2,1,0} broadcast(%neg.53), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/mul"}
+  %mul.509 = f32[1,197]{1,0} reshape(%mul.508), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/mul"}
+  %mul.510 = f32[1,197,768]{2,1,0} broadcast(%mul.509), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/mul"}
+  %mul.511 = f32[1,197,768]{2,1,0} multiply(%mul.510, %mul.507), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/mul"}
+  %constant.323 = f32[1,1,768]{2,1,0} constant({...})
+  %add.691 = f32[1,1,768]{2,1,0} broadcast(%constant.323), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/add"}
+  %add.692 = f32[1,768]{1,0} reshape(%add.691), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/add"}
+  %add.693 = f32[1,197,768]{2,1,0} broadcast(%add.692), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/add"}
+  %add.694 = f32[1,197,768]{2,1,0} add(%mul.511, %add.693), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/add"}
+  %add.695 = f32[1,197,768]{2,1,0} add(%mul.512, %add.694), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/add"}
+  %convert_element_type.206 = bf16[1,197,768]{2,1,0} convert(%add.695), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/ln_2/convert_element_type"}
+  %constant.457 = f32[768,3072]{1,0} constant({...})
+  %convert_element_type.207 = bf16[768,3072]{1,0} convert(%constant.457), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/convert_element_type"}
+  %dot_general.143 = bf16[1,197,3072]{2,1,0} dot(%convert_element_type.206, %convert_element_type.207), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/dot_general"}
+  %constant.322 = bf16[1,1,3072]{2,1,0} constant({...})
+  %add.696 = bf16[1,1,3072]{2,1,0} broadcast(%constant.322), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/add"}
+  %add.697 = bf16[1,3072]{1,0} reshape(%add.696), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/add"}
+  %add.698 = bf16[1,197,3072]{2,1,0} broadcast(%add.697), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/add"}
+  %add.699 = bf16[1,197,3072]{2,1,0} add(%dot_general.143, %add.698), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/add"}
+  %mul.513 = bf16[1,197,3072]{2,1,0} multiply(%add.699, %broadcast.35), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/mul"}
+  %neg.54 = bf16[1,197,3072]{2,1,0} negate(%add.699), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/neg"}
+  %mul.514 = bf16[1,197,3072]{2,1,0} multiply(%neg.54, %broadcast.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/mul"}
+  %erfc.1105 = f32[1,197,3072]{2,1,0} convert(%mul.514), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1166 = f32[1,197,3072]{2,1,0} abs(%erfc.1105), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1167 = pred[1,197,3072]{2,1,0} compare(%erfc.1166, %broadcast.67), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1151 = f32[1,197,3072]{2,1,0} multiply(%erfc.1105, %erfc.1105), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1152 = f32[1,197,3072]{2,1,0} multiply(%erfc.1151, %broadcast.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1153 = f32[1,197,3072]{2,1,0} add(%erfc.1152, %broadcast.45), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1154 = f32[1,197,3072]{2,1,0} multiply(%erfc.1153, %erfc.1151), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1155 = f32[1,197,3072]{2,1,0} add(%erfc.1154, %broadcast.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1156 = f32[1,197,3072]{2,1,0} multiply(%erfc.1155, %erfc.1151), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1157 = f32[1,197,3072]{2,1,0} add(%erfc.1156, %broadcast.43), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1158 = f32[1,197,3072]{2,1,0} multiply(%erfc.1157, %erfc.1151), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1159 = f32[1,197,3072]{2,1,0} add(%erfc.1158, %broadcast.42), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1160 = f32[1,197,3072]{2,1,0} multiply(%erfc.1159, %erfc.1151), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1161 = f32[1,197,3072]{2,1,0} add(%erfc.1160, %broadcast.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1162 = f32[1,197,3072]{2,1,0} multiply(%erfc.1161, %erfc.1151), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1163 = f32[1,197,3072]{2,1,0} add(%erfc.1162, %broadcast.40), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1164 = f32[1,197,3072]{2,1,0} multiply(%erfc.1105, %erfc.1163), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1165 = f32[1,197,3072]{2,1,0} subtract(%broadcast.67, %erfc.1164), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1148 = pred[1,197,3072]{2,1,0} compare(%erfc.1105, %broadcast.47), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1106 = f32[1,197,3072]{2,1,0} multiply(%erfc.1105, %erfc.1105), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1107 = f32[1,197,3072]{2,1,0} negate(%erfc.1106), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1146 = pred[1,197,3072]{2,1,0} compare(%erfc.1107, %broadcast.48), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1110 = f32[1,197,3072]{2,1,0} exponential(%erfc.1107), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1108 = f32[1,197,3072]{2,1,0} abs(%erfc.1105), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1111 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1108), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1112 = f32[1,197,3072]{2,1,0} multiply(%erfc.1110, %erfc.1111), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1113 = pred[1,197,3072]{2,1,0} compare(%erfc.1108, %broadcast.66), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1109 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1106), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1114 = f32[1,197,3072]{2,1,0} multiply(%erfc.1109, %broadcast.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1115 = f32[1,197,3072]{2,1,0} add(%erfc.1114, %broadcast.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1116 = f32[1,197,3072]{2,1,0} multiply(%erfc.1115, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1117 = f32[1,197,3072]{2,1,0} add(%erfc.1116, %broadcast.63), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1118 = f32[1,197,3072]{2,1,0} multiply(%erfc.1117, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1119 = f32[1,197,3072]{2,1,0} add(%erfc.1118, %broadcast.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1120 = f32[1,197,3072]{2,1,0} multiply(%erfc.1119, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1121 = f32[1,197,3072]{2,1,0} add(%erfc.1120, %broadcast.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1122 = f32[1,197,3072]{2,1,0} multiply(%erfc.1121, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1123 = f32[1,197,3072]{2,1,0} add(%erfc.1122, %broadcast.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1124 = f32[1,197,3072]{2,1,0} multiply(%erfc.1123, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1125 = f32[1,197,3072]{2,1,0} add(%erfc.1124, %broadcast.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1126 = f32[1,197,3072]{2,1,0} multiply(%erfc.1125, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1127 = f32[1,197,3072]{2,1,0} add(%erfc.1126, %broadcast.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1128 = f32[1,197,3072]{2,1,0} multiply(%erfc.1127, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1129 = f32[1,197,3072]{2,1,0} add(%erfc.1128, %broadcast.57), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1130 = f32[1,197,3072]{2,1,0} multiply(%erfc.1109, %broadcast.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1131 = f32[1,197,3072]{2,1,0} add(%erfc.1130, %broadcast.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1132 = f32[1,197,3072]{2,1,0} multiply(%erfc.1131, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1133 = f32[1,197,3072]{2,1,0} add(%erfc.1132, %broadcast.54), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1134 = f32[1,197,3072]{2,1,0} multiply(%erfc.1133, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1135 = f32[1,197,3072]{2,1,0} add(%erfc.1134, %broadcast.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1136 = f32[1,197,3072]{2,1,0} multiply(%erfc.1135, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1137 = f32[1,197,3072]{2,1,0} add(%erfc.1136, %broadcast.52), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1138 = f32[1,197,3072]{2,1,0} multiply(%erfc.1137, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1139 = f32[1,197,3072]{2,1,0} add(%erfc.1138, %broadcast.51), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1140 = f32[1,197,3072]{2,1,0} multiply(%erfc.1139, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1141 = f32[1,197,3072]{2,1,0} add(%erfc.1140, %broadcast.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1142 = f32[1,197,3072]{2,1,0} multiply(%erfc.1141, %erfc.1109), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1143 = f32[1,197,3072]{2,1,0} add(%erfc.1142, %broadcast.49), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1144 = f32[1,197,3072]{2,1,0} select(%erfc.1113, %erfc.1129, %erfc.1143), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1145 = f32[1,197,3072]{2,1,0} multiply(%erfc.1112, %erfc.1144), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1147 = f32[1,197,3072]{2,1,0} select(%erfc.1146, %broadcast.47, %erfc.1145), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1149 = f32[1,197,3072]{2,1,0} subtract(%broadcast.66, %erfc.1147), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1150 = f32[1,197,3072]{2,1,0} select(%erfc.1148, %erfc.1149, %erfc.1147), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1168 = f32[1,197,3072]{2,1,0} select(%erfc.1167, %erfc.1165, %erfc.1150), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %erfc.1169 = bf16[1,197,3072]{2,1,0} convert(%erfc.1168), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/erfc"}
+  %mul.515 = bf16[1,197,3072]{2,1,0} multiply(%mul.513, %erfc.1169), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_1/mul"}
+  %constant.458 = f32[3072,768]{1,0} constant({...})
+  %convert_element_type.208 = bf16[3072,768]{1,0} convert(%constant.458), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_2/convert_element_type"}
+  %dot_general.144 = bf16[1,197,768]{2,1,0} dot(%mul.515, %convert_element_type.208), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_2/dot_general"}
+  %constant.321 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.700 = bf16[1,1,768]{2,1,0} broadcast(%constant.321), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_2/add"}
+  %add.701 = bf16[1,768]{1,0} reshape(%add.700), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_2/add"}
+  %add.702 = bf16[1,197,768]{2,1,0} broadcast(%add.701), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_2/add"}
+  %add.703 = bf16[1,197,768]{2,1,0} add(%dot_general.144, %add.702), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/mlp/dense_2/add"}
+  %add.704 = bf16[1,197,768]{2,1,0} add(%add.689, %add.703), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_6/add"}
+  %convert_element_type.209 = f32[1,197,768]{2,1,0} convert(%add.704), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/convert_element_type"}
+  %jit__var_.37 = f32[1,197,1]{2,1,0} call(%convert_element_type.209, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/jit(_var)"}
+  %add.705 = f32[1,197,1]{2,1,0} add(%jit__var_.37, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/add"}
+  %rsqrt.37 = f32[1,197,1]{2,1,0} rsqrt(%add.705), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/rsqrt"}
+  %mul.516 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.37), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/mul"}
+  %mul.517 = f32[1,197]{1,0} reshape(%mul.516), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/mul"}
+  %mul.518 = f32[1,197,768]{2,1,0} broadcast(%mul.517), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/mul"}
+  %constant.320 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.519 = f32[1,1,768]{2,1,0} broadcast(%constant.320), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/mul"}
+  %mul.520 = f32[1,768]{1,0} reshape(%mul.519), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/mul"}
+  %mul.521 = f32[1,197,768]{2,1,0} broadcast(%mul.520), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/mul"}
+  %mul.522 = f32[1,197,768]{2,1,0} multiply(%mul.518, %mul.521), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/mul"}
+  %mul.527 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.209, %mul.522), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/mul"}
+  %reduce_sum.293 = f32[1,197]{1,0} reduce(%convert_element_type.209, %constant.419), dimensions={2}, to_apply=%region_27.32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/reduce_sum"}
+  %broadcast_in_dim.67 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.293), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/broadcast_in_dim"}
+  %div.117 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.67, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/div"}
+  %neg.55 = f32[1,197,1]{2,1,0} negate(%div.117), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/neg"}
+  %mul.523 = f32[1,197,1]{2,1,0} broadcast(%neg.55), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/mul"}
+  %mul.524 = f32[1,197]{1,0} reshape(%mul.523), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/mul"}
+  %mul.525 = f32[1,197,768]{2,1,0} broadcast(%mul.524), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/mul"}
+  %mul.526 = f32[1,197,768]{2,1,0} multiply(%mul.525, %mul.522), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/mul"}
+  %constant.319 = f32[1,1,768]{2,1,0} constant({...})
+  %add.706 = f32[1,1,768]{2,1,0} broadcast(%constant.319), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/add"}
+  %add.707 = f32[1,768]{1,0} reshape(%add.706), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/add"}
+  %add.708 = f32[1,197,768]{2,1,0} broadcast(%add.707), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/add"}
+  %add.709 = f32[1,197,768]{2,1,0} add(%mul.526, %add.708), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/add"}
+  %add.710 = f32[1,197,768]{2,1,0} add(%mul.527, %add.709), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/add"}
+  %convert_element_type.210 = bf16[1,197,768]{2,1,0} convert(%add.710), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_1/convert_element_type"}
+  %constant.461 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.213 = bf16[768,12,64]{2,1,0} convert(%constant.461), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/value/convert_element_type"}
+  %dot_general.147 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.210, %convert_element_type.213), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/value/abc,cde->abde/dot_general"}
+  %constant.316 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.719 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.316), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/value/add"}
+  %add.720 = bf16[1,12,64]{2,1,0} reshape(%add.719), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/value/add"}
+  %add.721 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.720), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/value/add"}
+  %add.722 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.147, %add.721), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/value/add"}
+  %constant.459 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.211 = bf16[768,12,64]{2,1,0} convert(%constant.459), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/query/convert_element_type"}
+  %dot_general.145 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.210, %convert_element_type.211), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/query/abc,cde->abde/dot_general"}
+  %constant.318 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.711 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.318), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/query/add"}
+  %add.712 = bf16[1,12,64]{2,1,0} reshape(%add.711), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/query/add"}
+  %add.713 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.712), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/query/add"}
+  %add.714 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.145, %add.713), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/query/add"}
+  %reshape.38 = bf16[1,197,12,1,64]{4,3,2,1,0} reshape(%add.714), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/reshape"}
+  %constant.460 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.212 = bf16[768,12,64]{2,1,0} convert(%constant.460), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/key/convert_element_type"}
+  %dot_general.146 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.210, %convert_element_type.212), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/key/abc,cde->abde/dot_general"}
+  %constant.317 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.715 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.317), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/key/add"}
+  %add.716 = bf16[1,12,64]{2,1,0} reshape(%add.715), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/key/add"}
+  %add.717 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.716), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/key/add"}
+  %add.718 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.146, %add.717), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/key/add"}
+  %dot_general.148 = f32[1,12,197,1,197]{4,3,2,1,0} dot(%reshape.38, %add.718), lhs_batch_dims={0,2}, lhs_contracting_dims={4}, rhs_batch_dims={0,2}, rhs_contracting_dims={3}, algorithm=dot_bf16_bf16_f32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap(BTNH,BSNH->BNTS)/dot_general"}
+  %mul.528 = f32[1,12,197,1,197]{4,3,2,1,0} multiply(%dot_general.148, %broadcast.37), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/mul"}
+  %transpose.55 = f32[1,1,12,197,197]{4,3,2,1,0} reshape(%mul.528), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/transpose"}
+  %reduce_max.90 = f32[1,12,197,1]{3,2,1,0} reduce(%mul.528, %constant.417), dimensions={4}, to_apply=%region_28.33, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/reduce_max"}
+  %max.18 = f32[1,12,197,1]{3,2,1,0} maximum(%reduce_max.90, %broadcast.36), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/max"}
+  %transpose.54 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%max.18), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/broadcast_in_dim;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/transpose"}
+  %sub.82 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%transpose.54), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/sub"}
+  %sub.83 = f32[1,1,12,197]{3,2,1,0} reshape(%sub.82), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/sub"}
+  %sub.84 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%sub.83), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/sub"}
+  %sub.85 = f32[1,1,12,197,197]{4,3,2,1,0} subtract(%transpose.55, %sub.84), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/sub"}
+  %exp.18 = f32[1,1,12,197,197]{4,3,2,1,0} exponential(%sub.85), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/exp"}
+  %reduce_sum.294 = f32[1,1,12,197]{3,2,1,0} reduce(%exp.18, %constant.419), dimensions={4}, to_apply=%region_29.34, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/reduce_sum"}
+  %broadcast_in_dim.68 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%reduce_sum.294), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/broadcast_in_dim"}
+  %div.118 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%broadcast_in_dim.68), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/div"}
+  %div.119 = f32[1,1,12,197]{3,2,1,0} reshape(%div.118), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/div"}
+  %div.120 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%div.119), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/div"}
+  %div.121 = f32[1,1,12,197,197]{4,3,2,1,0} divide(%exp.18, %div.120), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/div"}
+  %convert_element_type.214 = bf16[1,1,12,197,197]{4,3,2,1,0} convert(%div.121), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/convert_element_type"}
+  %dot_general.149 = bf16[1,12,64,1,197]{4,3,2,1,0} dot(%add.722, %convert_element_type.214), lhs_batch_dims={0,2}, lhs_contracting_dims={1}, rhs_batch_dims={1,2}, rhs_contracting_dims={4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap(BNTS,BSNH->BTNH)/dot_general"}
+  %transpose.56 = bf16[1,197,12,1,64]{1,3,4,2,0} transpose(%dot_general.149), dimensions={0,4,1,3,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap()/transpose;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/vmap(BNTS,BSNH->BTNH)/transpose"}
+  %reshape.39 = bf16[1,197,12,64]{3,2,1,0} reshape(%transpose.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/reshape"}
+  %constant.462 = f32[12,64,768]{2,1,0} constant({...})
+  %convert_element_type.215 = bf16[12,64,768]{2,1,0} convert(%constant.462), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/attention_output/convert_element_type"}
+  %dot_general.150 = bf16[1,197,768]{2,1,0} dot(%reshape.39, %convert_element_type.215), lhs_contracting_dims={2,3}, rhs_contracting_dims={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/attention_output/abcd,cde->abe/dot_general"}
+  %constant.315 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.723 = bf16[1,1,768]{2,1,0} broadcast(%constant.315), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/attention_output/add"}
+  %add.724 = bf16[1,768]{1,0} reshape(%add.723), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/attention_output/add"}
+  %add.725 = bf16[1,197,768]{2,1,0} broadcast(%add.724), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/attention_output/add"}
+  %add.726 = bf16[1,197,768]{2,1,0} add(%dot_general.150, %add.725), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mha/attention_output/add"}
+  %add.727 = bf16[1,197,768]{2,1,0} add(%add.726, %add.704), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/add"}
+  %convert_element_type.216 = f32[1,197,768]{2,1,0} convert(%add.727), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/convert_element_type"}
+  %jit__var_.38 = f32[1,197,1]{2,1,0} call(%convert_element_type.216, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/jit(_var)"}
+  %add.728 = f32[1,197,1]{2,1,0} add(%jit__var_.38, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/add"}
+  %rsqrt.38 = f32[1,197,1]{2,1,0} rsqrt(%add.728), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/rsqrt"}
+  %mul.529 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.38), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/mul"}
+  %mul.530 = f32[1,197]{1,0} reshape(%mul.529), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/mul"}
+  %mul.531 = f32[1,197,768]{2,1,0} broadcast(%mul.530), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/mul"}
+  %constant.314 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.532 = f32[1,1,768]{2,1,0} broadcast(%constant.314), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/mul"}
+  %mul.533 = f32[1,768]{1,0} reshape(%mul.532), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/mul"}
+  %mul.534 = f32[1,197,768]{2,1,0} broadcast(%mul.533), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/mul"}
+  %mul.535 = f32[1,197,768]{2,1,0} multiply(%mul.531, %mul.534), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/mul"}
+  %mul.540 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.216, %mul.535), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/mul"}
+  %reduce_sum.295 = f32[1,197]{1,0} reduce(%convert_element_type.216, %constant.419), dimensions={2}, to_apply=%region_30.35, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/reduce_sum"}
+  %broadcast_in_dim.69 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.295), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/broadcast_in_dim"}
+  %div.122 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.69, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/div"}
+  %neg.56 = f32[1,197,1]{2,1,0} negate(%div.122), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/neg"}
+  %mul.536 = f32[1,197,1]{2,1,0} broadcast(%neg.56), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/mul"}
+  %mul.537 = f32[1,197]{1,0} reshape(%mul.536), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/mul"}
+  %mul.538 = f32[1,197,768]{2,1,0} broadcast(%mul.537), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/mul"}
+  %mul.539 = f32[1,197,768]{2,1,0} multiply(%mul.538, %mul.535), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/mul"}
+  %constant.313 = f32[1,1,768]{2,1,0} constant({...})
+  %add.729 = f32[1,1,768]{2,1,0} broadcast(%constant.313), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/add"}
+  %add.730 = f32[1,768]{1,0} reshape(%add.729), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/add"}
+  %add.731 = f32[1,197,768]{2,1,0} broadcast(%add.730), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/add"}
+  %add.732 = f32[1,197,768]{2,1,0} add(%mul.539, %add.731), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/add"}
+  %add.733 = f32[1,197,768]{2,1,0} add(%mul.540, %add.732), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/add"}
+  %convert_element_type.217 = bf16[1,197,768]{2,1,0} convert(%add.733), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/ln_2/convert_element_type"}
+  %constant.463 = f32[768,3072]{1,0} constant({...})
+  %convert_element_type.218 = bf16[768,3072]{1,0} convert(%constant.463), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/convert_element_type"}
+  %dot_general.151 = bf16[1,197,3072]{2,1,0} dot(%convert_element_type.217, %convert_element_type.218), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/dot_general"}
+  %constant.312 = bf16[1,1,3072]{2,1,0} constant({...})
+  %add.734 = bf16[1,1,3072]{2,1,0} broadcast(%constant.312), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/add"}
+  %add.735 = bf16[1,3072]{1,0} reshape(%add.734), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/add"}
+  %add.736 = bf16[1,197,3072]{2,1,0} broadcast(%add.735), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/add"}
+  %add.737 = bf16[1,197,3072]{2,1,0} add(%dot_general.151, %add.736), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/add"}
+  %mul.541 = bf16[1,197,3072]{2,1,0} multiply(%add.737, %broadcast.35), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/mul"}
+  %neg.57 = bf16[1,197,3072]{2,1,0} negate(%add.737), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/neg"}
+  %mul.542 = bf16[1,197,3072]{2,1,0} multiply(%neg.57, %broadcast.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/mul"}
+  %erfc.1170 = f32[1,197,3072]{2,1,0} convert(%mul.542), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1231 = f32[1,197,3072]{2,1,0} abs(%erfc.1170), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1232 = pred[1,197,3072]{2,1,0} compare(%erfc.1231, %broadcast.67), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1216 = f32[1,197,3072]{2,1,0} multiply(%erfc.1170, %erfc.1170), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1217 = f32[1,197,3072]{2,1,0} multiply(%erfc.1216, %broadcast.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1218 = f32[1,197,3072]{2,1,0} add(%erfc.1217, %broadcast.45), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1219 = f32[1,197,3072]{2,1,0} multiply(%erfc.1218, %erfc.1216), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1220 = f32[1,197,3072]{2,1,0} add(%erfc.1219, %broadcast.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1221 = f32[1,197,3072]{2,1,0} multiply(%erfc.1220, %erfc.1216), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1222 = f32[1,197,3072]{2,1,0} add(%erfc.1221, %broadcast.43), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1223 = f32[1,197,3072]{2,1,0} multiply(%erfc.1222, %erfc.1216), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1224 = f32[1,197,3072]{2,1,0} add(%erfc.1223, %broadcast.42), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1225 = f32[1,197,3072]{2,1,0} multiply(%erfc.1224, %erfc.1216), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1226 = f32[1,197,3072]{2,1,0} add(%erfc.1225, %broadcast.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1227 = f32[1,197,3072]{2,1,0} multiply(%erfc.1226, %erfc.1216), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1228 = f32[1,197,3072]{2,1,0} add(%erfc.1227, %broadcast.40), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1229 = f32[1,197,3072]{2,1,0} multiply(%erfc.1170, %erfc.1228), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1230 = f32[1,197,3072]{2,1,0} subtract(%broadcast.67, %erfc.1229), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1213 = pred[1,197,3072]{2,1,0} compare(%erfc.1170, %broadcast.47), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1171 = f32[1,197,3072]{2,1,0} multiply(%erfc.1170, %erfc.1170), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1172 = f32[1,197,3072]{2,1,0} negate(%erfc.1171), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1211 = pred[1,197,3072]{2,1,0} compare(%erfc.1172, %broadcast.48), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1175 = f32[1,197,3072]{2,1,0} exponential(%erfc.1172), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1173 = f32[1,197,3072]{2,1,0} abs(%erfc.1170), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1176 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1173), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1177 = f32[1,197,3072]{2,1,0} multiply(%erfc.1175, %erfc.1176), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1178 = pred[1,197,3072]{2,1,0} compare(%erfc.1173, %broadcast.66), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1174 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1171), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1179 = f32[1,197,3072]{2,1,0} multiply(%erfc.1174, %broadcast.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1180 = f32[1,197,3072]{2,1,0} add(%erfc.1179, %broadcast.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1181 = f32[1,197,3072]{2,1,0} multiply(%erfc.1180, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1182 = f32[1,197,3072]{2,1,0} add(%erfc.1181, %broadcast.63), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1183 = f32[1,197,3072]{2,1,0} multiply(%erfc.1182, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1184 = f32[1,197,3072]{2,1,0} add(%erfc.1183, %broadcast.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1185 = f32[1,197,3072]{2,1,0} multiply(%erfc.1184, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1186 = f32[1,197,3072]{2,1,0} add(%erfc.1185, %broadcast.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1187 = f32[1,197,3072]{2,1,0} multiply(%erfc.1186, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1188 = f32[1,197,3072]{2,1,0} add(%erfc.1187, %broadcast.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1189 = f32[1,197,3072]{2,1,0} multiply(%erfc.1188, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1190 = f32[1,197,3072]{2,1,0} add(%erfc.1189, %broadcast.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1191 = f32[1,197,3072]{2,1,0} multiply(%erfc.1190, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1192 = f32[1,197,3072]{2,1,0} add(%erfc.1191, %broadcast.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1193 = f32[1,197,3072]{2,1,0} multiply(%erfc.1192, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1194 = f32[1,197,3072]{2,1,0} add(%erfc.1193, %broadcast.57), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1195 = f32[1,197,3072]{2,1,0} multiply(%erfc.1174, %broadcast.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1196 = f32[1,197,3072]{2,1,0} add(%erfc.1195, %broadcast.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1197 = f32[1,197,3072]{2,1,0} multiply(%erfc.1196, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1198 = f32[1,197,3072]{2,1,0} add(%erfc.1197, %broadcast.54), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1199 = f32[1,197,3072]{2,1,0} multiply(%erfc.1198, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1200 = f32[1,197,3072]{2,1,0} add(%erfc.1199, %broadcast.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1201 = f32[1,197,3072]{2,1,0} multiply(%erfc.1200, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1202 = f32[1,197,3072]{2,1,0} add(%erfc.1201, %broadcast.52), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1203 = f32[1,197,3072]{2,1,0} multiply(%erfc.1202, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1204 = f32[1,197,3072]{2,1,0} add(%erfc.1203, %broadcast.51), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1205 = f32[1,197,3072]{2,1,0} multiply(%erfc.1204, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1206 = f32[1,197,3072]{2,1,0} add(%erfc.1205, %broadcast.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1207 = f32[1,197,3072]{2,1,0} multiply(%erfc.1206, %erfc.1174), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1208 = f32[1,197,3072]{2,1,0} add(%erfc.1207, %broadcast.49), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1209 = f32[1,197,3072]{2,1,0} select(%erfc.1178, %erfc.1194, %erfc.1208), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1210 = f32[1,197,3072]{2,1,0} multiply(%erfc.1177, %erfc.1209), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1212 = f32[1,197,3072]{2,1,0} select(%erfc.1211, %broadcast.47, %erfc.1210), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1214 = f32[1,197,3072]{2,1,0} subtract(%broadcast.66, %erfc.1212), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1215 = f32[1,197,3072]{2,1,0} select(%erfc.1213, %erfc.1214, %erfc.1212), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1233 = f32[1,197,3072]{2,1,0} select(%erfc.1232, %erfc.1230, %erfc.1215), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %erfc.1234 = bf16[1,197,3072]{2,1,0} convert(%erfc.1233), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/erfc"}
+  %mul.543 = bf16[1,197,3072]{2,1,0} multiply(%mul.541, %erfc.1234), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_1/mul"}
+  %constant.464 = f32[3072,768]{1,0} constant({...})
+  %convert_element_type.219 = bf16[3072,768]{1,0} convert(%constant.464), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_2/convert_element_type"}
+  %dot_general.152 = bf16[1,197,768]{2,1,0} dot(%mul.543, %convert_element_type.219), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_2/dot_general"}
+  %constant.311 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.738 = bf16[1,1,768]{2,1,0} broadcast(%constant.311), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_2/add"}
+  %add.739 = bf16[1,768]{1,0} reshape(%add.738), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_2/add"}
+  %add.740 = bf16[1,197,768]{2,1,0} broadcast(%add.739), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_2/add"}
+  %add.741 = bf16[1,197,768]{2,1,0} add(%dot_general.152, %add.740), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/mlp/dense_2/add"}
+  %add.742 = bf16[1,197,768]{2,1,0} add(%add.727, %add.741), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_7/add"}
+  %convert_element_type.220 = f32[1,197,768]{2,1,0} convert(%add.742), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/convert_element_type"}
+  %jit__var_.39 = f32[1,197,1]{2,1,0} call(%convert_element_type.220, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/jit(_var)"}
+  %add.743 = f32[1,197,1]{2,1,0} add(%jit__var_.39, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/add"}
+  %rsqrt.39 = f32[1,197,1]{2,1,0} rsqrt(%add.743), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/rsqrt"}
+  %mul.544 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.39), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/mul"}
+  %mul.545 = f32[1,197]{1,0} reshape(%mul.544), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/mul"}
+  %mul.546 = f32[1,197,768]{2,1,0} broadcast(%mul.545), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/mul"}
+  %constant.310 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.547 = f32[1,1,768]{2,1,0} broadcast(%constant.310), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/mul"}
+  %mul.548 = f32[1,768]{1,0} reshape(%mul.547), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/mul"}
+  %mul.549 = f32[1,197,768]{2,1,0} broadcast(%mul.548), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/mul"}
+  %mul.550 = f32[1,197,768]{2,1,0} multiply(%mul.546, %mul.549), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/mul"}
+  %mul.555 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.220, %mul.550), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/mul"}
+  %reduce_sum.296 = f32[1,197]{1,0} reduce(%convert_element_type.220, %constant.419), dimensions={2}, to_apply=%region_31.36, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/reduce_sum"}
+  %broadcast_in_dim.70 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.296), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/broadcast_in_dim"}
+  %div.123 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.70, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/div"}
+  %neg.58 = f32[1,197,1]{2,1,0} negate(%div.123), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/neg"}
+  %mul.551 = f32[1,197,1]{2,1,0} broadcast(%neg.58), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/mul"}
+  %mul.552 = f32[1,197]{1,0} reshape(%mul.551), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/mul"}
+  %mul.553 = f32[1,197,768]{2,1,0} broadcast(%mul.552), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/mul"}
+  %mul.554 = f32[1,197,768]{2,1,0} multiply(%mul.553, %mul.550), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/mul"}
+  %constant.309 = f32[1,1,768]{2,1,0} constant({...})
+  %add.744 = f32[1,1,768]{2,1,0} broadcast(%constant.309), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/add"}
+  %add.745 = f32[1,768]{1,0} reshape(%add.744), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/add"}
+  %add.746 = f32[1,197,768]{2,1,0} broadcast(%add.745), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/add"}
+  %add.747 = f32[1,197,768]{2,1,0} add(%mul.554, %add.746), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/add"}
+  %add.748 = f32[1,197,768]{2,1,0} add(%mul.555, %add.747), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/add"}
+  %convert_element_type.221 = bf16[1,197,768]{2,1,0} convert(%add.748), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_1/convert_element_type"}
+  %constant.467 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.224 = bf16[768,12,64]{2,1,0} convert(%constant.467), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/value/convert_element_type"}
+  %dot_general.155 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.221, %convert_element_type.224), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/value/abc,cde->abde/dot_general"}
+  %constant.306 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.757 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.306), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/value/add"}
+  %add.758 = bf16[1,12,64]{2,1,0} reshape(%add.757), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/value/add"}
+  %add.759 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.758), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/value/add"}
+  %add.760 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.155, %add.759), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/value/add"}
+  %constant.465 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.222 = bf16[768,12,64]{2,1,0} convert(%constant.465), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/query/convert_element_type"}
+  %dot_general.153 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.221, %convert_element_type.222), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/query/abc,cde->abde/dot_general"}
+  %constant.308 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.749 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.308), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/query/add"}
+  %add.750 = bf16[1,12,64]{2,1,0} reshape(%add.749), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/query/add"}
+  %add.751 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.750), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/query/add"}
+  %add.752 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.153, %add.751), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/query/add"}
+  %reshape.40 = bf16[1,197,12,1,64]{4,3,2,1,0} reshape(%add.752), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/reshape"}
+  %constant.466 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.223 = bf16[768,12,64]{2,1,0} convert(%constant.466), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/key/convert_element_type"}
+  %dot_general.154 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.221, %convert_element_type.223), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/key/abc,cde->abde/dot_general"}
+  %constant.307 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.753 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.307), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/key/add"}
+  %add.754 = bf16[1,12,64]{2,1,0} reshape(%add.753), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/key/add"}
+  %add.755 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.754), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/key/add"}
+  %add.756 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.154, %add.755), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/key/add"}
+  %dot_general.156 = f32[1,12,197,1,197]{4,3,2,1,0} dot(%reshape.40, %add.756), lhs_batch_dims={0,2}, lhs_contracting_dims={4}, rhs_batch_dims={0,2}, rhs_contracting_dims={3}, algorithm=dot_bf16_bf16_f32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap(BTNH,BSNH->BNTS)/dot_general"}
+  %mul.556 = f32[1,12,197,1,197]{4,3,2,1,0} multiply(%dot_general.156, %broadcast.37), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/mul"}
+  %transpose.58 = f32[1,1,12,197,197]{4,3,2,1,0} reshape(%mul.556), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/transpose"}
+  %reduce_max.91 = f32[1,12,197,1]{3,2,1,0} reduce(%mul.556, %constant.417), dimensions={4}, to_apply=%region_32.37, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/reduce_max"}
+  %max.19 = f32[1,12,197,1]{3,2,1,0} maximum(%reduce_max.91, %broadcast.36), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/max"}
+  %transpose.57 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%max.19), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/broadcast_in_dim;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/transpose"}
+  %sub.86 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%transpose.57), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/sub"}
+  %sub.87 = f32[1,1,12,197]{3,2,1,0} reshape(%sub.86), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/sub"}
+  %sub.88 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%sub.87), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/sub"}
+  %sub.89 = f32[1,1,12,197,197]{4,3,2,1,0} subtract(%transpose.58, %sub.88), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/sub"}
+  %exp.19 = f32[1,1,12,197,197]{4,3,2,1,0} exponential(%sub.89), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/exp"}
+  %reduce_sum.297 = f32[1,1,12,197]{3,2,1,0} reduce(%exp.19, %constant.419), dimensions={4}, to_apply=%region_33.38, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/reduce_sum"}
+  %broadcast_in_dim.71 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%reduce_sum.297), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/broadcast_in_dim"}
+  %div.124 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%broadcast_in_dim.71), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/div"}
+  %div.125 = f32[1,1,12,197]{3,2,1,0} reshape(%div.124), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/div"}
+  %div.126 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%div.125), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/div"}
+  %div.127 = f32[1,1,12,197,197]{4,3,2,1,0} divide(%exp.19, %div.126), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/div"}
+  %convert_element_type.225 = bf16[1,1,12,197,197]{4,3,2,1,0} convert(%div.127), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/convert_element_type"}
+  %dot_general.157 = bf16[1,12,64,1,197]{4,3,2,1,0} dot(%add.760, %convert_element_type.225), lhs_batch_dims={0,2}, lhs_contracting_dims={1}, rhs_batch_dims={1,2}, rhs_contracting_dims={4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap(BNTS,BSNH->BTNH)/dot_general"}
+  %transpose.59 = bf16[1,197,12,1,64]{1,3,4,2,0} transpose(%dot_general.157), dimensions={0,4,1,3,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap()/transpose;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/vmap(BNTS,BSNH->BTNH)/transpose"}
+  %reshape.41 = bf16[1,197,12,64]{3,2,1,0} reshape(%transpose.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/reshape"}
+  %constant.468 = f32[12,64,768]{2,1,0} constant({...})
+  %convert_element_type.226 = bf16[12,64,768]{2,1,0} convert(%constant.468), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/attention_output/convert_element_type"}
+  %dot_general.158 = bf16[1,197,768]{2,1,0} dot(%reshape.41, %convert_element_type.226), lhs_contracting_dims={2,3}, rhs_contracting_dims={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/attention_output/abcd,cde->abe/dot_general"}
+  %constant.305 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.761 = bf16[1,1,768]{2,1,0} broadcast(%constant.305), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/attention_output/add"}
+  %add.762 = bf16[1,768]{1,0} reshape(%add.761), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/attention_output/add"}
+  %add.763 = bf16[1,197,768]{2,1,0} broadcast(%add.762), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/attention_output/add"}
+  %add.764 = bf16[1,197,768]{2,1,0} add(%dot_general.158, %add.763), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mha/attention_output/add"}
+  %add.765 = bf16[1,197,768]{2,1,0} add(%add.764, %add.742), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/add"}
+  %convert_element_type.227 = f32[1,197,768]{2,1,0} convert(%add.765), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/convert_element_type"}
+  %jit__var_.40 = f32[1,197,1]{2,1,0} call(%convert_element_type.227, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/jit(_var)"}
+  %add.766 = f32[1,197,1]{2,1,0} add(%jit__var_.40, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/add"}
+  %rsqrt.40 = f32[1,197,1]{2,1,0} rsqrt(%add.766), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/rsqrt"}
+  %mul.557 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.40), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/mul"}
+  %mul.558 = f32[1,197]{1,0} reshape(%mul.557), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/mul"}
+  %mul.559 = f32[1,197,768]{2,1,0} broadcast(%mul.558), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/mul"}
+  %constant.304 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.560 = f32[1,1,768]{2,1,0} broadcast(%constant.304), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/mul"}
+  %mul.561 = f32[1,768]{1,0} reshape(%mul.560), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/mul"}
+  %mul.562 = f32[1,197,768]{2,1,0} broadcast(%mul.561), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/mul"}
+  %mul.563 = f32[1,197,768]{2,1,0} multiply(%mul.559, %mul.562), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/mul"}
+  %mul.568 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.227, %mul.563), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/mul"}
+  %reduce_sum.298 = f32[1,197]{1,0} reduce(%convert_element_type.227, %constant.419), dimensions={2}, to_apply=%region_34.39, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/reduce_sum"}
+  %broadcast_in_dim.72 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.298), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/broadcast_in_dim"}
+  %div.128 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.72, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/div"}
+  %neg.59 = f32[1,197,1]{2,1,0} negate(%div.128), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/neg"}
+  %mul.564 = f32[1,197,1]{2,1,0} broadcast(%neg.59), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/mul"}
+  %mul.565 = f32[1,197]{1,0} reshape(%mul.564), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/mul"}
+  %mul.566 = f32[1,197,768]{2,1,0} broadcast(%mul.565), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/mul"}
+  %mul.567 = f32[1,197,768]{2,1,0} multiply(%mul.566, %mul.563), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/mul"}
+  %constant.303 = f32[1,1,768]{2,1,0} constant({...})
+  %add.767 = f32[1,1,768]{2,1,0} broadcast(%constant.303), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/add"}
+  %add.768 = f32[1,768]{1,0} reshape(%add.767), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/add"}
+  %add.769 = f32[1,197,768]{2,1,0} broadcast(%add.768), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/add"}
+  %add.770 = f32[1,197,768]{2,1,0} add(%mul.567, %add.769), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/add"}
+  %add.771 = f32[1,197,768]{2,1,0} add(%mul.568, %add.770), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/add"}
+  %convert_element_type.228 = bf16[1,197,768]{2,1,0} convert(%add.771), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/ln_2/convert_element_type"}
+  %constant.469 = f32[768,3072]{1,0} constant({...})
+  %convert_element_type.229 = bf16[768,3072]{1,0} convert(%constant.469), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/convert_element_type"}
+  %dot_general.159 = bf16[1,197,3072]{2,1,0} dot(%convert_element_type.228, %convert_element_type.229), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/dot_general"}
+  %constant.302 = bf16[1,1,3072]{2,1,0} constant({...})
+  %add.772 = bf16[1,1,3072]{2,1,0} broadcast(%constant.302), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/add"}
+  %add.773 = bf16[1,3072]{1,0} reshape(%add.772), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/add"}
+  %add.774 = bf16[1,197,3072]{2,1,0} broadcast(%add.773), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/add"}
+  %add.775 = bf16[1,197,3072]{2,1,0} add(%dot_general.159, %add.774), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/add"}
+  %mul.569 = bf16[1,197,3072]{2,1,0} multiply(%add.775, %broadcast.35), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/mul"}
+  %neg.60 = bf16[1,197,3072]{2,1,0} negate(%add.775), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/neg"}
+  %mul.570 = bf16[1,197,3072]{2,1,0} multiply(%neg.60, %broadcast.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/mul"}
+  %erfc.1235 = f32[1,197,3072]{2,1,0} convert(%mul.570), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1296 = f32[1,197,3072]{2,1,0} abs(%erfc.1235), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1297 = pred[1,197,3072]{2,1,0} compare(%erfc.1296, %broadcast.67), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1281 = f32[1,197,3072]{2,1,0} multiply(%erfc.1235, %erfc.1235), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1282 = f32[1,197,3072]{2,1,0} multiply(%erfc.1281, %broadcast.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1283 = f32[1,197,3072]{2,1,0} add(%erfc.1282, %broadcast.45), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1284 = f32[1,197,3072]{2,1,0} multiply(%erfc.1283, %erfc.1281), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1285 = f32[1,197,3072]{2,1,0} add(%erfc.1284, %broadcast.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1286 = f32[1,197,3072]{2,1,0} multiply(%erfc.1285, %erfc.1281), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1287 = f32[1,197,3072]{2,1,0} add(%erfc.1286, %broadcast.43), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1288 = f32[1,197,3072]{2,1,0} multiply(%erfc.1287, %erfc.1281), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1289 = f32[1,197,3072]{2,1,0} add(%erfc.1288, %broadcast.42), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1290 = f32[1,197,3072]{2,1,0} multiply(%erfc.1289, %erfc.1281), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1291 = f32[1,197,3072]{2,1,0} add(%erfc.1290, %broadcast.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1292 = f32[1,197,3072]{2,1,0} multiply(%erfc.1291, %erfc.1281), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1293 = f32[1,197,3072]{2,1,0} add(%erfc.1292, %broadcast.40), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1294 = f32[1,197,3072]{2,1,0} multiply(%erfc.1235, %erfc.1293), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1295 = f32[1,197,3072]{2,1,0} subtract(%broadcast.67, %erfc.1294), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1278 = pred[1,197,3072]{2,1,0} compare(%erfc.1235, %broadcast.47), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1236 = f32[1,197,3072]{2,1,0} multiply(%erfc.1235, %erfc.1235), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1237 = f32[1,197,3072]{2,1,0} negate(%erfc.1236), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1276 = pred[1,197,3072]{2,1,0} compare(%erfc.1237, %broadcast.48), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1240 = f32[1,197,3072]{2,1,0} exponential(%erfc.1237), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1238 = f32[1,197,3072]{2,1,0} abs(%erfc.1235), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1241 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1238), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1242 = f32[1,197,3072]{2,1,0} multiply(%erfc.1240, %erfc.1241), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1243 = pred[1,197,3072]{2,1,0} compare(%erfc.1238, %broadcast.66), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1239 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1236), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1244 = f32[1,197,3072]{2,1,0} multiply(%erfc.1239, %broadcast.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1245 = f32[1,197,3072]{2,1,0} add(%erfc.1244, %broadcast.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1246 = f32[1,197,3072]{2,1,0} multiply(%erfc.1245, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1247 = f32[1,197,3072]{2,1,0} add(%erfc.1246, %broadcast.63), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1248 = f32[1,197,3072]{2,1,0} multiply(%erfc.1247, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1249 = f32[1,197,3072]{2,1,0} add(%erfc.1248, %broadcast.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1250 = f32[1,197,3072]{2,1,0} multiply(%erfc.1249, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1251 = f32[1,197,3072]{2,1,0} add(%erfc.1250, %broadcast.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1252 = f32[1,197,3072]{2,1,0} multiply(%erfc.1251, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1253 = f32[1,197,3072]{2,1,0} add(%erfc.1252, %broadcast.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1254 = f32[1,197,3072]{2,1,0} multiply(%erfc.1253, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1255 = f32[1,197,3072]{2,1,0} add(%erfc.1254, %broadcast.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1256 = f32[1,197,3072]{2,1,0} multiply(%erfc.1255, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1257 = f32[1,197,3072]{2,1,0} add(%erfc.1256, %broadcast.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1258 = f32[1,197,3072]{2,1,0} multiply(%erfc.1257, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1259 = f32[1,197,3072]{2,1,0} add(%erfc.1258, %broadcast.57), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1260 = f32[1,197,3072]{2,1,0} multiply(%erfc.1239, %broadcast.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1261 = f32[1,197,3072]{2,1,0} add(%erfc.1260, %broadcast.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1262 = f32[1,197,3072]{2,1,0} multiply(%erfc.1261, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1263 = f32[1,197,3072]{2,1,0} add(%erfc.1262, %broadcast.54), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1264 = f32[1,197,3072]{2,1,0} multiply(%erfc.1263, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1265 = f32[1,197,3072]{2,1,0} add(%erfc.1264, %broadcast.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1266 = f32[1,197,3072]{2,1,0} multiply(%erfc.1265, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1267 = f32[1,197,3072]{2,1,0} add(%erfc.1266, %broadcast.52), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1268 = f32[1,197,3072]{2,1,0} multiply(%erfc.1267, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1269 = f32[1,197,3072]{2,1,0} add(%erfc.1268, %broadcast.51), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1270 = f32[1,197,3072]{2,1,0} multiply(%erfc.1269, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1271 = f32[1,197,3072]{2,1,0} add(%erfc.1270, %broadcast.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1272 = f32[1,197,3072]{2,1,0} multiply(%erfc.1271, %erfc.1239), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1273 = f32[1,197,3072]{2,1,0} add(%erfc.1272, %broadcast.49), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1274 = f32[1,197,3072]{2,1,0} select(%erfc.1243, %erfc.1259, %erfc.1273), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1275 = f32[1,197,3072]{2,1,0} multiply(%erfc.1242, %erfc.1274), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1277 = f32[1,197,3072]{2,1,0} select(%erfc.1276, %broadcast.47, %erfc.1275), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1279 = f32[1,197,3072]{2,1,0} subtract(%broadcast.66, %erfc.1277), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1280 = f32[1,197,3072]{2,1,0} select(%erfc.1278, %erfc.1279, %erfc.1277), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1298 = f32[1,197,3072]{2,1,0} select(%erfc.1297, %erfc.1295, %erfc.1280), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %erfc.1299 = bf16[1,197,3072]{2,1,0} convert(%erfc.1298), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/erfc"}
+  %mul.571 = bf16[1,197,3072]{2,1,0} multiply(%mul.569, %erfc.1299), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_1/mul"}
+  %constant.470 = f32[3072,768]{1,0} constant({...})
+  %convert_element_type.230 = bf16[3072,768]{1,0} convert(%constant.470), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_2/convert_element_type"}
+  %dot_general.160 = bf16[1,197,768]{2,1,0} dot(%mul.571, %convert_element_type.230), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_2/dot_general"}
+  %constant.301 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.776 = bf16[1,1,768]{2,1,0} broadcast(%constant.301), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_2/add"}
+  %add.777 = bf16[1,768]{1,0} reshape(%add.776), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_2/add"}
+  %add.778 = bf16[1,197,768]{2,1,0} broadcast(%add.777), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_2/add"}
+  %add.779 = bf16[1,197,768]{2,1,0} add(%dot_general.160, %add.778), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/mlp/dense_2/add"}
+  %add.780 = bf16[1,197,768]{2,1,0} add(%add.765, %add.779), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_8/add"}
+  %convert_element_type.231 = f32[1,197,768]{2,1,0} convert(%add.780), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/convert_element_type"}
+  %jit__var_.41 = f32[1,197,1]{2,1,0} call(%convert_element_type.231, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/jit(_var)"}
+  %add.781 = f32[1,197,1]{2,1,0} add(%jit__var_.41, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/add"}
+  %rsqrt.41 = f32[1,197,1]{2,1,0} rsqrt(%add.781), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/rsqrt"}
+  %mul.572 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.41), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/mul"}
+  %mul.573 = f32[1,197]{1,0} reshape(%mul.572), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/mul"}
+  %mul.574 = f32[1,197,768]{2,1,0} broadcast(%mul.573), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/mul"}
+  %constant.300 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.575 = f32[1,1,768]{2,1,0} broadcast(%constant.300), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/mul"}
+  %mul.576 = f32[1,768]{1,0} reshape(%mul.575), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/mul"}
+  %mul.577 = f32[1,197,768]{2,1,0} broadcast(%mul.576), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/mul"}
+  %mul.578 = f32[1,197,768]{2,1,0} multiply(%mul.574, %mul.577), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/mul"}
+  %mul.583 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.231, %mul.578), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/mul"}
+  %reduce_sum.299 = f32[1,197]{1,0} reduce(%convert_element_type.231, %constant.419), dimensions={2}, to_apply=%region_35.40, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/reduce_sum"}
+  %broadcast_in_dim.73 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.299), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/broadcast_in_dim"}
+  %div.129 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.73, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/div"}
+  %neg.61 = f32[1,197,1]{2,1,0} negate(%div.129), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/neg"}
+  %mul.579 = f32[1,197,1]{2,1,0} broadcast(%neg.61), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/mul"}
+  %mul.580 = f32[1,197]{1,0} reshape(%mul.579), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/mul"}
+  %mul.581 = f32[1,197,768]{2,1,0} broadcast(%mul.580), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/mul"}
+  %mul.582 = f32[1,197,768]{2,1,0} multiply(%mul.581, %mul.578), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/mul"}
+  %constant.299 = f32[1,1,768]{2,1,0} constant({...})
+  %add.782 = f32[1,1,768]{2,1,0} broadcast(%constant.299), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/add"}
+  %add.783 = f32[1,768]{1,0} reshape(%add.782), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/add"}
+  %add.784 = f32[1,197,768]{2,1,0} broadcast(%add.783), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/add"}
+  %add.785 = f32[1,197,768]{2,1,0} add(%mul.582, %add.784), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/add"}
+  %add.786 = f32[1,197,768]{2,1,0} add(%mul.583, %add.785), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/add"}
+  %convert_element_type.232 = bf16[1,197,768]{2,1,0} convert(%add.786), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_1/convert_element_type"}
+  %constant.473 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.235 = bf16[768,12,64]{2,1,0} convert(%constant.473), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/value/convert_element_type"}
+  %dot_general.163 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.232, %convert_element_type.235), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/value/abc,cde->abde/dot_general"}
+  %constant.296 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.795 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.296), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/value/add"}
+  %add.796 = bf16[1,12,64]{2,1,0} reshape(%add.795), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/value/add"}
+  %add.797 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.796), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/value/add"}
+  %add.798 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.163, %add.797), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/value/add"}
+  %constant.471 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.233 = bf16[768,12,64]{2,1,0} convert(%constant.471), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/query/convert_element_type"}
+  %dot_general.161 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.232, %convert_element_type.233), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/query/abc,cde->abde/dot_general"}
+  %constant.298 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.787 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.298), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/query/add"}
+  %add.788 = bf16[1,12,64]{2,1,0} reshape(%add.787), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/query/add"}
+  %add.789 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.788), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/query/add"}
+  %add.790 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.161, %add.789), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/query/add"}
+  %reshape.42 = bf16[1,197,12,1,64]{4,3,2,1,0} reshape(%add.790), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/reshape"}
+  %constant.472 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.234 = bf16[768,12,64]{2,1,0} convert(%constant.472), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/key/convert_element_type"}
+  %dot_general.162 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.232, %convert_element_type.234), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/key/abc,cde->abde/dot_general"}
+  %constant.297 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.791 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.297), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/key/add"}
+  %add.792 = bf16[1,12,64]{2,1,0} reshape(%add.791), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/key/add"}
+  %add.793 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.792), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/key/add"}
+  %add.794 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.162, %add.793), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/key/add"}
+  %dot_general.164 = f32[1,12,197,1,197]{4,3,2,1,0} dot(%reshape.42, %add.794), lhs_batch_dims={0,2}, lhs_contracting_dims={4}, rhs_batch_dims={0,2}, rhs_contracting_dims={3}, algorithm=dot_bf16_bf16_f32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap(BTNH,BSNH->BNTS)/dot_general"}
+  %mul.584 = f32[1,12,197,1,197]{4,3,2,1,0} multiply(%dot_general.164, %broadcast.37), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/mul"}
+  %transpose.61 = f32[1,1,12,197,197]{4,3,2,1,0} reshape(%mul.584), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/transpose"}
+  %reduce_max.92 = f32[1,12,197,1]{3,2,1,0} reduce(%mul.584, %constant.417), dimensions={4}, to_apply=%region_36.41, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/reduce_max"}
+  %max.20 = f32[1,12,197,1]{3,2,1,0} maximum(%reduce_max.92, %broadcast.36), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/max"}
+  %transpose.60 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%max.20), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/broadcast_in_dim;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/transpose"}
+  %sub.90 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%transpose.60), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/sub"}
+  %sub.91 = f32[1,1,12,197]{3,2,1,0} reshape(%sub.90), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/sub"}
+  %sub.92 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%sub.91), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/sub"}
+  %sub.93 = f32[1,1,12,197,197]{4,3,2,1,0} subtract(%transpose.61, %sub.92), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/sub"}
+  %exp.20 = f32[1,1,12,197,197]{4,3,2,1,0} exponential(%sub.93), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/exp"}
+  %reduce_sum.300 = f32[1,1,12,197]{3,2,1,0} reduce(%exp.20, %constant.419), dimensions={4}, to_apply=%region_37.42, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/reduce_sum"}
+  %broadcast_in_dim.74 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%reduce_sum.300), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/broadcast_in_dim"}
+  %div.130 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%broadcast_in_dim.74), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/div"}
+  %div.131 = f32[1,1,12,197]{3,2,1,0} reshape(%div.130), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/div"}
+  %div.132 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%div.131), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/div"}
+  %div.133 = f32[1,1,12,197,197]{4,3,2,1,0} divide(%exp.20, %div.132), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/div"}
+  %convert_element_type.236 = bf16[1,1,12,197,197]{4,3,2,1,0} convert(%div.133), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/convert_element_type"}
+  %dot_general.165 = bf16[1,12,64,1,197]{4,3,2,1,0} dot(%add.798, %convert_element_type.236), lhs_batch_dims={0,2}, lhs_contracting_dims={1}, rhs_batch_dims={1,2}, rhs_contracting_dims={4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap(BNTS,BSNH->BTNH)/dot_general"}
+  %transpose.62 = bf16[1,197,12,1,64]{1,3,4,2,0} transpose(%dot_general.165), dimensions={0,4,1,3,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap()/transpose;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/vmap(BNTS,BSNH->BTNH)/transpose"}
+  %reshape.43 = bf16[1,197,12,64]{3,2,1,0} reshape(%transpose.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/reshape"}
+  %constant.474 = f32[12,64,768]{2,1,0} constant({...})
+  %convert_element_type.237 = bf16[12,64,768]{2,1,0} convert(%constant.474), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/attention_output/convert_element_type"}
+  %dot_general.166 = bf16[1,197,768]{2,1,0} dot(%reshape.43, %convert_element_type.237), lhs_contracting_dims={2,3}, rhs_contracting_dims={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/attention_output/abcd,cde->abe/dot_general"}
+  %constant.295 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.799 = bf16[1,1,768]{2,1,0} broadcast(%constant.295), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/attention_output/add"}
+  %add.800 = bf16[1,768]{1,0} reshape(%add.799), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/attention_output/add"}
+  %add.801 = bf16[1,197,768]{2,1,0} broadcast(%add.800), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/attention_output/add"}
+  %add.802 = bf16[1,197,768]{2,1,0} add(%dot_general.166, %add.801), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mha/attention_output/add"}
+  %add.803 = bf16[1,197,768]{2,1,0} add(%add.802, %add.780), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/add"}
+  %convert_element_type.238 = f32[1,197,768]{2,1,0} convert(%add.803), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/convert_element_type"}
+  %jit__var_.42 = f32[1,197,1]{2,1,0} call(%convert_element_type.238, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/jit(_var)"}
+  %add.804 = f32[1,197,1]{2,1,0} add(%jit__var_.42, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/add"}
+  %rsqrt.42 = f32[1,197,1]{2,1,0} rsqrt(%add.804), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/rsqrt"}
+  %mul.585 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.42), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/mul"}
+  %mul.586 = f32[1,197]{1,0} reshape(%mul.585), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/mul"}
+  %mul.587 = f32[1,197,768]{2,1,0} broadcast(%mul.586), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/mul"}
+  %constant.294 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.588 = f32[1,1,768]{2,1,0} broadcast(%constant.294), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/mul"}
+  %mul.589 = f32[1,768]{1,0} reshape(%mul.588), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/mul"}
+  %mul.590 = f32[1,197,768]{2,1,0} broadcast(%mul.589), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/mul"}
+  %mul.591 = f32[1,197,768]{2,1,0} multiply(%mul.587, %mul.590), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/mul"}
+  %mul.596 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.238, %mul.591), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/mul"}
+  %reduce_sum.301 = f32[1,197]{1,0} reduce(%convert_element_type.238, %constant.419), dimensions={2}, to_apply=%region_38.43, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/reduce_sum"}
+  %broadcast_in_dim.75 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.301), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/broadcast_in_dim"}
+  %div.134 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.75, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/div"}
+  %neg.62 = f32[1,197,1]{2,1,0} negate(%div.134), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/neg"}
+  %mul.592 = f32[1,197,1]{2,1,0} broadcast(%neg.62), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/mul"}
+  %mul.593 = f32[1,197]{1,0} reshape(%mul.592), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/mul"}
+  %mul.594 = f32[1,197,768]{2,1,0} broadcast(%mul.593), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/mul"}
+  %mul.595 = f32[1,197,768]{2,1,0} multiply(%mul.594, %mul.591), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/mul"}
+  %constant.293 = f32[1,1,768]{2,1,0} constant({...})
+  %add.805 = f32[1,1,768]{2,1,0} broadcast(%constant.293), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/add"}
+  %add.806 = f32[1,768]{1,0} reshape(%add.805), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/add"}
+  %add.807 = f32[1,197,768]{2,1,0} broadcast(%add.806), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/add"}
+  %add.808 = f32[1,197,768]{2,1,0} add(%mul.595, %add.807), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/add"}
+  %add.809 = f32[1,197,768]{2,1,0} add(%mul.596, %add.808), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/add"}
+  %convert_element_type.239 = bf16[1,197,768]{2,1,0} convert(%add.809), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/ln_2/convert_element_type"}
+  %constant.475 = f32[768,3072]{1,0} constant({...})
+  %convert_element_type.240 = bf16[768,3072]{1,0} convert(%constant.475), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/convert_element_type"}
+  %dot_general.167 = bf16[1,197,3072]{2,1,0} dot(%convert_element_type.239, %convert_element_type.240), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/dot_general"}
+  %constant.292 = bf16[1,1,3072]{2,1,0} constant({...})
+  %add.810 = bf16[1,1,3072]{2,1,0} broadcast(%constant.292), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/add"}
+  %add.811 = bf16[1,3072]{1,0} reshape(%add.810), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/add"}
+  %add.812 = bf16[1,197,3072]{2,1,0} broadcast(%add.811), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/add"}
+  %add.813 = bf16[1,197,3072]{2,1,0} add(%dot_general.167, %add.812), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/add"}
+  %mul.597 = bf16[1,197,3072]{2,1,0} multiply(%add.813, %broadcast.35), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/mul"}
+  %neg.63 = bf16[1,197,3072]{2,1,0} negate(%add.813), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/neg"}
+  %mul.598 = bf16[1,197,3072]{2,1,0} multiply(%neg.63, %broadcast.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/mul"}
+  %erfc.1300 = f32[1,197,3072]{2,1,0} convert(%mul.598), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1361 = f32[1,197,3072]{2,1,0} abs(%erfc.1300), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1362 = pred[1,197,3072]{2,1,0} compare(%erfc.1361, %broadcast.67), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1346 = f32[1,197,3072]{2,1,0} multiply(%erfc.1300, %erfc.1300), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1347 = f32[1,197,3072]{2,1,0} multiply(%erfc.1346, %broadcast.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1348 = f32[1,197,3072]{2,1,0} add(%erfc.1347, %broadcast.45), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1349 = f32[1,197,3072]{2,1,0} multiply(%erfc.1348, %erfc.1346), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1350 = f32[1,197,3072]{2,1,0} add(%erfc.1349, %broadcast.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1351 = f32[1,197,3072]{2,1,0} multiply(%erfc.1350, %erfc.1346), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1352 = f32[1,197,3072]{2,1,0} add(%erfc.1351, %broadcast.43), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1353 = f32[1,197,3072]{2,1,0} multiply(%erfc.1352, %erfc.1346), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1354 = f32[1,197,3072]{2,1,0} add(%erfc.1353, %broadcast.42), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1355 = f32[1,197,3072]{2,1,0} multiply(%erfc.1354, %erfc.1346), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1356 = f32[1,197,3072]{2,1,0} add(%erfc.1355, %broadcast.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1357 = f32[1,197,3072]{2,1,0} multiply(%erfc.1356, %erfc.1346), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1358 = f32[1,197,3072]{2,1,0} add(%erfc.1357, %broadcast.40), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1359 = f32[1,197,3072]{2,1,0} multiply(%erfc.1300, %erfc.1358), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1360 = f32[1,197,3072]{2,1,0} subtract(%broadcast.67, %erfc.1359), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1343 = pred[1,197,3072]{2,1,0} compare(%erfc.1300, %broadcast.47), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1301 = f32[1,197,3072]{2,1,0} multiply(%erfc.1300, %erfc.1300), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1302 = f32[1,197,3072]{2,1,0} negate(%erfc.1301), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1341 = pred[1,197,3072]{2,1,0} compare(%erfc.1302, %broadcast.48), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1305 = f32[1,197,3072]{2,1,0} exponential(%erfc.1302), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1303 = f32[1,197,3072]{2,1,0} abs(%erfc.1300), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1306 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1303), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1307 = f32[1,197,3072]{2,1,0} multiply(%erfc.1305, %erfc.1306), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1308 = pred[1,197,3072]{2,1,0} compare(%erfc.1303, %broadcast.66), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1304 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1301), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1309 = f32[1,197,3072]{2,1,0} multiply(%erfc.1304, %broadcast.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1310 = f32[1,197,3072]{2,1,0} add(%erfc.1309, %broadcast.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1311 = f32[1,197,3072]{2,1,0} multiply(%erfc.1310, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1312 = f32[1,197,3072]{2,1,0} add(%erfc.1311, %broadcast.63), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1313 = f32[1,197,3072]{2,1,0} multiply(%erfc.1312, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1314 = f32[1,197,3072]{2,1,0} add(%erfc.1313, %broadcast.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1315 = f32[1,197,3072]{2,1,0} multiply(%erfc.1314, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1316 = f32[1,197,3072]{2,1,0} add(%erfc.1315, %broadcast.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1317 = f32[1,197,3072]{2,1,0} multiply(%erfc.1316, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1318 = f32[1,197,3072]{2,1,0} add(%erfc.1317, %broadcast.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1319 = f32[1,197,3072]{2,1,0} multiply(%erfc.1318, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1320 = f32[1,197,3072]{2,1,0} add(%erfc.1319, %broadcast.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1321 = f32[1,197,3072]{2,1,0} multiply(%erfc.1320, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1322 = f32[1,197,3072]{2,1,0} add(%erfc.1321, %broadcast.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1323 = f32[1,197,3072]{2,1,0} multiply(%erfc.1322, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1324 = f32[1,197,3072]{2,1,0} add(%erfc.1323, %broadcast.57), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1325 = f32[1,197,3072]{2,1,0} multiply(%erfc.1304, %broadcast.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1326 = f32[1,197,3072]{2,1,0} add(%erfc.1325, %broadcast.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1327 = f32[1,197,3072]{2,1,0} multiply(%erfc.1326, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1328 = f32[1,197,3072]{2,1,0} add(%erfc.1327, %broadcast.54), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1329 = f32[1,197,3072]{2,1,0} multiply(%erfc.1328, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1330 = f32[1,197,3072]{2,1,0} add(%erfc.1329, %broadcast.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1331 = f32[1,197,3072]{2,1,0} multiply(%erfc.1330, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1332 = f32[1,197,3072]{2,1,0} add(%erfc.1331, %broadcast.52), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1333 = f32[1,197,3072]{2,1,0} multiply(%erfc.1332, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1334 = f32[1,197,3072]{2,1,0} add(%erfc.1333, %broadcast.51), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1335 = f32[1,197,3072]{2,1,0} multiply(%erfc.1334, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1336 = f32[1,197,3072]{2,1,0} add(%erfc.1335, %broadcast.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1337 = f32[1,197,3072]{2,1,0} multiply(%erfc.1336, %erfc.1304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1338 = f32[1,197,3072]{2,1,0} add(%erfc.1337, %broadcast.49), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1339 = f32[1,197,3072]{2,1,0} select(%erfc.1308, %erfc.1324, %erfc.1338), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1340 = f32[1,197,3072]{2,1,0} multiply(%erfc.1307, %erfc.1339), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1342 = f32[1,197,3072]{2,1,0} select(%erfc.1341, %broadcast.47, %erfc.1340), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1344 = f32[1,197,3072]{2,1,0} subtract(%broadcast.66, %erfc.1342), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1345 = f32[1,197,3072]{2,1,0} select(%erfc.1343, %erfc.1344, %erfc.1342), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1363 = f32[1,197,3072]{2,1,0} select(%erfc.1362, %erfc.1360, %erfc.1345), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %erfc.1364 = bf16[1,197,3072]{2,1,0} convert(%erfc.1363), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/erfc"}
+  %mul.599 = bf16[1,197,3072]{2,1,0} multiply(%mul.597, %erfc.1364), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_1/mul"}
+  %constant.476 = f32[3072,768]{1,0} constant({...})
+  %convert_element_type.241 = bf16[3072,768]{1,0} convert(%constant.476), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_2/convert_element_type"}
+  %dot_general.168 = bf16[1,197,768]{2,1,0} dot(%mul.599, %convert_element_type.241), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_2/dot_general"}
+  %constant.291 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.814 = bf16[1,1,768]{2,1,0} broadcast(%constant.291), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_2/add"}
+  %add.815 = bf16[1,768]{1,0} reshape(%add.814), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_2/add"}
+  %add.816 = bf16[1,197,768]{2,1,0} broadcast(%add.815), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_2/add"}
+  %add.817 = bf16[1,197,768]{2,1,0} add(%dot_general.168, %add.816), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/mlp/dense_2/add"}
+  %add.818 = bf16[1,197,768]{2,1,0} add(%add.803, %add.817), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_9/add"}
+  %convert_element_type.242 = f32[1,197,768]{2,1,0} convert(%add.818), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/convert_element_type"}
+  %jit__var_.43 = f32[1,197,1]{2,1,0} call(%convert_element_type.242, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/jit(_var)"}
+  %add.819 = f32[1,197,1]{2,1,0} add(%jit__var_.43, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/add"}
+  %rsqrt.43 = f32[1,197,1]{2,1,0} rsqrt(%add.819), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/rsqrt"}
+  %mul.600 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.43), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/mul"}
+  %mul.601 = f32[1,197]{1,0} reshape(%mul.600), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/mul"}
+  %mul.602 = f32[1,197,768]{2,1,0} broadcast(%mul.601), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/mul"}
+  %constant.290 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.603 = f32[1,1,768]{2,1,0} broadcast(%constant.290), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/mul"}
+  %mul.604 = f32[1,768]{1,0} reshape(%mul.603), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/mul"}
+  %mul.605 = f32[1,197,768]{2,1,0} broadcast(%mul.604), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/mul"}
+  %mul.606 = f32[1,197,768]{2,1,0} multiply(%mul.602, %mul.605), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/mul"}
+  %mul.611 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.242, %mul.606), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/mul"}
+  %reduce_sum.302 = f32[1,197]{1,0} reduce(%convert_element_type.242, %constant.419), dimensions={2}, to_apply=%region_39.44, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/reduce_sum"}
+  %broadcast_in_dim.76 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.302), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/broadcast_in_dim"}
+  %div.135 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.76, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/div"}
+  %neg.64 = f32[1,197,1]{2,1,0} negate(%div.135), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/neg"}
+  %mul.607 = f32[1,197,1]{2,1,0} broadcast(%neg.64), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/mul"}
+  %mul.608 = f32[1,197]{1,0} reshape(%mul.607), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/mul"}
+  %mul.609 = f32[1,197,768]{2,1,0} broadcast(%mul.608), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/mul"}
+  %mul.610 = f32[1,197,768]{2,1,0} multiply(%mul.609, %mul.606), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/mul"}
+  %constant.289 = f32[1,1,768]{2,1,0} constant({...})
+  %add.820 = f32[1,1,768]{2,1,0} broadcast(%constant.289), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/add"}
+  %add.821 = f32[1,768]{1,0} reshape(%add.820), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/add"}
+  %add.822 = f32[1,197,768]{2,1,0} broadcast(%add.821), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/add"}
+  %add.823 = f32[1,197,768]{2,1,0} add(%mul.610, %add.822), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/add"}
+  %add.824 = f32[1,197,768]{2,1,0} add(%mul.611, %add.823), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/add"}
+  %convert_element_type.243 = bf16[1,197,768]{2,1,0} convert(%add.824), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_1/convert_element_type"}
+  %constant.479 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.246 = bf16[768,12,64]{2,1,0} convert(%constant.479), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/value/convert_element_type"}
+  %dot_general.171 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.243, %convert_element_type.246), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/value/abc,cde->abde/dot_general"}
+  %constant.286 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.833 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.286), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/value/add"}
+  %add.834 = bf16[1,12,64]{2,1,0} reshape(%add.833), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/value/add"}
+  %add.835 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.834), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/value/add"}
+  %add.836 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.171, %add.835), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/value/add"}
+  %constant.477 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.244 = bf16[768,12,64]{2,1,0} convert(%constant.477), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/query/convert_element_type"}
+  %dot_general.169 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.243, %convert_element_type.244), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/query/abc,cde->abde/dot_general"}
+  %constant.288 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.825 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.288), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/query/add"}
+  %add.826 = bf16[1,12,64]{2,1,0} reshape(%add.825), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/query/add"}
+  %add.827 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.826), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/query/add"}
+  %add.828 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.169, %add.827), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/query/add"}
+  %reshape.44 = bf16[1,197,12,1,64]{4,3,2,1,0} reshape(%add.828), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/reshape"}
+  %constant.478 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.245 = bf16[768,12,64]{2,1,0} convert(%constant.478), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/key/convert_element_type"}
+  %dot_general.170 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.243, %convert_element_type.245), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/key/abc,cde->abde/dot_general"}
+  %constant.287 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.829 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.287), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/key/add"}
+  %add.830 = bf16[1,12,64]{2,1,0} reshape(%add.829), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/key/add"}
+  %add.831 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.830), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/key/add"}
+  %add.832 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.170, %add.831), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/key/add"}
+  %dot_general.172 = f32[1,12,197,1,197]{4,3,2,1,0} dot(%reshape.44, %add.832), lhs_batch_dims={0,2}, lhs_contracting_dims={4}, rhs_batch_dims={0,2}, rhs_contracting_dims={3}, algorithm=dot_bf16_bf16_f32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap(BTNH,BSNH->BNTS)/dot_general"}
+  %mul.612 = f32[1,12,197,1,197]{4,3,2,1,0} multiply(%dot_general.172, %broadcast.37), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/mul"}
+  %transpose.64 = f32[1,1,12,197,197]{4,3,2,1,0} reshape(%mul.612), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/transpose"}
+  %reduce_max.93 = f32[1,12,197,1]{3,2,1,0} reduce(%mul.612, %constant.417), dimensions={4}, to_apply=%region_40.45, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/reduce_max"}
+  %max.21 = f32[1,12,197,1]{3,2,1,0} maximum(%reduce_max.93, %broadcast.36), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/max"}
+  %transpose.63 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%max.21), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/broadcast_in_dim;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/transpose"}
+  %sub.94 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%transpose.63), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/sub"}
+  %sub.95 = f32[1,1,12,197]{3,2,1,0} reshape(%sub.94), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/sub"}
+  %sub.96 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%sub.95), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/sub"}
+  %sub.97 = f32[1,1,12,197,197]{4,3,2,1,0} subtract(%transpose.64, %sub.96), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/sub"}
+  %exp.21 = f32[1,1,12,197,197]{4,3,2,1,0} exponential(%sub.97), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/exp"}
+  %reduce_sum.303 = f32[1,1,12,197]{3,2,1,0} reduce(%exp.21, %constant.419), dimensions={4}, to_apply=%region_41.46, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/reduce_sum"}
+  %broadcast_in_dim.77 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%reduce_sum.303), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/broadcast_in_dim"}
+  %div.136 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%broadcast_in_dim.77), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/div"}
+  %div.137 = f32[1,1,12,197]{3,2,1,0} reshape(%div.136), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/div"}
+  %div.138 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%div.137), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/div"}
+  %div.139 = f32[1,1,12,197,197]{4,3,2,1,0} divide(%exp.21, %div.138), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/div"}
+  %convert_element_type.247 = bf16[1,1,12,197,197]{4,3,2,1,0} convert(%div.139), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/convert_element_type"}
+  %dot_general.173 = bf16[1,12,64,1,197]{4,3,2,1,0} dot(%add.836, %convert_element_type.247), lhs_batch_dims={0,2}, lhs_contracting_dims={1}, rhs_batch_dims={1,2}, rhs_contracting_dims={4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap(BNTS,BSNH->BTNH)/dot_general"}
+  %transpose.65 = bf16[1,197,12,1,64]{1,3,4,2,0} transpose(%dot_general.173), dimensions={0,4,1,3,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap()/transpose;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/vmap(BNTS,BSNH->BTNH)/transpose"}
+  %reshape.45 = bf16[1,197,12,64]{3,2,1,0} reshape(%transpose.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/reshape"}
+  %constant.480 = f32[12,64,768]{2,1,0} constant({...})
+  %convert_element_type.248 = bf16[12,64,768]{2,1,0} convert(%constant.480), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/attention_output/convert_element_type"}
+  %dot_general.174 = bf16[1,197,768]{2,1,0} dot(%reshape.45, %convert_element_type.248), lhs_contracting_dims={2,3}, rhs_contracting_dims={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/attention_output/abcd,cde->abe/dot_general"}
+  %constant.285 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.837 = bf16[1,1,768]{2,1,0} broadcast(%constant.285), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/attention_output/add"}
+  %add.838 = bf16[1,768]{1,0} reshape(%add.837), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/attention_output/add"}
+  %add.839 = bf16[1,197,768]{2,1,0} broadcast(%add.838), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/attention_output/add"}
+  %add.840 = bf16[1,197,768]{2,1,0} add(%dot_general.174, %add.839), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mha/attention_output/add"}
+  %add.841 = bf16[1,197,768]{2,1,0} add(%add.840, %add.818), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/add"}
+  %convert_element_type.249 = f32[1,197,768]{2,1,0} convert(%add.841), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/convert_element_type"}
+  %jit__var_.44 = f32[1,197,1]{2,1,0} call(%convert_element_type.249, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/jit(_var)"}
+  %add.842 = f32[1,197,1]{2,1,0} add(%jit__var_.44, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/add"}
+  %rsqrt.44 = f32[1,197,1]{2,1,0} rsqrt(%add.842), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/rsqrt"}
+  %mul.613 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.44), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/mul"}
+  %mul.614 = f32[1,197]{1,0} reshape(%mul.613), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/mul"}
+  %mul.615 = f32[1,197,768]{2,1,0} broadcast(%mul.614), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/mul"}
+  %constant.284 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.616 = f32[1,1,768]{2,1,0} broadcast(%constant.284), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/mul"}
+  %mul.617 = f32[1,768]{1,0} reshape(%mul.616), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/mul"}
+  %mul.618 = f32[1,197,768]{2,1,0} broadcast(%mul.617), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/mul"}
+  %mul.619 = f32[1,197,768]{2,1,0} multiply(%mul.615, %mul.618), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/mul"}
+  %mul.624 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.249, %mul.619), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/mul"}
+  %reduce_sum.304 = f32[1,197]{1,0} reduce(%convert_element_type.249, %constant.419), dimensions={2}, to_apply=%region_42.47, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/reduce_sum"}
+  %broadcast_in_dim.78 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.304), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/broadcast_in_dim"}
+  %div.140 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.78, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/div"}
+  %neg.65 = f32[1,197,1]{2,1,0} negate(%div.140), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/neg"}
+  %mul.620 = f32[1,197,1]{2,1,0} broadcast(%neg.65), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/mul"}
+  %mul.621 = f32[1,197]{1,0} reshape(%mul.620), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/mul"}
+  %mul.622 = f32[1,197,768]{2,1,0} broadcast(%mul.621), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/mul"}
+  %mul.623 = f32[1,197,768]{2,1,0} multiply(%mul.622, %mul.619), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/mul"}
+  %constant.283 = f32[1,1,768]{2,1,0} constant({...})
+  %add.843 = f32[1,1,768]{2,1,0} broadcast(%constant.283), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/add"}
+  %add.844 = f32[1,768]{1,0} reshape(%add.843), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/add"}
+  %add.845 = f32[1,197,768]{2,1,0} broadcast(%add.844), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/add"}
+  %add.846 = f32[1,197,768]{2,1,0} add(%mul.623, %add.845), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/add"}
+  %add.847 = f32[1,197,768]{2,1,0} add(%mul.624, %add.846), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/add"}
+  %convert_element_type.250 = bf16[1,197,768]{2,1,0} convert(%add.847), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/ln_2/convert_element_type"}
+  %constant.481 = f32[768,3072]{1,0} constant({...})
+  %convert_element_type.251 = bf16[768,3072]{1,0} convert(%constant.481), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/convert_element_type"}
+  %dot_general.175 = bf16[1,197,3072]{2,1,0} dot(%convert_element_type.250, %convert_element_type.251), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/dot_general"}
+  %constant.282 = bf16[1,1,3072]{2,1,0} constant({...})
+  %add.848 = bf16[1,1,3072]{2,1,0} broadcast(%constant.282), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/add"}
+  %add.849 = bf16[1,3072]{1,0} reshape(%add.848), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/add"}
+  %add.850 = bf16[1,197,3072]{2,1,0} broadcast(%add.849), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/add"}
+  %add.851 = bf16[1,197,3072]{2,1,0} add(%dot_general.175, %add.850), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/add"}
+  %mul.625 = bf16[1,197,3072]{2,1,0} multiply(%add.851, %broadcast.35), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/mul"}
+  %neg.66 = bf16[1,197,3072]{2,1,0} negate(%add.851), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/neg"}
+  %mul.626 = bf16[1,197,3072]{2,1,0} multiply(%neg.66, %broadcast.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/mul"}
+  %erfc.1365 = f32[1,197,3072]{2,1,0} convert(%mul.626), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1426 = f32[1,197,3072]{2,1,0} abs(%erfc.1365), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1427 = pred[1,197,3072]{2,1,0} compare(%erfc.1426, %broadcast.67), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1411 = f32[1,197,3072]{2,1,0} multiply(%erfc.1365, %erfc.1365), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1412 = f32[1,197,3072]{2,1,0} multiply(%erfc.1411, %broadcast.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1413 = f32[1,197,3072]{2,1,0} add(%erfc.1412, %broadcast.45), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1414 = f32[1,197,3072]{2,1,0} multiply(%erfc.1413, %erfc.1411), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1415 = f32[1,197,3072]{2,1,0} add(%erfc.1414, %broadcast.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1416 = f32[1,197,3072]{2,1,0} multiply(%erfc.1415, %erfc.1411), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1417 = f32[1,197,3072]{2,1,0} add(%erfc.1416, %broadcast.43), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1418 = f32[1,197,3072]{2,1,0} multiply(%erfc.1417, %erfc.1411), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1419 = f32[1,197,3072]{2,1,0} add(%erfc.1418, %broadcast.42), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1420 = f32[1,197,3072]{2,1,0} multiply(%erfc.1419, %erfc.1411), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1421 = f32[1,197,3072]{2,1,0} add(%erfc.1420, %broadcast.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1422 = f32[1,197,3072]{2,1,0} multiply(%erfc.1421, %erfc.1411), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1423 = f32[1,197,3072]{2,1,0} add(%erfc.1422, %broadcast.40), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1424 = f32[1,197,3072]{2,1,0} multiply(%erfc.1365, %erfc.1423), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1425 = f32[1,197,3072]{2,1,0} subtract(%broadcast.67, %erfc.1424), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1408 = pred[1,197,3072]{2,1,0} compare(%erfc.1365, %broadcast.47), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1366 = f32[1,197,3072]{2,1,0} multiply(%erfc.1365, %erfc.1365), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1367 = f32[1,197,3072]{2,1,0} negate(%erfc.1366), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1406 = pred[1,197,3072]{2,1,0} compare(%erfc.1367, %broadcast.48), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1370 = f32[1,197,3072]{2,1,0} exponential(%erfc.1367), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1368 = f32[1,197,3072]{2,1,0} abs(%erfc.1365), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1371 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1368), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1372 = f32[1,197,3072]{2,1,0} multiply(%erfc.1370, %erfc.1371), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1373 = pred[1,197,3072]{2,1,0} compare(%erfc.1368, %broadcast.66), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1369 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1366), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1374 = f32[1,197,3072]{2,1,0} multiply(%erfc.1369, %broadcast.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1375 = f32[1,197,3072]{2,1,0} add(%erfc.1374, %broadcast.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1376 = f32[1,197,3072]{2,1,0} multiply(%erfc.1375, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1377 = f32[1,197,3072]{2,1,0} add(%erfc.1376, %broadcast.63), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1378 = f32[1,197,3072]{2,1,0} multiply(%erfc.1377, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1379 = f32[1,197,3072]{2,1,0} add(%erfc.1378, %broadcast.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1380 = f32[1,197,3072]{2,1,0} multiply(%erfc.1379, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1381 = f32[1,197,3072]{2,1,0} add(%erfc.1380, %broadcast.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1382 = f32[1,197,3072]{2,1,0} multiply(%erfc.1381, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1383 = f32[1,197,3072]{2,1,0} add(%erfc.1382, %broadcast.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1384 = f32[1,197,3072]{2,1,0} multiply(%erfc.1383, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1385 = f32[1,197,3072]{2,1,0} add(%erfc.1384, %broadcast.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1386 = f32[1,197,3072]{2,1,0} multiply(%erfc.1385, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1387 = f32[1,197,3072]{2,1,0} add(%erfc.1386, %broadcast.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1388 = f32[1,197,3072]{2,1,0} multiply(%erfc.1387, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1389 = f32[1,197,3072]{2,1,0} add(%erfc.1388, %broadcast.57), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1390 = f32[1,197,3072]{2,1,0} multiply(%erfc.1369, %broadcast.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1391 = f32[1,197,3072]{2,1,0} add(%erfc.1390, %broadcast.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1392 = f32[1,197,3072]{2,1,0} multiply(%erfc.1391, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1393 = f32[1,197,3072]{2,1,0} add(%erfc.1392, %broadcast.54), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1394 = f32[1,197,3072]{2,1,0} multiply(%erfc.1393, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1395 = f32[1,197,3072]{2,1,0} add(%erfc.1394, %broadcast.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1396 = f32[1,197,3072]{2,1,0} multiply(%erfc.1395, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1397 = f32[1,197,3072]{2,1,0} add(%erfc.1396, %broadcast.52), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1398 = f32[1,197,3072]{2,1,0} multiply(%erfc.1397, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1399 = f32[1,197,3072]{2,1,0} add(%erfc.1398, %broadcast.51), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1400 = f32[1,197,3072]{2,1,0} multiply(%erfc.1399, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1401 = f32[1,197,3072]{2,1,0} add(%erfc.1400, %broadcast.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1402 = f32[1,197,3072]{2,1,0} multiply(%erfc.1401, %erfc.1369), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1403 = f32[1,197,3072]{2,1,0} add(%erfc.1402, %broadcast.49), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1404 = f32[1,197,3072]{2,1,0} select(%erfc.1373, %erfc.1389, %erfc.1403), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1405 = f32[1,197,3072]{2,1,0} multiply(%erfc.1372, %erfc.1404), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1407 = f32[1,197,3072]{2,1,0} select(%erfc.1406, %broadcast.47, %erfc.1405), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1409 = f32[1,197,3072]{2,1,0} subtract(%broadcast.66, %erfc.1407), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1410 = f32[1,197,3072]{2,1,0} select(%erfc.1408, %erfc.1409, %erfc.1407), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1428 = f32[1,197,3072]{2,1,0} select(%erfc.1427, %erfc.1425, %erfc.1410), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %erfc.1429 = bf16[1,197,3072]{2,1,0} convert(%erfc.1428), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/erfc"}
+  %mul.627 = bf16[1,197,3072]{2,1,0} multiply(%mul.625, %erfc.1429), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_1/mul"}
+  %constant.482 = f32[3072,768]{1,0} constant({...})
+  %convert_element_type.252 = bf16[3072,768]{1,0} convert(%constant.482), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_2/convert_element_type"}
+  %dot_general.176 = bf16[1,197,768]{2,1,0} dot(%mul.627, %convert_element_type.252), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_2/dot_general"}
+  %constant.281 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.852 = bf16[1,1,768]{2,1,0} broadcast(%constant.281), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_2/add"}
+  %add.853 = bf16[1,768]{1,0} reshape(%add.852), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_2/add"}
+  %add.854 = bf16[1,197,768]{2,1,0} broadcast(%add.853), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_2/add"}
+  %add.855 = bf16[1,197,768]{2,1,0} add(%dot_general.176, %add.854), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/mlp/dense_2/add"}
+  %add.856 = bf16[1,197,768]{2,1,0} add(%add.841, %add.855), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_10/add"}
+  %convert_element_type.253 = f32[1,197,768]{2,1,0} convert(%add.856), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/convert_element_type"}
+  %jit__var_.45 = f32[1,197,1]{2,1,0} call(%convert_element_type.253, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/jit(_var)"}
+  %add.857 = f32[1,197,1]{2,1,0} add(%jit__var_.45, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/add"}
+  %rsqrt.45 = f32[1,197,1]{2,1,0} rsqrt(%add.857), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/rsqrt"}
+  %mul.628 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.45), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/mul"}
+  %mul.629 = f32[1,197]{1,0} reshape(%mul.628), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/mul"}
+  %mul.630 = f32[1,197,768]{2,1,0} broadcast(%mul.629), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/mul"}
+  %constant.280 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.631 = f32[1,1,768]{2,1,0} broadcast(%constant.280), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/mul"}
+  %mul.632 = f32[1,768]{1,0} reshape(%mul.631), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/mul"}
+  %mul.633 = f32[1,197,768]{2,1,0} broadcast(%mul.632), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/mul"}
+  %mul.634 = f32[1,197,768]{2,1,0} multiply(%mul.630, %mul.633), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/mul"}
+  %mul.639 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.253, %mul.634), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/mul"}
+  %reduce_sum.305 = f32[1,197]{1,0} reduce(%convert_element_type.253, %constant.419), dimensions={2}, to_apply=%region_43.48, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/reduce_sum"}
+  %broadcast_in_dim.79 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.305), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/broadcast_in_dim"}
+  %div.141 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.79, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/div"}
+  %neg.67 = f32[1,197,1]{2,1,0} negate(%div.141), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/neg"}
+  %mul.635 = f32[1,197,1]{2,1,0} broadcast(%neg.67), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/mul"}
+  %mul.636 = f32[1,197]{1,0} reshape(%mul.635), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/mul"}
+  %mul.637 = f32[1,197,768]{2,1,0} broadcast(%mul.636), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/mul"}
+  %mul.638 = f32[1,197,768]{2,1,0} multiply(%mul.637, %mul.634), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/mul"}
+  %constant.279 = f32[1,1,768]{2,1,0} constant({...})
+  %add.858 = f32[1,1,768]{2,1,0} broadcast(%constant.279), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/add"}
+  %add.859 = f32[1,768]{1,0} reshape(%add.858), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/add"}
+  %add.860 = f32[1,197,768]{2,1,0} broadcast(%add.859), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/add"}
+  %add.861 = f32[1,197,768]{2,1,0} add(%mul.638, %add.860), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/add"}
+  %add.862 = f32[1,197,768]{2,1,0} add(%mul.639, %add.861), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/add"}
+  %convert_element_type.254 = bf16[1,197,768]{2,1,0} convert(%add.862), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_1/convert_element_type"}
+  %constant.485 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.257 = bf16[768,12,64]{2,1,0} convert(%constant.485), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/value/convert_element_type"}
+  %dot_general.179 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.254, %convert_element_type.257), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/value/abc,cde->abde/dot_general"}
+  %constant.276 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.871 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.276), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/value/add"}
+  %add.872 = bf16[1,12,64]{2,1,0} reshape(%add.871), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/value/add"}
+  %add.873 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.872), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/value/add"}
+  %add.874 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.179, %add.873), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/value/add"}
+  %constant.483 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.255 = bf16[768,12,64]{2,1,0} convert(%constant.483), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/query/convert_element_type"}
+  %dot_general.177 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.254, %convert_element_type.255), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/query/abc,cde->abde/dot_general"}
+  %constant.278 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.863 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.278), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/query/add"}
+  %add.864 = bf16[1,12,64]{2,1,0} reshape(%add.863), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/query/add"}
+  %add.865 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.864), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/query/add"}
+  %add.866 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.177, %add.865), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/query/add"}
+  %reshape.46 = bf16[1,197,12,1,64]{4,3,2,1,0} reshape(%add.866), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/reshape"}
+  %constant.484 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.256 = bf16[768,12,64]{2,1,0} convert(%constant.484), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/key/convert_element_type"}
+  %dot_general.178 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.254, %convert_element_type.256), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/key/abc,cde->abde/dot_general"}
+  %constant.277 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.867 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.277), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/key/add"}
+  %add.868 = bf16[1,12,64]{2,1,0} reshape(%add.867), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/key/add"}
+  %add.869 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.868), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/key/add"}
+  %add.870 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.178, %add.869), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/key/add"}
+  %dot_general.180 = f32[1,12,197,1,197]{4,3,2,1,0} dot(%reshape.46, %add.870), lhs_batch_dims={0,2}, lhs_contracting_dims={4}, rhs_batch_dims={0,2}, rhs_contracting_dims={3}, algorithm=dot_bf16_bf16_f32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap(BTNH,BSNH->BNTS)/dot_general"}
+  %mul.640 = f32[1,12,197,1,197]{4,3,2,1,0} multiply(%dot_general.180, %broadcast.37), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/mul"}
+  %transpose.67 = f32[1,1,12,197,197]{4,3,2,1,0} reshape(%mul.640), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/transpose"}
+  %reduce_max.94 = f32[1,12,197,1]{3,2,1,0} reduce(%mul.640, %constant.417), dimensions={4}, to_apply=%region_44.49, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/reduce_max"}
+  %max.22 = f32[1,12,197,1]{3,2,1,0} maximum(%reduce_max.94, %broadcast.36), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/max"}
+  %transpose.66 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%max.22), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/broadcast_in_dim;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/transpose"}
+  %sub.98 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%transpose.66), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/sub"}
+  %sub.99 = f32[1,1,12,197]{3,2,1,0} reshape(%sub.98), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/sub"}
+  %sub.100 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%sub.99), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/sub"}
+  %sub.101 = f32[1,1,12,197,197]{4,3,2,1,0} subtract(%transpose.67, %sub.100), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/sub"}
+  %exp.22 = f32[1,1,12,197,197]{4,3,2,1,0} exponential(%sub.101), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/exp"}
+  %reduce_sum.306 = f32[1,1,12,197]{3,2,1,0} reduce(%exp.22, %constant.419), dimensions={4}, to_apply=%region_45.50, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/reduce_sum"}
+  %broadcast_in_dim.80 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%reduce_sum.306), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/broadcast_in_dim"}
+  %div.142 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%broadcast_in_dim.80), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/div"}
+  %div.143 = f32[1,1,12,197]{3,2,1,0} reshape(%div.142), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/div"}
+  %div.144 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%div.143), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/div"}
+  %div.145 = f32[1,1,12,197,197]{4,3,2,1,0} divide(%exp.22, %div.144), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/div"}
+  %convert_element_type.258 = bf16[1,1,12,197,197]{4,3,2,1,0} convert(%div.145), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/convert_element_type"}
+  %dot_general.181 = bf16[1,12,64,1,197]{4,3,2,1,0} dot(%add.874, %convert_element_type.258), lhs_batch_dims={0,2}, lhs_contracting_dims={1}, rhs_batch_dims={1,2}, rhs_contracting_dims={4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap(BNTS,BSNH->BTNH)/dot_general"}
+  %transpose.68 = bf16[1,197,12,1,64]{1,3,4,2,0} transpose(%dot_general.181), dimensions={0,4,1,3,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap()/transpose;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/vmap(BNTS,BSNH->BTNH)/transpose"}
+  %reshape.47 = bf16[1,197,12,64]{3,2,1,0} reshape(%transpose.68), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/reshape"}
+  %constant.486 = f32[12,64,768]{2,1,0} constant({...})
+  %convert_element_type.259 = bf16[12,64,768]{2,1,0} convert(%constant.486), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/attention_output/convert_element_type"}
+  %dot_general.182 = bf16[1,197,768]{2,1,0} dot(%reshape.47, %convert_element_type.259), lhs_contracting_dims={2,3}, rhs_contracting_dims={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/attention_output/abcd,cde->abe/dot_general"}
+  %constant.275 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.875 = bf16[1,1,768]{2,1,0} broadcast(%constant.275), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/attention_output/add"}
+  %add.876 = bf16[1,768]{1,0} reshape(%add.875), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/attention_output/add"}
+  %add.877 = bf16[1,197,768]{2,1,0} broadcast(%add.876), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/attention_output/add"}
+  %add.878 = bf16[1,197,768]{2,1,0} add(%dot_general.182, %add.877), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mha/attention_output/add"}
+  %add.879 = bf16[1,197,768]{2,1,0} add(%add.878, %add.856), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/add"}
+  %convert_element_type.260 = f32[1,197,768]{2,1,0} convert(%add.879), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/convert_element_type"}
+  %jit__var_.46 = f32[1,197,1]{2,1,0} call(%convert_element_type.260, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/jit(_var)"}
+  %add.880 = f32[1,197,1]{2,1,0} add(%jit__var_.46, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/add"}
+  %rsqrt.46 = f32[1,197,1]{2,1,0} rsqrt(%add.880), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/rsqrt"}
+  %mul.641 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.46), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/mul"}
+  %mul.642 = f32[1,197]{1,0} reshape(%mul.641), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/mul"}
+  %mul.643 = f32[1,197,768]{2,1,0} broadcast(%mul.642), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/mul"}
+  %constant.274 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.644 = f32[1,1,768]{2,1,0} broadcast(%constant.274), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/mul"}
+  %mul.645 = f32[1,768]{1,0} reshape(%mul.644), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/mul"}
+  %mul.646 = f32[1,197,768]{2,1,0} broadcast(%mul.645), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/mul"}
+  %mul.647 = f32[1,197,768]{2,1,0} multiply(%mul.643, %mul.646), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/mul"}
+  %mul.652 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.260, %mul.647), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/mul"}
+  %reduce_sum.307 = f32[1,197]{1,0} reduce(%convert_element_type.260, %constant.419), dimensions={2}, to_apply=%region_46.51, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/reduce_sum"}
+  %broadcast_in_dim.81 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.307), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/broadcast_in_dim"}
+  %div.146 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.81, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/div"}
+  %neg.68 = f32[1,197,1]{2,1,0} negate(%div.146), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/neg"}
+  %mul.648 = f32[1,197,1]{2,1,0} broadcast(%neg.68), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/mul"}
+  %mul.649 = f32[1,197]{1,0} reshape(%mul.648), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/mul"}
+  %mul.650 = f32[1,197,768]{2,1,0} broadcast(%mul.649), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/mul"}
+  %mul.651 = f32[1,197,768]{2,1,0} multiply(%mul.650, %mul.647), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/mul"}
+  %constant.273 = f32[1,1,768]{2,1,0} constant({...})
+  %add.881 = f32[1,1,768]{2,1,0} broadcast(%constant.273), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/add"}
+  %add.882 = f32[1,768]{1,0} reshape(%add.881), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/add"}
+  %add.883 = f32[1,197,768]{2,1,0} broadcast(%add.882), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/add"}
+  %add.884 = f32[1,197,768]{2,1,0} add(%mul.651, %add.883), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/add"}
+  %add.885 = f32[1,197,768]{2,1,0} add(%mul.652, %add.884), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/add"}
+  %convert_element_type.261 = bf16[1,197,768]{2,1,0} convert(%add.885), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/ln_2/convert_element_type"}
+  %constant.487 = f32[768,3072]{1,0} constant({...})
+  %convert_element_type.262 = bf16[768,3072]{1,0} convert(%constant.487), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/convert_element_type"}
+  %dot_general.183 = bf16[1,197,3072]{2,1,0} dot(%convert_element_type.261, %convert_element_type.262), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/dot_general"}
+  %constant.272 = bf16[1,1,3072]{2,1,0} constant({...})
+  %add.886 = bf16[1,1,3072]{2,1,0} broadcast(%constant.272), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/add"}
+  %add.887 = bf16[1,3072]{1,0} reshape(%add.886), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/add"}
+  %add.888 = bf16[1,197,3072]{2,1,0} broadcast(%add.887), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/add"}
+  %add.889 = bf16[1,197,3072]{2,1,0} add(%dot_general.183, %add.888), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/add"}
+  %mul.653 = bf16[1,197,3072]{2,1,0} multiply(%add.889, %broadcast.35), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/mul"}
+  %neg.69 = bf16[1,197,3072]{2,1,0} negate(%add.889), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/neg"}
+  %mul.654 = bf16[1,197,3072]{2,1,0} multiply(%neg.69, %broadcast.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/mul"}
+  %erfc.1430 = f32[1,197,3072]{2,1,0} convert(%mul.654), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1491 = f32[1,197,3072]{2,1,0} abs(%erfc.1430), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1492 = pred[1,197,3072]{2,1,0} compare(%erfc.1491, %broadcast.67), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1476 = f32[1,197,3072]{2,1,0} multiply(%erfc.1430, %erfc.1430), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1477 = f32[1,197,3072]{2,1,0} multiply(%erfc.1476, %broadcast.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1478 = f32[1,197,3072]{2,1,0} add(%erfc.1477, %broadcast.45), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1479 = f32[1,197,3072]{2,1,0} multiply(%erfc.1478, %erfc.1476), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1480 = f32[1,197,3072]{2,1,0} add(%erfc.1479, %broadcast.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1481 = f32[1,197,3072]{2,1,0} multiply(%erfc.1480, %erfc.1476), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1482 = f32[1,197,3072]{2,1,0} add(%erfc.1481, %broadcast.43), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1483 = f32[1,197,3072]{2,1,0} multiply(%erfc.1482, %erfc.1476), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1484 = f32[1,197,3072]{2,1,0} add(%erfc.1483, %broadcast.42), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1485 = f32[1,197,3072]{2,1,0} multiply(%erfc.1484, %erfc.1476), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1486 = f32[1,197,3072]{2,1,0} add(%erfc.1485, %broadcast.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1487 = f32[1,197,3072]{2,1,0} multiply(%erfc.1486, %erfc.1476), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1488 = f32[1,197,3072]{2,1,0} add(%erfc.1487, %broadcast.40), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1489 = f32[1,197,3072]{2,1,0} multiply(%erfc.1430, %erfc.1488), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1490 = f32[1,197,3072]{2,1,0} subtract(%broadcast.67, %erfc.1489), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1473 = pred[1,197,3072]{2,1,0} compare(%erfc.1430, %broadcast.47), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1431 = f32[1,197,3072]{2,1,0} multiply(%erfc.1430, %erfc.1430), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1432 = f32[1,197,3072]{2,1,0} negate(%erfc.1431), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1471 = pred[1,197,3072]{2,1,0} compare(%erfc.1432, %broadcast.48), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1435 = f32[1,197,3072]{2,1,0} exponential(%erfc.1432), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1433 = f32[1,197,3072]{2,1,0} abs(%erfc.1430), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1436 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1433), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1437 = f32[1,197,3072]{2,1,0} multiply(%erfc.1435, %erfc.1436), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1438 = pred[1,197,3072]{2,1,0} compare(%erfc.1433, %broadcast.66), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1434 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1431), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1439 = f32[1,197,3072]{2,1,0} multiply(%erfc.1434, %broadcast.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1440 = f32[1,197,3072]{2,1,0} add(%erfc.1439, %broadcast.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1441 = f32[1,197,3072]{2,1,0} multiply(%erfc.1440, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1442 = f32[1,197,3072]{2,1,0} add(%erfc.1441, %broadcast.63), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1443 = f32[1,197,3072]{2,1,0} multiply(%erfc.1442, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1444 = f32[1,197,3072]{2,1,0} add(%erfc.1443, %broadcast.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1445 = f32[1,197,3072]{2,1,0} multiply(%erfc.1444, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1446 = f32[1,197,3072]{2,1,0} add(%erfc.1445, %broadcast.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1447 = f32[1,197,3072]{2,1,0} multiply(%erfc.1446, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1448 = f32[1,197,3072]{2,1,0} add(%erfc.1447, %broadcast.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1449 = f32[1,197,3072]{2,1,0} multiply(%erfc.1448, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1450 = f32[1,197,3072]{2,1,0} add(%erfc.1449, %broadcast.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1451 = f32[1,197,3072]{2,1,0} multiply(%erfc.1450, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1452 = f32[1,197,3072]{2,1,0} add(%erfc.1451, %broadcast.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1453 = f32[1,197,3072]{2,1,0} multiply(%erfc.1452, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1454 = f32[1,197,3072]{2,1,0} add(%erfc.1453, %broadcast.57), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1455 = f32[1,197,3072]{2,1,0} multiply(%erfc.1434, %broadcast.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1456 = f32[1,197,3072]{2,1,0} add(%erfc.1455, %broadcast.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1457 = f32[1,197,3072]{2,1,0} multiply(%erfc.1456, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1458 = f32[1,197,3072]{2,1,0} add(%erfc.1457, %broadcast.54), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1459 = f32[1,197,3072]{2,1,0} multiply(%erfc.1458, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1460 = f32[1,197,3072]{2,1,0} add(%erfc.1459, %broadcast.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1461 = f32[1,197,3072]{2,1,0} multiply(%erfc.1460, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1462 = f32[1,197,3072]{2,1,0} add(%erfc.1461, %broadcast.52), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1463 = f32[1,197,3072]{2,1,0} multiply(%erfc.1462, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1464 = f32[1,197,3072]{2,1,0} add(%erfc.1463, %broadcast.51), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1465 = f32[1,197,3072]{2,1,0} multiply(%erfc.1464, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1466 = f32[1,197,3072]{2,1,0} add(%erfc.1465, %broadcast.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1467 = f32[1,197,3072]{2,1,0} multiply(%erfc.1466, %erfc.1434), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1468 = f32[1,197,3072]{2,1,0} add(%erfc.1467, %broadcast.49), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1469 = f32[1,197,3072]{2,1,0} select(%erfc.1438, %erfc.1454, %erfc.1468), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1470 = f32[1,197,3072]{2,1,0} multiply(%erfc.1437, %erfc.1469), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1472 = f32[1,197,3072]{2,1,0} select(%erfc.1471, %broadcast.47, %erfc.1470), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1474 = f32[1,197,3072]{2,1,0} subtract(%broadcast.66, %erfc.1472), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1475 = f32[1,197,3072]{2,1,0} select(%erfc.1473, %erfc.1474, %erfc.1472), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1493 = f32[1,197,3072]{2,1,0} select(%erfc.1492, %erfc.1490, %erfc.1475), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %erfc.1494 = bf16[1,197,3072]{2,1,0} convert(%erfc.1493), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/erfc"}
+  %mul.655 = bf16[1,197,3072]{2,1,0} multiply(%mul.653, %erfc.1494), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_1/mul"}
+  %constant.488 = f32[3072,768]{1,0} constant({...})
+  %convert_element_type.263 = bf16[3072,768]{1,0} convert(%constant.488), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_2/convert_element_type"}
+  %dot_general.184 = bf16[1,197,768]{2,1,0} dot(%mul.655, %convert_element_type.263), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_2/dot_general"}
+  %constant.271 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.890 = bf16[1,1,768]{2,1,0} broadcast(%constant.271), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_2/add"}
+  %add.891 = bf16[1,768]{1,0} reshape(%add.890), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_2/add"}
+  %add.892 = bf16[1,197,768]{2,1,0} broadcast(%add.891), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_2/add"}
+  %add.893 = bf16[1,197,768]{2,1,0} add(%dot_general.184, %add.892), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/mlp/dense_2/add"}
+  %add.894 = bf16[1,197,768]{2,1,0} add(%add.879, %add.893), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_11/add"}
+  %convert_element_type.264 = f32[1,197,768]{2,1,0} convert(%add.894), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/convert_element_type"}
+  %jit__var_.47 = f32[1,197,1]{2,1,0} call(%convert_element_type.264, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/jit(_var)"}
+  %add.895 = f32[1,197,1]{2,1,0} add(%jit__var_.47, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/add"}
+  %rsqrt.47 = f32[1,197,1]{2,1,0} rsqrt(%add.895), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/rsqrt"}
+  %mul.656 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.47), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/mul"}
+  %mul.657 = f32[1,197]{1,0} reshape(%mul.656), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/mul"}
+  %mul.658 = f32[1,197,768]{2,1,0} broadcast(%mul.657), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/mul"}
+  %constant.270 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.659 = f32[1,1,768]{2,1,0} broadcast(%constant.270), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/mul"}
+  %mul.660 = f32[1,768]{1,0} reshape(%mul.659), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/mul"}
+  %mul.661 = f32[1,197,768]{2,1,0} broadcast(%mul.660), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/mul"}
+  %mul.662 = f32[1,197,768]{2,1,0} multiply(%mul.658, %mul.661), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/mul"}
+  %mul.667 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.264, %mul.662), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/mul"}
+  %reduce_sum.308 = f32[1,197]{1,0} reduce(%convert_element_type.264, %constant.419), dimensions={2}, to_apply=%region_47.52, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/reduce_sum"}
+  %broadcast_in_dim.82 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.308), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/broadcast_in_dim"}
+  %div.147 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.82, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/div"}
+  %neg.70 = f32[1,197,1]{2,1,0} negate(%div.147), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/neg"}
+  %mul.663 = f32[1,197,1]{2,1,0} broadcast(%neg.70), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/mul"}
+  %mul.664 = f32[1,197]{1,0} reshape(%mul.663), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/mul"}
+  %mul.665 = f32[1,197,768]{2,1,0} broadcast(%mul.664), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/mul"}
+  %mul.666 = f32[1,197,768]{2,1,0} multiply(%mul.665, %mul.662), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/mul"}
+  %constant.269 = f32[1,1,768]{2,1,0} constant({...})
+  %add.896 = f32[1,1,768]{2,1,0} broadcast(%constant.269), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/add"}
+  %add.897 = f32[1,768]{1,0} reshape(%add.896), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/add"}
+  %add.898 = f32[1,197,768]{2,1,0} broadcast(%add.897), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/add"}
+  %add.899 = f32[1,197,768]{2,1,0} add(%mul.666, %add.898), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/add"}
+  %add.900 = f32[1,197,768]{2,1,0} add(%mul.667, %add.899), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/add"}
+  %convert_element_type.265 = bf16[1,197,768]{2,1,0} convert(%add.900), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_1/convert_element_type"}
+  %constant.491 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.268 = bf16[768,12,64]{2,1,0} convert(%constant.491), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/value/convert_element_type"}
+  %dot_general.187 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.265, %convert_element_type.268), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/value/abc,cde->abde/dot_general"}
+  %constant.266 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.909 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.266), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/value/add"}
+  %add.910 = bf16[1,12,64]{2,1,0} reshape(%add.909), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/value/add"}
+  %add.911 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.910), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/value/add"}
+  %add.912 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.187, %add.911), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/value/add"}
+  %constant.489 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.266 = bf16[768,12,64]{2,1,0} convert(%constant.489), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/query/convert_element_type"}
+  %dot_general.185 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.265, %convert_element_type.266), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/query/abc,cde->abde/dot_general"}
+  %constant.268 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.901 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.268), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/query/add"}
+  %add.902 = bf16[1,12,64]{2,1,0} reshape(%add.901), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/query/add"}
+  %add.903 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.902), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/query/add"}
+  %add.904 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.185, %add.903), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/query/add"}
+  %reshape.48 = bf16[1,197,12,1,64]{4,3,2,1,0} reshape(%add.904), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/reshape"}
+  %constant.490 = f32[768,12,64]{2,1,0} constant({...})
+  %convert_element_type.267 = bf16[768,12,64]{2,1,0} convert(%constant.490), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/key/convert_element_type"}
+  %dot_general.186 = bf16[1,197,12,64]{3,2,1,0} dot(%convert_element_type.265, %convert_element_type.267), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/key/abc,cde->abde/dot_general"}
+  %constant.267 = bf16[1,1,12,64]{3,2,1,0} constant({...})
+  %add.905 = bf16[1,1,12,64]{3,2,1,0} broadcast(%constant.267), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/key/add"}
+  %add.906 = bf16[1,12,64]{2,1,0} reshape(%add.905), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/key/add"}
+  %add.907 = bf16[1,197,12,64]{3,2,1,0} broadcast(%add.906), dimensions={0,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/key/add"}
+  %add.908 = bf16[1,197,12,64]{3,2,1,0} add(%dot_general.186, %add.907), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/key/add"}
+  %dot_general.188 = f32[1,12,197,1,197]{4,3,2,1,0} dot(%reshape.48, %add.908), lhs_batch_dims={0,2}, lhs_contracting_dims={4}, rhs_batch_dims={0,2}, rhs_contracting_dims={3}, algorithm=dot_bf16_bf16_f32, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap(BTNH,BSNH->BNTS)/dot_general"}
+  %mul.668 = f32[1,12,197,1,197]{4,3,2,1,0} multiply(%dot_general.188, %broadcast.37), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/mul"}
+  %transpose.70 = f32[1,1,12,197,197]{4,3,2,1,0} reshape(%mul.668), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/transpose"}
+  %reduce_max.95 = f32[1,12,197,1]{3,2,1,0} reduce(%mul.668, %constant.417), dimensions={4}, to_apply=%region_48.53, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/reduce_max"}
+  %max.23 = f32[1,12,197,1]{3,2,1,0} maximum(%reduce_max.95, %broadcast.36), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/max"}
+  %transpose.69 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%max.23), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/broadcast_in_dim;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/transpose"}
+  %sub.102 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%transpose.69), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/sub"}
+  %sub.103 = f32[1,1,12,197]{3,2,1,0} reshape(%sub.102), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/sub"}
+  %sub.104 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%sub.103), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/sub"}
+  %sub.105 = f32[1,1,12,197,197]{4,3,2,1,0} subtract(%transpose.70, %sub.104), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/sub"}
+  %exp.23 = f32[1,1,12,197,197]{4,3,2,1,0} exponential(%sub.105), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/exp"}
+  %reduce_sum.309 = f32[1,1,12,197]{3,2,1,0} reduce(%exp.23, %constant.419), dimensions={4}, to_apply=%region_49.54, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/reduce_sum"}
+  %broadcast_in_dim.83 = f32[1,1,12,197,1]{4,3,2,1,0} reshape(%reduce_sum.309), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/broadcast_in_dim"}
+  %div.148 = f32[1,1,12,197,1]{4,3,2,1,0} broadcast(%broadcast_in_dim.83), dimensions={0,1,2,3,4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/div"}
+  %div.149 = f32[1,1,12,197]{3,2,1,0} reshape(%div.148), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/div"}
+  %div.150 = f32[1,1,12,197,197]{4,3,2,1,0} broadcast(%div.149), dimensions={0,1,2,3}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/div"}
+  %div.151 = f32[1,1,12,197,197]{4,3,2,1,0} divide(%exp.23, %div.150), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/div"}
+  %convert_element_type.269 = bf16[1,1,12,197,197]{4,3,2,1,0} convert(%div.151), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/convert_element_type"}
+  %dot_general.189 = bf16[1,12,64,1,197]{4,3,2,1,0} dot(%add.912, %convert_element_type.269), lhs_batch_dims={0,2}, lhs_contracting_dims={1}, rhs_batch_dims={1,2}, rhs_contracting_dims={4}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap(BNTS,BSNH->BTNH)/dot_general"}
+  %transpose.71 = bf16[1,197,12,1,64]{1,3,4,2,0} transpose(%dot_general.189), dimensions={0,4,1,3,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap()/transpose;jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/vmap(BNTS,BSNH->BTNH)/transpose"}
+  %reshape.49 = bf16[1,197,12,64]{3,2,1,0} reshape(%transpose.71), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/reshape"}
+  %constant.492 = f32[12,64,768]{2,1,0} constant({...})
+  %convert_element_type.270 = bf16[12,64,768]{2,1,0} convert(%constant.492), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/attention_output/convert_element_type"}
+  %dot_general.190 = bf16[1,197,768]{2,1,0} dot(%reshape.49, %convert_element_type.270), lhs_contracting_dims={2,3}, rhs_contracting_dims={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/attention_output/abcd,cde->abe/dot_general"}
+  %constant.265 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.913 = bf16[1,1,768]{2,1,0} broadcast(%constant.265), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/attention_output/add"}
+  %add.914 = bf16[1,768]{1,0} reshape(%add.913), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/attention_output/add"}
+  %add.915 = bf16[1,197,768]{2,1,0} broadcast(%add.914), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/attention_output/add"}
+  %add.916 = bf16[1,197,768]{2,1,0} add(%dot_general.190, %add.915), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mha/attention_output/add"}
+  %add.917 = bf16[1,197,768]{2,1,0} add(%add.916, %add.894), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/add"}
+  %convert_element_type.271 = f32[1,197,768]{2,1,0} convert(%add.917), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/convert_element_type"}
+  %jit__var_.48 = f32[1,197,1]{2,1,0} call(%convert_element_type.271, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/jit(_var)"}
+  %add.918 = f32[1,197,1]{2,1,0} add(%jit__var_.48, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/add"}
+  %rsqrt.48 = f32[1,197,1]{2,1,0} rsqrt(%add.918), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/rsqrt"}
+  %mul.669 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.48), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/mul"}
+  %mul.670 = f32[1,197]{1,0} reshape(%mul.669), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/mul"}
+  %mul.671 = f32[1,197,768]{2,1,0} broadcast(%mul.670), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/mul"}
+  %constant.264 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.672 = f32[1,1,768]{2,1,0} broadcast(%constant.264), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/mul"}
+  %mul.673 = f32[1,768]{1,0} reshape(%mul.672), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/mul"}
+  %mul.674 = f32[1,197,768]{2,1,0} broadcast(%mul.673), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/mul"}
+  %mul.675 = f32[1,197,768]{2,1,0} multiply(%mul.671, %mul.674), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/mul"}
+  %mul.680 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.271, %mul.675), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/mul"}
+  %reduce_sum.310 = f32[1,197]{1,0} reduce(%convert_element_type.271, %constant.419), dimensions={2}, to_apply=%region_50.55, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/reduce_sum"}
+  %broadcast_in_dim.84 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.310), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/broadcast_in_dim"}
+  %div.152 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.84, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/div"}
+  %neg.71 = f32[1,197,1]{2,1,0} negate(%div.152), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/neg"}
+  %mul.676 = f32[1,197,1]{2,1,0} broadcast(%neg.71), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/mul"}
+  %mul.677 = f32[1,197]{1,0} reshape(%mul.676), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/mul"}
+  %mul.678 = f32[1,197,768]{2,1,0} broadcast(%mul.677), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/mul"}
+  %mul.679 = f32[1,197,768]{2,1,0} multiply(%mul.678, %mul.675), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/mul"}
+  %constant.263 = f32[1,1,768]{2,1,0} constant({...})
+  %add.919 = f32[1,1,768]{2,1,0} broadcast(%constant.263), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/add"}
+  %add.920 = f32[1,768]{1,0} reshape(%add.919), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/add"}
+  %add.921 = f32[1,197,768]{2,1,0} broadcast(%add.920), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/add"}
+  %add.922 = f32[1,197,768]{2,1,0} add(%mul.679, %add.921), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/add"}
+  %add.923 = f32[1,197,768]{2,1,0} add(%mul.680, %add.922), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/add"}
+  %convert_element_type.272 = bf16[1,197,768]{2,1,0} convert(%add.923), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/ln_2/convert_element_type"}
+  %constant.493 = f32[768,3072]{1,0} constant({...})
+  %convert_element_type.273 = bf16[768,3072]{1,0} convert(%constant.493), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/convert_element_type"}
+  %dot_general.191 = bf16[1,197,3072]{2,1,0} dot(%convert_element_type.272, %convert_element_type.273), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/dot_general"}
+  %constant.262 = bf16[1,1,3072]{2,1,0} constant({...})
+  %add.924 = bf16[1,1,3072]{2,1,0} broadcast(%constant.262), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/add"}
+  %add.925 = bf16[1,3072]{1,0} reshape(%add.924), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/add"}
+  %add.926 = bf16[1,197,3072]{2,1,0} broadcast(%add.925), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/add"}
+  %add.927 = bf16[1,197,3072]{2,1,0} add(%dot_general.191, %add.926), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/add"}
+  %mul.681 = bf16[1,197,3072]{2,1,0} multiply(%add.927, %broadcast.35), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/mul"}
+  %neg.72 = bf16[1,197,3072]{2,1,0} negate(%add.927), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/neg"}
+  %mul.682 = bf16[1,197,3072]{2,1,0} multiply(%neg.72, %broadcast.34), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/mul"}
+  %erfc.1495 = f32[1,197,3072]{2,1,0} convert(%mul.682), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1556 = f32[1,197,3072]{2,1,0} abs(%erfc.1495), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1557 = pred[1,197,3072]{2,1,0} compare(%erfc.1556, %broadcast.67), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1541 = f32[1,197,3072]{2,1,0} multiply(%erfc.1495, %erfc.1495), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1542 = f32[1,197,3072]{2,1,0} multiply(%erfc.1541, %broadcast.46), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1543 = f32[1,197,3072]{2,1,0} add(%erfc.1542, %broadcast.45), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1544 = f32[1,197,3072]{2,1,0} multiply(%erfc.1543, %erfc.1541), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1545 = f32[1,197,3072]{2,1,0} add(%erfc.1544, %broadcast.44), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1546 = f32[1,197,3072]{2,1,0} multiply(%erfc.1545, %erfc.1541), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1547 = f32[1,197,3072]{2,1,0} add(%erfc.1546, %broadcast.43), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1548 = f32[1,197,3072]{2,1,0} multiply(%erfc.1547, %erfc.1541), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1549 = f32[1,197,3072]{2,1,0} add(%erfc.1548, %broadcast.42), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1550 = f32[1,197,3072]{2,1,0} multiply(%erfc.1549, %erfc.1541), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1551 = f32[1,197,3072]{2,1,0} add(%erfc.1550, %broadcast.41), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1552 = f32[1,197,3072]{2,1,0} multiply(%erfc.1551, %erfc.1541), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1553 = f32[1,197,3072]{2,1,0} add(%erfc.1552, %broadcast.40), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1554 = f32[1,197,3072]{2,1,0} multiply(%erfc.1495, %erfc.1553), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1555 = f32[1,197,3072]{2,1,0} subtract(%broadcast.67, %erfc.1554), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1538 = pred[1,197,3072]{2,1,0} compare(%erfc.1495, %broadcast.47), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1496 = f32[1,197,3072]{2,1,0} multiply(%erfc.1495, %erfc.1495), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1497 = f32[1,197,3072]{2,1,0} negate(%erfc.1496), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1536 = pred[1,197,3072]{2,1,0} compare(%erfc.1497, %broadcast.48), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1500 = f32[1,197,3072]{2,1,0} exponential(%erfc.1497), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1498 = f32[1,197,3072]{2,1,0} abs(%erfc.1495), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1501 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1498), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1502 = f32[1,197,3072]{2,1,0} multiply(%erfc.1500, %erfc.1501), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1503 = pred[1,197,3072]{2,1,0} compare(%erfc.1498, %broadcast.66), direction=LT, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1499 = f32[1,197,3072]{2,1,0} divide(%broadcast.67, %erfc.1496), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1504 = f32[1,197,3072]{2,1,0} multiply(%erfc.1499, %broadcast.65), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1505 = f32[1,197,3072]{2,1,0} add(%erfc.1504, %broadcast.64), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1506 = f32[1,197,3072]{2,1,0} multiply(%erfc.1505, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1507 = f32[1,197,3072]{2,1,0} add(%erfc.1506, %broadcast.63), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1508 = f32[1,197,3072]{2,1,0} multiply(%erfc.1507, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1509 = f32[1,197,3072]{2,1,0} add(%erfc.1508, %broadcast.62), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1510 = f32[1,197,3072]{2,1,0} multiply(%erfc.1509, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1511 = f32[1,197,3072]{2,1,0} add(%erfc.1510, %broadcast.61), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1512 = f32[1,197,3072]{2,1,0} multiply(%erfc.1511, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1513 = f32[1,197,3072]{2,1,0} add(%erfc.1512, %broadcast.60), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1514 = f32[1,197,3072]{2,1,0} multiply(%erfc.1513, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1515 = f32[1,197,3072]{2,1,0} add(%erfc.1514, %broadcast.59), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1516 = f32[1,197,3072]{2,1,0} multiply(%erfc.1515, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1517 = f32[1,197,3072]{2,1,0} add(%erfc.1516, %broadcast.58), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1518 = f32[1,197,3072]{2,1,0} multiply(%erfc.1517, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1519 = f32[1,197,3072]{2,1,0} add(%erfc.1518, %broadcast.57), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1520 = f32[1,197,3072]{2,1,0} multiply(%erfc.1499, %broadcast.56), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1521 = f32[1,197,3072]{2,1,0} add(%erfc.1520, %broadcast.55), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1522 = f32[1,197,3072]{2,1,0} multiply(%erfc.1521, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1523 = f32[1,197,3072]{2,1,0} add(%erfc.1522, %broadcast.54), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1524 = f32[1,197,3072]{2,1,0} multiply(%erfc.1523, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1525 = f32[1,197,3072]{2,1,0} add(%erfc.1524, %broadcast.53), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1526 = f32[1,197,3072]{2,1,0} multiply(%erfc.1525, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1527 = f32[1,197,3072]{2,1,0} add(%erfc.1526, %broadcast.52), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1528 = f32[1,197,3072]{2,1,0} multiply(%erfc.1527, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1529 = f32[1,197,3072]{2,1,0} add(%erfc.1528, %broadcast.51), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1530 = f32[1,197,3072]{2,1,0} multiply(%erfc.1529, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1531 = f32[1,197,3072]{2,1,0} add(%erfc.1530, %broadcast.50), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1532 = f32[1,197,3072]{2,1,0} multiply(%erfc.1531, %erfc.1499), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1533 = f32[1,197,3072]{2,1,0} add(%erfc.1532, %broadcast.49), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1534 = f32[1,197,3072]{2,1,0} select(%erfc.1503, %erfc.1519, %erfc.1533), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1535 = f32[1,197,3072]{2,1,0} multiply(%erfc.1502, %erfc.1534), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1537 = f32[1,197,3072]{2,1,0} select(%erfc.1536, %broadcast.47, %erfc.1535), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1539 = f32[1,197,3072]{2,1,0} subtract(%broadcast.66, %erfc.1537), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1540 = f32[1,197,3072]{2,1,0} select(%erfc.1538, %erfc.1539, %erfc.1537), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1558 = f32[1,197,3072]{2,1,0} select(%erfc.1557, %erfc.1555, %erfc.1540), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %erfc.1559 = bf16[1,197,3072]{2,1,0} convert(%erfc.1558), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/erfc"}
+  %mul.683 = bf16[1,197,3072]{2,1,0} multiply(%mul.681, %erfc.1559), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_1/mul"}
+  %constant.494 = f32[3072,768]{1,0} constant({...})
+  %convert_element_type.274 = bf16[3072,768]{1,0} convert(%constant.494), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_2/convert_element_type"}
+  %dot_general.192 = bf16[1,197,768]{2,1,0} dot(%mul.683, %convert_element_type.274), lhs_contracting_dims={2}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_2/dot_general"}
+  %constant.261 = bf16[1,1,768]{2,1,0} constant({...})
+  %add.928 = bf16[1,1,768]{2,1,0} broadcast(%constant.261), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_2/add"}
+  %add.929 = bf16[1,768]{1,0} reshape(%add.928), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_2/add"}
+  %add.930 = bf16[1,197,768]{2,1,0} broadcast(%add.929), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_2/add"}
+  %add.931 = bf16[1,197,768]{2,1,0} add(%dot_general.192, %add.930), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/mlp/dense_2/add"}
+  %add.932 = bf16[1,197,768]{2,1,0} add(%add.917, %add.931), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/tranformer_block_12/add"}
+  %convert_element_type.275 = f32[1,197,768]{2,1,0} convert(%add.932), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/convert_element_type"}
+  %jit__var_.49 = f32[1,197,1]{2,1,0} call(%convert_element_type.275, %constant.418), to_apply=%_var.8, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/jit(_var)"}
+  %add.933 = f32[1,197,1]{2,1,0} add(%jit__var_.49, %broadcast.38), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/add"}
+  %rsqrt.49 = f32[1,197,1]{2,1,0} rsqrt(%add.933), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/rsqrt"}
+  %mul.684 = f32[1,197,1]{2,1,0} broadcast(%rsqrt.49), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/mul"}
+  %mul.685 = f32[1,197]{1,0} reshape(%mul.684), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/mul"}
+  %mul.686 = f32[1,197,768]{2,1,0} broadcast(%mul.685), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/mul"}
+  %constant.260 = f32[1,1,768]{2,1,0} constant({...})
+  %mul.687 = f32[1,1,768]{2,1,0} broadcast(%constant.260), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/mul"}
+  %mul.688 = f32[1,768]{1,0} reshape(%mul.687), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/mul"}
+  %mul.689 = f32[1,197,768]{2,1,0} broadcast(%mul.688), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/mul"}
+  %mul.690 = f32[1,197,768]{2,1,0} multiply(%mul.686, %mul.689), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/mul"}
+  %mul.695 = f32[1,197,768]{2,1,0} multiply(%convert_element_type.275, %mul.690), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/mul"}
+  %reduce_sum.311 = f32[1,197]{1,0} reduce(%convert_element_type.275, %constant.419), dimensions={2}, to_apply=%region_51.56, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/reduce_sum"}
+  %broadcast_in_dim.85 = f32[1,197,1]{2,1,0} reshape(%reduce_sum.311), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/broadcast_in_dim"}
+  %div.153 = f32[1,197,1]{2,1,0} divide(%broadcast_in_dim.85, %broadcast.39), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/div"}
+  %neg.73 = f32[1,197,1]{2,1,0} negate(%div.153), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/neg"}
+  %mul.691 = f32[1,197,1]{2,1,0} broadcast(%neg.73), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/mul"}
+  %mul.692 = f32[1,197]{1,0} reshape(%mul.691), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/mul"}
+  %mul.693 = f32[1,197,768]{2,1,0} broadcast(%mul.692), dimensions={0,1}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/mul"}
+  %mul.694 = f32[1,197,768]{2,1,0} multiply(%mul.693, %mul.690), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/mul"}
+  %constant.259 = f32[1,1,768]{2,1,0} constant({...})
+  %add.934 = f32[1,1,768]{2,1,0} broadcast(%constant.259), dimensions={0,1,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/add"}
+  %add.935 = f32[1,768]{1,0} reshape(%add.934), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/add"}
+  %add.936 = f32[1,197,768]{2,1,0} broadcast(%add.935), dimensions={0,2}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/add"}
+  %add.937 = f32[1,197,768]{2,1,0} add(%mul.694, %add.936), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/add"}
+  %add.938 = f32[1,197,768]{2,1,0} add(%mul.695, %add.937), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/add"}
+  %convert_element_type.276 = bf16[1,197,768]{2,1,0} convert(%add.938), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/vi_t_backbone/vit_encoder/ln/convert_element_type"}
+  %slice.1 = bf16[1,1,768]{2,1,0} slice(%convert_element_type.276), slice={[0:1], [0:1], [0:768]}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/slice"}
+  %squeeze.1 = bf16[1,768]{1,0} reshape(%slice.1), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/squeeze"}
+  %constant.495 = f32[768,1000]{1,0} constant({...})
+  %convert_element_type.277 = bf16[768,1000]{1,0} convert(%constant.495), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/predictions/convert_element_type"}
+  %dot_general.193 = bf16[1,1000]{1,0} dot(%squeeze.1, %convert_element_type.277), lhs_contracting_dims={1}, rhs_contracting_dims={0}, metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/predictions/dot_general"}
+  %constant.258 = bf16[1,1000]{1,0} constant({...})
+  ROOT %add.939 = bf16[1,1000]{1,0} add(%dot_general.193, %constant.258), metadata={op_name="jit(<unnamed function>)/vi_t_image_classifier/predictions/add"}
+}


### PR DESCRIPTION
📝 Summary of Changes
This PR adds HLO for keras vision transformer model with jax backend for BF16, BS=1
It uses this model, https://www.kaggle.com/models/keras/vit/keras/vit_base_patch16_224_imagenet/3
Used Jax v[0.11.1](https://pypi.org/project/jax/0.11.1/) to generate HLO

🎯 Justification
This will help run benchmarking to check for performance impacts of future performance optimization PRs

🚀 Kind of Contribution
Please remove what does not apply: 🧪 Tests
