### PR TITLE
[XLA:CPU][oneDNN] Move oneDNN tests out of restricted folder

### DIFF
--- a/xla/service/cpu/tests/BUILD
+++ b/xla/service/cpu/tests/BUILD
@@ -21,7 +21,8 @@ load("//xla:xla.default.bzl", "xla_cc_test")
 load("//xla/tests:build_defs.bzl", "xla_test")
 load("//xla/tsl:tsl.bzl", "tsl_copts")
 load("//xla/tsl:tsl.default.bzl", "filegroup")
-load("//xla/tsl/mkl:graph.bzl", "onednn_cc_test")
+load("//xla/tsl/mkl:build_defs.bzl", "if_graph_api")
+load("//xla/tsl/mkl:graph.bzl", "onednn_cc_test", "onednn_graph_cc_test")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -479,5 +480,105 @@ xla_test(
         "//xla/tsl/platform:test",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest",
+    ],
+)
+
+onednn_cc_test(
+    name = "onednn_matmul_test",
+    srcs = ["onednn_matmul_test.cc"],
+    copts = tsl_copts(),
+    shard_count = 4,
+    deps = [
+        "//xla:error_spec",
+        "//xla/hlo/testlib:test",
+        "//xla/service:cpu_plugin",
+        "//xla/service/cpu:onednn_util",
+        "//xla/tests:hlo_interpreter_reference_mixin",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:pjrt_cpu_client_registry",
+        "//xla/tests:xla_internal_test_main",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+onednn_cc_test(
+    name = "onednn_convolution_test",
+    srcs = ["onednn_convolution_test.cc"],
+    copts = tsl_copts(),
+    deps = [
+        "//xla:literal",
+        "//xla:shape_util",
+        "//xla/hlo/testlib:filecheck",
+        "//xla/hlo/testlib:test",
+        "//xla/hlo/testlib:test_helpers",
+        "//xla/hlo/utils:hlo_matchers",
+        "//xla/service:cpu_plugin",
+        "//xla/service/cpu:onednn_contraction_rewriter",
+        "//xla/service/cpu:onednn_util",
+        "//xla/tests:hlo_interpreter_reference_mixin",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:pjrt_cpu_client_registry",
+        "//xla/tests:xla_internal_test_main",
+        "@com_google_absl//absl/strings",
+        "@tsl//tsl/platform:platform_port",
+    ],
+)
+
+onednn_cc_test(
+    name = "onednn_layer_norm_test",
+    srcs = ["onednn_layer_norm_test.cc"],
+    copts = tsl_copts(),
+    deps = [
+        "//xla:error_spec",
+        "//xla/hlo/testlib:test",
+        "//xla/service:cpu_plugin",
+        "//xla/service/cpu:onednn_util",
+        "//xla/tests:hlo_interpreter_reference_mixin",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:pjrt_cpu_client_registry",
+        "//xla/tests:xla_internal_test_main",
+    ],
+)
+
+onednn_cc_test(
+    name = "onednn_softmax_test",
+    srcs = ["onednn_softmax_test.cc"],
+    copts = tsl_copts(),
+    shard_count = if_graph_api(4, 1),
+    deps = [
+        "//xla:shape_util",
+        "//xla/hlo/ir:hlo",
+        "//xla/hlo/testlib:pattern_matcher_gmock",
+        "//xla/hlo/testlib:test",
+        "//xla/service:cpu_plugin",
+        "//xla/service:pattern_matcher",
+        "//xla/service/cpu:backend_config_proto_cc",
+        "//xla/service/cpu:onednn_config_proto_cc",
+        "//xla/service/cpu:onednn_ops_rewriter",
+        "//xla/service/cpu:onednn_util",
+        "//xla/tests:hlo_interpreter_reference_mixin",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:pjrt_cpu_client_registry",
+        "//xla/tests:xla_internal_test_main",
+        "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+onednn_graph_cc_test(
+    name = "onednn_fusion_test",
+    srcs = ["onednn_fusion_test.cc"],
+    deps = [
+        "//xla:error_spec",
+        "//xla/backends/cpu:onednn_support",
+        "//xla/service:cpu_plugin",
+        "//xla/service/cpu:onednn_util",
+        "//xla/tests:hlo_interpreter_reference_mixin",
+        "//xla/tests:hlo_test_base",
+        "//xla/tests:pjrt_cpu_client_registry",
+        "//xla/tsl/platform:test",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/platform:platform_port",
     ],
 )

--- a/xla/service/cpu/tests/onednn_convolution_test.cc
+++ b/xla/service/cpu/tests/onednn_convolution_test.cc
@@ -25,17 +25,20 @@ limitations under the License.
 #include "xla/service/cpu/onednn_contraction_rewriter.h"
 #include "xla/service/cpu/onednn_util.h"
 #include "xla/shape_util.h"
-#include "xla/tests/restricted/hlo_test_base_legacy.h"
+#include "xla/tests/hlo_interpreter_reference_mixin.h"
+#include "xla/tests/hlo_test_base.h"
 
 namespace xla {
 namespace cpu {
 
-class ConvolutionTest : public HloTestBaseLegacy,
+class ConvolutionTest : public HloInterpreterReferenceMixin<HloTestBase>,
                         public ::testing::WithParamInterface<PrimitiveType> {
  protected:
   DebugOptions GetDebugOptionsForTest() const override {
-    DebugOptions debug_options = HloTestBaseLegacy::GetDebugOptionsForTest();
+    DebugOptions debug_options =
+        HloInterpreterReferenceMixin::GetDebugOptionsForTest();
     debug_options.set_xla_cpu_experimental_onednn_custom_call(true);
+    debug_options.clear_xla_cpu_experimental_ynn_fusion_type();
     return debug_options;
   }
 

--- a/xla/service/cpu/tests/onednn_fusion_test.cc
+++ b/xla/service/cpu/tests/onednn_fusion_test.cc
@@ -21,7 +21,8 @@ limitations under the License.
 #include "xla/backends/cpu/onednn_support.h"
 #include "xla/error_spec.h"
 #include "xla/service/cpu/onednn_util.h"
-#include "xla/tests/restricted/hlo_test_base_legacy.h"
+#include "xla/tests/hlo_interpreter_reference_mixin.h"
+#include "xla/tests/hlo_test_base.h"
 #include "xla/tsl/platform/test.h"
 #include "tsl/platform/cpu_info.h"
 
@@ -42,9 +43,17 @@ struct OneDnnFusionTestParams {
 };
 
 class OneDnnFusionTestBase
-    : public HloTestBaseLegacy,
+    : public HloInterpreterReferenceMixin<HloTestBase>,
       public ::testing::WithParamInterface<OneDnnFusionTestParams> {
  protected:
+  DebugOptions GetDebugOptionsForTest() const override {
+    DebugOptions debug_options =
+        HloInterpreterReferenceMixin::GetDebugOptionsForTest();
+    debug_options.set_xla_cpu_experimental_onednn_custom_call(true);
+    debug_options.clear_xla_cpu_experimental_ynn_fusion_type();
+    return debug_options;
+  }
+
   void SetUp() override {
     OneDnnFusionTestParams params = GetParam();
     data_type_ = params.dtype;

--- a/xla/service/cpu/tests/onednn_layer_norm_test.cc
+++ b/xla/service/cpu/tests/onednn_layer_norm_test.cc
@@ -18,16 +18,19 @@ limitations under the License.
 #include "xla/error_spec.h"
 #include "xla/hlo/testlib/test.h"
 #include "xla/service/cpu/onednn_util.h"
-#include "xla/tests/restricted/hlo_test_base_legacy.h"
+#include "xla/tests/hlo_interpreter_reference_mixin.h"
+#include "xla/tests/hlo_test_base.h"
 
 namespace xla {
 namespace {
 
-class LayerNormTest : public HloTestBaseLegacy {
+class LayerNormTest : public HloInterpreterReferenceMixin<HloTestBase> {
  protected:
   DebugOptions GetDebugOptionsForTest() const override {
-    DebugOptions debug_options = HloTestBaseLegacy::GetDebugOptionsForTest();
+    DebugOptions debug_options =
+        HloInterpreterReferenceMixin::GetDebugOptionsForTest();
     debug_options.set_xla_cpu_experimental_onednn_custom_call(true);
+    debug_options.clear_xla_cpu_experimental_ynn_fusion_type();
     return debug_options;
   }
 
@@ -349,4 +352,3 @@ TEST_F(LayerNormTest, LayerNormTest1_BF16) {
 
 }  // namespace
 }  // namespace xla
-

--- a/xla/service/cpu/tests/onednn_matmul_test.cc
+++ b/xla/service/cpu/tests/onednn_matmul_test.cc
@@ -19,16 +19,19 @@ limitations under the License.
 #include "xla/error_spec.h"
 #include "xla/hlo/testlib/test.h"
 #include "xla/service/cpu/onednn_util.h"
-#include "xla/tests/restricted/hlo_test_base_legacy.h"
+#include "xla/tests/hlo_interpreter_reference_mixin.h"
+#include "xla/tests/hlo_test_base.h"
 
 namespace xla {
 namespace cpu {
 
-class MatmulTest : public HloTestBaseLegacy {
+class MatmulTest : public HloInterpreterReferenceMixin<HloTestBase> {
  protected:
   DebugOptions GetDebugOptionsForTest() const override {
-    DebugOptions debug_options = HloTestBaseLegacy::GetDebugOptionsForTest();
+    DebugOptions debug_options =
+        HloInterpreterReferenceMixin::GetDebugOptionsForTest();
     debug_options.set_xla_cpu_experimental_onednn_custom_call(true);
+    debug_options.clear_xla_cpu_experimental_ynn_fusion_type();
     return debug_options;
   }
 

--- a/xla/service/cpu/tests/onednn_softmax_test.cc
+++ b/xla/service/cpu/tests/onednn_softmax_test.cc
@@ -29,7 +29,8 @@ limitations under the License.
 #include "xla/service/cpu/onednn_ops_rewriter.h"
 #include "xla/service/cpu/onednn_util.h"
 #include "xla/service/pattern_matcher.h"
-#include "xla/tests/restricted/hlo_test_base_legacy.h"
+#include "xla/tests/hlo_interpreter_reference_mixin.h"
+#include "xla/tests/hlo_test_base.h"
 #include "xla/tsl/platform/statusor.h"
 
 namespace xla {
@@ -45,12 +46,14 @@ std::string TestParamsToString(
 }
 
 class OneDnnSoftmaxTest
-    : public HloTestBaseLegacy,
+    : public HloInterpreterReferenceMixin<HloTestBase>,
       public ::testing::WithParamInterface<std::tuple<PrimitiveType, int>> {
  protected:
   DebugOptions GetDebugOptionsForTest() const override {
-    DebugOptions debug_options = HloTestBaseLegacy::GetDebugOptionsForTest();
+    DebugOptions debug_options =
+        HloInterpreterReferenceMixin::GetDebugOptionsForTest();
     debug_options.set_xla_cpu_experimental_onednn_custom_call(true);
+    debug_options.clear_xla_cpu_experimental_ynn_fusion_type();
     return debug_options;
   }
 

--- a/xla/service/cpu/tests/restricted/BUILD
+++ b/xla/service/cpu/tests/restricted/BUILD
@@ -15,9 +15,6 @@
 
 load("//xla:restricted_package.bzl", "xla_restricted_allow", "xla_restricted_verify")
 load("//xla:xla.default.bzl", "xla_cc_test")
-load("//xla/tsl:tsl.bzl", "tsl_copts")
-load("//xla/tsl/mkl:build_defs.bzl", "if_graph_api")
-load("//xla/tsl/mkl:graph.bzl", "onednn_cc_test", "onednn_graph_cc_test")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -56,128 +53,6 @@ xla_cc_test(
     ],
 )
 
-onednn_graph_cc_test(
-    name = "onednn_fusion_test",
-    srcs = ["onednn_fusion_test.cc"],
-    tags = [
-        "no_oss",
-        "notap",
-    ],
-    deps = [
-        "//xla:error_spec",
-        "//xla/backends/cpu:onednn_support",
-        "//xla/service:cpu_plugin",
-        "//xla/service/cpu:onednn_util",
-        "//xla/tests/restricted:hlo_test_base_legacy",
-        "//xla/tsl/platform:test",
-        "@com_google_absl//absl/strings",
-        "@com_google_googletest//:gtest_main",
-        "@tsl//tsl/platform:platform_port",
-    ],
-)
-
-onednn_cc_test(
-    name = "onednn_matmul_test",
-    srcs = ["onednn_matmul_test.cc"],
-    copts = tsl_copts(),
-    shard_count = 4,
-    tags = [
-        "no_oss",
-        "notap",
-        "pjrt_migration_candidate",
-    ],
-    deps = [
-        "//xla:error_spec",
-        "//xla/hlo/testlib:test",
-        "//xla/service:cpu_plugin",
-        "//xla/service/cpu:onednn_util",
-        "//xla/tests:xla_internal_test_main",
-        "//xla/tests/restricted:hlo_test_base_legacy",
-        "@com_google_absl//absl/strings",
-    ],
-)
-
-onednn_cc_test(
-    name = "onednn_convolution_test",
-    srcs = ["onednn_convolution_test.cc"],
-    copts = tsl_copts(),
-    tags = [
-        # TODO: reenable once onednn is supported by the thunk runtime.
-        "no_oss",
-        "notap",
-        "pjrt_migration_candidate",
-    ],
-    deps = [
-        "//xla:literal",
-        "//xla:shape_util",
-        "//xla/hlo/testlib:filecheck",
-        "//xla/hlo/testlib:test",
-        "//xla/hlo/testlib:test_helpers",
-        "//xla/hlo/utils:hlo_matchers",
-        "//xla/service:cpu_plugin",
-        "//xla/service/cpu:onednn_contraction_rewriter",
-        "//xla/service/cpu:onednn_util",
-        "//xla/tests:xla_internal_test_main",
-        "//xla/tests/restricted:hlo_test_base_legacy",
-        "@com_google_absl//absl/strings",
-        "@tsl//tsl/platform:platform_port",
-    ],
-)
-
-onednn_cc_test(
-    name = "onednn_layer_norm_test",
-    srcs = ["onednn_layer_norm_test.cc"],
-    copts = tsl_copts(),
-    tags = [
-        # TODO: reenable once onednn is supported by the thunk runtime.
-        "no_oss",
-        "notap",
-        "pjrt_migration_candidate",
-    ],
-    deps = [
-        "//xla:error_spec",
-        "//xla/hlo/testlib:test",
-        "//xla/service:cpu_plugin",
-        "//xla/service/cpu:onednn_util",
-        "//xla/tests:xla_internal_test_main",
-        "//xla/tests/restricted:hlo_test_base_legacy",
-    ],
-)
-
-onednn_cc_test(
-    name = "onednn_softmax_test",
-    srcs = ["onednn_softmax_test.cc"],
-    copts = tsl_copts(),
-    shard_count = if_graph_api(4, 1),
-    tags = [
-        # TODO: reenable once onednn is supported by the thunk runtime.
-        "no_oss",
-        "notap",
-        "pjrt_migration_candidate",
-    ],
-    deps = [
-        "//xla:shape_util",
-        "//xla/hlo/ir:hlo",
-        "//xla/hlo/testlib:pattern_matcher_gmock",
-        "//xla/hlo/testlib:test",
-        "//xla/service:cpu_plugin",
-        "//xla/service:pattern_matcher",
-        "//xla/service/cpu:backend_config_proto_cc",
-        "//xla/service/cpu:onednn_config_proto_cc",
-        "//xla/service/cpu:onednn_ops_rewriter",
-        "//xla/service/cpu:onednn_util",
-        "//xla/tests:xla_internal_test_main",
-        "//xla/tests/restricted:hlo_test_base_legacy",
-        "//xla/tsl/platform:statusor",
-        "@com_google_absl//absl/strings",
-    ],
-)
-
 xla_restricted_verify(allowed_targets = [
     xla_restricted_allow("cpu_aot_export_test"),
-    xla_restricted_allow("onednn_convolution_test"),
-    xla_restricted_allow("onednn_fusion_test"),
-    xla_restricted_allow("onednn_layer_norm_test"),
-    xla_restricted_allow("onednn_matmul_test"),
-    xla_restricted_allow("onednn_softmax_test"),
 ])


### PR DESCRIPTION
This PR moves the oneDNN tests out of the `restricted` folder (now that async oneDNN is included in the default XLA build) by migrating oneDNN tests from `HloTestBaseLegacy` to `HloTestBase`.
In addition, this PR removes the BUILD tags and explicitly disables `ynnpack` in the oneDNN tests so the tests run correctly in public CI moving forward.