### PR TITLE
[ROCm] Make hermetic tests work with bzlmod

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -292,20 +292,20 @@ common:rocm_clang_hermetic --@rules_ml_toolchain//common:enable_rocm=True
 common:rocm_clang_hermetic --@rules_ml_toolchain//common:enable_cuda=False
 common:rocm_clang_hermetic --@rules_ml_toolchain//common:enable_sycl=False
 common:rocm_clang_hermetic --@rules_ml_toolchain//common:enable_hermetic_cc=True
-common:rocm_clang_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic --config=workspace
+common:rocm_clang_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic
 common:rocm_clang_hermetic --strategy=CppLink=local
 common:rocm_clang_hermetic --@rules_ml_toolchain//common:static_libcxx=False
 
 common:rocm --config=rocm_clang_hermetic
 common:rocm_ci --config=rocm
-common:rocm_ci --@local_config_rocm//rocm:rocm_path_type=hermetic --config=workspace
+common:rocm_ci --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 common:rocm_ci_hermetic --dynamic_mode=off
 common:rocm_ci_hermetic --config=rocm_clang_hermetic
 common:rocm_ci_hermetic --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a"
 common:rocm_ci_hermetic --repo_env=ROCM_DISTRO_VERSION="rocm_7.13.0_gfx90a"
 common:rocm_ci_hermetic --repo_env=SYSROOT_DIST=linux_glibc_2_31
-common:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic --config=workspace
+common:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 # This config option is used for SYCL as GPU backend.
 # SYCL Configuration (non-hermetic)

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -129,16 +129,16 @@ cc_library(
     name = "rocm_rpath",
     linkopts = select({
         ":build_hermetic": [
-            "-Wl,-rpath,external/%{rocm_repo_name}/rocm/%{rocm_root}/lib",
+            "-Wl,-rpath,../%{rocm_repo_name}/rocm/%{rocm_root}/lib",
         ],
         ":link_only": [
         ],
         ":multiple_rocm_paths": [
-            "-Wl,-rpath,external/%{rocm_repo_name}/rocm/%{rocm_root}/lib",
+            "-Wl,-rpath,../%{rocm_repo_name}/rocm/%{rocm_root}/lib",
             "-Wl,-rpath=%{rocm_lib_paths}",
         ],
         "//conditions:default": [
-            "-Wl,-rpath,external/%{rocm_repo_name}/rocm/%{rocm_root}/lib",
+            "-Wl,-rpath,../%{rocm_repo_name}/rocm/%{rocm_root}/lib",
             "-Wl,-rpath,/opt/rocm/lib",
         ],
     }),

--- a/xla/lit.bzl
+++ b/xla/lit.bzl
@@ -16,6 +16,10 @@
 """Helper rules for writing LIT tests."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load(
+    "@local_config_rocm//rocm:build_defs.bzl",
+    "is_rocm_configured",
+)
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@xla//third_party/rules_python/python:defs.bzl", "py_binary")
 load(
@@ -459,6 +463,9 @@ def lit_test(
     )
 
     # copybara:comment_end
+
+    if is_rocm_configured():
+        env["ROCM_REPO_NAME"] = Label("@local_config_rocm//rocm:hip_runtime").repo_name
 
     native_test_rule(
         name = name,

--- a/xla/lit.cfg.py
+++ b/xla/lit.cfg.py
@@ -42,6 +42,7 @@ for env in [
     # Passthrough XLA_FLAGS.
     "XLA_FLAGS",
     "CUDA_VISIBLE_DEVICES",
+    "ROCM_REPO_NAME",
     # Propagate environment variables used by 'bazel coverage'.
     # These are exported by tools/coverage/collect_coverage.sh
     "BULK_COVERAGE_RUN",

--- a/xla/sh_test_with_runfiles.py
+++ b/xla/sh_test_with_runfiles.py
@@ -39,36 +39,50 @@ class ShTestWithRunfiles(lit.formats.ShTest):
           except FileExistsError:
             pass
 
-      # Dynamically resolve hermetic cuda_nvcc in runfiles if present.
-      # Static relative paths (e.g. %S/../../..) break for deeply nested targets
-      # or under Bazel 8 Bzlmod runfiles layouts. Instead, we dynamically locate
-      # the runfiles directory containing `bin/ptxas`.
-      cuda_dir = None
-      # Fast-path check for standard runfiles repository locations
-      for candidate in [
-          rf_path / "cuda_nvcc",
-          rf_path / "xla" / "cuda_nvcc",
-          rf_path.parent / "cuda_nvcc",
-      ]:
-        if (candidate / "bin" / "ptxas").is_file():
-          cuda_dir = candidate
-          break
-      # Fallback search for Bzlmod mangled repository names
-      # (e.g. rules_cuda~...~cuda_nvcc)
-      if not cuda_dir and rf_path.is_dir():
-        for p in rf_path.rglob("*cuda_nvcc*"):
-          if (p / "bin" / "ptxas").is_file():
-            cuda_dir = p
+      rocm_repo_name_env = os.environ.get("ROCM_REPO_NAME")
+      if rocm_repo_name_env:
+        rocm_repo_dir = rf_path / rocm_repo_name_env
+        if rocm_repo_dir.is_dir():
+          dst = pathlib.Path(test.getExecPath()).parent.parent
+          dst.mkdir(parents=True, exist_ok=True)
+          target = dst / rocm_repo_name_env
+          try:
+            target.symlink_to(rocm_repo_dir, target_is_directory=True)
+            created_symlinks.append(target)
+          except FileExistsError:
+            pass
+        del test.config.environment["ROCM_REPO_NAME"]
+      else:
+        # Dynamically resolve hermetic cuda_nvcc in runfiles if present.
+        # Static relative paths (e.g. %S/../../..) break for deeply nested targets
+        # or under Bazel 8 Bzlmod runfiles layouts. Instead, we dynamically locate
+        # the runfiles directory containing `bin/ptxas`.
+        cuda_dir = None
+        # Fast-path check for standard runfiles repository locations
+        for candidate in [
+            rf_path / "cuda_nvcc",
+            rf_path / "xla" / "cuda_nvcc",
+            rf_path.parent / "cuda_nvcc",
+        ]:
+          if (candidate / "bin" / "ptxas").is_file():
+            cuda_dir = candidate
             break
+        # Fallback search for Bzlmod mangled repository names
+        # (e.g. rules_cuda~...~cuda_nvcc)
+        if not cuda_dir and rf_path.is_dir():
+          for p in rf_path.rglob("*cuda_nvcc*"):
+            if (p / "bin" / "ptxas").is_file():
+              cuda_dir = p
+              break
 
-      # Inject --xla_gpu_cuda_data_dir into XLA_FLAGS if resolved
-      if cuda_dir:
-        existing_flags = test.config.environment.get("XLA_FLAGS", "")
-        if "--xla_gpu_cuda_data_dir" not in existing_flags:
-          flag = f"--xla_gpu_cuda_data_dir={cuda_dir}"
-          test.config.environment["XLA_FLAGS"] = (
-              f"{existing_flags} {flag}".strip()
-          )
+        # Inject --xla_gpu_cuda_data_dir into XLA_FLAGS if resolved
+        if cuda_dir:
+          existing_flags = test.config.environment.get("XLA_FLAGS", "")
+          if "--xla_gpu_cuda_data_dir" not in existing_flags:
+            flag = f"--xla_gpu_cuda_data_dir={cuda_dir}"
+            test.config.environment["XLA_FLAGS"] = (
+                f"{existing_flags} {flag}".strip()
+            )
 
     result = super().execute(test, lit_config)
     for target in created_symlinks:


### PR DESCRIPTION
📝 Summary of Changes
Ensure the way we link to rocm libraries works with bzlmod and or legacy_external_runfiles=false

🎯 Justification
Avoids the need for --config=workspace workarounds in our CI

🚀 Kind of Contribution
🐛 Bug 

📊 Benchmark (for Performance Improvements)
N\A

🧪 Unit Tests:
None

🧪 Execution Tests:
None
