### PR TITLE
[HLO] Fix nested dynamic-slice and dynamic-update-slice fold index clamping (miscompile)

### DIFF
--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -7993,12 +7993,26 @@ absl::Status AlgebraicSimplifierVisitor::HandleDynamicSlice(
     for (int64_t i = 1; i < dynamic_slice->operand_count(); ++i) {
       HloInstruction* index = dynamic_slice->mutable_operand(i);
       HloInstruction* inner_index = operand->mutable_operand(i);
+      const int64_t operand_dim =
+          operand->operand(0)->shape().dimensions(i - 1);
+      const int64_t inner_slice_size = operand->dynamic_slice_sizes()[i - 1];
+      const int64_t outer_slice_size =
+          dynamic_slice->dynamic_slice_sizes()[i - 1];
+      // The inner dynamic-slice clamps its start index to
+      // [0, operand_dim - inner_slice_size]; the outer one then clamps its own
+      // start, within the inner slice, to [0, inner_slice_size -
+      // outer_slice_size]. The start into the original operand is the sum of
+      // those two clamped values, so both indices must be clamped with their
+      // own bounds before adding. (Previously the inner index was clamped with
+      // the outer slice size and the outer index was added unclamped, which
+      // sliced the wrong elements for out-of-range but valid indices.)
       inner_index = inner_index->AddInstruction(HloInstruction::CreateTernary(
           inner_index->shape(), HloOpcode::kClamp,
           MakeScalarLike(inner_index, 0), inner_index,
-          MakeScalarLike(inner_index,
-                         operand->operand(0)->shape().dimensions(i - 1) -
-                             dynamic_slice->dynamic_slice_sizes()[i - 1])));
+          MakeScalarLike(inner_index, operand_dim - inner_slice_size)));
+      index = index->AddInstruction(HloInstruction::CreateTernary(
+          index->shape(), HloOpcode::kClamp, MakeScalarLike(index, 0), index,
+          MakeScalarLike(index, inner_slice_size - outer_slice_size)));
       if (inner_index->shape().element_type() !=
           index->shape().element_type()) {
         inner_index = inner_index->AddInstruction(

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -8194,6 +8194,16 @@ absl::Status AlgebraicSimplifierVisitor::HandleDynamicUpdateSlice(
               inner_index,
               dus_update->shape().dimensions(i - 2) -
                   dus_update->operand(1)->shape().dimensions(i - 2))));
+      // Clamp the outer index too: the inner ds(a, id) and the outer
+      // dus(..., id) both clamp id to [0, dim(a) - inner_update_size]. The
+      // composed start must clamp each index with its own bound before adding,
+      // otherwise an out-of-range (but valid, clamped) outer index writes the
+      // update at the wrong location.
+      index = index->AddInstruction(HloInstruction::CreateTernary(
+          index->shape(), HloOpcode::kClamp, MakeScalarLike(index, 0), index,
+          MakeScalarLike(index,
+                         dynamic_update_slice->shape().dimensions(i - 2) -
+                             dus_update->shape().dimensions(i - 2))));
       if (inner_index->shape().element_type() !=
           index->shape().element_type()) {
         inner_index = inner_index->AddInstruction(

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -8172,6 +8172,40 @@ TEST_F(AlgebraicSimplifierTest, DynamicSliceOfDynamicSliceClampsBothIndices) {
                  m::Clamp(m::Constant(), m::Parameter(1), m::Constant())))));
 }
 
+// dus(a, dus(ds(a, id){ds}, c, inner_id), id) folds to a single dus(a, c, ...).
+// Both start indices must be clamped to their own ranges before being added:
+// clamp(id, 0, dim - ds) + clamp(inner_id, 0, ds - c). Regression for a case
+// where the outer index `id` was added unclamped, writing the update at the
+// wrong location for out-of-range (but valid, clamped) indices.
+TEST_F(AlgebraicSimplifierTest,
+       DynamicUpdateSliceOfDynamicUpdateSliceClampsBothIndices) {
+  constexpr absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY test {
+      p = f32[10] parameter(0)
+      c = f32[2] parameter(1)
+      id = s32[] parameter(2)
+      inner_id = s32[] parameter(3)
+      ds = f32[4] dynamic-slice(p, id), dynamic_slice_sizes={4}
+      inner = f32[4] dynamic-update-slice(ds, c, inner_id)
+      ROOT dus = f32[10] dynamic-update-slice(p, inner, id)
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  AlgebraicSimplifier simplifier(default_options_);
+  ASSERT_THAT(simplifier.Run(module.get()), absl_testing::IsOkAndHolds(true));
+  auto root = module->entry_computation()->root_instruction();
+  EXPECT_THAT(
+      root,
+      GmockMatch(m::DynamicUpdateSlice(
+          m::Parameter(0), m::Parameter(1),
+          m::Add(m::Clamp(m::Constant(), m::Parameter(2), m::Constant()),
+                 m::Clamp(m::Constant(), m::Parameter(3), m::Constant())))));
+}
+
 TEST_F(AlgebraicSimplifierTest, DynamicSliceOfTrivialReshape) {
   constexpr absl::string_view hlo_string = R"(
     HloModule module

--- a/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -8140,6 +8140,38 @@ TEST_F(AlgebraicSimplifierTest, DynamicSliceOfTranspose) {
                                         m::Parameter(3), m::Parameter(2)))));
 }
 
+// ds(ds(x, inner_id){inner}, id){outer} folds to a single ds(x, ...). Both
+// start indices must be clamped to their own ranges before being added:
+// clamp(id, 0, inner - outer) + clamp(inner_id, 0, dim - inner). Regression for
+// a case where the outer index was added unclamped and the inner index was
+// clamped with the outer slice size, mis-slicing out-of-range (but valid,
+// clamped) indices.
+TEST_F(AlgebraicSimplifierTest, DynamicSliceOfDynamicSliceClampsBothIndices) {
+  constexpr absl::string_view hlo_string = R"(
+    HloModule module
+
+    ENTRY test {
+      x = f32[10] parameter(0)
+      inner_id = s32[] parameter(1)
+      id = s32[] parameter(2)
+      inner = f32[4] dynamic-slice(x, inner_id), dynamic_slice_sizes={4}
+      ROOT outer = f32[2] dynamic-slice(inner, id), dynamic_slice_sizes={2}
+    }
+  )";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  AlgebraicSimplifier simplifier(default_options_);
+  ASSERT_THAT(simplifier.Run(module.get()), absl_testing::IsOkAndHolds(true));
+  auto root = module->entry_computation()->root_instruction();
+  EXPECT_THAT(
+      root,
+      GmockMatch(m::DynamicSlice(
+          m::Parameter(0),
+          m::Add(m::Clamp(m::Constant(), m::Parameter(2), m::Constant()),
+                 m::Clamp(m::Constant(), m::Parameter(1), m::Constant())))));
+}
+
 TEST_F(AlgebraicSimplifierTest, DynamicSliceOfTrivialReshape) {
   constexpr absl::string_view hlo_string = R"(
     HloModule module


### PR DESCRIPTION
#ai-generated

## Problem

Two sibling folds in `AlgebraicSimplifier` compose the start indices of nested dynamic-slice / dynamic-update-slice ops incorrectly, so an **out-of-range but valid** index (HLO `DynamicSlice`/`DynamicUpdateSlice` clamp their start indices per the spec) is placed at the wrong offset — a silent miscompile. For in-range indices every clamp is a no-op, which is why it went unnoticed.

### 1. `HandleDynamicSlice` — `ds(ds(x, inner_id){inner}, id){outer}`

Correct composed start into `x` is `clamp(inner_id, 0, dim - inner_size) + clamp(id, 0, inner_size - outer_size)`. The fold (a) clamped the **inner** index with the **outer** slice size (`dim - outer_size` instead of `dim - inner_size`), and (b) added the **outer** index `id` **unclamped**.

Example `x=f32[10]`, `inner=ds(x,inner_id){4}`, `outer=ds(inner,id){2}`, `inner_id=8, id=0`: correct `{x6,x7}`, folded `{x8,x9}`.

### 2. `HandleDynamicUpdateSlice` — `dus(a, dus(ds(a, id){ds}, c, inner_id), id)`

Correct composed update start is `clamp(id, 0, dim - ds_size) + clamp(inner_id, 0, ds_size - c_size)`. The inner index is clamped correctly here, but the **outer** index `id` is added **unclamped**; the retained DUS only clamps the sum to `[0, dim - c_size]`, weaker than the `[0, dim - ds_size]` the original enforces (via both the inner `ds` and outer `dus`).

Example `a=f32[10]`, `ds{4}`, `c=f32[2]`, `id=100, inner_id=0`: correct writes `c` at `[6,8)`, folded writes at `[8,10)`.

## Fix

Clamp each index with its own bound before adding, in both folds. `inner_size >= outer_size` / `ds_size >= c_size` is guaranteed (the outer op slices/updates within the inner tensor), so the added clamp bound is non-negative, and the composed start lies in the range the retained op clamps to (making that clamp a no-op and the fold exact).

## Testing

XLA doesn't build on my dev box, so I verified the **index arithmetic** against ground-truth nested-slice semantics with standalone programs:

- dynamic-slice: 2,760 `(inner_id, id)` combinations × 7 `(dim, inner, outer)` configs — the fix matches truth for **all** (0 mismatches); the current code is wrong in **1,284**.
- dynamic-update-slice: 3,465 combinations × 7 configs — fix **0** mismatches, current **1,204**.

Added two structural regression tests (`DynamicSliceOfDynamicSliceClampsBothIndices`, `DynamicUpdateSliceOfDynamicUpdateSliceClampsBothIndices`) asserting the folded op clamps **both** start indices (`Add(Clamp(..), Clamp(..))`), which fail on the current code (the outer index is added unclamped). I couldn't run the C++ suite here — happy to adjust the matchers if CI flags them.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
