### PR TITLE
[ROCm] Use AMD device descriptions in perf model tests

### DIFF
--- a/xla/service/gpu/gpu_device_info_for_tests.cc
+++ b/xla/service/gpu/gpu_device_info_for_tests.cc
@@ -166,12 +166,40 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI210DeviceInfo() {
   b.set_core_count(104);
   b.set_fpus_per_core(128);
   b.set_block_dim_limit_x(2'147'483'647);
-  b.set_block_dim_limit_y(2'147'483'647);
-  b.set_block_dim_limit_z(2'147'483'647);
+  b.set_block_dim_limit_y(65536);
+  b.set_block_dim_limit_z(65536);
   b.set_memory_bandwidth(1'638'400'000'000);
   b.set_l2_cache_size(8 * 1024 * 1024);
   b.set_clock_rate_ghz(1.7);
   b.set_device_memory_size(67'628'957'696);
+  b.set_registers_per_core_limit(131072);
+  b.set_registers_per_block_limit(131072);
+  b.set_runtime_version(stream_executor::SemanticVersion{6, 0, 0});
+  b.set_driver_version(stream_executor::SemanticVersion{6, 0, 0});
+  return b;
+}
+
+stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI300DeviceInfo() {
+  stream_executor::DeviceDescription b;
+  b.set_gpu_compute_capability(stream_executor::GpuComputeCapability(
+      stream_executor::RocmComputeCapability("gfx942")));
+  b.set_threads_per_block_limit(1024);
+  b.set_threads_per_warp(64);
+  b.set_shared_memory_per_block(64 * 1024);
+  b.set_shared_memory_per_block_optin(64 * 1024);
+  b.set_shared_memory_per_core(64 * 1024);
+  b.set_threads_per_core_limit(2048);
+  b.set_core_count(304);
+  b.set_fpus_per_core(128);
+  b.set_block_dim_limit_x(2'147'483'647);
+  b.set_block_dim_limit_y(65536);
+  b.set_block_dim_limit_z(65536);
+  b.set_memory_bandwidth(5'300'000'000'000);
+  b.set_l2_cache_size(4 * 1024 * 1024);
+  b.set_clock_rate_ghz(2.1);
+  b.set_device_memory_size(int64_t{192} * 1024 * 1024 * 1024);
+  b.set_registers_per_core_limit(131072);
+  b.set_registers_per_block_limit(131072);
   b.set_runtime_version(stream_executor::SemanticVersion{6, 0, 0});
   b.set_driver_version(stream_executor::SemanticVersion{6, 0, 0});
   return b;

--- a/xla/service/gpu/gpu_device_info_for_tests.h
+++ b/xla/service/gpu/gpu_device_info_for_tests.h
@@ -41,6 +41,7 @@ class TestGpuDeviceInfo {
           stream_executor::GpuComputeCapability{
               stream_executor::CudaComputeCapability(10, 0)});
   static stream_executor::DeviceDescription AMDMI210DeviceInfo();
+  static stream_executor::DeviceDescription AMDMI300DeviceInfo();
   static stream_executor::DeviceDescription AMDMI350DeviceInfo();
   static stream_executor::DeviceDescription AMDRX7900DeviceInfo();
   // Returns default RTXA6000 or AMDMI210 device info

--- a/xla/service/gpu/model/collective_interpolator_test.cc
+++ b/xla/service/gpu/model/collective_interpolator_test.cc
@@ -1083,8 +1083,7 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 TEST(DefaultCollectivePerfTableTest, EstimatesGfx942DefaultProfile) {
-  se::DeviceDescription device_info = TestGpuDeviceInfo::RTXA6000DeviceInfo();
-  device_info.set_rocm_compute_capability("gfx942");
+  se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI300DeviceInfo();
   ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<CollectiveInterpolator> interpolator,
       CollectiveInterpolator::Create(kNumGpusPerHost, device_info));
@@ -1133,8 +1132,7 @@ TEST(DefaultCollectivePerfTableTest, EstimatesGfx942DefaultProfile) {
 }
 
 TEST(DefaultCollectivePerfTableTest, EstimatesGfx950DefaultProfile) {
-  se::DeviceDescription device_info = TestGpuDeviceInfo::RTXA6000DeviceInfo();
-  device_info.set_rocm_compute_capability("gfx950");
+  se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI350DeviceInfo();
   ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<CollectiveInterpolator> interpolator,
       CollectiveInterpolator::Create(kNumGpusPerHost, device_info));

--- a/xla/service/gpu/model/matmul_interpolator_test.cc
+++ b/xla/service/gpu/model/matmul_interpolator_test.cc
@@ -334,15 +334,11 @@ class MatmulInterpolatorDefaultTableTest
   }
 
   std::unique_ptr<MatmulInterpolator> GetMatmulInterpolatorGfx942() {
-    se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI210DeviceInfo();
-    device_info.set_rocm_compute_capability("gfx942");
-    return GetMatmulInterpolator(device_info);
+    return GetMatmulInterpolator(TestGpuDeviceInfo::AMDMI300DeviceInfo());
   }
 
   std::unique_ptr<MatmulInterpolator> GetMatmulInterpolatorGfx950() {
-    se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI210DeviceInfo();
-    device_info.set_rocm_compute_capability("gfx950");
-    return GetMatmulInterpolator(device_info);
+    return GetMatmulInterpolator(TestGpuDeviceInfo::AMDMI350DeviceInfo());
   }
 };
 
@@ -739,8 +735,7 @@ INSTANTIATE_TEST_SUITE_P(
            info) { return info.param.test_name; });
 
 TEST(DefaultMatmulPerfTableTest, Gfx942InterpolatesBetweenGridPoints) {
-  se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI210DeviceInfo();
-  device_info.set_rocm_compute_capability("gfx942");
+  se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI300DeviceInfo();
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<MatmulInterpolator> interpolator,
                        MatmulInterpolator::Create(device_info));
   ASSERT_OK_AND_ASSIGN(
@@ -838,8 +833,7 @@ INSTANTIATE_TEST_SUITE_P(
            info) { return info.param.test_name; });
 
 TEST(DefaultMatmulPerfTableTest, Gfx950InterpolatesBetweenGridPoints) {
-  se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI210DeviceInfo();
-  device_info.set_rocm_compute_capability("gfx950");
+  se::DeviceDescription device_info = TestGpuDeviceInfo::AMDMI350DeviceInfo();
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<MatmulInterpolator> interpolator,
                        MatmulInterpolator::Create(device_info));
   ASSERT_OK_AND_ASSIGN(

--- a/xla/service/gpu/model/sol_latency_estimator_test.cc
+++ b/xla/service/gpu/model/sol_latency_estimator_test.cc
@@ -980,8 +980,7 @@ TEST_F(IsSolLatencyEstimatorEnabledTest, CreatesEstimatorWithGfx950Profiles) {
     }
   )";
   ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
-  gpu_device_info_ = TestGpuDeviceInfo::AMDMI210DeviceInfo();
-  gpu_device_info_.set_rocm_compute_capability("gfx950");
+  gpu_device_info_ = TestGpuDeviceInfo::AMDMI350DeviceInfo();
 
   SchedulerConfig scheduler_config;
   ASSERT_OK_AND_ASSIGN(
@@ -1030,8 +1029,7 @@ TEST_F(IsSolLatencyEstimatorEnabledTest, CreatesEstimatorWithGfx942Profiles) {
     }
   )";
   ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(kHlo));
-  gpu_device_info_ = TestGpuDeviceInfo::AMDMI210DeviceInfo();
-  gpu_device_info_.set_rocm_compute_capability("gfx942");
+  gpu_device_info_ = TestGpuDeviceInfo::AMDMI300DeviceInfo();
 
   SchedulerConfig scheduler_config;
   ASSERT_OK_AND_ASSIGN(


### PR DESCRIPTION
📝 Summary of Changes
Adds `TestGpuDeviceInfo::AMDMI300XDeviceInfo()` and fixes places where an MI210 or an RTX A6000 was redefined into a different chip by overwriting its compute capability.

🎯 Justification
Tests named for gfx942/gfx950 were running against MI210 and A6000 geometry, i.e., wrong core counts, clocks, and bandwidth.

🚀 Kind of Contribution: ♻️ Cleanup
