### PR TITLE
[XLA:SPMD] Keep batch sharding for grouped convolutions

### DIFF
--- a/xla/service/spmd/dot_handler.cc
+++ b/xla/service/spmd/dot_handler.cc
@@ -3842,6 +3842,19 @@ absl::StatusOr<std::optional<HloInstruction*>> PartitionConv(
     if (original_hlo->feature_group_count() > 1 &&
         rhs.hlo()->shape().dimensions(dnums.kernel_input_feature_dimension()) >
             1) {
+      // If no group-relevant feature dimension is partitioned, the grouping
+      // is transparent to the generic dot partitioning, e.g. plain batch
+      // sharding. Fall through to it instead of giving up.
+      if (ShardCountAtDim(lhs.sharding(), dnums.input_feature_dimension()) ==
+              1 &&
+          ShardCountAtDim(rhs.sharding(),
+                          dnums.kernel_input_feature_dimension()) == 1 &&
+          ShardCountAtDim(rhs.sharding(),
+                          dnums.kernel_output_feature_dimension()) == 1 &&
+          ShardCountAtDim(output_sharding, dnums.output_feature_dimension()) ==
+              1) {
+        return std::nullopt;
+      }
       return nullptr;
     }
 

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -12241,6 +12241,33 @@ ENTRY entry {
   EXPECT_EQ(FindInstruction(module.get(), HloOpcode::kDynamicSlice), nullptr);
 }
 
+TEST_P(SpmdPartitioningTest,
+       PartitionConvWithFeatureGroupCountBatchSharded01oiKernel) {
+  absl::string_view hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  %lhs = f32[128,32,32,32] parameter(0), sharding={devices=[8,1,1,1]<=[8]}
+  %rhs = f32[3,3,32,16] parameter(1), sharding={replicated}
+  ROOT %conv = f32[128,32,32,32] convolution(%lhs, %rhs),
+    dim_labels=b01f_01oi->b01f, feature_group_count=2,
+    window={size=3x3 pad=1_1x1_1},
+    sharding={devices=[8,1,1,1]<=[8]}
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          PartitionComputation(hlo_string, /*num_devices=*/8));
+  VLOG(1) << module->ToString();
+  // Same as PartitionConvWithFeatureGroupCountBatchSharded, but with the
+  // kernel output feature dimension before the input feature dimension.
+  const auto root = module->entry_computation()->root_instruction();
+  EXPECT_THAT(root, AllOf(op::Convolution(op::Parameter(0), op::Parameter(1)),
+                          op::Shape("f32[16,32,32,32]")));
+  EXPECT_EQ(root->feature_group_count(), 2);
+  EXPECT_EQ(FindInstruction(module.get(), HloOpcode::kAllGather), nullptr);
+  EXPECT_EQ(FindInstruction(module.get(), HloOpcode::kDynamicSlice), nullptr);
+}
+
 TEST_P(SpmdPartitioningTest, PartitionConvWithFeatureGroupCount2) {
   absl::string_view hlo_string = R"(
 HloModule module

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -12214,6 +12214,33 @@ ENTRY entry {
       root, AllOf(op::Convolution(lhs, rhs), op::Shape("f32[16,801,1,1024]")));
 }
 
+TEST_P(SpmdPartitioningTest, PartitionConvWithFeatureGroupCountBatchSharded) {
+  absl::string_view hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  %lhs = f32[128,32,32,32] parameter(0), sharding={devices=[8,1,1,1]<=[8]}
+  %rhs = f32[3,3,16,32] parameter(1), sharding={replicated}
+  ROOT %conv = f32[128,32,32,32] convolution(%lhs, %rhs),
+    dim_labels=b01f_01io->b01f, feature_group_count=2,
+    window={size=3x3 pad=1_1x1_1},
+    sharding={devices=[8,1,1,1]<=[8]}
+})";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          PartitionComputation(hlo_string, /*num_devices=*/8));
+  VLOG(1) << module->ToString();
+  // A grouped convolution sharded only on the batch dimension partitions
+  // like its non-grouped counterpart: a local convolution per partition,
+  // with no collectives and no post-convolution slicing.
+  const auto root = module->entry_computation()->root_instruction();
+  EXPECT_THAT(root, AllOf(op::Convolution(op::Parameter(0), op::Parameter(1)),
+                          op::Shape("f32[16,32,32,32]")));
+  EXPECT_EQ(root->feature_group_count(), 2);
+  EXPECT_EQ(FindInstruction(module.get(), HloOpcode::kAllGather), nullptr);
+  EXPECT_EQ(FindInstruction(module.get(), HloOpcode::kDynamicSlice), nullptr);
+}
+
 TEST_P(SpmdPartitioningTest, PartitionConvWithFeatureGroupCount2) {
   absl::string_view hlo_string = R"(
 HloModule module


### PR DESCRIPTION
## 📝 Summary of Changes

Fixes #47945.

The SPMD partitioner currently gives up on any convolution with
`feature_group_count > 1` that is not depthwise shaped
(`kernel_input_feature_dim > 1`): `PartitionConv` returns an engaged null
optional, which aborts the whole `PartitionDot` strategy search, so the
partitioner falls back to replicating the operands. For a conv that is only
sharded on the batch dimension this means: all-gather the full batch on
every partition, run the full-batch grouped conv redundantly everywhere,
then dynamic-slice the local shard back out. The same conv with
`feature_group_count = 1` partitions into a local conv with no collectives.

The grouping only constrains the feature dimensions, so when none of the
group-relevant feature dimensions is partitioned (input feature, kernel
input feature, kernel output feature, output feature), the grouping is
transparent to the generic dot partitioning. This change makes
`PartitionConv` fall through (`std::nullopt`) to the generic logic in
exactly that case, so a batch-sharded grouped conv partitions like its
dense counterpart: each partition runs the grouped conv on its local batch
shard against the replicated kernel. `CreateShardedConvolution` recomputes
`feature_group_count` from the sharded operand shapes, and with feature
dims unpartitioned that reproduces the original group count, so the local
conv is correct as-is.

When any of the four feature dimensions is partitioned the behavior is
unchanged (hard bail, replicate fallback): the generic dot logic must not
see those cases, because contracting-dim or output-feature partitioning
would recompute wrong groups on feature shards.

## 🎯 Justification

The reporter measured a production 8xB200 data-parallel training job where
the redundant grouped-conv all-gathers account for ~30% of device time and
the full-batch grouped convs ~45%. Per-partition compute and memory scale
with the global batch (N times the local batch on N partitions). The
repro in the issue shows the exact all-gather + full conv + dynamic-slice
pattern on 8 forced CPU devices, so it is backend-independent.

## 🚀 Kind of Contribution

⚡️ Performance Improvement

## 🧪 Unit Tests:

`PartitionConvWithFeatureGroupCountBatchSharded` in
`spmd_partitioner_test.cc`: partitions a `feature_group_count=2`,
`kernel_input_feature=16` conv sharded `[8,1,1,1]` on batch for 8 devices,
and asserts the root is a local `f32[16,32,32,32]` convolution of the two
parameters with `feature_group_count=2` and that the module contains no
all-gather and no dynamic-slice. The test fails before this change (root is
a dynamic-slice of a replicated full-batch conv behind an all-gather) and
passes with it. All existing tests in `//xla/service/spmd/...` pass; the
existing grouped-conv tests (all depthwise-shaped or feature-sharded) are
unaffected.

## 🧪 Execution Tests:

The issue's JAX reproducer on 8 forced CPU devices: with this change the
grouped case compiles to a local conv with zero all-gathers, matching the
`feature_group_count=1` control.