### PR TITLE
[XLA:GPU] Fix loop emitter insert point after emitting a loop mid-block

### DIFF
--- a/xla/service/llvm_ir/llvm_loop.cc
+++ b/xla/service/llvm_ir/llvm_loop.cc
@@ -149,8 +149,9 @@ void ForLoop::Emit(llvm::IRBuilderBase* b) {
     back_branch->setMetadata(llvm::LLVMContext::MD_loop, loop_id);
   }
 
-  // Re-point the IR builder to the loop exit block.
-  b->SetInsertPoint(exit_bb_);
+  // Re-point the IR builder to the loop exit block, inserting before any
+  // instructions the split moved there (e.g. the original terminator).
+  b->SetInsertPoint(exit_bb_, exit_bb_->getFirstInsertionPt());
 }
 
 std::vector<llvm::Metadata*> ForLoop::GetLoopMetadata(llvm::IRBuilderBase* b) {

--- a/xla/service/llvm_ir/loop_emitter.cc
+++ b/xla/service/llvm_ir/loop_emitter.cc
@@ -215,8 +215,10 @@ absl::Status LoopEmitter::EmitLoop(absl::string_view loop_name,
 
   // Set the insertion point of b_ to the loop exit, so that
   // code emitted for later instructions will be correctly placed.
+  // Insert before any instructions the loop emission split off into the
+  // exit block (e.g. a terminator), not at the block's end.
   if (exit_bb_ != nullptr) {
-    b_->SetInsertPoint(exit_bb_);
+    b_->SetInsertPoint(exit_bb_, exit_bb_->getFirstInsertionPt());
   }
   return absl::OkStatus();
 }

--- a/xla/tests/sort_test.cc
+++ b/xla/tests/sort_test.cc
@@ -91,6 +91,36 @@ TEST_F(SortTest, SortTwiceWithSameComparator) {
   EXPECT_TRUE(RunAndCompare(hlo_text_module, ErrorSpec{0.0, 0.0}));
 }
 
+TEST_F(SortTest, MultiElementComparator) {
+  // Regression test for https://github.com/openxla/xla/issues/47372: a
+  // comparator with non-scalar intermediate values used to crash the GPU
+  // LLVM IR emitter (llvm_loop.cc CHECK) on the second loop-emitted op.
+  // The comparator is semantically p0 < p1, computed via f32[2] values.
+  absl::string_view hlo_text_module = R"(
+    HloModule sort
+
+    compare {
+      p0 = f32[] parameter(0)
+      p1 = f32[] parameter(1)
+      idx = f32[2] iota(), iota_dimension=0
+      b0 = f32[2] broadcast(p0), dimensions={}
+      b1 = f32[2] broadcast(p1), dimensions={}
+      sum0 = f32[2] add(b0, idx)
+      sum1 = f32[2] add(b1, idx)
+      cmp = pred[2] compare(sum0, sum1), direction=LT
+      first = pred[1] slice(cmp), slice={[0:1]}
+      ROOT r = pred[] reshape(first)
+    }
+
+    ENTRY e {
+      x = f32[32] parameter(0)
+      ROOT sort = f32[32] sort(x), dimensions={0}, to_apply=compare
+    }
+  )";
+
+  EXPECT_TRUE(RunAndCompare(hlo_text_module, ErrorSpec{0.0, 0.0}));
+}
+
 // TODO(b/456833594): Enable this test once PJRT packs int4 types.
 TEST_F(SortTest, DISABLED_SortTuple) {
   absl::string_view hlo_text_module = R"(


### PR DESCRIPTION
## 📝 Summary of Changes

Fixes #47372.

A sort comparator that computes non-scalar intermediate values crashes GPU
compilation with `llvm_loop.cc:76] Check failed:
!preheader_bb_->hasTerminator()`. The GPU nested computation emitter
(`CodegenNestedComputation`) emits comparators as inline functions with the
builder positioned before a pre-created `ret void`. The first multi-element
op emits its loop through `ForLoop::Emit`'s split path, which moves the
`ret` into the new `loop_exit` block. `LoopEmitter::EmitLoop` (and
`ForLoop::Emit` itself) then reposition the builder at the end of
`loop_exit`, which is after the moved `ret`. The next loop-emitting op sees
an insert point at the end of a terminated block and trips the CHECK.

The fix repositions the builder at the exit block's first insertion point
instead of its end, in both `LoopEmitter::EmitLoop` and `ForLoop::Emit`.
For the common case (the loop was emitted at the end of an unterminated
block, so the exit block is a fresh empty block) this is identical to the
old behavior. For the mid-block split case it puts follow-up code where the
original insertion point was: before whatever the split moved into the exit
block. `ParallelLoopEmitter::EmitLoop` already handles its exit block this
way; the shared llvm_ir helpers never did.

## 🎯 Justification

The module in the issue is valid HLO (plain ops, runs fine on CPU and
interpreter); the GPU backend aborts the whole process while compiling it.
Any custom sort comparator with non-scalar intermediates that survive
simplification hits this, as does any nested call computation emitted
through `CallNestedComputation`. The crash reproduces without any XLA
flags.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

`SortTest.MultiElementComparator` in `xla/tests/sort_test.cc`: sorts
`f32[32]` with a comparator that is semantically `p0 < p1` but computed
through `f32[2]` intermediates (iota, two broadcasts, two adds, elementwise
compare, slice, reshape), compared against the interpreter reference with
zero tolerance. Without the fix the GPU test dies on the `llvm_loop.cc:76`
CHECK; with the fix it passes. `sort_test_cpu`, `sort_test_nvgpu_any`, all
`//xla/service/llvm_ir/...` and `//xla/service/cpu/tests/...` targets pass
with the change.

## 🧪 Execution Tests:

The issue's original StableHLO module and a reduced 19-line HLO module both
compile and run on one GPU (RTX 2070, sm_75) with the fix and abort at the
CHECK without it. The fixed binary's outputs match the interpreter
elementwise for order-consistent comparators.