### PR TITLE
[XLA:CPU] Do not multi-output fuse scatter fusions

### DIFF
--- a/xla/service/cpu/cpu_multi_output_fusion.cc
+++ b/xla/service/cpu/cpu_multi_output_fusion.cc
@@ -76,8 +76,11 @@ bool CpuMultiOutputFusion::IsFusible(HloInstruction* instr) {
     return false;
   }
 
+  // Dot and scatter fusions are emitted by dedicated emitters that do not
+  // support multi-output fusion roots.
   if (instr->IsLoopFusion() &&
-      instr->fused_expression_root()->opcode() != HloOpcode::kDot) {
+      instr->fused_expression_root()->opcode() != HloOpcode::kDot &&
+      instr->fused_expression_root()->opcode() != HloOpcode::kScatter) {
     return true;
   }
 

--- a/xla/service/cpu/cpu_multi_output_fusion_test.cc
+++ b/xla/service/cpu/cpu_multi_output_fusion_test.cc
@@ -159,5 +159,74 @@ TEST_F(MultiOutputFusionTest, DoesNotFuseInsideSortComparator) {
   }
 }
 
+// Regression test for https://github.com/openxla/xla/issues/47367: merging
+// scatter fusions creates a tuple-rooted fusion that bypasses the dedicated
+// scatter emitter and crashes the loop emitter's indexing analysis.
+TEST_F(MultiOutputFusionTest, DoesNotFuseScatterFusions) {
+  static constexpr absl::string_view kHloModule = R"(
+    HloModule module
+
+    %add_a {
+      %a = f32[] parameter(0)
+      %b = f32[] parameter(1)
+      ROOT %add = f32[] add(%a, %b)
+    }
+
+    %add_b {
+      %a = f32[] parameter(0)
+      %b = f32[] parameter(1)
+      ROOT %add = f32[] add(%a, %b)
+    }
+
+    %scatter_a {
+      %operand = f32[10,5] parameter(0)
+      %indices = s32[24,1] parameter(1)
+      %updates = f32[24,2,3] parameter(2)
+      ROOT %scatter = f32[10,5] scatter(%operand, %indices, %updates),
+        update_window_dims={1,2}, inserted_window_dims={},
+        scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%add_a
+    }
+
+    %scatter_b {
+      %operand = f32[10,5] parameter(0)
+      %indices = s32[24,1] parameter(1)
+      %updates = f32[24,2,3] parameter(2)
+      ROOT %scatter = f32[10,5] scatter(%operand, %indices, %updates),
+        update_window_dims={1,2}, inserted_window_dims={},
+        scatter_dims_to_operand_dims={0}, index_vector_dim=1, to_apply=%add_b
+    }
+
+    ENTRY %main {
+      %arg0 = f32[10,5] parameter(0)
+      %arg1 = f32[10,5] parameter(1)
+      %indices = s32[24,1] parameter(2)
+      %updates = f32[24,2,3] parameter(3)
+      %scatter0 = f32[10,5] fusion(%arg0, %indices, %updates), kind=kLoop,
+        calls=%scatter_a
+      %scatter1 = f32[10,5] fusion(%arg1, %indices, %updates), kind=kLoop,
+        calls=%scatter_b
+      ROOT %sum = f32[10,5] add(%scatter0, %scatter1)
+    }
+  )";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto hlo_module,
+                          ParseAndReturnVerifiedModule(kHloModule));
+  TF_ASSERT_OK_AND_ASSIGN(
+      bool changed, CpuMultiOutputFusion(&alias_info_).Run(hlo_module.get()));
+  EXPECT_FALSE(changed) << hlo_module->ToString();
+  int num_scatter_fusions = 0;
+  for (const HloInstruction* instr :
+       hlo_module->entry_computation()->instructions()) {
+    if (instr->opcode() == HloOpcode::kFusion) {
+      EXPECT_NE(instr->fused_expression_root()->opcode(), HloOpcode::kTuple)
+          << "Scatter fusions must not be merged into a multi-output fusion: "
+          << instr->ToString();
+      num_scatter_fusions +=
+          instr->fused_expression_root()->opcode() == HloOpcode::kScatter;
+    }
+  }
+  EXPECT_EQ(num_scatter_fusions, 2);
+}
+
 }  // namespace
 }  // namespace xla::cpu


### PR DESCRIPTION
## 📝 Summary of Changes

Fixes #47367.

With `--xla_backend_extra_options=xla_cpu_use_multi_output_fusion`, a
module containing two scatters that share operands crashes CPU
compilation with `symbolic_map.cc:196] Check failed: GetNumDims() ==
other.GetNumResults() (3 vs. 2)`.

`CpuMultiOutputFusion::IsFusible` accepts any loop fusion whose root is
not a dot, so two scatter-rooted wrapped fusions sharing indices/updates
get merged into a multi-output fusion rooted at `tuple(scatter,
scatter)`. The fusion kernel emitter dispatches to the dedicated scatter
emitter only when the fusion root itself is a scatter; the tuple root
falls through to the generic loop fusion emitter, whose indexing
analysis cannot express scatter (the operand indexing lives in the
update space, 3 dims here, while the subgraph indexing is over the root
space, 2 dims), and it dies on the CHECK.

This change excludes scatter-rooted fusions from multi-output fusion,
exactly like the existing dot exclusion in the same condition (both ops
have dedicated emitters that do not support multi-output roots). Nothing
regresses: the fusions this rejects currently crash the compiler.

## 🎯 Justification

The input is valid HLO (the same module compiles and runs fine without
the flag, and on GPU and interpreter); the flag is the CPU multi-output
fusion feature added in 52a47ae3ae. GPU's fusion machinery already treats
scatter specially (`IsInputFusibleScatter`) and never presents tuple-of-
scatter fusions to its emitters.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

`MultiOutputFusionTest.DoesNotFuseScatterFusions` in
`cpu_multi_output_fusion_test.cc`: two wrapped scatter fusions sharing
indices and updates, results added; expects the pass to make no change
and asserts no tuple-rooted fusion is formed. Fails before this change
(the pass merges the scatters), passes after. All
`//xla/service/cpu/tests/...` targets pass.

## 🧪 Execution Tests:

With the flag set, the issue's original module and a reduced two-scatter
module both compile on CPU and produce results elementwise-identical to
the interpreter after this change; before it both abort on the CHECK.