### PR TITLE
Fix ambiguous conversion in `ExpandIntegerPower` on GCC

### DIFF
--- a/xla/codegen/emitters/transforms/expand_integer_power.cc
+++ b/xla/codegen/emitters/transforms/expand_integer_power.cc
@@ -48,7 +48,8 @@ mlir::LogicalResult ExpandIntegerPower(mlir::math::IPowIOp op,
   llvm::SmallVector<mlir::Type> arg_types(op->getOperandTypes());
   mlir::Value result =
       mlir::mhlo::impl::mapMhloOpToStdScalarOp<mlir::mhlo::PowOp>(
-          op.getLoc(), result_types, arg_types, {op->getOperands()},
+          op.getLoc(), result_types, arg_types,
+          mlir::mhlo::PowOp::Adaptor(op->getOperands()),
           op->getAttrs(), &rewriter);
 
   rewriter.replaceOp(op, result);


### PR DESCRIPTION
📝 Summary of Changes
Construct the Adaptor class explicitly to avoid an ambiguous conversion in `ExpandIntegerPower` on GCC

🎯 Justification
GCC considers the constructors from `mlir::mhlo::PowOpAdaptor::PowOpAdaptor` and `PowOpGenericAdaptor` as conversions.
See `PowOpGenericAdaptor(RangeT values, mlir::DictionaryAttr attrs = nullptr)`
That leads to ambiguity.



<details>
<summary>Full error:</summary>

```
external/xla/xla/codegen/emitters/transforms/expand_integer_power.cc: In function 'llvm::LogicalResult xla::emitters::{anonymous}::ExpandIntegerPower(mlir::math::IPowIOp, mlir::PatternRewriter&)':
external/xla/xla/codegen/emitters/transforms/expand_integer_power.cc:51:66: error: conversion from '<brace-enclosed initializer list>' to 'mlir::mhlo::PowOp::Adaptor' {aka 'mlir::mhlo::PowOpAdaptor'} is ambiguous
   51 |       mlir::mhlo::impl::mapMhloOpToStdScalarOp<mlir::mhlo::PowOp>(
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
   52 |           op.getLoc(), result_types, arg_types, {op->getOperands()},
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   53 |           op->getAttrs(), &rewriter);
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~                              
In file included from bazel-out/k8-opt/bin/external/xla/xla/mlir_hlo/_virtual_includes/mlir_hlo/mhlo/IR/hlo_ops.h:104,
                 from external/xla/xla/codegen/emitters/transforms/expand_integer_power.cc:20:
bazel-out/k8-opt/bin/external/xla/xla/mlir_hlo/_virtual_includes/hlo_ops_inc_gen/mhlo/IR/hlo_ops.h.inc:23828:3: note: candidate: 'mlir::mhlo::PowOpGenericAdaptor<RangeT>::PowOpGenericAdaptor(RangeT, mlir::DictionaryAttr) [with RangeT = mlir::ValueRange]'
23828 |   PowOpGenericAdaptor(RangeT values, ::mlir::DictionaryAttr attrs = nullptr) : PowOpGenericAdaptor(values, attrs, Properties{}, {}) {}
      |   ^~~~~~~~~~~~~~~~~~~
bazel-out/k8-opt/bin/external/xla/xla/mlir_hlo/_virtual_includes/hlo_ops_inc_gen/mhlo/IR/hlo_ops.h.inc:23862:30: note:   inherited here
23862 |   using PowOpGenericAdaptor::PowOpGenericAdaptor;
      |                              ^~~~~~~~~~~~~~~~~~~
bazel-out/k8-opt/bin/external/xla/xla/mlir_hlo/_virtual_includes/hlo_ops_inc_gen/mhlo/IR/hlo_ops.h.inc:23860:7: note: candidate: 'constexpr mlir::mhlo::PowOpAdaptor::PowOpAdaptor(const mlir::mhlo::PowOpAdaptor&)'
23860 | class PowOpAdaptor : public PowOpGenericAdaptor<::mlir::ValueRange> {
      |       ^~~~~~~~~~~~
bazel-out/k8-opt/bin/external/xla/xla/mlir_hlo/_virtual_includes/hlo_ops_inc_gen/mhlo/IR/hlo_ops.h.inc:23860:7: note: candidate: 'constexpr mlir::mhlo::PowOpAdaptor::PowOpAdaptor(mlir::mhlo::PowOpAdaptor&&)'
In file included from external/xla/xla/codegen/emitters/transforms/expand_integer_power.cc:37:
external/xla/xla/mlir_hlo/mhlo/transforms/map_mhlo_to_scalar_op.h:1059:26: note:   initializing argument 4 of 'mlir::Value mlir::mhlo::impl::mapMhloOpToStdScalarOp(mlir::Location, llvm::ArrayRef<mlir::Type>, llvm::ArrayRef<mlir::Type>, typename MhloOpTy::Adaptor, llvm::ArrayRef<mlir::NamedAttribute>, mlir::OpBuilder*) [with MhloOpTy = mlir::mhlo::PowOp; typename MhloOpTy::Adaptor = mlir::mhlo::PowOpAdaptor]'
 1059 |     mhlo::PowOp::Adaptor adaptor, ArrayRef<NamedAttribute> attributes,
      |     ~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```

I'm not entirely sure why it is ambiguous as the inherited PowOpGenericAdaptor is the better match compared to the PowOpAdaptor->PowOpAdaptor-copy-ctor sequence

</details>

🚀 Kind of Contribution
🐛 Bug Fix

