### PR TITLE
Propagate min/max value inference bounds

### DIFF
--- a/xla/hlo/builder/value_inference.cc
+++ b/xla/hlo/builder/value_inference.cc
@@ -221,9 +221,10 @@ enum PostorderDFSNodeType {
   kConstantLowerBound,
   // This node is about figuring out whether a value is dynamic.
   kValueIsDynamic,
-  // This node is about figuring out whether a bound value is dynamic. It's
-  // similar to kValueIsDynamic, but views shape bound as static values.
-  kBoundIsDynamic,
+  // These nodes are about figuring out whether a bound value is dynamic. They
+  // are similar to kValueIsDynamic, but view shape bounds as static values.
+  kUpperBoundIsDynamic,
+  kLowerBoundIsDynamic,
 };
 
 std::string PostorderDFSNodeTypeToString(PostorderDFSNodeType type) {
@@ -236,9 +237,16 @@ std::string PostorderDFSNodeTypeToString(PostorderDFSNodeType type) {
       return "kConstantLowerBound";
     case kValueIsDynamic:
       return "kValueIsDynamic";
-    case kBoundIsDynamic:
-      return "kBoundIsDynamic";
+    case kUpperBoundIsDynamic:
+      return "kUpperBoundIsDynamic";
+    case kLowerBoundIsDynamic:
+      return "kLowerBoundIsDynamic";
   }
+}
+
+bool IsBoundDynamism(PostorderDFSNodeType type) {
+  return type == PostorderDFSNodeType::kUpperBoundIsDynamic ||
+         type == PostorderDFSNodeType::kLowerBoundIsDynamic;
 }
 
 struct InferenceContext {
@@ -478,6 +486,23 @@ PostorderDFSNode CreateAllDynamicResult(const Shape& shape,
       });
 }
 
+absl::StatusOr<Literal> EvaluateMinMaxBoundWithOptionalOperand(
+    HloEvaluator& evaluator, HloOpcode opcode, const Literal& lhs_bound,
+    const Literal& lhs_bound_is_dynamic, const Literal& rhs_bound,
+    const Literal& rhs_bound_is_dynamic) {
+  ABSL_ASSIGN_OR_RETURN(
+      Literal binary_bound,
+      evaluator.EvaluateElementwiseBinaryOp(opcode, lhs_bound, rhs_bound));
+  ABSL_ASSIGN_OR_RETURN(
+      Literal rhs_or_binary_bound,
+      evaluator.EvaluateElementwiseTernaryOp(HloOpcode::kSelect,
+                                             lhs_bound_is_dynamic, rhs_bound,
+                                             binary_bound));
+  return evaluator.EvaluateElementwiseTernaryOp(HloOpcode::kSelect,
+                                                rhs_bound_is_dynamic, lhs_bound,
+                                                rhs_or_binary_bound);
+}
+
 }  // namespace
 
 // Analyze a tensor's constant value, upper-bound value or lower-bound value.
@@ -695,6 +720,37 @@ absl::StatusOr<PostorderDFSNode> PostorderDFSVisitor::AnalyzeUpperBound(
                 HloOpcode::kMaximum, lower_bound_abs, upper_bound_abs);
           });
     }
+    case HloOpcode::kMaximum: {
+      // upper-bound(max(lhs, rhs)) = max(upper-bound(lhs), upper-bound(rhs))
+      return PostorderDFSNode()
+          .AddDependency(root->operand_ids(0),
+                         PostorderDFSNodeType::kConstantUpperBound, context)
+          .AddDependency(root->operand_ids(1),
+                         PostorderDFSNodeType::kConstantUpperBound, context)
+          .AddVisit([this](Literal lhs_bound,
+                           Literal rhs_bound) -> absl::StatusOr<Literal> {
+            return evaluator.EvaluateElementwiseBinaryOp(
+                HloOpcode::kMaximum, lhs_bound, rhs_bound);
+          });
+    }
+    case HloOpcode::kMinimum: {
+      // upper-bound(min(lhs, rhs)) can use either operand's upper bound.
+      return PostorderDFSNode()
+          .AddDependency(root->operand_ids(0),
+                         PostorderDFSNodeType::kConstantUpperBound, context)
+          .AddDependency(root->operand_ids(0),
+                         PostorderDFSNodeType::kUpperBoundIsDynamic, context)
+          .AddDependency(root->operand_ids(1),
+                         PostorderDFSNodeType::kConstantUpperBound, context)
+          .AddDependency(root->operand_ids(1),
+                         PostorderDFSNodeType::kUpperBoundIsDynamic, context)
+          .AddVisit([this](absl::Span<Literal> operands)
+                        -> absl::StatusOr<Literal> {
+            return EvaluateMinMaxBoundWithOptionalOperand(
+                evaluator, HloOpcode::kMinimum, operands[0], operands[1],
+                operands[2], operands[3]);
+          });
+    }
     case HloOpcode::kSort: {
       auto dfs = PostorderDFSNode();
       InferenceContext dep_context = context;
@@ -867,6 +923,37 @@ absl::StatusOr<PostorderDFSNode> PostorderDFSVisitor::AnalyzeLowerBound(
                                  HloOpcode::kAbs, upper_bound));
             return evaluator.EvaluateElementwiseBinaryOp(
                 HloOpcode::kMinimum, lower_bound_abs, upper_bound_abs);
+          });
+    }
+    case HloOpcode::kMaximum: {
+      // lower-bound(max(lhs, rhs)) can use either operand's lower bound.
+      return PostorderDFSNode()
+          .AddDependency(root->operand_ids(0),
+                         PostorderDFSNodeType::kConstantLowerBound, context)
+          .AddDependency(root->operand_ids(0),
+                         PostorderDFSNodeType::kLowerBoundIsDynamic, context)
+          .AddDependency(root->operand_ids(1),
+                         PostorderDFSNodeType::kConstantLowerBound, context)
+          .AddDependency(root->operand_ids(1),
+                         PostorderDFSNodeType::kLowerBoundIsDynamic, context)
+          .AddVisit([this](absl::Span<Literal> operands)
+                        -> absl::StatusOr<Literal> {
+            return EvaluateMinMaxBoundWithOptionalOperand(
+                evaluator, HloOpcode::kMaximum, operands[0], operands[1],
+                operands[2], operands[3]);
+          });
+    }
+    case HloOpcode::kMinimum: {
+      // lower-bound(min(lhs, rhs)) = min(lower-bound(lhs), lower-bound(rhs))
+      return PostorderDFSNode()
+          .AddDependency(root->operand_ids(0),
+                         PostorderDFSNodeType::kConstantLowerBound, context)
+          .AddDependency(root->operand_ids(1),
+                         PostorderDFSNodeType::kConstantLowerBound, context)
+          .AddVisit([this](Literal lhs_bound,
+                           Literal rhs_bound) -> absl::StatusOr<Literal> {
+            return evaluator.EvaluateElementwiseBinaryOp(
+                HloOpcode::kMinimum, lhs_bound, rhs_bound);
           });
     }
     case HloOpcode::kNegate: {
@@ -1050,7 +1137,7 @@ absl::StatusOr<PostorderDFSNode> PostorderDFSVisitor::AnalyzeIsDynamic(
                        handle_to_instruction(operand_handle));
       return PostorderDFSNode().AddVisit(
           [operand_proto, dimension, type]() -> absl::StatusOr<Literal> {
-            if (type == PostorderDFSNodeType::kBoundIsDynamic) {
+            if (IsBoundDynamism(type)) {
               // The bound of dynamic dimension is not dynamic.
               return LiteralUtil::CreateR0<bool>(false);
             }
@@ -1082,7 +1169,7 @@ absl::StatusOr<PostorderDFSNode> PostorderDFSVisitor::AnalyzeIsDynamic(
               !all_operands_values_static,
               ShapeUtil::GetSubshape(root_shape, context.shape_index));
         }
-        CHECK(type == PostorderDFSNodeType::kBoundIsDynamic);
+        CHECK(IsBoundDynamism(type));
         // The condition for bounds are more relaxed than values. If we know the
         // bounds of each element [B0, B1... Bn], all results have the same
         // bound
@@ -1168,8 +1255,6 @@ absl::StatusOr<PostorderDFSNode> PostorderDFSVisitor::AnalyzeIsDynamic(
     case HloOpcode::kAtan2:
     case HloOpcode::kDivide:
     case HloOpcode::kComplex:
-    case HloOpcode::kMaximum:
-    case HloOpcode::kMinimum:
     case HloOpcode::kMultiply:
     case HloOpcode::kPower:
     case HloOpcode::kRemainder:
@@ -1187,6 +1272,22 @@ absl::StatusOr<PostorderDFSNode> PostorderDFSVisitor::AnalyzeIsDynamic(
             .WithPrimitiveType(PRED)
             .WithOpCode(HloOpcode::kOr)
             .Evaluate();
+      });
+    }
+    case HloOpcode::kMaximum:
+    case HloOpcode::kMinimum: {
+      return result.AddVisit([opcode, type,
+                              this](absl::Span<Literal> operands)
+                                 -> absl::StatusOr<Literal> {
+        HloOpcode mask_opcode = HloOpcode::kOr;
+        if ((opcode == HloOpcode::kMinimum &&
+             type == PostorderDFSNodeType::kUpperBoundIsDynamic) ||
+            (opcode == HloOpcode::kMaximum &&
+             type == PostorderDFSNodeType::kLowerBoundIsDynamic)) {
+          mask_opcode = HloOpcode::kAnd;
+        }
+        return evaluator.EvaluateElementwiseBinaryOp(mask_opcode, operands[0],
+                                                     operands[1]);
       });
     }
     case HloOpcode::kTuple:
@@ -1483,8 +1584,9 @@ absl::StatusOr<PostorderDFSNode> PostorderDFSVisitor::AnalyzeIsDynamic(
       if (root->custom_call_target() == "SetBound") {
         return PostorderDFSNode().AddVisit([type,
                                             root]() -> absl::StatusOr<Literal> {
-          if (type == PostorderDFSNodeType::kBoundIsDynamic) {
-            ABSL_ASSIGN_OR_RETURN(Shape root_shape, Shape::FromProto(root->shape()));
+          if (IsBoundDynamism(type)) {
+            ABSL_ASSIGN_OR_RETURN(Shape root_shape,
+                                  Shape::FromProto(root->shape()));
             return CreatePredLiteral(false, root_shape);
           } else {
             if (root->literal().shape().element_type() == TUPLE) {
@@ -1621,7 +1723,8 @@ absl::StatusOr<Literal> PostorderDFSVisitor::PostOrderDFSVisit(
         ABSL_ASSIGN_OR_RETURN(node, AnalyzeUpperBound(item.handle, item.context));
         break;
       }
-      case PostorderDFSNodeType::kBoundIsDynamic:
+      case PostorderDFSNodeType::kUpperBoundIsDynamic:
+      case PostorderDFSNodeType::kLowerBoundIsDynamic:
       case PostorderDFSNodeType::kValueIsDynamic: {
         VLOG(1) << "value is dynamic";
         ABSL_ASSIGN_OR_RETURN(
@@ -1842,7 +1945,8 @@ absl::StatusOr<OptionalLiteral> ValueInference::AnalyzeConstant(
     case ValueInferenceMode::kLowerBound: {
       ABSL_ASSIGN_OR_RETURN(Literal mask,
                        visitor.PostOrderDFSVisit(
-                           handle, PostorderDFSNodeType::kBoundIsDynamic));
+                           handle,
+                           PostorderDFSNodeType::kLowerBoundIsDynamic));
       if (mask.IsAll(1)) {
         // Everything is dynamic, no need to do constant inference.
         return OptionalLiteral(CreateGarbageLiteral(op_shape), std::move(mask));
@@ -1856,7 +1960,8 @@ absl::StatusOr<OptionalLiteral> ValueInference::AnalyzeConstant(
     case ValueInferenceMode::kUpperBound: {
       ABSL_ASSIGN_OR_RETURN(Literal mask,
                        visitor.PostOrderDFSVisit(
-                           handle, PostorderDFSNodeType::kBoundIsDynamic));
+                           handle,
+                           PostorderDFSNodeType::kUpperBoundIsDynamic));
       if (mask.IsAll(1)) {
         // Everything is dynamic, no need to do constant inference.
         return OptionalLiteral(CreateGarbageLiteral(op_shape), std::move(mask));

--- a/xla/hlo/builder/value_inference_test.cc
+++ b/xla/hlo/builder/value_inference_test.cc
@@ -624,6 +624,18 @@ class UpperBoundInferenceTest : public ValueInferenceTest {
   }
 };
 
+class LowerBoundInferenceTest : public ValueInferenceTest {
+ public:
+  absl::StatusOr<OptionalLiteral> ComputeLowerBoundLiteral(
+      XlaOp operand, XlaBuilder* builder, Layout* output_layout = nullptr) {
+    ValueInference value_inference(builder);
+    ABSL_ASSIGN_OR_RETURN(auto literal,
+                          value_inference.AnalyzeConstant(
+                              operand, ValueInferenceMode::kLowerBound));
+    return literal;
+  }
+};
+
 TEST_F(UpperBoundInferenceTest, GetDimensionSize) {
   XlaBuilder b(TestName());
   auto p =
@@ -736,6 +748,52 @@ TEST_F(UpperBoundInferenceTest, ParamCantInferBound) {
   auto sub = Div(gds, p1);
   EXPECT_FALSE(
       ComputeUpperBoundLiteral(sub, &b).value().Get<int32_t>({}).has_value());
+}
+
+TEST_F(UpperBoundInferenceTest, MinimumWithDynamicOperandKeepsUpperBound) {
+  XlaBuilder b(TestName());
+  auto p0 = Parameter(&b, 0, ShapeUtil::MakeShape(S32, {2}, {true}), "p0");
+  auto p1 = Parameter(&b, 1, ShapeUtil::MakeScalarShape(S32), "p1");
+
+  auto min = Min(GetDimensionSize(p0, 0), p1);
+  auto result = ComputeUpperBoundLiteral(min, &b).value().Get<int32_t>({});
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), 2);
+}
+
+TEST_F(UpperBoundInferenceTest, MaximumWithDynamicOperandCantInferUpperBound) {
+  XlaBuilder b(TestName());
+  auto p0 = Parameter(&b, 0, ShapeUtil::MakeShape(S32, {2}, {true}), "p0");
+  auto p1 = Parameter(&b, 1, ShapeUtil::MakeScalarShape(S32), "p1");
+
+  auto max = Max(GetDimensionSize(p0, 0), p1);
+  auto result = ComputeUpperBoundLiteral(max, &b).value().Get<int32_t>({});
+
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(LowerBoundInferenceTest, MaximumWithDynamicOperandKeepsLowerBound) {
+  XlaBuilder b(TestName());
+  auto p0 = Parameter(&b, 0, ShapeUtil::MakeShape(S32, {2}, {true}), "p0");
+  auto p1 = Parameter(&b, 1, ShapeUtil::MakeScalarShape(S32), "p1");
+
+  auto max = Max(GetDimensionSize(p0, 0), p1);
+  auto result = ComputeLowerBoundLiteral(max, &b).value().Get<int32_t>({});
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), 0);
+}
+
+TEST_F(LowerBoundInferenceTest, MinimumWithDynamicOperandCantInferLowerBound) {
+  XlaBuilder b(TestName());
+  auto p0 = Parameter(&b, 0, ShapeUtil::MakeShape(S32, {2}, {true}), "p0");
+  auto p1 = Parameter(&b, 1, ShapeUtil::MakeScalarShape(S32), "p1");
+
+  auto min = Min(GetDimensionSize(p0, 0), p1);
+  auto result = ComputeLowerBoundLiteral(min, &b).value().Get<int32_t>({});
+
+  EXPECT_FALSE(result.has_value());
 }
 
 TEST_F(UpperBoundInferenceTest, KeyValueSort) {


### PR DESCRIPTION
## Summary

This updates XLA value inference to preserve one-sided bounds through `minimum` and `maximum` when the other operand is dynamic.

- Split bound dynamism tracking into separate upper-bound and lower-bound masks.
- Add asymmetric dynamism propagation for `minimum` and `maximum`.
- Add explicit upper/lower bound evaluation for `minimum` and `maximum` so static one-sided bounds are not discarded.
- Add focused tests for the upper/lower bound propagation behavior.

## Root Cause

The previous single bound-dynamism mask was too conservative for `minimum` and `maximum`. For example, `upper_bound(min(a, b))` can still be bounded by `upper_bound(a)` even when `b` is dynamic, and `lower_bound(max(a, b))` can still be bounded by `lower_bound(a)` when `b` is dynamic.

## Testing

`bazelisk test //xla/hlo/builder:value_inference_test --test_output=errors --repo_env=HERMETIC_PYTHON_VERSION=3.11`

Originally submitted against TensorFlow as tensorflow/tensorflow#124514, but these files are maintained upstream in OpenXLA/XLA.