### PR TITLE
[ROCm] Dynamically select rocm repo runfiles

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -292,20 +292,20 @@ common:rocm_clang_hermetic --@rules_ml_toolchain//common:enable_rocm=True
 common:rocm_clang_hermetic --@rules_ml_toolchain//common:enable_cuda=False
 common:rocm_clang_hermetic --@rules_ml_toolchain//common:enable_sycl=False
 common:rocm_clang_hermetic --@rules_ml_toolchain//common:enable_hermetic_cc=True
-common:rocm_clang_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic --config=workspace
+common:rocm_clang_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic
 common:rocm_clang_hermetic --strategy=CppLink=local
 common:rocm_clang_hermetic --@rules_ml_toolchain//common:static_libcxx=False
 
 common:rocm --config=rocm_clang_hermetic
 common:rocm_ci --config=rocm
-common:rocm_ci --@local_config_rocm//rocm:rocm_path_type=hermetic --config=workspace
+common:rocm_ci --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 common:rocm_ci_hermetic --dynamic_mode=off
 common:rocm_ci_hermetic --config=rocm_clang_hermetic
 common:rocm_ci_hermetic --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a"
 common:rocm_ci_hermetic --repo_env=ROCM_DISTRO_VERSION="rocm_7.13.0_gfx90a"
 common:rocm_ci_hermetic --repo_env=SYSROOT_DIST=linux_glibc_2_31
-common:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic --config=workspace
+common:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 # This config option is used for SYCL as GPU backend.
 # SYCL Configuration (non-hermetic)

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -129,16 +129,16 @@ cc_library(
     name = "rocm_rpath",
     linkopts = select({
         ":build_hermetic": [
-            "-Wl,-rpath,external/%{rocm_repo_name}/rocm/%{rocm_root}/lib",
+            "-Wl,-rpath,../%{rocm_repo_name}/rocm/%{rocm_root}/lib",
         ],
         ":link_only": [
         ],
         ":multiple_rocm_paths": [
-            "-Wl,-rpath,external/%{rocm_repo_name}/rocm/%{rocm_root}/lib",
+            "-Wl,-rpath,../%{rocm_repo_name}/rocm/%{rocm_root}/lib",
             "-Wl,-rpath=%{rocm_lib_paths}",
         ],
         "//conditions:default": [
-            "-Wl,-rpath,external/%{rocm_repo_name}/rocm/%{rocm_root}/lib",
+            "-Wl,-rpath,../%{rocm_repo_name}/rocm/%{rocm_root}/lib",
             "-Wl,-rpath,/opt/rocm/lib",
         ],
     }),

--- a/xla/sh_test_with_runfiles.py
+++ b/xla/sh_test_with_runfiles.py
@@ -17,7 +17,6 @@ import os
 import pathlib
 
 import lit.formats
-import subprocess
 
 
 class ShTestWithRunfiles(lit.formats.ShTest):
@@ -38,8 +37,11 @@ class ShTestWithRunfiles(lit.formats.ShTest):
         if item.is_dir():
           test_exec_symlink = test_exec_dir.parent / item.name
           if not test_exec_symlink.exists():
-            test_exec_symlink.symlink_to(item, target_is_directory=True)
-            created_symlinks.append(test_exec_symlink)
+            try:
+              test_exec_symlink.symlink_to(item, target_is_directory=True)
+              created_symlinks.append(test_exec_symlink)
+            except FileExistsError:
+              pass
 
 
       # Dynamically resolve hermetic cuda_nvcc in runfiles if present.
@@ -77,6 +79,9 @@ class ShTestWithRunfiles(lit.formats.ShTest):
 
     # Clean up created symlinks
     for target in created_symlinks:
-      target.unlink()
+      try:
+        target.unlink()
+      except FileNotFoundError:
+        pass
 
     return result

--- a/xla/sh_test_with_runfiles.py
+++ b/xla/sh_test_with_runfiles.py
@@ -32,23 +32,13 @@ class ShTestWithRunfiles(lit.formats.ShTest):
       test_exec_dir = pathlib.Path(test.getExecPath()).parent
       test_exec_dir.mkdir(parents=True, exist_ok=True)
 
-      # Map: runfiles path to check -> symlink name to create
-      # RUNPATH has "../+rocm_configure_ext+local_config_rocm/..." so symlink at parent
-      candidates = {
-          "+rocm_configure_ext+local_config_rocm": "+rocm_configure_ext+local_config_rocm",
-          "_main/external/+rocm_configure_ext+local_config_rocm": "+rocm_configure_ext+local_config_rocm",
-          "external/+rocm_configure_ext+local_config_rocm": "+rocm_configure_ext+local_config_rocm",
-          "+llvm_extension+llvm-project": "+llvm_extension+llvm-project",
-          "_main/external/+llvm_extension+llvm-project": "+llvm_extension+llvm-project",
-          "external/+llvm_extension+llvm-project": "+llvm_extension+llvm-project",
-      }
-
-      for runfiles_path, symlink_name in candidates.items():
-        if (rf_path / runfiles_path).is_dir():
-          # RUNPATH has "../..." so create symlink at parent level
-          test_exec_symlink = test_exec_dir.parent / symlink_name
+      # Symlink all directories from runfiles root to test_exec_dir.parent
+      # RUNPATH has "../+rocm_configure_ext+local_config_rocm/..." patterns
+      for item in rf_path.iterdir():
+        if item.is_dir():
+          test_exec_symlink = test_exec_dir.parent / item.name
           if not test_exec_symlink.exists():
-            test_exec_symlink.symlink_to(rf_path / runfiles_path, target_is_directory=True)
+            test_exec_symlink.symlink_to(item, target_is_directory=True)
             created_symlinks.append(test_exec_symlink)
 
 

--- a/xla/sh_test_with_runfiles.py
+++ b/xla/sh_test_with_runfiles.py
@@ -29,25 +29,27 @@ class ShTestWithRunfiles(lit.formats.ShTest):
     if runfiles_env:
       rf_path = pathlib.Path(runfiles_env)
 
-      runfiles_external = None
-      for candidate in [
-          rf_path / "_main" / "external",
-          rf_path / "external",
-      ]:
-        if candidate and candidate.is_dir():
-          runfiles_external = candidate
-          break
+      test_exec_dir = pathlib.Path(test.getExecPath()).parent
+      test_exec_dir.mkdir(parents=True, exist_ok=True)
 
-      if runfiles_external:
-        # Create symlink at the directory where the test actually executes
-        test_exec_dir = pathlib.Path(test.getExecPath()).parent
-        test_exec_external = test_exec_dir / "external"
-        test_exec_dir.mkdir(parents=True, exist_ok=True)
-        if not test_exec_external.exists():
-          test_exec_external.symlink_to(runfiles_external, target_is_directory=True)
-          created_symlinks.append(test_exec_external)
-      else:
-        print("DEBUG: Could not find external directory in runfiles")
+      # Map: runfiles path to check -> symlink name to create
+      # RUNPATH has "../+rocm_configure_ext+local_config_rocm/..." so symlink at parent
+      candidates = {
+          "+rocm_configure_ext+local_config_rocm": "+rocm_configure_ext+local_config_rocm",
+          "_main/external/+rocm_configure_ext+local_config_rocm": "+rocm_configure_ext+local_config_rocm",
+          "external/+rocm_configure_ext+local_config_rocm": "+rocm_configure_ext+local_config_rocm",
+          "+llvm_extension+llvm-project": "+llvm_extension+llvm-project",
+          "_main/external/+llvm_extension+llvm-project": "+llvm_extension+llvm-project",
+          "external/+llvm_extension+llvm-project": "+llvm_extension+llvm-project",
+      }
+
+      for runfiles_path, symlink_name in candidates.items():
+        if (rf_path / runfiles_path).is_dir():
+          # RUNPATH has "../..." so create symlink at parent level
+          test_exec_symlink = test_exec_dir.parent / symlink_name
+          if not test_exec_symlink.exists():
+            test_exec_symlink.symlink_to(rf_path / runfiles_path, target_is_directory=True)
+            created_symlinks.append(test_exec_symlink)
 
 
       # Dynamically resolve hermetic cuda_nvcc in runfiles if present.

--- a/xla/sh_test_with_runfiles.py
+++ b/xla/sh_test_with_runfiles.py
@@ -17,6 +17,7 @@ import os
 import pathlib
 
 import lit.formats
+import subprocess
 
 
 class ShTestWithRunfiles(lit.formats.ShTest):
@@ -27,17 +28,27 @@ class ShTestWithRunfiles(lit.formats.ShTest):
     created_symlinks = []
     if runfiles_env:
       rf_path = pathlib.Path(runfiles_env)
-      runfiles_dir = rf_path / "xla"
-      if runfiles_dir.is_dir():
-        dst = pathlib.Path(test.getExecPath()).parent
-        dst.mkdir(parents=True, exist_ok=True)
-        for item in runfiles_dir.iterdir():
-          target = dst / item.name
-          try:
-            target.symlink_to(item, target_is_directory=item.is_dir())
-            created_symlinks.append(target)
-          except FileExistsError:
-            pass
+
+      runfiles_external = None
+      for candidate in [
+          rf_path / "_main" / "external",
+          rf_path / "external",
+      ]:
+        if candidate and candidate.is_dir():
+          runfiles_external = candidate
+          break
+
+      if runfiles_external:
+        # Create symlink at the directory where the test actually executes
+        test_exec_dir = pathlib.Path(test.getExecPath()).parent
+        test_exec_external = test_exec_dir / "external"
+        test_exec_dir.mkdir(parents=True, exist_ok=True)
+        if not test_exec_external.exists():
+          test_exec_external.symlink_to(runfiles_external, target_is_directory=True)
+          created_symlinks.append(test_exec_external)
+      else:
+        print("DEBUG: Could not find external directory in runfiles")
+
 
       # Dynamically resolve hermetic cuda_nvcc in runfiles if present.
       # Static relative paths (e.g. %S/../../..) break for deeply nested targets
@@ -71,6 +82,9 @@ class ShTestWithRunfiles(lit.formats.ShTest):
           )
 
     result = super().execute(test, lit_config)
+
+    # Clean up created symlinks
     for target in created_symlinks:
       target.unlink()
+
     return result


### PR DESCRIPTION
📝 Summary of Changes
Symlink all the runfiles from lit test deps to execution path

🎯 Justification
This change is required to support bzlmod builds in lit tests,
we now switch rocm ci builds to bzlmod

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
