### PR TITLE
[XLA:CPU] Fix crash when a sort comparator calls nested computations

### DIFF
--- a/xla/service/cpu/ir_emitter2.cc
+++ b/xla/service/cpu/ir_emitter2.cc
@@ -352,6 +352,19 @@ absl::StatusOr<IrEmitter2::ComparatorInfo> IrEmitter2::EmitSortComparator(
   });
   if (info != comparators_.end()) return *info;
 
+  // Emit computations transitively called from the comparator (e.g. a
+  // reduce's reducer), so that EmitThreadLocalCall can find them later.
+  for (HloInstruction* instr : comparator->instructions()) {
+    bool is_reducer = instr->opcode() == HloOpcode::kReduce ||
+                      instr->opcode() == HloOpcode::kReduceWindow;
+    for (HloComputation* called : instr->called_computations()) {
+      RETURN_IF_ERROR(nested_ir_emitter_
+                          ->EmitNestedComputation(
+                              *called, llvm_ir::IrName(instr), is_reducer)
+                          .status());
+    }
+  }
+
   // We use simple post-order schedule as we are not emitting a "real"
   // computation that requires buffer assignment.
   auto schedule = comparator->MakeInstructionPostOrder();

--- a/xla/service/cpu/tests/BUILD
+++ b/xla/service/cpu/tests/BUILD
@@ -337,6 +337,22 @@ xla_test(
 )
 
 xla_test(
+    name = "cpu_sort_test",
+    srcs = ["cpu_sort_test.cc"],
+    backends = ["cpu"],
+    deps = [
+        "//xla:literal",
+        "//xla:literal_util",
+        "//xla/hlo/testlib:verified_hlo_module",
+        "//xla/tests:hlo_pjrt_test_base",
+        "//xla/tests:literal_test_util",
+        "//xla/tests:xla_internal_test_main",
+        "//xla/tsl/platform:statusor",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+xla_test(
     name = "cpu_profiling_test",
     srcs = ["cpu_profiling_test.cc"],
     backends = ["cpu"],

--- a/xla/service/cpu/tests/cpu_sort_test.cc
+++ b/xla/service/cpu/tests/cpu_sort_test.cc
@@ -1,0 +1,85 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+#include "xla/hlo/testlib/verified_hlo_module.h"
+#include "xla/literal.h"
+#include "xla/literal_util.h"
+#include "xla/tests/hlo_pjrt_test_base.h"
+#include "xla/tests/literal_test_util.h"
+#include "xla/tsl/platform/statusor.h"
+
+namespace xla {
+namespace cpu {
+namespace {
+
+class CpuSortTest : public HloTestBase {};
+
+// Regression test for https://github.com/openxla/xla/issues/47366: a sort
+// comparator containing computation-calling ops (map, reduce) crashed the
+// thunk emitter because the called computations were never emitted.
+TEST_F(CpuSortTest, ComparatorCallingNestedComputations) {
+  const std::string hlo_text = R"(
+HloModule sort_comparator_with_nested_computations
+
+add_f32 {
+  a = f32[] parameter(0)
+  b = f32[] parameter(1)
+  ROOT add = f32[] add(a, b)
+}
+
+double_f32 {
+  x = f32[] parameter(0)
+  two = f32[] constant(2)
+  ROOT mul = f32[] multiply(x, two)
+}
+
+compare {
+  p0 = f32[] parameter(0)
+  p1 = f32[] parameter(1)
+  bcast0 = f32[2] broadcast(p0), dimensions={}
+  bcast1 = f32[2] broadcast(p1), dimensions={}
+  iota = f32[2] iota(), iota_dimension=0
+  sum0 = f32[2] add(bcast0, iota)
+  sum1 = f32[2] add(bcast1, iota)
+  m0 = f32[2] map(sum0), to_apply=double_f32
+  m1 = f32[2] map(sum1), to_apply=double_f32
+  zero = f32[] constant(0)
+  r0 = f32[] reduce(m0, zero), dimensions={0}, to_apply=add_f32
+  r1 = f32[] reduce(m1, zero), dimensions={0}, to_apply=add_f32
+  ROOT lt = pred[] compare(r0, r1), direction=LT
+}
+
+ENTRY entry {
+  p = f32[8] parameter(0)
+  ROOT sort = f32[8] sort(p), dimensions={0}, is_stable=true, to_apply=compare
+}
+)";
+
+  // The comparator orders by 4*p+2, which is equivalent to p0 < p1.
+  TF_ASSERT_OK_AND_ASSIGN(auto module, ParseAndReturnVerifiedModule(hlo_text));
+  Literal input = LiteralUtil::CreateR1<float>({3, -1, 7, 0, -5, 2, 8, 1});
+  TF_ASSERT_OK_AND_ASSIGN(const Literal result,
+                          Execute(std::move(module), {&input}));
+  LiteralTestUtil::ExpectR1Equal<float>({-5, -1, 0, 1, 2, 3, 7, 8}, result);
+}
+
+}  // namespace
+}  // namespace cpu
+}  // namespace xla


### PR DESCRIPTION
## 📝 Summary of Changes

Fixes #47366.

Compiling a sort whose comparator contains a computation-calling op (reduce, reduce-window, map) crashes the CPU thunk emitter with `map_util.h:50 Check failed: it != collection.end() Map key not found`. `IrEmitter2::EmitSortComparator` emits the comparator directly with `EmitComputation`, so the computations the comparator transitively calls (for example a reduce's reducer) are never emitted, and the later `FindOrDie(emitted_functions_, ...)` lookup in `IrEmitter::EmitThreadLocalCall` dies.

This change pre-emits the comparator's transitively called computations through `IrEmitter::EmitNestedComputation` before emitting the comparator, the same way the other kernel emit paths already do (`IrEmitter2::EmitFusionHostKernel`, `ElementalKernelEmitter::ThreadLocalCallbackFactory`, `ComputationKernelEmitter`). `EmitNestedComputation` handles recursion and deduplicates through `emitted_functions_`, so comparators without called computations are unaffected.

## 🎯 Justification

The input is valid HLO: reduce/map inside a sort comparator is legal and the same modules run fine on the interpreter. The gap exists since the sort thunk emitter was introduced; simple elementwise comparators never hit it. With this change the reported module and several variants (reduce, reduce-window, map in the comparator) compile and run, and ordering-valid comparators match the interpreter reference.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

New `cpu_sort_test.cc` (CPU-only): a sort whose comparator calls a map and a reduce, with a deterministic input and exact expected output. Without the fix it crashes on the exact `Map key not found` CHECK; with the fix it passes. `//xla/service/cpu/tests/...`, `//xla/tests:sort_test_cpu` and `//xla/tests:topk_test_cpu` pass (the only failure, `cpu_vectorization_test`, fails identically at the base commit and is unrelated).

## 🧪 Execution Tests:

Ran the issue's original StableHLO module and three reduced HLO variants with `run_hlo_module` on CPU: no crashes; ordering-valid comparators match the interpreter reference exactly.