### PR TITLE
update cudnn fe to 1.26

### DIFF
--- a/third_party/cudnn_frontend/workspace.bzl
+++ b/third_party/cudnn_frontend/workspace.bzl
@@ -22,7 +22,7 @@ def repo():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "4abb1568ad8d27a99fe987193be6c8bf71980beade115fe11bd27ef5e2c23e45",
-        strip_prefix = "cudnn-frontend-1.22.1",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.22.1.zip"),
+        sha256 = "abe33b7c1892655377cc1e82ada80504e76e81f868f55b95ed2efd35c2df587c",
+        strip_prefix = "cudnn-frontend-1.26.0",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.26.0.zip"),
     )


### PR DESCRIPTION
📝 Summary of Changes
Update cuDNN FE to 1.26 which is required by https://github.com/openxla/xla/pull/47839 for cuDNN tensorIR integration.