### PR TITLE
[ROCm] Use 'no_hash' string to download changing nightly/devreleases rocm tarballs

### DIFF
--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -384,6 +384,8 @@ def _setup_rocm_distro_dir(repository_ctx):
         rocm_distro_hash = repository_ctx.os.environ.get(_ROCM_DISTRO_HASH)
         if not rocm_distro_hash:
             fail("{} environment variable is required".format(_ROCM_DISTRO_HASH))
+        elif rocm_distro_hash == 'no_hash':
+            rocm_distro_hash = ''
         rocm_distro_links = repository_ctx.os.environ.get(_ROCM_DISTRO_LINKS, "")
         rocm_distro = create_rocm_distro(rocm_distro_url, rocm_distro_hash, rocm_distro_links)
         return _setup_rocm_distro_dir_impl(repository_ctx, rocm_distro)


### PR DESCRIPTION


📝 Summary of Changes
Passes empty hash when no_hash string is provided to download theRock tar balls.

🎯 Justification
 nightly theRock and deverelases change frequently and until their hash is published, we would want to skip the hash check whilst downloading those packages for our internal runs..

🚀 Kind of Contribution
 ♻️ Cleanup, 🧪 Tests

