### PR TITLE
[ROCm] Use dynamic mode fully for ci builds hlo fix

### DIFF
--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -300,6 +300,7 @@ common:rocm --config=rocm_clang_hermetic
 common:rocm_ci --config=rocm
 common:rocm_ci --@local_config_rocm//rocm:rocm_path_type=hermetic
 
+common:rocm_ci_hermetic --dynamic_mode=fully
 common:rocm_ci_hermetic --@rules_ml_toolchain//common:enable_xla_test_global_symbol_version=True
 common:rocm_ci_hermetic --config=rocm_clang_hermetic
 common:rocm_ci_hermetic --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a"

--- a/third_party/gpus/sycl/BUILD.tpl
+++ b/third_party/gpus/sycl/BUILD.tpl
@@ -47,6 +47,8 @@ cc_library(
         ".",
         "level_zero/include",
     ],
+    # -supports_dynamic_linker: Forces static linking even with --dynamic_mode=fully
+    features = ["-supports_dynamic_linker"],
     linkstatic = 1,
     visibility = ["//visibility:public"],
 )
@@ -70,6 +72,8 @@ cc_library(
         ".",
         "sycl/include",
     ],
+    # -supports_dynamic_linker: Forces static linking even with --dynamic_mode=fully
+    features = ["-supports_dynamic_linker"],
     linkopts = ["-Wl,-Bstatic,-lsvml,-lirng,-limf,-lirc,-lirc_s,-Bdynamic"],
     linkstatic = 1,
     visibility = ["//visibility:public"],

--- a/third_party/tensorrt/BUILD.tpl
+++ b/third_party/tensorrt/BUILD.tpl
@@ -51,6 +51,8 @@ cc_library(
         ":use_static_tensorrt": [],
         "//conditions:default": [":tensorrt_lib"],
     }),
+    # -supports_dynamic_linker: Forces static linking even with --dynamic_mode=fully
+    features = ["-supports_dynamic_linker"],
     linkstatic = 1,
     deps = [
         ":tensorrt_headers",

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -262,6 +262,8 @@ cc_library(
         "cupti_wrapper_stub.cc",
     ],
     hdrs = ["cupti_wrapper.h"],
+    # -supports_dynamic_linker: Forces static linking even with --dynamic_mode=fully
+    features = ["-supports_dynamic_linker"],
     linkstatic = 1,
     tags = [
         "cuda-only",

--- a/xla/mlir/utils/BUILD
+++ b/xla/mlir/utils/BUILD
@@ -47,6 +47,8 @@ cc_library(
 xla_cc_test(
     name = "error_util_test",
     srcs = ["error_util_test.cc"],
+    # -supports_dynamic_linker: Forces static linking even with --dynamic_mode=fully
+    features = ["-supports_dynamic_linker"],
     linkstatic = 1,
     deps = [
         ":error_util",

--- a/xla/sh_test_with_runfiles.py
+++ b/xla/sh_test_with_runfiles.py
@@ -84,18 +84,18 @@ class ShTestWithRunfiles(lit.formats.ShTest):
       # Support both bzlmod and workspace mode layouts
       lib_dirs = []
 
-      # Check all possible _solib_x86_64 locations
-      solib_paths = [
-        rf_path / "_main" / "_solib_x86_64",  # bzlmod
-        rf_path / "xla" / "_solib_x86_64",    # workspace with legacy_external_runfiles
-      ]
-      for solib in solib_paths:
-        if solib.is_dir():
-          lib_dirs.append(str(solib))
+      for candidate_root in [rf_path / "_main", rf_path / "xla", rf_path]:
+        if candidate_root.is_dir():
+          for solib in candidate_root.glob("_solib_*"):
+            if solib.is_dir():
+              lib_dirs.append(str(solib))
 
       if lib_dirs:
-        ld_library_path = ":".join(lib_dirs)
-        test.config.environment["LD_LIBRARY_PATH"] = ld_library_path
+        existing_ld_path = test.config.environment.get("LD_LIBRARY_PATH", "")
+        new_ld_path = ":".join(lib_dirs)
+        if existing_ld_path:
+          new_ld_path = f"{new_ld_path}:{existing_ld_path}"
+        test.config.environment["LD_LIBRARY_PATH"] = new_ld_path
 
     result = super().execute(test, lit_config)
 

--- a/xla/sh_test_with_runfiles.py
+++ b/xla/sh_test_with_runfiles.py
@@ -25,20 +25,26 @@ class ShTestWithRunfiles(lit.formats.ShTest):
   def execute(self, test, lit_config):
     runfiles_env = os.environ.get("RUNFILES_DIR")
     created_symlinks = []
+
     if runfiles_env:
       rf_path = pathlib.Path(runfiles_env)
 
       test_exec_dir = pathlib.Path(test.getExecPath()).parent
       test_exec_dir.mkdir(parents=True, exist_ok=True)
 
-      # Symlink all directories from runfiles root to test_exec_dir.parent
-      # RUNPATH has "../+rocm_configure_ext+local_config_rocm/..." patterns
+      # Symlink the entire runfiles structure to match what RUNPATH expects
+      # Binaries have RUNPATH like $ORIGIN/../../../../../_solib_x86_64/...
+      # They execute from lit_bin which is at runfiles/_main/xla/.../lit_bin/
+      # So we need _main accessible from there
+      # Symlink to test_exec_dir.parent to match RUNPATH patterns
       for item in rf_path.iterdir():
         if item.is_dir():
           test_exec_symlink = test_exec_dir.parent / item.name
           if not test_exec_symlink.exists():
             try:
-              test_exec_symlink.symlink_to(item, target_is_directory=True)
+              # Use relative symlinks for portability between local and RBE
+              relative_target = os.path.relpath(item, test_exec_dir.parent)
+              test_exec_symlink.symlink_to(relative_target, target_is_directory=True)
               created_symlinks.append(test_exec_symlink)
             except FileExistsError:
               pass
@@ -73,6 +79,23 @@ class ShTestWithRunfiles(lit.formats.ShTest):
           test.config.environment["XLA_FLAGS"] = (
               f"{existing_flags} {flag}".strip()
           )
+
+      # For --dynamic_mode=fully, set LD_LIBRARY_PATH to point to library directories
+      # Support both bzlmod and workspace mode layouts
+      lib_dirs = []
+
+      # Check all possible _solib_x86_64 locations
+      solib_paths = [
+        rf_path / "_main" / "_solib_x86_64",  # bzlmod
+        rf_path / "xla" / "_solib_x86_64",    # workspace with legacy_external_runfiles
+      ]
+      for solib in solib_paths:
+        if solib.is_dir():
+          lib_dirs.append(str(solib))
+
+      if lib_dirs:
+        ld_library_path = ":".join(lib_dirs)
+        test.config.environment["LD_LIBRARY_PATH"] = ld_library_path
 
     result = super().execute(test, lit_config)
 

--- a/xla/tsl/platform/default/BUILD
+++ b/xla/tsl/platform/default/BUILD
@@ -450,6 +450,8 @@ cc_library(
     name = "stacktrace_handler",
     srcs = ["stacktrace_handler.cc"],
     hdrs = ["@tsl//tsl/platform:stacktrace_handler_hdrs"],
+    # -supports_dynamic_linker: Forces static linking even with --dynamic_mode=fully
+    features = ["-supports_dynamic_linker"],
     linkstatic = 1,
     deps = [
         "@tsl//tsl/platform",


### PR DESCRIPTION
📝 Summary of Changes
This pr fixes lit tests when building under --dynamic_mode=fully

🎯 Justification
--dynamic_mode=fully mode reduces the load from our
network during the CI builds. While we generate many
small binaries the amount of cached binaries is bigger as
the artifacts are more granular, hence upload/download data
is smaller

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
