### PR TITLE
[ROCm] Add a per-arch core info table

### DIFF
--- a/xla/service/gpu/BUILD
+++ b/xla/service/gpu/BUILD
@@ -359,7 +359,7 @@ cc_library(
         "//xla/stream_executor:device_description",
         "//xla/stream_executor:semantic_version",
         "//xla/stream_executor/cuda:cuda_compute_capability",
-        "//xla/stream_executor/cuda:cuda_core_info_table",
+        "//xla/stream_executor/gpu:core_info",
         "//xla/stream_executor/rocm:rocm_compute_capability",
     ],
 )

--- a/xla/service/gpu/gpu_device_info_for_tests.cc
+++ b/xla/service/gpu/gpu_device_info_for_tests.cc
@@ -17,8 +17,8 @@ limitations under the License.
 
 #include <utility>
 
-#include "xla/stream_executor/cuda/cuda_core_info_table.h"
 #include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/gpu/core_info.h"
 #include "xla/stream_executor/rocm/rocm_compute_capability.h"
 #include "xla/stream_executor/semantic_version.h"
 #include "xla/xla_data.pb.h"
@@ -76,13 +76,11 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::A100SXMDeviceInfo(
   b.set_runtime_version(stream_executor::SemanticVersion{12, 8, 0});
   b.set_driver_version(stream_executor::SemanticVersion{12, 8, 0});
 
-  b.set_fpus_per_core(
-      stream_executor::gpu::GetFpusPerCore(*cc.cuda_compute_capability()));
+  b.set_fpus_per_core(stream_executor::gpu::GetFpusPerCore(cc));
   stream_executor::DeviceInterconnectInfo interconnect_info;
   interconnect_info.active_links = 12;
   b.set_device_interconnect_info(std::move(interconnect_info));
-  stream_executor::gpu::FillExecutionUnitDesc(*cc.cuda_compute_capability(),
-                                              b.clock_rate_ghz(), b);
+  stream_executor::gpu::FillExecutionUnitDesc(cc, b.clock_rate_ghz(), b);
   return b;
 }
 
@@ -109,13 +107,11 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::H100SXMDeviceInfo(
   b.set_runtime_version(stream_executor::SemanticVersion{12, 8, 0});
   b.set_driver_version(stream_executor::SemanticVersion{12, 8, 0});
 
-  b.set_fpus_per_core(
-      stream_executor::gpu::GetFpusPerCore(*cc.cuda_compute_capability()));
+  b.set_fpus_per_core(stream_executor::gpu::GetFpusPerCore(cc));
   stream_executor::DeviceInterconnectInfo interconnect_info;
   interconnect_info.active_links = 18;
   b.set_device_interconnect_info(std::move(interconnect_info));
-  stream_executor::gpu::FillExecutionUnitDesc(*cc.cuda_compute_capability(),
-                                              b.clock_rate_ghz(), b);
+  stream_executor::gpu::FillExecutionUnitDesc(cc, b.clock_rate_ghz(), b);
   return b;
 }
 
@@ -143,20 +139,19 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::B200SXMDeviceInfo(
   b.set_runtime_version(stream_executor::SemanticVersion{13, 2, 0});
   b.set_driver_version(stream_executor::SemanticVersion{13, 2, 0});
 
-  b.set_fpus_per_core(
-      stream_executor::gpu::GetFpusPerCore(*cc.cuda_compute_capability()));
+  b.set_fpus_per_core(stream_executor::gpu::GetFpusPerCore(cc));
   stream_executor::DeviceInterconnectInfo interconnect_info;
   interconnect_info.active_links = 18;
   b.set_device_interconnect_info(std::move(interconnect_info));
-  stream_executor::gpu::FillExecutionUnitDesc(*cc.cuda_compute_capability(),
-                                              b.clock_rate_ghz(), b);
+  stream_executor::gpu::FillExecutionUnitDesc(cc, b.clock_rate_ghz(), b);
   return b;
 }
 
 stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI210DeviceInfo() {
+  const stream_executor::GpuComputeCapability cc(
+      stream_executor::RocmComputeCapability("gfx90a"));
   stream_executor::DeviceDescription b;
-  b.set_gpu_compute_capability(stream_executor::GpuComputeCapability(
-      stream_executor::RocmComputeCapability("gfx90a")));
+  b.set_gpu_compute_capability(cc);
   b.set_threads_per_block_limit(1024);
   b.set_threads_per_warp(64);
   b.set_shared_memory_per_block(64 * 1024);
@@ -164,7 +159,6 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI210DeviceInfo() {
   b.set_shared_memory_per_core(64 * 1024);
   b.set_threads_per_core_limit(2048);
   b.set_core_count(104);
-  b.set_fpus_per_core(128);
   b.set_block_dim_limit_x(2'147'483'647);
   b.set_block_dim_limit_y(65536);
   b.set_block_dim_limit_z(65536);
@@ -176,13 +170,17 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI210DeviceInfo() {
   b.set_registers_per_block_limit(131072);
   b.set_runtime_version(stream_executor::SemanticVersion{6, 0, 0});
   b.set_driver_version(stream_executor::SemanticVersion{6, 0, 0});
+
+  b.set_fpus_per_core(stream_executor::gpu::GetFpusPerCore(cc));
+  stream_executor::gpu::FillExecutionUnitDesc(cc, b.clock_rate_ghz(), b);
   return b;
 }
 
 stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI300DeviceInfo() {
+  const stream_executor::GpuComputeCapability cc(
+      stream_executor::RocmComputeCapability("gfx942"));
   stream_executor::DeviceDescription b;
-  b.set_gpu_compute_capability(stream_executor::GpuComputeCapability(
-      stream_executor::RocmComputeCapability("gfx942")));
+  b.set_gpu_compute_capability(cc);
   b.set_threads_per_block_limit(1024);
   b.set_threads_per_warp(64);
   b.set_shared_memory_per_block(64 * 1024);
@@ -190,7 +188,6 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI300DeviceInfo() {
   b.set_shared_memory_per_core(64 * 1024);
   b.set_threads_per_core_limit(2048);
   b.set_core_count(304);
-  b.set_fpus_per_core(128);
   b.set_block_dim_limit_x(2'147'483'647);
   b.set_block_dim_limit_y(65536);
   b.set_block_dim_limit_z(65536);
@@ -202,13 +199,17 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI300DeviceInfo() {
   b.set_registers_per_block_limit(131072);
   b.set_runtime_version(stream_executor::SemanticVersion{6, 0, 0});
   b.set_driver_version(stream_executor::SemanticVersion{6, 0, 0});
+
+  b.set_fpus_per_core(stream_executor::gpu::GetFpusPerCore(cc));
+  stream_executor::gpu::FillExecutionUnitDesc(cc, b.clock_rate_ghz(), b);
   return b;
 }
 
 stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI350DeviceInfo() {
+  const stream_executor::GpuComputeCapability cc(
+      stream_executor::RocmComputeCapability("gfx950"));
   stream_executor::DeviceDescription b;
-  b.set_gpu_compute_capability(stream_executor::GpuComputeCapability(
-      stream_executor::RocmComputeCapability("gfx950")));
+  b.set_gpu_compute_capability(cc);
   b.set_threads_per_block_limit(1024);
   b.set_threads_per_warp(64);
   b.set_shared_memory_per_block(160 * 1024);
@@ -216,7 +217,6 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI350DeviceInfo() {
   b.set_shared_memory_per_core(160 * 1024);
   b.set_threads_per_core_limit(2048);
   b.set_core_count(256);
-  b.set_fpus_per_core(128);
   b.set_block_dim_limit_x(2'147'483'647);
   b.set_block_dim_limit_y(65536);
   b.set_block_dim_limit_z(65536);
@@ -229,13 +229,17 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::AMDMI350DeviceInfo() {
   b.set_registers_per_block_limit(131072);
   b.set_runtime_version(stream_executor::SemanticVersion{6, 0, 0});
   b.set_driver_version(stream_executor::SemanticVersion{6, 0, 0});
+
+  b.set_fpus_per_core(stream_executor::gpu::GetFpusPerCore(cc));
+  stream_executor::gpu::FillExecutionUnitDesc(cc, b.clock_rate_ghz(), b);
   return b;
 }
 
 stream_executor::DeviceDescription TestGpuDeviceInfo::AMDRX7900DeviceInfo() {
+  const stream_executor::GpuComputeCapability cc(
+      stream_executor::RocmComputeCapability("gfx1100"));
   stream_executor::DeviceDescription b;
-  b.set_gpu_compute_capability(stream_executor::GpuComputeCapability(
-      stream_executor::RocmComputeCapability("gfx1100")));
+  b.set_gpu_compute_capability(cc);
   b.set_threads_per_block_limit(1024);
   b.set_threads_per_warp(32);
   b.set_shared_memory_per_block(64 * 1024);
@@ -243,7 +247,6 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::AMDRX7900DeviceInfo() {
   b.set_shared_memory_per_core(64 * 1024);
   b.set_threads_per_core_limit(2048);
   b.set_core_count(96);
-  b.set_fpus_per_core(128);
   b.set_block_dim_limit_x(2'147'483'647);
   b.set_block_dim_limit_y(2'147'483'647);
   b.set_block_dim_limit_z(2'147'483'647);
@@ -253,6 +256,11 @@ stream_executor::DeviceDescription TestGpuDeviceInfo::AMDRX7900DeviceInfo() {
   b.set_device_memory_size(24'000'000'000);
   b.set_runtime_version(stream_executor::SemanticVersion{6, 0, 0});
   b.set_driver_version(stream_executor::SemanticVersion{6, 0, 0});
+
+  // RDNA3 is not in the ROCm table, so picks up 128 through the fallback.
+  // Routing it through the lookup anyway keeps every device here on one path.
+  b.set_fpus_per_core(stream_executor::gpu::GetFpusPerCore(cc));
+  stream_executor::gpu::FillExecutionUnitDesc(cc, b.clock_rate_ghz(), b);
   return b;
 }
 

--- a/xla/service/gpu/model/gpu_performance_model_base_test.cc
+++ b/xla/service/gpu/model/gpu_performance_model_base_test.cc
@@ -340,6 +340,43 @@ TEST_F(GpuPerformanceModelBaseTest, CalculatePeakF64OpsPerNsH100) {
   EXPECT_LT(flops_per_ns, 68000);
 }
 
+// MI300X MFMA peaks below are from the CDNA 3 white paper.
+TEST_F(GpuPerformanceModelBaseTest, CalculatePeakBF16OpsPerNsMI300X) {
+  se::DeviceDescription mi300_device_info =
+      TestGpuDeviceInfo::AMDMI300DeviceInfo();
+  int64_t flops_per_ns = GpuPerformanceModelBase::CalculatePeakMatrixOpsPerNs(
+      mi300_device_info, xla::PrimitiveType::BF16);
+  // MI300X has a peak of 1307.4 TFLOPS/s for BF16.
+  EXPECT_GT(flops_per_ns, 1300000);
+  EXPECT_LT(flops_per_ns, 1315000);
+}
+
+TEST_F(GpuPerformanceModelBaseTest, CalculatePeakFP8OpsPerNsMI300X) {
+  se::DeviceDescription mi300_device_info =
+      TestGpuDeviceInfo::AMDMI300DeviceInfo();
+  int64_t flops_per_ns = GpuPerformanceModelBase::CalculatePeakMatrixOpsPerNs(
+      mi300_device_info, xla::PrimitiveType::F8E4M3);
+  // MI300X has a peak of 2614.9 TFLOPS/s for FP8.
+  EXPECT_GT(flops_per_ns, 2600000);
+  EXPECT_LT(flops_per_ns, 2620000);
+}
+
+// Guards against matrix_unit_description silently going unset, in which case
+// CalculatePeakMatrixOpsPerNs degrades to the vector FP32 peak instead of
+// failing, and the ratio below collapses to 1.
+TEST_F(GpuPerformanceModelBaseTest, MFMAPathExceedsScalarFallbackMI300X) {
+  se::DeviceDescription mi300_device_info =
+      TestGpuDeviceInfo::AMDMI300DeviceInfo();
+  int64_t mfma_bf16 = GpuPerformanceModelBase::CalculatePeakMatrixOpsPerNs(
+      mi300_device_info, xla::PrimitiveType::BF16);
+  int64_t scalar_fallback =
+      GpuPerformanceModelBase::CalculateEffectiveFlopsPerNs(
+          mi300_device_info, /*num_blocks=*/mi300_device_info.core_count(),
+          /*num_threads_per_block=*/mi300_device_info.fpus_per_core());
+  // 1307.4 TF against 163.4 TF, so 5x leaves ample margin.
+  EXPECT_GT(mfma_bf16, 5 * scalar_fallback);
+}
+
 TEST_F(GpuPerformanceModelBaseTest, RecordEstimatedRunTimeWithName) {
   EstimateRunTimeData data = {/*flops=*/100,
                               /*bytes_read=*/200,

--- a/xla/stream_executor/cuda/BUILD
+++ b/xla/stream_executor/cuda/BUILD
@@ -1488,11 +1488,8 @@ cc_library(
     hdrs = ["cuda_core_info_table.h"],
     deps = [
         ":cuda_compute_capability",
-        "//xla:shape_util",
-        "//xla:xla_data_proto_cc",
-        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/gpu:dtype_core_info",
         "@com_google_absl//absl/base:no_destructor",
-        "@com_google_absl//absl/container:flat_hash_map",
     ],
 )
 
@@ -1501,10 +1498,10 @@ xla_cc_test(
     srcs = ["cuda_core_info_table_test.cc"],
     deps = [
         ":cuda_compute_capability",
-        ":cuda_core_info_table",
         "//xla:xla_data_proto_cc",
         "//xla/service/gpu:gpu_device_info_for_tests",
         "//xla/stream_executor:device_description",
+        "//xla/stream_executor/gpu:core_info",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1569,7 +1566,6 @@ cc_library(
         ":cuda_command_buffer",
         ":cuda_compute_capability",
         ":cuda_context",
-        ":cuda_core_info_table",
         ":cuda_device_allocator",
         ":cuda_event",
         ":cuda_executor",
@@ -1617,6 +1613,7 @@ cc_library(
         "//xla/stream_executor:stream_executor_h",
         "//xla/stream_executor:tensor_map",
         "//xla/stream_executor/gpu:context",
+        "//xla/stream_executor/gpu:core_info",
         "//xla/stream_executor/gpu:gpu_executor_header",
         "//xla/stream_executor/gpu:multicast_memory",
         "//xla/stream_executor/gpu:read_numa_node",

--- a/xla/stream_executor/cuda/cuda_core_info_table.cc
+++ b/xla/stream_executor/cuda/cuda_core_info_table.cc
@@ -15,47 +15,16 @@ limitations under the License.
 
 #include "xla/stream_executor/cuda/cuda_core_info_table.h"
 
-#include <utility>
 #include <vector>
 
 #include "absl/base/no_destructor.h"
-#include "absl/container/flat_hash_map.h"
-#include "xla/primitive_util.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
-#include "xla/stream_executor/device_description.h"
-#include "xla/xla_data.pb.h"
+#include "xla/stream_executor/gpu/dtype_core_info.h"
 
 namespace stream_executor {
 namespace gpu {
-namespace {
 
-// Instead of using base primitive types we use a simple description that maps
-// to several primitive types at once. This way we can keep the types in the
-// table below more abstract.
-struct DTypeDescr {
-  bool is_float;
-  int bitwidth;
-};
-
-constexpr DTypeDescr kI8 = DTypeDescr{/*is_float=*/false, 8};
-constexpr DTypeDescr kI32 = DTypeDescr{/*is_float=*/false, 32};
-
-constexpr DTypeDescr kF4 = DTypeDescr{/*is_float=*/true, 4};
-constexpr DTypeDescr kF6 = DTypeDescr{/*is_float=*/true, 6};
-constexpr DTypeDescr kF8 = DTypeDescr{/*is_float=*/true, 8};
-constexpr DTypeDescr kF16 = DTypeDescr{/*is_float=*/true, 16};
-constexpr DTypeDescr kF32 = DTypeDescr{/*is_float=*/true, 32};
-constexpr DTypeDescr kF64 = DTypeDescr{/*is_float=*/true, 64};
-
-struct DTypeCoreInfo {
-  DTypeDescr dtype;
-  int units_per_sm;
-  int ops_per_clock = 1;    // Note: FMA is considered 1 op.
-  float clock_scale = 1.0;  // Ratio of clock rate of this unit vs base device.
-};
-
-const std::vector<DTypeCoreInfo>* FindCoreInfoForDType(CudaComputeCapability cc,
-                                                       bool is_tensor) {
+CoreInfo FindCudaCoreInfo(CudaComputeCapability cc) {
   struct CoreInfoTableForCC {
     CudaComputeCapability cc;
     std::vector<DTypeCoreInfo> cuda_core_infos;
@@ -188,95 +157,14 @@ const std::vector<DTypeCoreInfo>* FindCoreInfoForDType(CudaComputeCapability cc,
 
   for (const auto& config : *kTable) {
     if (config.cc.major == cc.major) {
-      return is_tensor ? &config.tensor_core_infos : &config.cuda_core_infos;
+      return CoreInfo{config.cuda_core_infos, config.tensor_core_infos};
     }
   }
 
-  return nullptr;
+  return CoreInfo{};
 }
 
-absl::flat_hash_map<int, DTypeCoreInfo> MakeBitwidthToRowMap(
-    const std::vector<DTypeCoreInfo>& rows, bool is_float) {
-  absl::flat_hash_map<int, DTypeCoreInfo> bitwidth_to_row;
-  for (const auto& row : rows) {
-    if (row.dtype.is_float != is_float) {
-      continue;
-    }
-    bitwidth_to_row[row.dtype.bitwidth] = row;
-  }
-  return bitwidth_to_row;
-}
-
-void AddDTypeInfoToDesc(
-    xla::PrimitiveType dtype, float base_clock_rate_ghz,
-    const absl::flat_hash_map<int, DTypeCoreInfo>& bitwidth_to_row,
-    ExecutionUnitDescription& desc) {
-  int bitwidth = xla::primitive_util::BitWidth(dtype);
-  const auto& bitwidth_it = bitwidth_to_row.find(bitwidth);
-  if (bitwidth_it == bitwidth_to_row.end()) {
-    return;
-  }
-  const DTypeCoreInfo& perf_info = bitwidth_it->second;
-  float clock_rate_ghz = perf_info.clock_scale * base_clock_rate_ghz;
-  desc.SetRateInfo(dtype, stream_executor::ExecutionUnitDescription::RateInfo{
-                              /*units_per_core=*/perf_info.units_per_sm,
-                              /*clock_rate_ghz=*/clock_rate_ghz,
-                              /*ops_per_clock=*/perf_info.ops_per_clock});
-}
-
-ExecutionUnitDescription CreateEuDescription(
-    float base_clock_rate_ghz, const std::vector<DTypeCoreInfo>& perf_rows) {
-  ExecutionUnitDescription desc;
-  absl::flat_hash_map<int, DTypeCoreInfo> bitwidth_to_float_row =
-      MakeBitwidthToRowMap(perf_rows, /*is_float=*/true);
-
-  xla::primitive_util::FloatingPointTypeForEach([&](auto dtype) {
-    AddDTypeInfoToDesc(dtype, base_clock_rate_ghz, bitwidth_to_float_row, desc);
-  });
-
-  absl::flat_hash_map<int, DTypeCoreInfo> bitwidth_to_int_row =
-      MakeBitwidthToRowMap(perf_rows, /*is_float=*/false);
-  xla::primitive_util::IntegralTypeForEach([&](auto dtype) {
-    AddDTypeInfoToDesc(dtype, base_clock_rate_ghz, bitwidth_to_int_row, desc);
-  });
-
-  return desc;
-}
-
-}  // namespace
-
-void FillExecutionUnitDesc(CudaComputeCapability cc, float base_clock_rate_ghz,
-                           DeviceDescription& desc) {
-  const std::vector<DTypeCoreInfo>* cuda_core_rows =
-      FindCoreInfoForDType(cc, /*is_tensor=*/false);
-  if (cuda_core_rows != nullptr) {
-    ExecutionUnitDescription cuda_core_desc =
-        CreateEuDescription(base_clock_rate_ghz, *cuda_core_rows);
-    desc.set_scalar_unit_description(std::move(cuda_core_desc));
-  }
-
-  const std::vector<DTypeCoreInfo>* tc_rows =
-      FindCoreInfoForDType(cc, /*is_tensor=*/true);
-  if (tc_rows != nullptr) {
-    ExecutionUnitDescription tc_desc =
-        CreateEuDescription(base_clock_rate_ghz, *tc_rows);
-    desc.set_matrix_unit_description(std::move(tc_desc));
-  }
-}
-
-int GetFpusPerCore(CudaComputeCapability cc) {
-  const std::vector<DTypeCoreInfo>* cuda_core_rows =
-      FindCoreInfoForDType(cc, /*is_tensor=*/false);
-
-  if (cuda_core_rows != nullptr) {
-    for (const auto& perf : *cuda_core_rows) {
-      if (perf.dtype.is_float && perf.dtype.bitwidth == 32) {
-        return perf.units_per_sm;
-      }
-    }
-  }
-
-  // Fallback to hardcoded values if not found in the table.
+int CudaFpusPerCoreFallback(CudaComputeCapability cc) {
   // Source:
   // https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/#throughput-of-native-arithmetic-instructions
   int n = 128;          // 5.x, 6.1, 6.2, 8.6, 9.0 -> 128.

--- a/xla/stream_executor/cuda/cuda_core_info_table_test.cc
+++ b/xla/stream_executor/cuda/cuda_core_info_table_test.cc
@@ -13,8 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "xla/stream_executor/cuda/cuda_core_info_table.h"
-
 #include <cstdint>
 #include <optional>
 
@@ -22,6 +20,7 @@ limitations under the License.
 #include "xla/service/gpu/gpu_device_info_for_tests.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/gpu/core_info.h"
 #include "xla/xla_data.pb.h"
 
 namespace stream_executor {
@@ -57,7 +56,7 @@ void CheckPeakOpsPerNs(const DeviceDescription& device_info,
 TEST(CudaCoreInfoTableTest, CalculatePeakOpsPerNsA100) {
   DeviceDescription a100_device_info =
       xla::gpu::TestGpuDeviceInfo::A100SXMDeviceInfo();
-  FillExecutionUnitDesc(a100_device_info.cuda_compute_capability(),
+  FillExecutionUnitDesc(a100_device_info.gpu_compute_capability(),
                         a100_device_info.clock_rate_ghz(), a100_device_info);
 
   CheckPeakOpsPerNs(a100_device_info, /*is_matrix_unit=*/true,
@@ -89,7 +88,7 @@ TEST(CudaCoreInfoTableTest, CalculatePeakOpsPerNsA100) {
 TEST(CudaCoreInfoTableTest, CalculatePeakOpsPerNsH100) {
   DeviceDescription h100_device_info =
       xla::gpu::TestGpuDeviceInfo::H100SXMDeviceInfo();
-  FillExecutionUnitDesc(h100_device_info.cuda_compute_capability(),
+  FillExecutionUnitDesc(h100_device_info.gpu_compute_capability(),
                         h100_device_info.clock_rate_ghz(), h100_device_info);
 
   CheckPeakOpsPerNs(h100_device_info, /*is_matrix_unit=*/true,
@@ -119,7 +118,7 @@ TEST(CudaCoreInfoTableTest, CalculatePeakOpsPerNsH100) {
 TEST(CudaCoreInfoTableTest, CalculatePeakOpsPerNsB200) {
   DeviceDescription b200_device_info =
       xla::gpu::TestGpuDeviceInfo::B200SXMDeviceInfo();
-  FillExecutionUnitDesc(b200_device_info.cuda_compute_capability(),
+  FillExecutionUnitDesc(b200_device_info.gpu_compute_capability(),
                         b200_device_info.clock_rate_ghz(), b200_device_info);
 
   CheckPeakOpsPerNs(b200_device_info, /*is_matrix_unit=*/true,

--- a/xla/stream_executor/cuda/cuda_executor.cc
+++ b/xla/stream_executor/cuda/cuda_executor.cc
@@ -63,7 +63,6 @@ limitations under the License.
 #include "xla/stream_executor/cuda/cuda_command_buffer.h"
 #include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/cuda/cuda_context.h"
-#include "xla/stream_executor/cuda/cuda_core_info_table.h"
 #include "xla/stream_executor/cuda/cuda_device_allocator.h"
 #include "xla/stream_executor/cuda/cuda_event.h"
 #include "xla/stream_executor/cuda/cuda_host_allocator.h"
@@ -85,6 +84,7 @@ limitations under the License.
 #include "xla/stream_executor/generic_memory_allocation.h"
 #include "xla/stream_executor/generic_memory_allocator.h"
 #include "xla/stream_executor/gpu/context.h"
+#include "xla/stream_executor/gpu/core_info.h"
 #include "xla/stream_executor/gpu/gpu_executor.h"
 #include "xla/stream_executor/gpu/multicast_memory.h"
 #include "xla/stream_executor/gpu/read_numa_node.h"
@@ -1832,7 +1832,8 @@ CudaExecutor::CreateDeviceDescription(int device_ordinal) {
       GetMaxBlocksPerMultiprocessor(device).value());
   int core_count = GetMultiprocessorCount(device).value();
   desc.set_core_count(core_count);
-  desc.set_fpus_per_core(GetFpusPerCore(cc));
+  const GpuComputeCapability gpu_cc(cc);
+  desc.set_fpus_per_core(GetFpusPerCore(gpu_cc));
   desc.set_threads_per_core_limit(
       GetMaxThreadsPerMultiprocessor(device).value());
   desc.set_registers_per_block_limit(GetMaxRegistersPerBlock(device).value());
@@ -1842,7 +1843,7 @@ CudaExecutor::CreateDeviceDescription(int device_ordinal) {
                          device)
           .value());
 
-  FillExecutionUnitDesc(cc, device_clock_rate_ghz, desc);
+  FillExecutionUnitDesc(gpu_cc, device_clock_rate_ghz, desc);
 
   auto value_or = [](const auto& status_or, auto default_val) {
     if (status_or.ok()) {

--- a/xla/stream_executor/gpu/BUILD
+++ b/xla/stream_executor/gpu/BUILD
@@ -71,6 +71,28 @@ cc_library(
 )
 
 cc_library(
+    name = "dtype_core_info",
+    hdrs = ["dtype_core_info.h"],
+    deps = ["@com_google_absl//absl/types:span"],
+)
+
+cc_library(
+    name = "core_info",
+    srcs = ["core_info.cc"],
+    hdrs = ["core_info.h"],
+    deps = [
+        ":dtype_core_info",
+        "//xla:shape_util",
+        "//xla:xla_data_proto_cc",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/cuda:cuda_core_info_table",
+        "//xla/stream_executor/rocm:rocm_core_info_table",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_library(
     name = "context_map",
     hdrs = ["context_map.h"],
     deps = [

--- a/xla/stream_executor/gpu/core_info.cc
+++ b/xla/stream_executor/gpu/core_info.cc
@@ -1,0 +1,133 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/gpu/core_info.h"
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/types/span.h"
+#include "xla/primitive_util.h"
+#include "xla/stream_executor/cuda/cuda_core_info_table.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/gpu/dtype_core_info.h"
+#include "xla/stream_executor/rocm/rocm_core_info_table.h"
+#include "xla/xla_data.pb.h"
+
+namespace stream_executor {
+namespace gpu {
+namespace {
+
+// Assumed when the architecture has no FP32 vector info and its backend offers
+// no better guess. Every untabulated backend/target lands here.
+constexpr int kUntabulatedFpusPerCore = 128;
+
+absl::flat_hash_map<int, DTypeCoreInfo> MakeBitwidthToInfoMap(
+    absl::Span<const DTypeCoreInfo> infos, bool is_float) {
+  absl::flat_hash_map<int, DTypeCoreInfo> bitwidth_to_info;
+  for (const auto& info : infos) {
+    if (info.dtype.is_float != is_float) {
+      continue;
+    }
+    bitwidth_to_info[info.dtype.bitwidth] = info;
+  }
+  return bitwidth_to_info;
+}
+
+void AddDTypeInfoToDesc(
+    xla::PrimitiveType dtype, float base_clock_rate_ghz,
+    const absl::flat_hash_map<int, DTypeCoreInfo>& bitwidth_to_info,
+    ExecutionUnitDescription& desc) {
+  int bitwidth = xla::primitive_util::BitWidth(dtype);
+  const auto bitwidth_it = bitwidth_to_info.find(bitwidth);
+  if (bitwidth_it == bitwidth_to_info.end()) {
+    return;
+  }
+  const DTypeCoreInfo& perf_info = bitwidth_it->second;
+  float clock_rate_ghz = perf_info.clock_scale * base_clock_rate_ghz;
+  desc.SetRateInfo(dtype, ExecutionUnitDescription::RateInfo{
+                              /*units_per_core=*/perf_info.units_per_core,
+                              /*clock_rate_ghz=*/clock_rate_ghz,
+                              /*ops_per_clock=*/perf_info.ops_per_clock});
+}
+
+ExecutionUnitDescription CreateEuDescription(
+    float base_clock_rate_ghz, absl::Span<const DTypeCoreInfo> core_infos) {
+  ExecutionUnitDescription desc;
+  absl::flat_hash_map<int, DTypeCoreInfo> bitwidth_to_float_info =
+      MakeBitwidthToInfoMap(core_infos, /*is_float=*/true);
+
+  xla::primitive_util::FloatingPointTypeForEach([&](auto dtype) {
+    AddDTypeInfoToDesc(dtype, base_clock_rate_ghz, bitwidth_to_float_info,
+                       desc);
+  });
+
+  absl::flat_hash_map<int, DTypeCoreInfo> bitwidth_to_int_info =
+      MakeBitwidthToInfoMap(core_infos, /*is_float=*/false);
+  xla::primitive_util::IntegralTypeForEach([&](auto dtype) {
+    AddDTypeInfoToDesc(dtype, base_clock_rate_ghz, bitwidth_to_int_info, desc);
+  });
+
+  return desc;
+}
+
+CoreInfo FindCoreInfoForCapability(const GpuComputeCapability& cc) {
+  if (const CudaComputeCapability* cuda_cc = cc.cuda_compute_capability()) {
+    return FindCudaCoreInfo(*cuda_cc);
+  }
+  if (const RocmComputeCapability* rocm_cc = cc.rocm_compute_capability()) {
+    return FindRocmCoreInfo(*rocm_cc);
+  }
+  return CoreInfo{};
+}
+
+const DTypeCoreInfo* FindFp32Info(absl::Span<const DTypeCoreInfo> infos) {
+  for (const DTypeCoreInfo& info : infos) {
+    if (info.dtype.is_float && info.dtype.bitwidth == 32) {
+      return &info;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+void FillExecutionUnitDesc(const GpuComputeCapability& cc,
+                           float base_clock_rate_ghz, DeviceDescription& desc) {
+  // Leaving a field unset is deliberate. Consumers treat it as "unknown" and
+  // fall back to their own estimates.
+  CoreInfo core_info = FindCoreInfoForCapability(cc);
+  if (!core_info.vector_infos.empty()) {
+    desc.set_scalar_unit_description(
+        CreateEuDescription(base_clock_rate_ghz, core_info.vector_infos));
+  }
+  if (!core_info.matrix_infos.empty()) {
+    desc.set_matrix_unit_description(
+        CreateEuDescription(base_clock_rate_ghz, core_info.matrix_infos));
+  }
+}
+
+int GetFpusPerCore(const GpuComputeCapability& cc) {
+  CoreInfo core_info = FindCoreInfoForCapability(cc);
+  const DTypeCoreInfo* fp32_info = FindFp32Info(core_info.vector_infos);
+  if (fp32_info != nullptr) {
+    return fp32_info->units_per_core;
+  }
+  if (const CudaComputeCapability* cuda_cc = cc.cuda_compute_capability()) {
+    return CudaFpusPerCoreFallback(*cuda_cc);
+  }
+  return kUntabulatedFpusPerCore;
+}
+
+}  // namespace gpu
+}  // namespace stream_executor

--- a/xla/stream_executor/gpu/core_info.h
+++ b/xla/stream_executor/gpu/core_info.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 The OpenXLA Authors.
+/* Copyright 2026 The OpenXLA Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,22 +13,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef XLA_STREAM_EXECUTOR_CUDA_CUDA_CORE_INFO_TABLE_H_
-#define XLA_STREAM_EXECUTOR_CUDA_CUDA_CORE_INFO_TABLE_H_
+#ifndef XLA_STREAM_EXECUTOR_GPU_CORE_INFO_H_
+#define XLA_STREAM_EXECUTOR_GPU_CORE_INFO_H_
 
-#include "xla/stream_executor/cuda/cuda_compute_capability.h"
-#include "xla/stream_executor/gpu/dtype_core_info.h"
+#include "xla/stream_executor/device_description.h"
 
 namespace stream_executor {
 namespace gpu {
 
-// Returns the core info for `cc`, empty if it is not in the table.
-CoreInfo FindCudaCoreInfo(CudaComputeCapability cc);
+// Fills the scalar and matrix unit fields in `desc` with vector and matrix
+// unit descriptions if available for the given compute capability.
+void FillExecutionUnitDesc(const GpuComputeCapability& cc,
+                           float base_clock_rate_ghz, DeviceDescription& desc);
 
-// Number of FPUs (CUDA Cores) per SM to assume when `cc` is not in the table.
-int CudaFpusPerCoreFallback(CudaComputeCapability cc);
+// Gets the number of FPUs per core. Assumes FP32 cores.
+int GetFpusPerCore(const GpuComputeCapability& cc);
 
 }  // namespace gpu
 }  // namespace stream_executor
 
-#endif  // XLA_STREAM_EXECUTOR_CUDA_CUDA_CORE_INFO_TABLE_H_
+#endif  // XLA_STREAM_EXECUTOR_GPU_CORE_INFO_H_

--- a/xla/stream_executor/gpu/dtype_core_info.h
+++ b/xla/stream_executor/gpu/dtype_core_info.h
@@ -1,0 +1,62 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_STREAM_EXECUTOR_GPU_DTYPE_CORE_INFO_H_
+#define XLA_STREAM_EXECUTOR_GPU_DTYPE_CORE_INFO_H_
+
+#include "absl/types/span.h"
+
+namespace stream_executor {
+namespace gpu {
+
+// Instead of using base primitive types we use a simple description that maps
+// to several primitive types at once. This way we can keep the types in the
+// backend tables more abstract.
+struct DTypeDescr {
+  bool is_float;
+  int bitwidth;
+};
+
+constexpr DTypeDescr kI8 = DTypeDescr{/*is_float=*/false, 8};
+constexpr DTypeDescr kI32 = DTypeDescr{/*is_float=*/false, 32};
+
+constexpr DTypeDescr kF4 = DTypeDescr{/*is_float=*/true, 4};
+constexpr DTypeDescr kF6 = DTypeDescr{/*is_float=*/true, 6};
+constexpr DTypeDescr kF8 = DTypeDescr{/*is_float=*/true, 8};
+constexpr DTypeDescr kF16 = DTypeDescr{/*is_float=*/true, 16};
+constexpr DTypeDescr kF32 = DTypeDescr{/*is_float=*/true, 32};
+constexpr DTypeDescr kF64 = DTypeDescr{/*is_float=*/true, 64};
+
+// Throughput of one execution unit for every primitive type matching `dtype`.
+// Per unit rates only. Core count and base clock come from the
+// DeviceDescription instead, since they vary between SKUs of one architecture.
+struct DTypeCoreInfo {
+  DTypeDescr dtype;
+  int units_per_core;
+  int ops_per_clock = 1;    // Note: FMA is considered 1 op.
+  float clock_scale = 1.0;  // Ratio of clock rate of this unit vs base device.
+};
+
+// What a backend table holds for one architecture. Either span may be empty,
+// and both point into the table itself, which has static storage duration.
+struct CoreInfo {
+  absl::Span<const DTypeCoreInfo> vector_infos;
+  absl::Span<const DTypeCoreInfo> matrix_infos;
+};
+
+}  // namespace gpu
+}  // namespace stream_executor
+
+#endif  // XLA_STREAM_EXECUTOR_GPU_DTYPE_CORE_INFO_H_

--- a/xla/stream_executor/rocm/BUILD
+++ b/xla/stream_executor/rocm/BUILD
@@ -53,6 +53,31 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "rocm_core_info_table",
+    srcs = ["rocm_core_info_table.cc"],
+    hdrs = ["rocm_core_info_table.h"],
+    deps = [
+        ":rocm_compute_capability",
+        "//xla/stream_executor/gpu:dtype_core_info",
+        "@com_google_absl//absl/base:no_destructor",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_core_info_table_test",
+    srcs = ["rocm_core_info_table_test.cc"],
+    deps = [
+        ":rocm_compute_capability",
+        "//xla:xla_data_proto_cc",
+        "//xla/service/gpu:gpu_device_info_for_tests",
+        "//xla/stream_executor:device_description",
+        "//xla/stream_executor/gpu:core_info",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 xla_cc_test(
     name = "rocm_compute_capability_test",
     srcs = ["rocm_compute_capability_test.cc"],
@@ -140,6 +165,7 @@ cc_library(
     ],
     deps = [
         ":rocm_command_buffer",
+        ":rocm_compute_capability",
         ":rocm_context",
         ":rocm_event",
         ":rocm_kernel",
@@ -179,6 +205,7 @@ cc_library(
         "//xla/stream_executor:stream",
         "//xla/stream_executor:stream_executor_h",
         "//xla/stream_executor/gpu:context",
+        "//xla/stream_executor/gpu:core_info",
         "//xla/stream_executor/gpu:gpu_executor_header",
         "//xla/stream_executor/gpu:read_numa_node",
         "//xla/stream_executor/gpu:scoped_activate_context",

--- a/xla/stream_executor/rocm/rocm_core_info_table.cc
+++ b/xla/stream_executor/rocm/rocm_core_info_table.cc
@@ -1,0 +1,133 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/stream_executor/rocm/rocm_core_info_table.h"
+
+#include <vector>
+
+#include "absl/base/no_destructor.h"
+#include "absl/strings/string_view.h"
+#include "xla/stream_executor/gpu/dtype_core_info.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
+
+namespace stream_executor {
+namespace gpu {
+
+CoreInfo FindRocmCoreInfo(const RocmComputeCapability& cc) {
+  struct CoreInfoTableForArch {
+    absl::string_view gfx_version;
+    std::vector<DTypeCoreInfo> vector_infos;
+    std::vector<DTypeCoreInfo> matrix_infos;
+  };
+
+  // =============== Sources ===============
+  // [CDNA1] Introducing AMD CDNA Architecture, Table 1, p.7 (MI100).
+  //   https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/
+  //   white-papers/amd-cdna-white-paper.pdf
+  // [CDNA2] AMD CDNA 2 White Paper, Table 1, p.10 (MI250X).
+  //   https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/
+  //   white-papers/amd-cdna2-white-paper.pdf
+  // [CDNA3] AMD CDNA 3 White Paper, Table 1, p.7 (MI300X/MI325X).
+  //   https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/
+  //   white-papers/amd-cdna-3-white-paper.pdf
+  // [CDNA4] Introducing AMD CDNA 4 Architecture, Table 1, p.8 (MI355X).
+  //   https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/
+  //   white-papers/amd-cdna-4-architecture-whitepaper.pdf
+  //
+  // Every CDNA CU has 4 SIMD/Matrix engines, hence units_per_core=4 throughout
+  // matrix_infos. vector_infos instead counts FP32 FMA equivalent lanes, picked
+  // so that units * ops * 2 reproduces the FLOPS/clock/CU in the tables above.
+
+  static const absl::NoDestructor<std::vector<CoreInfoTableForArch>> kTable(
+      std::vector<CoreInfoTableForArch>{
+          // ===== gfx908 / CDNA1 / MI100 =====
+          {"gfx908",
+           /*vector_infos=*/
+           {
+               // DType, Units/CU, Ops/Clk        => FLOPS/clock/CU
+               {kF32, 64, 1},  // 128 [CDNA1]
+               {kF16, 64, 1},  // 128 (packed; assumed equal)
+               {kF64, 32, 1},  //  64 [CDNA1]
+           },
+           /*matrix_infos=*/
+           {
+               // DType, Units/CU, Ops/Clk        => FLOPS/clock/CU
+               {kF16, 4, 128},  // 1024 [CDNA1]
+               // BF16 is 512 [CDNA1], half of FP16, but entries are keyed by
+               // bitwidth so both share this one and BF16 comes out 2x high.
+               {kF32, 4, 32},  //  256 [CDNA1]
+               {kI8, 4, 128},  // 1024 [CDNA1]
+           }},
+          // ===== gfx90a / CDNA2 / MI210/MI250/MI250X =====
+          {"gfx90a",
+           /*vector_infos=*/
+           {
+               {kF32, 64, 1},  // 128 [CDNA2]
+               {kF16, 64, 1},  // 128 (packed; assumed equal)
+               {kF64, 64, 1},  // 128 [CDNA2]
+           },
+           /*matrix_infos=*/
+           {
+               {kF16, 4, 128},  // 1024 [CDNA2]
+               {kF32, 4, 32},   //  256 [CDNA2]
+               {kF64, 4, 32},   //  256 [CDNA2]
+               {kI8, 4, 128},   // 1024 [CDNA2]
+           }},
+          // ===== gfx942 / CDNA3 / MI300A/MI300X/MI325X =====
+          {"gfx942",
+           /*vector_infos=*/
+           {
+               {kF32, 128, 1},  // 256 [CDNA3]
+               {kF16, 128, 1},  // 256 (packed; assumed equal)
+               {kF64, 64, 1},   // 128 [CDNA3]
+           },
+           /*matrix_infos=*/
+           {
+               {kF8, 4, 512},   // 4096 [CDNA3]
+               {kF16, 4, 256},  // 2048 [CDNA3]
+               {kF32, 4, 32},   //  256 [CDNA3]
+               {kF64, 4, 32},   //  256 [CDNA3]
+               {kI8, 4, 512},   // 4096 [CDNA3]
+           }},
+          // ===== gfx950 / CDNA4 / MI350/MI355X =====
+          {"gfx950",
+           /*vector_infos=*/
+           {
+               {kF32, 128, 1},  // 256 [CDNA4]
+               {kF16, 128, 1},  // 256 [CDNA4] (vector FP16)
+               {kF64, 64, 1},   // 128 [CDNA4]
+           },
+           /*matrix_infos=*/
+           {
+               {kF4, 4, 2048},  // 16384 [CDNA4] MXFP4
+               {kF6, 4, 2048},  // 16384 [CDNA4] MXFP6
+               {kF8, 4, 1024},  //  8192 [CDNA4]
+               {kF16, 4, 512},  //  4096 [CDNA4]
+               {kF32, 4, 32},   //   256 [CDNA4]
+               {kF64, 4, 16},   //   128 [CDNA4] (halved)
+               {kI8, 4, 1024},  //  8192 [CDNA4]
+           }},
+      });
+
+  for (const auto& entry : *kTable) {
+    if (cc.gfx_version() == entry.gfx_version) {
+      return CoreInfo{entry.vector_infos, entry.matrix_infos};
+    }
+  }
+  return CoreInfo{};
+}
+
+}  // namespace gpu
+}  // namespace stream_executor

--- a/xla/stream_executor/rocm/rocm_core_info_table.h
+++ b/xla/stream_executor/rocm/rocm_core_info_table.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 The OpenXLA Authors.
+/* Copyright 2026 The OpenXLA Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,22 +13,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef XLA_STREAM_EXECUTOR_CUDA_CUDA_CORE_INFO_TABLE_H_
-#define XLA_STREAM_EXECUTOR_CUDA_CUDA_CORE_INFO_TABLE_H_
+#ifndef XLA_STREAM_EXECUTOR_ROCM_ROCM_CORE_INFO_TABLE_H_
+#define XLA_STREAM_EXECUTOR_ROCM_ROCM_CORE_INFO_TABLE_H_
 
-#include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/gpu/dtype_core_info.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
 
 namespace stream_executor {
 namespace gpu {
 
 // Returns the core info for `cc`, empty if it is not in the table.
-CoreInfo FindCudaCoreInfo(CudaComputeCapability cc);
-
-// Number of FPUs (CUDA Cores) per SM to assume when `cc` is not in the table.
-int CudaFpusPerCoreFallback(CudaComputeCapability cc);
+CoreInfo FindRocmCoreInfo(const RocmComputeCapability& cc);
 
 }  // namespace gpu
 }  // namespace stream_executor
 
-#endif  // XLA_STREAM_EXECUTOR_CUDA_CUDA_CORE_INFO_TABLE_H_
+#endif  // XLA_STREAM_EXECUTOR_ROCM_ROCM_CORE_INFO_TABLE_H_

--- a/xla/stream_executor/rocm/rocm_core_info_table_test.cc
+++ b/xla/stream_executor/rocm/rocm_core_info_table_test.cc
@@ -1,0 +1,98 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+#include "xla/service/gpu/gpu_device_info_for_tests.h"
+#include "xla/stream_executor/device_description.h"
+#include "xla/stream_executor/gpu/core_info.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
+#include "xla/xla_data.pb.h"
+
+namespace stream_executor {
+namespace gpu {
+namespace {
+
+// Asserts that the table reproduces the peak TFLOPS the AMD white papers quote
+void CheckPeakOpsPerNs(const DeviceDescription& device_info, bool is_matrix,
+                       xla::PrimitiveType dtype, double expected_tflops) {
+  const ExecutionUnitDescription* eu =
+      is_matrix ? device_info.matrix_unit_description()
+                : device_info.scalar_unit_description();
+  ASSERT_NE(eu, nullptr);
+
+  std::optional<ExecutionUnitDescription::RateInfo> rate =
+      eu->GetRateInfo(dtype);
+  ASSERT_TRUE(rate.has_value())
+      << "No rate info for dtype " << xla::PrimitiveType_Name(dtype);
+
+  double flops_per_ns_per_unit =
+      rate->clock_rate_ghz * rate->ops_per_clock * 2;  // FMA = 2 ops.
+  int64_t n_units = device_info.core_count() * rate->units_per_core;
+  double tflops = flops_per_ns_per_unit * n_units / 1000.0;
+
+  // 2% tolerance to absorb boost-clock rounding in the white papers.
+  EXPECT_NEAR(tflops, expected_tflops, expected_tflops * 0.02)
+      << "dtype: " << xla::PrimitiveType_Name(dtype);
+}
+
+// From CDNA 3 white paper
+TEST(RocmCoreInfoTableTest, CalculatePeakOpsPerNsMI300X) {
+  DeviceDescription d = xla::gpu::TestGpuDeviceInfo::AMDMI300DeviceInfo();
+  CheckPeakOpsPerNs(d, /*is_matrix=*/false, xla::F32, 163.4);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/false, xla::F64, 81.7);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::F32, 163.4);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::F64, 163.4);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::F16, 1307.4);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::BF16, 1307.4);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::F8E4M3, 2614.9);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::S8, 2614.9);
+}
+
+// From CDNA 4 white paper
+TEST(RocmCoreInfoTableTest, CalculatePeakOpsPerNsMI350X) {
+  DeviceDescription d = xla::gpu::TestGpuDeviceInfo::AMDMI350DeviceInfo();
+  CheckPeakOpsPerNs(d, /*is_matrix=*/false, xla::F32, 144.2);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/false, xla::F64, 72.1);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::F32, 144.2);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::F64, 72.1);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::F16, 2306.9);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::BF16, 2306.9);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::F8E4M3, 4613.7);
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::S8, 4613.7);
+  // MXFP6 / MXFP4 -> 9.2 PF.
+  CheckPeakOpsPerNs(d, /*is_matrix=*/true, xla::F4E2M1FN, 9227.5);
+}
+
+TEST(RocmCoreInfoTableTest, GetFpusPerCore) {
+  auto fpus = [](std::string gfx) {
+    return GetFpusPerCore(
+        GpuComputeCapability(RocmComputeCapability(std::move(gfx))));
+  };
+  EXPECT_EQ(fpus("gfx908"), 64);   // CDNA1
+  EXPECT_EQ(fpus("gfx90a"), 64);   // CDNA2
+  EXPECT_EQ(fpus("gfx942"), 128);  // CDNA3
+  EXPECT_EQ(fpus("gfx950"), 128);  // CDNA4
+  // Untabulated gfx targets take the default.
+  EXPECT_EQ(fpus("gfx1100"), 128);
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace stream_executor

--- a/xla/stream_executor/rocm/rocm_executor.cc
+++ b/xla/stream_executor/rocm/rocm_executor.cc
@@ -61,6 +61,7 @@ limitations under the License.
 #include "xla/stream_executor/generic_memory_allocation.h"
 #include "xla/stream_executor/generic_memory_allocator.h"
 #include "xla/stream_executor/gpu/context.h"
+#include "xla/stream_executor/gpu/core_info.h"
 #include "xla/stream_executor/gpu/read_numa_node.h"
 #include "xla/stream_executor/gpu/scoped_activate_context.h"
 #include "xla/stream_executor/kernel.h"
@@ -76,6 +77,7 @@ limitations under the License.
 #include "xla/stream_executor/platform/initialize.h"
 #include "xla/stream_executor/plugin_registry.h"
 #include "xla/stream_executor/rocm/rocm_command_buffer.h"
+#include "xla/stream_executor/rocm/rocm_compute_capability.h"
 #include "xla/stream_executor/rocm/rocm_context.h"
 #include "xla/stream_executor/rocm/rocm_event.h"
 #include "xla/stream_executor/rocm/rocm_kernel.h"
@@ -1263,10 +1265,11 @@ RocmExecutor::CreateDeviceDescription(int device_ordinal) {
       GetMaxSharedMemoryPerBlock(device).value());
   int core_count = GetMultiprocessorCount(device).value();
   desc.set_core_count(core_count);
-  // TODO(ROCm): replace this hardcoded value with a per-arch lookup table and
-  // populate scalar_unit_description / matrix_unit_description so the perf
-  // model picks the right FP32 path (vector vs. matrix).
-  desc.set_fpus_per_core(128);
+  {
+    const GpuComputeCapability cc{RocmComputeCapability(gcn_arch_name)};
+    desc.set_fpus_per_core(GetFpusPerCore(cc));
+    FillExecutionUnitDesc(cc, desc.clock_rate_ghz(), desc);
+  }
   desc.set_threads_per_core_limit(
       GetMaxThreadsPerMultiprocessor(device).value());
   desc.set_registers_per_block_limit(GetMaxRegistersPerBlock(device).value());


### PR DESCRIPTION
📝 Summary of Changes
Values in `DeviceDescription` that change on ROCm:
  - `fpus_per_core` becomes 64 on gfx908 and gfx90a, stays 128 on gfx942 and gfx950, stays 128 elsewhere via the fallback.
  - `scalar_unit_description` and `matrix_unit_description` are populated on CDNA1 through CDNA4, previously null on all ROCm targets.

No CUDA-visible values change, the CUDA table is only moved behind the shared entry points.

🎯 Justification
Provides correct per-arch, per-dtype compute rates for the cost models on ROCm.

🚀 Kind of Contribution: ✨ New Feature

📊 Benchmark
The matrix rates are inert for now, as every path reading them is either CUDA-gated or behind a non-default flag. `fpus_per_core` does change on gfx908 and gfx90a, but measured runtime on gfx90a is barely changed.

🧪 Unit Tests:
`rocm_core_info_table_test.cc` reconstructs peak TFLOPS from the table and checks it against the CDNA 3 and CDNA 4 white paper figures. `gpu_performance_model_base_test.cc` adds three tests.

🧪 Execution Tests: none
