### PR TITLE
[XLA:GPU][oneAPI][Bugfix] Prevent compile-time hangs in VectorizeLoad trunc-user walk

### DIFF
--- a/xla/codegen/emitters/transforms/vectorize_loads_stores.cc
+++ b/xla/codegen/emitters/transforms/vectorize_loads_stores.cc
@@ -300,7 +300,9 @@ struct VectorizeLoad : mlir::OpRewritePattern<mlir::tensor::ExtractOp> {
     llvm::DenseSet<mlir::Operation*> visited;
     std::function<bool(mlir::Operation*)> has_sub_byte_trunc_user =
         [&](mlir::Operation* op) {
-          if (!visited.insert(op).second) return false;
+          if (!visited.insert(op).second) {
+            return false;
+          }
           return absl::c_any_of(op->getUsers(), [&](mlir::Operation* user) {
             auto trunc = mlir::dyn_cast<mlir::arith::TruncIOp>(user);
             if (trunc && IsSubByteIntOrFloatType(trunc.getResult().getType()))

--- a/xla/codegen/emitters/transforms/vectorize_loads_stores.cc
+++ b/xla/codegen/emitters/transforms/vectorize_loads_stores.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/log/check.h"
 #include "absl/numeric/bits.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -296,8 +297,10 @@ struct VectorizeLoad : mlir::OpRewritePattern<mlir::tensor::ExtractOp> {
     // trunc (extractelement <4 x i8> %X, i64 0) to i2 ->
     // extractelement <16 x i2> (bitcast <4 x i8> %X to <16 x i2>), i64 0. The
     // sub-byte vector types are not supported in the LLVM SPIR-V backend.
+    llvm::DenseSet<mlir::Operation*> visited;
     std::function<bool(mlir::Operation*)> has_sub_byte_trunc_user =
         [&](mlir::Operation* op) {
+          if (!visited.insert(op).second) return false;
           return absl::c_any_of(op->getUsers(), [&](mlir::Operation* user) {
             auto trunc = mlir::dyn_cast<mlir::arith::TruncIOp>(user);
             if (trunc && IsSubByteIntOrFloatType(trunc.getResult().getType()))


### PR DESCRIPTION
This PR fixes exponential re-exploration in the recursive walk used during the transitive search over arith.trunci users that narrow to a sub-byte type. Because the walk did not track visited operations, reconverging use graphs could cause compile-time hangs, even though the generated result was unchanged.

testcase fixed:
random_lax_test.py::DistributionsTest.testDirichlet0
random_lax_test.py::DistributionsTest.testDirichlet1