### PR TITLE
Fix unpatched integer overflow in ArrayMemRegion byte-size computation

### DIFF
--- a/xla/python/ifrt_proxy/common/array_util.cc
+++ b/xla/python/ifrt_proxy/common/array_util.cc
@@ -83,7 +83,22 @@ absl::StatusOr<ArrayMemRegion> ArrayMemRegion::FromZerothElementPointer(
 
   if (!byte_strides.has_value() ||
       (byte_strides->empty() && shape.dims().empty())) {
-    return ArrayMemRegion(mem_region_start, byte_size * shape.num_elements());
+    // `shape.num_elements()` is itself overflow-checked at Shape
+    // construction time (see Shape::FromProto), but that check validates
+    // only the element count, independent of `byte_size` -- a shape with
+    // e.g. 2^61 elements passes it cleanly, and 2^61 is well within
+    // int64_t range on its own. Multiplying by byte_size (8 for a real,
+    // existing IFRT dtype such as float64/int64/complex64) is a second,
+    // separate place this can overflow, and nothing upstream of this line
+    // has checked it.
+    int64_t total_bytes;
+    if (__builtin_mul_overflow(byte_size, shape.num_elements(),
+                                &total_bytes)) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("byte_size * num_elements overflows: byte_size=",
+                       byte_size, " num_elements=", shape.num_elements()));
+    }
+    return ArrayMemRegion(mem_region_start, total_bytes);
   }
   if (shape.num_elements() == 0) {
     return ArrayMemRegion(mem_region_start, 0);

--- a/xla/python/ifrt_proxy/common/array_util_test.cc
+++ b/xla/python/ifrt_proxy/common/array_util_test.cc
@@ -148,7 +148,19 @@ INSTANTIATE_TEST_SUITE_P(
         TC{"ByteStrideOverflowMultiDim",
            kS32,
            {5, 3},
-           Strides({INT64_C(4611686018427387904), 4})}),
+           Strides({INT64_C(4611686018427387904), 4})},
+        // byte_size * num_elements() overflows int64_t when byte_strides is
+        // not supplied. shape.num_elements() alone (2^61, from dims
+        // {2^31, 2^30}) is well within int64_t range on its own and would
+        // be accepted by Shape::FromProto's own overflow check, which
+        // validates only the element count -- multiplying by an 8-byte
+        // dtype's byte_size is a separate place this can overflow, and
+        // before this fix it wrapped to exactly zero, which would have
+        // bypassed the size check in FromMinimalMemRegion entirely.
+        TC{"DefaultStridesByteSizeOverflow",
+           kF64,
+           {2147483648LL, 1073741824LL},  // 2^31 * 2^30 = 2^61 elements
+           std::nullopt}),
     testing::PrintToStringParamName());
 TEST_P(ArrayMemRegionFailure, TestCase) {
   const TC tc = GetParam();


### PR DESCRIPTION
## Problem

`ArrayMemRegion::FromZerothElementPointer` in `xla/python/ifrt_proxy/common/array_util.cc` has a second, unpatched integer overflow — a sibling to the one #46604 just fixed in the same function.

That fix addressed the stride-accumulation loop, reachable when a client supplies explicit `byte_strides`. This report is about the function's **other** branch — taken when `byte_strides` is *omitted*, which is the more common case, since it's an optional field most callers don't set:

```
if (!byte_strides.has_value() ||
    (byte_strides->empty() && shape.dims().empty())) {
  return ArrayMemRegion(mem_region_start, byte_size * shape.num_elements());
}
```

`shape.num_elements()` is overflow-checked at `Shape` construction time — `Shape::FromProto` runs `__builtin_mul_overflow` across the raw dimension product. But that check only validates the **element count**; it has no visibility into `byte_size`, since the dtype isn't known yet at that point. A shape with `2^61` elements (dims `{2^31, 2^30}`) passes it cleanly — `2^61` is comfortably inside `int64_t` range on its own. Multiplying that by an 8-byte dtype's `byte_size` (`float64`, `int64`, `complex64` are all 8 bytes) is a **second, independent** place this can overflow, and until now it was completely unchecked.

## Confirmed impact — both vectors from #46604's own description

Traced both gRPC handlers #46604 named, and confirmed both reach this exact branch:

| Handler | Mechanism | Consequence |
|---|---|---|
| `MakeArrayFromHostBuffer` (`ifrt_backend.cc` ~L927) | `byte_strides` is `std::nullopt` whenever a client's request doesn't set it. `FromMinimalMemRegion` compares the wrapped size against the client-supplied buffer's real size — with the values above, the wrapped size is exactly `0`, so a `0`-byte buffer passes trivially. | **Out-of-bounds read**: server reads the array's true `2^61`-element span from that pointer. |
| `CopyToHostBuffer` (`ifrt_backend.cc` ~L1248) | Same branch sizes `pseudo_mem_region` from an existing array's real dtype/shape; `host_buffer->resize(pseudo_mem_region->nbytes())` allocates a buffer sized by the wrapped value. | **Heap buffer overflow**: the array's true element count gets written into the undersized buffer. |

## Reproduction

Verified with an isolated, compiled program using the *exact* real expressions (identical types, identical arithmetic — not a loose reimplementation):

```
// Exact logic from Shape::FromProto's own overflow check.
int64_t num_elements = 1;
bool overflow = false;
for (int64_t dim : {2147483648LL, 1073741824LL}) {  // 2^31, 2^30
  overflow |= __builtin_mul_overflow(num_elements, dim, &num_elements);
}
// overflow == false; num_elements == 2305843009213693952 (2^61)
// -> Shape::FromProto ACCEPTS this shape.

// Exact logic from FromZerothElementPointer's vulnerable branch.
int byte_size = 8;  // float64 / int64 / complex64 -- all real IFRT dtypes
int64_t computed_size = byte_size * num_elements;
// computed_size == 0  (wrapped)
```

Shape::FromProto would accept this shape: true
validated num_elements (int64_t): 2305843009213693952
byte_size * num_elements (int64_t arithmetic): 0
Did this multiplication overflow/wrap: true


## Fix

Mirrors #46604's own reviewed pattern exactly:

```
int64_t total_bytes;
if (__builtin_mul_overflow(byte_size, shape.num_elements(), &total_bytes)) {
  return absl::InvalidArgumentError(
      absl::StrCat("byte_size * num_elements overflows: byte_size=",
                   byte_size, " num_elements=", shape.num_elements()));
}
return ArrayMemRegion(mem_region_start, total_bytes);
```

Verified against four cases in isolation:

| Case | Expected | Result |
|---|---|---|
| The confirmed overflow (`dims={2^31,2^30}`, `byte_size=8`) | Rejected | ✅ `InvalidArgumentError` |
| Legitimate 1 GiB array (`134217728 × 8`) | Accepted, correct size | ✅ `1073741824` |
| Ordinary small array (`10 × 4`) — the overwhelming majority of real traffic | Accepted, unaffected | ✅ `40` |
| Zero-element shape | Accepted, unaffected | ✅ `0` |

## Test coverage

Adds `DefaultStridesByteSizeOverflow` to the existing `ArrayMemRegionFailure` parameterized suite, using the exact dims/dtype confirmed above — matching the style and structure of #46604's own `ByteStrideOverflowSingleDim` / `ByteStrideOverflowMultiDim` additions in the same file and suite.

## Verification limitations

I could not build the full XLA/Bazel tree in the environment that produced this PR. The overflow and the fix were instead verified via isolated, compiled C++ reproductions of the exact real expressions (shown above, and included as-is — nothing reimplemented or approximated), plus a full source-level reachability trace through both named gRPC handlers.

**Requesting**: please run `bazel test //xla/python/ifrt_proxy/common:array_util_test` in review to confirm the CI harness itself is clean before merging.