### PR TITLE
[XLA:CPU] Explicitly disable oneDNN for YNN-specific tests

### DIFF
--- a/xla/backends/cpu/transforms/ynn_matcher_test.cc
+++ b/xla/backends/cpu/transforms/ynn_matcher_test.cc
@@ -31,6 +31,7 @@ class YnnE2eTest : public HloTestBase {
     debug_options.add_xla_cpu_experimental_ynn_fusion_type(
         DebugOptions::LIBRARY_FUSION_TYPE_INDIVIDUAL_CONVOLUTION);
     debug_options.clear_xla_cpu_experimental_ynn_fusion_type();
+    debug_options.set_xla_cpu_experimental_onednn_custom_call(false);
     return debug_options;
   }
 };
@@ -60,6 +61,7 @@ class YnnReduceTest : public HloTestBase {
     DebugOptions debug_options = HloTestBase::GetDebugOptionsForTest();
     debug_options.add_xla_cpu_experimental_ynn_fusion_type(
         DebugOptions::LIBRARY_FUSION_TYPE_REDUCE);
+    debug_options.set_xla_cpu_experimental_onednn_custom_call(false);
     return debug_options;
   }
 };
@@ -218,6 +220,7 @@ class YnnDotTest : public HloTestBase,
     DebugOptions debug_options = HloTestBase::GetDebugOptionsForTest();
     debug_options.add_xla_cpu_experimental_ynn_fusion_type(
         DebugOptions::LIBRARY_FUSION_TYPE_INDIVIDUAL_DOT);
+    debug_options.set_xla_cpu_experimental_onednn_custom_call(false);
     return debug_options;
   }
 };
@@ -279,6 +282,7 @@ class YnnReduceEltwiseTest : public HloTestBase {
         DebugOptions::LIBRARY_FUSION_TYPE_REDUCE);
     debug_options.add_xla_cpu_experimental_ynn_fusion_type(
         DebugOptions::LIBRARY_FUSION_TYPE_ELTWISE);
+    debug_options.set_xla_cpu_experimental_onednn_custom_call(false);
     return debug_options;
   }
 };

--- a/xla/service/cpu/cpu_compiler_test.cc
+++ b/xla/service/cpu/cpu_compiler_test.cc
@@ -100,6 +100,7 @@ ENTRY main {
   DebugOptions debug_options = GetDebugOptionsForTest();
   debug_options.add_xla_cpu_experimental_ynn_fusion_type(
       xla::DebugOptions::LIBRARY_FUSION_TYPE_INDIVIDUAL_DOT);
+  debug_options.set_xla_cpu_experimental_onednn_custom_call(false);
   debug_options.mutable_xla_backend_extra_options()->insert(
       {"xla_is_host_offload", "true"});
   config.set_debug_options(debug_options);


### PR DESCRIPTION
This PR explicitly disables oneDNN custom calls for YNN-specific tests to avoid unit test failures when running with oneDNN (as `--xla_cpu_experimental_onednn_custom_call` is `false` by default).