### PR TITLE
[ROCm] Use xla_test symbol version provided by the toolchain, avoiding clash…

### DIFF
--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -199,18 +199,6 @@ jobs:
         run: |
           wget -O build_tools/rocm/execute_ci_build_upstream.sh "${EXECUTE_CI_BUILD_URL}"
           chmod +x build_tools/rocm/execute_ci_build_upstream.sh
-          wget -O build_tools/rocm/global_symbol_version.lds "${GLOBAL_SYMBOL_VERSION_LDS_URL}"
-          LDS_SHA=$(sha256sum build_tools/rocm/global_symbol_version.lds | cut -d' ' -f1)
-          # Workaround for the symbol clash with ROCm's libLLVM.so
-          {
-            echo "LLVM_SYMBOL_CLASH_WAR<<EOF"
-            echo "--dynamic_mode=default"
-            echo "--linkopt=-Wl,--version-script,/work/build_tools/rocm/global_symbol_version.lds"
-            echo "--sandbox_add_mount_pair=/work/build_tools/rocm/global_symbol_version.lds"
-            echo "--action_env=global_symbol_version_lds_CACHEBUSTER=${LDS_SHA}"
-            echo "EOF"
-          } >> "$GITHUB_ENV"
-
       - *start_container
 
       - name: CPU Info
@@ -232,7 +220,6 @@ jobs:
             --local_test_jobs=1 \
             --internal_spawn_scheduler \
             --strategy=TestRunner=dynamic \
-            ${LLVM_SYMBOL_CLASH_WAR} \
             --bes_keywords=xla \
             --bes_keywords=upstream \
             --bes_keywords=gpu \
@@ -252,7 +239,6 @@ jobs:
             --repo_env=ROCM_PATH="" \
             --repo_env=ROCM_DISTRO_URL="${ROCM_DISTRO_URL}" \
             --repo_env=ROCM_DISTRO_HASH="${ROCM_DISTRO_HASH}" \
-            ${LLVM_SYMBOL_CLASH_WAR} \
             --bes_keywords=xla \
             --bes_keywords=upstream \
             --bes_keywords=cpu \

--- a/.github/workflows/rocm_ci.yml
+++ b/.github/workflows/rocm_ci.yml
@@ -180,7 +180,6 @@ jobs:
       ROCM_DISTRO_URL: ${{ needs.rocm-config.outputs.rocm-distro-url }}
       ROCM_DISTRO_HASH: ${{ needs.rocm-config.outputs.rocm-distro-hash }}
       EXECUTE_CI_BUILD_URL: https://raw.githubusercontent.com/ROCm/xla/refs/heads/${{ inputs.rocm_xla_branch || 'rocm-dev-infra' }}/build_tools/rocm/execute_ci_build_upstream.sh
-      GLOBAL_SYMBOL_VERSION_LDS_URL: https://raw.githubusercontent.com/ROCm/xla/refs/heads/${{ inputs.rocm_xla_branch || 'rocm-dev-infra' }}/build_tools/rocm/global_symbol_version.lds
       # Unique per run so a crashed run cannot collide with this one on a pooled node.
       CONTAINER_NAME: xla-${{ github.run_id }}-${{ github.run_attempt }}
       # Stable label so leftover containers from crashed runs can be swept on a pooled node.
@@ -207,7 +206,6 @@ jobs:
       - name: Test XLA [single_gpu]
         timeout-minutes: 120
         run: |
-          # LLVM_SYMBOL_CLASH_WAR is intentionally unquoted so it splits into one flag per line.
           # shellcheck disable=SC2086
           docker exec "${CONTAINER_NAME}" build_tools/rocm/execute_ci_build_upstream.sh \
             --config=rocm_ci_hermetic \
@@ -228,7 +226,6 @@ jobs:
       - name: Test XLA [rocm_cpu]
         timeout-minutes: 80
         run: |
-          # LLVM_SYMBOL_CLASH_WAR is intentionally unquoted so it splits into one flag per line.
           # shellcheck disable=SC2086
           docker exec "${CONTAINER_NAME}" build_tools/rocm/execute_ci_build_upstream.sh \
             --config=rocm_ci_hermetic \

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,9 +46,9 @@ bazel_dep(name = "rules_ml_toolchain")
 # echo "sha256-${HASH}"
 archive_override(
     module_name = "rules_ml_toolchain",
-    integrity = "sha256-dcy3xNxpk0PwLQLwtbqm2sCcAT1GuStg8YVjRI6lnnc=",
-    strip_prefix = "rules_ml_toolchain-73cb731fed3ccf7551beac710bf1c5dbeb8be298",
-    urls = ["https://github.com/google-ml-infra/rules_ml_toolchain/archive/73cb731fed3ccf7551beac710bf1c5dbeb8be298.tar.gz"],
+    integrity = "sha256-Ztgjtsa06m8J1572/knhgeUwF1nuB9F2psgqAeEifWs=",
+    strip_prefix = "rules_ml_toolchain-e8709f15382e4da1de5ca15672cb4412da3d989d",
+    urls = ["https://github.com/google-ml-infra/rules_ml_toolchain/archive/e8709f15382e4da1de5ca15672cb4412da3d989d.tar.gz"],
 )
 
 # TODO: Upstream the patch?

--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -298,15 +298,14 @@ common:rocm_clang_hermetic --@rules_ml_toolchain//common:static_libcxx=False
 
 common:rocm --config=rocm_clang_hermetic
 common:rocm_ci --config=rocm
-common:rocm_ci --@local_config_rocm//rocm:rocm_path_type=hermetic --config=workspace
+common:rocm_ci --@local_config_rocm//rocm:rocm_path_type=hermetic
 
-common:rocm_ci_hermetic --dynamic_mode=default
 common:rocm_ci_hermetic --@rules_ml_toolchain//common:enable_xla_test_global_symbol_version=True
 common:rocm_ci_hermetic --config=rocm_clang_hermetic
 common:rocm_ci_hermetic --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a"
 common:rocm_ci_hermetic --repo_env=ROCM_DISTRO_VERSION="rocm_7.13.0_gfx90a"
 common:rocm_ci_hermetic --repo_env=SYSROOT_DIST=linux_glibc_2_31
-common:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic --config=workspace
+common:rocm_ci_hermetic --@local_config_rocm//rocm:rocm_path_type=hermetic
 
 # This config option is used for SYCL as GPU backend.
 # SYCL Configuration (non-hermetic)

--- a/tensorflow.bazelrc
+++ b/tensorflow.bazelrc
@@ -300,7 +300,8 @@ common:rocm --config=rocm_clang_hermetic
 common:rocm_ci --config=rocm
 common:rocm_ci --@local_config_rocm//rocm:rocm_path_type=hermetic --config=workspace
 
-common:rocm_ci_hermetic --dynamic_mode=off
+common:rocm_ci_hermetic --dynamic_mode=default
+common:rocm_ci_hermetic --@rules_ml_toolchain//common:enable_xla_test_global_symbol_version=True
 common:rocm_ci_hermetic --config=rocm_clang_hermetic
 common:rocm_ci_hermetic --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a"
 common:rocm_ci_hermetic --repo_env=ROCM_DISTRO_VERSION="rocm_7.13.0_gfx90a"

--- a/workspace3.bzl
+++ b/workspace3.bzl
@@ -76,10 +76,10 @@ def workspace():
     # Details: https://github.com/google-ml-infra/rules_ml_toolchain
     tf_http_archive(
         name = "rules_ml_toolchain",
-        sha256 = "75ccb7c4dc699343f02d02f0b5baa6dac09c013d46b92b60f18563448ea59e77",
-        strip_prefix = "rules_ml_toolchain-73cb731fed3ccf7551beac710bf1c5dbeb8be298",
+        sha256 = "66d823b6c6b4ea6f09d79ef6fe49e181e5301759ee07d176a6c82a01e1227d6b",
+        strip_prefix = "rules_ml_toolchain-e8709f15382e4da1de5ca15672cb4412da3d989d",
         urls = tf_mirror_urls(
-            "https://github.com/google-ml-infra/rules_ml_toolchain/archive/73cb731fed3ccf7551beac710bf1c5dbeb8be298.tar.gz",
+            "https://github.com/google-ml-infra/rules_ml_toolchain/archive/e8709f15382e4da1de5ca15672cb4412da3d989d.tar.gz",
         ),
     )
 


### PR DESCRIPTION
… for llvm symbols

📝 Summary of Changes
Use --@rules_ml_toolchain//common:enable_xla_test_global_symbol_version=True and clean-up 
rocm ci workflow file

🎯 Justification
This change utilize the xla_test symbol version provided by rules_ml_toolchain.
Instead of having to download the file and do complex manipulations in our
ci pipeline script we utilize this simple flag which does the same job but in a
native bazel way. This also allow to build locally the same way as we do on ci.

🚀 Kind of Contribution
Please remove what does not apply: ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
