### PR TITLE
[XLA:CPU] Do not send reductions with non-trivial reducers to YNNPACK

### DIFF
--- a/xla/backends/cpu/transforms/library_rewriter_test.cc
+++ b/xla/backends/cpu/transforms/library_rewriter_test.cc
@@ -700,6 +700,59 @@ TEST_F(CpuLibraryTest, ReduceSquareConvert) {
   RunTestInternal(spec, hlo_template, {HloOpcode::kReduce, 1, 5, true});
 }
 
+TEST_F(CpuLibraryTest, DoNotFuseReduceWithNonTrivialReducer) {
+  // The reducer has a side-effecting outfeed next to the add, so it is not the
+  // plain `add(p0, p1)` computation that the YNN emitter expects.
+  const absl::string_view hlo_template = R"(
+    HloModule reduce_with_outfeed_in_reducer
+
+    reducer_add_with_outfeed {
+      lhs = f32[] parameter(0)
+      rhs = f32[] parameter(1)
+      c = f32[] constant(42)
+      token0 = token[] after-all()
+      outfeed = token[] outfeed(c, token0), outfeed_shape=f32[]
+      ROOT sum = f32[] add(lhs, rhs)
+    }
+
+    ENTRY main {
+      input = f32[10,10,10,10]{3,2,1,0} parameter(0)
+      c = f32[] constant(0)
+      ROOT output = f32[10,10]{1,0} reduce(input, c), dimensions={0,2},
+          to_apply=reducer_add_with_outfeed
+    }
+    )";
+  DotRewriteTestSpec spec = GetDefaultTestSpec();
+  spec.fusion_mode = "reduce";
+  RunTestInternal(spec, hlo_template, {HloOpcode::kReduce, 0, 0, false});
+}
+
+TEST_F(CpuLibraryTest, DoNotFuseReduceWindowWithNonTrivialReducer) {
+  // Same reducer as above; reduce-window must not be fused either.
+  const absl::string_view hlo_template = R"(
+    HloModule reduce_window_with_outfeed_in_reducer
+
+    reducer_add_with_outfeed {
+      lhs = f32[] parameter(0)
+      rhs = f32[] parameter(1)
+      c = f32[] constant(42)
+      token0 = token[] after-all()
+      outfeed = token[] outfeed(c, token0), outfeed_shape=f32[]
+      ROOT sum = f32[] add(lhs, rhs)
+    }
+
+    ENTRY main {
+      input = f32[512,512]{1,0} parameter(0)
+      c = f32[] constant(0)
+      ROOT output = f32[256,256]{1,0} reduce-window(input, c),
+          window={size=2x2 stride=2x2}, to_apply=reducer_add_with_outfeed
+    }
+    )";
+  DotRewriteTestSpec spec = GetDefaultTestSpec();
+  spec.fusion_mode = "reduce";
+  RunTestInternal(spec, hlo_template, {HloOpcode::kReduceWindow, 0, 0, false});
+}
+
 TEST_F(CpuLibraryTest, RetryFusion) {
   //   p0 -> A (abs) -> B (add) -> C (dot) -> E (add)
   //                     \___________________/

--- a/xla/backends/cpu/ynn_support.cc
+++ b/xla/backends/cpu/ynn_support.cc
@@ -509,6 +509,12 @@ bool IsReduceLikeOpSupportedByYnn(const HloInstruction* hlo) {
 
   const HloComputation* to_apply = hlo->to_apply();
   CHECK_NE(to_apply, nullptr);
+  // DefineReduceOp and DefineReduceWindowOp in ynn_emitter.cc only map the
+  // reducer root, so the reducer must be exactly the two parameters and the
+  // root (no side effects).
+  if (to_apply->instruction_count() != 3) {
+    return false;
+  }
   if (Match(to_apply->root_instruction(),
             match::AnyOf<HloInstruction>(match::Add())
                 .WithBinaryOperandsAnyOrder(match::Parameter(0),


### PR DESCRIPTION
## 📝 Summary of Changes

`IsReduceLikeOpSupportedByYnn` only looked at the root of the reducer computation (`add`/`max`/`min` of the two parameters). If the reducer has any other instructions in it, for example a side-effecting outfeed like in the module from #47374, the reduce still got wrapped into a `__ynn_fusion`. The YNN emitter then hits `CHECK_EQ(reduce_instr->to_apply()->instruction_count(), 3)` in `DefineReduceOp` when the YNN executable is built on the first execution, so compile succeeds and the process aborts at run time. For `reduce-window` there is no CHECK and the extra instructions were just dropped.

This change makes the matcher require the reducer to be exactly the two parameters plus the root, which is the shape the emitter can actually express (same guard as in `all_reduce_key.cc`, `all_reduce_combiner.cc` etc.). Such reductions now take the regular CPU path instead.

Added two tests to `library_rewriter_test.cc` that run `LibraryRewriter` on a `reduce` and a `reduce-window` with an outfeed in the reducer and check that no YNN fusion is created. Both fail before this change.

Note that the module from the issue still does not compile on CPU after this change: it now hits the `computation_partitioner.cc:269` CHECK in the MLIR fusion emitter, which is the same crash site as #47373 and not YNN-specific.

## 🎯 Justification

Fixes #47374. Process abort at run time on valid (if unusual) HLO with default flags.

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

`bazel test //xla/backends/cpu/transforms:ynn_matcher_test_cpu //xla/backends/cpu/transforms:library_rewriter_test //xla/backends/cpu/tests:ynn_fusion_test_cpu`

## 🧪 Execution Tests:

None (CPU only, covered by the unit tests above).