### PR TITLE
[XLA:GPU][Bugfix][ONEAPI] Pjrt c api test fix

### DIFF
--- a/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
@@ -85,8 +85,10 @@ namespace gpu_plugin {
 
 #if TENSORFLOW_USE_ROCM
 #define PJRT_GPU_PLUGIN_PLATFORM_NAME "ROCM"
+//TODO(Intel-tf)  this will be changed to ONEAPI
+//when the SYCL backend has been renamed to ONEAPI.
 #elif TENSORFLOW_USE_SYCL
-#define PJRT_GPU_PLUGIN_PLATFORM_NAME "ONEAPI"
+#define PJRT_GPU_PLUGIN_PLATFORM_NAME "SYCL"
 #else
 #define PJRT_GPU_PLUGIN_PLATFORM_NAME "CUDA"
 #endif
@@ -339,7 +341,7 @@ PJRT_Error* PJRT_GpuDeviceTopology_Create(
   if (plugin_platform == "ROCM") {
     platform_id = xla::RocmId();
     platform_name = xla::RocmName();
-  } else if (plugin_platform == "ONEAPI") {
+  } else if (plugin_platform == "SYCL") {
     platform_id = xla::OneapiId();
     platform_name = xla::OneapiName();
   } else {

--- a/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
+++ b/xla/pjrt/c/pjrt_c_api_gpu_internal.cc
@@ -85,9 +85,9 @@ namespace gpu_plugin {
 
 #if TENSORFLOW_USE_ROCM
 #define PJRT_GPU_PLUGIN_PLATFORM_NAME "ROCM"
-//TODO(Intel-tf)  this will be changed to ONEAPI
-//when the SYCL backend has been renamed to ONEAPI.
 #elif TENSORFLOW_USE_SYCL
+// TODO(Intel-tf)  this will be changed to ONEAPI
+// when the SYCL backend has been renamed to ONEAPI.
 #define PJRT_GPU_PLUGIN_PLATFORM_NAME "SYCL"
 #else
 #define PJRT_GPU_PLUGIN_PLATFORM_NAME "CUDA"


### PR DESCRIPTION
This PR temporarily updates the PJRT GPU plugin name to SYCL to pass unit tests, we are reverting back to naming the PLUGIN NAME as SYCL to be consistent with the stream executor name of SYCL.

Unit Test Fixes:
//xla/pjrt/c/c:pjrt_c_api_gpu_test_intelgpu_any