### PR TITLE
[XLA] Handle variadic reduces in HostOffloader

### DIFF
--- a/xla/hlo/transforms/host_offloader.cc
+++ b/xla/hlo/transforms/host_offloader.cc
@@ -139,8 +139,13 @@ bool HostOffloader::InstructionIsAllowedBetweenDsAndMoveToDevice(
     const HloInstruction* instruction) const {
   if (instruction->opcode() == HloOpcode::kReduce) {
     // TODO(b/333902007): Remove this once trivial reduces no longer appear.
+    // A variadic reduce has a tuple shape; the verifier guarantees all its
+    // elements have the same dimensions, so the first one is representative.
+    const Shape& output_shape = instruction->shape().IsTuple()
+                                    ? instruction->shape().tuple_shapes(0)
+                                    : instruction->shape();
     return ShapeUtil::TrueNumDimensions(instruction->operand(0)->shape()) ==
-           ShapeUtil::TrueNumDimensions(instruction->shape());
+           ShapeUtil::TrueNumDimensions(output_shape);
   }
   if (instruction->opcode() == HloOpcode::kReshape) {
     return ShapeUtil::ReshapeIsBitcast(instruction->operand(0)->shape(),
@@ -338,9 +343,18 @@ absl::StatusOr<bool> HostOffloader::WalkDownHostMemoryOffloadPaths(
       const Shape& output_shape = ShapeUtil::GetSubshape(
           instruction->GetModule()->entry_computation_layout().result_shape(),
           instruction_and_shape_index.shape_index);
-      CHECK(output_shape.has_layout())
-          << "Expecting output shape of entry computation to have a layout.";
-      if (output_shape.layout().memory_space() == Layout::kHostMemorySpace) {
+      // The output may be a tuple (e.g. a variadic reduce is the root); it is
+      // output streamed when every leaf is in host memory.
+      bool output_in_host_memory = true;
+      ShapeUtil::ForEachLeafShape(
+          output_shape, [&](const Shape& leaf, const ShapeIndex&) {
+            CHECK(leaf.has_layout())
+                << "Expecting output shape of entry computation to have a "
+                   "layout.";
+            output_in_host_memory &=
+                leaf.layout().memory_space() == Layout::kHostMemorySpace;
+          });
+      if (output_in_host_memory) {
         VLOG(2) << absl::StreamFormat(
             "Memory offloaded starting from %s is output streamed",
             starting_instruction_and_index.ToString());

--- a/xla/hlo/transforms/host_offloader_test.cc
+++ b/xla/hlo/transforms/host_offloader_test.cc
@@ -5168,5 +5168,164 @@ ENTRY main {
   TestShapeHasMemorySpace(dus->shape(), Layout::kHostMemorySpace);
 }
 
+TEST_F(HostOffloaderTest, VariadicReduceOnHostMemoryBecomesHostCompute) {
+  // A variadic reduce has a tuple shape; the walk must handle it like a
+  // non-variadic reduce instead of crashing.
+  const std::string& hlo_string = R"(
+HloModule m, entry_computation_layout={(f32[16,8]{1,0})->(f32[16]{0}, f32[16]{0})}
+
+reducer {
+  a = f32[] parameter(0)
+  b = f32[] parameter(1)
+  c = f32[] parameter(2)
+  d = f32[] parameter(3)
+  max = f32[] maximum(a, c)
+  add = f32[] add(b, d)
+  ROOT t = (f32[], f32[]) tuple(max, add)
+}
+
+ENTRY main {
+  p = f32[16,8] parameter(0)
+  mth = f32[16,8] custom-call(p), custom_call_target="MoveToHost"
+  slice = f32[16,4] slice(mth), slice={[0:16], [0:4]}
+  c0 = f32[] constant(0)
+  reduce = (f32[16], f32[16]) reduce(slice, slice, c0, c0), dimensions={1}, to_apply=reducer
+  gte0 = f32[16] get-tuple-element(reduce), index=0
+  gte1 = f32[16] get-tuple-element(reduce), index=1
+  mtd0 = f32[16] custom-call(gte0), custom_call_target="MoveToDevice"
+  mtd1 = f32[16] custom-call(gte1), custom_call_target="MoveToDevice"
+  ROOT t = (f32[16], f32[16]) tuple(mtd0, mtd1)
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunHostOffloader(module.get()));
+  EXPECT_TRUE(changed);
+  VLOG(1) << "module after: " << module->ToString();
+
+  EXPECT_FALSE(HaveRemainingOffloadAnnotations(module.get()));
+
+  HloInstruction* slice = FindInstruction(module.get(), "slice");
+  ASSERT_NE(slice, nullptr);
+  EXPECT_TRUE(host_offload_utils::ComputeTypeIsHost(slice));
+  TestShapeHasMemorySpace(slice->shape(), Layout::kHostMemorySpace);
+
+  HloInstruction* reduce = FindInstruction(module.get(), "reduce");
+  ASSERT_NE(reduce, nullptr);
+  EXPECT_TRUE(host_offload_utils::ComputeTypeIsHost(reduce));
+  ASSERT_TRUE(reduce->shape().IsTuple());
+  for (const Shape& subshape : reduce->shape().tuple_shapes()) {
+    TestShapeHasMemorySpace(subshape, Layout::kHostMemorySpace);
+  }
+
+  // Both outputs are followed and copied back to device.
+  const HloInstruction* root = module->entry_computation()->root_instruction();
+  ASSERT_EQ(root->opcode(), HloOpcode::kTuple);
+  for (const HloInstruction* copy : root->operands()) {
+    EXPECT_EQ(copy->opcode(), HloOpcode::kCopy);
+    TestShapeHasMemorySpace(copy->shape(), Layout::kDefaultMemorySpace);
+    EXPECT_EQ(copy->operand(0)->opcode(), HloOpcode::kGetTupleElement);
+    TestShapeHasMemorySpace(copy->operand(0)->shape(),
+                            Layout::kHostMemorySpace);
+  }
+}
+
+TEST_F(HostOffloaderTest, TrivialVariadicReduceBetweenDsAndMoveToDevice) {
+  // A variadic reduce that only removes a unit dimension is allowed between
+  // the dynamic-slice and MoveToDevice, like a non-variadic one.
+  const std::string& hlo_string = R"(
+HloModule m, entry_computation_layout={(f32[16,8]{1,0})->f32[16]{0}}
+
+reducer {
+  a = f32[] parameter(0)
+  b = f32[] parameter(1)
+  c = f32[] parameter(2)
+  d = f32[] parameter(3)
+  max = f32[] maximum(a, c)
+  add = f32[] add(b, d)
+  ROOT t = (f32[], f32[]) tuple(max, add)
+}
+
+ENTRY main {
+  p = f32[16,8] parameter(0)
+  mth = f32[16,8] custom-call(p), custom_call_target="MoveToHost"
+  zero = s32[] constant(0)
+  ds = f32[16,1] dynamic-slice(mth, zero, zero), dynamic_slice_sizes={16,1}
+  c0 = f32[] constant(0)
+  reduce = (f32[16], f32[16]) reduce(ds, ds, c0, c0), dimensions={1}, to_apply=reducer
+  gte = f32[16] get-tuple-element(reduce), index=0
+  ROOT mtd = f32[16] custom-call(gte), custom_call_target="MoveToDevice"
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunHostOffloader(module.get()));
+  EXPECT_TRUE(changed);
+  VLOG(1) << "module after: " << module->ToString();
+
+  EXPECT_FALSE(HaveRemainingOffloadAnnotations(module.get()));
+
+  // The dynamic-slice moves the data back to device; nothing after it is
+  // host compute.
+  HloInstruction* ds = FindInstruction(module.get(), "ds");
+  ASSERT_NE(ds, nullptr);
+  TestShapeHasMemorySpace(ds->operand(0)->shape(), Layout::kHostMemorySpace);
+  TestShapeHasMemorySpace(ds->shape(), Layout::kDefaultMemorySpace);
+
+  HloInstruction* reduce = FindInstruction(module.get(), "reduce");
+  ASSERT_NE(reduce, nullptr);
+  EXPECT_FALSE(host_offload_utils::ComputeTypeIsHost(reduce));
+  ASSERT_TRUE(reduce->shape().IsTuple());
+  for (const Shape& subshape : reduce->shape().tuple_shapes()) {
+    TestShapeHasMemorySpace(subshape, Layout::kDefaultMemorySpace);
+  }
+}
+
+TEST_F(HostOffloaderTest, VariadicReduceAsEntryRootOutputStreamed) {
+  // The entry result shape is a tuple; every leaf is in host memory.
+  const std::string& hlo_string = R"(
+HloModule m, entry_computation_layout={(f32[16,8]{1,0})->(f32[16]{0:S(5)}, f32[16]{0:S(5)})}
+
+reducer {
+  a = f32[] parameter(0)
+  b = f32[] parameter(1)
+  c = f32[] parameter(2)
+  d = f32[] parameter(3)
+  max = f32[] maximum(a, c)
+  add = f32[] add(b, d)
+  ROOT t = (f32[], f32[]) tuple(max, add)
+}
+
+ENTRY main {
+  p = f32[16,8] parameter(0)
+  mth = f32[16,8] custom-call(p), custom_call_target="MoveToHost"
+  slice = f32[16,4] slice(mth), slice={[0:16], [0:4]}
+  c0 = f32[] constant(0)
+  ROOT reduce = (f32[16], f32[16]) reduce(slice, slice, c0, c0), dimensions={1}, to_apply=reducer
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnVerifiedModule(hlo_string));
+
+  TF_ASSERT_OK_AND_ASSIGN(bool changed, RunHostOffloader(module.get()));
+  EXPECT_TRUE(changed);
+  VLOG(1) << "module after: " << module->ToString();
+
+  EXPECT_FALSE(HaveRemainingOffloadAnnotations(module.get()));
+
+  HloInstruction* reduce = FindInstruction(module.get(), "reduce");
+  ASSERT_NE(reduce, nullptr);
+  EXPECT_TRUE(host_offload_utils::ComputeTypeIsHost(reduce));
+  ASSERT_TRUE(reduce->shape().IsTuple());
+  for (const Shape& subshape : reduce->shape().tuple_shapes()) {
+    TestShapeHasMemorySpace(subshape, Layout::kHostMemorySpace);
+  }
+}
+
 }  // namespace
 }  // namespace xla

--- a/xla/service/host_offload_utils.cc
+++ b/xla/service/host_offload_utils.cc
@@ -95,10 +95,12 @@ absl::StatusOr<std::vector<InstructionAndShapeIndex>> GetSuccessors(
       }
     } else if (user->opcode() == HloOpcode::kGetTupleElement) {
       ShapeIndex tmp_shape_index = instruction_and_shape_index.shape_index;
-      CHECK(!tmp_shape_index.empty())
-          << "Expected shape index to be non-empty.";
-      const auto index = tmp_shape_index.front();
-      if (index == user->tuple_index()) {
+      if (tmp_shape_index.empty()) {
+        // The instruction itself produces the tuple (e.g. a variadic reduce),
+        // so the whole tuple is on host and every element read from it is a
+        // successor.
+        result.push_back({user, std::move(tmp_shape_index)});
+      } else if (tmp_shape_index.front() == user->tuple_index()) {
         // This GTE is for the buffer we're tracking.
         tmp_shape_index.pop_front();
         result.push_back({user, std::move(tmp_shape_index)});


### PR DESCRIPTION
## 📝 Summary of Changes

`HostOffloader` crashes at compile time when a variadic (tuple-shaped) `reduce` sits on a host-offloaded path, like in the module from #47382. The pass assumes only tuple/while/call plumbing can have a tuple shape, and that breaks in three places:

- `InstructionIsAllowedBetweenDsAndMoveToDevice` calls `ShapeUtil::TrueNumDimensions` on the reduce's result shape to detect "trivial" reduces. For a variadic reduce that shape is a tuple and `TrueNumDimensions` CHECK-fails. This is the crash reported in the issue.
- Once that is fixed, the walk continues past the reduce (now marked as host compute) into its `get-tuple-element` users, and `host_offload_utils::GetSuccessors` CHECK-fails because it expects a non-empty shape index whenever it meets a GTE. The reduce is tracked with an empty shape index because it is the instruction that produces the tuple.
- If the reduce is the entry root (which `TupleSimplifier` produces from `ROOT tuple(gte0, gte1)` before this pass runs), the output-streaming check in `WalkDownHostMemoryOffloadPaths` does `CHECK(has_layout())` on the tuple-shaped result and fails, since tuple shapes have no layout.

This change makes the predicate compare the operand against the first tuple element (all outputs of a variadic reduce have the same dimensions), makes `GetSuccessors` treat an empty shape index on a tuple-shaped instruction as "the whole tuple is tracked" so every GTE reading from it is a successor, and checks the entry output memory space per leaf. Array-shaped instructions go through exactly the same code as before. A non-trivial variadic reduce on host memory now becomes host compute with all outputs in host memory space, same as the non-variadic case; a trivial one stays on the dynamic-slice fast path, also same as the non-variadic case.

Added three tests to `host_offloader_test.cc`, one per case. All abort before this change.

## 🎯 Justification

Fixes #47382. Compile-time process abort on valid HLO with default flags (GPU, and TPU since the pass is shared; CPU does not run `HostOffloader`).

## 🚀 Kind of Contribution

🐛 Bug Fix

## 🧪 Unit Tests:

`bazel test //xla/hlo/transforms:host_offloader_test //xla/hlo/transforms:host_offload_legalize_test //xla/service:host_offload_utils_test`

## 🧪 Execution Tests:

None (hardware-independent pass tests).