### PR TITLE
Force link statically specific targets even with dynamic_mode=fully

### DIFF
--- a/third_party/gpus/sycl/BUILD.tpl
+++ b/third_party/gpus/sycl/BUILD.tpl
@@ -47,6 +47,8 @@ cc_library(
         ".",
         "level_zero/include",
     ],
+    # -supports_dynamic_linker: Forces static linking even with --dynamic_mode=fully
+    features = ["-supports_dynamic_linker"],
     linkstatic = 1,
     visibility = ["//visibility:public"],
 )
@@ -70,6 +72,8 @@ cc_library(
         ".",
         "sycl/include",
     ],
+    # -supports_dynamic_linker: Forces static linking even with --dynamic_mode=fully
+    features = ["-supports_dynamic_linker"],
     linkopts = ["-Wl,-Bstatic,-lsvml,-lirng,-limf,-lirc,-lirc_s,-Bdynamic"],
     linkstatic = 1,
     visibility = ["//visibility:public"],

--- a/third_party/tensorrt/BUILD.tpl
+++ b/third_party/tensorrt/BUILD.tpl
@@ -51,6 +51,8 @@ cc_library(
         ":use_static_tensorrt": [],
         "//conditions:default": [":tensorrt_lib"],
     }),
+    # -supports_dynamic_linker: Forces static linking even with --dynamic_mode=fully
+    features = ["-supports_dynamic_linker"],
     linkstatic = 1,
     deps = [
         ":tensorrt_headers",

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -262,6 +262,8 @@ cc_library(
         "cupti_wrapper_stub.cc",
     ],
     hdrs = ["cupti_wrapper.h"],
+    # -supports_dynamic_linker: Forces static linking even with --dynamic_mode=fully
+    features = ["-supports_dynamic_linker"],
     linkstatic = 1,
     tags = [
         "cuda-only",

--- a/xla/mlir/utils/BUILD
+++ b/xla/mlir/utils/BUILD
@@ -47,6 +47,8 @@ cc_library(
 xla_cc_test(
     name = "error_util_test",
     srcs = ["error_util_test.cc"],
+    # -supports_dynamic_linker: Forces static linking even with --dynamic_mode=fully
+    features = ["-supports_dynamic_linker"],
     linkstatic = 1,
     deps = [
         ":error_util",

--- a/xla/tsl/platform/default/BUILD
+++ b/xla/tsl/platform/default/BUILD
@@ -450,6 +450,8 @@ cc_library(
     name = "stacktrace_handler",
     srcs = ["stacktrace_handler.cc"],
     hdrs = ["@tsl//tsl/platform:stacktrace_handler_hdrs"],
+    # -supports_dynamic_linker: Forces static linking even with --dynamic_mode=fully
+    features = ["-supports_dynamic_linker"],
     linkstatic = 1,
     deps = [
         "@tsl//tsl/platform",


### PR DESCRIPTION
📝 Summary of Changes
Force static linking on certain targets even when compiled through
--dynamic_mode=fully

🎯 Justification
We switched rocm to dynamic_mode=fully, that in order to 
reduce the network load to our CI. However some targets
are supposed to be linked statically through linkstatic=True.
This is ignored by dynamic_mode=fully.

🚀 Kind of Contribution
Please remove what does not apply:  ♻️ Cleanup

📊 Benchmark (for Performance Improvements)
Not relevant

🧪 Unit Tests:
CI

🧪 Execution Tests:
CI
