### PR TITLE
[ROCm] Add  `ProfileOptions.advanced_configuration` into the ROCm tracer (PR1)

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -536,6 +536,16 @@ cc_library(
     ],
 )
 
+xla_cc_test(
+    name = "rocm_tracer_utils_test",
+    size = "small",
+    srcs = ["rocm_tracer_utils_test.cc"],
+    deps = [
+        ":rocm_tracer_utils",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "rocm_collector",
     srcs = ["rocm_collector.cc"],

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -96,7 +96,6 @@ RocmTraceCollectorOptions GpuTracer::GetRocmTraceCollectorOptions(
 
   options.max_callback_api_events = max_events;
   options.max_activity_api_events = max_events;
-  options.max_annotation_strings = max_events;
   return options;
 }
 

--- a/xla/backends/profiler/gpu/rocm_collector_test.cc
+++ b/xla/backends/profiler/gpu/rocm_collector_test.cc
@@ -55,7 +55,6 @@ TEST(RocmCollectorTest, TestAddKernelEventAndExport) {
   RocmTraceCollectorOptions options;
   options.max_callback_api_events = 100;
   options.max_activity_api_events = 100;
-  options.max_annotation_strings = 100;
   options.num_gpus = 1;
 
   constexpr uint64_t kStartWallTimeNs = 1000;
@@ -133,7 +132,6 @@ TEST(RocmCollectorTest, MultipleActivitiesPerCorrelationIdAllExported) {
   RocmTraceCollectorOptions options;
   options.max_callback_api_events = 100;
   options.max_activity_api_events = 100;
-  options.max_annotation_strings = 100;
   options.num_gpus = 1;
 
   constexpr uint64_t kStartWallTimeNs = 1000;
@@ -269,7 +267,6 @@ TEST(RocmCollectorTest, MarkerEventsRespectMaxCallbackApiEvents) {
   RocmTraceCollectorOptions options;
   options.max_callback_api_events = 8;
   options.max_activity_api_events = 100;
-  options.max_annotation_strings = 100;
   options.num_gpus = 1;
 
   DropCountingCollector collector(options, /*start_walltime_ns=*/1000,
@@ -310,7 +307,6 @@ TEST(RocmCollectorTest, MarkerEventsDroppedWhenNoGpusReported) {
   RocmTraceCollectorOptions options;
   options.max_callback_api_events = 100;
   options.max_activity_api_events = 100;
-  options.max_annotation_strings = 100;
   options.num_gpus = 0;
 
   RocmTraceCollectorImpl collector(options, /*start_walltime_ns=*/1000,
@@ -338,7 +334,6 @@ TEST(RocmCollectorTest, MarkerAndApiEventsOnSameThreadGetSeparateLines) {
   RocmTraceCollectorOptions options;
   options.max_callback_api_events = 100;
   options.max_activity_api_events = 100;
-  options.max_annotation_strings = 100;
   options.num_gpus = 1;
 
   RocmTraceCollectorImpl collector(options, /*start_walltime_ns=*/1000,

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -164,9 +164,12 @@ absl::Status RocmTracer::Enable(const RocmTracerOptions& options,
     return absl::AlreadyExistsError("ROCM tracer is already running");
   }
 
-  // Clear per-session state while holding collector_mutex_ so no in-flight
-  // callback can race between the clear and the new session start.
-  annotation_map_.Clear();
+  // Reset clears all entries and sets the new capacity under one lock, so
+  // there is no window in which a straggler callback from the previous session
+  // (rocprofiler_stop_context closes the gate without joining threads already
+  // past it) can observe an inconsistent state. Must run before
+  // rocprofiler_start_context opens the gate for the new session.
+  annotation_map_.Reset(options.max_annotation_strings);
   // ROCTX frames live on thread_local stacks this thread cannot reach, so
   // isolate by generation instead of clearing: any frame pushed before this
   // point is now stale and will be dropped at pop rather than emitted into

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -33,12 +33,6 @@ namespace profiler {
 // forward declare (interface)
 class RocmTraceCollector;
 
-struct RocmTracerOptions {
-  // maximum number of annotation strings that AnnotationMap in RocmTracer can
-  // store. e.g. 1M
-  uint64_t max_annotation_strings;
-};
-
 // The class use to enable rocprofiler-sdk buffered callback/activity tracing
 // and forward the collected trace events to RocmTraceCollector. There should be
 // only one RocmTracer per process.
@@ -121,7 +115,7 @@ class RocmTracer {
   bool api_tracing_enabled_{false};
   bool activity_tracing_enabled_{false};
 
-  AnnotationMap annotation_map_{/* default size, e.g. */ 1024 * 1024};
+  AnnotationMap annotation_map_;
 
   // ROCTX range state lives in a thread_local stack in rocm_tracer.cc, not
   // here. roctx pushes and pops are thread-local by definition and the

--- a/xla/backends/profiler/gpu/rocm_tracer_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_test.cc
@@ -85,7 +85,6 @@ std::unique_ptr<TestRocmTraceCollector> CreateTestCollector() {
   RocmTraceCollectorOptions options;
   options.max_callback_api_events = 2 * 1024 * 1024;
   options.max_activity_api_events = 2 * 1024 * 1024;
-  options.max_annotation_strings = 1024 * 1024;
   options.num_gpus = 1;
 
   uint64_t walltime_ns = RocmTracer::GetTimestamp();
@@ -151,7 +150,8 @@ TEST(RocmTracerTest, EnableAndDisableLifecycle) {
   RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
   auto collector = CreateTestCollector();
 
-  RocmTracerOptions tracer_options{/*max_annotation_strings=*/128};
+  RocmTracerOptions tracer_options;
+  tracer_options.max_annotation_strings = 128;
   TF_ASSERT_OK(tracer.Enable(tracer_options, collector.get()));
 
   EXPECT_FALSE(tracer.IsAvailable())
@@ -171,6 +171,7 @@ TEST(RocmTracerTest, AnnotationMapWorks) {
   RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
   AnnotationMap* map = tracer.annotation_map();
   ASSERT_NE(map, nullptr);
+  map->Reset(1024);  // no Enable() in this test, so set the capacity here
 
   uint64_t id = 42;
   std::string annotation = "matmul_fused_op";
@@ -184,13 +185,14 @@ TEST(RocmTracerTest, AnnotationMapClear) {
   RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
   AnnotationMap* map = tracer.annotation_map();
   ASSERT_NE(map, nullptr);
+  map->Reset(1024);  // no Enable() in this test, so set the capacity here
 
   map->Add(100, "op_a");
   map->Add(101, "op_b");
   EXPECT_EQ(map->LookUp(100), "op_a");
   EXPECT_EQ(map->LookUp(101), "op_b");
 
-  map->Clear();
+  map->Reset(1024);
 
   EXPECT_TRUE(map->LookUp(100).empty());
   EXPECT_TRUE(map->LookUp(101).empty());
@@ -217,7 +219,6 @@ class EventCapturingCollector : public RocmTraceCollector {
     RocmTraceCollectorOptions options;
     options.max_callback_api_events = 2 * 1024 * 1024;
     options.max_activity_api_events = 2 * 1024 * 1024;
-    options.max_annotation_strings = 1024 * 1024;
     options.num_gpus = RocmTracer::GetRocmTracerSingleton().NumGpus();
     return options;
   }
@@ -239,7 +240,8 @@ TEST(RocmTracerTest, CapturesHipEvents) {
   EventCapturingCollector* collector_ptr = collector.get();
 
   RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
-  RocmTracerOptions tracer_options{/*max_annotation_strings=*/1024 * 1024};
+  RocmTracerOptions tracer_options;
+  tracer_options.max_annotation_strings = 1024 * 1024;
   TF_ASSERT_OK(tracer.Enable(tracer_options, collector.get()));
 
   constexpr size_t kNumFloats = 1024;
@@ -272,7 +274,8 @@ TEST(RocmTracerTest, DisableStopsRocprofilerContext) {
   ASSERT_TRUE(tracer.IsAvailable());
 
   auto collector = CreateTestCollector();
-  RocmTracerOptions tracer_options{/*max_annotation_strings=*/128};
+  RocmTracerOptions tracer_options;
+  tracer_options.max_annotation_strings = 128;
   TF_ASSERT_OK(tracer.Enable(tracer_options, collector.get()));
 
   int active = -1;
@@ -297,7 +300,8 @@ TEST(RocmTracerTest, DisableIsolatesNextSession) {
   RocmTracer& tracer = RocmTracer::GetRocmTracerSingleton();
   ASSERT_TRUE(tracer.IsAvailable());
 
-  RocmTracerOptions tracer_options{/*max_annotation_strings=*/1024 * 1024};
+  RocmTracerOptions tracer_options;
+  tracer_options.max_annotation_strings = 1024 * 1024;
   constexpr size_t kNumFloats = 1024;
   constexpr size_t kSize = kNumFloats * sizeof(float);
   std::vector<float> host_data(kNumFloats, 1.0f);
@@ -374,7 +378,6 @@ class MarkerCapturingCollector : public RocmTraceCollector {
     RocmTraceCollectorOptions o;
     o.max_callback_api_events = 1024;
     o.max_activity_api_events = 1024;
-    o.max_annotation_strings = 1024;
     o.num_gpus = 1;
     return o;
   }
@@ -405,7 +408,8 @@ TEST(RocmTracerTest, MarkerCallbackPushPopEmitsRoctxRange) {
   auto collector = std::make_unique<MarkerCapturingCollector>();
   MarkerCapturingCollector* cptr = collector.get();
 
-  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  RocmTracerOptions opts;
+  opts.max_annotation_strings = 1024;
   TF_ASSERT_OK(tracer.Enable(opts, cptr));
 
   const uint64_t tid = 12345;
@@ -459,7 +463,8 @@ TEST(RocmTracerTest, MarkerCallbackMarkEmitsInstantaneousEvent) {
   auto collector = std::make_unique<MarkerCapturingCollector>();
   MarkerCapturingCollector* cptr = collector.get();
 
-  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  RocmTracerOptions opts;
+  opts.max_annotation_strings = 1024;
   TF_ASSERT_OK(tracer.Enable(opts, cptr));
 
   const uint64_t tid = 77777;
@@ -493,7 +498,8 @@ TEST(RocmTracerTest, MarkerCallbackUnmatchedPopIsIgnored) {
   auto collector = std::make_unique<MarkerCapturingCollector>();
   MarkerCapturingCollector* cptr = collector.get();
 
-  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  RocmTracerOptions opts;
+  opts.max_annotation_strings = 1024;
   TF_ASSERT_OK(tracer.Enable(opts, cptr));
 
   // Pop without any preceding Push — must not crash, must not emit any event.
@@ -516,7 +522,8 @@ TEST(RocmTracerTest, MarkerCallbackNullLabelRangeIsDroppedNotEmitted) {
   auto collector = std::make_unique<MarkerCapturingCollector>();
   MarkerCapturingCollector* cptr = collector.get();
 
-  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  RocmTracerOptions opts;
+  opts.max_annotation_strings = 1024;
   TF_ASSERT_OK(tracer.Enable(opts, cptr));
 
   const uint64_t tid = 2222;
@@ -556,7 +563,8 @@ TEST(RocmTracerTest, MarkerCallbackNullLabelRangeKeepsStackBalanced) {
   auto collector = std::make_unique<MarkerCapturingCollector>();
   MarkerCapturingCollector* cptr = collector.get();
 
-  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  RocmTracerOptions opts;
+  opts.max_annotation_strings = 1024;
   TF_ASSERT_OK(tracer.Enable(opts, cptr));
 
   const uint64_t tid = 2223;
@@ -601,7 +609,6 @@ TEST(RocmTracerTest, MarkerEventAppearsInExportedXSpace) {
   RocmTraceCollectorOptions col_opts;
   col_opts.max_callback_api_events = 1024;
   col_opts.max_activity_api_events = 1024;
-  col_opts.max_annotation_strings = 1024;
   col_opts.num_gpus = tracer.NumGpus() > 0 ? tracer.NumGpus() : 1;
 
   uint64_t start_gpu = RocmTracer::GetTimestamp();
@@ -610,7 +617,8 @@ TEST(RocmTracerTest, MarkerEventAppearsInExportedXSpace) {
       std::make_unique<RocmTraceCollectorImpl>(col_opts, start_wall, start_gpu);
   collector->SetGpuAgents(tracer.GpuAgents());
 
-  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  RocmTracerOptions opts;
+  opts.max_annotation_strings = 1024;
   TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
 
   const uint64_t tid = 4242;
@@ -716,7 +724,6 @@ TEST(RocmTracerTest, RealRoctxCallsProduceNvtxRangeInXSpace) {
   RocmTraceCollectorOptions col_opts;
   col_opts.max_callback_api_events = 1024;
   col_opts.max_activity_api_events = 1024;
-  col_opts.max_annotation_strings = 1024;
   col_opts.num_gpus = tracer.NumGpus() > 0 ? tracer.NumGpus() : 1;
 
   uint64_t start_gpu = RocmTracer::GetTimestamp();
@@ -725,7 +732,8 @@ TEST(RocmTracerTest, RealRoctxCallsProduceNvtxRangeInXSpace) {
       std::make_unique<RocmTraceCollectorImpl>(col_opts, start_wall, start_gpu);
   collector->SetGpuAgents(tracer.GpuAgents());
 
-  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  RocmTracerOptions opts;
+  opts.max_annotation_strings = 1024;
   TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
 
   // Emit real ROCTX ranges — rocprofiler-sdk intercepts these and fires
@@ -812,7 +820,8 @@ TEST(RocmTracerTest, GetCurrentRoctxLabelReturnsTopOfStack) {
   ASSERT_TRUE(tracer.IsAvailable());
 
   auto collector = std::make_unique<MarkerCapturingCollector>();
-  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  RocmTracerOptions opts;
+  opts.max_annotation_strings = 1024;
   TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
 
   const uint64_t tid = 55555;
@@ -840,7 +849,8 @@ TEST(RocmTracerTest, GetCurrentRoctxLabelEmptyAfterPop) {
   ASSERT_TRUE(tracer.IsAvailable());
 
   auto collector = std::make_unique<MarkerCapturingCollector>();
-  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  RocmTracerOptions opts;
+  opts.max_annotation_strings = 1024;
   TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
 
   const uint64_t tid = 55556;
@@ -862,19 +872,21 @@ TEST(RocmTracerTest, GetCurrentRoctxLabelEmptyAfterPop) {
 }
 
 TEST(RocmTracerTest, AnnotationMapStoresRoctxRange) {
-  AnnotationMap map(1024);
+  AnnotationMap map;
+  map.Reset(1024);
   map.Add(99, "my_annotation", "my_roctx_label", {});
   EXPECT_EQ(map.LookUp(99), "my_annotation");
   EXPECT_EQ(map.LookUpRoctxRange(99), "my_roctx_label");
 
   EXPECT_EQ(map.LookUpRoctxRange(100), "");
 
-  map.Clear();
+  map.Reset(1024);
   EXPECT_EQ(map.LookUpRoctxRange(99), "");
 }
 
 TEST(RocmTracerTest, AnnotationMapRoctxRangeEmptyWhenNotProvided) {
-  AnnotationMap map(1024);
+  AnnotationMap map;
+  map.Reset(1024);
   map.Add(42, "some_op", {}, {});
   EXPECT_EQ(map.LookUp(42), "some_op");
   EXPECT_EQ(map.LookUpRoctxRange(42), "");
@@ -884,7 +896,8 @@ TEST(RocmTracerTest, AnnotationMapRoctxRangeEmptyWhenNotProvided) {
 // so that standalone ROCTX annotations (no XLA AnnotationStack text) still
 // produce kNVTXRange on kernel events.
 TEST(RocmTracerTest, AnnotationMapStoresRoctxRangeWhenAnnotationEmpty) {
-  AnnotationMap map(1024);
+  AnnotationMap map;
+  map.Reset(1024);
   // annotation is empty, roctx_range is not.
   map.Add(77, /*annotation=*/"", "roctx_only_label", {});
   EXPECT_EQ(map.LookUp(77), "")
@@ -905,7 +918,8 @@ TEST(RocmTracerTest, GetCurrentRoctxLabelViewIsValidUntilNextRoctxCall) {
   ASSERT_TRUE(tracer.IsAvailable());
 
   auto collector = std::make_unique<MarkerCapturingCollector>();
-  RocmTracerOptions opts{/*max_annotation_strings=*/1024};
+  RocmTracerOptions opts;
+  opts.max_annotation_strings = 1024;
   TF_ASSERT_OK(tracer.Enable(opts, collector.get()));
 
   const uint64_t tid = 66666;

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.cc
@@ -158,13 +158,14 @@ ScopeRangeIdTree AnnotationMap::TakeScopeRangeIdTree() {
   return std::move(map_.scope_range_id_tree);
 }
 
-void AnnotationMap::Clear() {
+void AnnotationMap::Reset(uint64_t max_size) {
   absl::MutexLock lock(map_.mutex);
   map_.correlation_map.clear();
   map_.roctx_range_map.clear();
   map_.scope_range_id_map.clear();
   map_.scope_range_id_tree.clear();
   map_.annotations.clear();
+  max_size_ = max_size;
 }
 
 }  // namespace profiler

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -174,7 +174,7 @@ struct RoctxFrame {
   // TODO(rocm-profiler): carry a reference into AnnotationMap's intern pool
   // instead of owning a copy. Blocked on lifetime, not on the generation
   // check: the generation guards *emission*, but Enable() calls
-  // annotation_map_.Clear() while frames pushed before it are still live on
+  // annotation_map_.Reset() while frames pushed before it are still live on
   // some other thread's stack, so a reference would dangle even though the
   // frame is correctly dropped at pop. Needs the pool to outlive the session
   // (or a per-frame refcount) before the copy can go.
@@ -188,6 +188,15 @@ struct RoctxFrame {
   uint64_t generation;
 };
 
+struct RocmTracerOptions {
+  // Maximum number of annotation strings that AnnotationMap in RocmTracer can
+  // store. GpuTracer::BuildOptions is the single source of truth; callers that
+  // value-initialize this struct (e.g. RocmTracerOptions{}) will get 0, which
+  // is a valid value meaning "retain no annotations". Always set this field
+  // explicitly before passing the struct to Enable().
+  uint64_t max_annotation_strings;
+};
+
 struct RocmTraceCollectorOptions {
   // Maximum number of events to collect from callback API; if -1, no limit.
   // if 0, the callback API is enabled to build a correlation map, but no
@@ -195,15 +204,16 @@ struct RocmTraceCollectorOptions {
   uint64_t max_callback_api_events;
   // Maximum number of events to collect from activity API; if -1, no limit.
   uint64_t max_activity_api_events;
-  // Maximum number of annotation strings that we can accommodate.
-  uint64_t max_annotation_strings;
-  // Number of GPUs involved.
+  // Number of GPUs involved. No default: 0 silently produces an empty profile
+  // (RocmTraceCollectorImpl drops every event when num_gpus_==0).
   uint32_t num_gpus;
 };
 
 class AnnotationMap {
  public:
-  explicit AnnotationMap(uint64_t max_size) : max_size_(max_size) {}
+  // Constructed with a capacity of 0, i.e. retaining nothing. Reset() sets the
+  // capacity, and RocmTracer::Enable() calls it before any callback can fire.
+  AnnotationMap() = default;
   void Add(uint64_t correlation_id, const std::string& annotation,
            absl::string_view roctx_range = {},
            absl::Span<const int64_t> scope_range_ids = {});
@@ -211,7 +221,12 @@ class AnnotationMap {
   absl::string_view LookUpRoctxRange(uint64_t correlation_id);
   int64_t LookUpScopeRangeId(uint64_t correlation_id);
   ScopeRangeIdTree TakeScopeRangeIdTree();
-  void Clear();
+
+  // Clears all entries and sets the new capacity for the coming session.
+  // Both operations are performed under a single acquisition of map_.mutex,
+  // so there is no window in which a straggler Add() from the previous session
+  // can observe the map in a partially-reset state.
+  void Reset(uint64_t max_size);
 
  private:
   struct AnnotationMapImpl {
@@ -231,8 +246,8 @@ class AnnotationMap {
         ABSL_GUARDED_BY(mutex);
     ScopeRangeIdTree scope_range_id_tree ABSL_GUARDED_BY(mutex);
   };
-  const uint64_t max_size_;
   AnnotationMapImpl map_;
+  uint64_t max_size_ ABSL_GUARDED_BY(map_.mutex) = 0;
 
  public:
   // Disable copy and move.

--- a/xla/backends/profiler/gpu/rocm_tracer_utils_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils_test.cc
@@ -1,0 +1,152 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+
+#include <cstdint>
+#include <string>  // AnnotationMap::Add takes const std::string&
+
+#include <gtest/gtest.h>
+
+namespace xla {
+namespace profiler {
+namespace {
+
+// The AnnotationMap capacity is what gpu_max_annotation_strings ultimately
+// controls, so it needs a test that does not require a GPU. rocm_tracer_utils
+// has no ROCm dependency, which is what makes this file host-only.
+
+TEST(AnnotationMapTest, HonoursConfiguredSize) {
+  AnnotationMap map;
+  map.Reset(2);
+  map.Add(1, "first");
+  map.Add(2, "second");
+  map.Add(3, "third");
+
+  EXPECT_EQ(map.LookUp(1), "first");
+  EXPECT_EQ(map.LookUp(2), "second");
+  // Over capacity: silently not retained. Add() is on the callback hot path
+  // and deliberately does not log per-drop.
+  EXPECT_TRUE(map.LookUp(3).empty());
+}
+
+TEST(AnnotationMapTest, FullStringSetAlsoStopsCorrelatingKnownStrings) {
+  // Characterisation test, not an endorsement. The size check gates the whole
+  // Add(), correlation-map insertion included, so once the distinct-string set
+  // is full, later events are left uncorrelated even when their annotation is
+  // one the map already holds. Repeating an annotation is therefore *not*
+  // free at the boundary.
+  //
+  // CUPTI does the same thing (AnnotationMap::Add in cupti_buffer_events.cc
+  // gates on annotation_deduper.Size() < max_size_ before correlation_map
+  // insertion),
+  // so this is shared cross-vendor behaviour rather than a ROCm defect, and
+  // changing it is out of scope here. Pinned so that a future change to either
+  // side is a deliberate one.
+  AnnotationMap map;
+  map.Reset(1);
+  for (uint32_t i = 0; i < 100; ++i) {
+    map.Add(i, "same_annotation");
+  }
+  EXPECT_EQ(map.LookUp(0), "same_annotation");
+  EXPECT_TRUE(map.LookUp(99).empty());
+}
+
+TEST(AnnotationMapTest, ResetRaisesTheCapAndClearsEntries) {
+  // Reset atomically clears entries and sets a new capacity -- the path
+  // RocmTracer::Enable takes at the start of each session.
+  AnnotationMap map;
+  map.Reset(1);
+  map.Add(1, "first");
+  ASSERT_TRUE(map.LookUp(2).empty()) << "precondition: cap of 1 is in force";
+
+  map.Reset(3);  // clears "first" and raises the cap in one step
+  map.Add(1, "first");
+  map.Add(2, "second");
+  map.Add(3, "third");
+
+  EXPECT_EQ(map.LookUp(1), "first");
+  EXPECT_EQ(map.LookUp(2), "second");
+  EXPECT_EQ(map.LookUp(3), "third");
+}
+
+TEST(AnnotationMapTest, ResetLowersTheCapForSubsequentAdds) {
+  AnnotationMap map;
+  map.Reset(100);
+  map.Reset(1);
+  map.Add(1, "first");
+  map.Add(2, "second");
+
+  EXPECT_EQ(map.LookUp(1), "first");
+  EXPECT_TRUE(map.LookUp(2).empty());
+}
+
+TEST(AnnotationMapTest, ResetToZeroRetainsNothing) {
+  // 0 means "retain no annotation strings", not "unlimited". RocmTracer::Enable
+  // passes gpu_max_annotation_strings straight through, so this is the value a
+  // user gets by asking for zero -- it must not be reinterpreted, and it must
+  // not silently leave the previous capacity in force.
+  AnnotationMap map;
+  map.Reset(8);
+  map.Reset(0);
+  map.Add(1, "first");
+
+  EXPECT_TRUE(map.LookUp(1).empty());
+}
+
+TEST(AnnotationMapTest, ResetClearsOldEntriesBeforeNewSession) {
+  // Reset drops all entries from the old session and sets the new capacity in
+  // one step. An entry that was live before Reset must not be visible after.
+  AnnotationMap map;
+  map.Reset(8);
+  map.Add(1, "old_entry");
+  ASSERT_EQ(map.LookUp(1), "old_entry");
+
+  map.Reset(2);  // new session starts; old_entry must be gone
+  EXPECT_TRUE(map.LookUp(1).empty()) << "Reset must clear old entries";
+
+  map.Add(2, "new_a");
+  map.Add(3, "new_b");
+  map.Add(4, "past_cap");  // cap=2, so this is dropped
+  EXPECT_EQ(map.LookUp(2), "new_a");
+  EXPECT_EQ(map.LookUp(3), "new_b");
+  EXPECT_TRUE(map.LookUp(4).empty());
+}
+
+TEST(AnnotationMapTest, EmptyAnnotationIsIgnored) {
+  // Empty annotations must not consume capacity; the ROCTX path can produce
+  // them and they would otherwise crowd out real ones.
+  AnnotationMap map;
+  map.Reset(1);
+  map.Add(1, "");
+  map.Add(2, "real");
+
+  EXPECT_TRUE(map.LookUp(1).empty());
+  EXPECT_EQ(map.LookUp(2), "real");
+}
+
+TEST(AnnotationMapTest, ResetDropsEntries) {
+  AnnotationMap map;
+  map.Reset(8);
+  map.Add(1, "first");
+  ASSERT_EQ(map.LookUp(1), "first");
+
+  map.Reset(8);  // same cap; entries must be gone
+  EXPECT_TRUE(map.LookUp(1).empty());
+}
+
+}  // namespace
+}  // namespace profiler
+}  // namespace xla

--- a/xla/service/gpu/model/hlo_op_profiler_rocm.cc
+++ b/xla/service/gpu/model/hlo_op_profiler_rocm.cc
@@ -65,7 +65,6 @@ class RocmKernelTracer : public HloOpProfiler::KernelTracer,
     profiler::RocmTraceCollectorOptions options;
     options.max_callback_api_events = 2 * 1024 * 1024;
     options.max_activity_api_events = 2 * 1024 * 1024;
-    options.max_annotation_strings = 1024 * 1024;
     options.num_gpus = num_gpus;
     return options;
   }


### PR DESCRIPTION
## Problem

This is the first PR of three to add `ProfileOptions.advanced_configuration` into the ROCm tracer.

Currently, the ROCm `GpuTracer` ignores `advanced_configuration` entirely — it reads only
`device_type()` and drops the rest. A JAX user who sets any `gpu_*` key, or
misspells one, gets the same hardcoded trace with nothing in the result to say why.

The CUPTI backend parses the map but fails `Start()` on a bad key.
`ProfilerController::CollectData` only forwards to a tracer whose `Start()`
succeeded, so the `add_errors` calls at `kStoppedOk` are never reached — the
user loses the GPU plane with no in-trace explanation.

**Move `RocmTracerOptions` to `rocm_tracer_utils.h`.** `rocm_tracer.h` pulls in
the rocprofiler-sdk headers; `rocm_tracer_utils` has no ROCm dependency. This is
what makes PR 2's new library host-buildable. Source-compatible: `rocm_tracer.h`
already includes `rocm_tracer_utils.h`.

**Add `AnnotationMap::SetMaxSize()`.** `max_size_` was `const` and hardcoded at
4 M, so `gpu_max_annotation_strings` had nowhere to land. `SetMaxSize` is called
from `Enable()` immediately after `Clear()` and **before**
`rocprofiler_start_context()` — once that returns, callback threads are live.

Adds `kDefaultMaxAnnotationStrings = 4 * 1024 * 1024` so the three sites that
name this value (the member initialiser, the struct NSDMI, and PR 3's
`BuildOptions`) stay in sync.

**Tests:** `rocm_tracer_utils_test.cc`, 8 cases, host-only, no GPU.