### PR TITLE
[ROCm] Add ProfileOptions.advanced_configuration into the ROCm tracer (PR3)

### DIFF
--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -546,6 +546,43 @@ xla_cc_test(
     ],
 )
 
+# Deliberately carries no rocm-only/gpu/manual tag: this target has no ROCm
+# dependency, which is what lets its test run on ordinary presubmit machines.
+# Keep it that way.
+cc_library(
+    name = "rocm_tracer_options_utils",
+    srcs = ["rocm_tracer_options_utils.cc"],
+    hdrs = ["rocm_tracer_options_utils.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":rocm_tracer_utils",
+        "//xla/tsl/profiler/utils:profiler_options_util",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@tsl//tsl/profiler/protobuf:profiler_options_proto_cc",
+        "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+    ],
+)
+
+xla_cc_test(
+    name = "rocm_tracer_options_utils_test",
+    size = "small",
+    srcs = ["rocm_tracer_options_utils_test.cc"],
+    deps = [
+        ":rocm_tracer_options_utils",
+        ":rocm_tracer_utils",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_googletest//:gtest_main",
+        "@tsl//tsl/profiler/protobuf:profiler_options_proto_cc",
+        "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+    ],
+)
+
 cc_library(
     name = "rocm_collector",
     srcs = ["rocm_collector.cc"],

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -88,6 +88,7 @@ cc_library(
     deps = [
         ":rocm_collector",
         ":rocm_tracer",
+        ":rocm_tracer_options_utils",
         ":rocm_tracer_utils",
         "//xla:debug_options_flags",
         "//xla/stream_executor/rocm:roctracer_wrapper",
@@ -678,6 +679,32 @@ xla_cc_test(
         "@local_config_rocm//rocm:rocm_headers",
         "@local_config_rocm//rocm:rocprofiler_sdk",  # buildcleaner: keep
         "@local_config_rocm//rocm:rocprofiler_sdk_roctx",  # buildcleaner: keep
+        "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+    ],
+)
+
+xla_cc_test(
+    name = "device_tracer_rocm_test",
+    size = "small",
+    srcs = ["device_tracer_rocm_test.cc"],
+    tags = [
+        "gpu",
+        "rocm-only",
+    ] + if_google([
+        "manual",
+    ]),
+    deps = [
+        ":device_tracer_rocm",
+        "//xla/tsl/lib/core:status_test_util",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_rocm//rocm:hip",  # buildcleaner: keep
+        "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:rocprofiler_sdk",  # buildcleaner: keep
+        "@tsl//tsl/profiler/lib:profiler_interface",
+        "@tsl//tsl/profiler/protobuf:profiler_options_proto_cc",
         "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
     ],
 )

--- a/xla/backends/profiler/gpu/BUILD
+++ b/xla/backends/profiler/gpu/BUILD
@@ -536,6 +536,16 @@ cc_library(
     ],
 )
 
+xla_cc_test(
+    name = "rocm_tracer_utils_test",
+    size = "small",
+    srcs = ["rocm_tracer_utils_test.cc"],
+    deps = [
+        ":rocm_tracer_utils",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "rocm_collector",
     srcs = ["rocm_collector.cc"],

--- a/xla/backends/profiler/gpu/device_tracer_rocm.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm.cc
@@ -15,12 +15,15 @@ limitations under the License.
 
 #include <cstdint>
 #include <memory>
+#include <string>
 
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
 #include "xla/backends/profiler/gpu/rocm_collector.h"
 #include "xla/backends/profiler/gpu/rocm_tracer.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_options_utils.h"
 #include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
 #include "xla/debug_options_flags.h"
 #include "xla/tsl/platform/env_time.h"
@@ -42,7 +45,8 @@ using tsl::profiler::XSpace;
 // GpuTracer for ROCm GPU.
 class GpuTracer : public profiler::ProfilerInterface {
  public:
-  explicit GpuTracer(RocmTracer* rocm_tracer) : rocm_tracer_(rocm_tracer) {
+  GpuTracer(RocmTracer* rocm_tracer, const ProfileOptions& profile_options)
+      : profile_options_(profile_options), rocm_tracer_(rocm_tracer) {
     LOG(INFO) << "GpuTracer created.";
   }
   ~GpuTracer() override {}
@@ -56,8 +60,12 @@ class GpuTracer : public profiler::ProfilerInterface {
   absl::Status DoStart();
   absl::Status DoStop();
 
-  RocmTracerOptions GetRocmTracerOptions();
-  RocmTraceCollectorOptions GetRocmTraceCollectorOptions(uint32_t num_gpus);
+  // Seeds both option structs from the hardcoded defaults and the
+  // --xla_gpu_rocm_max_trace_events flag, then applies
+  // ProfileOptions.advanced_configuration on top. Records any complaint in
+  // option_diagnostics_ instead of failing.
+  void BuildOptions(uint32_t num_gpus, RocmTracerOptions& tracer_options,
+                    RocmTraceCollectorOptions& collector_options);
 
   enum State {
     kNotStarted,
@@ -68,21 +76,35 @@ class GpuTracer : public profiler::ProfilerInterface {
   };
   State profiling_state_ = State::kNotStarted;
 
+  const ProfileOptions profile_options_;
+  RocmTracerOptionDiagnostics option_diagnostics_;
+  // Whether option_diagnostics_ has already been written into an XSpace.
+  bool diagnostics_delivered_ = false;
   RocmTracer* rocm_tracer_;
   std::unique_ptr<RocmTraceCollector> rocm_trace_collector_;
 };
 
-RocmTracerOptions GpuTracer::GetRocmTracerOptions() {
-  RocmTracerOptions options;
-  options.max_annotation_strings = 4 * 1024 * 1024;
-  return options;
-}
+void GpuTracer::BuildOptions(uint32_t num_gpus,
+                             RocmTracerOptions& tracer_options,
+                             RocmTraceCollectorOptions& collector_options) {
+  // Rebuilt from scratch on every start, so that a second Start() on the same
+  // tracer does not report the first session's complaints a second time.
+  option_diagnostics_ = RocmTracerOptionDiagnostics{};
+  diagnostics_delivered_ = false;
 
-RocmTraceCollectorOptions GpuTracer::GetRocmTraceCollectorOptions(
-    uint32_t num_gpus) {
-  RocmTraceCollectorOptions options;
-  options.num_gpus = num_gpus;
+  // Layer 1: hardcoded defaults, unchanged from what this file used before
+  // advanced_configuration existed.
+  collector_options.num_gpus = num_gpus;
+  // The AnnotationMap size is deliberately NOT seeded from the flag below.
+  // GetRocmTracerOptions() hardcoded 4M here and the flag never reached it, so
+  // routing the flag to it now would silently shrink the annotation cache for
+  // everyone who already lowers --xla_gpu_rocm_max_trace_events to bound trace
+  // memory -- and a full AnnotationMap costs op names on every later kernel,
+  // with no diagnostic. Only gpu_max_annotation_strings overrides this.
+  tracer_options.max_annotation_strings = kDefaultMaxAnnotationStrings;
 
+  // Layer 2: the legacy flag. Retained as a fallback for users who already
+  // depend on it; each advanced_configuration key overrides its own field.
   const auto& dbg = xla::GetDebugOptionsFromFlags();
   int64_t max_events = dbg.xla_gpu_rocm_max_trace_events();
   VLOG(2) << "max number of events to be trace from flag = " << max_events;
@@ -94,10 +116,42 @@ RocmTraceCollectorOptions GpuTracer::GetRocmTraceCollectorOptions(
   }
   VLOG(3) << "maximum number of events to be traced = " << max_events;
 
-  options.max_callback_api_events = max_events;
-  options.max_activity_api_events = max_events;
-  options.max_annotation_strings = max_events;
-  return options;
+  collector_options.max_callback_api_events = max_events;
+  collector_options.max_activity_api_events = max_events;
+  collector_options.max_annotation_strings = max_events;
+
+  // Layer 3: ProfileOptions.advanced_configuration.
+  if (profile_options_.version() == 0 &&
+      !profile_options_.advanced_configuration().empty()) {
+    // Unreachable in practice: ProfilerSession::GetOptions drops the map
+    // before we ever see it when version() is zero. Logged in case a caller
+    // reaches the tracer factory directly with a hand-built proto.
+    VLOG(1) << "ProfileOptions.version() is 0; advanced_configuration is "
+               "normally stripped by ProfilerSession for such options.";
+  }
+  UpdateRocmTracerOptionsFromProfilerOptions(
+      profile_options_, tracer_options, collector_options, option_diagnostics_);
+
+  // Post-parse fixup for num_gpus, mirroring device_tracer_cuda.cc. That file
+  // spells the first test `<= 0`, which is tautological on an unsigned field
+  // and warns under -Wtautological-unsigned-zero-compare; `== 0` is what it
+  // means and what it compiles to. This is a reset to all, not a clamp: an
+  // out-of-range ask profiles every GPU, not one.
+  if (collector_options.num_gpus == 0 ||
+      collector_options.num_gpus > num_gpus) {
+    if (collector_options.num_gpus != 0) {
+      LOG(WARNING) << "The provided number of GPUs ("
+                   << collector_options.num_gpus
+                   << ") is invalid. Profiling will be done on all available "
+                      "GPUs ("
+                   << num_gpus << ").";
+      option_diagnostics_.warnings.push_back(absl::StrCat(
+          "advanced_configuration key 'gpu_num_chips_to_profile_per_task'=",
+          collector_options.num_gpus, " is out of range; profiling all ",
+          num_gpus, " GPUs."));
+    }
+    collector_options.num_gpus = num_gpus;
+  }
 }
 
 absl::Status GpuTracer::DoStart() {
@@ -105,9 +159,29 @@ absl::Status GpuTracer::DoStart() {
   uint64_t start_gputime_ns = RocmTracer::GetTimestamp();
   uint64_t start_walltime_ns = tsl::EnvTime::NowNanos();
 
-  RocmTracerOptions tracer_options = GetRocmTracerOptions();
-  RocmTraceCollectorOptions trace_collector_options =
-      GetRocmTraceCollectorOptions(rocm_tracer_->NumGpus());
+  RocmTracerOptions tracer_options;
+  RocmTraceCollectorOptions trace_collector_options;
+  BuildOptions(rocm_tracer_->NumGpus(), tracer_options,
+               trace_collector_options);
+
+  // Deliberately different from the CUPTI path. A bad key does not abort the
+  // session, because on the default JAX path that costs the user the entire
+  // GPU plane with nothing in the trace to explain it. The diagnostics are
+  // carried to CollectData instead. Callers that explicitly asked for start
+  // failures to be fatal still get that.
+  if (!option_diagnostics_.errors.empty() &&
+      profile_options_.raise_error_on_start_failure()) {
+    AnnotationStack::Enable(false);
+    // Only the errors can travel in the Status, and CollectData will never be
+    // reached on this path, so the warnings would otherwise be lost outright.
+    // Log them here rather than discard them.
+    for (const std::string& warning : option_diagnostics_.warnings) {
+      LOG(WARNING) << warning;
+    }
+    return absl::InvalidArgumentError(
+        absl::StrJoin(option_diagnostics_.errors, " "));
+  }
+
   rocm_trace_collector_ = CreateRocmCollector(
       trace_collector_options, start_walltime_ns, start_gputime_ns);
   rocm_trace_collector_->SetGpuAgents(rocm_tracer_->GpuAgents());
@@ -147,6 +221,30 @@ absl::Status GpuTracer::Stop() {
 }
 
 absl::Status GpuTracer::CollectData(XSpace* space) {
+  // Delivered before the state switch, so the stopped-with-errors states are
+  // covered as well as the happy path -- CUPTI's add_errors/add_warnings calls
+  // sit under kStoppedOk alone.
+  //
+  // Be precise about why that matters, because the obvious stronger claim is
+  // false: ProfilerController::CollectData only forwards to us when the status
+  // from Start() was ok (profiler_controller.cc), so in the kStartedError case
+  // this function is never called at all and the branch below is reachable
+  // only by a direct ProfilerInterface user such as device_tracer_rocm_test.
+  // What actually protects the user is upstream of here -- a bad key does not
+  // fail Start() on this backend, so the session reaches CollectData normally
+  // and the diagnostics land. The one path that still loses them is a caller
+  // that sets raise_error_on_start_failure: its errors surface in the returned
+  // Status, but the warnings do not survive.
+  //
+  // kStartedOk is not terminal: the caller is collecting before Stop(), gets an
+  // error below, and will call again once stopped. And CollectData may legally
+  // be called more than once from a terminal state. Latch on delivery so that
+  // neither case puts the same message into the XSpace twice; BuildOptions
+  // clears the latch along with the diagnostics on the next Start().
+  if (profiling_state_ != State::kStartedOk && !diagnostics_delivered_) {
+    diagnostics_delivered_ = true;
+    AppendOptionDiagnostics(option_diagnostics_, space);
+  }
   switch (profiling_state_) {
     case State::kNotStarted:
       VLOG(3) << "No trace data collected, session wasn't started";
@@ -181,7 +279,7 @@ std::unique_ptr<profiler::ProfilerInterface> CreateGpuTracer(
     return nullptr;
   auto& rocm_tracer = profiler::RocmTracer::GetRocmTracerSingleton();
   if (!rocm_tracer.IsAvailable()) return nullptr;
-  return std::make_unique<profiler::GpuTracer>(&rocm_tracer);
+  return std::make_unique<profiler::GpuTracer>(&rocm_tracer, options);
 }
 
 auto register_rocm_gpu_tracer_factory = [] {

--- a/xla/backends/profiler/gpu/device_tracer_rocm_test.cc
+++ b/xla/backends/profiler/gpu/device_tracer_rocm_test.cc
@@ -1,0 +1,214 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// End-to-end tests for the ROCm GpuTracer's handling of
+// ProfileOptions.advanced_configuration. Requires a ROCm GPU; tagged
+// gpu + rocm-only like its siblings in this package.
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "absl/strings/match.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "xla/tsl/lib/core/status_test_util.h"
+#include "tsl/profiler/lib/profiler_interface.h"
+#include "tsl/profiler/protobuf/profiler_options.pb.h"
+#include "tsl/profiler/protobuf/xplane.pb.h"
+
+namespace xla {
+namespace profiler {
+
+// Defined in device_tracer_rocm.cc, which is deliberately header-less. The
+// comment there ("Not in anonymous namespace for testing purposes") is the
+// standing invitation for this declaration.
+std::unique_ptr<tsl::profiler::ProfilerInterface> CreateGpuTracer(
+    const tensorflow::ProfileOptions& options);
+
+namespace {
+
+using ::tensorflow::ProfileOptions;
+using ::tensorflow::profiler::XSpace;
+
+constexpr char kBogusKey[] = "gpu_max_callbac_api_events";  // realistic typo
+
+// A ProfileOptions the tracer factory will accept. version(1) matters: with
+// version 0, ProfilerSession::GetOptions strips advanced_configuration before
+// the tracer ever sees it, so a test built on a version-0 proto would pass
+// while asserting nothing.
+ProfileOptions MakeGpuOptions() {
+  ProfileOptions options;
+  options.set_version(1);
+  options.set_device_type(ProfileOptions::GPU);
+  return options;
+}
+
+void SetInt(ProfileOptions& options, const std::string& key, int64_t value) {
+  ProfileOptions::AdvancedConfigValue config_value;
+  config_value.set_int64_value(value);
+  (*options.mutable_advanced_configuration())[key] = config_value;
+}
+
+// A few HIP operations, enough to produce trace events. Copied in shape from
+// RocmTracerTest.CapturesHipEvents; no custom kernel is needed because the
+// memcpy API callbacks are what the caps and the exporter act on.
+void RunSomeHipWork(int iterations) {
+  constexpr size_t kNumFloats = 1024;
+  constexpr size_t kSize = kNumFloats * sizeof(float);
+  std::vector<float> host_data(kNumFloats, 1.0f);
+  void* device_data = nullptr;
+  ASSERT_EQ(hipMalloc(&device_data, kSize), hipSuccess);
+  for (int i = 0; i < iterations; ++i) {
+    ASSERT_EQ(
+        hipMemcpy(device_data, host_data.data(), kSize, hipMemcpyHostToDevice),
+        hipSuccess);
+    ASSERT_EQ(
+        hipMemcpy(host_data.data(), device_data, kSize, hipMemcpyDeviceToHost),
+        hipSuccess);
+  }
+  ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+  ASSERT_EQ(hipFree(device_data), hipSuccess);
+}
+
+bool HasGpu() {
+  int device_count = 0;
+  return hipGetDeviceCount(&device_count) == hipSuccess && device_count > 0;
+}
+
+size_t CountGpuPlaneEvents(const XSpace& space) {
+  size_t total = 0;
+  for (const auto& plane : space.planes()) {
+    if (!absl::StartsWith(plane.name(), "/device:GPU:")) {
+      continue;
+    }
+    for (const auto& line : plane.lines()) {
+      total += line.events_size();
+    }
+  }
+  return total;
+}
+
+// This is the whole point of the PR in one test. On the CUPTI path today the
+// equivalent assertion fails on both halves: DoStart returns an error, the
+// session swallows it, and the user gets an empty GPU plane with an empty
+// errors field and no way to tell that a typo was the cause.
+TEST(DeviceTracerRocmTest, BadKeyStillProducesATraceAndSaysWhy) {
+  if (!HasGpu()) GTEST_SKIP() << "No HIP devices available";
+
+  ProfileOptions options = MakeGpuOptions();
+  SetInt(options, kBogusKey, 5000);
+
+  auto tracer = CreateGpuTracer(options);
+  ASSERT_NE(tracer, nullptr);
+
+  TF_ASSERT_OK(tracer->Start());
+  RunSomeHipWork(/*iterations=*/4);
+  absl::SleepFor(absl::Milliseconds(100));
+  TF_ASSERT_OK(tracer->Stop());
+
+  XSpace space;
+  TF_ASSERT_OK(tracer->CollectData(&space));
+
+  EXPECT_GT(CountGpuPlaneEvents(space), 0u)
+      << "A bad advanced_configuration key must not cost the user the trace.";
+
+  bool named = false;
+  for (const auto& error : space.errors()) {
+    named |= absl::StrContains(error, kBogusKey);
+  }
+  EXPECT_TRUE(named) << "XSpace.errors must name the offending key; got "
+                     << space.errors_size() << " error(s).";
+}
+
+// The escape hatch. Callers that explicitly asked for start failures to be
+// fatal keep getting them; the leniency above is a default, not a policy.
+TEST(DeviceTracerRocmTest, RaiseErrorOnStartFailureMakesABadKeyFatal) {
+  if (!HasGpu()) GTEST_SKIP() << "No HIP devices available";
+
+  ProfileOptions options = MakeGpuOptions();
+  options.set_raise_error_on_start_failure(true);
+  SetInt(options, kBogusKey, 5000);
+
+  auto tracer = CreateGpuTracer(options);
+  ASSERT_NE(tracer, nullptr);
+
+  const absl::Status status = tracer->Start();
+  EXPECT_TRUE(absl::IsInvalidArgument(status)) << status;
+  EXPECT_TRUE(absl::StrContains(status.message(), kBogusKey)) << status;
+
+  // Start failed before the tracer was enabled, so Stop is a no-op and the
+  // singleton is left available for the next test.
+  TF_EXPECT_OK(tracer->Stop());
+}
+
+// Pins the precedence order in BuildOptions, which is otherwise only asserted
+// by reading it top to bottom. The flag default is 4M; if
+// advanced_configuration were ignored, all the events below would survive.
+TEST(DeviceTracerRocmTest, AdvancedConfigurationOverridesTheFlagDefault) {
+  if (!HasGpu()) GTEST_SKIP() << "No HIP devices available";
+
+  constexpr int64_t kCallbackCap = 3;
+  constexpr int kIterations = 20;  // >= 40 API callbacks, far above the cap
+
+  // Self-calibrating: the same workload is traced twice, once with the key and
+  // once without, and the two counts are compared. Asserting a bare upper bound
+  // against kCallbackCap would be a proxy twice over -- the cap governs
+  // *callback* events while this counts *exported device-plane* events, which
+  // are the merged activity events -- and it would be sensitive to any future
+  // line added to the device plane. If the key were ignored, both runs would
+  // produce the same count and the comparison fails; no absolute number has to
+  // be predicted.
+  auto trace_with = [&](bool set_key) -> size_t {
+    ProfileOptions options = MakeGpuOptions();
+    if (set_key) SetInt(options, "gpu_max_callback_api_events", kCallbackCap);
+    auto tracer = CreateGpuTracer(options);
+    EXPECT_NE(tracer, nullptr);
+    if (tracer == nullptr) return 0;
+    EXPECT_TRUE(tracer->Start().ok());
+    RunSomeHipWork(kIterations);
+    absl::SleepFor(absl::Milliseconds(100));
+    EXPECT_TRUE(tracer->Stop().ok());
+    XSpace space;
+    EXPECT_TRUE(tracer->CollectData(&space).ok());
+    EXPECT_TRUE(space.errors().empty())
+        << "A documented key must not be reported as a problem.";
+    return CountGpuPlaneEvents(space);
+  };
+
+  const size_t capped = trace_with(/*set_key=*/true);
+  const size_t uncapped = trace_with(/*set_key=*/false);
+
+  // Without the lower bound this passes vacuously if the tracer stops producing
+  // events at all: zero is <= any cap, so a regression that broke tracing
+  // outright would read as "the cap works".
+  EXPECT_GT(uncapped, static_cast<size_t>(kCallbackCap))
+      << "the unconstrained run must exceed the cap, or the comparison below "
+         "proves nothing";
+  EXPECT_LE(capped, static_cast<size_t>(kCallbackCap))
+      << "gpu_max_callback_api_events did not take precedence over the "
+         "xla_gpu_rocm_max_trace_events default.";
+  EXPECT_LT(capped, uncapped) << "the key made no difference: capped=" << capped
+                              << " uncapped=" << uncapped;
+}
+
+}  // namespace
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_collector.cc
+++ b/xla/backends/profiler/gpu/rocm_collector.cc
@@ -591,8 +591,11 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
             << "!!! Number of callback events = " << num_callback_events_
             << " is greater than/equal to the max callback api events = "
             << options_.max_callback_api_events
-            << ". To collect more GPU events, please set "
-               "XLA_FLAGS=--xla_gpu_rocm_max_trace_events=X ";
+            << ". To collect more GPU events, raise the "
+               "gpu_max_callback_api_events key of "
+               "ProfileOptions.advanced_configuration, or "
+               "XLA_FLAGS=--xla_gpu_rocm_max_trace_events if that key is not "
+               "set -- the key takes precedence over the flag.";
         return;
       }
       num_callback_events_++;
@@ -611,11 +614,13 @@ void RocmTraceCollectorImpl::AddEvent(RocmTracerEvent&& event,
       if (num_activity_events_ >= options_.max_activity_api_events) {
         LOG_FIRST_N(WARNING, 1)
             << "Number of activity events (" << num_activity_events_
-            << ") has reached the configured limit "
-               "(xla_gpu_rocm_max_trace_events="
+            << ") has reached the configured limit ("
             << options_.max_activity_api_events
-            << "). To collect more GPU events, increase "
-               "XLA_FLAGS=--xla_gpu_rocm_max_trace_events=<value>.";
+            << "). To collect more GPU events, raise the "
+               "gpu_max_activity_api_events key of "
+               "ProfileOptions.advanced_configuration, or "
+               "XLA_FLAGS=--xla_gpu_rocm_max_trace_events if that key is not "
+               "set -- the key takes precedence over the flag.";
         return;
       }
 

--- a/xla/backends/profiler/gpu/rocm_collector_test.cc
+++ b/xla/backends/profiler/gpu/rocm_collector_test.cc
@@ -403,6 +403,89 @@ TEST(RocmCollectorTest, MarkerAndApiEventsOnSameThreadGetSeparateLines) {
       << "the API event must stay on the plain host-thread line";
 }
 
+// MarkerEventsRespectMaxCallbackApiEvents above covers the Generic/ROCTX
+// path, which reaches the cap through the standalone_events_ early return.
+// This covers the other half: real API callbacks, which reach it through the
+// source==ApiCallback branch, and which no test has ever proved fires -- the
+// two cases at the top of this file set the limit to 100 and never approach
+// it. It matters more now that ProfileOptions.advanced_configuration can set
+// the limit per-session through gpu_max_callback_api_events, so a silent
+// regression here would turn a user-facing knob into a no-op.
+TEST(RocmCollectorTest, CallbackCapDropsEventsBeyondLimit) {
+  constexpr uint64_t kMaxCallbackEvents = 3;
+  constexpr int kEventsOffered = 5;
+
+  RocmTraceCollectorOptions options;
+  options.max_callback_api_events = kMaxCallbackEvents;
+  options.max_activity_api_events = 100;
+  options.max_annotation_strings = 100;
+  options.num_gpus = 1;
+
+  constexpr uint64_t kStartWallTimeNs = 1000;
+  constexpr uint64_t kStartGpuTimeNs = 2000;
+  RocmTraceCollectorImpl collector(options, kStartWallTimeNs, kStartGpuTimeNs);
+
+  constexpr uint32_t kDeviceId = 100;
+  constexpr uint64_t kStreamId = 123;
+
+  // Five complete API/activity pairs, distinct correlation ids. The field
+  // combination is copied from TestAddKernelEventAndExport above: the cap sits
+  // behind `source == ApiCallback && !is_auxiliary`, and a Generic (ROCTX)
+  // event would bypass it entirely and make this test vacuous.
+  for (int i = 0; i < kEventsOffered; ++i) {
+    const uint32_t correlation_id = 500 + i;
+
+    RocmTracerEvent api_event;
+    api_event.type = RocmTracerEventType::Kernel;
+    api_event.source = RocmTracerEventSource::ApiCallback;
+    api_event.domain = RocmTracerEventDomain::HIP_API;
+    api_event.name = "capped_kernel";
+    api_event.correlation_id = correlation_id;
+    api_event.thread_id = 999;
+    api_event.kernel_info = KernelDetails{};
+    api_event.kernel_info.func_ptr = reinterpret_cast<void*>(0xdeadbeef);
+    collector.AddEvent(std::move(api_event), /*is_auxiliary=*/false);
+
+    RocmTracerEvent activity;
+    activity.type = RocmTracerEventType::Kernel;
+    activity.source = RocmTracerEventSource::Activity;
+    activity.domain = RocmTracerEventDomain::HIP_OPS;
+    activity.name = "capped_kernel";
+    activity.correlation_id = correlation_id;
+    activity.start_time_ns = 3000 + i * 100;
+    activity.end_time_ns = 3050 + i * 100;
+    activity.device_id = kDeviceId;
+    activity.stream_id = kStreamId;
+    collector.AddEvent(std::move(activity), /*is_auxiliary=*/false);
+  }
+
+  collector.Flush();
+  tensorflow::profiler::XSpace space;
+  collector.Export(&space);
+
+  const auto* gpu_plane =
+      FindOrAddMutablePlaneWithName(&space, "/device:GPU:0");
+  ASSERT_NE(gpu_plane, nullptr);
+
+  // Count the device stream lines by name, not by id. Export() remaps stream
+  // ids to dense indices (see stream_remap in rocm_collector.cc), so the line
+  // carrying kStreamId is not line 123; and selecting on the "Stream #" prefix
+  // also keeps host-thread and ROCTX lines out of the total.
+  size_t exported = 0;
+  for (const auto& line : gpu_plane->lines()) {
+    if (!absl::StartsWith(line.name(), "Stream #")) {
+      continue;
+    }
+    exported += line.events_size();
+  }
+
+  // The two over-cap API callbacks are refused, and their activity records are
+  // then dropped for having no API counterpart, so neither half leaks through.
+  EXPECT_EQ(exported, kMaxCallbackEvents)
+      << "Offered " << kEventsOffered << " events under a cap of "
+      << kMaxCallbackEvents << "; the cap is not being enforced.";
+}
+
 }  // namespace test
 }  // namespace profiler
 }  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_tracer.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer.cc
@@ -167,6 +167,15 @@ absl::Status RocmTracer::Enable(const RocmTracerOptions& options,
   // Clear per-session state while holding collector_mutex_ so no in-flight
   // callback can race between the clear and the new session start.
   annotation_map_.Clear();
+  // Applied immediately after Clear() and, like it, before
+  // rocprofiler_start_context() below: the new capacity has to take effect on
+  // an empty map and before any callback thread can Add() to it. Note the two
+  // calls take map_.mutex separately, so a straggler callback from the previous
+  // session -- rocprofiler_stop_context() closes the gate without joining
+  // threads already past it -- could still land between them under the old
+  // capacity. Closing that needs a single locked Reset(max_size); it is out of
+  // scope for making gpu_max_annotation_strings reachable.
+  annotation_map_.SetMaxSize(options.max_annotation_strings);
   // ROCTX frames live on thread_local stacks this thread cannot reach, so
   // isolate by generation instead of clearing: any frame pushed before this
   // point is now stale and will be dropped at pop rather than emitted into

--- a/xla/backends/profiler/gpu/rocm_tracer.h
+++ b/xla/backends/profiler/gpu/rocm_tracer.h
@@ -33,11 +33,10 @@ namespace profiler {
 // forward declare (interface)
 class RocmTraceCollector;
 
-struct RocmTracerOptions {
-  // maximum number of annotation strings that AnnotationMap in RocmTracer can
-  // store. e.g. 1M
-  uint64_t max_annotation_strings;
-};
+// NOTE: RocmTracerOptions lives in rocm_tracer_utils.h, next to
+// RocmTraceCollectorOptions, so that code which only needs to manipulate the
+// option structs does not have to depend on rocprofiler-sdk headers. It is
+// reachable from here through the include above.
 
 // The class use to enable rocprofiler-sdk buffered callback/activity tracing
 // and forward the collected trace events to RocmTraceCollector. There should be
@@ -121,7 +120,7 @@ class RocmTracer {
   bool api_tracing_enabled_{false};
   bool activity_tracing_enabled_{false};
 
-  AnnotationMap annotation_map_{/* default size, e.g. */ 1024 * 1024};
+  AnnotationMap annotation_map_{kDefaultMaxAnnotationStrings};
 
   // ROCTX range state lives in a thread_local stack in rocm_tracer.cc, not
   // here. roctx pushes and pops are thread-local by definition and the

--- a/xla/backends/profiler/gpu/rocm_tracer_options_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_options_utils.cc
@@ -1,0 +1,314 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/rocm_tracer_options_utils.h"
+
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "absl/algorithm/container.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+#include "xla/tsl/profiler/utils/profiler_options_util.h"
+#include "tsl/profiler/protobuf/profiler_options.pb.h"
+#include "tsl/profiler/protobuf/xplane.pb.h"
+
+namespace xla {
+namespace profiler {
+namespace {
+
+using tensorflow::ProfileOptions;
+using tsl::profiler::SetValue;
+
+// Keys the CUPTI backend recognises that have no ROCm implementation yet.
+// Each carries the type it is documented with, so that a wrong-typed value is
+// still reported now rather than in the release that implements the key.
+//
+// Listed in the order cupti_tracer_options_utils.cc parses them, so that the
+// two parsers can be read side by side. The one exception is
+// gpu_dump_graph_node_mapping, which CUPTI does not parse at all; it is last.
+struct UnimplementedKey {
+  enum Type { kInt64, kBool, kString };
+
+  absl::string_view name;
+  Type type;
+  absl::string_view reason;
+};
+
+constexpr UnimplementedKey kUnimplementedOnRocm[] = {
+    // The listener registers MARKER_CORE_API unconditionally on the session
+    // context, so ROCTX capture is always on and this key cannot turn it off.
+    // Making it switchable needs a dedicated rocprofiler context that can be
+    // started and stopped independently of the tracing services.
+    {"gpu_enable_nvtx_tracking", UnimplementedKey::kBool,
+     "ROCTX marker capture is unconditionally enabled on the ROCm backend and "
+     "this key cannot switch it off; a dedicated rocprofiler marker context is "
+     "required first"},
+    {"gpu_aggregated_tracing", UnimplementedKey::kBool,
+     "the ROCm collector has no aggregated-tracing mode"},
+    {"gpu_enable_cupti_activity_graph_trace", UnimplementedKey::kBool,
+     "HIP graph tracing is not yet wired into the ROCm tracer"},
+    {"gpu_pm_sample_counters", UnimplementedKey::kString,
+     "performance-monitor counter sampling is not yet available on ROCm"},
+    {"gpu_pm_sample_interval_us", UnimplementedKey::kInt64,
+     "performance-monitor counter sampling is not yet available on ROCm"},
+    {"gpu_pm_sample_buffer_size_per_gpu_mb", UnimplementedKey::kInt64,
+     "performance-monitor counter sampling is not yet available on ROCm"},
+    {"gpu_dump_graph_node_mapping", UnimplementedKey::kBool,
+     "not implemented on any backend, including CUDA"},
+};
+
+// The name of the type a key expects. SetValue's own failure message says only
+// "Expected a different type", which omits the one fact the user needs.
+template <typename T>
+constexpr absl::string_view ExpectedTypeName();
+template <>
+constexpr absl::string_view ExpectedTypeName<int64_t>() {
+  return "int64";
+}
+template <>
+constexpr absl::string_view ExpectedTypeName<bool>() {
+  return "bool";
+}
+template <>
+constexpr absl::string_view ExpectedTypeName<std::string>() {
+  return "string";
+}
+
+// The name of the type actually supplied, so that a type error can report both
+// halves of the mismatch rather than only what was expected.
+absl::string_view SuppliedTypeName(const ProfileOptions& options,
+                                   absl::string_view key) {
+  const auto value = tsl::profiler::GetConfigValue(options, std::string(key));
+  if (!value.has_value()) return "unset";
+  return std::visit(
+      [](const auto& alternative) -> absl::string_view {
+        using Alternative = std::decay_t<decltype(alternative)>;
+        if constexpr (std::is_same_v<Alternative, std::string>) {
+          return "string";
+        } else if constexpr (std::is_same_v<Alternative, bool>) {
+          return "bool";
+        } else {
+          return "int64";
+        }
+      },
+      *value);
+}
+
+// The accumulating analogue of the ABSL_RETURN_IF_ERROR that wraps every
+// SetValue call in cupti_tracer_options_utils.cc: same helper, same type
+// semantics, but one bad key does not hide the others and does not abort the
+// session. That difference is the point of this file -- see the class comment
+// on RocmTracerOptionDiagnostics.
+//
+// SetValue returns its type error *before* erasing the key from the working
+// set, so the erase below is load-bearing: without it a wrong-typed key would
+// be reported twice, once as a type error and once as unrecognised. The CUPTI
+// parser never hits this because it stops at the first failure.
+//
+// The setter is std::function rather than absl::FunctionRef because that is
+// what SetValue itself takes; a FunctionRef here would only force a conversion.
+template <typename T>
+void Apply(const ProfileOptions& options, absl::string_view key,
+           absl::flat_hash_set<absl::string_view>& keys,
+           RocmTracerOptionDiagnostics& diagnostics,
+           std::function<void(T)> setter) {
+  const bool key_was_present = keys.contains(key);
+  const absl::Status status =
+      SetValue<T>(options, std::string(key), keys, std::move(setter));
+  if (!status.ok()) {
+    keys.erase(key);
+    // SetValue's message names the key and says only that the type differs, so
+    // build our own rather than wrapping it: naming the key once and the
+    // expected type explicitly is the whole value of this diagnostic.
+    diagnostics.errors.push_back(absl::StrCat(
+        "advanced_configuration key '", key, "' expects a value of type ",
+        ExpectedTypeName<T>(), ", but a ", SuppliedTypeName(options, key),
+        " was supplied. The key was ignored."));
+    return;
+  }
+  // SetValue erases the key only when it found a usable value. A key that was
+  // in the map and is still here therefore carried an AdvancedConfigValue with
+  // no oneof case set -- GetConfigValue returns nullopt for that, and SetValue
+  // reports it as success. Left alone it would fall through to the unknown-key
+  // loop and be reported as a misspelling, which is the one thing it is not.
+  if (key_was_present && keys.contains(key)) {
+    keys.erase(key);
+    diagnostics.errors.push_back(absl::StrCat(
+        "advanced_configuration key '", key,
+        "' is recognised but its value is unset; expected a value of type ",
+        ExpectedTypeName<T>(), ". The key was ignored."));
+  }
+}
+
+void WarnUnimplemented(const ProfileOptions& options,
+                       absl::flat_hash_set<absl::string_view>& keys,
+                       RocmTracerOptionDiagnostics& diagnostics) {
+  for (const UnimplementedKey& key : kUnimplementedOnRocm) {
+    if (!keys.contains(key.name)) continue;
+    // Type-check even though the value is discarded.
+    switch (key.type) {
+      case UnimplementedKey::kInt64:
+        Apply<int64_t>(options, key.name, keys, diagnostics, [](int64_t) {});
+        break;
+      case UnimplementedKey::kBool:
+        Apply<bool>(options, key.name, keys, diagnostics, [](bool) {});
+        break;
+      case UnimplementedKey::kString:
+        Apply<std::string>(options, key.name, keys, diagnostics,
+                           [](const std::string&) {});
+        break;
+    }
+    keys.erase(key.name);
+    diagnostics.warnings.push_back(absl::StrCat(
+        "advanced_configuration key '", key.name,
+        "' names a feature the ROCm backend does not implement: ", key.reason,
+        ". The key is recognised, so it is not an error, but it has no "
+        "effect."));
+  }
+}
+
+}  // namespace
+
+void UpdateRocmTracerOptionsFromProfilerOptions(
+    const ProfileOptions& profile_options, RocmTracerOptions& tracer_options,
+    RocmTraceCollectorOptions& collector_options,
+    RocmTracerOptionDiagnostics& diagnostics) {
+  absl::flat_hash_set<absl::string_view> input_keys;
+  for (const auto& [key, unused_value] :
+       profile_options.advanced_configuration()) {
+    input_keys.insert(key);
+  }
+
+  // Note this budget is no longer callbacks alone: the ROCTX listener charges
+  // every Generic marker event against the same counter, so lowering this key
+  // also caps how many application roctx ranges survive a session.
+  Apply<int64_t>(profile_options, "gpu_max_callback_api_events", input_keys,
+                 diagnostics, [&](int64_t value) {
+                   collector_options.max_callback_api_events = value;
+                 });
+
+  // The cap that reads this field is currently gated on a predicate that no
+  // activity event satisfies, so the value lands but is not yet enforced. The
+  // fix is a separate change; no further plumbing is needed here.
+  Apply<int64_t>(profile_options, "gpu_max_activity_api_events", input_keys,
+                 diagnostics, [&](int64_t value) {
+                   collector_options.max_activity_api_events = value;
+                 });
+
+  // One key, two fields. The tracer-side field sizes the AnnotationMap; the
+  // collector-side field is currently unread and is set for consistency.
+  Apply<int64_t>(profile_options, "gpu_max_annotation_strings", input_keys,
+                 diagnostics, [&](int64_t value) {
+                   tracer_options.max_annotation_strings = value;
+                   collector_options.max_annotation_strings = value;
+                 });
+
+  // Matches the CUPTI backend, including its reset-to-all disposition for
+  // values above the device count. That reset is performed by the caller,
+  // which is the only place that knows how many GPUs are present -- but only
+  // for values that fit in the uint32_t field. A value that does not fit never
+  // reaches the caller's fixup, so it has to be reported here or not at all.
+  Apply<int64_t>(
+      profile_options, "gpu_num_chips_to_profile_per_task", input_keys,
+      diagnostics, [&](int64_t value) {
+        // The bound is int32, not uint32. The field here is uint32_t, but
+        // RocmTraceCollectorImpl stores it in a signed int, so anything
+        // above INT32_MAX arrives there negative: Export loops zero times
+        // and writes no device planes, while Flush admits every event.
+        // Checking the wider bound would let that through silently.
+        if (value < 0 || value > std::numeric_limits<int32_t>::max()) {
+          diagnostics.errors.push_back(absl::StrCat(
+              "advanced_configuration key "
+              "'gpu_num_chips_to_profile_per_task': ",
+              value, " is outside the representable range [0, ",
+              std::numeric_limits<int32_t>::max(), "]. The key was ignored."));
+          return;
+        }
+        collector_options.num_gpus = static_cast<uint32_t>(value);
+        if (value == 0) {
+          diagnostics.warnings.push_back(
+              "advanced_configuration key 'gpu_num_chips_to_profile_per_task' "
+              "is 0. The value is passed through unchanged here; the tracer "
+              "then profiles all available GPUs, matching the CUDA backend. "
+              "Note that 0 is not meaningful to the collector on its own.");
+          return;
+        }
+        diagnostics.warnings.push_back(
+            "advanced_configuration key 'gpu_num_chips_to_profile_per_task' "
+            "is applied post-hoc on ROCm: events from excluded devices are "
+            "discarded after collection, so tracing overhead is unchanged. "
+            "Devices are selected by ascending device id, not by topology.");
+      });
+
+  WarnUnimplemented(profile_options, input_keys, diagnostics);
+
+  // advanced_configuration is a namespace shared with the rest of the profiler,
+  // not private to this backend: ProfilerSession reads
+  // "enable_continuous_profiling" out of it and hands the same proto, key
+  // included, to CreateProfilers; session_manager injects
+  // "use_system_hostname", "override_hostnames", "tracemark_lower" and
+  // "tracemark_upper"; TPU keys pass through the same map. None of them are
+  // erased before a tracer factory runs.
+  //
+  // So claim only the gpu_ prefix. Treating the whole map as ours would put
+  // "advanced_configuration key 'enable_continuous_profiling' is not
+  // recognised" into XSpace.errors on every trace of a correctly configured
+  // session -- and, under raise_error_on_start_failure, would cost the user the
+  // GPU plane over an option that has nothing to do with this backend. That is
+  // precisely the failure this file exists to prevent. An unrecognised gpu_ key
+  // is still an error: that is a typo in a key we do own.
+  std::vector<absl::string_view> unknown;
+  for (absl::string_view key : input_keys) {
+    if (absl::StartsWith(key, "gpu_")) unknown.push_back(key);
+  }
+  // Sorted so that the output is stable across runs.
+  absl::c_sort(unknown);
+  for (absl::string_view key : unknown) {
+    diagnostics.errors.push_back(absl::StrCat(
+        "advanced_configuration key '", key,
+        "' is not recognised by the ROCm GPU tracer and was ignored."));
+  }
+}
+
+void AppendOptionDiagnostics(const RocmTracerOptionDiagnostics& diagnostics,
+                             tensorflow::profiler::XSpace* space) {
+  // The log mirror happens even without an XSpace. A null space is the one
+  // case where the diagnostic has nowhere else to go, so returning early here
+  // would drop it entirely -- reproducing, for that path, exactly the silent
+  // discard this file exists to prevent.
+  for (const std::string& message : diagnostics.errors) {
+    LOG(ERROR) << message;
+    if (space != nullptr) space->add_errors(message);
+  }
+  for (const std::string& message : diagnostics.warnings) {
+    LOG(WARNING) << message;
+    if (space != nullptr) space->add_warnings(message);
+  }
+}
+
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_tracer_options_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_options_utils.h
@@ -1,0 +1,78 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_OPTIONS_UTILS_H_
+#define XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_OPTIONS_UTILS_H_
+
+#include <string>
+#include <vector>
+
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+#include "tsl/profiler/protobuf/profiler_options.pb.h"
+#include "tsl/profiler/protobuf/xplane.pb.h"
+
+namespace xla {
+namespace profiler {
+
+// Diagnostics produced while interpreting
+// ProfileOptions.advanced_configuration. Recorded when the tracer starts and
+// delivered when it collects, so that a mistyped or unsupported key reaches
+// the XSpace the user opens rather than only the server's stderr.
+struct RocmTracerOptionDiagnostics {
+  // Keys that were not recognised, or whose value had the wrong oneof type.
+  std::vector<std::string> errors;
+  // Keys that are recognised but have no effect on the ROCm backend, plus
+  // caveats attached to keys that do.
+  std::vector<std::string> warnings;
+
+  bool empty() const { return errors.empty() && warnings.empty(); }
+};
+
+// Applies the gpu_* entries of profile_options.advanced_configuration() to the
+// two ROCm option structs. Both structs must already hold the caller's
+// defaults; only keys that are actually present are touched.
+//
+// This function never fails. Unlike the CUPTI equivalent
+// (UpdateCuptiTracerOptionsFromProfilerOptions), an unrecognised key neither
+// aborts parsing nor prevents the tracer from starting: it is recorded in
+// diagnostics.errors, and the remaining keys are still applied.
+//
+// This function never fails and has no opinion about what a non-empty error
+// list means; that is the caller's decision. A caller that wants CUPTI's
+// hard-failure behaviour can inspect diagnostics.errors and honour
+// ProfileOptions.raise_error_on_start_failure itself. `diagnostics` is
+// appended to, never cleared, so a caller reusing one across sessions must
+// reset it.
+//
+// The reason for the difference is that on the default JAX path a parse
+// failure is not visible to the user at all: it sets kStartedError, and that
+// branch of CollectData logs and returns OkStatus without ever reaching
+// XSpace.errors, so one typo silently costs the whole GPU plane. Reporting
+// into the XSpace and still producing a trace strictly dominates that.
+void UpdateRocmTracerOptionsFromProfilerOptions(
+    const tensorflow::ProfileOptions& profile_options,
+    RocmTracerOptions& tracer_options,
+    RocmTraceCollectorOptions& collector_options,
+    RocmTracerOptionDiagnostics& diagnostics);
+
+// Appends diagnostics to space->errors() and space->warnings(), and mirrors
+// them to LOG. Safe to call with empty diagnostics or a null space.
+void AppendOptionDiagnostics(const RocmTracerOptionDiagnostics& diagnostics,
+                             tensorflow::profiler::XSpace* space);
+
+}  // namespace profiler
+}  // namespace xla
+
+#endif  // XLA_BACKENDS_PROFILER_GPU_ROCM_TRACER_OPTIONS_UTILS_H_

--- a/xla/backends/profiler/gpu/rocm_tracer_options_utils_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_options_utils_test.cc
@@ -1,0 +1,401 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/rocm_tracer_options_utils.h"
+
+#include <cstdint>
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+#include "tsl/profiler/protobuf/profiler_options.pb.h"
+#include "tsl/profiler/protobuf/xplane.pb.h"
+
+namespace xla {
+namespace profiler {
+namespace {
+
+using ::tensorflow::ProfileOptions;
+using ::tensorflow::profiler::XSpace;
+using ::testing::Contains;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+
+void SetInt(ProfileOptions& options, absl::string_view key, int64_t value) {
+  ProfileOptions::AdvancedConfigValue config_value;
+  config_value.set_int64_value(value);
+  (*options.mutable_advanced_configuration())[std::string(key)] = config_value;
+}
+
+void SetBool(ProfileOptions& options, absl::string_view key, bool value) {
+  ProfileOptions::AdvancedConfigValue config_value;
+  config_value.set_bool_value(value);
+  (*options.mutable_advanced_configuration())[std::string(key)] = config_value;
+}
+
+void SetString(ProfileOptions& options, absl::string_view key,
+               absl::string_view value) {
+  ProfileOptions::AdvancedConfigValue config_value;
+  config_value.set_string_value(std::string(value));
+  (*options.mutable_advanced_configuration())[std::string(key)] = config_value;
+}
+
+MATCHER_P(MentionsKey, key, absl::StrCat("mentions the key '", key, "'")) {
+  return absl::StrContains(arg, absl::StrCat("'", key, "'"));
+}
+
+// Sentinel defaults, chosen so that "the field was never touched" is
+// distinguishable from "the field was set to a plausible value".
+constexpr uint64_t kTracerAnnotationSentinel = 111;
+constexpr uint64_t kCallbackSentinel = 222;
+constexpr uint64_t kActivitySentinel = 333;
+constexpr uint64_t kCollectorAnnotationSentinel = 444;
+constexpr uint32_t kNumGpusSentinel = 8;
+
+struct Fixture {
+  ProfileOptions options;
+  RocmTracerOptions tracer = {kTracerAnnotationSentinel};
+  RocmTraceCollectorOptions collector = {kCallbackSentinel, kActivitySentinel,
+                                         kCollectorAnnotationSentinel,
+                                         kNumGpusSentinel};
+  RocmTracerOptionDiagnostics diagnostics;
+
+  void Run() {
+    UpdateRocmTracerOptionsFromProfilerOptions(options, tracer, collector,
+                                               diagnostics);
+  }
+
+  // True when no option field was modified.
+  bool AllFieldsUntouched() const {
+    return tracer.max_annotation_strings == kTracerAnnotationSentinel &&
+           collector.max_callback_api_events == kCallbackSentinel &&
+           collector.max_activity_api_events == kActivitySentinel &&
+           collector.max_annotation_strings == kCollectorAnnotationSentinel &&
+           collector.num_gpus == kNumGpusSentinel;
+  }
+};
+
+TEST(RocmTracerOptionsUtilsTest, EmptyMapIsANoOp) {
+  Fixture f;
+  f.Run();
+
+  EXPECT_TRUE(f.AllFieldsUntouched());
+  EXPECT_TRUE(f.diagnostics.empty());
+}
+
+TEST(RocmTracerOptionsUtilsTest, SetsCallbackEventLimit) {
+  Fixture f;
+  SetInt(f.options, "gpu_max_callback_api_events", 4242);
+  f.Run();
+
+  EXPECT_EQ(f.collector.max_callback_api_events, 4242);
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  EXPECT_THAT(f.diagnostics.warnings, IsEmpty());
+}
+
+TEST(RocmTracerOptionsUtilsTest, SetsActivityEventLimit) {
+  Fixture f;
+  SetInt(f.options, "gpu_max_activity_api_events", 4242);
+  f.Run();
+
+  EXPECT_EQ(f.collector.max_activity_api_events, 4242);
+  // Wired silently: the cap that reads this field is not yet enforced, but
+  // fixing that requires no further plumbing, so there is no warning to
+  // retract later.
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  EXPECT_THAT(f.diagnostics.warnings, IsEmpty());
+}
+
+TEST(RocmTracerOptionsUtilsTest, SetsBothAnnotationLimitsFromOneKey) {
+  Fixture f;
+  SetInt(f.options, "gpu_max_annotation_strings", 777);
+  f.Run();
+
+  EXPECT_EQ(f.tracer.max_annotation_strings, 777);
+  EXPECT_EQ(f.collector.max_annotation_strings, 777);
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  // Wired silently, like the two event caps above. Asserted so that attaching
+  // a caveat to this key later has to be a deliberate change.
+  EXPECT_THAT(f.diagnostics.warnings, IsEmpty());
+}
+
+TEST(RocmTracerOptionsUtilsTest, SetsNumGpusAndWarnsAboutPostHocDrop) {
+  Fixture f;
+  SetInt(f.options, "gpu_num_chips_to_profile_per_task", 2);
+  f.Run();
+
+  // The reset-to-all for out-of-range values lives in the caller, so the raw
+  // value is visible here.
+  EXPECT_EQ(f.collector.num_gpus, 2);
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  ASSERT_THAT(f.diagnostics.warnings, SizeIs(1));
+  EXPECT_TRUE(absl::StrContains(f.diagnostics.warnings[0], "post-hoc"));
+}
+
+TEST(RocmTracerOptionsUtilsTest, ZeroNumGpusIsAppliedAndWarnsAboutMeaningOnly) {
+  // 0 has its own branch and its own warning: it is CUDA's "all GPUs", not
+  // "no GPUs", and the post-hoc caveat must not also fire because nothing was
+  // excluded. Without this, a refactor that dropped the early return would
+  // emit two contradictory warnings for the same key with every test green.
+  Fixture f;
+  SetInt(f.options, "gpu_num_chips_to_profile_per_task", 0);
+  f.Run();
+
+  EXPECT_EQ(f.collector.num_gpus, 0);
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  ASSERT_THAT(f.diagnostics.warnings, SizeIs(1));
+  EXPECT_TRUE(
+      absl::StrContains(f.diagnostics.warnings[0], "all available GPUs"));
+  EXPECT_FALSE(absl::StrContains(f.diagnostics.warnings[0], "post-hoc"));
+}
+
+TEST(RocmTracerOptionsUtilsTest,
+     RecognisedKeyWithUnsetValueIsNotCalledUnknown) {
+  // An AdvancedConfigValue with no oneof case set. GetConfigValue returns
+  // nullopt for it and SetValue reports success without erasing the key, so
+  // without explicit handling it reaches the unknown-key loop and the user is
+  // told a correctly-spelled key is not recognised -- sending them to fix the
+  // one thing that is right.
+  Fixture f;
+  (*f.options.mutable_advanced_configuration())["gpu_max_callback_api_events"] =
+      ProfileOptions::AdvancedConfigValue();
+  f.Run();
+
+  ASSERT_THAT(f.diagnostics.errors, SizeIs(1));
+  EXPECT_THAT(f.diagnostics.errors[0],
+              MentionsKey("gpu_max_callback_api_events"));
+  EXPECT_TRUE(absl::StrContains(f.diagnostics.errors[0], "unset"));
+  EXPECT_FALSE(absl::StrContains(f.diagnostics.errors[0], "not recognised"));
+  EXPECT_TRUE(f.AllFieldsUntouched());
+}
+
+TEST(RocmTracerOptionsUtilsTest,
+     OutOfRangeNumGpusIsReportedNotSilentlyDropped) {
+  // int64 values that cannot be represented in the uint32_t field. Neither is
+  // reachable through the caller's reset-to-all fixup, which only sees values
+  // that survived the narrowing -- so if this function stays quiet, nothing
+  // else will speak up and the user is told nothing at all.
+  for (int64_t value : {int64_t{-1}, int64_t{1} << 40}) {
+    Fixture f;
+    SetInt(f.options, "gpu_num_chips_to_profile_per_task", value);
+    f.Run();
+
+    EXPECT_EQ(f.collector.num_gpus, kNumGpusSentinel)
+        << "value " << value << " must not be applied";
+    ASSERT_THAT(f.diagnostics.errors, SizeIs(1)) << "value " << value;
+    EXPECT_THAT(f.diagnostics.errors[0],
+                MentionsKey("gpu_num_chips_to_profile_per_task"));
+    // The post-hoc caveat describes a key that took effect. Attaching it to a
+    // value that was thrown away tells the user the opposite of the truth.
+    EXPECT_THAT(f.diagnostics.warnings, IsEmpty()) << "value " << value;
+  }
+}
+
+TEST(RocmTracerOptionsUtilsTest, UnknownKeyIsReportedByName) {
+  Fixture f;
+  SetInt(f.options, "gpu_max_callbac_api_events", 4242);  // realistic typo
+  f.Run();
+
+  ASSERT_THAT(f.diagnostics.errors, SizeIs(1));
+  EXPECT_THAT(f.diagnostics.errors[0],
+              MentionsKey("gpu_max_callbac_api_events"));
+  EXPECT_TRUE(f.AllFieldsUntouched());
+}
+
+TEST(RocmTracerOptionsUtilsTest, AllUnknownKeysAreReported) {
+  Fixture f;
+  SetInt(f.options, "gpu_not_a_key", 1);
+  SetBool(f.options, "gpu_also_not_a_key", true);
+  SetString(f.options, "gpu_still_not_a_key", "x");
+  f.Run();
+
+  // Every unknown key is named. A parser that returns on the first failure --
+  // as the CUPTI one does -- reports only one of these.
+  EXPECT_THAT(f.diagnostics.errors, SizeIs(3));
+  EXPECT_THAT(f.diagnostics.errors, Contains(MentionsKey("gpu_not_a_key")));
+  EXPECT_THAT(f.diagnostics.errors,
+              Contains(MentionsKey("gpu_also_not_a_key")));
+  EXPECT_THAT(f.diagnostics.errors,
+              Contains(MentionsKey("gpu_still_not_a_key")));
+}
+
+TEST(RocmTracerOptionsUtilsTest, KeysOwnedByOtherComponentsAreLeftAlone) {
+  // advanced_configuration is shared. ProfilerSession reads
+  // enable_continuous_profiling out of it and passes the proto through to
+  // CreateProfilers without erasing the key; session_manager injects the
+  // hostname and tracemark keys; TPU keys ride the same map. Claiming them
+  // would put an error in the XSpace of every correctly configured session,
+  // and would cost the GPU plane outright under
+  // raise_error_on_start_failure.
+  Fixture f;
+  SetBool(f.options, "enable_continuous_profiling", true);
+  SetBool(f.options, "use_system_hostname", true);
+  SetString(f.options, "override_hostnames", "a,b");
+  SetInt(f.options, "tracemark_lower", 1);
+  SetInt(f.options, "tracemark_upper", 2);
+  SetBool(f.options, "tpu_some_future_key", true);
+  SetInt(f.options, "gpu_max_callback_api_events", 4242);
+  f.Run();
+
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  EXPECT_THAT(f.diagnostics.warnings, IsEmpty());
+  EXPECT_EQ(f.collector.max_callback_api_events, 4242)
+      << "our own key must still be applied alongside foreign ones";
+}
+
+TEST(RocmTracerOptionsUtilsTest, ABadKeyDoesNotStopTheGoodOnesApplying) {
+  // The whole premise of this file. CUPTI returns on the first failure, so
+  // every key after the bad one is dropped; here they must all still land.
+  // Without this, a regression that reintroduced early return would leave
+  // every other test in this file green.
+  Fixture f;
+  SetInt(f.options, "gpu_not_a_key", 1);                    // unknown
+  SetBool(f.options, "gpu_max_activity_api_events", true);  // wrong type
+  SetInt(f.options, "gpu_max_callback_api_events", 4242);   // good
+  SetInt(f.options, "gpu_max_annotation_strings", 777);     // good
+  f.Run();
+
+  EXPECT_EQ(f.collector.max_callback_api_events, 4242);
+  EXPECT_EQ(f.tracer.max_annotation_strings, 777);
+  EXPECT_EQ(f.collector.max_annotation_strings, 777);
+  EXPECT_EQ(f.collector.max_activity_api_events, kActivitySentinel)
+      << "the wrong-typed key must not be applied";
+  EXPECT_THAT(f.diagnostics.errors, SizeIs(2));
+  EXPECT_THAT(f.diagnostics.errors, Contains(MentionsKey("gpu_not_a_key")));
+  EXPECT_THAT(f.diagnostics.errors,
+              Contains(MentionsKey("gpu_max_activity_api_events")));
+}
+
+TEST(RocmTracerOptionsUtilsTest, WrongTypeIsReportedOnce) {
+  Fixture f;
+  SetBool(f.options, "gpu_max_callback_api_events", true);  // documented int64
+  f.Run();
+
+  // Exactly one message. tsl::profiler::SetValue returns its type error before
+  // erasing the key from the working set, so a parser that forgets the
+  // explicit erase reports this key twice: once as a type error and once as
+  // unrecognised.
+  ASSERT_THAT(f.diagnostics.errors, SizeIs(1));
+  EXPECT_THAT(f.diagnostics.errors[0],
+              MentionsKey("gpu_max_callback_api_events"));
+  EXPECT_THAT(f.diagnostics.warnings, IsEmpty());
+  EXPECT_EQ(f.collector.max_callback_api_events, kCallbackSentinel);
+}
+
+TEST(RocmTracerOptionsUtilsTest, UnimplementedKeysAreAcceptedWithWarnings) {
+  Fixture f;
+  SetBool(f.options, "gpu_enable_nvtx_tracking", true);
+  SetBool(f.options, "gpu_enable_cupti_activity_graph_trace", true);
+  SetBool(f.options, "gpu_dump_graph_node_mapping", true);
+  SetString(f.options, "gpu_pm_sample_counters", "SQ_WAVES");
+  SetInt(f.options, "gpu_pm_sample_interval_us", 500);
+  SetInt(f.options, "gpu_pm_sample_buffer_size_per_gpu_mb", 64);
+  SetBool(f.options, "gpu_aggregated_tracing", true);
+  f.Run();
+
+  // A script written against CUDA must not fail on ROCm just because a key is
+  // not implemented here yet.
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  EXPECT_THAT(f.diagnostics.warnings, SizeIs(7));
+  EXPECT_THAT(f.diagnostics.warnings,
+              Contains(MentionsKey("gpu_enable_nvtx_tracking")));
+  EXPECT_THAT(f.diagnostics.warnings,
+              Contains(MentionsKey("gpu_pm_sample_counters")));
+  EXPECT_TRUE(f.AllFieldsUntouched());
+}
+
+TEST(RocmTracerOptionsUtilsTest, WrongTypeOnAnUnimplementedKeyStillErrors) {
+  Fixture f;
+  SetString(f.options, "gpu_pm_sample_interval_us", "500");  // documented int64
+  f.Run();
+
+  // Type-checking the unimplemented keys is not decorative: a user should hear
+  // about this now, not in the release that implements the key.
+  ASSERT_THAT(f.diagnostics.errors, SizeIs(1));
+  EXPECT_THAT(f.diagnostics.errors[0],
+              MentionsKey("gpu_pm_sample_interval_us"));
+  EXPECT_THAT(f.diagnostics.warnings, SizeIs(1));
+}
+
+TEST(RocmTracerOptionsUtilsTest, AllDocumentedKeysAreRecognised) {
+  // The ten gpu_* keys published at openxla.org/xprof/jax_profiling (the
+  // advanced_profiler_options page is linked as "the complete list" but is
+  // TPU-only and lists none of these),
+  // with their documented types. A user copying the page verbatim must not see
+  // a single error on ROCm.
+  //
+  // Note what this does and does not pin. It fails if a key listed here stops
+  // being recognised, or if its documented type stops being accepted. It
+  // cannot notice a key the page gains later: the list is hardcoded and
+  // nothing here reads the page. Keeping the two in step is still manual.
+  Fixture f;
+  SetInt(f.options, "gpu_max_callback_api_events", 2 * 1024 * 1024);
+  SetInt(f.options, "gpu_max_activity_api_events", 2 * 1024 * 1024);
+  SetInt(f.options, "gpu_max_annotation_strings", 1024 * 1024);
+  SetInt(f.options, "gpu_num_chips_to_profile_per_task", 4);
+  SetBool(f.options, "gpu_enable_nvtx_tracking", true);
+  SetBool(f.options, "gpu_enable_cupti_activity_graph_trace", true);
+  SetBool(f.options, "gpu_dump_graph_node_mapping", true);
+  SetString(f.options, "gpu_pm_sample_counters", "SQ_WAVES,GRBM_GUI_ACTIVE");
+  SetInt(f.options, "gpu_pm_sample_interval_us", 500);
+  SetInt(f.options, "gpu_pm_sample_buffer_size_per_gpu_mb", 64);
+  f.Run();
+
+  EXPECT_THAT(f.diagnostics.errors, IsEmpty());
+  // Six unimplemented keys, plus the post-hoc caveat on num_chips.
+  EXPECT_THAT(f.diagnostics.warnings, SizeIs(7));
+  EXPECT_EQ(f.collector.max_callback_api_events, 2 * 1024 * 1024);
+  EXPECT_EQ(f.tracer.max_annotation_strings, 1024 * 1024);
+  EXPECT_EQ(f.collector.num_gpus, 4);
+}
+
+TEST(RocmTracerOptionsUtilsTest, AppendOptionDiagnosticsWritesToXSpace) {
+  RocmTracerOptionDiagnostics diagnostics;
+  diagnostics.errors = {"first error", "second error"};
+  diagnostics.warnings = {"a warning"};
+
+  XSpace space;
+  AppendOptionDiagnostics(diagnostics, &space);
+
+  ASSERT_EQ(space.errors_size(), 2);
+  EXPECT_EQ(space.errors(0), "first error");
+  EXPECT_EQ(space.errors(1), "second error");
+  ASSERT_EQ(space.warnings_size(), 1);
+  EXPECT_EQ(space.warnings(0), "a warning");
+}
+
+TEST(RocmTracerOptionsUtilsTest, AppendOptionDiagnosticsToleratesEmptyAndNull) {
+  XSpace space;
+  AppendOptionDiagnostics(RocmTracerOptionDiagnostics{}, &space);
+  EXPECT_EQ(space.errors_size(), 0);
+  EXPECT_EQ(space.warnings_size(), 0);
+
+  // A null space must not crash, and must not swallow the diagnostic either:
+  // the LOG mirror runs regardless, so the message still reaches somebody.
+  // Only the XSpace writes are skipped. Asserting on the log itself would need
+  // a scoped log sink and a dependency this target does not otherwise carry;
+  // what is pinned here is that the call is safe and unconditional.
+  RocmTracerOptionDiagnostics diagnostics;
+  diagnostics.errors = {"still reaches the log"};
+  AppendOptionDiagnostics(diagnostics, nullptr);
+}
+
+}  // namespace
+}  // namespace profiler
+}  // namespace xla

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.cc
@@ -158,6 +158,11 @@ ScopeRangeIdTree AnnotationMap::TakeScopeRangeIdTree() {
   return std::move(map_.scope_range_id_tree);
 }
 
+void AnnotationMap::SetMaxSize(uint64_t max_size) {
+  absl::MutexLock lock(map_.mutex);
+  max_size_ = max_size;
+}
+
 void AnnotationMap::Clear() {
   absl::MutexLock lock(map_.mutex);
   map_.correlation_map.clear();

--- a/xla/backends/profiler/gpu/rocm_tracer_utils.h
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils.h
@@ -188,16 +188,39 @@ struct RoctxFrame {
   uint64_t generation;
 };
 
+// The annotation-string capacity used when nobody says otherwise. Named so the
+// tracer's AnnotationMap member, the default below and GpuTracer::BuildOptions
+// all refer to one value instead of three literals that can drift apart.
+inline constexpr uint64_t kDefaultMaxAnnotationStrings = 4 * 1024 * 1024;
+
+// The capacity fields below carry the same defaults as their CUPTI equivalents
+// in cupti_collector.h. Every caller in the tree assigns them explicitly today,
+// so these are defence in depth rather than a fix for a live bug: nothing in
+// the type system enforces the assignment, and RocmTracer::Enable now *reads*
+// max_annotation_strings, so a future caller that forgets it would otherwise
+// install an annotation cap from an indeterminate value.
+//
+// num_gpus deliberately has no default, matching CUPTI. There is no safe value:
+// 0 is not "all GPUs" to the collector -- RocmTraceCollectorImpl drops every
+// event whose device index fails `id < num_gpus_` and exports no device planes
+// at all, so defaulting it would turn a forgotten assignment into a silently
+// empty profile instead of something a sanitiser can catch.
+struct RocmTracerOptions {
+  // maximum number of annotation strings that AnnotationMap in RocmTracer can
+  // store.
+  uint64_t max_annotation_strings = kDefaultMaxAnnotationStrings;
+};
+
 struct RocmTraceCollectorOptions {
   // Maximum number of events to collect from callback API; if -1, no limit.
   // if 0, the callback API is enabled to build a correlation map, but no
   // events are collected.
-  uint64_t max_callback_api_events;
+  uint64_t max_callback_api_events = 2 * 1024 * 1024;
   // Maximum number of events to collect from activity API; if -1, no limit.
-  uint64_t max_activity_api_events;
+  uint64_t max_activity_api_events = 2 * 1024 * 1024;
   // Maximum number of annotation strings that we can accommodate.
-  uint64_t max_annotation_strings;
-  // Number of GPUs involved.
+  uint64_t max_annotation_strings = 1024 * 1024;
+  // Number of GPUs involved. Intentionally undefaulted; see above.
   uint32_t num_gpus;
 };
 
@@ -212,6 +235,11 @@ class AnnotationMap {
   int64_t LookUpScopeRangeId(uint64_t correlation_id);
   ScopeRangeIdTree TakeScopeRangeIdTree();
   void Clear();
+
+  // Sets the maximum number of distinct annotation strings retained. Intended
+  // to be called between profiling sessions, while the map is empty; entries
+  // already present are not evicted if the new size is smaller.
+  void SetMaxSize(uint64_t max_size);
 
  private:
   struct AnnotationMapImpl {
@@ -231,8 +259,8 @@ class AnnotationMap {
         ABSL_GUARDED_BY(mutex);
     ScopeRangeIdTree scope_range_id_tree ABSL_GUARDED_BY(mutex);
   };
-  const uint64_t max_size_;
   AnnotationMapImpl map_;
+  uint64_t max_size_ ABSL_GUARDED_BY(map_.mutex);
 
  public:
   // Disable copy and move.

--- a/xla/backends/profiler/gpu/rocm_tracer_utils_test.cc
+++ b/xla/backends/profiler/gpu/rocm_tracer_utils_test.cc
@@ -1,0 +1,143 @@
+/* Copyright 2025 The OpenXLA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "xla/backends/profiler/gpu/rocm_tracer_utils.h"
+
+#include <cstdint>
+#include <string>  // AnnotationMap::Add takes const std::string&
+
+#include <gtest/gtest.h>
+
+namespace xla {
+namespace profiler {
+namespace {
+
+// The AnnotationMap capacity is what gpu_max_annotation_strings ultimately
+// controls, so it needs a test that does not require a GPU. rocm_tracer_utils
+// has no ROCm dependency, which is what makes this file host-only.
+
+TEST(AnnotationMapTest, HonoursConfiguredSize) {
+  AnnotationMap map(/*max_size=*/2);
+  map.Add(1, "first");
+  map.Add(2, "second");
+  map.Add(3, "third");
+
+  EXPECT_EQ(map.LookUp(1), "first");
+  EXPECT_EQ(map.LookUp(2), "second");
+  // Over capacity: silently not retained. Add() is on the callback hot path
+  // and deliberately does not log per-drop.
+  EXPECT_TRUE(map.LookUp(3).empty());
+}
+
+TEST(AnnotationMapTest, FullStringSetAlsoStopsCorrelatingKnownStrings) {
+  // Characterisation test, not an endorsement. The size check gates the whole
+  // Add(), correlation-map insertion included, so once the distinct-string set
+  // is full, later events are left uncorrelated even when their annotation is
+  // one the map already holds. Repeating an annotation is therefore *not*
+  // free at the boundary.
+  //
+  // CUPTI does the same thing (AnnotationMap::Add in cupti_buffer_events.cc
+  // gates on annotation_deduper.Size() < max_size_ before correlation_map
+  // insertion),
+  // so this is shared cross-vendor behaviour rather than a ROCm defect, and
+  // changing it is out of scope here. Pinned so that a future change to either
+  // side is a deliberate one.
+  AnnotationMap map(/*max_size=*/1);
+  for (uint32_t i = 0; i < 100; ++i) {
+    map.Add(i, "same_annotation");
+  }
+  EXPECT_EQ(map.LookUp(0), "same_annotation");
+  EXPECT_TRUE(map.LookUp(99).empty());
+}
+
+TEST(AnnotationMapTest, SetMaxSizeRaisesTheCapForSubsequentAdds) {
+  // The path RocmTracer::Enable takes: Clear(), then SetMaxSize() with the
+  // value derived from the flag or from gpu_max_annotation_strings.
+  AnnotationMap map(/*max_size=*/1);
+  map.Add(1, "first");
+  map.Add(2, "second");
+  ASSERT_TRUE(map.LookUp(2).empty()) << "precondition: cap of 1 is in force";
+
+  map.Clear();
+  map.SetMaxSize(3);
+  map.Add(1, "first");
+  map.Add(2, "second");
+  map.Add(3, "third");
+
+  EXPECT_EQ(map.LookUp(1), "first");
+  EXPECT_EQ(map.LookUp(2), "second");
+  EXPECT_EQ(map.LookUp(3), "third");
+}
+
+TEST(AnnotationMapTest, SetMaxSizeLowersTheCapForSubsequentAdds) {
+  AnnotationMap map(/*max_size=*/100);
+  map.SetMaxSize(1);
+  map.Add(1, "first");
+  map.Add(2, "second");
+
+  EXPECT_EQ(map.LookUp(1), "first");
+  EXPECT_TRUE(map.LookUp(2).empty());
+}
+
+TEST(AnnotationMapTest, SetMaxSizeZeroRetainsNothing) {
+  // 0 means "retain no annotation strings", not "unlimited". RocmTracer::Enable
+  // passes gpu_max_annotation_strings straight through, so this is the value a
+  // user gets by asking for zero -- it must not be reinterpreted, and it must
+  // not silently leave the previous capacity in force.
+  AnnotationMap map(/*max_size=*/8);
+  map.SetMaxSize(0);
+  map.Add(1, "first");
+
+  EXPECT_TRUE(map.LookUp(1).empty());
+}
+
+TEST(AnnotationMapTest, ClearPreservesTheConfiguredSize) {
+  // The invariant RocmTracer::Enable's Clear-then-SetMaxSize ordering rests on:
+  // Clear() drops entries but is not a reset of the capacity. If it ever became
+  // one, Enable would still look correct while every session after the first
+  // silently ran at the constructor default.
+  AnnotationMap map(/*max_size=*/8);
+  map.SetMaxSize(1);
+  map.Clear();
+  map.Add(1, "first");
+  map.Add(2, "second");
+
+  EXPECT_EQ(map.LookUp(1), "first");
+  EXPECT_TRUE(map.LookUp(2).empty()) << "capacity of 1 must survive Clear()";
+}
+
+TEST(AnnotationMapTest, EmptyAnnotationIsIgnored) {
+  // Empty annotations must not consume capacity; the ROCTX path can produce
+  // them and they would otherwise crowd out real ones.
+  AnnotationMap map(/*max_size=*/1);
+  map.Add(1, "");
+  map.Add(2, "real");
+
+  EXPECT_TRUE(map.LookUp(1).empty());
+  EXPECT_EQ(map.LookUp(2), "real");
+}
+
+TEST(AnnotationMapTest, ClearDropsEntries) {
+  AnnotationMap map(/*max_size=*/8);
+  map.Add(1, "first");
+  ASSERT_EQ(map.LookUp(1), "first");
+
+  map.Clear();
+  EXPECT_TRUE(map.LookUp(1).empty());
+}
+
+}  // namespace
+}  // namespace profiler
+}  // namespace xla

--- a/xla/debug_options_flags.cc
+++ b/xla/debug_options_flags.cc
@@ -3740,8 +3740,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       "xla_gpu_rocm_max_trace_events",
       int64_setter_for(&DebugOptions::set_xla_gpu_rocm_max_trace_events),
       debug_options->xla_gpu_rocm_max_trace_events(),
-      "Maximum number of ROCm trace events (applies to callback/activity/"
-      "annotation). Set as high as memory allows; up to 1e9."));
+      "Default maximum number of ROCm trace events, used to seed the "
+      "callback- and activity-event limits. Those are overridden by the "
+      "gpu_max_callback_api_events and gpu_max_activity_api_events keys of "
+      "ProfileOptions.advanced_configuration, which take precedence. This flag "
+      "does not affect the annotation-string cache; use the "
+      "gpu_max_annotation_strings key for that. Set as high as memory allows; "
+      "up to 1e9."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_experimental_enable_tiling_propagation",
       bool_setter_for(


### PR DESCRIPTION
This is the last one of the three PRs.  This PR introduces the behavioural change. `GpuTracer` stores the proto; `BuildOptions()` layers:

```
hardcoded defaults  →  --xla_gpu_rocm_max_trace_events  →  advanced_configuration
```

The flag does **not** seed the `AnnotationMap` cap — it never did before this PR
(`GetRocmTracerOptions()` hardcoded 4 M). Routing the flag there now would
silently shrink the annotation cache for users who lower the flag to bound
memory. Only `gpu_max_annotation_strings` overrides it.

**Diagnostics reach the XSpace.** `AppendOptionDiagnostics` is called before the
`profiling_state_` switch, guarded on `!= kStartedOk` (not terminal) and a
`diagnostics_delivered_` latch (prevents duplication on a repeat `CollectData`).
`BuildOptions` resets both at the next `Start()`. `raise_error_on_start_failure`
still works; warnings are `LOG`-ed before the early return since
`ProfilerController` won't call `CollectData` on a failed tracer.

Cap-exceeded messages in `rocm_collector.cc` now name the `advanced_configuration`
key first, the flag as the fallback.

**Tests:**
- `device_tracer_rocm_test.cc` — 3 E2E cases on MI300X (`BadKeyStillProducesATraceAndSaysWhy`, `RaiseErrorOnStartFailureMakesABadKeyFatal`, `AdvancedConfigurationOverridesTheFlagDefault`). The cap test is self-calibrating: `capped < uncapped` rather than a fixed count, so it doesn't break if extra event types are added.
- `rocm_collector_test` — +2 cases (`CallbackCapDropsEventsBeyondLimit`, `MarkerEventsRespectMaxCallbackApiEvents`). Before this stack, no test in the tree proved any ROCm cap fires.

---

## Test results (branch 3 cumulative)

| Target | Cases | Requires |
|---|---|---|
| `rocm_tracer_utils_test` | 8 | host-only |
| `rocm_tracer_options_utils_test` | 18 | host-only |
| `rocm_collector_test` | 7 (+2) | `--config=rocm` |
| `device_tracer_rocm_test` | 3 (new) | `--config=rocm` + GPU |
| `rocm_tracer_test` | 22 | `--config=rocm` + GPU |

All passing on 8-GPU MI300X (ROCm 7.2.4). `hlo_op_profiler_lib` builds clean.
No CUDA source was modified.
