### PR TITLE
Fix uint64 accumulation overflow in IFRT ArrayMemRegion byte-stride span

### DIFF
--- a/xla/python/ifrt_proxy/common/array_util.cc
+++ b/xla/python/ifrt_proxy/common/array_util.cc
@@ -131,10 +131,27 @@ absl::StatusOr<ArrayMemRegion> ArrayMemRegion::FromZerothElementPointer(
             "byte_stride[", i, "] * (dim[", i,
             "] - 1) overflows: stride=", stride, " dim=", shape.dims()[i]));
       }
-      last_element_byte_offset += static_cast<uint64_t>(product);
+      // Each product is independently in int64 range (checked above), but the
+      // uint64 accumulation of those products can still wrap. Example:
+      // shape=[2,2,2], strides=[INT64_MAX, INT64_MAX, 2] -> each mul succeeds
+      // and the running sum is 2^64 == 0.
+      const uint64_t term = static_cast<uint64_t>(product);
+      if (__builtin_add_overflow(last_element_byte_offset, term,
+                                 &last_element_byte_offset)) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "byte-stride span overflows uint64 while accumulating byte_stride[",
+            i, "] * (dim[", i, "] - 1): stride=", stride,
+            " dim=", shape.dims()[i]));
+      }
     }
   }
-  return ArrayMemRegion(mem_region_start, last_element_byte_offset + byte_size);
+  uint64_t total_size;
+  if (__builtin_add_overflow(last_element_byte_offset,
+                             static_cast<uint64_t>(byte_size), &total_size)) {
+    return absl::InvalidArgumentError(
+        "byte-stride span overflows uint64: last-element offset + dtype size");
+  }
+  return ArrayMemRegion(mem_region_start, total_size);
 }
 
 absl::StatusOr<ArrayMemRegion> ArrayMemRegion::FromMinimalMemRegion(

--- a/xla/python/ifrt_proxy/common/array_util_test.cc
+++ b/xla/python/ifrt_proxy/common/array_util_test.cc
@@ -41,6 +41,7 @@ using ::testing::TestWithParam;
 
 constexpr DType::Kind kF64 = DType::Kind::kF64;
 constexpr DType::Kind kS32 = DType::Kind::kS32;
+constexpr DType::Kind kU8 = DType::Kind::kU8;
 constexpr DType::Kind kString = DType::Kind::kString;
 using Strides = std::vector<int64_t>;
 
@@ -97,7 +98,10 @@ INSTANTIATE_TEST_SUITE_P(
         // Non-compact strides.
         TC{"NonCompactSingleDimension", kS32, {5}, Strides({16}), 68},
         TC{"NonCompactDim0", kS32, {4, 3, 5}, Strides({120, 20, 4}), 420},
-        TC{"PaddedElements", kS32, {4, 3, 5}, Strides({120, 40, 8}), 476}),
+        TC{"PaddedElements", kS32, {4, 3, 5}, Strides({120, 40, 8}), 476},
+        // Products individually fit in int64; the accumulated span also fits.
+        TC{"U8ThreeDimsDefault", kU8, {2, 2, 2}, std::nullopt},
+        TC{"U8ThreeDimsCompactStrides", kU8, {2, 2, 2}, Strides({4, 2, 1})}),
     testing::PrintToStringParamName());
 TEST_P(ArrayMemRegionSuccess, TestCase) {
   const TC tc = GetParam();
@@ -148,7 +152,20 @@ INSTANTIATE_TEST_SUITE_P(
         TC{"ByteStrideOverflowMultiDim",
            kS32,
            {5, 3},
-           Strides({INT64_C(4611686018427387904), 4})}),
+           Strides({INT64_C(4611686018427387904), 4})},
+        // Each product stride*(dim-1) fits in int64 (the #46604 mul check
+        // succeeds) but the uint64 accumulation wraps:
+        // (INT64_MAX) + (INT64_MAX) + 2 == 2^64 == 0.
+        TC{"ByteStrideAccumOverflowUint64",
+           kU8,
+           {2, 2, 2},
+           Strides({INT64_MAX, INT64_MAX, 2})},
+        // Accumulation itself fits (INT64_MAX + INT64_MAX + 1 == UINT64_MAX);
+        // the final last-element-offset + dtype-size add is what overflows.
+        TC{"ByteStrideFinalSizeOverflowUint64",
+           kU8,
+           {2, 2, 2},
+           Strides({INT64_MAX, INT64_MAX, 1})}),
     testing::PrintToStringParamName());
 TEST_P(ArrayMemRegionFailure, TestCase) {
   const TC tc = GetParam();


### PR DESCRIPTION
#ai-generated

I found this while reviewing the recently landed #46604 byte-stride overflow fix and verified the remaining accumulation wrap against the current XLA tree with an in-tree Bazel regression test.

`FromZerothElementPointer` already rejects a `stride * (dim - 1)` product that overflows `int64`. Adding those products into a `uint64_t` without an overflow check still wraps:

```text
shape   = [2, 2, 2]
strides = [INT64_MAX, INT64_MAX, 2]
dtype   = u8
accepted region size = 1
```

A second case, `strides = [INT64_MAX, INT64_MAX, 1]`, accumulates to `UINT64_MAX` and only overflows on the final `+ dtype-size` add.

This change checks `__builtin_add_overflow` on the running sum and on the final add. Tests: `ByteStrideAccumOverflowUint64`, `ByteStrideFinalSizeOverflowUint64`, plus compact `u8` `[2,2,2]` success cases. Compact-layout `byte_size * shape.num_elements()` is not changed (#48286).

```text
bazel test //xla/python/ifrt_proxy/common:array_util_test
```

**PASSED**, 42/42, including `ByteStrideAccumOverflowUint64` and `ByteStrideFinalSizeOverflowUint64`.
