### PR TITLE
[XLA:SPMD] Preserve batch sharding for FFTs

### DIFF
--- a/xla/service/spmd/fft_handler.cc
+++ b/xla/service/spmd/fft_handler.cc
@@ -353,8 +353,21 @@ HloInstruction* SliceValidData(HloInstruction* hlo, const Shape& target_shape,
 
 // Distributed FFT using the algorithm described in go/tpu-spmd-fft.
 absl::Status SpmdPartitioningVisitor::HandleFft(HloInstruction* hlo) {
-  if (hlo->operand(0)->shape().dimensions().size() < 3 ||
-      hlo->fft_type() != FftType::FFT) {
+  const int64_t rank = hlo->operand(0)->shape().dimensions().size();
+  const int64_t first_fft_dim = rank - hlo->fft_length().size();
+  if (hlo->has_sharding() && hlo->sharding().IsTiled()) {
+    bool fft_dims_unsharded = true;
+    for (int64_t dim = first_fft_dim; dim < rank; ++dim) {
+      fft_dims_unsharded &= hlo->sharding().dimension(dim) == 1;
+    }
+    if (fft_dims_unsharded) {
+      // FFTs are independent across non-transformed dimensions, so they can
+      // use the same local partitioning as elementwise operations.
+      return HandleElementwise(hlo);
+    }
+  }
+
+  if (rank < 3 || hlo->fft_type() != FftType::FFT) {
     return DefaultAction(hlo);
   }
 

--- a/xla/service/spmd/spmd_partitioner_test.cc
+++ b/xla/service/spmd/spmd_partitioner_test.cc
@@ -13057,6 +13057,99 @@ ENTRY entry {
       AllOf(op::GetTupleElement(op::While()), op::Shape("c128[1,1,3]")));
 }
 
+TEST_P(SpmdPartitioningTest, FftBatchDimension) {
+  absl::string_view hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  input = c64[8,16] parameter(0), sharding={devices=[2,1]<=[2]}
+  ROOT fft = c64[8,16] fft(input), fft_type=FFT, fft_length={16},
+    sharding={devices=[2,1]<=[2]}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          PartitionComputation(hlo_string, /*num_devices=*/2));
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              AllOf(op::Fft(op::Parameter()), op::Shape("c64[4,16]")));
+  VerifyNoCollectives(module.get());
+}
+
+TEST_P(SpmdPartitioningTest, IfftBatchDimension) {
+  absl::string_view hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  input = c64[8,4,16] parameter(0), sharding={devices=[2,1,1]<=[2]}
+  ROOT fft = c64[8,4,16] fft(input), fft_type=IFFT, fft_length={4,16},
+    sharding={devices=[2,1,1]<=[2]}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          PartitionComputation(hlo_string, /*num_devices=*/2));
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              AllOf(op::Fft(op::Parameter()), op::Shape("c64[4,4,16]")));
+  VerifyNoCollectives(module.get());
+}
+
+TEST_P(SpmdPartitioningTest, RfftBatchDimension) {
+  absl::string_view hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  input = f32[8,4,16,32] parameter(0),
+    sharding={devices=[2,1,1,1]<=[2]}
+  ROOT fft = c64[8,4,16,17] fft(input), fft_type=RFFT,
+    fft_length={16,32}, sharding={devices=[2,1,1,1]<=[2]}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          PartitionComputation(hlo_string, /*num_devices=*/2));
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              AllOf(op::Fft(op::Parameter()), op::Shape("c64[4,4,16,17]")));
+  VerifyNoCollectives(module.get());
+}
+
+TEST_P(SpmdPartitioningTest, IrfftBatchDimension) {
+  absl::string_view hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  input = c64[8,4,16,17] parameter(0),
+    sharding={devices=[2,1,1,1]<=[2]}
+  ROOT fft = f32[8,4,16,32] fft(input), fft_type=IRFFT,
+    fft_length={16,32}, sharding={devices=[2,1,1,1]<=[2]}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          PartitionComputation(hlo_string, /*num_devices=*/2));
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              AllOf(op::Fft(op::Parameter()), op::Shape("f32[4,4,16,32]")));
+  VerifyNoCollectives(module.get());
+}
+
+TEST_P(SpmdPartitioningTest, FftBatchDimensionWithPartialReplication) {
+  absl::string_view hlo_string = R"(
+HloModule module
+
+ENTRY entry {
+  input = c64[8,16] parameter(0),
+    sharding={devices=[2,1,2]<=[4] last_tile_dim_replicate}
+  ROOT fft = c64[8,16] fft(input), fft_type=FFT, fft_length={16},
+    sharding={devices=[2,1,2]<=[4] last_tile_dim_replicate}
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          PartitionComputation(hlo_string, /*num_devices=*/4));
+  EXPECT_THAT(module->entry_computation()->root_instruction(),
+              AllOf(op::Fft(op::Parameter()), op::Shape("c64[4,16]")));
+  VerifyNoCollectives(module.get());
+}
+
 TEST_P(SpmdPartitioningTest, Fft3DSmallShardFallsBack) {
   // The last FFT dimension is sharded down to a per-shard size of 1, so halo
   // exchange (which establishes the divisibility that the per-partition shuffle


### PR DESCRIPTION
## Summary

When an FFT is sharded only along non-transformed dimensions, each partition already contains all data needed for its local FFT. The SPMD partitioner currently falls back to the default handler for these cases, which replicates the full operand before running the FFT.

Treat FFTs as elementwise for partitioning when every transformed dimension has tile count 1. This preserves sharding along batch/non-transformed dimensions and avoids unnecessary collectives. The existing distributed FFT path remains unchanged when a transformed dimension is sharded.

This applies to FFT, IFFT, RFFT, and IRFFT, including partially replicated shardings.

Addresses openxla/xla#24.
Addresses jax-ml/jax#15680.

## Tests

- `BUILD_WORKSPACE_DIRECTORY="$PWD" REMOTE=upstream build_tools/ci/run_clang_format.sh`
- `npx -y @bazel/bazelisk test //xla/service/spmd:spmd_partitioner_test --test_sharding_strategy=disabled --test_filter='\*Fft\*' --test_output=errors`