### PR TITLE
Prevent overflow when rounding BFC allocation sizes

### DIFF
--- a/xla/tsl/framework/bfc_allocator.cc
+++ b/xla/tsl/framework/bfc_allocator.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <cstdint>
 #include <cstdlib>
 #include <deque>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -524,6 +525,12 @@ void* BFCAllocator::AllocateRawInternal(size_t alignment, size_t num_bytes,
                                         AllocationEnd allocation_end) {
   if (ABSL_PREDICT_FALSE(num_bytes == 0)) {
     VLOG(2) << "tried to allocate 0 bytes";
+    return nullptr;
+  }
+  if (ABSL_PREDICT_FALSE(
+          num_bytes > std::numeric_limits<size_t>::max() -
+                          (kMinAllocationSize - 1))) {
+    VLOG(2) << "allocation size cannot be safely rounded: " << num_bytes;
     return nullptr;
   }
   // First, always allocate memory of at least kMinAllocationSize

--- a/xla/tsl/framework/bfc_allocator_test.cc
+++ b/xla/tsl/framework/bfc_allocator_test.cc
@@ -153,6 +153,17 @@ TEST(BFCAllocatorTest, DefaultAlignment) {
   alloc.DeallocateRaw(ptr);
 }
 
+TEST(BFCAllocatorTest, RejectsAllocationWhoseRoundedSizeWouldOverflow) {
+  BFCAllocator::Options opts;
+  opts.allow_retry_on_failure = false;
+  BFCAllocator alloc(std::make_unique<FakeSubAllocator>(),
+                     /*total_memory=*/1 << 20, /*name=*/"test", opts);
+
+  EXPECT_EQ(alloc.AllocateRaw(
+                kAlignment, std::numeric_limits<size_t>::max() - 1),
+            nullptr);
+}
+
 TEST(BFCAllocatorTest, OomLogsAllocationAnnotations) {
   BFCAllocator::Options opts;
   opts.allow_growth = false;


### PR DESCRIPTION
## Summary of Changes

Reject BFC allocation requests that cannot be rounded up to the minimum allocation size without overflowing size_t. Add a focused allocator regression test for the overflow boundary.

## Justification

A request near SIZE_MAX currently wraps to zero during rounding. The allocator can then return an undersized chunk and later fail while validating corrupted chunk metadata. This was observed through TensorFlow in tensorflow/tensorflow#108904, but the affected allocator is maintained in OpenXLA.

## Kind of Contribution

Bug fix and tests.

## Benchmark

Not applicable; this only adds a cold-path bounds check before allocation.

## Unit Tests

The new BFCAllocatorTest.RejectsAllocationWhoseRoundedSizeWouldOverflow test uses the fake suballocator and does not reserve a large buffer. Local validation: git diff --check.

## Execution Tests

Not applicable; the regression is covered at the allocator boundary.