### PR TITLE
[ROCm] Fix silently dropped scales in Triton scaled-dot.

### DIFF
--- a/xla/backends/gpu/codegen/triton/BUILD
+++ b/xla/backends/gpu/codegen/triton/BUILD
@@ -585,6 +585,7 @@ cc_library(
     deps = [
         "//xla:shape_util",
         "//xla:xla_data_proto_cc",
+        "//xla/codegen/xtile/codegen:emitter_helpers",
         "//xla/hlo/ir:hlo",
         "//xla/service:algorithm_util",
         "//xla/service:decision",

--- a/xla/backends/gpu/codegen/triton/support.cc
+++ b/xla/backends/gpu/codegen/triton/support.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
+#include "xla/codegen/xtile/codegen/emitter_helpers.h"
 #include "xla/hlo/ir/hlo_casting_utils.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
@@ -692,18 +693,27 @@ CodegenDecision IsTritonSupportedScaledDot(
   PrimitiveType rhs_scale_type = dot.operand(3)->shape().element_type();
   std::vector<PrimitiveType> supported_scale_types = {F8E4M3FN, F8E5M2,
                                                       F8E8M0FNU, S8};
-  // Unscaled 16-bit operands (BF16) do not use dequantization block scales.
-  // In HLO, they carry dummy/placeholder scale constants (e.g. BF16 1.0), so
-  // we skip the scale type check when the operand type is BF16.
-  if (lhs_type != BF16 &&
-      !absl::c_linear_search(supported_scale_types, lhs_scale_type)) {
-    return CodegenDecision::Forbid(absl::StrCat(
-        "Unsupported LHS scale type: ", PrimitiveType_Name(lhs_scale_type)));
+  // tt.dot_scaled only dequantizes some operand types; a scale on any other
+  // operand type is dropped, so it has to be all ones to be emittable.
+  if (xtile::IsTritonDotScaledOperandType(lhs_type)) {
+    if (!absl::c_linear_search(supported_scale_types, lhs_scale_type)) {
+      return CodegenDecision::Forbid(absl::StrCat(
+          "Unsupported LHS scale type: ", PrimitiveType_Name(lhs_scale_type)));
+    }
+  } else if (!xtile::IsAllOnesScale(*dot.operand(2))) {
+    return CodegenDecision::Forbid(
+        absl::StrCat("LHS scale is ignored for operand type ",
+                     PrimitiveType_Name(lhs_type), " but is not all ones."));
   }
-  if (rhs_type != BF16 &&
-      !absl::c_linear_search(supported_scale_types, rhs_scale_type)) {
-    return CodegenDecision::Forbid(absl::StrCat(
-        "Unsupported RHS scale type: ", PrimitiveType_Name(rhs_scale_type)));
+  if (xtile::IsTritonDotScaledOperandType(rhs_type)) {
+    if (!absl::c_linear_search(supported_scale_types, rhs_scale_type)) {
+      return CodegenDecision::Forbid(absl::StrCat(
+          "Unsupported RHS scale type: ", PrimitiveType_Name(rhs_scale_type)));
+    }
+  } else if (!xtile::IsAllOnesScale(*dot.operand(3))) {
+    return CodegenDecision::Forbid(
+        absl::StrCat("RHS scale is ignored for operand type ",
+                     PrimitiveType_Name(rhs_type), " but is not all ones."));
   }
   return CodegenDecision::Allow();
 }

--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -2177,9 +2177,6 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(TritonEmitterTestWithTilingParam,
        ScaledDotIsSupportedByReferencePlatform) {
-  if (GpuComputeCapability().IsRocm()) {
-    GTEST_SKIP() << "Scaled dot is not supported on AMD.";
-  }
   constexpr absl::string_view kHloText = R"(
     HloModule ScaledDotIsSupportedByReferencePlatform
 

--- a/xla/codegen/xtile/codegen/BUILD
+++ b/xla/codegen/xtile/codegen/BUILD
@@ -172,6 +172,7 @@ cc_library(
     compatible_with = get_compatible_with_portable(),
     deps = [
         ":emitter_helpers",
+        "//xla:shape_util",
         "//xla:xla_data_proto_cc",
         "//xla/codegen/xtile/ir:xtile",
         "//xla/hlo/ir:hlo",

--- a/xla/codegen/xtile/codegen/dot_algorithms.cc
+++ b/xla/codegen/xtile/codegen/dot_algorithms.cc
@@ -41,8 +41,10 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/hlo/ir/hlo_instructions.h"
 #include "xla/hlo/ir/hlo_module.h"
+#include "xla/hlo/ir/hlo_print_options.h"
 #include "xla/hlo/translate/hlo_to_mhlo/attribute_importer.h"
 #include "xla/service/algorithm_util.h"
+#include "xla/shape_util.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/xla_data.pb.h"
 
@@ -91,6 +93,25 @@ absl::StatusOr<Value> ScaledDot(mlir::ImplicitLocOpBuilder& b,
                                 ScaledDotOperands& operands) {
   PrimitiveType lhs_primitive_type = dot.operand(0)->shape().element_type();
   PrimitiveType rhs_primitive_type = dot.operand(1)->shape().element_type();
+
+  // Scales that are not attached to tt.dot_scaled must not change the operand.
+  // A fusion extracted into its own module no longer has the scale's defining
+  // constant, so an effectively scalar shape also denotes an omitted scale.
+  for (int operand_index : {0, 1}) {
+    PrimitiveType operand_type =
+        dot.operand(operand_index)->shape().element_type();
+    if (IsTritonDotScaledOperandType(operand_type)) {
+      continue;
+    }
+    const HloInstruction* scale = dot.operand(operand_index + 2);
+    if (!IsAllOnesScale(*scale) &&
+        !ShapeUtil::IsEffectiveScalar(scale->shape())) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Cannot apply a scale to a ", PrimitiveType_Name(operand_type),
+          " scaled-dot operand: ",
+          scale->ToString(HloPrintOptions::ShortParsable())));
+    }
+  }
 
   Value lhs_scale;
   if (IsTritonDotScaledOperandType(lhs_primitive_type) && operands.lhs_scale) {

--- a/xla/codegen/xtile/codegen/emitter_helpers.cc
+++ b/xla/codegen/xtile/codegen/emitter_helpers.cc
@@ -262,6 +262,33 @@ bool IsPackedTritonDotScaledOperandType(PrimitiveType type) {
          primitive_util::IsSubByteNonPredType(type);
 }
 
+bool IsAllOnesScale(const HloInstruction& scale) {
+  const HloInstruction* value = &scale;
+  while (true) {
+    switch (value->opcode()) {
+      case HloOpcode::kBitcast:
+      case HloOpcode::kBroadcast:
+      case HloOpcode::kConvert:
+      case HloOpcode::kCopy:
+      case HloOpcode::kReshape:
+        value = value->operand(0);
+        break;
+      case HloOpcode::kParameter: {
+        const HloInstruction* fusion = value->parent()->FusionInstruction();
+        if (fusion == nullptr ||
+            value->parameter_number() >= fusion->operand_count()) {
+          return false;
+        }
+        value = fusion->operand(value->parameter_number());
+        break;
+      }
+      default:
+        return value->opcode() == HloOpcode::kConstant &&
+               value->literal().IsAll(1);
+    }
+  }
+}
+
 absl::StatusOr<SmallVector<int64_t>> GetStorageShape(
     ArrayRef<int64_t> logical_shape_dims, const Shape& logical_shape) {
   SmallVector<int64_t> storage_shape(logical_shape_dims.begin(),

--- a/xla/codegen/xtile/codegen/emitter_helpers.h
+++ b/xla/codegen/xtile/codegen/emitter_helpers.h
@@ -238,6 +238,10 @@ mlir::Type GetSignlessType(mlir::Type t);
 // operand to tt.dot_scaled.
 bool IsTritonDotScaledOperandType(PrimitiveType type);
 
+// Returns true if `scale` is provably all ones. Looks through value-preserving
+// ops and fusion parameters, as the scale may be defined outside the fusion.
+bool IsAllOnesScale(const HloInstruction& scale);
+
 // Some Triton dot-scaled value dtypes are smaller than one byte. XTile stores
 // those logical elements inside byte-sized carrier elements, so storage shapes
 // and offsets are expressed in carrier elements rather than logical elements.


### PR DESCRIPTION
📝 Summary of Changes
tt.dot_scaled only dequantizes F4E2M1FN/F8E4M3FN/F8E5M2 operands, so scales on other operand types are never attached to it. IsTritonSupportedScaledDot assumed BF16 scales were always dummy 1.0 and skipped validation, so real scales were silently dropped and an unscaled dot was emitted. Such scales must now be provably all ones, otherwise the op is forbidden and ScaledDotRewriter decomposes it.

🎯 Justification
scaled-dot with 16-bit operands and non-trivial scales silently produced wrong results. Not ROCm-specific: NVIDIA is correct only because CUBLASLT_FISSION survives --xla_gpu_experimental_disable_binary_libraries while HIPBLASLT_FISSION does not, and hits the same bug whenever that fallback is absent.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix

🧪 Unit Tests:
support decision is already covered by support_test.cc ScaledDotTest.ScaledDotOperandTypes

🧪 Execution Tests:
Re-enabled TritonEmitterTest.ScaledDotIsSupportedByReferencePlatform on ROCm by removing its skip.
