### PR TITLE
[XLA:GPU][Triton] Error on cross-host one-shot collective when ROCm targets (unsupported)

### DIFF
--- a/xla/backends/gpu/runtime/all_gather.cc
+++ b/xla/backends/gpu/runtime/all_gather.cc
@@ -154,6 +154,17 @@ absl::StatusOr<AllGatherInfo> BuildAllGatherInfo(
   ABSL_ASSIGN_OR_RETURN(
       const bool is_local,
       IsAllReplicasLocal(gpu_topology, *all_gather, device_assignment));
+  const DebugOptions& debug_options =
+      all_gather->GetModule()->config().debug_options();
+  if (IsCrossHostOneShotKernelEnabled(debug_options, DebugOptions::ALLGATHER) &&
+      device_info.gpu_compute_capability().IsRocm()) {
+    return absl::UnimplementedError(
+        "Cross-host one-shot all-gather (xla_gpu_unsupported_use_cross_host_"
+        "one_shot_kernel=ALLGATHER) requires kLoadStoreAccessible symmetric "
+        "memory (NCCL symmetric-memory windows), which is not supported on "
+        "ROCm/RCCL. Disable the cross-host flag to use the single-host "
+        "kXlaRendezvous path, or run on a CUDA/NCCL target.");
+  }
   ABSL_RETURN_IF_ERROR(IsAllGatherKernelSupported(
       is_collective_kernel_enabled, device_info, num_operands, num_devices,
       num_elements, element_type, is_local, all_gather->replica_groups()));

--- a/xla/backends/gpu/runtime/all_reduce.cc
+++ b/xla/backends/gpu/runtime/all_reduce.cc
@@ -352,6 +352,17 @@ absl::StatusOr<AllReduceInfo> BuildAllReduceInfo(
   ABSL_ASSIGN_OR_RETURN(
       const bool is_local,
       IsAllReplicasLocal(gpu_topology, *all_reduce, device_assignment));
+  const DebugOptions& debug_options =
+      all_reduce->GetModule()->config().debug_options();
+  if (IsCrossHostOneShotKernelEnabled(debug_options, DebugOptions::ALLREDUCE) &&
+      device_info.gpu_compute_capability().IsRocm()) {
+    return absl::UnimplementedError(
+        "Cross-host one-shot all-reduce (xla_gpu_unsupported_use_cross_host_"
+        "one_shot_kernel=ALLREDUCE) requires kLoadStoreAccessible symmetric "
+        "memory (NCCL symmetric-memory windows), which is not supported on "
+        "ROCm/RCCL. Disable the cross-host flag to use the single-host "
+        "kXlaRendezvous path, or run on a CUDA/NCCL target.");
+  }
   if (device_info.device_interconnect_info().active_links <= 0) {
     return absl::UnimplementedError(
         "Collective kernels are only supported on devices with NVLink/UALink "

--- a/xla/backends/gpu/tests/BUILD
+++ b/xla/backends/gpu/tests/BUILD
@@ -1722,6 +1722,10 @@ xla_test(
     backends = [
         "gpu",
     ],
+    # This test exercises the cross-host one-shot all-gather path, which relies
+    # on kLoadStoreAccessible symmetric memory (NCCL symmetric-memory windows).
+    # That mechanism is not available on ROCm/RCCL, so restrict to CUDA.
+    tags = ["cuda-only"],
     deps = [
         "//xla:debug_options_flags",
         "//xla:literal",
@@ -1779,6 +1783,10 @@ xla_test(
     backends = [
         "gpu",
     ],
+    # This test exercises the cross-host one-shot all-reduce path, which relies
+    # on kLoadStoreAccessible symmetric memory (NCCL symmetric-memory windows).
+    # That mechanism is not available on ROCm/RCCL, so restrict to CUDA.
+    tags = ["cuda-only"],
     deps = [
         "//xla:debug_options_flags",
         "//xla:literal",


### PR DESCRIPTION
📝 Summary of Changes
Raises an `UnimplementedError` in BuildAllGatherInfo/BuildAllReduceInfo when cross-host is enabled (xla_gpu_unsupported_use_cross_host_one_shot_kernel) on a ROCm target.

Also tag all_gather_e2e_multiprocess_test and all_reduce_e2e_multiprocess_test as cuda-only, since it exercises the cross-host path which is not supported on ROCm.

🎯 Justification
The cross-host one-shot all-gather/all-reduce path (xla_gpu_unsupported_use_cross_host_one_shot_kernel) relies on `kLoadStoreAccessible` symmetric memory (NCCL symmetric-memory windows), which is not available on `ROCm/RCCL` at the moment.
Instead of silently falling back to the single-host kXlaRendezvous path, fail loudly with an `UnimplementedError` in BuildAllGatherInfo/BuildAllReduceInfo when the flag is set on a ROCm target.

🚀 Kind of Contribution
Please remove what does not apply: 🐛 Bug Fix, 📚 Documentation
