### PR TITLE
[XLA:GPU][oneAPI] Implement batch-pointers kernel for oneAPI backend

### DIFF
--- a/xla/backends/gpu/runtime/BUILD
+++ b/xla/backends/gpu/runtime/BUILD
@@ -4125,6 +4125,7 @@ cc_library(
         "//xla/stream_executor/gpu:gpu_kernel_registry",
         "//xla/stream_executor/gpu:make_batch_pointers_kernel",
         "//xla/stream_executor/rocm:rocm_platform_id",
+        "//xla/stream_executor/sycl:sycl_platform_id",
         "//xla/tsl/platform:statusor",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:status_macros",

--- a/xla/backends/gpu/runtime/make_batch_pointers.cc
+++ b/xla/backends/gpu/runtime/make_batch_pointers.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "xla/stream_executor/rocm/rocm_platform_id.h"
 #include "xla/stream_executor/stream.h"
 #include "xla/stream_executor/stream_executor.h"
+#include "xla/stream_executor/sycl/sycl_platform_id.h"
 #include "xla/tsl/platform/statusor.h"
 #include "xla/util.h"
 
@@ -36,10 +37,13 @@ absl::Status MakeBatchPointers(se::Stream* stream,
                                size_t stride_bytes, size_t n,
                                se::DeviceAddressBase ptrs_out) {
   se::StreamExecutor* executor = stream->parent();
-  size_t threads_per_block = [&] {
-    if (executor->GetPlatform()->id() ==
-        stream_executor::rocm::kROCmPlatformId) {
+  size_t threads_per_block = [&]() -> size_t {
+    se::PlatformId platform_id = executor->GetPlatform()->id();
+    if (platform_id == stream_executor::rocm::kROCmPlatformId) {
       return 256;
+    } else if (platform_id == stream_executor::sycl::kSyclPlatformId) {
+      return std::min<int64_t>(
+          128, executor->GetDeviceDescription().threads_per_block_limit());
     }
     return 128;
   }();

--- a/xla/stream_executor/kernel_spec.h
+++ b/xla/stream_executor/kernel_spec.h
@@ -61,6 +61,8 @@ namespace stream_executor {
 // Loads kernel from in process symbol pointer (e.g. pointer to C++ device
 // function).
 struct InProcessSymbol {
+  // For SYCL, this points to a getter function returning a
+  // `sycl::kernel_id`, interpreted by SyclExecutor::LoadKernel.
   void* symbol;
   // If not empty, this symbol can be looked up by this name in the kernel
   // symbol registry.

--- a/xla/stream_executor/sycl/BUILD
+++ b/xla/stream_executor/sycl/BUILD
@@ -101,6 +101,7 @@ cc_library(
     copts = tsl_copts(),
     visibility = ["//visibility:public"],
     deps = if_sycl_is_configured([
+        ":make_batch_pointers_kernel_sycl",
         ":sycl_platform",
         ":sycl_blas_lt_plugin",
         ":sycl_dnn",
@@ -315,6 +316,7 @@ cc_library(
         "//xla/stream_executor/gpu:gpu_executor_header",
         "//xla/tsl/platform:errors",
         "//xla/tsl/platform:statusor",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/log",
@@ -557,6 +559,26 @@ xla_test(
         "//xla/tsl/platform:logging",
         "@com_google_googletest//:gtest_main",
     ],
+)
+
+sycl_library(
+    name = "make_batch_pointers_kernel_sycl",
+    srcs = ["make_batch_pointers_kernel_sycl.cc"],
+    tags = [
+        "gpu",
+        "oneapi-only",
+    ],
+    deps = [
+        ":sycl_platform_id",
+        "//xla/stream_executor:kernel_spec",
+        "//xla/stream_executor/gpu:gpu_kernel_registry",
+        "//xla/stream_executor/gpu:make_batch_pointers_kernel",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+    alwayslink = 1,
 )
 
 cc_library(

--- a/xla/stream_executor/sycl/make_batch_pointers_kernel_sycl.cc
+++ b/xla/stream_executor/sycl/make_batch_pointers_kernel_sycl.cc
@@ -1,0 +1,79 @@
+/* Copyright 2026 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstddef>
+
+// clang-format off
+#include <sycl/sycl.hpp>
+// clang-format on
+
+#include "absl/base/casts.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "xla/stream_executor/gpu/gpu_kernel_registry.h"
+#include "xla/stream_executor/gpu/make_batch_pointers_kernel.h"
+#include "xla/stream_executor/kernel_spec.h"
+#include "xla/stream_executor/sycl/sycl_platform_id.h"
+
+namespace {
+
+namespace syclexp = ::sycl::ext::oneapi::experimental;
+namespace syclext = ::sycl::ext::oneapi;
+
+}  // namespace
+
+// Free-function kernels require global scope since stream_executor::sycl
+// namespace would shadow ::sycl in SYCL_EXT_ONEAPI_FUNCTION_PROPERTY's macro
+// expansion. Also, the toolchain-generated integration header cannot resolve a
+// namespaced free-function kernel.
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<3>))
+void MakeBatchPointersSycl(char* base, size_t stride, size_t n,
+                           void** ptrs_out) {
+  size_t idx = syclext::this_work_item::get_nd_item<3>().get_global_linear_id();
+  if (idx >= n) {
+    return;
+  }
+  ptrs_out[idx] = base + idx * stride;
+}
+
+namespace stream_executor::sycl {
+
+// Host-only: get_kernel_id<> needs is_kernel<> specialization from the
+// integration header, which is unavailable during the device compilation pass.
+#ifndef __SYCL_DEVICE_ONLY__
+
+absl::StatusOr<::sycl::kernel_id> GetMakeBatchPointersKernelId() {
+  try {
+    return syclexp::get_kernel_id<MakeBatchPointersSycl>();
+  } catch (const ::sycl::exception& e) {
+    return absl::InternalError(absl::StrCat(
+        "GetMakeBatchPointersKernelId: Failed to get kernel id, got ",
+        e.what()));
+  }
+}
+
+GPU_KERNEL_REGISTRY_REGISTER_KERNEL_STATICALLY(
+    MakeBatchPointersKernelSycl, stream_executor::gpu::MakeBatchPointersKernel,
+    stream_executor::sycl::kSyclPlatformId, ([](size_t arity) {
+      return stream_executor::KernelLoaderSpec::CreateInProcessSymbolSpec(
+          absl::bit_cast<void*>(
+              &stream_executor::sycl::GetMakeBatchPointersKernelId),
+          "MakeBatchPointersSycl", arity);
+    }));
+
+#endif  // __SYCL_DEVICE_ONLY__
+
+}  // namespace stream_executor::sycl

--- a/xla/stream_executor/sycl/sycl_executor.cc
+++ b/xla/stream_executor/sycl/sycl_executor.cc
@@ -32,6 +32,7 @@ limitations under the License.
 #include <utility>
 #include <variant>
 
+#include "absl/base/casts.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/numeric/int128.h"
@@ -425,82 +426,93 @@ absl::Status SyclExecutor::Init() {
 
 absl::StatusOr<std::unique_ptr<Kernel>> SyclExecutor::LoadKernel(
     const KernelLoaderSpec& spec) {
-  // Check that a SPIR-V binary is provided in the spec.
-  if (!spec.has_cuda_cubin_in_memory()) {
-    return absl::InternalError(
-        "SyclExecutor::LoadKernel: No SPIR-V binary provided in spec.");
-  }
-
-  // Create a new SyclKernel instance for the loaded kernel.
   auto sycl_kernel = std::make_unique<SyclKernel>(this);
   const std::string& kernel_name = spec.kernel_name();
-  const char* spirv_binary = reinterpret_cast<const char*>(
-      spec.cuda_cubin_in_memory()->cubin_bytes.data());
-  size_t spirv_size = spec.cuda_cubin_in_memory()->cubin_bytes.size();
+  std::unique_ptr<sycl::kernel> kernel_function;
 
-  ModuleHandle module_handle{spirv_binary};
-  ze_module_handle_t module = nullptr;
-
-  // Check if the module is already loaded.
-  {
-    absl::MutexLock lock{&in_memory_modules_mu_};
-    auto in_mem_it = in_memory_modules_.find(module_handle);
-    if (in_mem_it != in_memory_modules_.end()) {
-      module = in_mem_it->second;
+  if (spec.has_in_process_symbol()) {
+    ABSL_ASSIGN_OR_RETURN(sycl::context sycl_context, GetContext());
+    using KernelIdGetter = absl::StatusOr<sycl::kernel_id> (*)();
+    ABSL_ASSIGN_OR_RETURN(
+        sycl::kernel_id kernel_id,
+        absl::bit_cast<KernelIdGetter>(spec.in_process_symbol()->symbol)());
+    try {
+      auto kernel_bundle =
+          sycl::get_kernel_bundle<sycl::bundle_state::executable>(sycl_context,
+                                                                  {kernel_id});
+      kernel_function =
+          std::make_unique<sycl::kernel>(kernel_bundle.get_kernel(kernel_id));
+    } catch (const sycl::exception& e) {
+      return absl::InternalError(absl::StrCat(
+          "SyclExecutor::LoadKernel: Failed to get kernel bundle for '",
+          kernel_name, "', got ", e.what()));
     }
-  }
+  } else if (spec.has_cuda_cubin_in_memory()) {
+    const char* spirv_binary = reinterpret_cast<const char*>(
+        spec.cuda_cubin_in_memory()->cubin_bytes.data());
+    size_t spirv_size = spec.cuda_cubin_in_memory()->cubin_bytes.size();
 
-  // If module is not loaded, load it outside the lock for efficiency.
-  // Only the first thread to load the module inserts it into the cache.
-  // Other threads reuse the cached module and unload their own redundant
-  // module.
-  if (module == nullptr) {
-    ABSL_ASSIGN_OR_RETURN(module, LoadLevelZeroModule(sycl_context_.get(),
-                                                 spirv_binary, spirv_size));
+    // Lookup key for the module cache; keyed by pointer address, not content.
+    ModuleHandle module_handle{spirv_binary};
+
+    ze_module_handle_t lz_module_handle = nullptr;
+    // Check if the module is already loaded.
     {
       absl::MutexLock lock{&in_memory_modules_mu_};
-      // Try to insert the newly loaded module into the cache.
-      auto [in_mem_it, inserted] =
-          in_memory_modules_.emplace(module_handle, module);
-      if (!inserted) {
-        // Another thread loaded the module first.
-        // Unload the redundant module inside the lock since unloading is fast
-        // and also to avoid resource leaks.
-        UnloadLevelZeroModule(sycl_context_.get(), module);
-        module = in_mem_it->second;
-
-        // Increment reference count in gpu_binary_to_module_.
-        auto gpu_bin_it = gpu_binary_to_module_.find(module_handle);
-        if (gpu_bin_it != gpu_binary_to_module_.end()) {
-          ++(gpu_bin_it->second.second);
-        } else {
-          // This should not happen since in_memory_modules_ and
-          // gpu_binary_to_module_ should be consistent.
-          return absl::InternalError(
-              "SyclExecutor::LoadKernel: Inconsistent module cache state.");
-        }
-      } else {
-        // Newly inserted module: Set reference count to 1 in
-        // gpu_binary_to_module_.
-        gpu_binary_to_module_[module_handle] = std::make_pair(module, 1);
+      auto in_mem_it = in_memory_modules_.find(module_handle);
+      if (in_mem_it != in_memory_modules_.end()) {
+        lz_module_handle = in_mem_it->second;
+        ABSL_RETURN_IF_ERROR(IncrementModuleRefCount(module_handle));
       }
     }
+    // If module is not loaded, load it outside the lock for efficiency.
+    // Only the first thread to load the module inserts it into the cache.
+    // Other threads reuse the cached module.
+    if (lz_module_handle == nullptr) {
+      ABSL_ASSIGN_OR_RETURN(
+          lz_module_handle,
+          LoadLevelZeroModule(sycl_context_.get(), spirv_binary, spirv_size));
+      {
+        absl::MutexLock lock{&in_memory_modules_mu_};
+        // Try to insert the newly loaded module into the cache.
+        auto [in_mem_it, inserted] =
+            in_memory_modules_.emplace(module_handle, lz_module_handle);
+        if (!inserted) {
+          // Another thread already loaded the module, so unload and use
+          // existing handle.
+          UnloadLevelZeroModule(sycl_context_.get(), lz_module_handle);
+          lz_module_handle = in_mem_it->second;
+          ABSL_RETURN_IF_ERROR(IncrementModuleRefCount(module_handle));
+        } else {
+          // Newly inserted module: Set reference count to 1 in
+          // gpu_binary_to_module_.
+          gpu_binary_to_module_[module_handle] =
+              std::make_pair(lz_module_handle, 1);
+        }
+      }
+    }
+    // Retrieve the kernel function from the loaded module.
+    VLOG(2) << "Getting function " << kernel_name << " from module "
+            << lz_module_handle;
+    ABSL_ASSIGN_OR_RETURN(
+        kernel_function,
+        GetModuleFunction(sycl_context_.get(), lz_module_handle,
+                          kernel_name.c_str()));
+    {
+      absl::MutexLock lock{&in_memory_modules_mu_};
+      kernel_to_gpu_binary_[sycl_kernel.get()] = module_handle;
+    }
+  } else {
+    return absl::InternalError(
+        "SyclExecutor::LoadKernel: No method of loading SYCL kernel "
+        "provided.");
   }
-
-  // Retrieve the kernel function from the loaded module.
-  VLOG(2) << "Getting function " << kernel_name << " from module " << module;
-  ABSL_ASSIGN_OR_RETURN(
-      std::unique_ptr<sycl::kernel> function,
-      GetModuleFunction(sycl_context_.get(), module, kernel_name.c_str()));
   {
     absl::MutexLock lock{&in_memory_modules_mu_};
-    // Track which kernels are loaded and their associated modules.
-    kernel_to_gpu_binary_[sycl_kernel.get()] = module_handle;
     loaded_kernels_.insert(sycl_kernel.get());
   }
-
   // Set kernel function and metadata.
-  sycl_kernel->set_gpu_function(function.release());
+  sycl_kernel->set_gpu_function(kernel_function.release());
   // We have to trust the kernel loader spec arity because there doesn't
   // appear to be a way to reflect on the number of expected arguments w/the
   // SPIR API.
@@ -972,6 +984,19 @@ bool SyclExecutor::UnloadGpuBinary(ModuleHandle module_handle) {
     if (mem_it != ModuleHandle{}) in_memory_modules_.erase(mem_it);
   }
   return true;
+}
+
+absl::Status SyclExecutor::IncrementModuleRefCount(ModuleHandle module_handle) {
+  auto module_it = gpu_binary_to_module_.find(module_handle);
+  if (module_it == gpu_binary_to_module_.end()) {
+    // This should not happen since in_memory_modules_ and
+    // gpu_binary_to_module_ should be consistent.
+    return absl::InternalError(
+        "SyclExecutor::IncrementModuleRefCount: Inconsistent module cache "
+        "state.");
+  }
+  ++(module_it->second.second);
+  return absl::OkStatus();
 }
 
 absl::StatusOr<DeviceAddressBase> SyclExecutor::GetSymbol(

--- a/xla/stream_executor/sycl/sycl_executor.h
+++ b/xla/stream_executor/sycl/sycl_executor.h
@@ -246,6 +246,12 @@ class SyclExecutor : public gpu::GpuExecutor {
   bool UnloadGpuBinary(ModuleHandle module_handle)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(in_memory_modules_mu_);
 
+  // Increments the reference count of an already-cached module.
+  // REQUIRES: Caller must hold in_memory_modules_mu_.
+  // Returns an error if module_handle is not in gpu_binary_to_module_.
+  absl::Status IncrementModuleRefCount(ModuleHandle module_handle)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(in_memory_modules_mu_);
+
   // Mutex for blas, dnn, and fft.
   absl::Mutex mu_;
   std::unique_ptr<blas::BlasSupport> blas_ ABSL_GUARDED_BY(mu_);


### PR DESCRIPTION
This PR adds a device-side batch-pointers kernel for the oneAPI backend. The kernel computes an array of batch pointers on the GPU by striding from a base address which is used in batched operations.

This kernel is registered as a free-function SYCL kernel, which is a plain function compiled directly into the binary and identified by a `sycl::kernel_id`, rather than loaded from a separate SPIR-V blob.

Kernel loading in `sycl_executor.cc` now also handles in-process symbol specs by resolving the kernel's id from the registered function pointer and building an executable kernel bundle via the SYCL host runtime.

No new tests were added since this kernel is already covered by `//xla/backends/gpu/runtime:make_batch_pointers_test`.