### PR TITLE
[XLA:GPU] Support num_ctas > 1 for Triton GEMM fusions

### DIFF
--- a/xla/backends/gpu/autotuner/triton/dot_search_space.cc
+++ b/xla/backends/gpu/autotuner/triton/dot_search_space.cc
@@ -137,6 +137,7 @@ std::vector<TritonGemmConfig> TritonDotFusionSearchSpace::GenerateConfigs(
   if (stream_executor::gpu::IsTmaAvailableForDevice(device_description_)) {
     ExtendConfigs(configs, &TritonDotFusionSearchSpace::AddTmaParameter);
   }
+  ExtendConfigs(configs, &TritonDotFusionSearchSpace::AddClusterSizeParameter);
   if (autotune_warp_specialization) {
     ExtendConfigs(configs,
                   &TritonDotFusionSearchSpace::AddWarpSpecializationParameter);
@@ -148,10 +149,7 @@ std::vector<TritonGemmConfig> TritonDotFusionSearchSpace::GenerateConfigs(
   std::vector<TritonGemmConfig> result;
   result.reserve(configs.size());
   for (ConfigWithNotes& config_with_notes : configs) {
-    TritonGemmConfig& config = config_with_notes.config;
-    // TODO: b/408386169 - Implement CTA cluster support.
-    config.num_ctas = 1;
-    result.push_back(config);
+    result.push_back(config_with_notes.config);
   }
   return result;
 }
@@ -545,6 +543,24 @@ void TritonDotFusionSearchSpace::AddTmaParameter(
 
   if (exhaustive_tiling_search_ || IsTmaRecommended(config.config)) {
     new_config.config.is_tma_allowed = true;
+    updated_configs.push_back(new_config);
+  }
+}
+
+void TritonDotFusionSearchSpace::AddClusterSizeParameter(
+    const ConfigWithNotes& config,
+    std::vector<ConfigWithNotes>& updated_configs) const {
+  ConfigWithNotes new_config = config;
+  new_config.config.num_ctas = 1;
+  updated_configs.push_back(new_config);
+  // Two CTAs per cluster: TMA multicast on Hopper, tcgen05 cta_group::2 on
+  // Blackwell.
+  constexpr int kClusterSize = 2;
+  if (exhaustive_tiling_search_ &&
+      device_description_.cuda_compute_capability().IsAtLeastHopper()) {
+    new_config.config.num_ctas = kClusterSize;
+    VLOG(10) << "Adding cluster size parameter: config = "
+             << new_config.ToString();
     updated_configs.push_back(new_config);
   }
 }

--- a/xla/backends/gpu/autotuner/triton/dot_search_space.h
+++ b/xla/backends/gpu/autotuner/triton/dot_search_space.h
@@ -209,6 +209,11 @@ class TritonDotFusionSearchSpace {
   void AddTmaParameter(const ConfigWithNotes& config,
                        std::vector<ConfigWithNotes>& updated_configs) const;
 
+  // Extend the passed configs with the number of CTAs per cluster.
+  void AddClusterSizeParameter(
+      const ConfigWithNotes& config,
+      std::vector<ConfigWithNotes>& updated_configs) const;
+
   // Extend the passed configs with automatic warp specialization.
   void AddWarpSpecializationParameter(
       const ConfigWithNotes& config,

--- a/xla/backends/gpu/autotuner/triton/dot_search_space_test.cc
+++ b/xla/backends/gpu/autotuner/triton/dot_search_space_test.cc
@@ -527,6 +527,27 @@ TEST_F(DotSearchSpaceTest, CudaDoesNotGenerateWavesPerEuConfigs) {
               AllOf(Not(IsEmpty()), Each(WavesPerEuIs(Eq(0)))));
 }
 
+TEST_F(DotSearchSpaceTest, DefaultSearchSpaceUsesSingleCtaClusters) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                       GetDefaultDotModule());
+  TritonDotFusionSearchSpace search_space = MakeSearchSpace(module.get());
+
+  EXPECT_THAT(search_space.GenerateConfigs(),
+              AllOf(Not(IsEmpty()), Each(NumCtasIs(Eq(1)))));
+}
+
+TEST_F(DotSearchSpaceTest, ExhaustiveSearchSpaceConsidersTwoCtaClusters) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                       GetDefaultDotModule());
+  auto debug_options = module->config().debug_options();
+  debug_options.set_xla_gpu_exhaustive_tiling_search(true);
+  module->mutable_config().set_debug_options(debug_options);
+  TritonDotFusionSearchSpace search_space = MakeSearchSpace(module.get());
+
+  EXPECT_THAT(search_space.GenerateConfigs(),
+              AllOf(Contains(NumCtasIs(Eq(2))), Each(NumCtasIs(AnyOf(1, 2)))));
+}
+
 class RocmDotSearchSpaceTest : public DefaultDeviceDotSearchSpaceTest {
  protected:
   RocmDotSearchSpaceTest() {
@@ -549,6 +570,32 @@ TEST_F(RocmDotSearchSpaceTest, GeneratesWavesPerEuConfigs) {
 
   EXPECT_THAT(configs, AllOf(Not(IsEmpty()), Contains(WavesPerEuIs(Ge(1))),
                              Each(WavesPerEuIs(AnyOf(0, 1, 2, 4)))));
+}
+
+class AmpereDotSearchSpaceTest : public DefaultDeviceDotSearchSpaceTest {
+ protected:
+  AmpereDotSearchSpaceTest() {
+    // A100 SXM parameters.
+    device_description_.set_registers_per_block_limit(64 * 1024);
+    device_description_.set_core_count(108);
+    device_description_.set_threads_per_block_limit(1024);
+    device_description_.set_threads_per_warp(32);
+    device_description_.set_shared_memory_per_block_optin(164 * 1024);
+    device_description_.set_gpu_compute_capability(
+        se::CudaComputeCapability::Ampere());
+  }
+};
+
+TEST_F(AmpereDotSearchSpaceTest, DoesNotGenerateClusterConfigsBeforeHopper) {
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> module,
+                       GetDefaultDotModule());
+  auto debug_options = module->config().debug_options();
+  debug_options.set_xla_gpu_exhaustive_tiling_search(true);
+  module->mutable_config().set_debug_options(debug_options);
+  TritonDotFusionSearchSpace search_space = MakeSearchSpace(module.get());
+
+  EXPECT_THAT(search_space.GenerateConfigs(),
+              AllOf(Not(IsEmpty()), Each(NumCtasIs(Eq(1)))));
 }
 
 }  // namespace

--- a/xla/backends/gpu/codegen/triton/fusion.cc
+++ b/xla/backends/gpu/codegen/triton/fusion.cc
@@ -375,18 +375,20 @@ std::optional<TritonFusion::LaunchConfig> TritonFusion::GetLaunchConfig(
              num_blocks);
   }
 
+  const int64_t total_ctas = num_blocks * block_level_parameters.num_ctas;
+
   LaunchConfig launch_config;
   // TODO(b/451901200): We eventually also want to be able to predict this
   // value without compiling so the cost model can rely on it. Currently, we
   // need the override for auto warp specialization.
   if (thread_dims_override) {
     launch_config.launch_dimensions = LaunchDimensions{
-        se::BlockDim(num_blocks), thread_dims_override.value()};
+        se::BlockDim(total_ctas), thread_dims_override.value()};
   } else {
     int64_t estimated_threads_per_block =
         block_level_parameters.num_warps * WarpSize(analysis->device_info());
     launch_config.launch_dimensions =
-        LaunchDimensions{static_cast<uint64_t>(num_blocks),
+        LaunchDimensions{static_cast<uint64_t>(total_ctas),
                          static_cast<uint64_t>(estimated_threads_per_block)};
   }
 

--- a/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
+++ b/xla/backends/gpu/codegen/triton/tests/fusion_emitter_device_test.cc
@@ -1022,6 +1022,43 @@ ENTRY entry_computation {
   EXPECT_TRUE(RunAndCompareNoHloPasses(hlo_text, kExactMatch));
 }
 
+// Parameterized to make sure that a cluster launch also works when TMA is
+// enabled.
+TEST_P(TmaParameterizedTritonEmitterTest, TestDotWithTwoCtaCluster) {
+  if (!GetCudaComputeCapability().IsAtLeastHopper()) {
+    GTEST_SKIP() << "Thread block clusters require sm_90+.";
+  }
+  constexpr absl::string_view kHloTextTemplate = R"(
+HloModule m
+
+triton_dot {
+  p0 = bf16[512,512] parameter(0)
+  p1 = bf16[512,512] parameter(1)
+  ROOT dot = f32[512,512] dot(p0, p1),
+    lhs_contracting_dims={1}, rhs_contracting_dims={0},
+    backend_config={sizes:[64]}
+}
+
+ENTRY e {
+  p0 = bf16[512,512] parameter(0)
+  p1 = bf16[512,512] parameter(1)
+  ROOT fusion = f32[512,512] fusion(p0, p1), kind=kCustom, calls=triton_dot,
+    backend_config={"fusion_backend_config":{
+      "kind":"__triton_nested_gemm_fusion",
+      "block_level_fusion_config":{
+        "output_tiles":[{"sizes":["128","128"]}],
+        "num_warps":"8",
+        "num_ctas":"2",
+        "num_stages":"3",
+        "is_tma_allowed":"$0"}}}
+})";
+  const bool is_tma_allowed = std::get<0>(GetParam());
+  const std::string hlo_text =
+      absl::Substitute(kHloTextTemplate, is_tma_allowed);
+  EXPECT_TRUE(RunAndCompareNoHloPasses(hlo_text, ErrorSpec{/*aabs=*/1e-2,
+                                                           /*arel=*/1e-2}));
+}
+
 TEST_P(TritonEmitterTestWithTilingParam,
        TestSliceWithTileElementsNotAllContiguous) {
   constexpr absl::string_view kHloText = R"(


### PR DESCRIPTION
Support num_ctas > 1 for Triton GEMM fusions
#ai-generated

📝 Summary of Changes
- Resolves `// TODO: b/408386169 - Implement CTA cluster support.`
- Fixes the launch grid in `TritonFusion::GetLaunchConfig` for `num_ctas > 1`.
  Triton uses `%clusterid` as the program id in that case, so one program is a
  whole cluster and we need `num_tiles * num_ctas` CTAs, not `num_tiles`. No host-side cluster attribute is needed, as ncu shows `launch__cluster_dim_x = 2` after the fix.
- Adds a cluster size parameter to `TritonDotFusionSearchSpace`. Default
  configs stay at `num_ctas = 1`. `num_ctas = 2` is only tried on sm_90+ with
  `--xla_gpu_exhaustive_tiling_search`. 


🎯 Justification
Explain why this change is important and which workload benefits from this
change.
- I was looking at the `b/408386169` TODO and tried a GEMM fusion with
  `num_ctas: 2` to see what happens. It runs fine but the result is silently
  wrong: with a 1024x1024 output and 128x128 tiles we launch 64 CTAs, the
  driver groups them into 32 clusters (the cluster size is in the PTX), so
  `%clusterid` only goes up to 31 and rows 512 to 1023 of the output are never
  written. RunAndCompareNoHloPasses against the HLO interpreter reports a 50% mismatch. If the grid uses 128 CTAs, the same config passes.

🚀 Kind of Contribution
Please remove what does not apply: 
🐛 Bug Fix, 🧪 Tests


📊 Benchmark (for Performance Improvements)
Please measure and include speedups for one of the public HLOs in
`compiler/xla/tools/benchmarks/hlo/`.

🧪 Unit Tests:
What unit tests were added? For example, a new pass should be tested on minimal
HLO. The transformation can be tested with FileCheck tests or assertions on the
transformed HLO.

In `dot_search_space_test.cc`, `DefaultSearchSpaceUsesSingleCtaClusters`,`ExhaustiveSearchSpaceConsidersTwoCtaClusters`, `AmpereDotSearchSpaceTest.DoesNotGenerateClusterConfigsBeforeHopper` were added.

🧪 Execution Tests:
What execution tests were added? For example, a new optimization should be
tested with an end-to-end execution test triggering the optimization and
asserting correctness. Please provide test cases running with at most 2 GPUs.

In `fusion_emitter_device_test.cc`, `TestDotWithTwoCtaCluster` was added.
