### PR TITLE
[XLA:GPU][codegen] Use driver intrinsics to lower math.cbrt in the SPIR-V backend

### DIFF
--- a/xla/codegen/emitters/transforms/lowering_utils.h
+++ b/xla/codegen/emitters/transforms/lowering_utils.h
@@ -49,10 +49,11 @@ template <typename... Ops>
 struct SPIRVMathOps {};
 
 inline auto getSPIRVMathOps() {
-  return SPIRVMathOps<
-      mm::AcosOp, mm::AcoshOp, mm::AsinOp, mm::AsinhOp, mm::Atan2Op, mm::AtanOp,
-      mm::AtanhOp, mm::CosOp, mm::CoshOp, mm::ErfOp, mm::ExpM1Op, mm::ExpOp,
-      mm::Log1pOp, mm::LogOp, mm::SinOp, mm::SinhOp, mm::TanOp, mm::TanhOp>{};
+  return SPIRVMathOps<mm::AcosOp, mm::AcoshOp, mm::AsinOp, mm::AsinhOp,
+                      mm::Atan2Op, mm::AtanOp, mm::AtanhOp, mm::CbrtOp,
+                      mm::CosOp, mm::CoshOp, mm::ErfOp, mm::ExpM1Op, mm::ExpOp,
+                      mm::Log1pOp, mm::LogOp, mm::SinOp, mm::SinhOp, mm::TanOp,
+                      mm::TanhOp>{};
 }
 
 template <typename Op>


### PR DESCRIPTION
This PR uses driver intrinsics to lower cbrt for single, double and 16-bit floating point precisions in the SPIR-V backend.
This fixes legalization error in `//xla/codegen/intrinsic/accuracy:intrinsic_accuracy_test` that fails with "failed to legalize operation 'math.cbrt'"
