### PR TITLE
[XLA:CPU] Fix out-of-bounds read and crash in spatial convolution with negative padding

### DIFF
--- a/xla/tsl/framework/convolution/eigen_spatial_convolutions-inl.h
+++ b/xla/tsl/framework/convolution/eigen_spatial_convolutions-inl.h
@@ -881,19 +881,27 @@ class TensorContractionSubMapper<
     // possible to guarantee "no padding or skipping" for non-standard packing.
     if (nonStandardPatches()) return true;
 
-    // Non zero padding before.
-    if (m_base_mapper.m_rowPaddingTop > 0) return true;
-    if (m_base_mapper.m_colPaddingLeft > 0) return true;
+    if (m_base_mapper.m_outputRows <= 0 || m_base_mapper.m_outputCols <= 0) {
+      return false;
+    }
 
-    // Non zero padding after in rows.
+    // Check row bounds.
+    const Index first_row = -m_base_mapper.m_rowPaddingTop;
+    if (first_row < 0 || first_row >= m_base_mapper.m_inputRows) return true;
+
     const Index last_row =
-        (m_base_mapper.m_outputRows - 1) * m_base_mapper.m_row_strides;
-    if (last_row + (patchRows() - 1) >= m_base_mapper.m_inputRows) return true;
+        (m_base_mapper.m_outputRows - 1) * m_base_mapper.m_row_strides -
+        m_base_mapper.m_rowPaddingTop + (patchRows() - 1);
+    if (last_row < 0 || last_row >= m_base_mapper.m_inputRows) return true;
 
-    // Non zero padding after in cols.
+    // Check col bounds.
+    const Index first_col = -m_base_mapper.m_colPaddingLeft;
+    if (first_col < 0 || first_col >= m_base_mapper.m_inputCols) return true;
+
     const Index last_col =
-        (m_base_mapper.m_outputCols - 1) * m_base_mapper.m_col_strides;
-    if (last_col + (patchCols() - 1) >= m_base_mapper.m_inputCols) return true;
+        (m_base_mapper.m_outputCols - 1) * m_base_mapper.m_col_strides -
+        m_base_mapper.m_colPaddingLeft + (patchCols() - 1);
+    if (last_col < 0 || last_col >= m_base_mapper.m_inputCols) return true;
 
     return false;
   }

--- a/xla/tsl/framework/convolution/eigen_spatial_convolutions_test.cc
+++ b/xla/tsl/framework/convolution/eigen_spatial_convolutions_test.cc
@@ -761,6 +761,114 @@ TEST(EigenSpatialConvolutionsTest, SpatialConvContractionMapper) {
   EigenApprox(8.0f, direct(0, 1, 3, 0));
 }
 
+TEST(EigenSpatialConvolutionsTest, NegativeLowPaddingSpatialConvolution) {
+  const int input_depth = 8;
+  const int input_rows = 15;
+  const int input_cols = 6;
+  const int num_batches = 1;
+  const int output_depth = 8;
+  const int patch_rows = 1;
+  const int patch_cols = 1;
+
+  // Negative low padding on columns: crop 5 columns on left, pad 1 on right.
+  // Effective input_cols = 6 + (-5) + 1 = 2.
+  const int padding_top = 0;
+  const int padding_bottom = 0;
+  const int padding_left = -5;
+  const int padding_right = 1;
+
+  const int output_rows = input_rows;
+  const int output_cols = input_cols + padding_left + padding_right;
+
+  Tensor<float, 4> input(input_depth, input_rows, input_cols, num_batches);
+  Tensor<float, 4> kernel(output_depth, input_depth, patch_rows, patch_cols);
+
+  // Initialize input: input(c, r, col, b)
+  for (int b = 0; b < num_batches; ++b) {
+    for (int col = 0; col < input_cols; ++col) {
+      for (int r = 0; r < input_rows; ++r) {
+        for (int c = 0; c < input_depth; ++c) {
+          input(c, r, col, b) = 100.0f * r + 10.0f * col + c;
+        }
+      }
+    }
+  }
+
+  // 1x1 identity kernel across channels
+  for (int od = 0; od < output_depth; ++od) {
+    for (int id = 0; id < input_depth; ++id) {
+      kernel(od, id, 0, 0) = (od == id) ? 1.0f : 0.0f;
+    }
+  }
+
+  Tensor<float, 4> result =
+      SpatialConvolution(input, kernel, /*row_stride=*/1, /*col_stride=*/1,
+                         PADDING_VALID, /*row_in_stride=*/1, /*col_in_stride=*/1,
+                         NoOpOutputKernel(), padding_top, padding_bottom,
+                         padding_left, padding_right);
+
+  EXPECT_EQ(result.dimension(0), output_depth);
+  EXPECT_EQ(result.dimension(1), output_rows);
+  EXPECT_EQ(result.dimension(2), output_cols);
+  EXPECT_EQ(result.dimension(3), num_batches);
+
+  for (int b = 0; b < num_batches; ++b) {
+    for (int r = 0; r < output_rows; ++r) {
+      for (int c = 0; c < output_depth; ++c) {
+        // First column should be cropped col 5: 100*r + 10*5 + c
+        EigenApprox(result(c, r, 0, b), 100.0f * r + 50.0f + c);
+        // Second column should be zero padding
+        EigenApprox(result(c, r, 1, b), 0.0f);
+      }
+    }
+  }
+}
+
+TEST(EigenSpatialConvolutionsTest, CropEntireDimensionSpatialConvolution) {
+  const int input_depth = 20;
+  const int input_rows = 15;
+  const int input_cols = 6;
+  const int num_batches = 1;
+  const int output_depth = 20;
+  const int patch_rows = 1;
+  const int patch_cols = 1;
+
+  // Crop all 15 rows from top, pad 1 on bottom
+  const int padding_top = -15;
+  const int padding_bottom = 1;
+  const int padding_left = 0;
+  const int padding_right = 0;
+
+  const int output_rows = input_rows + padding_top + padding_bottom;  // 1
+  const int output_cols = input_cols;
+
+  Tensor<float, 4> input(input_depth, input_rows, input_cols, num_batches);
+  Tensor<float, 4> kernel(output_depth, input_depth, patch_rows, patch_cols);
+
+  input.setRandom();
+  kernel.setRandom();
+
+  Tensor<float, 4> result =
+      SpatialConvolution(input, kernel, /*row_stride=*/1, /*col_stride=*/1,
+                         PADDING_VALID, /*row_in_stride=*/1, /*col_in_stride=*/1,
+                         NoOpOutputKernel(), padding_top, padding_bottom,
+                         padding_left, padding_right);
+
+  EXPECT_EQ(result.dimension(0), output_depth);
+  EXPECT_EQ(result.dimension(1), output_rows);
+  EXPECT_EQ(result.dimension(2), output_cols);
+  EXPECT_EQ(result.dimension(3), num_batches);
+
+  // The output row is entirely in the padded area, so all values must be 0
+  for (int b = 0; b < num_batches; ++b) {
+    for (int col = 0; col < output_cols; ++col) {
+      for (int c = 0; c < output_depth; ++c) {
+        EigenApprox(result(c, 0, col, b), 0.0f);
+      }
+    }
+  }
+}
+
 template <typename T>
 static void PackRhsHelper(::testing::benchmark::State& state,
                           /* Input dimensions: */


### PR DESCRIPTION
#ai-generated

### Root Cause
In `xla/tsl/framework/convolution/eigen_spatial_convolutions-inl.h`, `hasPadding()` only verified positive padding (`m_rowPaddingTop > 0`, `m_colPaddingLeft > 0`) and omitted padding offsets from `last_row` and `last_col` calculations. When a spatial convolution specifies negative low padding (cropping) combined with high padding, or crops an entire dimension, `hasPadding()` incorrectly returned `false`, selecting the unpadded fast path (`packetNoPadding`). This resulted in out-of-bounds reads into uninitialized memory and `SIGSEGV` / access violations when vectorizing across wide channel dimensions.

### Fix Approach
Update `hasPadding()` to:
1. Include `-m_rowPaddingTop` and `-m_colPaddingLeft` in `first_row`/`first_col` and `last_row`/`last_col` calculations.
2. Return `true` whenever the first or last accessed spatial coordinates fall outside `[0, input_dim)`.
3. Preserve the vectorized fast path when cropping strictly within input bounds.

### Test Verification
- Added `NegativeLowPaddingSpatialConvolution` and `CropEntireDimensionSpatialConvolution` unit tests in `eigen_spatial_convolutions_test.cc`.
- Verified against the JAX reproducer in #48713, confirming padded boundaries evaluate to zero without out-of-bounds reads or crashes.

Fixes #48713
